### PR TITLE
CORE-12316: Upgrade to Kotlin 1.8.20.

### DIFF
--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
@@ -18,6 +18,7 @@ import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -62,10 +63,9 @@ class QueryRegistrationRequestsHandlerTest {
     private val order = mock<Order>()
     private val query = mock<CriteriaQuery<RegistrationRequestEntity>> {
         on { from(RegistrationRequestEntity::class.java) } doReturn root
-        on { select(root) } doReturn mock
-        on { where() } doReturn mock
-        on { where(any()) } doReturn mock
-        on { orderBy(order) } doReturn mock
+        on { select(any()) } doReturn mock
+        on { where(anyVararg()) } doReturn mock
+        on { orderBy(anyVararg<Order>()) } doReturn mock
     }
     private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>> {
         on { deserialize(any()) } doReturn KeyValuePairList(emptyList())
@@ -104,9 +104,7 @@ class QueryRegistrationRequestsHandlerTest {
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { cordaAvroSerializationFactory } doReturn serializationFactory
     }
-    private val context = mock<MembershipRequestContext> {
-        on { holdingIdentity } doReturn holdingIdentity
-    }
+    private val context = MembershipRequestContext(Instant.ofEpochSecond(0), null, holdingIdentity)
 
     private val handler = QueryRegistrationRequestsHandler(service)
 

--- a/components/virtual-node/virtual-node-write-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-write-service-impl/build.gradle
@@ -52,4 +52,5 @@ dependencies {
 
     testRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     testRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # General repository setup properties
 artifactoryContextUrl=https://software.r3.com/artifactory
 kotlin.code.style=official
-kotlinVersion=1.8.10
+kotlinVersion=1.8.20
 kotlin.stdlib.default.dependency=false
 kotlinMetadataVersion = 0.6.0
 


### PR DESCRIPTION
Upgrade Kotlin 1.8.10 -> 1.8.20.

Kotlin 1.8.20 and Mockito do not appear to want to play "nicely" with each other, for reasons unknown. But something seems to be breaking "equality matching" when mocks are involved.

Some of these mock-heavy tests - e.g. _Mock Hibernate?!_ - may be more useful if rewritten as integration tests with a _real_ database.