### PR TITLE
CORE-12083 - Flow External Messaging - Add support for storing routing data on VirtualNodeInfo

### DIFF
--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
@@ -221,6 +221,7 @@ class VirtualNodeRestResourceImplTest {
             operational,
             operational,
             null,
+            null,
             -1,
             mock(),
             false

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/factories/RecordFactory.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/factories/RecordFactory.kt
@@ -10,7 +10,8 @@ internal interface RecordFactory {
     fun createVirtualNodeInfoRecord(
         holdingIdentity: HoldingIdentity,
         cpiIdentifier: CpiIdentifier,
-        dbConnections: VirtualNodeDbConnections
+        dbConnections: VirtualNodeDbConnections,
+        externalMessagingRouteConfig: String?
     ): Record<*, *>
 
     fun createMgmInfoRecord(

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/factories/RecordFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/factories/RecordFactoryImpl.kt
@@ -21,7 +21,8 @@ internal class RecordFactoryImpl(
     override fun createVirtualNodeInfoRecord(
         holdingIdentity: HoldingIdentity,
         cpiIdentifier: CpiIdentifier,
-        dbConnections: VirtualNodeDbConnections
+        dbConnections: VirtualNodeDbConnections,
+        externalMessagingRouteConfig: String?
     ): Record<*, *> {
         val virtualNodeInfo = with(dbConnections) {
             VirtualNodeInfo(
@@ -33,6 +34,7 @@ internal class RecordFactoryImpl(
                 cryptoDmlConnectionId,
                 uniquenessDdlConnectionId,
                 uniquenessDmlConnectionId,
+                externalMessagingRouteConfig = externalMessagingRouteConfig,
                 timestamp = clock.instant(),
             ).toAvro()
         }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
@@ -90,7 +90,8 @@ internal class CreateVirtualNodeOperationHandler(
                     holdingId,
                     vNodeDbs,
                     cpiMetadata.id,
-                    request.updateActor
+                    request.updateActor,
+                    externalMessagingRouteConfig = null
                 )
             }
 
@@ -107,7 +108,14 @@ internal class CreateVirtualNodeOperationHandler(
                 mutableListOf(recordFactory.createMgmInfoRecord(holdingId, mgmInfo))
             }
 
-            records.add(recordFactory.createVirtualNodeInfoRecord(holdingId, cpiMetadata.id, vNodeConnections))
+            records.add(
+                recordFactory.createVirtualNodeInfoRecord(
+                    holdingId,
+                    cpiMetadata.id,
+                    vNodeConnections,
+                    externalMessagingRouteConfig = null
+                )
+            )
 
             execLog.measureExecTime("publish virtual node and MGM info") {
                 createVirtualNodeService.publishRecords(records)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeService.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeService.kt
@@ -23,7 +23,8 @@ internal interface CreateVirtualNodeService {
         holdingIdentity: HoldingIdentity,
         vNodeDbs: Map<VirtualNodeDbType,VirtualNodeDb>,
         cpiId: CpiIdentifier,
-        updateActor: String
+        updateActor: String,
+        externalMessagingRouteConfig: String?
     ): VirtualNodeDbConnections
 
     fun publishRecords(records: List<Record<*, *>>)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
@@ -127,7 +127,8 @@ internal class CreateVirtualNodeServiceImpl(
         holdingIdentity: HoldingIdentity,
         vNodeDbs: Map<VirtualNodeDbType, VirtualNodeDb>,
         cpiId: CpiIdentifier,
-        updateActor: String
+        updateActor: String,
+        externalMessagingRouteConfig: String?
     ): VirtualNodeDbConnections {
         try {
             return dbConnectionManager.getClusterEntityManagerFactory().createEntityManager().transaction { em ->
@@ -152,6 +153,7 @@ internal class CreateVirtualNodeServiceImpl(
                     dbConnections.cryptoDmlConnectionId,
                     dbConnections.uniquenessDdlConnectionId,
                     dbConnections.uniquenessDmlConnectionId,
+                    externalMessagingRouteConfig = externalMessagingRouteConfig
                 )
 
                 dbConnections

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/factories/RecordFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/factories/RecordFactoryImplTest.kt
@@ -28,12 +28,12 @@ class RecordFactoryImplTest {
 
     @Test
     fun `create mgm info record`() {
-        var memberProvidedContext= mock<MemberContext>().apply {
+        var memberProvidedContext = mock<MemberContext>().apply {
             whenever(this.parse("corda.groupId", String::class.java)).thenReturn(GROUP_ID1)
             whenever(entries).thenReturn(setOf())
         }
 
-        var mgmProvidedContext= mock<MGMContext>().apply {
+        var mgmProvidedContext = mock<MGMContext>().apply {
             whenever(entries).thenReturn(setOf())
         }
 
@@ -43,7 +43,7 @@ class RecordFactoryImplTest {
             whenever(this.mgmProvidedContext).thenReturn(mgmProvidedContext)
         }
 
-        val expectedPayload =  PersistentMemberInfo(
+        val expectedPayload = PersistentMemberInfo(
             ALICE_HOLDING_ID1.toAvro(),
             memberProvidedContext.toAvro(),
             mgmProvidedContext.toAvro()
@@ -51,7 +51,7 @@ class RecordFactoryImplTest {
 
         val target = RecordFactoryImpl(mock())
 
-        val result = target.createMgmInfoRecord(ALICE_HOLDING_ID1,mgmMemberInfo)
+        val result = target.createMgmInfoRecord(ALICE_HOLDING_ID1, mgmMemberInfo)
 
         assertThat(result.topic).isEqualTo(MEMBER_LIST_TOPIC)
         assertThat(result.key).isEqualTo("${ALICE_HOLDING_ID1.shortHash}-${MGM_HOLDING_ID1.shortHash}")
@@ -88,7 +88,12 @@ class RecordFactoryImplTest {
 
         val target = RecordFactoryImpl(clock)
 
-        val result = target.createVirtualNodeInfoRecord(ALICE_HOLDING_ID1, CPI_IDENTIFIER1, dbConnections)
+        val result = target.createVirtualNodeInfoRecord(
+            ALICE_HOLDING_ID1,
+            CPI_IDENTIFIER1,
+            dbConnections,
+            externalMessagingRouteConfig = null
+        )
 
         assertThat(result.topic).isEqualTo(VIRTUAL_NODE_INFO_TOPIC)
         assertThat(result.key).isEqualTo(ALICE_HOLDING_ID1.toAvro())

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandlerTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandlerTest.kt
@@ -151,7 +151,8 @@ class CreateVirtualNodeOperationHandlerTest {
             ALICE_HOLDING_ID1,
             virtualNodeDbs,
             CPI_IDENTIFIER1,
-            request.updateActor
+            request.updateActor,
+            null
         )
     }
 
@@ -161,14 +162,15 @@ class CreateVirtualNodeOperationHandlerTest {
         val virtualNodeInfoRecord = Record("vnode", "", "")
         val dbConnections = mock<VirtualNodeDbConnections>()
 
-        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any())).thenReturn(
+        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), eq(null))).thenReturn(
             dbConnections
         )
         whenever(
             recordFactory.createVirtualNodeInfoRecord(
                 ALICE_HOLDING_ID1,
                 CPI_IDENTIFIER1,
-                dbConnections
+                dbConnections,
+                externalMessagingRouteConfig = null
             )
         ).thenReturn(
             virtualNodeInfoRecord
@@ -189,14 +191,15 @@ class CreateVirtualNodeOperationHandlerTest {
         val mgmInfoRecord = Record("mgm", "", "")
         val dbConnections = mock<VirtualNodeDbConnections>()
 
-        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any())).thenReturn(
+        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), eq(null))).thenReturn(
             dbConnections
         )
         whenever(
             recordFactory.createVirtualNodeInfoRecord(
                 ALICE_HOLDING_ID1,
                 CPI_IDENTIFIER1,
-                dbConnections
+                dbConnections,
+                externalMessagingRouteConfig = null
             )
         ).thenReturn(
             virtualNodeInfoRecord
@@ -261,14 +264,15 @@ class CreateVirtualNodeOperationHandlerTest {
         val virtualNodeInfoRecord = Record("vnode", "", "")
         val dbConnections = mock<VirtualNodeDbConnections>()
 
-        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any())).thenReturn(
+        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), eq(null))).thenReturn(
             dbConnections
         )
         whenever(
             recordFactory.createVirtualNodeInfoRecord(
                 ALICE_HOLDING_ID1,
                 CPI_IDENTIFIER1,
-                dbConnections
+                dbConnections,
+                externalMessagingRouteConfig = null
             )
         ).thenReturn(virtualNodeInfoRecord)
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/services/CreateVirtualNodeServiceImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/services/CreateVirtualNodeServiceImplTest.kt
@@ -115,7 +115,7 @@ class CreateVirtualNodeServiceImplTest {
 
     @Test
     fun `run CPI migrations throw on failure`() {
-        val cpkChangeLogId1 = CpkDbChangeLogIdentifier(SecureHashImpl("SHA-256","checksum1".toByteArray()), "fp1")
+        val cpkChangeLogId1 = CpkDbChangeLogIdentifier(SecureHashImpl("SHA-256", "checksum1".toByteArray()), "fp1")
         val cpkChangeLogEntity1 = CpkDbChangeLog(cpkChangeLogId1, "content")
 
         whenever(
@@ -134,9 +134,9 @@ class CreateVirtualNodeServiceImplTest {
 
     @Test
     fun `run CPI migrations runs all CPK migrations`() {
-        val cpkChangeLogId1 = CpkDbChangeLogIdentifier(SecureHashImpl("SHA-256","checksum1".toByteArray()), "fp1")
-        val cpkChangeLogId2 = CpkDbChangeLogIdentifier(SecureHashImpl("SHA-256","checksum1".toByteArray()), "fp2")
-        val cpkChangeLogId3 = CpkDbChangeLogIdentifier(SecureHashImpl("SHA-256","checksum2".toByteArray()), "fp1")
+        val cpkChangeLogId1 = CpkDbChangeLogIdentifier(SecureHashImpl("SHA-256", "checksum1".toByteArray()), "fp1")
+        val cpkChangeLogId2 = CpkDbChangeLogIdentifier(SecureHashImpl("SHA-256", "checksum1".toByteArray()), "fp2")
+        val cpkChangeLogId3 = CpkDbChangeLogIdentifier(SecureHashImpl("SHA-256", "checksum2".toByteArray()), "fp1")
         val cpkChangeLogEntity1 = CpkDbChangeLog(cpkChangeLogId1, "content1")
         val cpkChangeLogEntity2 = CpkDbChangeLog(cpkChangeLogId2, "content2")
         val cpkChangeLogEntity3 = CpkDbChangeLog(cpkChangeLogId3, "content3")
@@ -238,7 +238,13 @@ class CreateVirtualNodeServiceImplTest {
             )
         ).thenReturn(uniquenessDmlDbConnectionDetailsId)
 
-        target.persistHoldingIdAndVirtualNode(ALICE_HOLDING_ID1, virtualNodeDbs, CPI_IDENTIFIER1, updateActor)
+        target.persistHoldingIdAndVirtualNode(
+            ALICE_HOLDING_ID1,
+            virtualNodeDbs,
+            CPI_IDENTIFIER1,
+            updateActor,
+            externalMessagingRouteConfig = null
+        )
 
         verify(holdingIdentityRepository).put(entityManager, ALICE_HOLDING_ID1)
 
@@ -252,6 +258,7 @@ class CreateVirtualNodeServiceImplTest {
             cryptoDmlDbConnectionDetailsId,
             uniquenessDdlDbConnectionDetailsId,
             uniquenessDmlDbConnectionDetailsId,
+            externalMessagingRouteConfig = null
         )
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.738-alpha-1680100208525
+cordaApiVersion=5.0.0.738-beta+
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.737-alpha-1680085637380
+cordaApiVersion=5.0.0.738-alpha-1680100208525
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,8 +40,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.738-beta+
-
+cordaApiVersion=5.0.0.737-alpha-1680085637380
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,7 @@ bouncycastleVersion=1.72
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
 cordaApiVersion=5.0.0.738-beta+
+
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VNodeTestUtils.kt
@@ -24,7 +24,8 @@ internal object VNodeTestUtils {
         cpiVersion: String,
         cpiSignerSummaryHash: SecureHash,
         virtualNodeOperationEntity: VirtualNodeOperationEntity? = null,
-        holdingIdentityEntity: HoldingIdentityEntity? = null
+        holdingIdentityEntity: HoldingIdentityEntity? = null,
+        externalMessagingRouteConfig: String?,
     ): VirtualNodeEntity {
 
         println("Creating VNode for testing: $cpiName, $cpiVersion, $cpiSignerSummaryHash")
@@ -43,7 +44,8 @@ internal object VNodeTestUtils {
             UUID.randomUUID(),
             UUID.randomUUID(),
             UUID.randomUUID(),
-            operationInProgress = virtualNodeOperationEntity
+            operationInProgress = virtualNodeOperationEntity,
+            externalMessagingRouteConfig = externalMessagingRouteConfig
         )
 
         entityManagerFactory.createEntityManager().transaction { em ->

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeEntitiesIntegrationTest.kt
@@ -95,7 +95,7 @@ class VirtualNodeEntitiesIntegrationTest {
         val version = "1.0-${Instant.now().toEpochMilli()}"
         val cpiSignerSummaryHash = TestRandom.secureHash()
 
-        val vnodeEntity = VNodeTestUtils.newVNode(entityManagerFactory, name, version, cpiSignerSummaryHash)
+        val vnodeEntity = VNodeTestUtils.newVNode(entityManagerFactory, name, version, cpiSignerSummaryHash, externalMessagingRouteConfig = null)
 
         assertThat(entityManagerFactory.createEntityManager().find(VirtualNodeEntity::class.java, vnodeEntity.holdingIdentityId))
             .isEqualTo(vnodeEntity)
@@ -114,7 +114,7 @@ class VirtualNodeEntitiesIntegrationTest {
             em.persist(holdingIdentityEntity)
         }
 
-        val vnodeEntity = VNodeTestUtils.newVNode(entityManagerFactory, name, version, cpiSignerSummaryHash, holdingIdentityEntity = holdingIdentityEntity)
+        val vnodeEntity = VNodeTestUtils.newVNode(entityManagerFactory, name, version, cpiSignerSummaryHash, holdingIdentityEntity = holdingIdentityEntity, externalMessagingRouteConfig = null)
 
         assertThat(entityManagerFactory.createEntityManager().find(VirtualNodeEntity::class.java, vnodeEntity.holdingIdentityId))
             .isEqualTo(vnodeEntity)
@@ -135,7 +135,7 @@ class VirtualNodeEntitiesIntegrationTest {
             OperationType.UPGRADE,
             Instant.now()
         )
-        val vnodeEntity = VNodeTestUtils.newVNode(entityManagerFactory, name, version, cpiSignerSummaryHash, virtualNodeOperationEntity)
+        val vnodeEntity = VNodeTestUtils.newVNode(entityManagerFactory, name, version, cpiSignerSummaryHash, virtualNodeOperationEntity, externalMessagingRouteConfig = null)
 
         val foundEntity = entityManagerFactory.createEntityManager().find(VirtualNodeEntity::class.java, vnodeEntity.holdingIdentityId)
         val operationEntity =

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/VirtualNodeRepositoryTest.kt
@@ -82,7 +82,9 @@ class VirtualNodeRepositoryTest {
                 entityManagerFactory,
                 "Test CPI $i",
                 "1.0-${Instant.now().toEpochMilli()}",
-                TestRandom.secureHash())
+                TestRandom.secureHash(),
+                externalMessagingRouteConfig = null
+            )
         }
 
         // Now check the query - and also we should look at the console output for this
@@ -114,7 +116,9 @@ class VirtualNodeRepositoryTest {
                 entityManagerFactory,
                 "Test CPI ${UUID.randomUUID()}",
                 "1.0-${Instant.now().toEpochMilli()}",
-                TestRandom.secureHash())
+                TestRandom.secureHash(),
+                externalMessagingRouteConfig = null
+            )
         }
 
         // Now check the query - and also we should look at the console output for this
@@ -158,7 +162,9 @@ class VirtualNodeRepositoryTest {
                 entityManagerFactory,
                 "Test CPI $i ${UUID.randomUUID()}",
                 "1.0-${Instant.now().toEpochMilli()}",
-                TestRandom.secureHash())
+                TestRandom.secureHash(),
+                externalMessagingRouteConfig = null
+            )
         }
 
         val virtualNode = entityManagerFactory.createEntityManager().use {
@@ -171,7 +177,14 @@ class VirtualNodeRepositoryTest {
     @Test
     fun put() {
         val cpiSignerSummaryHash = TestRandom.secureHash()
-        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", cpiSignerSummaryHash)
+        val vnode =
+            VNodeTestUtils.newVNode(
+                entityManagerFactory,
+                "Testing ${UUID.randomUUID()}",
+                "1.0",
+                cpiSignerSummaryHash,
+                externalMessagingRouteConfig = null
+            )
 
         val hi = vnode.holdingIdentity.toHoldingIdentity()
         val cpiId = CpiIdentifier(vnode.cpiName, vnode.cpiVersion, cpiSignerSummaryHash)
@@ -187,6 +200,7 @@ class VirtualNodeRepositoryTest {
                 vnode.cryptoDMLConnectionId!!,
                 vnode.uniquenessDDLConnectionId,
                 vnode.uniquenessDMLConnectionId,
+                externalMessagingRouteConfig = null
             )
         }
 
@@ -218,7 +232,9 @@ class VirtualNodeRepositoryTest {
                     null,
                     UUID.randomUUID(),
                     null,
-                    UUID.randomUUID())
+                    UUID.randomUUID(),
+                    externalMessagingRouteConfig = null
+                )
             }
         }
     }
@@ -227,11 +243,18 @@ class VirtualNodeRepositoryTest {
     fun updateVirtualNodeState() {
         val cpiSignerSummaryHash = TestRandom.secureHash()
         val vnode = VNodeTestUtils
-            .newVNode(entityManagerFactory, "Testing ${UUID.randomUUID()}", "1.0", cpiSignerSummaryHash)
+            .newVNode(
+                entityManagerFactory,
+                "Testing ${UUID.randomUUID()}",
+                "1.0",
+                cpiSignerSummaryHash,
+                externalMessagingRouteConfig = null
+            )
 
         entityManagerFactory.createEntityManager().use {
             VirtualNodeRepositoryImpl().updateVirtualNodeState(
-                it, vnode.holdingIdentity.holdingIdentityShortHash, OperationalStatus.INACTIVE)
+                it, vnode.holdingIdentity.holdingIdentityShortHash, OperationalStatus.INACTIVE
+            )
         }
 
         val changedEntity = entityManagerFactory.createEntityManager().use {
@@ -249,7 +272,13 @@ class VirtualNodeRepositoryTest {
     fun `upgrade virtual node CPI test`() {
         val signerSummaryHash = TestRandom.secureHash()
         val testName = "Testing ${UUID.randomUUID()}"
-        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, testName, "v1", signerSummaryHash)
+        val vnode = VNodeTestUtils.newVNode(
+            entityManagerFactory,
+            testName,
+            "v1",
+            signerSummaryHash,
+            externalMessagingRouteConfig = null
+        )
 
         entityManagerFactory.createEntityManager().transaction { em ->
             //cpiMetadataRepository = CpiMetadataRepositoryImpl()
@@ -266,7 +295,7 @@ class VirtualNodeRepositoryTest {
                 holdingIdentityShortHash,
                 testName, "v2", signerSummaryHash.toString(),
                 requestId, requestTimestamp, "serializedRequest"
-                )
+            )
         }
         assertThat(upgradeVirtualNodeInfo).isNotNull
         assertThat(upgradeVirtualNodeInfo.cpiIdentifier.name).isEqualTo(testName)
@@ -297,9 +326,18 @@ class VirtualNodeRepositoryTest {
         val operationId = UUID.randomUUID().toString()
         val requestId = UUID.randomUUID().toString()
 
-        val operation = VirtualNodeOperationEntity(operationId, requestId, "data", VirtualNodeOperationState.IN_PROGRESS,
-            OperationType.UPGRADE, Instant.now())
-        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, testName, "v1", signerSummaryHash, operation)
+        val operation = VirtualNodeOperationEntity(
+            operationId, requestId, "data", VirtualNodeOperationState.IN_PROGRESS,
+            OperationType.UPGRADE, Instant.now()
+        )
+        val vnode = VNodeTestUtils.newVNode(
+            entityManagerFactory,
+            testName,
+            "v1",
+            signerSummaryHash,
+            operation,
+            externalMessagingRouteConfig = null
+        )
 
         entityManagerFactory.createEntityManager().transaction {
             VirtualNodeRepositoryImpl().completedOperation(it, vnode.holdingIdentityId)
@@ -330,9 +368,18 @@ class VirtualNodeRepositoryTest {
         val operationId = UUID.randomUUID().toString()
         val requestId = UUID.randomUUID().toString()
 
-        val operation = VirtualNodeOperationEntity(operationId, requestId, "data", VirtualNodeOperationState.IN_PROGRESS,
-            OperationType.UPGRADE, Instant.now())
-        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, testName, "v1", signerSummaryHash, operation)
+        val operation = VirtualNodeOperationEntity(
+            operationId, requestId, "data", VirtualNodeOperationState.IN_PROGRESS,
+            OperationType.UPGRADE, Instant.now()
+        )
+        val vnode = VNodeTestUtils.newVNode(
+            entityManagerFactory,
+            testName,
+            "v1",
+            signerSummaryHash,
+            operation,
+            externalMessagingRouteConfig = null
+        )
 
         entityManagerFactory.createEntityManager().transaction {
             VirtualNodeRepositoryImpl().failedOperation(
@@ -372,7 +419,13 @@ class VirtualNodeRepositoryTest {
         val testName = "Testing ${UUID.randomUUID()}"
         val requestId = UUID.randomUUID().toString()
 
-        val vnode = VNodeTestUtils.newVNode(entityManagerFactory, testName, "v1", signerSummaryHash)
+        val vnode = VNodeTestUtils.newVNode(
+            entityManagerFactory,
+            testName,
+            "v1",
+            signerSummaryHash,
+            externalMessagingRouteConfig = null
+        )
 
         entityManagerFactory.createEntityManager().transaction {
             VirtualNodeRepositoryImpl().failedOperation(

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -38,6 +38,7 @@ import javax.persistence.Version
  * @param flowOperationalStatus The virtual node's ability to run flows, to have checkpoints, to continue in-progress flows.
  * @param vaultDbOperationalStatus The virtual node's ability to perform persistence operations on the virtual node's vault.
  * @param operationInProgress Details of the current operation in progress.
+ * @param externalMessagingRouteConfig Route configuration for external messaging.
  */
 @Entity
 @Table(name = VIRTUAL_NODE_DB_TABLE)
@@ -99,6 +100,9 @@ internal class VirtualNodeEntity(
     @JoinColumn(name = "operation_in_progress")
     var operationInProgress: VirtualNodeOperationEntity? = null,
 
+    @Column(name = "external_messaging_route_config", nullable = true)
+    var externalMessagingRouteConfig: String? = null,
+
     @Column(name = "insert_ts", insertable = false)
     var insertTimestamp: Instant? = null,
 
@@ -139,6 +143,7 @@ internal class VirtualNodeEntity(
             flowOperationalStatus,
             vaultDbOperationalStatus,
             operationInProgress?.requestId,
+            externalMessagingRouteConfig,
             entityVersion,
             insertTimestamp!!,
             isDeleted

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepository.kt
@@ -47,7 +47,8 @@ interface VirtualNodeRepository {
         cryptoDDLConnectionId: UUID?,
         cryptoDMLConnectionId: UUID,
         uniquenessDDLConnectionId: UUID?,
-        uniquenessDMLConnectionId: UUID?
+        uniquenessDMLConnectionId: UUID?,
+        externalMessagingRouteConfig: String?
     )
 
     /**

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -101,7 +101,8 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
         cryptoDDLConnectionId: UUID?,
         cryptoDMLConnectionId: UUID,
         uniquenessDDLConnectionId: UUID?,
-        uniquenessDMLConnectionId: UUID?
+        uniquenessDMLConnectionId: UUID?,
+        externalMessagingRouteConfig: String?
     ) {
         val signerSummaryHash = cpiId.signerSummaryHash.toString()
         val hie = entityManager.find(HoldingIdentityEntity::class.java, holdingId.shortHash.value)
@@ -129,6 +130,7 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
             cryptoDMLConnectionId = cryptoDMLConnectionId,
             uniquenessDDLConnectionId = uniquenessDDLConnectionId,
             uniquenessDMLConnectionId = uniquenessDMLConnectionId,
+            externalMessagingRouteConfig = externalMessagingRouteConfig
         )
 
         entityManager.persist(foundVNode)

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -43,6 +43,8 @@ data class VirtualNodeInfo(
     val vaultDbOperationalStatus: OperationalStatus = DEFAULT_INITIAL_STATE,
     /** The requestId of an operation that is in progress on this virtual node. Null if no operation is in progress */
     val operationInProgress: String? = null,
+    /** The route configuration for the external messaging. Null if no configuration was provided.*/
+    val externalMessagingRouteConfig: String? = null,
     /** Version of this vnode */
     val version: Int = -1,
     /** Creation timestamp */
@@ -97,6 +99,7 @@ fun VirtualNodeInfoAvro.toCorda(): VirtualNodeInfo {
         OperationalStatus.fromAvro(flowOperationalStatus),
         OperationalStatus.fromAvro(vaultDbOperationalStatus),
         operationInProgress,
+        externalMessagingRouteConfig,
         version,
         timestamp,
         false


### PR DESCRIPTION
Added the field `externalMessagingRouteConfig` to the `VirtualNodeEntity` entity.
Updated the `VirtualNodeInfo` class accordingly since this a dto class that represents the `VirtualNodeEntity` entity.
Updated the tests with `null` values for the `externalMessagingRouteConfig`. This is temporary and the tests will be properly updated in following PRs related to this ticket.

`corda-api` PR: https://github.com/corda/corda-api/pull/1002