### PR TITLE
CORE-11836 - Hide mgm plugin commands that are not ready for external use yet

### DIFF
--- a/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoard.kt
+++ b/tools/plugins/mgm/src/main/kotlin/net/corda/cli/plugins/mgm/OnBoard.kt
@@ -9,6 +9,7 @@ import picocli.CommandLine.Command
         OnBoardMember::class,
         AllowClientCertificate::class,
     ],
-    description = ["On board a member."]
+    description = ["On board a member."],
+    hidden = true
 )
 class OnBoard


### PR DESCRIPTION
### Changes
Hiding mgm plugin commands that are not ready for external use yet from the usage help of the parent command. Note that these commands will still be executable, so that we can use them for internal testing but they shouldn't be discoverable by end users that don't know about them and so they will be considered unsupported at the moment. Also, I elected to not hide subcommands of `onboard` as well, so that it's a bit easier to use internally by us.

### Testing
Downloaded the CLI from [here](https://docs.r3.com/en/platform/corda/5.0-beta/developing/getting-started/installing-corda-cli.html) and replaced the mgm plugin with one built locally with the changes.

Running:
```
java -jar corda-cli.jar mgm
```
gives (`onboard` command not visible anymore):
```
Usage: corda mgm [COMMAND]
Plugin for membership operations.
Commands:
  groupPolicy  Generates GroupPolicy.json file.
```