### PR TITLE
CORE-9085 - Fail MGM registration if trust root specified is not valid PEM certificate

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidator.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidator.kt
@@ -82,6 +82,9 @@ internal class MGMRegistrationContextValidator(
             context.keys.filter { TRUSTSTORE_SESSION.format("[0-9]+").toRegex().matches(it) }.apply {
                 require(isNotEmpty()) { "No session trust store was provided." }
                 require(orderVerifier.isOrdered(this, 4)) { "Provided session trust stores are incorrectly numbered." }
+                this.map { key ->
+                    validateTrustrootCert(context[key]!!, key)
+                }
             }
         }
         context.keys.filter { TRUSTSTORE_TLS.format("[0-9]+").toRegex().matches(it) }.apply {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -163,6 +163,7 @@ class MGMRegistrationService @Activate constructor(
         private val mgmRegistrationContextValidator = MGMRegistrationContextValidator(
             membershipSchemaValidatorFactory,
             configurationGetService = configurationGetService,
+            clock = UTCClock()
         )
         private val mgmRegistrationMemberInfoHandler = MGMRegistrationMemberInfoHandler(
             clock,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
@@ -2,7 +2,6 @@ package net.corda.membership.impl.registration.dynamic.mgm
 
 import net.corda.configuration.read.ConfigurationGetService
 import net.corda.libs.configuration.SmartConfig
-import net.corda.membership.impl.registration.staticnetwork.TestUtils
 import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.URL_KEY
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidationException
@@ -10,7 +9,6 @@ import net.corda.membership.lib.schema.validation.MembershipSchemaValidator
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
 import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 import net.corda.schema.membership.MembershipSchema
-import org.apache.commons.text.StringEscapeUtils
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -59,7 +57,7 @@ class MGMRegistrationContextValidatorTest {
                 PKI_TLS to "TLS PKI property",
                 URL_KEY.format(0) to "https://localhost:8080",
                 PROTOCOL_VERSION.format(0) to "1",
-                TRUSTSTORE_SESSION.format(0) to "session truststore",
+                TRUSTSTORE_SESSION.format(0) to r3comCert,
                 TRUSTSTORE_TLS.format(0) to r3comCert
             )
 
@@ -185,8 +183,16 @@ class MGMRegistrationContextValidatorTest {
     }
 
     @Test
-    fun `invalid trust root will throw an exception`() {
+    fun `invalid TLS trust root will throw an exception`() {
         val context = validTestContext + (TRUSTSTORE_TLS.format(0) to "invalid-pem-payload")
+        assertThrows<MGMRegistrationContextValidationException> {
+            mgmRegistrationContextValidator.validate(context)
+        }
+    }
+
+    @Test
+    fun `invalid session trust root will throw an exception`() {
+        val context = validTestContext + (TRUSTSTORE_SESSION.format(0) to "invalid-pem-payload")
         assertThrows<MGMRegistrationContextValidationException> {
             mgmRegistrationContextValidator.validate(context)
         }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
@@ -43,7 +43,7 @@ class MGMRegistrationContextValidatorTest {
     )
 
     companion object {
-        private val r3comCert = this::class.java.getResource("/r3Com.pem")!!.readText()
+        private val trustrootCert = this::class.java.getResource("/r3Com.pem")!!.readText()
 
         private val validTestContext
             get() = mutableMapOf(
@@ -57,8 +57,8 @@ class MGMRegistrationContextValidatorTest {
                 PKI_TLS to "TLS PKI property",
                 URL_KEY.format(0) to "https://localhost:8080",
                 PROTOCOL_VERSION.format(0) to "1",
-                TRUSTSTORE_SESSION.format(0) to r3comCert,
-                TRUSTSTORE_TLS.format(0) to r3comCert
+                TRUSTSTORE_SESSION.format(0) to trustrootCert,
+                TRUSTSTORE_TLS.format(0) to trustrootCert
             )
 
         @JvmStatic

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -124,6 +124,8 @@ class MGMRegistrationServiceTest {
         const val ECDH_KEY_STRING = "5678"
         const val ECDH_KEY_ID = "BBC123456789"
         const val PUBLISHER_CLIENT_ID = "mgm-registration-service"
+
+        private val trustrootCert = this::class.java.getResource("/r3Com.pem")!!.readText()
     }
 
     private val groupId = "43b5b6e6-4f2d-498f-8b41-5e2f8f97e7e8"
@@ -283,10 +285,8 @@ class MGMRegistrationServiceTest {
         "corda.group.pki.tls" to "C5",
         "corda.endpoints.0.connectionURL" to "https://localhost:1080",
         "corda.endpoints.0.protocolVersion" to "1",
-        "corda.group.trustroot.session.0"
-                to "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----",
-        "corda.group.trustroot.tls.0"
-                to "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----",
+        "corda.group.trustroot.session.0" to trustrootCert,
+        "corda.group.trustroot.tls.0" to trustrootCert,
     )
 
     private fun postStartEvent() {
@@ -435,10 +435,8 @@ class MGMRegistrationServiceTest {
                         "key.session.policy" to "Combined",
                         "pki.session" to "Standard",
                         "pki.tls" to "C5",
-                        "trustroot.session.0"
-                                to "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----",
-                        "trustroot.tls.0"
-                                to "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----",
+                        "trustroot.session.0" to trustrootCert,
+                        "trustroot.tls.0" to trustrootCert,
                     ).entries
                 )
             registrationService.stop()
@@ -556,8 +554,7 @@ class MGMRegistrationServiceTest {
             postConfigChangedEvent()
             val testProperties =
                 properties + mapOf(
-                    "corda.group.trustroot.tls.100" to
-                            "-----BEGIN CERTIFICATE-----Base64–encoded certificate-----END CERTIFICATE-----"
+                    "corda.group.trustroot.tls.100" to trustrootCert
                 )
             registrationService.start()
 


### PR DESCRIPTION
### Changes
Changing the MGM registration logic, so that if any of the specified TLS trustroots is invalid then the registration fails. 

Given how easy it was, I added the same checks for session trust roots although it's out of scope of the associated bug.

### Testing
Tested by following the onboarding steps for an MGM up until registration where I used an invalid string for TLS trustroot. Registration was submitted successfully and checking the registration status returned the following:
```
{
  "registrationId": "836c3a0e-22aa-4d15-bac3-d00842c2d923",
  "registrationSent": "2023-03-29T14:16:26.049Z",
  "registrationUpdated": "2023-03-29T14:16:28.787Z",
  "registrationStatus": "INVALID",
  "memberInfoSubmitted": {
    "data": {
      "registrationProtocolVersion": "1",
      "corda.session.keys.0.id": "09D8C3F24172",
      "corda.ecdh.key.id": "C111168C006D",
      "corda.group.protocol.registration": "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService",
      "corda.group.protocol.synchronisation": "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
      "corda.group.protocol.p2p.mode": "Authenticated_Encryption",
      "corda.group.key.session.policy": "Combined",
      "corda.group.pki.session": "NoPKI",
      "corda.group.pki.tls": "Standard",
      "corda.group.tls.type": "OneWay",
      "corda.group.tls.version": "1.3",
      "corda.endpoints.0.connectionURL": "https://corda-p2p-gateway-worker.corda-cluster-a:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "corda.group.trustroot.tls.0": "TLS CA Pem Certificate"
    }
  },
  "reason": "Onboarding MGM failed. Trust root certificate specified in registration context under key corda.group.trustroot.tls.0 was not a valid PEM certificate.",
  "serial": null
}
```