### PR TITLE
CORE-12177 - Flow External Messaging - Add vNode route building

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -39,7 +39,7 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "name": "a.b.c",
-                            "type": "send"
+                            "type": "SEND"
                         },
                       ]
                     }
@@ -62,11 +62,11 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "name": "a.b.c",
-                            "type": "send"
+                            "type": "SEND"
                         },
                         {
                             "name": "1.2.3",
-                            "type": "send-receive"
+                            "type": "SEND_RECEIVE"
                         }
                       ]
                     }
@@ -129,7 +129,7 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "name": "a.b.c",
-                            "type": "send"
+                            "type": "SEND"
                         }
                       ],
                       "unknown": "value"
@@ -153,7 +153,7 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "name": "a.b.c",
-                            "type": "send",
+                            "type": "SEND",
                             "unknown": "value"
                         }
                       ]
@@ -177,7 +177,7 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "nam": "a.b.c",
-                            "type": "send"
+                            "type": "SEND"
                         }
                       ],
                     }
@@ -200,7 +200,7 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "name": "a.b.c",
-                            "typ": "send"
+                            "typ": "SEND"
                         }
                       ],
                     }
@@ -222,7 +222,7 @@ class ExternalChannelsConfigValidatorTest {
                     {
                       "channels": [
                         {
-                            "type": "send"
+                            "type": "SEND"
                         }
                       ],
                     }
@@ -267,7 +267,7 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "name": "a.b.c"
-                            "type": "send1"
+                            "type": "SEND1"
                         }
                       ],
                     }
@@ -290,7 +290,7 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "name": "a:b:c"
-                            "type": "send"
+                            "type": "SEND"
                         }
                       ],
                     }
@@ -313,7 +313,7 @@ class ExternalChannelsConfigValidatorTest {
                       "channels": [
                         {
                             "name": ""
-                            "type": "send"
+                            "type": "SEND"
                         }
                       ],
                     }

--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -5,14 +5,12 @@ import net.corda.libs.configuration.validation.ConfigurationValidationException
 import net.corda.libs.configuration.validation.impl.ConfigurationValidatorFactoryImpl
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkMetadata
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
-@Disabled("Temporary until the api is updated")
 class ExternalChannelsConfigValidatorTest {
 
     private val cordappConfigValidator =

--- a/components/virtual-node/virtual-node-write-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-write-service-impl/build.gradle
@@ -7,7 +7,6 @@ description "Configuration Write Service Impl"
 
 dependencies {
     api project(':libs:virtual-node:virtual-node-info')
-    implementation project(path: ':libs:external-messaging')
 
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
@@ -31,6 +30,7 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:virtual-node:virtual-node-common')
     implementation project(':libs:virtual-node:virtual-node-datamodel')
+    implementation project(":libs:external-messaging")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation 'javax.persistence:javax.persistence-api'

--- a/components/virtual-node/virtual-node-write-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-write-service-impl/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:virtual-node:virtual-node-common')
     implementation project(':libs:virtual-node:virtual-node-datamodel')
-    implementation project(":libs:external-messaging")
+    implementation project(':libs:external-messaging')
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation 'javax.persistence:javax.persistence-api'

--- a/components/virtual-node/virtual-node-write-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-write-service-impl/build.gradle
@@ -7,6 +7,7 @@ description "Configuration Write Service Impl"
 
 dependencies {
     api project(':libs:virtual-node:virtual-node-info')
+    implementation project(path: ':libs:external-messaging')
 
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
@@ -1,5 +1,6 @@
 package net.corda.virtualnode.write.db.impl.tests
 
+import javax.persistence.EntityManagerFactory
 import net.corda.crypto.core.parseSecureHash
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
@@ -18,8 +19,6 @@ import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.util.*
-import javax.persistence.EntityManagerFactory
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class VirtualNodeEntityRepositoryTest {
@@ -70,7 +69,7 @@ internal class VirtualNodeEntityRepositoryTest {
         val signerSummaryHash = "TEST:121212121212"
         val cpiId = CpiIdentifier("Test CPI", "1.0", parseSecureHash(signerSummaryHash))
         val expectedCpiMetadata =
-            CpiMetadataLite(cpiId, parseSecureHash(fileChecksum), "Test Group ID", "Test Group Policy")
+            CpiMetadataLite(cpiId, parseSecureHash(fileChecksum), "Test Group ID", "Test Group Policy", emptySet())
 
         val cpiMetadataEntity = with(expectedCpiMetadata) {
             CpiMetadataEntity(
@@ -82,7 +81,7 @@ internal class VirtualNodeEntityRepositoryTest {
                 "Test Group Policy",
                 "Test Group ID",
                 "Request ID",
-                emptySet(),
+                emptySet() // Todo: This should actually not be empty. We should be testing that this field is being properly set when the CpiMetadataLite is creeated
             )
         }
 
@@ -129,7 +128,7 @@ internal class VirtualNodeEntityRepositoryTest {
         val cpiId = CpiIdentifier("Test CPI 2", "2.0", parseSecureHash(signerSummaryHash))
         val mgmGroupId = "Test Group ID 2"
         val groupPolicy = "Test Group Policy 2"
-        val expectedCpiMetadata = CpiMetadataLite(cpiId, parseSecureHash(fileChecksum), mgmGroupId, groupPolicy)
+        val expectedCpiMetadata = CpiMetadataLite(cpiId, parseSecureHash(fileChecksum), mgmGroupId, groupPolicy, emptySet())
 
         val cpiMetadataEntity = with(expectedCpiMetadata) {
             CpiMetadataEntity(

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
@@ -69,7 +69,7 @@ internal class VirtualNodeEntityRepositoryTest {
         val signerSummaryHash = "TEST:121212121212"
         val cpiId = CpiIdentifier("Test CPI", "1.0", parseSecureHash(signerSummaryHash))
         val expectedCpiMetadata =
-            CpiMetadataLite(cpiId, parseSecureHash(fileChecksum), "Test Group ID", "Test Group Policy", emptySet()) // The empty set should be replaced
+            CpiMetadataLite(cpiId, parseSecureHash(fileChecksum), "Test Group ID", "Test Group Policy", emptySet())
 
         val cpiMetadataEntity = with(expectedCpiMetadata) {
             CpiMetadataEntity(
@@ -81,7 +81,7 @@ internal class VirtualNodeEntityRepositoryTest {
                 "Test Group Policy",
                 "Test Group ID",
                 "Request ID",
-                emptySet() // Todo: This should actually not be empty. We should be testing that this field is being properly set when the CpiMetadataLite is creeated
+                emptySet()
             )
         }
 
@@ -115,7 +115,7 @@ internal class VirtualNodeEntityRepositoryTest {
         cpiMetadata = repository.getCpiMetadataByChecksum("123456AbCdEf")
         Assertions.assertThat(cpiMetadata).isEqualTo(expectedCpiMetadata)
 
-        // Noll returned if not found
+        // Null returned if not found
         cpiMetadata = repository.getCpiMetadataByChecksum("111111")
         Assertions.assertThat(cpiMetadata).isNull()
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/integrationTest/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeEntityRepositoryTest.kt
@@ -69,7 +69,7 @@ internal class VirtualNodeEntityRepositoryTest {
         val signerSummaryHash = "TEST:121212121212"
         val cpiId = CpiIdentifier("Test CPI", "1.0", parseSecureHash(signerSummaryHash))
         val expectedCpiMetadata =
-            CpiMetadataLite(cpiId, parseSecureHash(fileChecksum), "Test Group ID", "Test Group Policy", emptySet())
+            CpiMetadataLite(cpiId, parseSecureHash(fileChecksum), "Test Group ID", "Test Group Policy", emptySet()) // The empty set should be replaced
 
         val cpiMetadataEntity = with(expectedCpiMetadata) {
             CpiMetadataEntity(

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeWriteEventHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeWriteEventHandler.kt
@@ -42,7 +42,7 @@ internal class VirtualNodeWriteEventHandler(
     }
 
     private fun onConfigChangedEvent(coordinator: LifecycleCoordinator, event: ConfigChangedEvent) {
-        // This methods must be updated to process events relate to the EXTERNAL_MESSAGING_CONFIG
+        // Todos: This methods must be updated to process events relate to the EXTERNAL_MESSAGING_CONFIG and tested
         val msgConfig = event.config.getConfig(ConfigKeys.MESSAGING_CONFIG)
         val externalMsgConfig = event.config.getConfig(ConfigKeys.EXTERNAL_MESSAGING_CONFIG)
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeWriteEventHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeWriteEventHandler.kt
@@ -42,7 +42,6 @@ internal class VirtualNodeWriteEventHandler(
     }
 
     private fun onConfigChangedEvent(coordinator: LifecycleCoordinator, event: ConfigChangedEvent) {
-        // Todos: This methods must be updated to process events relate to the EXTERNAL_MESSAGING_CONFIG and tested
         val msgConfig = event.config.getConfig(ConfigKeys.MESSAGING_CONFIG)
         val externalMsgConfig = event.config.getConfig(ConfigKeys.EXTERNAL_MESSAGING_CONFIG)
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/CpiMetadataLite.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/CpiMetadataLite.kt
@@ -17,5 +17,5 @@ internal data class CpiMetadataLite(
     val fileChecksum: SecureHash,
     val mgmGroupId: String,
     val groupPolicy: String,
-    val cpks: Set<CpkMetadata> // Todo: Not sure what Lite means but by adding this new field this data class becomes anything but light
+    val cpks: Set<CpkMetadata> // Todos: Not sure what Lite means but by adding this new field this data class becomes anything but light
 )

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/CpiMetadataLite.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/CpiMetadataLite.kt
@@ -1,6 +1,7 @@
 package net.corda.virtualnode.write.db.impl.writer
 
 import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.v5.crypto.SecureHash
 
 /**
@@ -15,5 +16,6 @@ internal data class CpiMetadataLite(
     val id: CpiIdentifier,
     val fileChecksum: SecureHash,
     val mgmGroupId: String,
-    val groupPolicy: String
+    val groupPolicy: String,
+    val cpks: Set<CpkMetadata> // Todo: Not sure what Lite means but by adding this new field this data class becomes anything but light
 )

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/CpiMetadataLite.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/CpiMetadataLite.kt
@@ -17,5 +17,5 @@ internal data class CpiMetadataLite(
     val fileChecksum: SecureHash,
     val mgmGroupId: String,
     val groupPolicy: String,
-    val cpks: Set<CpkMetadata> // Todos: Not sure what Lite means but by adding this new field this data class becomes anything but light
+    val cpks: Set<CpkMetadata>
 )

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterFactory.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterFactory.kt
@@ -10,7 +10,10 @@ import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.cpi.datamodel.repository.CpkDbChangeLogRepository
 import net.corda.libs.cpi.datamodel.repository.CpkDbChangeLogRepositoryImpl
+import net.corda.libs.external.messaging.ExternalMessagingConfigProviderImpl
 import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGeneratorImpl
+import net.corda.libs.external.messaging.serialization.ExternalMessagingChannelConfigSerializerImpl
+import net.corda.libs.external.messaging.serialization.ExternalMessagingRouteConfigSerializerImpl
 import net.corda.libs.virtualnode.datamodel.repository.HoldingIdentityRepositoryImpl
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepository
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepositoryImpl
@@ -106,7 +109,11 @@ internal class VirtualNodeWriterFactory(
                 recordFactory,
                 groupPolicyParser,
                 publisher,
-                ExternalMessagingRouteConfigGeneratorImpl(externalMsgConfig),
+                ExternalMessagingRouteConfigGeneratorImpl(
+                    ExternalMessagingConfigProviderImpl(externalMsgConfig),
+                    ExternalMessagingRouteConfigSerializerImpl(),
+                    ExternalMessagingChannelConfigSerializerImpl()
+                ),
                 LoggerFactory.getLogger(CreateVirtualNodeOperationHandler::class.java)
             )
         )
@@ -152,7 +159,8 @@ internal class VirtualNodeWriterFactory(
             VirtualNodeEntityRepository(dbConnectionManager.getClusterEntityManagerFactory())
 
         val virtualNodeRepository: VirtualNodeRepository = VirtualNodeRepositoryImpl()
-        val virtualNodeOperationStatusHandler = VirtualNodeOperationStatusHandler(dbConnectionManager, virtualNodeRepository)
+        val virtualNodeOperationStatusHandler =
+            VirtualNodeOperationStatusHandler(dbConnectionManager, virtualNodeRepository)
 
         val processor = VirtualNodeWriterProcessor(
             vNodePublisher,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
@@ -1,9 +1,10 @@
 package net.corda.virtualnode.write.db.impl.writer.asyncoperation.handlers
 
+import java.time.Instant
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
 import net.corda.data.virtualnode.VirtualNodeOperationStatus
 import net.corda.db.connection.manager.VirtualNodeDbType
-import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGenerator
 import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationStateDto
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
 import net.corda.messaging.api.publisher.Publisher
@@ -12,14 +13,12 @@ import net.corda.schema.Schemas.VirtualNode.VIRTUAL_NODE_OPERATION_STATUS_TOPIC
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.virtualnode.toCorda
-import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGenerator
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbFactory
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeWriterProcessor
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.VirtualNodeAsyncOperationHandler
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.factories.RecordFactory
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.services.CreateVirtualNodeService
 import org.slf4j.Logger
-import java.time.Instant
 
 @Suppress("LongParameterList")
 internal class CreateVirtualNodeOperationHandler(
@@ -100,7 +99,7 @@ internal class CreateVirtualNodeOperationHandler(
                     vNodeDbs,
                     cpiMetadata.id,
                     request.updateActor,
-                    externalMessagingRouteConfig = externalMessagingRouteConfig
+                    externalMessagingRouteConfig
                 )
             }
 
@@ -122,7 +121,7 @@ internal class CreateVirtualNodeOperationHandler(
                     holdingId,
                     cpiMetadata.id,
                     vNodeConnections,
-                    externalMessagingRouteConfig = null
+                    externalMessagingRouteConfig
                 )
             )
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/ExampleData.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/ExampleData.kt
@@ -31,7 +31,7 @@ internal const val CPI_VERSION1 = "1.0"
 internal val CPI_CHECKSUM1 = SecureHashImpl("SHA-256","CPI_CHECKSUM1".toByteArray())
 internal val CPI_SIGNER_HASH1 = parseSecureHash("SHA-256:1234567890123456")
 internal val CPI_IDENTIFIER1 = CpiIdentifier(CPI_NAME1, CPI_VERSION1, CPI_SIGNER_HASH1)
-internal val CPI_METADATA1 = CpiMetadataLite(CPI_IDENTIFIER1, CPI_CHECKSUM1, GROUP_ID1, GROUP_POLICY1)
+internal val CPI_METADATA1 = CpiMetadataLite(CPI_IDENTIFIER1, CPI_CHECKSUM1, GROUP_ID1, GROUP_POLICY1, emptySet())
 
 internal fun getValidRequest(): VirtualNodeCreateRequest {
     return VirtualNodeCreateRequest().apply {

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeWriteConfigHandlerTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeWriteConfigHandlerTests.kt
@@ -42,7 +42,12 @@ class VirtualNodeWriteConfigHandlerTests {
         val eventHandler = VirtualNodeWriteEventHandler(mock(), vnodeWriterFactory)
         val event = ConfigChangedEvent(
             setOf(REST_CONFIG, MESSAGING_CONFIG),
-            mapOf(REST_CONFIG to config, BOOT_CONFIG to config, MESSAGING_CONFIG to config, EXTERNAL_MESSAGING_CONFIG to config)
+            mapOf(
+                REST_CONFIG to config,
+                BOOT_CONFIG to config,
+                MESSAGING_CONFIG to config,
+                EXTERNAL_MESSAGING_CONFIG to config
+            )
         )
         eventHandler.processEvent(event, coordinator)
 
@@ -99,7 +104,12 @@ class VirtualNodeWriteConfigHandlerTests {
 
         val event = ConfigChangedEvent(
             setOf(REST_CONFIG, MESSAGING_CONFIG),
-            mapOf(REST_CONFIG to config, BOOT_CONFIG to config, MESSAGING_CONFIG to config, EXTERNAL_MESSAGING_CONFIG to config)
+            mapOf(
+                REST_CONFIG to config,
+                BOOT_CONFIG to config,
+                MESSAGING_CONFIG to config,
+                EXTERNAL_MESSAGING_CONFIG to config
+            )
         )
 
         eventHandler.processEvent(event, coordinator)

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterFactoryTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterFactoryTests.kt
@@ -1,6 +1,7 @@
 package net.corda.virtualnode.write.db.impl.tests.writer
 
 import com.typesafe.config.ConfigFactory
+import javax.persistence.EntityManagerFactory
 import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.data.virtualnode.VirtualNodeManagementRequest
 import net.corda.data.virtualnode.VirtualNodeManagementResponse
@@ -27,7 +28,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import javax.persistence.EntityManagerFactory
 
 /** Tests of [VirtualNodeWriterFactory]. */
 class VirtualNodeWriterFactoryTests {
@@ -54,11 +54,12 @@ class VirtualNodeWriterFactoryTests {
     fun `factory creates a publisher with the correct configuration`() {
         val expectedPublisherConfig = PublisherConfig(CLIENT_NAME_DB)
         val expectedConfig = configFactory.create(ConfigFactory.parseMap(mapOf("dummyKey" to "dummyValue")))
+        val externalMsgConfig = configFactory.create(ConfigFactory.parseMap(mapOf("dummyKey" to "dummyValue")))
 
         val publisherFactory = getPublisherFactory()
         val virtualNodeWriterFactory = VirtualNodeWriterFactory(
             getSubscriptionFactory(), publisherFactory, getDbConnectionManager(), mock(), mock(), mock())
-        virtualNodeWriterFactory.create(expectedConfig)
+        virtualNodeWriterFactory.create(expectedConfig, externalMsgConfig)
 
         verify(publisherFactory).createPublisher(expectedPublisherConfig, expectedConfig)
     }
@@ -76,6 +77,7 @@ class VirtualNodeWriterFactoryTests {
             "virtual.node.async.operation.group", Schemas.VirtualNode.VIRTUAL_NODE_ASYNC_REQUEST_TOPIC
         )
         val expectedConfig = configFactory.create(ConfigFactory.parseMap(mapOf("dummyKey" to "dummyValue")))
+        val externalMsgConfig = configFactory.create(ConfigFactory.parseMap(mapOf("dummyKey" to "dummyValue")))
 
         val subscriptionFactory = getSubscriptionFactory()
         val virtualNodeWriterFactory = VirtualNodeWriterFactory(
@@ -83,7 +85,7 @@ class VirtualNodeWriterFactoryTests {
         )
 
         val processor = argumentCaptor<VirtualNodeAsyncOperationProcessor>()
-        virtualNodeWriterFactory.create(expectedConfig)
+        virtualNodeWriterFactory.create(expectedConfig, externalMsgConfig)
 
         verify(subscriptionFactory).createRPCSubscription(eq(expectedRPCConfig), eq(expectedConfig), any())
         verify(subscriptionFactory).createDurableSubscription(eq(subscriptionConfig), processor.capture(), eq(expectedConfig), eq(null))

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandlerTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandlerTest.kt
@@ -1,5 +1,7 @@
 package net.corda.virtualnode.write.db.impl.tests.writer.asyncoperation.handlers
 
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
 import net.corda.data.virtualnode.VirtualNodeOperationStatus
 import net.corda.db.connection.manager.VirtualNodeDbType.CRYPTO
 import net.corda.db.connection.manager.VirtualNodeDbType.UNIQUENESS
@@ -36,8 +38,6 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.time.Instant
-import java.util.concurrent.CompletableFuture
 
 class CreateVirtualNodeOperationHandlerTest {
     private val timestamp = Instant.now()
@@ -72,6 +72,7 @@ class CreateVirtualNodeOperationHandlerTest {
         recordFactory,
         groupPolicyParser,
         statusPublisher,
+        mock(),
         mock()
     )
 
@@ -259,7 +260,8 @@ class CreateVirtualNodeOperationHandlerTest {
         whenever(createVirtualNodeService.getCpiMetaData(CPI_CHECKSUM1.toString()))
             .thenReturn(CpiMetadataLite(CPI_IDENTIFIER1, CPI_CHECKSUM1, GROUP_ID1, """
                 {"$PROTOCOL_PARAMETERS": { "$STATIC_NETWORK": {}}}
-            """.trimIndent()))
+            """.trimIndent(), emptySet()
+            ))
         val request = getValidRequest()
         val virtualNodeInfoRecord = Record("vnode", "", "")
         val dbConnections = mock<VirtualNodeDbConnections>()

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandlerTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandlerTest.kt
@@ -6,6 +6,7 @@ import net.corda.data.virtualnode.VirtualNodeOperationStatus
 import net.corda.db.connection.manager.VirtualNodeDbType.CRYPTO
 import net.corda.db.connection.manager.VirtualNodeDbType.UNIQUENESS
 import net.corda.db.connection.manager.VirtualNodeDbType.VAULT
+import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGenerator
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyKeys.ProtocolParameters.STATIC_NETWORK
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyKeys.Root.PROTOCOL_PARAMETERS
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
@@ -46,7 +47,7 @@ class CreateVirtualNodeOperationHandlerTest {
     private val vaultPlatformManagedVirtualNodeDb = getVNodeDb(VAULT, true)
     private val cryptoUserManagedVirtualNodeDb = getVNodeDb(CRYPTO, false)
     private val uniquenessPlatformManagedVirtualNodeDb = getVNodeDb(UNIQUENESS, true)
-
+    private val externalMessagingRouteConfig = """{ "dummy": "dummy" }"""
     private val virtualNodeDbs = mapOf(
         VAULT to vaultPlatformManagedVirtualNodeDb,
         CRYPTO to cryptoUserManagedVirtualNodeDb,
@@ -56,6 +57,10 @@ class CreateVirtualNodeOperationHandlerTest {
     private val createVirtualNodeService = mock<CreateVirtualNodeService>().apply {
         whenever(validateRequest(any())).thenReturn(null)
         whenever(getCpiMetaData(CPI_CHECKSUM1.toString())).thenReturn(CPI_METADATA1)
+    }
+
+    private val externalMessagingRouteConfigGenerator = mock<ExternalMessagingRouteConfigGenerator>().apply {
+        whenever(generateConfig(any(),any(),any())).thenReturn(externalMessagingRouteConfig)
     }
 
     private val virtualNodeDbFactory = mock<VirtualNodeDbFactory>().apply {
@@ -72,7 +77,7 @@ class CreateVirtualNodeOperationHandlerTest {
         recordFactory,
         groupPolicyParser,
         statusPublisher,
-        mock(),
+        externalMessagingRouteConfigGenerator,
         mock()
     )
 
@@ -153,7 +158,7 @@ class CreateVirtualNodeOperationHandlerTest {
             virtualNodeDbs,
             CPI_IDENTIFIER1,
             request.updateActor,
-            null
+            externalMessagingRouteConfig
         )
     }
 
@@ -163,7 +168,7 @@ class CreateVirtualNodeOperationHandlerTest {
         val virtualNodeInfoRecord = Record("vnode", "", "")
         val dbConnections = mock<VirtualNodeDbConnections>()
 
-        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), eq(null))).thenReturn(
+        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), any())).thenReturn(
             dbConnections
         )
         whenever(
@@ -171,7 +176,7 @@ class CreateVirtualNodeOperationHandlerTest {
                 ALICE_HOLDING_ID1,
                 CPI_IDENTIFIER1,
                 dbConnections,
-                externalMessagingRouteConfig = null
+                externalMessagingRouteConfig
             )
         ).thenReturn(
             virtualNodeInfoRecord
@@ -192,7 +197,7 @@ class CreateVirtualNodeOperationHandlerTest {
         val mgmInfoRecord = Record("mgm", "", "")
         val dbConnections = mock<VirtualNodeDbConnections>()
 
-        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), eq(null))).thenReturn(
+        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), any())).thenReturn(
             dbConnections
         )
         whenever(
@@ -200,7 +205,7 @@ class CreateVirtualNodeOperationHandlerTest {
                 ALICE_HOLDING_ID1,
                 CPI_IDENTIFIER1,
                 dbConnections,
-                externalMessagingRouteConfig = null
+                externalMessagingRouteConfig
             )
         ).thenReturn(
             virtualNodeInfoRecord
@@ -266,7 +271,7 @@ class CreateVirtualNodeOperationHandlerTest {
         val virtualNodeInfoRecord = Record("vnode", "", "")
         val dbConnections = mock<VirtualNodeDbConnections>()
 
-        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), eq(null))).thenReturn(
+        whenever(createVirtualNodeService.persistHoldingIdAndVirtualNode(any(), any(), any(), any(), any())).thenReturn(
             dbConnections
         )
         whenever(
@@ -274,7 +279,7 @@ class CreateVirtualNodeOperationHandlerTest {
                 ALICE_HOLDING_ID1,
                 CPI_IDENTIFIER1,
                 dbConnections,
-                externalMessagingRouteConfig = null
+                externalMessagingRouteConfig
             )
         ).thenReturn(virtualNodeInfoRecord)
 

--- a/libs/external-messaging/build.gradle
+++ b/libs/external-messaging/build.gradle
@@ -13,10 +13,10 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     
-    implementation project(':libs:crypto:crypto-core')
-    implementation project(':libs:packaging:packaging-core')
-    implementation project(path: ':libs:virtual-node:virtual-node-info')
-    implementation project(path: ':libs:configuration:configuration-core')
+    implementation project(":libs:crypto:crypto-core")
+    implementation project(":libs:packaging:packaging-core")
+    implementation project(":libs:virtual-node:virtual-node-info")
+    implementation project(":libs:configuration:configuration-core")
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"

--- a/libs/external-messaging/build.gradle
+++ b/libs/external-messaging/build.gradle
@@ -9,10 +9,14 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
+    implementation "net.corda:corda-config-schema"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:packaging:packaging-core')
+    implementation project(path: ':libs:virtual-node:virtual-node-info')
+    implementation project(path: ':libs:configuration:configuration-core')
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"

--- a/libs/external-messaging/src/main/java/net/corda/libs/external/messaging/package-info.java
+++ b/libs/external-messaging/src/main/java/net/corda/libs/external/messaging/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.libs.external.messaging;
+
+import org.osgi.annotation.bundle.Export;

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingConfigDefaults.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingConfigDefaults.kt
@@ -1,0 +1,9 @@
+package net.corda.libs.external.messaging
+
+import net.corda.libs.external.messaging.entities.InactiveResponseType
+
+data class ExternalMessagingConfigDefaults(
+    val receiveTopicPattern: String,
+    val isActive: Boolean,
+    val inactiveResponseType: InactiveResponseType
+)

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingConfigProvider.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingConfigProvider.kt
@@ -1,0 +1,6 @@
+package net.corda.libs.external.messaging
+
+interface ExternalMessagingConfigProvider
+{
+    fun getDefaults(): ExternalMessagingConfigDefaults
+}

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingConfigProviderImpl.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingConfigProviderImpl.kt
@@ -25,5 +25,4 @@ class ExternalMessagingConfigProviderImpl(private val externalMessagingConfigDef
     override fun getDefaults(): ExternalMessagingConfigDefaults {
         return externalMessagingConfigDefaults
     }
-
 }

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingConfigProviderImpl.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingConfigProviderImpl.kt
@@ -1,0 +1,29 @@
+package net.corda.libs.external.messaging
+
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.external.messaging.entities.InactiveResponseType
+import net.corda.schema.configuration.ExternalMessagingConfig
+
+class ExternalMessagingConfigProviderImpl(private val externalMessagingConfigDefaults: ExternalMessagingConfigDefaults) :
+    ExternalMessagingConfigProvider {
+
+    private companion object {
+        fun toExternalMessagingConfigDefaults(defaultConfig: SmartConfig): ExternalMessagingConfigDefaults =
+            ExternalMessagingConfigDefaults(
+                defaultConfig.getString(ExternalMessagingConfig.EXTERNAL_MESSAGING_RECEIVE_TOPIC_PATTERN),
+                defaultConfig.getBoolean(ExternalMessagingConfig.EXTERNAL_MESSAGING_ACTIVE),
+                defaultConfig.getEnum(
+                    InactiveResponseType::class.java,
+                    ExternalMessagingConfig.EXTERNAL_MESSAGING_INTERACTIVE_RESPONSE_TYPE
+                )
+            )
+    }
+
+    constructor(defaultConfig: SmartConfig) :
+            this(toExternalMessagingConfigDefaults(defaultConfig))
+
+    override fun getDefaults(): ExternalMessagingConfigDefaults {
+        return externalMessagingConfigDefaults
+    }
+
+}

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGenerator.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGenerator.kt
@@ -1,0 +1,9 @@
+package net.corda.libs.external.messaging
+
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.virtualnode.HoldingIdentity
+
+interface ExternalMessagingRouteConfigGenerator {
+    fun generateConfig(holdingId: HoldingIdentity, cpiId: CpiIdentifier, cpks: Set<CpkMetadata>): String
+}

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
@@ -1,41 +1,20 @@
 package net.corda.libs.external.messaging
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import net.corda.libs.configuration.SmartConfig
-import net.corda.libs.external.messaging.entities.ExternalMessagingChannelsConfig
-import net.corda.libs.external.messaging.entities.InactiveResponseType
 import net.corda.libs.external.messaging.entities.Route
 import net.corda.libs.external.messaging.entities.RouteConfiguration
 import net.corda.libs.external.messaging.entities.Routes
-import net.corda.libs.external.messaging.serialization.ExternalMessagingRouteConfigSerializerImpl
+import net.corda.libs.external.messaging.serialization.ExternalMessagingChannelConfigSerializer
+import net.corda.libs.external.messaging.serialization.ExternalMessagingRouteConfigSerializer
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpkMetadata
-import net.corda.schema.configuration.ExternalMessagingConfig
 import net.corda.virtualnode.HoldingIdentity
 
-// Todo: This class probably should exist elsewhere
-data class ExternalMessagingConfigDefaults(
-    val receiveTopicPattern: String,
-    val isActive: Boolean,
-    val inactiveResponseType: InactiveResponseType
-)
+class ExternalMessagingRouteConfigGeneratorImpl(
+    private val externalMessagingConfigProvider: ExternalMessagingConfigProvider,
+    private val routeConfigSerializer: ExternalMessagingRouteConfigSerializer,
+    private val channelsConfigSerializer: ExternalMessagingChannelConfigSerializer
+) : ExternalMessagingRouteConfigGenerator {
 
-
-class ExternalMessagingRouteConfigGeneratorImpl(private val externalMessagingConfigDefaults: ExternalMessagingConfigDefaults) :
-    ExternalMessagingRouteConfigGenerator {
-
-    constructor(defaultConfig: SmartConfig) :
-            this(
-                // Todo: The following conversion should be placed in a more generic place
-                ExternalMessagingConfigDefaults(
-                    defaultConfig.getString(ExternalMessagingConfig.EXTERNAL_MESSAGING_RECEIVE_TOPIC_PATTERN),
-                    defaultConfig.getBoolean(ExternalMessagingConfig.EXTERNAL_MESSAGING_ACTIVE),
-                    defaultConfig.getEnum(
-                        InactiveResponseType::class.java,
-                        ExternalMessagingConfig.EXTERNAL_MESSAGING_INTERACTIVE_RESPONSE_TYPE
-                    )
-                )
-            )
 
     // Todo
     // This function probably should return List<Route> instead of a list
@@ -45,7 +24,7 @@ class ExternalMessagingRouteConfigGeneratorImpl(private val externalMessagingCon
         // cpi -> cpiMetadata.id
         // externalChannelConfig -> CpkMetadata cpiMetadata.cpks
         val routes = generateRoutes(holdingId, cpks)
-        return ExternalMessagingRouteConfigSerializerImpl().serialize(
+        return routeConfigSerializer.serialize(
             RouteConfiguration(
                 Routes(cpiId, routes),
                 emptyList()
@@ -57,21 +36,22 @@ class ExternalMessagingRouteConfigGeneratorImpl(private val externalMessagingCon
         holdingId: HoldingIdentity,
         cpks: Set<CpkMetadata>
     ): List<Route> {
-        val topicRoutes = cpks.map { cpkMetadata ->
-            val mapper = jacksonObjectMapper()
-            val externalChannelsConfig =
-                mapper.readValue(cpkMetadata.externalChannelsConfig, ExternalMessagingChannelsConfig::class.java)
+        val topicRoutes = cpks.mapNotNull { it.externalChannelsConfig }.map { externalChannelsConfigJsonStr ->
+
+            val externalChannelsConfig = channelsConfigSerializer.deserialize(externalChannelsConfigJsonStr)
 
             externalChannelsConfig.channels.map { channelConfig ->
-                val topicPattern =  externalMessagingConfigDefaults.receiveTopicPattern
-                    .replace("\$HOLDING_ID\$",holdingId.shortHash.toString())
+                val defaultConfig = externalMessagingConfigProvider.getDefaults()
+                val topicPattern = defaultConfig.receiveTopicPattern
+
+                    .replace("\$HOLDING_ID\$", holdingId.shortHash.toString())
                     .replace("\$CHANNEL_NAME\$", channelConfig.name)
 
                 Route(
                     channelConfig.name,
                     topicPattern,
-                    externalMessagingConfigDefaults.isActive,
-                    externalMessagingConfigDefaults.inactiveResponseType
+                    defaultConfig.isActive,
+                    defaultConfig.inactiveResponseType
                 )
             }
         }.flatten()

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
@@ -15,10 +15,6 @@ class ExternalMessagingRouteConfigGeneratorImpl(
     private val channelsConfigSerializer: ExternalMessagingChannelConfigSerializer
 ) : ExternalMessagingRouteConfigGenerator {
 
-
-    // Todo
-    // This function probably should return List<Route> instead of a list
-    // The data should be then serialized when storing to the database
     override fun generateConfig(holdingId: HoldingIdentity, cpiId: CpiIdentifier, cpks: Set<CpkMetadata>): String {
         // Get the default configuration
         // cpi -> cpiMetadata.id

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
@@ -1,0 +1,81 @@
+package net.corda.libs.external.messaging
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.external.messaging.entities.ExternalMessagingChannelsConfig
+import net.corda.libs.external.messaging.entities.InactiveResponseType
+import net.corda.libs.external.messaging.entities.Route
+import net.corda.libs.external.messaging.entities.RouteConfiguration
+import net.corda.libs.external.messaging.entities.Routes
+import net.corda.libs.external.messaging.serialization.ExternalMessagingRouteConfigSerializerImpl
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.schema.configuration.ExternalMessagingConfig
+import net.corda.virtualnode.HoldingIdentity
+
+// Todo: This class probably should exist elsewhere
+data class ExternalMessagingConfigDefaults(
+    val receiveTopicPattern: String,
+    val isActive: Boolean,
+    val inactiveResponseType: InactiveResponseType
+)
+
+
+class ExternalMessagingRouteConfigGeneratorImpl(private val externalMessagingConfigDefaults: ExternalMessagingConfigDefaults) :
+    ExternalMessagingRouteConfigGenerator {
+
+    constructor(defaultConfig: SmartConfig) :
+            this(
+                // Todo: The following conversion should be placed in a more generic place
+                ExternalMessagingConfigDefaults(
+                    defaultConfig.getString(ExternalMessagingConfig.EXTERNAL_MESSAGING_RECEIVE_TOPIC_PATTERN),
+                    defaultConfig.getBoolean(ExternalMessagingConfig.EXTERNAL_MESSAGING_ACTIVE),
+                    defaultConfig.getEnum(
+                        InactiveResponseType::class.java,
+                        ExternalMessagingConfig.EXTERNAL_MESSAGING_INTERACTIVE_RESPONSE_TYPE
+                    )
+                )
+            )
+
+    // Todo
+    // This function probably should return List<Route> instead of a list
+    // The data should be then serialized when storing to the database
+    override fun generateConfig(holdingId: HoldingIdentity, cpiId: CpiIdentifier, cpks: Set<CpkMetadata>): String {
+        // Get the default configuration
+        // cpi -> cpiMetadata.id
+        // externalChannelConfig -> CpkMetadata cpiMetadata.cpks
+        val routes = generateRoutes(holdingId, cpks)
+        return ExternalMessagingRouteConfigSerializerImpl().serialize(
+            RouteConfiguration(
+                Routes(cpiId, routes),
+                emptyList()
+            )
+        )
+    }
+
+    private fun generateRoutes(
+        holdingId: HoldingIdentity,
+        cpks: Set<CpkMetadata>
+    ): List<Route> {
+        val topicRoutes = cpks.map { cpkMetadata ->
+            val mapper = jacksonObjectMapper()
+            val externalChannelsConfig =
+                mapper.readValue(cpkMetadata.externalChannelsConfig, ExternalMessagingChannelsConfig::class.java)
+
+            externalChannelsConfig.channels.map { channelConfig ->
+                val topicPattern =  externalMessagingConfigDefaults.receiveTopicPattern
+                    .replace("\$HOLDING_ID\$",holdingId.shortHash.toString())
+                    .replace("\$CHANNEL_NAME\$", channelConfig.name)
+
+                Route(
+                    channelConfig.name,
+                    topicPattern,
+                    externalMessagingConfigDefaults.isActive,
+                    externalMessagingConfigDefaults.inactiveResponseType
+                )
+            }
+        }.flatten()
+
+        return topicRoutes
+    }
+}

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
@@ -16,9 +16,6 @@ class ExternalMessagingRouteConfigGeneratorImpl(
 ) : ExternalMessagingRouteConfigGenerator {
 
     override fun generateConfig(holdingId: HoldingIdentity, cpiId: CpiIdentifier, cpks: Set<CpkMetadata>): String {
-        // Get the default configuration
-        // cpi -> cpiMetadata.id
-        // externalChannelConfig -> CpkMetadata cpiMetadata.cpks
         val routes = generateRoutes(holdingId, cpks)
         return routeConfigSerializer.serialize(
             RouteConfiguration(

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/Channel.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/Channel.kt
@@ -1,0 +1,3 @@
+package net.corda.libs.external.messaging.entities
+
+data class Channel(val name: String, val type: ChannelType)

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/ChannelType.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/ChannelType.kt
@@ -1,14 +1,6 @@
 package net.corda.libs.external.messaging.entities
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
-enum class ChannelType(val value: String) {
-    @JsonProperty("send")
-    SEND("send"),
-    @JsonProperty("send-receive")
-    SEND_RECEIVE("send-receive");
-
-    override fun toString(): String {
-        return value
-    }
+enum class ChannelType() {
+    SEND,
+    SEND_RECEIVE
 }

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/ChannelType.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/ChannelType.kt
@@ -1,0 +1,14 @@
+package net.corda.libs.external.messaging.entities
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+enum class ChannelType(val value: String) {
+    @JsonProperty("send")
+    SEND("send"),
+    @JsonProperty("send-receive")
+    SEND_RECEIVE("send-receive");
+
+    override fun toString(): String {
+        return value
+    }
+}

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/ChannelType.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/ChannelType.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.external.messaging.entities
 
-enum class ChannelType() {
+@Suppress("unused")
+enum class ChannelType {
     SEND,
     SEND_RECEIVE
 }

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/ExternalMessagingChannelsConfig.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/entities/ExternalMessagingChannelsConfig.kt
@@ -1,0 +1,3 @@
+package net.corda.libs.external.messaging.entities
+
+data class ExternalMessagingChannelsConfig(val channels: List<Channel>)

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/serialization/ExternalMessagingChannelConfigSerializer.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/serialization/ExternalMessagingChannelConfigSerializer.kt
@@ -1,0 +1,7 @@
+package net.corda.libs.external.messaging.serialization
+
+import net.corda.libs.external.messaging.entities.ExternalMessagingChannelsConfig
+
+interface ExternalMessagingChannelConfigSerializer{
+    fun deserialize(channelsConfig: String): ExternalMessagingChannelsConfig
+}

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/serialization/ExternalMessagingChannelConfigSerializerImpl.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/serialization/ExternalMessagingChannelConfigSerializerImpl.kt
@@ -1,0 +1,12 @@
+package net.corda.libs.external.messaging.serialization
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import net.corda.libs.external.messaging.entities.ExternalMessagingChannelsConfig
+
+class ExternalMessagingChannelConfigSerializerImpl : ExternalMessagingChannelConfigSerializer  {
+    val mapper = jacksonObjectMapper()
+
+    override fun deserialize(channelsConfig: String): ExternalMessagingChannelsConfig {
+        return mapper.readValue(channelsConfig, ExternalMessagingChannelsConfig::class.java)
+    }
+}

--- a/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingConfigProviderTest.kt
+++ b/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingConfigProviderTest.kt
@@ -1,0 +1,38 @@
+package net.corda.libs.external.messaging.test
+
+import com.typesafe.config.ConfigFactory
+import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.libs.external.messaging.ExternalMessagingConfigDefaults
+import net.corda.libs.external.messaging.ExternalMessagingConfigProviderImpl
+import net.corda.libs.external.messaging.entities.InactiveResponseType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExternalMessagingConfigProviderTest {
+
+    @Test
+    fun `ensure the smart config is processed correctly`() {
+        val expectedConfigDefaults =
+            ExternalMessagingConfigDefaults("user.123.a.b.c.receive", false, InactiveResponseType.IGNORE)
+
+        val defaultConfig = genRouteDefaultConfig(expectedConfigDefaults)
+
+        val configProvider = ExternalMessagingConfigProviderImpl(defaultConfig)
+        assertThat(configProvider.getDefaults()).isEqualTo(expectedConfigDefaults)
+    }
+
+    private fun genRouteDefaultConfig(expectedConfigDefaults: ExternalMessagingConfigDefaults) =
+        SmartConfigFactory.createWithoutSecurityServices()
+            .create(ConfigFactory.parseString(genRouteDefaultConfigJsonStr(expectedConfigDefaults)))
+
+    private fun genRouteDefaultConfigJsonStr(expectedConfigDefaults: ExternalMessagingConfigDefaults) =
+        """
+            {
+                "routeDefaults": {
+                    "receiveTopicPattern": "${expectedConfigDefaults.receiveTopicPattern}",
+                    "active": "${expectedConfigDefaults.isActive}",
+                    "inactiveResponseType": "${expectedConfigDefaults.inactiveResponseType}"
+                }
+            }
+        """.trimIndent()
+}

--- a/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingConfigProviderTest.kt
+++ b/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingConfigProviderTest.kt
@@ -5,6 +5,9 @@ import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.external.messaging.ExternalMessagingConfigDefaults
 import net.corda.libs.external.messaging.ExternalMessagingConfigProviderImpl
 import net.corda.libs.external.messaging.entities.InactiveResponseType
+import net.corda.schema.configuration.ExternalMessagingConfig.EXTERNAL_MESSAGING_ACTIVE
+import net.corda.schema.configuration.ExternalMessagingConfig.EXTERNAL_MESSAGING_INTERACTIVE_RESPONSE_TYPE
+import net.corda.schema.configuration.ExternalMessagingConfig.EXTERNAL_MESSAGING_RECEIVE_TOPIC_PATTERN
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -15,24 +18,22 @@ class ExternalMessagingConfigProviderTest {
         val expectedConfigDefaults =
             ExternalMessagingConfigDefaults("user.123.a.b.c.receive", false, InactiveResponseType.IGNORE)
 
-        val defaultConfig = genRouteDefaultConfig(expectedConfigDefaults)
+        val defaultConfig = expectedConfigDefaults.toSmartConfig()
 
         val configProvider = ExternalMessagingConfigProviderImpl(defaultConfig)
         assertThat(configProvider.getDefaults()).isEqualTo(expectedConfigDefaults)
     }
 
-    private fun genRouteDefaultConfig(expectedConfigDefaults: ExternalMessagingConfigDefaults) =
+    private fun ExternalMessagingConfigDefaults.toSmartConfig() =
         SmartConfigFactory.createWithoutSecurityServices()
-            .create(ConfigFactory.parseString(genRouteDefaultConfigJsonStr(expectedConfigDefaults)))
+            .create(toConfig())
 
-    private fun genRouteDefaultConfigJsonStr(expectedConfigDefaults: ExternalMessagingConfigDefaults) =
-        """
-            {
-                "routeDefaults": {
-                    "receiveTopicPattern": "${expectedConfigDefaults.receiveTopicPattern}",
-                    "active": "${expectedConfigDefaults.isActive}",
-                    "inactiveResponseType": "${expectedConfigDefaults.inactiveResponseType}"
-                }
-            }
-        """.trimIndent()
+    private fun ExternalMessagingConfigDefaults.toConfig() =
+        ConfigFactory.parseMap(
+            mapOf<String, Any>(
+                EXTERNAL_MESSAGING_RECEIVE_TOPIC_PATTERN to receiveTopicPattern,
+                EXTERNAL_MESSAGING_ACTIVE to isActive,
+                EXTERNAL_MESSAGING_INTERACTIVE_RESPONSE_TYPE to inactiveResponseType.toString()
+            )
+        )
 }

--- a/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingRouteConfigGeneratorTest.kt
+++ b/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingRouteConfigGeneratorTest.kt
@@ -8,8 +8,11 @@ import java.util.UUID
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.libs.external.messaging.ExternalMessagingConfigProviderImpl
 import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGeneratorImpl
 import net.corda.libs.external.messaging.entities.InactiveResponseType
+import net.corda.libs.external.messaging.serialization.ExternalMessagingChannelConfigSerializerImpl
+import net.corda.libs.external.messaging.serialization.ExternalMessagingRouteConfigSerializerImpl
 import net.corda.libs.packaging.core.CordappManifest
 import net.corda.libs.packaging.core.CordappType
 import net.corda.libs.packaging.core.CpiIdentifier
@@ -96,18 +99,23 @@ class ExternalMessagingRouteConfigGeneratorTest {
         val smartConfig =
             genExternalMsgConfig("ext.\$HOLDING_ID\$.\$CHANNEL_NAME\$.receive", false, InactiveResponseType.IGNORE)
 
-        val externalMessagingRouteConfigGenerator = ExternalMessagingRouteConfigGeneratorImpl(smartConfig)
+        val externalMessagingRouteConfigGenerator =
+            ExternalMessagingRouteConfigGeneratorImpl(
+                ExternalMessagingConfigProviderImpl(smartConfig),
+                ExternalMessagingRouteConfigSerializerImpl(),
+                ExternalMessagingChannelConfigSerializerImpl()
+            )
 
         val externalChannelsConfigJson = """
                         {
                             "channels": [
                                 {
                                     "name": "a.b.c",
-                                    "type": "send"
+                                    "type": "SEND"
                                 },
                                 {
                                     "name": "1.2.3",
-                                    "type": "send-receive"
+                                    "type": "SEND_RECEIVE"
                                 }
                             ]
                         }
@@ -118,11 +126,11 @@ class ExternalMessagingRouteConfigGeneratorTest {
                             "channels": [
                                 {
                                     "name": "c.b.a",
-                                    "type": "send"
+                                    "type": "SEND"
                                 },
                                 {
                                     "name": "3.2.1",
-                                    "type": "send-receive"
+                                    "type": "SEND_RECEIVE"
                                 }
                             ]
                         }

--- a/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingRouteConfigGeneratorTest.kt
+++ b/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingRouteConfigGeneratorTest.kt
@@ -1,0 +1,180 @@
+package net.corda.libs.external.messaging.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigValueFactory
+import java.time.Instant
+import java.util.UUID
+import net.corda.crypto.core.SecureHashImpl
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.SmartConfigFactory
+import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGeneratorImpl
+import net.corda.libs.external.messaging.entities.InactiveResponseType
+import net.corda.libs.packaging.core.CordappManifest
+import net.corda.libs.packaging.core.CordappType
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpkFormatVersion
+import net.corda.libs.packaging.core.CpkIdentifier
+import net.corda.libs.packaging.core.CpkManifest
+import net.corda.libs.packaging.core.CpkMetadata
+import net.corda.libs.packaging.core.CpkType
+import net.corda.schema.configuration.ExternalMessagingConfig
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.crypto.DigestAlgorithmName
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ExternalMessagingRouteConfigGeneratorTest {
+
+    private companion object {
+        val ALICE_HOLDING_ID1 = net.corda.virtualnode.HoldingIdentity(
+            MemberX500Name.parse("CN=Alice, O=Alice Corp, L=LDN, C=GB"),
+            "GROUP_ID1"
+        )
+
+        val cpiId = CpiIdentifier(
+            "myCpi",
+            "1.0",
+            SecureHashImpl(DigestAlgorithmName.SHA2_256.name, "signerSummaryHash".toByteArray())
+        )
+
+        fun genExternalMsgConfig(
+            receiveTopicPattern: String,
+            isActive: Boolean,
+            inactiveResponseType: InactiveResponseType
+        ): SmartConfig {
+            val externalMsgConfig = ConfigFactory.empty()
+                .withValue(
+                    ExternalMessagingConfig.EXTERNAL_MESSAGING_RECEIVE_TOPIC_PATTERN,
+                    ConfigValueFactory.fromAnyRef(receiveTopicPattern)
+                )
+                .withValue(ExternalMessagingConfig.EXTERNAL_MESSAGING_ACTIVE, ConfigValueFactory.fromAnyRef(isActive))
+                .withValue(
+                    ExternalMessagingConfig.EXTERNAL_MESSAGING_INTERACTIVE_RESPONSE_TYPE,
+                    ConfigValueFactory.fromAnyRef(inactiveResponseType.toString())
+                )
+            return SmartConfigFactory.createWithoutSecurityServices().create(externalMsgConfig)
+        }
+
+        fun genCpk(externalChannelsConfigJson: String): CpkMetadata {
+            return CpkMetadata(
+                cpkId = CpkIdentifier(
+                    UUID.randomUUID().toString(),
+                    "1.0",
+                    cpiId.signerSummaryHash
+                ),
+                manifest = CpkManifest(CpkFormatVersion(1, 0)),
+                mainBundle = "main-bundle",
+                libraries = emptyList(),
+                cordappManifest = CordappManifest(
+                    "net.cordapp.Bundle",
+                    "1.2.3",
+                    12,
+                    34,
+                    CordappType.WORKFLOW,
+                    "someName",
+                    "R3",
+                    42,
+                    "some license",
+                    mapOf(
+                        "Corda-Contract-Classes" to "contractClass1, contractClass2",
+                        "Corda-Flow-Classes" to "flowClass1, flowClass2"
+                    ),
+                ),
+                type = CpkType.UNKNOWN,
+                fileChecksum = SecureHashImpl(DigestAlgorithmName.SHA2_256.name, ByteArray(32)),
+                cordappCertificates = emptySet(),
+                timestamp = Instant.now(),
+                externalChannelsConfig = externalChannelsConfigJson
+            )
+        }
+    }
+
+    @Test
+    fun `ensure the route configuration is generated correctly`() {
+
+        val smartConfig =
+            genExternalMsgConfig("ext.\$HOLDING_ID\$.\$CHANNEL_NAME\$.receive", false, InactiveResponseType.IGNORE)
+
+        val externalMessagingRouteConfigGenerator = ExternalMessagingRouteConfigGeneratorImpl(smartConfig)
+
+        val externalChannelsConfigJson = """
+                        {
+                            "channels": [
+                                {
+                                    "name": "a.b.c",
+                                    "type": "send"
+                                },
+                                {
+                                    "name": "1.2.3",
+                                    "type": "send-receive"
+                                }
+                            ]
+                        }
+                    """.trimMargin()
+
+        val externalChannelsConfigJson2 = """
+                        {
+                            "channels": [
+                                {
+                                    "name": "c.b.a",
+                                    "type": "send"
+                                },
+                                {
+                                    "name": "3.2.1",
+                                    "type": "send-receive"
+                                }
+                            ]
+                        }
+                    """.trimMargin()
+
+        val expectedRouteConfig =
+            """
+                {
+                    "currentRoutes": {
+                        "cpiIdentifier": {
+                            "name": "myCpi",
+                            "version": "1.0",
+                            "signerSummaryHash": "SHA-256:7369676E657253756D6D61727948617368"
+                        },
+                        "routes": [
+                            {
+                                "channelName": "a.b.c",
+                                "externalReceiveTopicName": "ext.7EA3CA6EF888.a.b.c.receive",
+                                "active": false,
+                                "inactiveResponseType": "IGNORE"
+                            },
+                            {
+                                "channelName": "1.2.3",
+                                "externalReceiveTopicName": "ext.7EA3CA6EF888.1.2.3.receive",
+                                "active": false,
+                                "inactiveResponseType": "IGNORE"
+                            },
+                            {
+                                "channelName": "c.b.a",
+                                "externalReceiveTopicName": "ext.7EA3CA6EF888.c.b.a.receive",
+                                "active": false,
+                                "inactiveResponseType": "IGNORE"
+                            },
+                            {
+                                "channelName": "3.2.1",
+                                "externalReceiveTopicName": "ext.7EA3CA6EF888.3.2.1.receive",
+                                "active": false,
+                                "inactiveResponseType": "IGNORE"
+                            }
+                        ]
+                    },
+                    "previousVersionRoutes": []
+                }
+            """.trimIndent()
+
+        val routesConfig = externalMessagingRouteConfigGenerator.generateConfig(
+            ALICE_HOLDING_ID1,
+            cpiId,
+            cpks = setOf(genCpk(externalChannelsConfigJson), genCpk(externalChannelsConfigJson2))
+        )
+
+        val mapper = ObjectMapper()
+        assertThat(mapper.readTree(routesConfig)).isEqualTo(mapper.readTree(expectedRouteConfig))
+    }
+}


### PR DESCRIPTION
Updated the code so that the route configuration is generated based on the route default and channels configuration.
The route configuration is stored as part of the virtual node.
Added the test `ExternalMessagingRouteConfigGeneratorTest` to ensure the generated configuration is generated correctly.
Added the test `ExternalMessagingConfigProviderTest` to ensure the ExternalMessaging configuration is converted correctly from a `SmartConfig` type to a dto.
The test `ExternalChannelsConfigValidatorTest` has been updated based recent changes to the API and has been enabled again.