### PR TITLE
CORE-12027 Additional input and reference state checking

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoTransactionBuilderVerifier.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoTransactionBuilderVerifier.kt
@@ -29,6 +29,8 @@ class UtxoTransactionBuilderVerifier(
          */
         verifySignatories(transactionBuilder.signatories)
         verifyInputsAndOutputs(transactionBuilder.inputStateRefs, transactionBuilder.outputStates)
+        verifyNoDuplicateInputsOrReferences(transactionBuilder.inputStateRefs, transactionBuilder.referenceStateRefs)
+        verifyNoInputAndReferenceOverlap(transactionBuilder.inputStateRefs, transactionBuilder.referenceStateRefs)
         verifyCommands(transactionBuilder.commands)
         verifyNotaryIsWhitelisted()
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoTransactionBuilderVerifierTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoTransactionBuilderVerifierTest.kt
@@ -139,4 +139,30 @@ class UtxoTransactionBuilderVerifierTest {
     fun `throws an exception if the notary is not allowed`() {
         // TODO CORE-8956 Check the notary is in the group parameters whitelist
     }
+
+    @Test
+    fun `throws an exception if the same input state appears twice`() {
+        whenever(transactionBuilder.inputStateRefs).thenReturn(listOf(stateRef, stateRef))
+        assertThatThrownBy { verifier.verify() }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Duplicate input states detected")
+    }
+
+    @Test
+    fun `throws an exception if the same reference state appears twice`() {
+        val referenceStateRef = mock<StateRef>()
+
+        whenever(transactionBuilder.referenceStateRefs).thenReturn(listOf(referenceStateRef, referenceStateRef))
+        assertThatThrownBy { verifier.verify() }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Duplicate reference states detected")
+    }
+
+    @Test
+    fun `throws an exception if there are overlapping input and reference states`() {
+        whenever(transactionBuilder.referenceStateRefs).thenReturn(listOf(stateRef))
+        assertThatThrownBy { verifier.verify() }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("cannot be both an input and a reference input in the same transaction.")
+    }
 }

--- a/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
@@ -894,7 +894,7 @@ class UniquenessCheckerImplDBIntegrationTests {
                     .setInputStates(listOf(state, state))
                     .build()
             ).let { responses ->
-                org.junit.jupiter.api.assertAll(
+                assertAll(
                     { assertThat(responses).hasSize(1) },
                     {
                         assertMalformedRequestResponse(
@@ -915,7 +915,7 @@ class UniquenessCheckerImplDBIntegrationTests {
                     .setReferenceStates(listOf(state, state))
                     .build()
             ).let { responses ->
-                org.junit.jupiter.api.assertAll(
+                assertAll(
                     { assertThat(responses).hasSize(1) },
                     {
                         assertMalformedRequestResponse(
@@ -937,7 +937,7 @@ class UniquenessCheckerImplDBIntegrationTests {
                     .setReferenceStates(state)
                     .build()
             ).let { responses ->
-                org.junit.jupiter.api.assertAll(
+                assertAll(
                     { assertThat(responses).hasSize(1) },
                     {
                         assertMalformedRequestResponse(

--- a/components/uniqueness/uniqueness-checker-impl/src/test/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/test/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplTests.kt
@@ -754,7 +754,43 @@ class UniquenessCheckerImplTests {
         }
 
         @Test
-        fun `Single tx with same state used for input and ref state is successful`() {
+        fun `Single tx with same input state specified twice fails`() {
+            val state = generateUnspentStates(1).single()
+
+            processRequests(
+                newRequestBuilder()
+                    .setInputStates(listOf(state, state))
+                    .build()
+            ).let { responses ->
+                assertAll(
+                    { assertThat(responses).hasSize(1) },
+                    { assertMalformedRequestResponse(
+                        responses[0],
+                        "Duplicate input states detected: ${listOf(state)}") }
+                )
+            }
+        }
+
+        @Test
+        fun `Single tx with same reference state specified twice fails`() {
+            val state = generateUnspentStates(1).single()
+
+            processRequests(
+                newRequestBuilder()
+                    .setReferenceStates(listOf(state, state))
+                    .build()
+            ).let { responses ->
+                assertAll(
+                    { assertThat(responses).hasSize(1) },
+                    { assertMalformedRequestResponse(
+                        responses[0],
+                        "Duplicate reference states detected: ${listOf(state)}") }
+                )
+            }
+        }
+
+        @Test
+        fun `Single tx with same state used for input and ref state fails`() {
             val state = generateUnspentStates(1)
 
             processRequests(
@@ -765,7 +801,10 @@ class UniquenessCheckerImplTests {
             ).let { responses ->
                 assertAll(
                     { assertThat(responses).hasSize(1) },
-                    { assertStandardSuccessResponse(responses[0], testClock) }
+                    { assertMalformedRequestResponse(
+                        responses[0],
+                        "A state cannot be both an input and a reference input in the same " +
+                                "request. Offending states: $state") }
                 )
             }
         }

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifier.kt
@@ -30,6 +30,8 @@ class UtxoLedgerTransactionVerifier(
          */
         verifySignatories(transaction.signatories)
         verifyInputsAndOutputs(transaction.inputStateRefs, transaction.outputContractStates)
+        verifyNoDuplicateInputsOrReferences(transaction.inputStateRefs, transaction.referenceStateRefs)
+        verifyNoInputAndReferenceOverlap(transaction.inputStateRefs, transaction.referenceStateRefs)
         verifyCommands(transaction.commands)
         verifyNotaryIsWhitelisted()
 
@@ -39,7 +41,6 @@ class UtxoLedgerTransactionVerifier(
         verifyInputNotaries()
         verifyInputsAreOlderThanOutputs()
     }
-
 
     private fun verifyInputNotaries() {
         val allInputs = transaction.inputTransactionStates + transaction.referenceTransactionStates

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionVerifier.kt
@@ -23,6 +23,25 @@ abstract class UtxoTransactionVerifier {
         }
     }
 
+    protected fun verifyNoDuplicateInputsOrReferences(inputStateRefs: List<StateRef>, referenceStateRefs: List<StateRef>) {
+        val duplicateInputs = inputStateRefs.groupingBy { it }.eachCount().filter { it.value > 1 }
+
+        check(duplicateInputs.isEmpty()) { "Duplicate input states detected: ${duplicateInputs.keys}" }
+
+        val duplicateReferences = referenceStateRefs.groupingBy { it }.eachCount().filter { it.value > 1 }
+
+        check(duplicateReferences.isEmpty()) { "Duplicate reference states detected: ${duplicateReferences.keys}" }
+    }
+
+    protected fun verifyNoInputAndReferenceOverlap(inputStateRefs: List<StateRef>, referenceStateRefs: List<StateRef>) {
+        val intersection = inputStateRefs intersect referenceStateRefs.toSet()
+        check(intersection.isEmpty()) {
+            "A state cannot be both an input and a reference input in the same transaction. Offending " +
+                    "states: $intersection"
+        }
+    }
+
+
     protected fun verifyCommands(commands: List<Command>) {
         check(commands.isNotEmpty()) {
             "At least one command must be applied to the current $subjectClass."

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
@@ -106,6 +106,32 @@ class UtxoLedgerTransactionVerifierTest {
     }
 
     @Test
+    fun `throws an exception if the same input state appears twice`() {
+        whenever(transaction.inputStateRefs).thenReturn(listOf(stateRef, stateRef))
+        assertThatThrownBy { verifier.verify() }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Duplicate input states detected")
+    }
+
+    @Test
+    fun `throws an exception if the same reference state appears twice`() {
+        val referenceStateRef = mock<StateRef>()
+
+        whenever(transaction.referenceStateRefs).thenReturn(listOf(referenceStateRef, referenceStateRef))
+        assertThatThrownBy { verifier.verify() }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Duplicate reference states detected")
+    }
+
+    @Test
+    fun `throws an exception if there are overlapping input and reference states`() {
+        whenever(transaction.referenceStateRefs).thenReturn(listOf(stateRef))
+        assertThatThrownBy { verifier.verify() }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("cannot be both an input and a reference input in the same transaction.")
+    }
+
+    @Test
     fun `throws an exception if the notary is not allowed`() {
         // TODO CORE-8956 Check the notary is in the group parameters whitelist
     }

--- a/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/internal/UniquenessCheckRequestInternal.kt
+++ b/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/internal/UniquenessCheckRequestInternal.kt
@@ -23,11 +23,25 @@ data class UniquenessCheckRequestInternal constructor(
 ) {
     companion object {
         fun create(externalRequest: UniquenessCheckRequestAvro): UniquenessCheckRequestInternal {
-            if (externalRequest.numOutputStates < 0) {
-                throw IllegalArgumentException("Number of output states cannot be less than 0.")
-            }
 
             with (externalRequest) {
+                require(numOutputStates >= 0) { "Number of output states cannot be less than 0." }
+
+                val duplicateInputs = inputStates.groupingBy { it }.eachCount().filter { it.value > 1 }
+
+                require(duplicateInputs.isEmpty()) { "Duplicate input states detected: ${duplicateInputs.keys}" }
+
+                val duplicateReferences = referenceStates.groupingBy { it }.eachCount().filter { it.value > 1 }
+
+                require(duplicateReferences.isEmpty()) { "Duplicate reference states detected: ${duplicateReferences.keys}" }
+
+                val intersection = inputStates intersect referenceStates.toSet()
+
+                require(intersection.isEmpty()) {
+                    "A state cannot be both an input and a reference input in the same request. Offending " +
+                            "states: $intersection"
+                }
+
                 return UniquenessCheckRequestInternal(
                     parseSecureHash(txId),
                     txId,


### PR DESCRIPTION
### Summary

This change re-instates some additional platform checks that were performed as part of transaction verification in Corda 4. The following checks have been re-instated:

- Specifying the same input or reference state multiple times in the same transaction is now an error
- Similarly, specifying the same state as both an input and reference state in the same transaction is now an error

These checks have also been added to the uniqueness checker logic (in addition to transaction verification) as a defensive measure, in case this service is used outside of the UTXO ledger in future.

The check for the presence of a notary that is performed in Corda 4 has not been re-instated; a notary is now required on every UTXO ledger transaction, which was not the case in Corda 4. This is therefore enforced by the API which requires a notary to be set.

### Testing

This change breaks several automated test cases, as we are changing the behavior of both transaction verification and uniqueness checking. Tests have been updated accordingly and additional test cases added to address gaps in the existing tests.