### PR TITLE
CORE-12178 - Document rules for X.500 names

### DIFF
--- a/wiki/X500-Name-rules.md
+++ b/wiki/X500-Name-rules.md
@@ -2,12 +2,13 @@
 
 Each virtual node within an application network is uniquely identified by its X.500 distinguished name. 
 The rules for a valid X.500 name in Corda are the following:
+* The string specified must use the grammar defined in RFC 1779 or RFC 2253.
 * The only supported attributes are CN, OU, O, L, ST, C.
 * Attributes cannot be duplicated and must have a single value.
 * The attributes O, L, C are mandatory.
 * The Organization attribute (O) cannot be blank and must be less than 128 characters.
 * The Locality attribute (L) cannot be blank and must be less than 64 characters.
-* The Country attribute (C) cannot be blank and must be an ISO 3166-1 2-letter country code.
+* The Country attribute (C) cannot be blank and must be an ISO 3166-1 2-letter country code or "ZZ" to indicate unspecified country.
 * If specified, the State attribute (ST) cannot be blank and must be less than 64 characters.
 * If specified, the Organization unit attribute (OU) cannot be blank and must be less than 64 characters.
 * If specified, the Common Name attribute (CN) cannot be blank and must be less than 64 characters.

--- a/wiki/X500-Name-rules.md
+++ b/wiki/X500-Name-rules.md
@@ -1,0 +1,13 @@
+# Rules for X500 names of virtual nodes
+
+Each virtual node within an application network is uniquely identified by its X.500 distinguished name. 
+The rules for a valid X.500 name in Corda are the following:
+* The only supported attributes are CN, OU, O, L, ST, C.
+* Attributes cannot be duplicated and must have a single value.
+* The attributes O, L, C are mandatory.
+* The Organization attribute (O) cannot be blank and must be less than 128 characters.
+* The Locality attribute (L) cannot be blank and must be less than 64 characters.
+* The Country attribute (C) cannot be blank and must be an ISO 3166-1 2-letter country code.
+* If specified, the State attribute (ST) cannot be blank and must be less than 64 characters.
+* If specified, the Organization unit attribute (OU) cannot be blank and must be less than 64 characters.
+* If specified, the Common Name attribute (CN) cannot be blank and must be less than 64 characters.


### PR DESCRIPTION
Documenting current platform rules for X.500 names of virtual nodes.

Rules were retrieved from the `MemberX500Name` type.