### PR TITLE
CORE-9790 Vault support in crypto plugin

### DIFF
--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
@@ -244,7 +244,7 @@ fun createCryptoBootstrapParamsMap(hsmId: String): Map<String, String> =
     mapOf(HSM_ID to hsmId)
 
 // TODO - get this from the JSON config schema, or eliminate this function
-fun createDefaultCryptoConfig(wrappingKeyPassphrase: Any, wrappingKeySalt: Any): SmartConfig =
+fun createDefaultCryptoConfig(wrappingKeyPassphrase: Any?, wrappingKeySalt: Any?): SmartConfig =
     SmartConfigFactory.createWithoutSecurityServices().create(ConfigFactory.empty())
         .withValue(
             CRYPTO_CONNECTION_FACTORY_OBJ, ConfigValueFactory.fromMap(
@@ -307,15 +307,20 @@ fun createDefaultCryptoConfig(wrappingKeyPassphrase: Any, wrappingKeySalt: Any):
                                     "maximumSize" to 1000
                                 )
                             ),
-                            "wrappingKeyMap" to mapOf(
+                            "wrappingKeyMap" to mutableMapOf(
                                 "name" to "CACHING",
-                                "salt" to wrappingKeySalt,
-                                "passphrase" to wrappingKeyPassphrase,
                                 "cache" to mapOf(
                                     "expireAfterAccessMins" to 60,
                                     "maximumSize" to 1000
                                 )
-                            ),
+                            ).also {
+                                if (wrappingKeySalt != null) {
+                                    it["salt"] = wrappingKeySalt
+                                }
+                                if (wrappingKeyPassphrase != null) {
+                                    it["passphrase"] = wrappingKeyPassphrase
+                                }
+                            },
                             "wrapping" to mapOf(
                                 "name" to "DEFAULT"
                             )

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -1,5 +1,6 @@
 package net.corda.crypto.config.impl
 
+import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
 import net.corda.crypto.core.CryptoConsts.SOFT_HSM_ID
 import net.corda.crypto.core.CryptoConsts.SOFT_HSM_SERVICE_NAME
@@ -91,6 +92,16 @@ class CryptoConfigUtilsTests {
         assertEquals(3, hsmRegistrationBusProcessor.maxAttempts)
         assertEquals(1, hsmRegistrationBusProcessor.waitBetweenMills.size)
         assertEquals(200L, hsmRegistrationBusProcessor.waitBetweenMills[0])
+    }
+
+    @Test
+    fun `Possible to create default config without wrapping key values`() {
+        val config = createDefaultCryptoConfig(null, null)
+        val softWorker = config.hsm(SOFT_HSM_ID)
+        val hsmCfg = softWorker.hsm.cfg
+
+        assertThrows<ConfigException.Missing> { hsmCfg.getString("wrappingKeyMap.salt") }
+        assertThrows<ConfigException.Missing> { hsmCfg.getString("wrappingKeyMap.passphrase") }
     }
 
     @Test


### PR DESCRIPTION
Added support for Vault in the crypto initial config plugin. This involves removing the wrapping key and wrapping salt from the Config entirely. I believe these are used to create a root key for `EncryptionSecretsServiceImpl` only and are not required for Vault.

@dickon please let me know if I got this wrong at all.