### PR TITLE
CORE-8151 Provide default digest algorithm and supported digest algorithms APIs

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
-import net.corda.crypto.core.CryptoConsts.Categories.LEDGER
 import net.corda.e2etest.utilities.FlowStatus
 import net.corda.e2etest.utilities.GROUP_ID
 import net.corda.e2etest.utilities.RPC_FLOW_STATUS_FAILED
@@ -15,7 +14,6 @@ import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
 import net.corda.e2etest.utilities.awaitRpcFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.configWithDefaultsNode
-import net.corda.e2etest.utilities.createKeyFor
 import net.corda.e2etest.utilities.getConfig
 import net.corda.e2etest.utilities.getFlowClasses
 import net.corda.e2etest.utilities.getHoldingIdShortHash
@@ -40,8 +38,6 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api.TestMethodOrder
 import java.util.UUID
-import net.corda.v5.application.flows.FlowContextPropertyKeys
-import net.corda.v5.crypto.KeySchemeCodes.RSA_CODE_NAME
 import kotlin.text.Typography.quote
 
 @Suppress("Unused", "FunctionName")
@@ -707,6 +703,32 @@ class FlowTests {
         assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
         assertThat(result.flowResult).isNotNull
         assertThat(flowResult.command).isEqualTo("crypto_CompositeKeyGenerator_works_in_flows")
+        assertThat(flowResult.result).isEqualTo("SUCCESS")
+    }
+
+    @Test
+    fun `Crypto - Get default digest algorithm`() {
+        val requestBody = RpcSmokeTestInput()
+        requestBody.command = "crypto_get_default_digest_algorithm"
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+        val result = awaitRpcFlowFinished(bobHoldingId, requestId)
+        val flowResult = result.getRpcFlowResult()
+        assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result.flowResult).isNotNull
+        assertThat(flowResult.command).isEqualTo("crypto_get_default_digest_algorithm")
+        assertThat(flowResult.result).isEqualTo("SUCCESS")
+    }
+
+    @Test
+    fun `Crypto - Get supported digest algorithms`() {
+        val requestBody = RpcSmokeTestInput()
+        requestBody.command = "crypto_get_supported_digest_algorithms"
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+        val result = awaitRpcFlowFinished(bobHoldingId, requestId)
+        val flowResult = result.getRpcFlowResult()
+        assertThat(result.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(result.flowResult).isNotNull
+        assertThat(flowResult.command).isEqualTo("crypto_get_supported_digest_algorithms")
         assertThat(flowResult.result).isEqualTo("SUCCESS")
     }
 

--- a/components/virtual-node/sandbox-crypto/src/main/kotlin/net/corda/sandbox/crypto/DigestAlgorithmFactoryProviderImpl.kt
+++ b/components/virtual-node/sandbox-crypto/src/main/kotlin/net/corda/sandbox/crypto/DigestAlgorithmFactoryProviderImpl.kt
@@ -26,7 +26,7 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 )
 class DigestAlgorithmFactoryProviderImpl @Activate constructor()
     : DigestAlgorithmFactoryProvider, UsedByFlow, UsedByPersistence, UsedByVerification, CustomMetadataConsumer {
-    private val provider = mutableMapOf<String, DigestAlgorithmFactory>()
+    private val provider = linkedMapOf<String, DigestAlgorithmFactory>()
 
     override fun accept(context: MutableSandboxGroupContext) {
         context.getMetadataServices<DigestAlgorithmFactory>().forEach { factory ->
@@ -37,4 +37,9 @@ class DigestAlgorithmFactoryProviderImpl @Activate constructor()
     override fun get(algorithmName: String): DigestAlgorithmFactory? {
         return provider[algorithmName]
     }
+
+    override fun getAllDigestAlgorithmNames(): Set<String> =
+        provider.mapTo(linkedSetOf()) {
+            it.key
+        }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.745-beta+
+cordaApiVersion=5.0.0.746-alpha-1681223007258
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.746-alpha-1681223007258
+cordaApiVersion=5.0.0.746-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
@@ -72,4 +72,16 @@ class DigestServiceImpl @Activate constructor(
         // Check any custom registered versions.
         customFactoriesProvider?.get(digestAlgorithmName.name)
             ?.getInstance()
+
+    override fun defaultDigestAlgorithm(): DigestAlgorithmName =
+        platformDigestService.defaultDigestAlgorithm()
+
+    override fun supportedDigestAlgorithms(): Set<DigestAlgorithmName> {
+        return platformDigestService.supportedDigestAlgorithms() +
+                (customFactoriesProvider?.let {
+                    it.getAllDigestAlgorithmNames().map { algorithmName ->
+                        DigestAlgorithmName(algorithmName)
+                    }
+                } ?: setOf())
+    }
 }

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
@@ -46,6 +46,21 @@ class PlatformDigestServiceImpl @Activate constructor(
             digestFor(platformDigestName).digestLength
         }
 
+    override fun defaultDigestAlgorithm(): DigestAlgorithmName =
+        DigestAlgorithmName.SHA2_256
+
+    companion object {
+        val supportedDigestAlgorithms = linkedSetOf(
+            DigestAlgorithmName.SHA2_256,
+            DigestAlgorithmName.SHA2_256D,
+            DigestAlgorithmName.SHA2_384,
+            DigestAlgorithmName.SHA2_512
+        )
+    }
+
+    override fun supportedDigestAlgorithms(): Set<DigestAlgorithmName> =
+        supportedDigestAlgorithms
+
     private fun digestFor(digestAlgorithmName: DigestAlgorithmName): DigestAlgorithm =
         factories.getOrPut(digestAlgorithmName.name) {
             SpiDigestAlgorithmFactory(schemeMetadata, digestAlgorithmName.name)

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/PlatformDigestService.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/PlatformDigestService.kt
@@ -38,4 +38,14 @@ interface PlatformDigestService {
      * @throws [IllegalArgumentException] if the digest algorithm is not supported.
      */
     fun digestLength(platformDigestName: DigestAlgorithmName): Int
+
+    /**
+     * Returns the defaulted digest algorithm.
+     */
+    fun defaultDigestAlgorithm(): DigestAlgorithmName
+
+    /**
+     * Returns the supported digest algorithms.
+     */
+    fun supportedDigestAlgorithms(): Set<DigestAlgorithmName>
 }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DigestAlgorithmFactoryProvider.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/DigestAlgorithmFactoryProvider.kt
@@ -10,4 +10,6 @@ interface DigestAlgorithmFactoryProvider {
      * Get the [DigestAlgorithmFactory] for the given [algorithmName]
      */
     fun get(algorithmName: String): DigestAlgorithmFactory?
+
+    fun getAllDigestAlgorithmNames(): Set<String>
 }

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/SignatureSpecUtilsTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/SignatureSpecUtilsTests.kt
@@ -91,5 +91,13 @@ class SignatureSpecUtilsTests {
 
         override fun digestLength(platformDigestName: DigestAlgorithmName): Int =
             MessageDigest.getInstance(platformDigestName.name).digestLength
+
+        override fun defaultDigestAlgorithm(): DigestAlgorithmName {
+            TODO("Not yet implemented")
+        }
+
+        override fun supportedDigestAlgorithms(): Set<DigestAlgorithmName> {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/tests/legacy/DigestServiceImpl.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/tests/legacy/DigestServiceImpl.kt
@@ -33,6 +33,14 @@ class DigestServiceImpl : PlatformDigestService {
         return digestFor(platformDigestName).digestLength
     }
 
+    override fun defaultDigestAlgorithm(): DigestAlgorithmName {
+        TODO("Not yet implemented")
+    }
+
+    override fun supportedDigestAlgorithms(): Set<DigestAlgorithmName> {
+        TODO("Not yet implemented")
+    }
+
     private fun digestAs(bytes: ByteArray, digestAlgorithmName: DigestAlgorithmName): ByteArray {
         return digestFor(digestAlgorithmName).get().digest(bytes)
     }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/hashing/SimulatedDigestService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/hashing/SimulatedDigestService.kt
@@ -26,4 +26,12 @@ class SimulatedDigestService : DigestService {
     override fun digestLength(digestName: DigestAlgorithmName): Int {
         TODO("Not yet implemented")
     }
+
+    override fun defaultDigestAlgorithm(): DigestAlgorithmName {
+        TODO("Not yet implemented")
+    }
+
+    override fun supportedDigestAlgorithms(): MutableSet<DigestAlgorithmName> {
+        TODO("Not yet implemented")
+    }
 }

--- a/testing/cpbs/test-cordapp/build.gradle
+++ b/testing/cpbs/test-cordapp/build.gradle
@@ -15,8 +15,10 @@ cordapp {
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
     cordaProvided 'net.corda:corda-application'
+    cordaProvided 'net.corda:corda-crypto-extensions'
     cordaProvided 'net.corda:corda-ledger-utxo'
     cordaProvided 'net.corda:corda-notary-plugin'
+
 
     cordapp project(':testing:bundles:testing-dogs')
     cordapp project(':testing:bundles:cpk-for-duplicate-changelog-testing')

--- a/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/digest/CustomDigest.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/net/cordapp/testing/smoketests/flow/digest/CustomDigest.kt
@@ -1,0 +1,36 @@
+package net.cordapp.testing.smoketests.flow.digest
+
+import net.corda.v5.crypto.extensions.DigestAlgorithm
+import net.corda.v5.crypto.extensions.DigestAlgorithmFactory
+import java.io.InputStream
+
+class CustomDigestFactory : DigestAlgorithmFactory {
+    override fun getAlgorithm(): String =
+        CustomDigestAlgorithm.algorithmName
+
+    override fun getInstance(): DigestAlgorithm =
+        TODO("Not yet implemented")
+}
+
+class CustomDigestAlgorithm : DigestAlgorithm {
+    companion object {
+        const val algorithmName = "CUSTOM_DIGEST"
+    }
+
+    override fun getAlgorithm(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDigestLength(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun digest(bytes: ByteArray): ByteArray {
+        TODO("Not yet implemented")
+    }
+
+    override fun digest(inputStream: InputStream): ByteArray {
+        TODO("Not yet implemented")
+    }
+
+}


### PR DESCRIPTION
- adds and implements default digest algorithm and supported digest algorithms for `PlatformDigestService` to return platform default and supported digest algorithms.
- implements default digest algorithm and supported digest algorithms for `DigestServiceImpl` to delegate to `PlatformDigestService` for platform digest algorithms and also delegate to per sandbox list of custom digest algorithms.

api PR: [#1045](https://github.com/corda/corda-api/pull/1045)