### PR TITLE
CORE-7993 key id follow up

### DIFF
--- a/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/transaction/TransactionSignatureServiceInternal.kt
+++ b/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/transaction/TransactionSignatureServiceInternal.kt
@@ -9,5 +9,5 @@ interface TransactionSignatureServiceInternal : TransactionSignatureService {
     fun getIdOfPublicKey(
         publicKey: PublicKey,
         digestAlgorithmName: String
-    ): SecureHash?
+    ): SecureHash
 }

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -77,7 +77,7 @@ class ConsensualSignedTransactionImpl(
     }
 
     override fun getMissingSignatories(): Set<PublicKey> {
-        val signatoriesWithValidSignatures = signatures.mapNotNull {
+        val publicKeysWithValidSignatures = signatures.mapNotNull {
             val signatureKey = getSignatoryKeyFromKeyId(it.by)
             if (signatureKey == null) {
                 null
@@ -92,11 +92,11 @@ class ConsensualSignedTransactionImpl(
         }.toSet()
 
         // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        return requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, signatoriesWithValidSignatures) }.toSet()
+        return requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, publicKeysWithValidSignatures) }.toSet()
     }
 
     override fun verifySignatures() {
-        val signatoriesWithValidSignatures = signatures.mapNotNull {
+        val publicKeysWithValidSignatures = signatures.mapNotNull {
             val signatureKey = getSignatoryKeyFromKeyId(it.by)
             if (signatureKey == null) {
                 null
@@ -115,7 +115,7 @@ class ConsensualSignedTransactionImpl(
         }.toSet()
 
         // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        val missingSignatories = requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, signatoriesWithValidSignatures) }.toSet()
+        val missingSignatories = requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, publicKeysWithValidSignatures) }.toSet()
         if (missingSignatories.isNotEmpty()) {
             throw TransactionMissingSignaturesException(
                 id,

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -85,7 +85,7 @@ class ConsensualSignedTransactionImpl(
             }
         }.toSet()
 
-        // isFulfilledBy() helps to make this working with CompositeKeys.
+        // isKeyFulfilledBy() helps to make this working with CompositeKeys.
         return requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatures) }.toSet()
     }
 
@@ -111,7 +111,7 @@ class ConsensualSignedTransactionImpl(
             }
         }.toSet()
 
-        // isFulfilledBy() helps to make this working with CompositeKeys.
+        // isKeyFulfilledBy() helps to make this working with CompositeKeys.
         val missingSignatories = requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatories) }.toSet()
         if (missingSignatories.isNotEmpty()) {
             throw TransactionMissingSignaturesException(

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -89,7 +89,6 @@ class ConsensualSignedTransactionImpl(
         return requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatures) }.toSet()
     }
 
