### PR TITLE
CORE-12386: Add logs to registration process, increase e2e test timeout

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/ClusterTestUtils.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/ClusterTestUtils.kt
@@ -273,12 +273,13 @@ fun E2eCluster.register(
             ).apply {
                 assertThat(registrationStatus).isEqualTo("SUBMITTED")
 
-                eventually(duration = 1.minutes, retryAllExceptions = true) {
+                eventually(duration = 3.minutes, retryAllExceptions = true) {
                     val registrationStatus = proxy.checkSpecificRegistrationProgress(member.holdingId, registrationId)
                     assertThat(registrationStatus.registrationStatus)
                         .withFailMessage {
                             "${member.name} failed to get to approved registration state. " +
-                                    "Last state was ${registrationStatus.registrationStatus}"
+                                "Last state was ${registrationStatus.registrationStatus}. " +
+                                "Registration ID was $registrationId"
                         }
                         .isEqualTo(RegistrationStatus.APPROVED)
                 }

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
@@ -272,7 +272,10 @@ class MembershipPersistenceClientImpl(
         registrationRequestStatus: RegistrationStatus,
         reason: String?,
     ): MembershipPersistenceOperation<Unit> {
-        logger.info("Updating the status of a registration request with ID '$registrationId'.")
+        logger.info(
+            "Updating the status of a registration request with" +
+                " ID '$registrationId' to status $registrationRequestStatus."
+        )
         val request = MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
             UpdateRegistrationRequestStatus(registrationId, registrationRequestStatus, reason)

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
@@ -14,7 +14,7 @@ internal class PersistRegistrationRequestHandler(
 
     override fun invoke(context: MembershipRequestContext, request: PersistRegistrationRequest) {
         val registrationId = request.registrationRequest.registrationId
-        logger.info("Persisting registration request with ID [$registrationId].")
+        logger.info("Persisting registration request with ID [$registrationId] to status ${request.status}.")
         transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             val now = clock.instant()
             val currentStatus = em.find(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
@@ -46,7 +46,7 @@ internal class UpdateMemberAndRegistrationRequestToApprovedHandler(
         request: UpdateMemberAndRegistrationRequestToApproved,
     ): UpdateMemberAndRegistrationRequestResponse {
         logger.info(
-            "Update member and registration request with registration ID ${request.registrationId} to approve.",
+            "Update member and registration request with registration ID ${request.registrationId} to approved.",
         )
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             val now = clock.instant()

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
@@ -45,7 +45,9 @@ internal class UpdateMemberAndRegistrationRequestToApprovedHandler(
         context: MembershipRequestContext,
         request: UpdateMemberAndRegistrationRequestToApproved,
     ): UpdateMemberAndRegistrationRequestResponse {
-        logger.info("Update member and registration request to approve.")
+        logger.info(
+            "Update member and registration request with registration ID ${request.registrationId} to approve.",
+        )
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             val now = clock.instant()
             val member = em.find(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandler.kt
@@ -26,6 +26,10 @@ internal class UpdateRegistrationRequestStatusHandler(
                         "${request.registrationStatus}, will ignore the update"
                 )
             } else {
+                logger.info(
+                    "Updating registration request ${request.registrationId} status from $currentStatus" +
+                        " to ${request.registrationStatus}",
+                )
                 registrationRequest.status = request.registrationStatus.name
                 registrationRequest.lastModified = clock.instant()
                 registrationRequest.reason = request.reason

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
@@ -112,7 +112,7 @@ class RegistrationProcessor(
         state: RegistrationState?,
         event: Record<String, RegistrationCommand>
     ): StateAndEventProcessor.Response<RegistrationState> {
-        logger.info("Processing registration command.")
+        logger.info("Processing registration command for registration ID ${event.key}.")
         val result = try {
             when (val command = event.value?.command) {
                 is StartRegistration -> {


### PR DESCRIPTION
Increase the timeout for waiting for registration.

Add the registration ID to some of the logs.