### PR TITLE
CORE-3819: Prevent Gradle trying to download new JDKs automatically.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ kotlinVersion=1.8.10
 kotlin.stdlib.default.dependency=false
 kotlinMetadataVersion = 0.6.0
 
+org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 # This is a FAKE VERSION! Update when we know what it should be!


### PR DESCRIPTION
Later versions of Gradle require `org.gradle.java.installations.auto-download` to be set explicitly.
