### PR TITLE
CORE-12375: Remove combined worker and notary cpb external publishing

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -6,8 +6,6 @@ plugins {
 }
 
 ext {
-    releasable = true
-
     // Use db message bus emulation by default, but allow switching to kafka without manually updating the build file
     if (!project.hasProperty('busImpl')) {
         busImplementation = 'db-message-bus-impl'

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
@@ -5,10 +5,6 @@ plugins {
     id 'corda.javadoc-generation'
 }
 
-ext {
-    releasable = true
-}
-
 description 'Corda Non-Validating Notary Plugin Server'
 
 group 'com.r3.corda.notary.plugin.nonvalidating'


### PR DESCRIPTION
* Remove reusable code block in build.gradle files which controls publishing to an internal staging area in S3, which is later promoted to maven Staging / Maven central 