### PR TITLE
CORE-9973 Flow mapper received session event for session which does not exist

### DIFF
--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
@@ -1,7 +1,5 @@
 package net.corda.session.manager.impl
 
-import java.nio.ByteBuffer
-import java.time.Instant
 import net.corda.data.chunking.Chunk
 import net.corda.data.flow.event.MessageDirection
 import net.corda.data.flow.event.SessionEvent
@@ -9,6 +7,7 @@ import net.corda.data.flow.event.session.SessionAck
 import net.corda.data.flow.event.session.SessionClose
 import net.corda.data.flow.event.session.SessionData
 import net.corda.data.flow.event.session.SessionError
+import net.corda.data.flow.event.session.SessionInit
 import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.data.identity.HoldingIdentity
@@ -25,6 +24,8 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.time.Instant
 
 @Component
 class SessionManagerImpl @Activate constructor(
@@ -182,12 +183,15 @@ class SessionManagerImpl @Activate constructor(
         config: SmartConfig,
     ): List<SessionEvent> {
         //get all events with a timestamp in the past, as well as any acks or errors
-        val sessionEvents = sessionState.sendEventsState.undeliveredMessages.filter {
-            it.timestamp <= instant || it.payload is SessionError
-        }
+        val eventsToSend = sessionState.sendEventsState.undeliveredMessages.filter(
+            when (sessionState.status) {
+                SessionStateType.CREATED -> { event: SessionEvent -> event.payload is SessionInit && event.timestamp <= instant }
+                else -> { event: SessionEvent -> event.timestamp <= instant || event.payload is SessionError }
+            }
+        )
 
         //update events with the latest ack info from the current state
-        sessionEvents.forEach { eventToSend ->
+        eventsToSend.forEach { eventToSend ->
             eventToSend.receivedSequenceNum = sessionState.receivedEventsState.lastProcessedSequenceNum
             eventToSend.outOfOrderSequenceNums = sessionState.receivedEventsState.undeliveredMessages.map { it.sequenceNum }
         }
@@ -196,7 +200,7 @@ class SessionManagerImpl @Activate constructor(
         val messageResendWindow = config.getLong(SESSION_MESSAGE_RESEND_WINDOW)
         updateSessionStateSendEvents(sessionState, instant, messageResendWindow)
 
-        return sessionEvents
+        return eventsToSend
     }
 
     /**


### PR DESCRIPTION
Session initiation is triggered from within the flow engine after a session is interacted with for the first time, i.e from the client code calling send or receive. For calls to send, we will send the SessionInit and the SessionData messages at the same time. This could result in the scenario of the flow mapper receiving the data first and sending back an error.  

This will be fixed by changing the session manager getMessagesToSend function. If there is a SessionInit message in the send queue then only send the SessionInit message, ignore other pending messages. Otherwise send all messages in the queue as normal. After the SessionInit is acknowledged by the other side it will be automatically removed from the send queue which will free up other messages to be sent.
