### PR TITLE
CORE-12078 Transaction backchain persist visible states

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.utxo.flow.impl.flows.backchain
 import net.corda.ledger.common.data.transaction.TransactionStatus.INVALID
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.common.data.transaction.TransactionStatus.VERIFIED
+import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.verifier.UtxoLedgerTransactionVerificationService
@@ -12,6 +13,7 @@ import net.corda.utilities.trace
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.utxo.VisibilityChecker
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -28,7 +30,9 @@ class TransactionBackchainVerifierImpl @Activate constructor(
     @Reference(service = UtxoLedgerPersistenceService::class)
     private val utxoLedgerPersistenceService: UtxoLedgerPersistenceService,
     @Reference(service = UtxoLedgerTransactionVerificationService::class)
-    private val utxoLedgerTransactionVerificationService: UtxoLedgerTransactionVerificationService
+    private val utxoLedgerTransactionVerificationService: UtxoLedgerTransactionVerificationService,
+    @Reference(service = VisibilityChecker::class)
+    private val visibilityChecker: VisibilityChecker
 ) : TransactionBackchainVerifier, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
@@ -82,9 +86,9 @@ class TransactionBackchainVerifierImpl @Activate constructor(
                         )
                         return false
                     }
-                    utxoLedgerPersistenceService.updateStatus(transactionId, VERIFIED)
-                    log.trace { "Backchain resolution of $initialTransactionIds - Updated status of transaction $transactionId" +
-                            " to verified" }
+                    val visibleStatesIndexes = transaction.getVisibleStateIndexes(visibilityChecker)
+                    utxoLedgerPersistenceService.persist(transaction, VERIFIED, visibleStatesIndexes)
+                    log.trace { "Backchain resolution of $initialTransactionIds - Stored transaction $transactionId as verified" }
                 }
 
                 else -> {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
@@ -104,10 +104,12 @@ class TransactionBackchainReceiverFlowV1(
             retrievedTransaction.dependencies.let { dependencies ->
                 val unseenDependencies = dependencies - sortedTransactionIds.transactionIds
                 log.trace {
+                    val ignoredDependencies = dependencies - unseenDependencies
                     "Backchain resolution of $initialTransactionIds - Adding dependencies for transaction ${retrievedTransaction.id} " +
-                            "dependencies: $unseenDependencies to transactions to retrieve"
+                            "dependencies: $unseenDependencies to transactions to retrieve. Ignoring dependencies: $ignoredDependencies " +
+                            "as they have already been seen."
                 }
-                sortedTransactionIds.add(retrievedTransaction.id, unseenDependencies)
+                sortedTransactionIds.add(retrievedTransaction.id, dependencies)
                 transactionsToRetrieve.addAll(unseenDependencies)
             }
         }

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
@@ -285,6 +285,7 @@ class UtxoBackchainResolutionDemoResponderFlow : ResponderFlow {
     override fun call(session: FlowSession) {
         @Suppress("unchecked_cast")
         val txs = session.receive(List::class.java) as List<Pair<Int, SecureHash>>
+        @Suppress("unchecked_cast")
         val tx3 = session.receive(Pair::class.java) as Pair<Int, SecureHash>
 
         txs.map { (index, id) -> index to utxoLedgerService.findSignedTransaction(id) }
@@ -311,6 +312,7 @@ class UtxoBackchainResolutionDemoResponderFlow : ResponderFlow {
             require(tx == null) { "Transaction TX${tx3.first} should not be resolved at this point" }
         }
 
+        @Suppress("unchecked_cast")
         val txs2 = session.receive(List::class.java) as List<Pair<Int, SecureHash>>
 
         txs2.map { (index, id) -> index to utxoLedgerService.findSignedTransaction(id) }

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoBackchainResolutionDemoFlow.kt
@@ -274,7 +274,7 @@ class UtxoBackchainResolutionDemoFlow : ClientStartableFlow {
 class UtxoBackchainResolutionDemoResponderFlow : ResponderFlow {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @CordaInject

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoEvolveFlow.kt
@@ -67,6 +67,7 @@ class UtxoDemoEvolveFlow : ClientStartableFlow {
 
             val output =
                 TestUtxoState(
+                    1,
                     request.update,
                     inputState.participants,
                     inputState.participantNames)

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/net/cordapp/demo/utxo/UtxoDemoFlow.kt
@@ -61,6 +61,7 @@ class UtxoDemoFlow : ClientStartableFlow {
                 }
             }
             val testUtxoState = TestUtxoState(
+                1,
                 request.input,
                 members.map { it.ledgerKeys.first() } + myInfo.ledgerKeys.first(),
                 request.members + listOf(myInfo.name.toString())

--- a/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestFindTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestFindTransactionFlow.kt
@@ -65,7 +65,7 @@ class TestFindTransactionFlow {
         val keyGenerator = KeyPairGenerator.getInstance("EC")
 
         val participantKey = keyGenerator.generateKeyPair().public
-        val testState = TestUtxoState("text", listOf(participantKey), listOf("") )
+        val testState = TestUtxoState(1, "text", listOf(participantKey), listOf("") )
 
         val ledgerTx = mock<UtxoLedgerTransaction>().apply {
             whenever(id).thenReturn(txIdGood)

--- a/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestPeekTransactionFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/test/kotlin/net/cordapp/demo/utxo/TestPeekTransactionFlow.kt
@@ -69,7 +69,7 @@ class TestPeekTransactionFlow {
             val keyGenerator = KeyPairGenerator.getInstance("EC")
 
             val participantKey = keyGenerator.generateKeyPair().public
-            val testState = TestUtxoState("text", listOf(participantKey), listOf(""))
+            val testState = TestUtxoState(1, "text", listOf(participantKey), listOf(""))
             val testContractState = mock<TransactionState<TestUtxoState>>().apply {
                 whenever(this.contractState).thenReturn(testState)
             }

--- a/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/net/cordapp/demo/utxo/contract/TestContract.kt
+++ b/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/net/cordapp/demo/utxo/contract/TestContract.kt
@@ -1,9 +1,18 @@
 package net.cordapp.demo.utxo.contract
 
 import net.corda.v5.ledger.utxo.Contract
+import net.corda.v5.ledger.utxo.ContractState
+import net.corda.v5.ledger.utxo.VisibilityChecker
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 
 class TestContract : Contract {
     override fun verify(transaction: UtxoLedgerTransaction) {
+    }
+
+    override fun isVisible(state: ContractState, checker: VisibilityChecker): Boolean {
+        return when (state) {
+            is TestUtxoState -> state.identifier % 2 == 0
+            else -> false
+        }
     }
 }

--- a/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/net/cordapp/demo/utxo/contract/TestUtxoState.kt
+++ b/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/net/cordapp/demo/utxo/contract/TestUtxoState.kt
@@ -6,6 +6,7 @@ import java.security.PublicKey
 
 @BelongsToContract(TestContract::class)
 class TestUtxoState(
+    val identifier: Int,
     val testField: String,
     private val participants: List<PublicKey>,
     val participantNames: List<String>

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -238,7 +238,7 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
 
                     repeat(outputStateCount) {
                         builder = builder.addOutputState(
-                            TestUtxoState("test", emptyList(), emptyList())
+                            TestUtxoState(1, "test", emptyList(), emptyList())
                         )
                     }
 


### PR DESCRIPTION
CORE-12078 Transaction backchain persist visible states

Transaction backchain resolution now persists visible states.

This means that transactions received as part of transaction backchain 
resolution will be stored in the visible states table if the state is 
deemed visible by a call to `Contract.isVisible`.

Fix a bug in `TransactionBackchainReceiverFlowV1Test` which was not 
correctly using the `TopologicalSort` class for sorting received 
transactions. This caused transactions to be verified in the wrong
order, which in turn caused verification of the transactions to fail.