### PR TITLE
CORE-11879 Add Enterprise Dependencies

### DIFF
--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -45,4 +45,9 @@ dependencies {
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
     testRuntimeOnly 'org.osgi:osgi.core'
+
+    // Required for enterprise addons, so must appear in all worker JARs even if they don't use them
+    runtimeOnly "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    runtimeOnly "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    runtimeOnly project(":libs:cache:cache-caffeine")
 }


### PR DESCRIPTION
Corda 5 Enterprise gets runtime dependencies from `runtime-os` transitively. We cannot create runtime dependencies against Enterprise because it creates OSGi errors where there are duplicates.

The problem is that some workers already have runtime dependencies Enterprise addons needs and some don't. In this case the Vault addon uses Jackson and Caffeine, but not all workers depend on this already.

Before this change, the Enterprise deployment looked like this:
<img width="871" alt="Screenshot 2023-03-30 at 16 28 43" src="https://user-images.githubusercontent.com/106170800/228949031-bdf11127-6f26-472c-ab30-d7183080bfe9.png">

After, it looks like this:
<img width="733" alt="Screenshot 2023-03-30 at 19 14 12" src="https://user-images.githubusercontent.com/106170800/228949132-00efbc94-050e-48da-8ea6-fc19783b0399.png">
