### PR TITLE
CORE-9157 Ledger keys are optional for notaries

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -467,11 +467,12 @@ class DynamicMemberRegistrationService @Activate constructor(
                 require(orderVerifier.isOrdered(this, 3)) { "Provided session key IDs are incorrectly numbered." }
             }
             p2pEndpointVerifier.verifyContext(context)
+            val isNotary = context.entries.any { it.key.startsWith(ROLES_PREFIX) && it.value == NOTARY_ROLE }
             context.keys.filter { ledgerIdRegex.matches(it) }.apply {
-                require(isNotEmpty()) { "No ledger key ID was provided." }
+                if (!isNotary) require(isNotEmpty()) { "No ledger key ID was provided." }
                 require(orderVerifier.isOrdered(this, 3)) { "Provided ledger key IDs are incorrectly numbered." }
             }
-            if (context.entries.any { it.key.startsWith(ROLES_PREFIX) && it.value == NOTARY_ROLE }) {
+            if (isNotary) {
                 context.keys.filter { notaryIdRegex.matches(it) }.apply {
                     require(isNotEmpty()) { "No notary key ID was provided." }
                     require(orderVerifier.isOrdered(this, 3)) { "Provided notary key IDs are incorrectly numbered." }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -1049,6 +1049,22 @@ class DynamicMemberRegistrationServiceTest {
                 registrationService.register(registrationResultId, member, testProperties)
             }
         }
+
+        @Test
+        fun `ledger keys are optional when notary role is set`() {
+            postConfigChangedEvent()
+            val testProperties =
+                context.filterNot { it.key.startsWith("corda.ledger") } + mapOf(
+                    String.format(ROLES_PREFIX, 0) to "notary",
+                    NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                )
+            registrationService.start()
+
+            assertDoesNotThrow {
+                registrationService.register(registrationResultId, member, testProperties)
+            }
+        }
     }
 
     @Nested


### PR DESCRIPTION
This change makes ledger keys optional during member registration if role is set to `NOTARY`.

a. [Valid] Member registration with notary role without ledger keys:
<img width="882" alt="Screenshot 2023-04-11 at 15 21 40" src="https://user-images.githubusercontent.com/17948697/231202783-2bf320ba-cfc4-499c-9915-8c6001871400.png">

b. [Invalid] Member registration without notary role without ledger keys:
<img width="871" alt="Screenshot 2023-04-11 at 15 24 03" src="https://user-images.githubusercontent.com/17948697/231202886-8929290d-c378-4fca-bbe6-8378788115e3.png">

c. [Valid] Member registration without notary role with ledger keys:
<img width="881" alt="Screenshot 2023-04-11 at 15 26 24" src="https://user-images.githubusercontent.com/17948697/231202949-f6329107-4ed6-460f-abdf-8529b5823752.png">
