### PR TITLE
CORE-12169: Configuration service should be up only when it's ready

### DIFF
--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
@@ -106,9 +106,11 @@ internal class ConfigReadServiceEventHandler(
             }
 
             is RegistrationStatusChangeEvent -> {
-                // Only registration is on the subscription
+                // Only registration is on the subscriptions
                 if (event.status == LifecycleStatus.UP) {
-                    coordinator.updateStatus(LifecycleStatus.UP)
+                    if (event.registration == configSubReg) {
+                        coordinator.updateStatus(LifecycleStatus.UP)
+                    }
                 } else {
                     coordinator.updateStatus(LifecycleStatus.DOWN)
                 }

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
@@ -106,7 +106,7 @@ internal class ConfigReadServiceEventHandler(
             }
 
             is RegistrationStatusChangeEvent -> {
-                // Only registration is on the subscriptions
+                // Only set LifecycleStatus.UP for coordinator after the config subscription is UP
                 if (event.status == LifecycleStatus.UP) {
                     if (event.registration == configSubReg) {
                         coordinator.updateStatus(LifecycleStatus.UP)

--- a/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandlerTest.kt
+++ b/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandlerTest.kt
@@ -138,7 +138,7 @@ internal class ConfigReadServiceEventHandlerTest {
         verify(configSubscription).start()
 
         configReadServiceEventHandler.processEvent(
-            RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP),
+            RegistrationStatusChangeEvent(configSubReg, LifecycleStatus.UP),
             coordinator
         )
         verify(coordinator).updateStatus(capture(lifecycleStatusCaptor), any())

--- a/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigurationReadServiceTest.kt
+++ b/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigurationReadServiceTest.kt
@@ -77,6 +77,9 @@ internal class ConfigurationReadServiceTest {
             verifyIsDown(subName)
             verifyIsDown<ConfigurationReadService>()
             bringDependenciesUp()
+            coordinatorFactory.registry.getCoordinator(
+                LifecycleCoordinatorName.forComponent<ConfigurationReadService>()
+            ).postEvent(SetupConfigSubscription())
             verifyIsUp<ConfigurationReadService>()
 
             repeat(5) {

--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
@@ -213,20 +213,20 @@ class LinkManagerIntegrationTest {
             logger.info("Publishing valid configuration")
             val validConfig = createLinkManagerConfiguration(replayPeriod)
             configPublisher.publishLinkManagerConfig(validConfig)
-            eventually(duration = 10.seconds) {
+            eventually(duration = 15.seconds) {
                 assertThat(linkManager.isRunning).isTrue
             }
 
             logger.info("Publishing invalid configuration")
             val invalidConfig = createLinkManagerConfiguration(-1)
             configPublisher.publishLinkManagerConfig(invalidConfig)
-            eventually(duration = 10.seconds) {
+            eventually(duration = 15.seconds) {
                 assertThat(linkManager.dominoTile.status).isEqualTo(LifecycleStatus.DOWN)
             }
 
             logger.info("Publishing valid configuration again")
             configPublisher.publishLinkManagerConfig(validConfig)
-            eventually(duration = 10.seconds) {
+            eventually(duration = 15.seconds) {
                 assertThat(linkManager.isRunning).isTrue
             }
         }

--- a/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
+++ b/components/membership/membership-group-read-impl/src/integrationTest/kotlin/net/corda/membership/impl/read/MembershipGroupReaderProviderIntegrationTest.kt
@@ -207,7 +207,7 @@ class MembershipGroupReaderProviderIntegrationTest {
 
     private fun MembershipGroupReaderProvider.getAliceGroupReader(): MembershipGroupReader {
         logger.info("Getting group reader for test.")
-        return eventually(duration = 10.seconds) {
+        return eventually(duration = 15.seconds) {
             assertDoesNotThrow {
                 getGroupReader(aliceHoldingIdentity)
             }

--- a/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
+++ b/components/membership/membership-p2p-impl/src/integrationTest/kotlin/net/corda/membership/impl/p2p/MembershipP2PIntegrationTest.kt
@@ -230,7 +230,7 @@ class MembershipP2PIntegrationTest {
                 messagingConfig = bootConfig
             ).also { it.start() }
 
-            eventually(duration = 10.seconds) {
+            eventually(duration = 15.seconds) {
                 logger.info("Waiting for required services to start...")
                 assertThat(coordinator.status).isEqualTo(LifecycleStatus.UP)
                 logger.info("Required services started.")

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -518,7 +518,7 @@ class MembershipPersistenceTest {
 
         private fun Lifecycle.startAndWait() {
             start()
-            eventually(10.seconds) {
+            eventually(15.seconds) {
                 assertTrue(isRunning)
             }
         }

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -229,7 +229,7 @@ class MemberRegistrationIntegrationTest {
                 )
             )
 
-            eventually(10.seconds) {
+            eventually(15.seconds) {
                 logger.info("Waiting for required services to start...")
                 assertThat(coordinator.status).isEqualTo(LifecycleStatus.UP)
                 logger.info("Required services started.")

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/osgitests/MessageBusIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/osgitests/MessageBusIntegrationTests.kt
@@ -46,6 +46,7 @@ import net.corda.uniqueness.checker.UniquenessChecker
 import net.corda.uniqueness.checker.impl.BatchedUniquenessCheckerImpl
 import net.corda.uniqueness.utils.UniquenessAssertions
 import net.corda.uniqueness.utils.UniquenessAssertions.assertUnknownInputStateResponse
+import net.corda.utilities.seconds
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
@@ -322,7 +323,7 @@ class MessageBusIntegrationTests {
         externalEventResponseMonitor =
             TestExternalEventResponseMonitor(subscriptionFactory, bootConfig)
 
-        eventually {
+        eventually(15.seconds) {
             logger.info("Waiting for required services to start...")
             assertThat(coordinator.status).isEqualTo(LifecycleStatus.UP)
             logger.info("Required services started.")

--- a/testing/flow/external-events/src/main/kotlin/net/corda/test/flow/external/events/TestExternalEventResponseMonitor.kt
+++ b/testing/flow/external-events/src/main/kotlin/net/corda/test/flow/external/events/TestExternalEventResponseMonitor.kt
@@ -37,7 +37,7 @@ class TestExternalEventResponseMonitor(
      */
     fun getResponses(
         requestIds: Collection<String>,
-        timeout: Duration = Duration.ofSeconds(10)
+        timeout: Duration = Duration.ofSeconds(15)
     ) : Map<String, ExternalEventResponse> {
 
         val responses = requestIds.associateWith { CompletableFuture<ExternalEventResponse>() }


### PR DESCRIPTION
1. The `ConfigReadServiceEventHandler` follows two subscriptions; it should be marked as up only when the last one is UP.
2. Increase timeouts of some of the tests.