### PR TITLE
CORE-12233 - Improve error messages for invalid endpoint

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/P2pEndpointVerifier.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/P2pEndpointVerifier.kt
@@ -24,10 +24,15 @@ internal class P2pEndpointVerifier(
     }
 
     private fun verifyP2pUrl(url: String) {
-        val uri = URI.create(url)
-        require(uri.scheme == "https") { "Endpoint URL must be https" }
-        require(uri.port > 0) { "Endpoint URL must have an explicit port" }
-        require(uri.host != null) { "Endpoint URL must have an explicit host" }
-        require(uri.userInfo == null) { "Endpoint URL must not have an authentication info" }
+        val uri = try {
+            URI.create(url)
+        } catch (e: java.lang.IllegalArgumentException) {
+            throw IllegalArgumentException("Endpoint URL ('$url') is not a valid URL.")
+        }
+
+        require(uri.scheme == "https") { "The scheme of the endpoint URL ('$url') was not https." }
+        require(uri.host != null) { "The host of the endpoint URL ('$url') was not specified or had an invalid value." }
+        require(uri.port > 0) { "The port of the endpoint URL ('$url') was not specified or had an invalid value." }
+        require(uri.userInfo == null) { "Endpoint URL ('$url') had user info specified, which must not be specified." }
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/P2pEndpointVerifierTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/P2pEndpointVerifierTest.kt
@@ -1,7 +1,7 @@
 package net.corda.membership.impl.registration.dynamic.verifiers
 
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -32,9 +32,10 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.1.protocolVersion" to "1",
         )
 
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("No endpoint URL was provided.")
     }
 
     @Test
@@ -43,10 +44,10 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.0.connectionURL" to "https://www.r3.com:8080",
             "corda.endpoints.1.connectionURL" to "https://www.corda.net:8888",
         )
-
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("No endpoint protocol was provided.")
     }
 
     @Test
@@ -67,9 +68,10 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.1.protocolVersion" to "1",
         )
 
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("Provided endpoint URLs are incorrectly numbered.")
     }
 
     @Test
@@ -90,9 +92,10 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.1.protocolVersion" to "1",
         )
 
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("Provided endpoint protocols are incorrectly numbered.")
     }
 
     @Test
@@ -104,9 +107,10 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.1.protocolVersion" to "1",
         )
 
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("Endpoint URL ('hi there') is not a valid URL.")
     }
 
     @Test
@@ -118,9 +122,10 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.1.protocolVersion" to "1",
         )
 
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("The port of the endpoint URL ('https://r3.com/') was not specified or had an invalid value.")
     }
 
     @Test
@@ -132,9 +137,10 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.1.protocolVersion" to "1",
         )
 
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("The host of the endpoint URL ('https://:4995/') was not specified or had an invalid value.")
     }
 
     @Test
@@ -146,9 +152,10 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.1.protocolVersion" to "1",
         )
 
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("The scheme of the endpoint URL ('http://www.corda.net:8888') was not https.")
     }
 
     @Test
@@ -160,8 +167,9 @@ class P2pEndpointVerifierTest {
             "corda.endpoints.1.protocolVersion" to "1",
         )
 
-        assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
-        }
+        }.isInstanceOf(IllegalArgumentException::class.java)
+         .hasMessageContaining("Endpoint URL ('https://username:password@www.corda.net:8888') had user info specified, which must not be specified.")
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/P2pEndpointVerifierTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/P2pEndpointVerifierTest.kt
@@ -170,6 +170,7 @@ class P2pEndpointVerifierTest {
         assertThatThrownBy {
             p2pEndpointVerifier.verifyContext(context)
         }.isInstanceOf(IllegalArgumentException::class.java)
-         .hasMessageContaining("Endpoint URL ('https://username:password@www.corda.net:8888') had user info specified, which must not be specified.")
+         .hasMessageContaining("Endpoint URL ('https://username:password@www.corda.net:8888') " +
+                 "had user info specified, which must not be specified.")
     }
 }


### PR DESCRIPTION
This change improves the error messages shown when one of the endpoint URLs are invalid. Previously, the order of checks was slightly incorrect and if someone provided a URI with an invalid host, they would get an error about port (see related ticket for more details). This re-orders the checks and adds an extra check for a completely invalid URL. 