### PR TITLE
CORE-12318: Record the exception stack trace when checkpointing fails.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -35,7 +35,7 @@ class FlowFiberImpl(
     private var flowCompletion = CompletableFuture<FlowIORequest<*>>()
 
     @Transient
-    var suspensionOutcome: FlowContinuation? = null
+    private var suspensionOutcome: FlowContinuation? = null
 
     override fun getExecutionContext(): FlowFiberExecutionContext {
         return flowFiberExecutionContext!!

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/KryoCheckpointSerializer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/KryoCheckpointSerializer.kt
@@ -34,7 +34,7 @@ class KryoCheckpointSerializer(
                 kryo.writeClassAndObject(this, obj)
             }
         } catch (ex: Exception) {
-            log.error("Failed to serialize: $ex")
+            log.error("Failed to serialize", ex)
             throw ex
         }
     }


### PR DESCRIPTION
We don't expect serializing a checkpoint to fail, and so we can afford to log the stack trace whenever it does! This will also allow someone to debug the problem.

There is also no reason for the fiber's `suspensionOutcome` property to be public.