### PR TITLE
CORE-12174: Upgrade Log4J 2.19.0 -> 2.20.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -64,7 +64,7 @@ kryoSerializerVersion = 0.43
 liquibaseVersion = 4.18.0
 # Needed by Liquibase:
 beanutilsVersion=1.9.4
-log4jVersion = 2.19.0
+log4jVersion = 2.20.0
 micrometerVersion=0.1.0-SNAPSHOT
 nettyVersion = 4.1.86.Final
 # com.networknt:json-schema-validator cannot be upgraded beyond 1.0.66 because it becomes dependent on com.ethlo.time which is not OSGi compatible.


### PR DESCRIPTION
This should also avoid a few ugly errors when running with the `SecurityManager` enabled.