### PR TITLE
CORE-10407: Resolve warnings related to Java modules.

### DIFF
--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -110,6 +110,8 @@ tasks.register('smokeTest', Test) {
     description = "Runs smoke tests."
     group = "verification"
 
+    dependsOn smokeTestResources
+
     testClassesDirs = project.sourceSets["smokeTest"].output.classesDirs
     classpath = project.sourceSets["smokeTest"].runtimeClasspath
 
@@ -129,9 +131,6 @@ tasks.register('smokeTest', Test) {
 
     systemProperty "combinedWorkerHealthHttp",
             project.getProperties().getOrDefault("combinedWorkerHealthHttp", combinedWorker ? "http://localhost:7004/" : null)
-}
 
-
-tasks.named('smokeTest', Test) {
-    dependsOn smokeTestResources
+    jvmArgs '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ allprojects {
 
         doFirst {
             systemProperty 'java.io.tmpdir', buildDir.absolutePath
+            jvmArgs '--illegal-access=deny'
         }
     }
 
@@ -413,7 +414,7 @@ subprojects {
     configurations.configureEach {
         resolutionStrategy {
             // FORCE Gradle to use latest dynamic versions.
-             cacheDynamicVersionsFor 0, 'seconds'
+            cacheDynamicVersionsFor 0, 'seconds'
 
             // FORCE Gradle to use latest SNAPSHOT versions.
             cacheChangingModulesFor 0, 'seconds'

--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -86,7 +86,12 @@ osgiRun {
     // Required by Quasar, Kryo and Kryo serializers.
     // Discovered using:
     //     $ java --illegal-access=warn -jar <application.jar>
-    addOpensAttribute.addAll 'java.base/java.lang', 'java.base/java.lang.invoke', 'java.base/java.nio', 'java.base/java.util'
+    addOpensAttribute.addAll \
+        'java.base/java.lang',\
+        'java.base/java.lang.invoke',\
+        'java.base/java.nio',\
+        'java.base/java.time',\
+        'java.base/java.util'
 }
 
 @CompileStatic

--- a/components/configuration/configuration-read-service-impl/test.bndrun
+++ b/components/configuration/configuration-read-service-impl/test.bndrun
@@ -1,7 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/components/flow/flow-mapper-service/test.bndrun
+++ b/components/flow/flow-mapper-service/test.bndrun
@@ -1,5 +1,6 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 #-runjdb: 5005

--- a/components/flow/flow-p2p-filter-service/test.bndrun
+++ b/components/flow/flow-p2p-filter-service/test.bndrun
@@ -1,7 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 #uncomment to remote debug
 #-runjdb: 5005

--- a/components/flow/flow-service/test.bndrun
+++ b/components/flow/flow-service/test.bndrun
@@ -1,17 +1,17 @@
 -tester: biz.aQute.tester.junit-platform
 -runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 
 # Enable debugging.
 #-runjdb: 5005
 
--resolve.effective: resolve,active
-
 -runvm: \
     -Djava.util.logging.config.file=${.}/logging.properties,\
     -Djava.io.tmpdir=${task.temporaryDir},\
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --illegal-access=deny
+
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\
     javax.xml.stream.events;version=1.0.0,\

--- a/components/ledger/ledger-common-flow/build.gradle
+++ b/components/ledger/ledger-common-flow/build.gradle
@@ -51,6 +51,11 @@ dependencies {
     cpis project(path: ':testing:ledger:ledger-common-empty-app', configuration: 'cordaCPB')
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+}
+
 //  Copy the cpi builds declared in the cpis configuration into our resources so we find and load them
 def integrationTestResources = tasks.named('processIntegrationTestResources', ProcessResources) {
     from(configurations.cpis) {

--- a/components/ledger/ledger-common-flow/test.bndrun
+++ b/components/ledger/ledger-common-flow/test.bndrun
@@ -4,6 +4,11 @@
 -resolve.effective: resolve,active
 -runtrace: true
 
+-runvm: \
+    --add-opens, 'java.base/java.lang.invoke=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.util=ALL-UNNAMED',\
+    --illegal-access=deny
+
 -runrequires: \
     bnd.identity;id='net.corda.ledger-common-flow',\
     bnd.identity;id='${project.archivesBaseName}-tests',\

--- a/components/ledger/ledger-consensual-flow/build.gradle
+++ b/components/ledger/ledger-consensual-flow/build.gradle
@@ -50,6 +50,11 @@ dependencies {
     cpis project(path: ':testing:ledger:ledger-consensual-state-app', configuration: 'cordaCPB')
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+}
+
 //  Copy the cpi builds declared in the cpis configuration into our resources so we find and load them
 def integrationTestResources = tasks.named('processIntegrationTestResources', ProcessResources) {
     from(configurations.cpis) {

--- a/components/ledger/ledger-consensual-flow/test.bndrun
+++ b/components/ledger/ledger-consensual-flow/test.bndrun
@@ -4,6 +4,15 @@
 -runee: JavaSE-11
 -runtrace: true
 
+-runvm: \
+    --add-opens, 'java.base/java.lang=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.lang.invoke=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.security=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.time=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.util=ALL-UNNAMED',\
+    --add-opens, 'jdk.crypto.ec/sun.security.ec=ALL-UNNAMED',\
+    --illegal-access=deny
+
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='net.corda.ledger-common-flow',\

--- a/components/ledger/ledger-persistence/test.bndrun
+++ b/components/ledger/ledger-persistence/test.bndrun
@@ -10,7 +10,7 @@
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
     -DpostgresPassword=${project.postgresPassword},\
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --illegal-access=deny
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -62,6 +62,11 @@ dependencies {
     cpis project(path: ':testing:ledger:ledger-utxo-state-app', configuration: 'cordaCPB')
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+}
+
 //  Copy the cpi builds declared in the cpis configuration into our resources so we find and load them
 def integrationTestResources = tasks.named('processIntegrationTestResources', ProcessResources) {
     from(configurations.cpis) {

--- a/components/ledger/ledger-utxo-flow/test.bndrun
+++ b/components/ledger/ledger-utxo-flow/test.bndrun
@@ -4,6 +4,15 @@
 -runee: JavaSE-11
 -runtrace: true
 
+-runvm: \
+    --add-opens, 'java.base/java.lang=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.lang.invoke=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.security=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.time=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.util=ALL-UNNAMED',\
+    --add-opens, 'jdk.crypto.ec/sun.security.ec=ALL-UNNAMED',\
+    --illegal-access=deny
+
 # Enable debugging.
 # -runjdb: 1044
 

--- a/components/ledger/ledger-verification/test.bndrun
+++ b/components/ledger/ledger-verification/test.bndrun
@@ -10,7 +10,7 @@
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
     -DpostgresPassword=${project.postgresPassword},\
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --illegal-access=deny
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/components/link-manager/test.bndrun
+++ b/components/link-manager/test.bndrun
@@ -1,13 +1,13 @@
 -tester: biz.aQute.tester.junit-platform
 -runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 
--resolve.effective: resolve,active
-
 -runvm: \
     -Djava.io.tmpdir=${task.temporaryDir},\
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --illegal-access=deny
+
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\
     javax.xml.stream.events;version=1.0.0,\

--- a/components/membership/membership-group-read-impl/test.bndrun
+++ b/components/membership/membership-group-read-impl/test.bndrun
@@ -1,7 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 -runproperties: \
     org.slf4j.simpleLogger.defaultLogLevel=info,\

--- a/components/membership/membership-p2p-impl/test.bndrun
+++ b/components/membership/membership-p2p-impl/test.bndrun
@@ -1,8 +1,12 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 #-runjdb: 5006
+
+-runvm: \
+    --illegal-access=deny
 
 -runsystempackages: \
     sun.security.x509

--- a/components/membership/membership-persistence-service-impl/test.bndrun
+++ b/components/membership/membership-persistence-service-impl/test.bndrun
@@ -1,5 +1,6 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 #-runjdb: 5006
@@ -9,7 +10,8 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword}
+    -DpostgresPassword=${project.postgresPassword},\
+    --illegal-access=deny
 
 -runsystempackages: \
     sun.security.x509

--- a/components/membership/registration-impl/build.gradle
+++ b/components/membership/registration-impl/build.gradle
@@ -51,9 +51,10 @@ dependencies {
     integrationTestImplementation project(':testing:db-message-bus-testkit')
 
     integrationTestRuntimeOnly project(':components:configuration:configuration-read-service-impl')
-    integrationTestRuntimeOnly project(':components:crypto:crypto-client-impl')
+    integrationTestRuntimeOnly project(':components:crypto:crypto-client-hsm-impl')
     integrationTestRuntimeOnly project(':components:db:db-connection-manager-impl')
     integrationTestRuntimeOnly project(':components:membership:membership-group-read-impl')
+    integrationTestRuntimeOnly project(':components:membership:membership-persistence-client-impl')
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')

--- a/components/membership/registration-impl/test.bndrun
+++ b/components/membership/registration-impl/test.bndrun
@@ -1,8 +1,17 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+# Enable debugging.
 #-runjdb: 5006
+
+-runvm: \
+    --illegal-access=deny
+
+-runsystemcapabilities: \
+    osgi.service;objectClass:List<String>='net.corda.membership.groupparams.writer.service.GroupParametersWriterService';effective:=active
 
 -runsystempackages: \
     sun.security.x509
@@ -11,7 +20,6 @@
     bnd.identity;id='net.corda.registration-impl',\
     bnd.identity;id='net.corda.membership-group-read-impl',\
     bnd.identity;id='net.corda.cipher-suite-impl',\
-    bnd.identity;id='net.corda.crypto-client-impl',\
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='net.corda.messaging-impl',\
     bnd.identity;id='net.corda.membership-impl',\
@@ -28,7 +36,7 @@
     bnd.identity;id='net.bytebuddy.byte-buddy',\
     bnd.identity;id='org.ops4j.pax.jdbc.hsqldb',\
     bnd.identity;id='org.osgi.service.jdbc',\
-    bnd.identity;id='org.hsqldb.hsqldb',\
+    bnd.identity;id='org.hsqldb.hsqldb'
 
 -runstartlevel: \
     order=sortbynameversion,\

--- a/components/membership/synchronisation-impl/test.bndrun
+++ b/components/membership/synchronisation-impl/test.bndrun
@@ -1,8 +1,14 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+# Enable debugging.
 #-runjdb: 5006
+
+-runvm: \
+    --illegal-access=deny
 
 -runsystempackages: \
     sun.security.x509
@@ -33,7 +39,7 @@
     bnd.identity;id='net.bytebuddy.byte-buddy',\
     bnd.identity;id='org.ops4j.pax.jdbc.hsqldb',\
     bnd.identity;id='org.osgi.service.jdbc',\
-    bnd.identity;id='org.hsqldb.hsqldb',\
+    bnd.identity;id='org.hsqldb.hsqldb'
 
 -runstartlevel: \
     order=sortbynameversion,\

--- a/components/security-manager/test.bndrun
+++ b/components/security-manager/test.bndrun
@@ -1,11 +1,18 @@
 -tester: biz.aQute.tester.junit-platform
 -runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 
 # Canonicalise the permissions paths
 -runvm: \
-    -Djdk.io.permissionsUseCanonicalPath=true
+    -Djdk.io.permissionsUseCanonicalPath=true,\
+    --illegal-access=deny
+
+-runsystemcapabilities: \
+    osgi.service;objectClass:List<String>='net.corda.lifecycle.LifecycleCoordinatorFactory';effective:=active,\
+    osgi.service;objectClass:List<String>='net.corda.configuration.read.ConfigurationReadService';effective:=active,\
+    osgi.service;objectClass:List<String>='org.osgi.service.condpermadmin.ConditionalPermissionAdmin';effective:=active
 
 -runsystempackages: \
     sun.security.x509

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/test.bndrun
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/test.bndrun
@@ -10,7 +10,7 @@
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
     -DpostgresPassword=${project.postgresPassword},\
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --illegal-access=deny
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/components/virtual-node/sandbox-group-context-service/test.bndrun
+++ b/components/virtual-node/sandbox-group-context-service/test.bndrun
@@ -9,7 +9,7 @@
 
 -runvm: \
     -Djdk.io.permissionsUseCanonicalPath=true, \
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --illegal-access=deny
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,9 @@ kotlinMetadataVersion = 0.6.0
 org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
+# Disable discovery of annotation processors on compile classpath.
+kapt.include.compile.classpath=false
+
 # This is a FAKE VERSION! Update when we know what it should be!
 platformVersion = 999
 
@@ -61,7 +64,7 @@ kafkaClientVersion=3.3.1_1
 # NOTE: Kryo cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.
 kryoVersion = 5.4.0
-kryoSerializerVersion = 0.45
+kryoSerializersVersion = 0.45
 liquibaseVersion = 4.18.0
 # Needed by Liquibase:
 beanutilsVersion=1.9.4

--- a/libs/application/addon-osgi-test/test.bndrun
+++ b/libs/application/addon-osgi-test/test.bndrun
@@ -1,9 +1,17 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='junit-jupiter-engine',\
-    bnd.identity;id='junit-platform-launcher',\
+    bnd.identity;id='junit-platform-launcher'
+
+-runstartlevel: \
+    order=sortbynameversion,\
+    begin=-1

--- a/libs/configuration/configuration-osgi-test/test.bndrun
+++ b/libs/configuration/configuration-osgi-test/test.bndrun
@@ -1,9 +1,17 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='junit-jupiter-engine',\
-    bnd.identity;id='junit-platform-launcher',\
+    bnd.identity;id='junit-platform-launcher'
+
+-runstartlevel: \
+    order=sortbynameversion,\
+    begin=-1

--- a/libs/configuration/configuration-validation/test.bndrun
+++ b/libs/configuration/configuration-validation/test.bndrun
@@ -1,8 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
--resolve.effective: active
+
+-runvm: \
+    --illegal-access=deny
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/libs/crypto/merkle-impl/test.bndrun
+++ b/libs/crypto/merkle-impl/test.bndrun
@@ -4,9 +4,16 @@
 -runee: JavaSE-11
 -runtrace: true
 
+-runvm: \
+    --illegal-access=deny
+
 -runrequires: \
     bnd.identity;id='net.corda.merkle-impl',\
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
     bnd.identity;id='org.apache.felix.framework.security'
+
+-runstartlevel: \
+    order=sortbynameversion,\
+    begin=-1

--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -1,5 +1,6 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 
@@ -8,7 +9,8 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword}
+    -DpostgresPassword=${project.postgresPassword},\
+    --illegal-access=deny
 
 -runsystempackages: \
     sun.security.x509

--- a/libs/flows/flow-mapper-impl/test.bndrun
+++ b/libs/flows/flow-mapper-impl/test.bndrun
@@ -1,7 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/libs/kotlin-reflection/test.bndrun
+++ b/libs/kotlin-reflection/test.bndrun
@@ -1,10 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
 -runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 
 -runvm: \
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --illegal-access=deny
 
 # Enable debugging.
 # -runjdb: 1044
@@ -21,6 +22,7 @@
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
     bnd.identity;id='slf4j.simple'
+
 -runstartlevel: \
     order=sortbynameversion,\
     begin=-1

--- a/libs/layered-property-map/test.bndrun
+++ b/libs/layered-property-map/test.bndrun
@@ -1,7 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 -runproperties: \
     org.slf4j.simpleLogger.defaultLogLevel=info,\

--- a/libs/ledger/ledger-common-data/test.bndrun
+++ b/libs/ledger/ledger-common-data/test.bndrun
@@ -4,6 +4,11 @@
 -resolve.effective: resolve,active
 -runtrace: true
 
+-runvm: \
+    --add-opens, 'java.base/java.lang.invoke=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.util=ALL-UNNAMED',\
+    --illegal-access=deny
+
 -runrequires: \
     bnd.identity;id='net.corda.ledger-common-data',\
     bnd.identity;id='${project.archivesBaseName}-tests',\

--- a/libs/permissions/permission-datamodel/test.bndrun
+++ b/libs/permissions/permission-datamodel/test.bndrun
@@ -1,5 +1,6 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 
@@ -8,7 +9,8 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword}
+    -DpostgresPassword=${project.postgresPassword},\
+    --illegal-access=deny
 
 -runsystempackages: \
     sun.security.x509

--- a/libs/platform-info/test.bndrun
+++ b/libs/platform-info/test.bndrun
@@ -1,9 +1,17 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='junit-jupiter-engine',\
-    bnd.identity;id='junit-platform-launcher',\
+    bnd.identity;id='junit-platform-launcher'
+
+-runstartlevel: \
+    order=sortbynameversion,\
+    begin=-1

--- a/libs/rest/rest-client/build.gradle
+++ b/libs/rest/rest-client/build.gradle
@@ -45,3 +45,6 @@ dependencies {
     integrationTestImplementation project(':libs:rest:ssl-cert-read-impl')
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens', 'java.base/java.net=ALL-UNNAMED'
+}

--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -71,3 +71,7 @@ dependencies {
     integrationTestImplementation project(':libs:rest:ssl-cert-read-impl')
     integrationTestImplementation project(":testing:test-utilities")
 }
+
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens', 'java.base/java.net=ALL-UNNAMED'
+}

--- a/libs/sandbox-internal/test.bndrun
+++ b/libs/sandbox-internal/test.bndrun
@@ -6,7 +6,8 @@
 
 -runvm: \
     -Djava.io.tmpdir=${task.temporaryDir},\
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --illegal-access=deny
+
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\
     javax.xml.stream.events;version=1.0.0,\

--- a/libs/serialization/kryo-serializers/build.gradle
+++ b/libs/serialization/kryo-serializers/build.gradle
@@ -27,7 +27,7 @@ configurations {
 
 dependencies {
     // This information has been read from kryo-serializers' original POM.
-    compileOnly "de.javakaffee:kryo-serializers:$kryoSerializerVersion"
+    compileOnly "de.javakaffee:kryo-serializers:$kryoSerializersVersion"
     compileOnly "com.github.andrewoma.dexx:collection:$kryoDexxCollectionVersion"
     compileOnly "com.google.protobuf:protobuf-java:$kryoProtobufVersion"
     compileOnly "org.apache.wicket:wicket:$kryoWicketVersion"
@@ -41,9 +41,10 @@ def jar = tasks.named('jar', Jar) {
 
     bundle {
         bnd """\
+Automatic-Module-Name: de.javakaffee.kryoserializers
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.kryo-serializers
-Bundle-Version: ${kryoSerializerVersion}
+Bundle-Version: ${kryoSerializersVersion}
 Export-Package: \
     de.javakaffee.kryoserializers.*
 Import-Package: \
@@ -55,7 +56,7 @@ Import-Package: \
     net.sf.cglib.*;resolution:=optional,\
     sun.reflect;resolution:=optional,\
     *
--includeresource: @kryo-serializers-${kryoSerializerVersion}.jar
+-includeresource: @kryo-serializers-${kryoSerializersVersion}.jar
 """
     }
 }

--- a/libs/serialization/serialization-amqp/test.bndrun
+++ b/libs/serialization/serialization-amqp/test.bndrun
@@ -6,7 +6,8 @@
 
 -runvm: \
     -Djava.io.tmpdir=${task.temporaryDir},\
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --add-opens, 'java.base/java.lang=ALL-UNNAMED',\
+    --illegal-access=deny
 
 # Enable debugging.
 # -runjdb: 5005

--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -66,6 +66,13 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
 }
 
+tasks.withType(Test).configureEach {
+    // Kryo needs reflective access to these packages.
+    jvmArgs '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED'
+}
+
 def integrationTestResources = tasks.named('processIntegrationTestResources', ProcessResources) {
     from configurations.cpbs
 }

--- a/libs/serialization/serialization-kryo/test.bndrun
+++ b/libs/serialization/serialization-kryo/test.bndrun
@@ -6,7 +6,9 @@
 
 -runvm: \
     -Djava.io.tmpdir=${task.temporaryDir},\
-    --add-opens, 'java.base/java.net=ALL-UNNAMED'
+    --add-opens, 'java.base/java.lang.invoke=ALL-UNNAMED',\
+    --add-opens, 'java.base/java.util=ALL-UNNAMED',\
+    --illegal-access=deny
 
 # Enable debugging.
 # -runjdb: 5005

--- a/processors/crypto-processor/test.bndrun
+++ b/processors/crypto-processor/test.bndrun
@@ -1,5 +1,6 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 
@@ -8,7 +9,8 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword}
+    -DpostgresPassword=${project.postgresPassword},\
+    --illegal-access=deny
 
 -runsystempackages: \
     sun.security.x509

--- a/processors/member-processor/test.bndrun
+++ b/processors/member-processor/test.bndrun
@@ -1,5 +1,6 @@
 -tester: biz.aQute.tester.junit-platform
--runfw: org.apache.felix.framework;
+-runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
 
@@ -11,7 +12,8 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword}
+    -DpostgresPassword=${project.postgresPassword},\
+    --illegal-access=deny
 
 -runsystempackages: \
     sun.security.x509

--- a/processors/rest-processor/test.bndrun
+++ b/processors/rest-processor/test.bndrun
@@ -1,9 +1,14 @@
 -tester: biz.aQute.tester.junit-platform
 -runfw: org.apache.felix.framework
+-resolve.effective: resolve,active
 -runee: JavaSE-11
 -runtrace: true
--resolve.effective: resolve,active
+
+#uncomment to remote debug
 # -runjdb: 5005
+
+-runvm: \
+    --illegal-access=deny
 
 -runsystempackages: \
     sun.security.x509

--- a/testing/kryo-serialization-testkit/build.gradle
+++ b/testing/kryo-serialization-testkit/build.gradle
@@ -5,7 +5,7 @@ plugins {
 description 'Kryo serialization test utilities'
 
 dependencies {
-    implementation "org.osgi:osgi.core"
+    runtimeOnly 'org.osgi:osgi.core'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.esotericsoftware:kryo:$kryoVersion"

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -118,9 +118,6 @@ def kafkaResolve = tasks.register('kafkaResolve', Resolve) {
 tasks.register('kafkaIntegrationTest', TestOSGi) {
     description = "Runs Kafka OSGi integration tests."
     group = "verification"
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = of(11)
-    }
     resultsDirectory = file("$testResultsDir/kafkaIntegrationTest")
     bundles = files(configurations.integrationTestRuntimeClasspath, configurations.kafkaIntegrationTestRuntimeOnly, configurations.archives.artifacts.files)
     bndrun = kafkaResolve.flatMap { it.outputBndrun }
@@ -129,9 +126,6 @@ tasks.register('kafkaIntegrationTest', TestOSGi) {
 tasks.register('dbIntegrationTest', TestOSGi) {
     description = "Runs DB Message Bus OSGi integration tests."
     group = "verification"
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = of(11)
-    }
     resultsDirectory = file("$testResultsDir/dbIntegrationTest")
     bundles = files(configurations.integrationTestRuntimeClasspath, configurations.dbIntegrationTestRuntimeOnly, configurations.archives.artifacts.files)
     bndrun = dbResolve.flatMap { it.outputBndrun }

--- a/testing/message-patterns/test.db.bndrun
+++ b/testing/message-patterns/test.db.bndrun
@@ -1,8 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
--runee: JavaSE-11
 -runfw: org.apache.felix.framework
--runtrace: true
 -resolve.effective: resolve, active
+-runee: JavaSE-11
+-runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 #uncomment to remote debug
 # -runjdb: 5005

--- a/testing/message-patterns/test.kafka.bndrun
+++ b/testing/message-patterns/test.kafka.bndrun
@@ -1,8 +1,11 @@
 -tester: biz.aQute.tester.junit-platform
--runee: JavaSE-11
 -runfw: org.apache.felix.framework
--runtrace: true
 -resolve.effective: resolve, active
+-runee: JavaSE-11
+-runtrace: true
+
+-runvm: \
+    --illegal-access=deny
 
 #uncomment to remote debug
 #-runjdb: 5005

--- a/testing/p2p/inmemory-messaging-impl/test.bndrun
+++ b/testing/p2p/inmemory-messaging-impl/test.bndrun
@@ -3,7 +3,10 @@
 
 -runee: JavaSE-11
 -runfw: org.apache.felix.framework
--resolve.effective: active
+-resolve.effective: resolve,active
+
+-runvm: \
+    --illegal-access=deny
 
 #uncomment to remote debug
 #-runjdb: 5005

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -14,6 +14,16 @@ configurations {
     cliHostDist
 }
 
+subprojects {
+    pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
+        kapt {
+            arguments {
+                arg("project", "${project.group}/${project.name}")
+            }
+        }
+    }
+}
+
 dependencies {
     cliHostDist "net.corda.cli.host:corda-cli:${pluginHostVersion}"
 }
@@ -57,8 +67,8 @@ tasks.register("cliInstallArchive", Zip) {
     from "$buildDir/cli"
     include '*'
     include '*/*'
-    archiveName 'corda-cli-dist.zip'
-    destinationDir(file("$buildDir/zip"))
+    archiveFileName = 'corda-cli-dist.zip'
+    destinationDirectory = file("$buildDir/zip")
 }
 
 tasks.register("cleanDir", Delete) {


### PR DESCRIPTION
Open selected Java modules to prevent warnings about "illegal access". This makes us more "Java 17 friendly" without actually migrating to Java 17.

Also fix some general Gradle warnings about deprecated APIs, and assign correct "Automatic Module Name" to our new `kryo-serializers` artifact.

---

There is a curious issue in the OSGi tests for `:components:membership:registration-impl`, which I don't have time to diagnose. Up to now, the `Resolve` task has not been checking that every service the tests ask for actually exists within the framework, and there have indeed been a few holes. However, if I now _provide_ the missing `GroupParametersWriterService` component then suddenly the tests fail for no apparent reason?!

I have worked around this for now by telling the resolver not to worry about the `GroupParametersWriterService` because the framework will provide it. _This is a fib,_ but strangely the integration tests don't seem to care... :exploding_head:.