### PR TITLE
CORE-9740 Change protocol name of non-validating notary plugin

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/ClusterTestUtils.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/ClusterTestUtils.kt
@@ -534,7 +534,7 @@ fun E2eCluster.onboardStaticMembers(groupPolicy: ByteArray, tempDir: Path) {
                 "corda.key.scheme" to ECDSA_SECP256R1_CODE_NAME,
                 "corda.roles.0" to "notary",
                 "corda.notary.service.name" to "O=MyNotaryService-$uniqueName, L=London, C=GB",
-                "corda.notary.service.flow.protocol.name" to "net.corda.notary.NonValidatingNotary",
+                "corda.notary.service.flow.protocol.name" to "com.r3.corda.notary.plugin.nonvalidating",
                 "corda.notary.service.flow.protocol.version.0" to "1"
             )
         } else {

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/MembershipTestUtils.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/MembershipTestUtils.kt
@@ -121,7 +121,7 @@ fun createMemberRegistrationContext(
             }.isNotEmpty
         it["corda.roles.0"] = "notary"
         it["corda.notary.service.name"] = "C=GB,L=London,O=NotaryService, OU=${memberE2eCluster.uniqueName}"
-        it["corda.notary.service.flow.protocol.name"] = "net.corda.notary.NonValidatingNotary"
+        it["corda.notary.service.flow.protocol.name"] = "com.r3.corda.notary.plugin.nonvalidating"
         it["corda.notary.service.flow.protocol.version.0"] = "1"
         it["corda.notary.keys.0.id"] = notaryKeyId!!
         it["corda.notary.keys.0.signature.spec"] = SIGNATURE_SPEC

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-client/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/client/NonValidatingNotaryClientFlowImpl.kt
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory
  * The client that is used for the non-validating notary logic. This class is very simple and uses the basic
  * send-and-receive logic, and it will also initiate the server side of the non-validating notary.
  */
-@InitiatingFlow(protocol = "net.corda.notary.NonValidatingNotary")
+@InitiatingFlow(protocol = "com.r3.corda.notary.plugin.nonvalidating", version = [1])
 class NonValidatingNotaryClientFlowImpl(
     private val stx: UtxoSignedTransaction,
     private val notaryRepresentative: MemberX500Name

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -28,9 +28,10 @@ import org.slf4j.LoggerFactory
 
 /**
  * The server-side implementation of the non-validating notary logic.
- * This will be initiated by the client side of this notary plugin: [NonValidatingNotaryClientFlowImpl]
+ * This will be initiated by the client side of this notary plugin,
+ * [NonValidatingNotaryClientFlowImpl][com.r3.corda.notary.plugin.nonvalidating.client.NonValidatingNotaryClientFlowImpl]
  */
-@InitiatedBy(protocol = "net.corda.notary.NonValidatingNotary")
+@InitiatedBy(protocol = "com.r3.corda.notary.plugin.nonvalidating", version = [1])
 class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
 
     private companion object {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -153,7 +153,7 @@ class ClusterBuilder {
             |    "corda.key.scheme" : "CORDA.ECDSA.SECP256R1", 
             |    "corda.roles.0" : "notary",
             |    "corda.notary.service.name" : "O=MyNotaryService, L=London, C=GB",
-            |    "corda.notary.service.flow.protocol.name" : "net.corda.notary.NonValidatingNotary",
+            |    "corda.notary.service.flow.protocol.name" : "com.r3.corda.notary.plugin.nonvalidating",
             |    "corda.notary.service.flow.protocol.version.0" : "1"
             |   } 
             | }""".trimMargin()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -111,7 +111,7 @@ fun onboardNotaryMember(
     mapOf(
         "corda.roles.0" to "notary",
         "corda.notary.service.name" to MemberX500Name.parse("O=NotaryService, L=London, C=GB").toString(),
-        "corda.notary.service.flow.protocol.name" to "net.corda.notary.NonValidatingNotary",
+        "corda.notary.service.flow.protocol.name" to "com.r3.corda.notary.plugin.nonvalidating",
         "corda.notary.service.flow.protocol.version.0" to "1",
         "corda.notary.keys.0.id" to notaryKeyId,
         "corda.notary.keys.0.signature.spec" to DEFAULT_SIGNATURE_SPEC


### PR DESCRIPTION
### Summary

This PR changes the protocol name of the non-validating notary plugin to better reflect the package structure. Most importantly, changing from `net.corda` to `com.r3.corda` makes it clear this is part of CorDapp, not "platform" code.

Version is now also set explicitly in both the client and server plugins rather than relying on the default of 1. This is to make it clear to anyone reading or copying the code that versioning is supported and needs to be considered.

### Testing

Ensure that all automated tests continue to pass.