### PR TITLE
CORE-12408 Passphrase location moved

### DIFF
--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -359,7 +359,7 @@ SALT and PASSPHRASE environment variables for decrypting configuration.
     secretKeyRef:
       {{- if .Values.config.encryption.passphrase.valueFrom.secretKeyRef.name }}
       name: {{ .Values.config.encryption.passphrase.valueFrom.secretKeyRef.name | quote }}
-      key: {{ required "Must specify config.encryption.passphrase.valueFrom.secretKeyRef.key" .Values.workers.db.passphrase.valueFrom.secretKeyRef.key | quote }}
+      key: {{ required "Must specify config.encryption.passphrase.valueFrom.secretKeyRef.key" .Values.config.encryption.passphrase.valueFrom.secretKeyRef.key | quote }}
       {{- else }}
       name: {{ (printf "%s-config" (include "corda.fullname" .)) | quote }}
       key: "passphrase"


### PR DESCRIPTION
When the passphrase moved from `workers.db` to `config.encryption` I must have missed this reference.