### PR TITLE
CORE-12190 - Update default gateway configuration for timeouts

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/GatewayConfiguration.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/GatewayConfiguration.kt
@@ -54,12 +54,12 @@ data class ConnectionConfiguration(
     /**
      * Time after which a message delivery is considered failed
      */
-    val responseTimeout: Duration = Duration.ofSeconds(1),
+    val responseTimeout: Duration = Duration.ofSeconds(3),
 
     /**
      * Time after which a message is retried, when previously failed.
      */
-    val retryDelay: Duration = Duration.ofSeconds(1),
+    val retryDelay: Duration = Duration.ofSeconds(2),
 
     /**
      * initial duration to wait before trying to reconnect disconnection.

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.740-beta+
+cordaApiVersion=5.0.0.740-alpha-1680261060801
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.740-alpha-1680261060801
+cordaApiVersion=5.0.0.740-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
### Changes
For context on the change, see description on https://github.com/corda/corda-api/pull/1030.
Currently, defaults exist in corda-runtime-os so updating them in the same way as in corda-api.

There's a [separate ticket](https://r3-cev.atlassian.net/browse/CORE-9946) to remove default from corda-runtime-os.