### PR TITLE
CORE-12177 - Disabled the test ExternalChannelsConfigValidatorTest

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/test/kotlin/net/corda/chunking/db/impl/validation/ExternalChannelsConfigValidatorTest.kt
@@ -5,12 +5,14 @@ import net.corda.libs.configuration.validation.ConfigurationValidationException
 import net.corda.libs.configuration.validation.impl.ConfigurationValidatorFactoryImpl
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.packaging.core.CpkMetadata
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@Disabled("Temporary until the api is updated")
 class ExternalChannelsConfigValidatorTest {
 
     private val cordappConfigValidator =


### PR DESCRIPTION
The test is temporary disabled. This is to avoid updating the api version number due to the breaking changes made in the PR 1035. The test will be enabled again once the PR https://github.com/corda/corda-api/pull/1035/files is merge.