### PR TITLE
CORE-11706 CORE-11710 CORE-12341 Fix notary composite key threshold and use correct checking function

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -211,14 +211,11 @@ data class UtxoSignedTransactionImpl(
         }.toSet()
         // If the notary service key (composite key) is provided we need to make sure it contains the key the
         // transaction was signed with. This means it was signed with one of the notary VNodes (worker).
-        if (!KeyUtils.isKeyInSet(
-                notaryKey,
-                notaryPublicKeysWithValidSignatures
-            )
-        ) {
+        if (!KeyUtils.isKeyFulfilledBy(notaryKey, notaryPublicKeysWithValidSignatures)) {
             throw TransactionSignatureException(
                 id,
-                "There are no notary signatures attached to the transaction.",
+                "Notary signing keys $notaryPublicKeysWithValidSignatures did not fulfil " +
+                        "requirements of notary service key $notaryKey",
                 null
             )
         }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
@@ -54,7 +54,7 @@ internal class UtxoSignedTransactionImplTest: UtxoLedgerTest() {
     }
 
     @Test
-    fun `verifyAttachedNotarySignature throws on unnotarized transaction`() {
+    fun `verifyNotarySignatureAttached throws on unnotarized transaction`() {
         Assertions.assertThatThrownBy { signedTransaction.verifyAttachedNotarySignature() }.isInstanceOf(
             TransactionSignatureException::class.java)
             .hasMessageContaining("There are no notary")
@@ -62,8 +62,7 @@ internal class UtxoSignedTransactionImplTest: UtxoLedgerTest() {
     }
 
     @Test
-    @Disabled("Composite key validation does not look correct at the moment.")
-    fun `verifyAttachedNotarySignature does not throw on notarized transaction`() {
+    fun `verifyNotarySignature does not throw on notarized transaction`() {
         val sig = getSignatureWithMetadataExample(notaryNode1PublicKey)
         signedTransaction = signedTransaction.addSignature(sig)
         assertDoesNotThrow {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
@@ -56,7 +56,7 @@ internal class UtxoSignedTransactionImplTest: UtxoLedgerTest() {
     fun `verifyAttachedNotarySignature throws on unnotarized transaction`() {
         Assertions.assertThatThrownBy { signedTransaction.verifyAttachedNotarySignature() }.isInstanceOf(
             TransactionSignatureException::class.java)
-            .hasMessageContaining("There are no notary")
+            .hasMessageContaining("did not fulfil requirements of notary service key")
 
     }
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
@@ -54,7 +54,7 @@ internal class UtxoSignedTransactionImplTest: UtxoLedgerTest() {
     }
 
     @Test
-    fun `verifyNotarySignatureAttached throws on unnotarized transaction`() {
+    fun `verifyAttachedNotarySignature throws on unnotarized transaction`() {
         Assertions.assertThatThrownBy { signedTransaction.verifyAttachedNotarySignature() }.isInstanceOf(
             TransactionSignatureException::class.java)
             .hasMessageContaining("There are no notary")
@@ -62,7 +62,7 @@ internal class UtxoSignedTransactionImplTest: UtxoLedgerTest() {
     }
 
     @Test
-    fun `verifyNotarySignature does not throw on notarized transaction`() {
+    fun `verifyAttachedNotarySignature does not throw on notarized transaction`() {
         val sig = getSignatureWithMetadataExample(notaryNode1PublicKey)
         signedTransaction = signedTransaction.addSignature(sig)
         assertDoesNotThrow {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImplTest.kt
@@ -13,7 +13,6 @@ import net.corda.v5.ledger.common.transaction.TransactionSignatureException
 import net.corda.v5.membership.NotaryInfo
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows

--- a/libs/membership/membership-impl/build.gradle
+++ b/libs/membership/membership-impl/build.gradle
@@ -5,15 +5,6 @@ plugins {
 
 description 'Membership implementation'
 
-kotlin {
-    target {
-        compilations.integrationTest {
-            // Needed to expose internal LayeredContextImpl class to this task
-            associateWith compilations.test
-        }
-    }
-}
-
 dependencies {
     api project(':libs:layered-property-map')
 

--- a/libs/membership/membership-impl/build.gradle
+++ b/libs/membership/membership-impl/build.gradle
@@ -5,6 +5,15 @@ plugins {
 
 description 'Membership implementation'
 
+kotlin {
+    target {
+        compilations.integrationTest {
+            // Needed to expose internal LayeredContextImpl class to this task
+            associateWith compilations.test
+        }
+    }
+}
+
 dependencies {
     api project(':libs:layered-property-map')
 

--- a/libs/membership/membership-impl/src/integrationTest/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverterIntegrationTest.kt
+++ b/libs/membership/membership-impl/src/integrationTest/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverterIntegrationTest.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.impl.CompositeKeyProviderImpl
 import net.corda.crypto.impl.converter.PublicKeyConverter
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
+import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.KeyUtils
 import net.corda.v5.membership.NotaryInfo
@@ -63,9 +64,11 @@ class NotaryInfoConverterIntegrationTest {
         }
     }
 
+    private class TestContext(map: LayeredPropertyMap) : LayeredPropertyMap by map
+
     private fun convertToNotaryInfo(context: SortedMap<String, String>): NotaryInfo =
         converters.find { it.type == NotaryInfo::class.java }?.convert(
-            LayeredPropertyMapMocks.createConversionContext<LayeredContextImpl>(
+            LayeredPropertyMapMocks.createConversionContext<TestContext>(
                 context,
                 converters,
                 ""

--- a/libs/membership/membership-impl/src/integrationTest/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverterIntegrationTest.kt
+++ b/libs/membership/membership-impl/src/integrationTest/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverterIntegrationTest.kt
@@ -1,0 +1,87 @@
+package net.corda.membership.lib.impl.converter
+
+import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.impl.CompositeKeyProviderImpl
+import net.corda.crypto.impl.converter.PublicKeyConverter
+import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.crypto.KeyUtils
+import net.corda.v5.membership.NotaryInfo
+import org.assertj.core.api.SoftAssertions.assertSoftly
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.security.KeyPairGenerator
+import java.security.PublicKey
+import java.util.SortedMap
+
+class NotaryInfoConverterIntegrationTest {
+    @Suppress("SpreadOperator")
+    private companion object {
+        val notaryService = MemberX500Name.parse("O=NotaryService,L=London,C=GB")
+        const val NOTARY_PROTOCOL = "testProtocol"
+        const val NAME = "name"
+        const val PROTOCOL = "flow.protocol.name"
+        const val PROTOCOL_VERSIONS = "flow.protocol.version.%s"
+        const val KEYS = "keys.%s"
+        const val KEY_VALUE_1 = "encoded_key1"
+        const val KEY_VALUE_2 = "encoded_key2"
+        val key1: PublicKey = KeyPairGenerator.getInstance("DSA").genKeyPair().public
+        val key2: PublicKey = KeyPairGenerator.getInstance("DSA").genKeyPair().public
+        val keyEncodingService: KeyEncodingService = mock {
+            on { encodeAsString(key1) } doReturn KEY_VALUE_1
+            on { encodeAsString(key2) } doReturn KEY_VALUE_2
+            on { decodePublicKey(KEY_VALUE_1) } doReturn key1
+            on { decodePublicKey(KEY_VALUE_2) } doReturn key2
+        }
+        val notaryKeys = listOf(key1, key2)
+
+        val correctContext = sortedMapOf(
+            NAME to notaryService.toString(),
+            PROTOCOL to NOTARY_PROTOCOL,
+            *convertNotaryProtocolVersions().toTypedArray(),
+            *convertNotaryKeys().toTypedArray()
+        )
+
+        val converters = listOf(
+            NotaryInfoConverter(CompositeKeyProviderImpl()),
+            PublicKeyConverter(keyEncodingService)
+        )
+
+        fun convertNotaryKeys(): List<Pair<String, String>> =
+            notaryKeys.mapIndexed { i, notaryKey ->
+                String.format(
+                    KEYS,
+                    i
+                ) to keyEncodingService.encodeAsString(notaryKey)
+            }
+
+        fun convertNotaryProtocolVersions(): List<Pair<String, String>> = List(3) { index ->
+            String.format(
+                PROTOCOL_VERSIONS, index
+            ) to (index + 1).toString()
+        }
+    }
+
+    private fun convertToNotaryInfo(context: SortedMap<String, String>): NotaryInfo =
+        converters.find { it.type == NotaryInfo::class.java }?.convert(
+            LayeredPropertyMapMocks.createConversionContext<LayeredContextImpl>(
+                context,
+                converters,
+                ""
+            )
+        ) as NotaryInfo
+
+    @Test
+    fun `converter converts notary service info successfully for multiple notary vnodes`() {
+        val result = convertToNotaryInfo(correctContext)
+        assertSoftly {
+            it.assertThat(result.name).isEqualTo(notaryService)
+            it.assertThat(result.protocol).isEqualTo(NOTARY_PROTOCOL)
+            it.assertThat(result.protocolVersions).containsExactlyInAnyOrder(1, 2, 3)
+            // Any notary vnode key should satisfy the composite key
+            it.assertThat(KeyUtils.isKeyFulfilledBy(result.publicKey, key1)).isEqualTo(true)
+            it.assertThat(KeyUtils.isKeyFulfilledBy(result.publicKey, key2)).isEqualTo(true)
+        }
+    }
+}

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/LayeredContextImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/LayeredContextImpl.kt
@@ -1,7 +1,0 @@
-package net.corda.membership.lib.impl.converter
-
-import net.corda.v5.base.types.LayeredPropertyMap
-
-internal class LayeredContextImpl(
-    private val map: LayeredPropertyMap
-) : LayeredPropertyMap by map

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverter.kt
@@ -48,7 +48,7 @@ class NotaryInfoConverter @Activate constructor(
             name,
             protocol,
             protocolVersions,
-            compositeKeyProvider.create(keysWithWeight, null)
+            compositeKeyProvider.create(keysWithWeight, 1)
         )
     }
 }

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/SignedGroupParametersImplTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/SignedGroupParametersImplTest.kt
@@ -20,6 +20,7 @@ import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -44,7 +45,7 @@ class SignedGroupParametersImplTest {
         on { decodePublicKey(KEY) } doReturn key
     }
     private val compositeKeyProvider: CompositeKeyProvider = mock {
-        on { create(eq(listOf(compositeKeyNodeAndWeight)), eq(null)) } doReturn compositeKey
+        on { create(eq(listOf(compositeKeyNodeAndWeight)), any()) } doReturn compositeKey
     }
 
 

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/UnsignedGroupParametersImplTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/UnsignedGroupParametersImplTest.kt
@@ -18,6 +18,7 @@ import net.corda.v5.crypto.CompositeKeyNodeAndWeight
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -42,7 +43,7 @@ class UnsignedGroupParametersImplTest {
         on { decodePublicKey(KEY) } doReturn key
     }
     private val compositeKeyProvider: CompositeKeyProvider = mock {
-        on { create(eq(listOf(compositeKeyNodeAndWeight)), eq(null)) } doReturn compositeKey
+        on { create(eq(listOf(compositeKeyNodeAndWeight)), any()) } doReturn compositeKey
     }
     private val serializedParameters = "group-params".toByteArray()
 

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverterTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverterTest.kt
@@ -5,6 +5,7 @@ import net.corda.crypto.core.CompositeKeyProvider
 import net.corda.crypto.impl.converter.PublicKeyConverter
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.v5.base.exceptions.ValueNotFoundException
+import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKeyNodeAndWeight
 import net.corda.v5.membership.NotaryInfo
@@ -96,9 +97,11 @@ class NotaryInfoConverterTest {
         }
     }
 
+    private class TestContext(map: LayeredPropertyMap) : LayeredPropertyMap by map
+
     private fun convertToNotaryInfo(context: SortedMap<String, String>): NotaryInfo =
         converters.find { it.type == NotaryInfo::class.java }?.convert(
-            LayeredPropertyMapMocks.createConversionContext<LayeredContextImpl>(
+            LayeredPropertyMapMocks.createConversionContext<TestContext>(
                 context,
                 converters,
                 ""

--- a/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverterTest.kt
+++ b/libs/membership/membership-impl/src/test/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverterTest.kt
@@ -12,6 +12,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -40,8 +41,8 @@ class NotaryInfoConverterTest {
             CompositeKeyNodeAndWeight(it, 1)
         }
         val compositeKeyProvider: CompositeKeyProvider = mock {
-            on { create(eq(weightedKeys), eq(null)) } doReturn compositeKeyForNonEmptyKeys
-            on { create(eq(emptyList()), eq(null)) } doReturn compositeKeyForEmptyKeys
+            on { create(eq(weightedKeys), any()) } doReturn compositeKeyForNonEmptyKeys
+            on { create(eq(emptyList()), any()) } doReturn compositeKeyForEmptyKeys
         }
 
         val correctContext = sortedMapOf(

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -235,7 +235,7 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
 
                     repeat(outputStateCount) {
                         builder = builder.addOutputState(
-                            TestUtxoState("test", emptyList(), emptyList())
+                            TestUtxoState(1,"test", emptyList(), emptyList())
                         )
                     }
 

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -108,11 +108,8 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
                 findSignatureKeyFromKeyId(signatureKeyId, notaryServiceInfo.publicKey)
                     ?: throw IllegalStateException("Signatory key id doesn't match received signature key id")
 
-            // TODO The below check is redundant now
-            // Since we are not calling finality flow for consuming transactions we need to verify that the signature
-            // is actually part of the notary service's composite key
             signatures.forEach {
-                require(KeyUtils.isKeyInSet(notaryServiceInfo.publicKey, setOf(notaryKeyThatSigned))) {
+                require(KeyUtils.isKeyFulfilledBy(notaryServiceInfo.publicKey, setOf(notaryKeyThatSigned))) {
                     "The plugin responded with a signature that is not part of the notary service's composite key."
                 }
             }
@@ -238,7 +235,7 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
 
                     repeat(outputStateCount) {
                         builder = builder.addOutputState(
-                            TestUtxoState(1, "test", emptyList(), emptyList())
+                            TestUtxoState("test", emptyList(), emptyList())
                         )
                     }
 


### PR DESCRIPTION
### Summary

This PR makes two changes to resolve issues with notary composite keys and checking:

- `NotaryInfoConverter` now correctly sets the threshold on the composite key for the notary service to 1 (addressing [CORE-11706](https://r3-cev.atlassian.net/browse/CORE-11706). This reflects the fact that a signature by any one of the notary virtual nodes constitutes a valid signature for the notary service. This behavior is not testable directly due to the current artificial restriction of a 1-1 mapping between notary virtual node and notary service, so a new integration test has been written to verify this behavior works as intended.
- Notary key checking now uses `isKeyFulfilledBy` instead of `isKeyInSet` (addressing [CORE-11710](https://r3-cev.atlassian.net/browse/CORE-11710)). This was always the correct API call to use, but was not possible due to the issue addressed in the first point.

As part of this change, the redundant `LayeredContextImpl` class that was only used by tests has also been removed (addressing [CORE-12341](https://r3-cev.atlassian.net/browse/CORE-12341))

### Testing

Existing automated test scenarios have been updated to reflect the change in behavior. New integration test written to verify the notary composite key behavior that is not currently reachable in a real system. All automated tests confirmed to pass.

[CORE-11706]: https://r3-cev.atlassian.net/browse/CORE-11706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-11710]: https://r3-cev.atlassian.net/browse/CORE-11710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CORE-12341]: https://r3-cev.atlassian.net/browse/CORE-12341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