-    @Suspendable
     override fun verifySignatures() {
         // TODO See if adding the following as property breaks CordaSerializable
         val requiredSignatories = this.toLedgerTransaction().requiredSignatories

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -71,7 +71,7 @@ class ConsensualSignedTransactionImpl(
     override fun getMissingSignatories(): Set<PublicKey> {
         // TODO See if adding the following as property breaks CordaSerializable
         val requiredSignatories = this.toLedgerTransaction().requiredSignatories
-        val appliedSignatures = signatures.mapNotNull {
+        val signatoriesWithValidSignatures = signatures.mapNotNull {
             val signatureKey = getSignatoryKeyFromKeyId(it.by, requiredSignatories)
             if (signatureKey == null) {
                 null
@@ -86,13 +86,13 @@ class ConsensualSignedTransactionImpl(
         }.toSet()
 
         // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        return requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatures) }.toSet()
+        return requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, signatoriesWithValidSignatures) }.toSet()
     }
 
     override fun verifySignatures() {
         // TODO See if adding the following as property breaks CordaSerializable
         val requiredSignatories = this.toLedgerTransaction().requiredSignatories
-        val appliedSignatories = signatures.mapNotNull {
+        val signatoriesWithValidSignatures = signatures.mapNotNull {
             val signatureKey = getSignatoryKeyFromKeyId(it.by, requiredSignatories)
             if (signatureKey == null) {
                 null
@@ -111,7 +111,7 @@ class ConsensualSignedTransactionImpl(
         }.toSet()
 
         // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        val missingSignatories = requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatories) }.toSet()
+        val missingSignatories = requiredSignatories.filterNot { KeyUtils.isKeyFulfilledBy(it, signatoriesWithValidSignatures) }.toSet()
         if (missingSignatories.isNotEmpty()) {
             throw TransactionMissingSignaturesException(
                 id,

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionInternal.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionInternal.kt
@@ -39,6 +39,7 @@ interface ConsensualSignedTransactionInternal: ConsensualSignedTransaction {
 
     /**
      * Gets the missing signatories from the current [ConsensualSignedTransactionInternal].
+     * It does not verify the available ones.
      *
      * @return Returns a [Set] of [PublicKey] representing the missing signatories from the current [ConsensualSignedTransactionInternal].
      */
@@ -51,5 +52,12 @@ interface ConsensualSignedTransactionInternal: ConsensualSignedTransaction {
      */
     fun verifySignatures()
 
+    /**
+     * Verify if a signature of a signatory is valid.
+     * It does not throw if the signature is not one of the signatories regardless of the validity since
+     * the public key is not available, the validity cannot be verified.
+     *
+     * @throws TransactionSignatureException if signature is owned by a signatory, and it is not valid.
+     */
     fun verifySignature(signature: DigitalSignatureAndMetadata)
 }

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionInternal.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionInternal.kt
@@ -42,7 +42,6 @@ interface ConsensualSignedTransactionInternal: ConsensualSignedTransaction {
      *
      * @return Returns a [Set] of [PublicKey] representing the missing signatories from the current [ConsensualSignedTransactionInternal].
      */
-    @Suspendable
     fun getMissingSignatories(): Set<PublicKey>
 
     /**
@@ -50,7 +49,6 @@ interface ConsensualSignedTransactionInternal: ConsensualSignedTransaction {
      *
      * @throws TransactionSignatureException if any signatures are invalid or missing.
      */
-    @Suspendable
     fun verifySignatures()
 
     fun verifySignature(signature: DigitalSignatureAndMetadata)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -129,7 +129,7 @@ data class UtxoSignedTransactionImpl(
 
     // Against signatories. Notary/Unknown signatures are ignored.
     override fun getMissingSignatories(): Set<PublicKey> {
-        val signatoriesWithValidSignatures = signatures.mapNotNull {
+        val publicKeysWithValidSignatures = signatures.mapNotNull {
             val publicKey = getSignatoryKeyFromKeyId(it.by)
             if (publicKey == null) {
                 null
@@ -144,12 +144,12 @@ data class UtxoSignedTransactionImpl(
         }.toSet()
 
         // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        return signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, signatoriesWithValidSignatures) }.toSet()
+        return signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, publicKeysWithValidSignatures) }.toSet()
     }
 
     // Against signatories. Notary/unknown signatures are ignored
     override fun verifySignatorySignatures() {
-        val signatoriesWithValidSignatures = signatures.mapNotNull {
+        val publicKeysWithValidSignatures = signatures.mapNotNull {
             val publicKey = getSignatoryKeyFromKeyId(it.by)
             if (publicKey == null) {
                 null// We do not care about non-notary/non-signatory keys
@@ -168,7 +168,7 @@ data class UtxoSignedTransactionImpl(
         }.toSet()
 
         // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        val missingSignatories = signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, signatoriesWithValidSignatures) }.toSet()
+        val missingSignatories = signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, publicKeysWithValidSignatures) }.toSet()
         if (missingSignatories.isNotEmpty()) {
             throw TransactionMissingSignaturesException(
                 id,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -140,7 +140,7 @@ data class UtxoSignedTransactionImpl(
             }
         }.toSet()
 
-        // isFulfilledBy() helps to make this working with CompositeKeys.
+        // isKeyFulfilledBy() helps to make this working with CompositeKeys.
         return signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatures) }.toSet()
     }
 
@@ -165,7 +165,7 @@ data class UtxoSignedTransactionImpl(
             }
         }.toSet()
 
-        // isFulfilledBy() helps to make this working with CompositeKeys.
+        // isKeyFulfilledBy() helps to make this working with CompositeKeys.
         val missingSignatories = signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatories) }.toSet()
         if (missingSignatories.isNotEmpty()) {
             throw TransactionMissingSignaturesException(

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -10,7 +10,6 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.KeyUtils
 import net.corda.v5.crypto.SecureHash
@@ -223,10 +222,12 @@ data class UtxoSignedTransactionImpl(
     @Suspendable
     override fun verifyNotarySignature(signature: DigitalSignatureAndMetadata) {
         val publicKey = getNotaryPublicKeyByKeyId(signature.by)
-            ?: throw CordaRuntimeException( // todo transition to TransactionSignatureException
+            ?: throw TransactionSignatureException(
+                id,
                 "Notary signature has not been created by the notary for this transaction. " +
                         "Notary public key: $notaryKey " +
-                        "Notary signature key Id: ${signature.by}"
+                        "Notary signature key Id: ${signature.by}",
+                null
             )
 
         try {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -127,55 +127,53 @@ data class UtxoSignedTransactionImpl(
         }[keyId]
     }
 
-    // Against signatories. Notary/Unknown signatures are ignored.
+    // Notary/unknown signatures are ignored.
     override fun getMissingSignatories(): Set<PublicKey> {
-        val publicKeysWithValidSignatures = signatures.mapNotNull {
-            val publicKey = getSignatoryKeyFromKeyId(it.by)
-            if (publicKey == null) {
-                null
-            } else {
-                try {
-                    transactionSignatureServiceInternal.verifySignature(this, it, publicKey)
-                    publicKey
-                } catch (e: Exception) {
-                    null
-                }
-            }
-        }.toSet()
-
-        // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        return signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, publicKeysWithValidSignatures) }.toSet()
+        return collectMissingSignatories(collectPublicKeysToSignatorySignatures())
     }
 
-    // Against signatories. Notary/unknown signatures are ignored
+    // Notary/unknown signatures are ignored
     override fun verifySignatorySignatures() {
-        val publicKeysWithValidSignatures = signatures.mapNotNull {
-            val publicKey = getSignatoryKeyFromKeyId(it.by)
-            if (publicKey == null) {
-                null// We do not care about non-notary/non-signatory keys
-            } else {
-                try {
-                    transactionSignatureServiceInternal.verifySignature(this, it, publicKey)
-                    publicKey
-                } catch (e: Exception) {
-                    throw TransactionSignatureException(
-                        id,
-                        "Failed to verify signature of ${it.signature} from $publicKey for transaction $id. Message: ${e.message}",
-                        e
-                    )
-                }
-            }
-        }.toSet()
+        val publicKeysToSignatures =
+            collectPublicKeysToSignatorySignatures()
 
-        // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        val missingSignatories = signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, publicKeysWithValidSignatures) }.toSet()
+        val missingSignatories = collectMissingSignatories(publicKeysToSignatures)
         if (missingSignatories.isNotEmpty()) {
             throw TransactionMissingSignaturesException(
                 id,
                 missingSignatories,
-                "Transaction $id is missing signatures for signatories (encoded) ${missingSignatories.map { it.encoded }}"
+                "Transaction $id is missing signatures for signatories (encoded) ${
+                    missingSignatories.map { it.encoded }
+                }"
             )
         }
+        publicKeysToSignatures.forEach { (publicKey, signature) ->
+            try {
+                transactionSignatureServiceInternal.verifySignature(this, signature, publicKey)
+            } catch (e: Exception) {
+                throw TransactionSignatureException(
+                    id,
+                    "Failed to verify signature of $signature from $publicKey for transaction $id. Message: ${e.message}",
+                    e
+                )
+            }
+        }
+    }
+
+    private fun collectMissingSignatories(publicKeysToSignatures: Map<PublicKey, DigitalSignatureAndMetadata>): Set<PublicKey> {
+        val publicKeysWithSignatures = publicKeysToSignatures.keys.toHashSet()
+
+        // TODO CORE-12207 isKeyFulfilledBy is not the most efficient
+        // isKeyFulfilledBy() helps to make this working with CompositeKeys.
+        return signatories
+            .filterNot { KeyUtils.isKeyFulfilledBy(it, publicKeysWithSignatures) }
+            .toSet()
+    }
+
+    private fun collectPublicKeysToSignatorySignatures(): Map<PublicKey, DigitalSignatureAndMetadata> {
+        return signatures.map { (getSignatoryKeyFromKeyId(it.by) ?: return@map null) to it }
+            .filterNotNull() // We do not care about non-notary/non-signatory keys
+            .toMap()
     }
 
     private fun getNotaryPublicKeyByKeyId(keyId: SecureHash): PublicKey? {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -124,7 +124,7 @@ data class UtxoSignedTransactionImpl(
 
     // Against signatories. Notary/Unknown signatures are ignored.
     override fun getMissingSignatories(): Set<PublicKey> {
-        val appliedSignatures = signatures.mapNotNull {
+        val signatoriesWithValidSignatures = signatures.mapNotNull {
             val publicKey = getSignatoryKeyFromKeyId(it.by)
             if (publicKey == null) {
                 null
@@ -139,12 +139,12 @@ data class UtxoSignedTransactionImpl(
         }.toSet()
 
         // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        return signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatures) }.toSet()
+        return signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, signatoriesWithValidSignatures) }.toSet()
     }
 
     // Against signatories. Notary/unknown signatures are ignored
     override fun verifySignatorySignatures() {
-        val appliedSignatories = signatures.mapNotNull {
+        val signatoriesWithValidSignatures = signatures.mapNotNull {
             val publicKey = getSignatoryKeyFromKeyId(it.by)
             if (publicKey == null) {
                 null// We do not care about non-notary/non-signatory keys
@@ -163,7 +163,7 @@ data class UtxoSignedTransactionImpl(
         }.toSet()
 
         // isKeyFulfilledBy() helps to make this working with CompositeKeys.
-        val missingSignatories = signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, appliedSignatories) }.toSet()
+        val missingSignatories = signatories.filterNot { KeyUtils.isKeyFulfilledBy(it, signatoriesWithValidSignatures) }.toSet()
         if (missingSignatories.isNotEmpty()) {
             throw TransactionMissingSignaturesException(
                 id,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -123,7 +123,6 @@ data class UtxoSignedTransactionImpl(
     }
 
     // Against signatories. Notary/Unknown signatures are ignored.
-    @Suspendable //TODO are these need to be suspendable?
     override fun getMissingSignatories(): Set<PublicKey> {
         val appliedSignatures = signatures.mapNotNull {
             val publicKey = getSignatoryKeyFromKeyId(it.by)
@@ -144,7 +143,6 @@ data class UtxoSignedTransactionImpl(
     }
 
     // Against signatories. Notary/unknown signatures are ignored
-    @Suspendable
     override fun verifySignatorySignatures() {
         val appliedSignatories = signatures.mapNotNull {
             val publicKey = getSignatoryKeyFromKeyId(it.by)
@@ -185,7 +183,6 @@ data class UtxoSignedTransactionImpl(
         return keyIdNotary[keyId]
     }
 
-    @Suspendable
     override fun verifyAttachedNotarySignature() {
         val notaryPublicKeysWithValidSignatures = signatures.mapNotNull {
             val publicKey = getNotaryPublicKeyByKeyId(it.by)
@@ -219,7 +216,6 @@ data class UtxoSignedTransactionImpl(
         }
     }
 
-    @Suspendable
     override fun verifyNotarySignature(signature: DigitalSignatureAndMetadata) {
         val publicKey = getNotaryPublicKeyByKeyId(signature.by)
             ?: throw TransactionSignatureException(
@@ -241,7 +237,6 @@ data class UtxoSignedTransactionImpl(
         }
     }
 
-    @Suspendable
     override fun verifySignatorySignature(signature: DigitalSignatureAndMetadata) {
         val publicKey = getSignatoryKeyFromKeyId(signature.by)
             ?: return // We do not care about non-notary/non-signatory signatures.

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
@@ -39,6 +39,7 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
 
     /**
      * Gets the missing signatories from the current [UtxoSignedTransactionInternal].
+     * It does not verify the available ones.
      *
      * @return Returns a [Set] of [PublicKey] representing the missing signatories from the current [UtxoSignedTransactionInternal].
      */
@@ -70,7 +71,7 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
     fun verifyNotarySignature(signature: DigitalSignatureAndMetadata)
 
     /**
-     * Verify if a signature is one of the signatories is valid.
+     * Verify if a signature of a signatory is valid.
      * It does not throw if the signature is not one of the signatories regardless of the validity since
      * the public key is not available, the validity cannot be verified.
      *

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
@@ -5,7 +5,6 @@ import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.common.transaction.TransactionSignatureException
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import java.security.PublicKey
@@ -69,8 +68,7 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
      *  - is made by the notary of the transaction
      *  - is valid
      *
-     * @throws CordaRuntimeException if not made by the notary // todo: change this to TransactionSignatureException
-     * @throws TransactionSignatureException if the signature is invalid
+     * @throws TransactionSignatureException if the signature is invalid or if not made by the notary
      */
     @Suspendable
     fun verifyNotarySignature(signature: DigitalSignatureAndMetadata)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
@@ -42,7 +42,6 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
      *
      * @return Returns a [Set] of [PublicKey] representing the missing signatories from the current [UtxoSignedTransactionInternal].
      */
-    @Suspendable
     fun getMissingSignatories(): Set<PublicKey>
 
     /**
@@ -51,7 +50,6 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
      *
      * @throws TransactionSignatureException if any signatures are missing or invalid.
      */
-    @Suspendable
     fun verifySignatorySignatures()
 
     /**
@@ -60,7 +58,6 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
      *
      * @throws TransactionSignatureException if notary signatures is missing or invalid.
      */
-    @Suspendable
     fun verifyAttachedNotarySignature()
 
     /**
@@ -70,7 +67,6 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
      *
      * @throws TransactionSignatureException if the signature is invalid or if not made by the notary
      */
-    @Suspendable
     fun verifyNotarySignature(signature: DigitalSignatureAndMetadata)
 
     /**
@@ -80,6 +76,5 @@ interface UtxoSignedTransactionInternal: UtxoSignedTransaction {
      *
      * @throws TransactionSignatureException if signature is owned by a signatory, and it is not valid.
      */
-    @Suspendable
     fun verifySignatorySignature(signature: DigitalSignatureAndMetadata)
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
@@ -54,7 +54,7 @@ internal class UtxoSignedTransactionImplTest: UtxoLedgerTest() {
     }
 
     @Test
-    fun `verifyNotarySignatureAttached throws on unnotarized transaction`() {
+    fun `verifyAttachedNotarySignature throws on unnotarized transaction`() {
         Assertions.assertThatThrownBy { signedTransaction.verifyAttachedNotarySignature() }.isInstanceOf(
             TransactionSignatureException::class.java)
             .hasMessageContaining("There are no notary")
@@ -63,7 +63,7 @@ internal class UtxoSignedTransactionImplTest: UtxoLedgerTest() {
 
     @Test
     @Disabled("Composite key validation does not look correct at the moment.")
-    fun `verifyNotarySignatureAttached does not throw on notarized transaction`() {
+    fun `verifyAttachedNotarySignature does not throw on notarized transaction`() {
         val sig = getSignatureWithMetadataExample(notaryNode1PublicKey)
         signedTransaction = signedTransaction.addSignature(sig)
         assertDoesNotThrow {

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/MockTransactionSignatureService.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/MockTransactionSignatureService.kt
@@ -23,7 +23,7 @@ private class MockTransactionSignatureService: TransactionSignatureServiceIntern
         publicKey: PublicKey
     ) {}
 
-    override fun getIdOfPublicKey(publicKey: PublicKey, digestAlgorithmName: String): SecureHash?
+    override fun getIdOfPublicKey(publicKey: PublicKey, digestAlgorithmName: String): SecureHash
         = SecureHashImpl(
             digestAlgorithmName,
             MessageDigest.getInstance(digestAlgorithmName).digest(publicKey.encoded)


### PR DESCRIPTION
* CORE-7993 follow up renames in test names, comments
* CORE-7993 Transition CordaRuntimeException to TransactionSignatureException in verifyNotarySignature
* CORE-7993 Remove unnecessary Suspendables
* CORE-12099 Cache keyIds
* CORE-12088 Cache requiredSignatories
* CORE-7993 Optimize signatory/signature verifications slightly
* `getMissingSignatories()`s do not verify the signatures anymore.
