### PR TITLE
CORE-12255 Crypto API refinements 

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -204,7 +204,7 @@ data class UtxoSignedTransactionImpl(
             } else {
                 null
             }
-        }
+        }.toSet()
         // If the notary service key (composite key) is provided we need to make sure it contains the key the
         // transaction was signed with. This means it was signed with one of the notary VNodes (worker).
         if (!KeyUtils.isKeyInSet(

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.742-beta+
+cordaApiVersion=5.0.0.743-alpha-1680540494467
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.743-alpha-1680540494467
+cordaApiVersion=5.0.0.743-alpha-1680601825204
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.743-alpha-1680601825204
+cordaApiVersion=5.0.0.743-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/base-internal/src/main/kotlin/net/corda/base/internal/ByteSequence.kt
+++ b/libs/base-internal/src/main/kotlin/net/corda/base/internal/ByteSequence.kt
@@ -1,6 +1,6 @@
 package net.corda.base.internal
 
-import net.corda.v5.base.types.ByteArrays.toHexString
+import net.corda.v5.base.util.ByteArrays.toHexString
 import java.io.ByteArrayInputStream
 import java.io.OutputStream
 import java.nio.ByteBuffer

--- a/libs/base-internal/src/test/kotlin/net/corda/base/internal/ByteArraysTest.kt
+++ b/libs/base-internal/src/test/kotlin/net/corda/base/internal/ByteArraysTest.kt
@@ -1,6 +1,6 @@
 package net.corda.base.internal
 
-import net.corda.v5.base.types.ByteArrays.toHexString
+import net.corda.v5.base.util.ByteArrays.toHexString
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoServiceUtils.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/CryptoServiceUtils.kt
@@ -2,7 +2,7 @@
 
 package net.corda.crypto.cipher.suite
 
-import net.corda.v5.base.types.ByteArrays
+import net.corda.v5.base.util.ByteArrays
 import net.corda.v5.crypto.MessageAuthenticationCode
 import net.corda.crypto.utils.hmac
 

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/PublicKeyHash.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/PublicKeyHash.kt
@@ -1,7 +1,7 @@
 @file:JvmName("PublicKeyUtils")
 package net.corda.crypto.cipher.suite
 
-import net.corda.v5.base.types.ByteArrays.toHexString
+import net.corda.v5.base.util.ByteArrays.toHexString
 import java.security.PublicKey
 
 /**

--- a/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/PublicKeyHashTests.kt
+++ b/libs/crypto/cipher-suite/src/test/kotlin/net/corda/crypto/cipher/suite/PublicKeyHashTests.kt
@@ -2,7 +2,7 @@ package net.corda.crypto.cipher.suite
 
 import net.corda.crypto.cipher.suite.mocks.generateKeyPair
 import net.corda.crypto.cipher.suite.mocks.specs
-import net.corda.v5.base.types.ByteArrays.toHexString
+import net.corda.v5.base.util.ByteArrays.toHexString
 import net.corda.v5.crypto.DigestAlgorithmName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
@@ -2,7 +2,7 @@ package net.corda.crypto.core
 
 import net.corda.base.internal.OpaqueBytes
 import net.corda.v5.base.annotations.CordaSerializable
-import net.corda.v5.base.types.ByteArrays
+import net.corda.v5.base.util.ByteArrays
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.SecureHash.DELIMITER
 import java.nio.ByteBuffer

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CompositeKeyImpl.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CompositeKeyImpl.kt
@@ -185,7 +185,7 @@ class CompositeKeyImpl(val threshold: Int, childrenUnsorted: List<CompositeKeyNo
      * key tree in question, and the total combined weight of all children is calculated for every intermediary node.
      * If all thresholds are satisfied, the composite key requirement is considered to be met.
      */
-    override fun isFulfilledBy(keysToCheck: Iterable<PublicKey>): Boolean {
+    override fun isFulfilledBy(keysToCheck: Set<PublicKey>): Boolean {
         // We validate keys only when checking if they're matched, as this checks sub keys as a result.
         // Doing these checks at deserialization/construction time would result in duplicate checks.
         checkValidity()

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CompositeKeyImpl.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CompositeKeyImpl.kt
@@ -165,7 +165,7 @@ class CompositeKeyImpl(val threshold: Int, childrenUnsorted: List<CompositeKeyNo
     override fun getFormat() = ASN1Encoding.DER
 
     // Return true when and if the threshold requirement is met.
-    private fun checkFulfilledBy(keysToCheck: Iterable<PublicKey>): Boolean {
+    private fun checkFulfilledBy(keysToCheck: Set<PublicKey>): Boolean {
         var totalWeight = 0
         children.forEach {
             val node = it.node

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/CompositeKeyImplTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/CompositeKeyImplTests.kt
@@ -71,7 +71,7 @@ class CompositeKeyImplTests {
         val aliceOrBob = target.createFromKeys(alicePublicKey, bobPublicKey)
         assertTrue { KeyUtils.isKeyFulfilledBy(aliceOrBob, aliceSignature.by) }
         assertTrue { KeyUtils.isKeyFulfilledBy(aliceOrBob, bobSignature.by) }
-        assertTrue { KeyUtils.isKeyFulfilledBy(aliceOrBob, listOf(aliceSignature.by, bobSignature.by)) }
+        assertTrue { KeyUtils.isKeyFulfilledBy(aliceOrBob, setOf(aliceSignature.by, bobSignature.by)) }
         assertFalse { KeyUtils.isKeyFulfilledBy(aliceOrBob, charlieSignature.by) }
     }
 

--- a/libs/layered-property-map/src/test/kotlin/net/corda/layeredpropertymap/LayeredPropertyMapTest.kt
+++ b/libs/layered-property-map/src/test/kotlin/net/corda/layeredpropertymap/LayeredPropertyMapTest.kt
@@ -10,8 +10,8 @@ import net.corda.utilities.parseList
 import net.corda.utilities.parseOrNull
 import net.corda.utilities.parseSet
 import net.corda.v5.base.exceptions.ValueNotFoundException
-import net.corda.v5.base.types.ByteArrays.toHexString
 import net.corda.v5.base.types.LayeredPropertyMap
+import net.corda.v5.base.util.ByteArrays.toHexString
 import org.junit.jupiter.api.Test
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
@@ -17,7 +17,7 @@ import net.corda.messaging.subscription.consumer.listener.PubSubConsumerRebalanc
 import net.corda.messaging.utils.toRecord
 import net.corda.metrics.CordaMetrics
 import net.corda.utilities.debug
-import net.corda.v5.base.types.ByteArrays.toHexString
+import net.corda.v5.base.util.ByteArrays.toHexString
 import org.slf4j.LoggerFactory
 
 /**

--- a/libs/schema-registry/schema-registry-impl/src/main/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImpl.kt
+++ b/libs/schema-registry/schema-registry-impl/src/main/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImpl.kt
@@ -7,7 +7,7 @@ import net.corda.data.SchemaLoadException
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.utilities.debug
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.types.ByteArrays.toHexString
+import net.corda.v5.base.util.ByteArrays.toHexString
 import org.apache.avro.Schema
 import org.apache.avro.SchemaNormalization
 import org.apache.avro.io.DecoderFactory

--- a/libs/schema-registry/schema-registry-impl/src/test/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImplTest.kt
+++ b/libs/schema-registry/schema-registry-impl/src/test/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImplTest.kt
@@ -8,8 +8,8 @@ import net.corda.data.test.EvolvedMessage
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.base.types.ByteArrays.parseAsHex
-import net.corda.v5.base.types.ByteArrays.toHexString
+import net.corda.v5.base.util.ByteArrays.parseAsHex
+import net.corda.v5.base.util.ByteArrays.toHexString
 import org.apache.avro.Schema
 import org.apache.avro.SchemaNormalization
 import org.apache.avro.generic.GenericContainer

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -112,7 +112,7 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
             // Since we are not calling finality flow for consuming transactions we need to verify that the signature
             // is actually part of the notary service's composite key
             signatures.forEach {
-                require(KeyUtils.isKeyInSet(notaryServiceInfo.publicKey, listOf(notaryKeyThatSigned))) {
+                require(KeyUtils.isKeyInSet(notaryServiceInfo.publicKey, setOf(notaryKeyThatSigned))) {
                     "The plugin responded with a signature that is not part of the notary service's composite key."
                 }
             }


### PR DESCRIPTION
- aligns with `ByteArrays` moving packages
- aligns with `KeyUtils` functions and `CompositeKey.isFulfilledBy` changed to take `Set<PublicKey>` instead of `Iterable<PublicKey>`


api PR: [#1032](https://github.com/corda/corda-api/pull/1032)