### PR TITLE
CORE-11477 Revisit crypto hsm configuration

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/CryptoServiceFactoryImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/CryptoServiceFactoryImpl.kt
@@ -101,7 +101,7 @@ class CryptoServiceFactoryImpl @Activate constructor(
         }
 
         private val cryptoService: CryptoService by lazy(LazyThreadSafetyMode.PUBLICATION) {
-            val retry = hsmConfig.retry
+            val retry = hsmConfig.retrying
             val cryptoService = cryptoServiceProvider.getInstance(cryptoConfig)
             CryptoServiceDecorator.create(
                 cryptoService,

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
@@ -128,8 +128,8 @@ open class SoftCryptoServiceProviderImpl @Activate constructor(
             val cachingConfig = config.getConfig("caching")
             val expireAfterAccessMins = cachingConfig.getConfig("expireAfterAccessMins").getLong("default")
             val maximumSize = cachingConfig.getConfig("maximumSize").getLong("default")
-            val hsmConfig = config.hsm().cfg
-            val keysList: ConfigList = hsmConfig.getList("wrappingKeys")
+            val hsmConfig = config.hsm()
+            val keysList: ConfigList = hsmConfig.wrappingKeys
             val unmanagedWrappingKeys: Map<String, WrappingKey> =
                 keysList.map { it: ConfigValue ->
                     when (it) {
@@ -145,7 +145,7 @@ open class SoftCryptoServiceProviderImpl @Activate constructor(
                         else -> throw InvalidParameterException("unexpected item ")
                     }
                 }.toMap()
-            val defaultUnmanagedWrappingKeyName = hsmConfig.getString("defaultWrappingKey")
+            val defaultUnmanagedWrappingKeyName = hsmConfig.defaultWrappingKey
             require(unmanagedWrappingKeys.containsKey(defaultUnmanagedWrappingKeyName)) {
                 "default key $defaultUnmanagedWrappingKeyName must be in wrappingKeys"
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.749-alpha-1681376700165
+cordaApiVersion=5.0.0.749-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.748-beta+
+cordaApiVersion=5.0.0.749-alpha-1681376700165
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/configuration/configuration-validation/src/integrationTest/kotlin/net/corda/libs/configuration/validation/integration/ConfigurationValidationIntegrationTest.kt
+++ b/libs/configuration/configuration-validation/src/integrationTest/kotlin/net/corda/libs/configuration/validation/integration/ConfigurationValidationIntegrationTest.kt
@@ -6,7 +6,6 @@ import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.validation.ConfigurationSchemaFetchException
 import net.corda.libs.configuration.validation.ConfigurationValidationException
 import net.corda.libs.configuration.validation.ConfigurationValidatorFactory
-import net.corda.schema.configuration.ConfigKeys.CRYPTO_CONFIG
 import net.corda.schema.configuration.ConfigKeys.DB_CONFIG
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MEMBERSHIP_CONFIG
@@ -82,7 +81,6 @@ class ConfigurationValidationIntegrationTest {
     @ParameterizedTest(name = "verify that a sensible default is created for config section: {0}")
     @ValueSource(strings = [
         MESSAGING_CONFIG,
-//        CRYPTO_CONFIG, // TODO Crypto defaulted values needs reviewing
         DB_CONFIG,
         FLOW_CONFIG,
         P2P_LINK_MANAGER_CONFIG,

--- a/libs/configuration/configuration-validation/src/integrationTest/kotlin/net/corda/libs/configuration/validation/integration/ConfigurationValidationIntegrationTest.kt
+++ b/libs/configuration/configuration-validation/src/integrationTest/kotlin/net/corda/libs/configuration/validation/integration/ConfigurationValidationIntegrationTest.kt
@@ -82,7 +82,7 @@ class ConfigurationValidationIntegrationTest {
     @ParameterizedTest(name = "verify that a sensible default is created for config section: {0}")
     @ValueSource(strings = [
         MESSAGING_CONFIG,
-        CRYPTO_CONFIG,
+//        CRYPTO_CONFIG, TODO Crypto defaulted values needs reviewing
         DB_CONFIG,
         FLOW_CONFIG,
         P2P_LINK_MANAGER_CONFIG,

--- a/libs/configuration/configuration-validation/src/integrationTest/kotlin/net/corda/libs/configuration/validation/integration/ConfigurationValidationIntegrationTest.kt
+++ b/libs/configuration/configuration-validation/src/integrationTest/kotlin/net/corda/libs/configuration/validation/integration/ConfigurationValidationIntegrationTest.kt
@@ -82,7 +82,7 @@ class ConfigurationValidationIntegrationTest {
     @ParameterizedTest(name = "verify that a sensible default is created for config section: {0}")
     @ValueSource(strings = [
         MESSAGING_CONFIG,
-        CRYPTO_CONFIG,
+//        CRYPTO_CONFIG, // TODO Crypto defaulted values needs reviewing
         DB_CONFIG,
         FLOW_CONFIG,
         P2P_LINK_MANAGER_CONFIG,

--- a/libs/configuration/configuration-validation/src/integrationTest/kotlin/net/corda/libs/configuration/validation/integration/ConfigurationValidationIntegrationTest.kt
+++ b/libs/configuration/configuration-validation/src/integrationTest/kotlin/net/corda/libs/configuration/validation/integration/ConfigurationValidationIntegrationTest.kt
@@ -82,7 +82,7 @@ class ConfigurationValidationIntegrationTest {
     @ParameterizedTest(name = "verify that a sensible default is created for config section: {0}")
     @ValueSource(strings = [
         MESSAGING_CONFIG,
-//        CRYPTO_CONFIG, TODO Crypto defaulted values needs reviewing
+        CRYPTO_CONFIG,
         DB_CONFIG,
         FLOW_CONFIG,
         P2P_LINK_MANAGER_CONFIG,

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
@@ -224,12 +224,6 @@ fun createDefaultCryptoConfig(wrappingKeyPassphrase: Any, wrappingKeySalt: Any):
                         CryptoHSMConfig.RetryConfig::maxAttempts.name to 3,
                         CryptoHSMConfig.RetryConfig::attemptTimeoutMills.name to 20000,
                     ),
-                    CryptoHSMConfig::categories.name to listOf(
-                        mapOf(
-                            CryptoHSMConfig.CategoryConfig::category.name to "*",
-                            CryptoHSMConfig.CategoryConfig::policy.name to PrivateKeyPolicy.WRAPPED.name,
-                        )
-                    ),
                     CryptoHSMConfig::masterKeyPolicy.name to MasterKeyPolicy.UNIQUE.name,
                     CryptoHSMConfig::capacity.name to -1,
                     CryptoHSMConfig::supportedSchemes.name to listOf(

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
@@ -225,16 +225,6 @@ fun createDefaultCryptoConfig(wrappingKeyPassphrase: Any, wrappingKeySalt: Any):
                         CryptoHSMConfig.RetryConfig::attemptTimeoutMills.name to 20000,
                     ),
                     CryptoHSMConfig::masterKeyPolicy.name to MasterKeyPolicy.UNIQUE.name,
-                    CryptoHSMConfig::supportedSchemes.name to listOf(
-                        "CORDA.RSA",
-                        "CORDA.ECDSA.SECP256R1",
-                        "CORDA.ECDSA.SECP256K1",
-                        "CORDA.EDDSA.ED25519",
-                        "CORDA.X25519",
-                        "CORDA.SM2",
-                        "CORDA.GOST3410.GOST3411",
-                        "CORDA.SPHINCS-256"
-                    ),
                     CryptoHSMConfig::cfg.name to ConfigValueFactory.fromMap(
                         mapOf(
                             "defaultWrappingKey" to ConfigValueFactory.fromAnyRef("root1"),

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
@@ -225,17 +225,13 @@ fun createDefaultCryptoConfig(wrappingKeyPassphrase: Any, wrappingKeySalt: Any):
                         CryptoHSMConfig.RetryConfig::attemptTimeoutMills.name to 20000,
                     ),
                     CryptoHSMConfig::masterKeyPolicy.name to MasterKeyPolicy.UNIQUE.name,
-                    CryptoHSMConfig::cfg.name to ConfigValueFactory.fromMap(
-                        mapOf(
-                            "defaultWrappingKey" to ConfigValueFactory.fromAnyRef("root1"),
-                            "wrappingKeys" to listOf(
-                                ConfigValueFactory.fromAnyRef(
-                                    mapOf(
-                                        "alias" to "root1",
-                                        "salt" to wrappingKeySalt,
-                                        "passphrase" to wrappingKeyPassphrase,
-                                    )
-                                )
+                    CryptoHSMConfig::defaultWrappingKey.name to ConfigValueFactory.fromAnyRef("root1"),
+                    CryptoHSMConfig::wrappingKeys.name to listOf(
+                        ConfigValueFactory.fromAnyRef(
+                            mapOf(
+                                "alias" to "root1",
+                                "salt" to wrappingKeySalt,
+                                "passphrase" to wrappingKeyPassphrase,
                             )
                         )
                     )

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
@@ -225,7 +225,6 @@ fun createDefaultCryptoConfig(wrappingKeyPassphrase: Any, wrappingKeySalt: Any):
                         CryptoHSMConfig.RetryConfig::attemptTimeoutMills.name to 20000,
                     ),
                     CryptoHSMConfig::masterKeyPolicy.name to MasterKeyPolicy.UNIQUE.name,
-                    CryptoHSMConfig::capacity.name to -1,
                     CryptoHSMConfig::supportedSchemes.name to listOf(
                         "CORDA.RSA",
                         "CORDA.ECDSA.SECP256R1",

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoConfigUtils.kt
@@ -220,11 +220,10 @@ fun createDefaultCryptoConfig(wrappingKeyPassphrase: Any, wrappingKeySalt: Any):
         .withValue(
             HSM, ConfigValueFactory.fromMap(
                 mapOf(
-                    CryptoHSMConfig::retry.name to mapOf(
+                    CryptoHSMConfig::retrying.name to mapOf(
                         CryptoHSMConfig.RetryConfig::maxAttempts.name to 3,
                         CryptoHSMConfig.RetryConfig::attemptTimeoutMills.name to 20000,
                     ),
-                    CryptoHSMConfig::masterKeyPolicy.name to MasterKeyPolicy.UNIQUE.name,
                     CryptoHSMConfig::defaultWrappingKey.name to ConfigValueFactory.fromAnyRef("root1"),
                     CryptoHSMConfig::wrappingKeys.name to listOf(
                         ConfigValueFactory.fromAnyRef(

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
@@ -1,6 +1,5 @@
 package net.corda.crypto.config.impl
 
-import com.typesafe.config.Config
 import net.corda.libs.configuration.SmartConfig
 
 class CryptoHSMConfig(private val config: SmartConfig) {
@@ -20,14 +19,6 @@ class CryptoHSMConfig(private val config: SmartConfig) {
             } catch (e: Throwable) {
                 throw IllegalStateException("Failed to get ${this::attemptTimeoutMills.name}", e)
             }
-        }
-    }
-
-    val categories: List<CategoryConfig> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        try {
-            config.getConfigList(this::categories.name).map { CategoryConfig(it) }
-        } catch (e: Throwable) {
-            throw IllegalStateException("Failed to get ${this::categories.name}", e)
         }
     }
 
@@ -68,24 +59,6 @@ class CryptoHSMConfig(private val config: SmartConfig) {
             config.getConfig(this::cfg.name)
         } catch (e: Throwable) {
             throw IllegalStateException("Failed to get ${this::cfg.name}", e)
-        }
-    }
-
-    class CategoryConfig(private val config: Config) {
-        val category: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
-            try {
-                config.getString(this::category.name)
-            } catch (e: Throwable) {
-                throw IllegalStateException("Failed to get ${this::category.name}", e)
-            }
-        }
-
-        val policy: PrivateKeyPolicy by lazy(LazyThreadSafetyMode.PUBLICATION) {
-            try {
-                config.getEnum(PrivateKeyPolicy::class.java, this::policy.name)
-            } catch (e: Throwable) {
-                throw IllegalStateException("Failed to get ${this::policy.name}", e)
-            }
         }
     }
 

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
@@ -30,14 +30,6 @@ class CryptoHSMConfig(private val config: SmartConfig) {
         }
     }
 
-    val masterKeyAlias: String? by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        if(config.hasPath(this::masterKeyAlias.name)) {
-            config.getString(this::masterKeyAlias.name)
-        } else {
-            null
-        }
-    }
-
     val supportedSchemes: List<String> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         try {
             config.getStringList(this::supportedSchemes.name)

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
@@ -46,14 +46,6 @@ class CryptoHSMConfig(private val config: SmartConfig) {
         }
     }
 
-    val capacity: Int by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        try {
-            config.getInt(this::capacity.name)
-        } catch (e: Throwable) {
-            throw IllegalStateException("Failed to get ${this::capacity.name}", e)
-        }
-    }
-
     val cfg: SmartConfig by lazy(LazyThreadSafetyMode.PUBLICATION) {
         try {
             config.getConfig(this::cfg.name)

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
@@ -23,14 +23,6 @@ class CryptoHSMConfig(private val config: SmartConfig) {
         }
     }
 
-    val masterKeyPolicy: MasterKeyPolicy by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        try {
-            config.getEnum(MasterKeyPolicy::class.java, this::masterKeyPolicy.name)
-        } catch (e: Throwable) {
-            throw IllegalStateException("Failed to get ${this::masterKeyPolicy.name}", e)
-        }
-    }
-
     val wrappingKeys: ConfigList by lazy(LazyThreadSafetyMode.PUBLICATION) {
         try {
             config.getList(this::wrappingKeys.name)
@@ -47,11 +39,11 @@ class CryptoHSMConfig(private val config: SmartConfig) {
         }
     }
 
-    val retry: RetryConfig by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    val retrying: RetryConfig by lazy(LazyThreadSafetyMode.PUBLICATION) {
         try {
-            RetryConfig(config.getConfig(this::retry.name))
+            RetryConfig(config.getConfig(this::retrying.name))
         } catch (e: Throwable) {
-            throw IllegalStateException("Failed to get ${this::retry.name}", e)
+            throw IllegalStateException("Failed to get ${this::retrying.name}", e)
         }
     }
 }

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
@@ -1,5 +1,6 @@
 package net.corda.crypto.config.impl
 
+import com.typesafe.config.ConfigList
 import net.corda.libs.configuration.SmartConfig
 
 class CryptoHSMConfig(private val config: SmartConfig) {
@@ -30,11 +31,19 @@ class CryptoHSMConfig(private val config: SmartConfig) {
         }
     }
 
-    val cfg: SmartConfig by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    val wrappingKeys: ConfigList by lazy(LazyThreadSafetyMode.PUBLICATION) {
         try {
-            config.getConfig(this::cfg.name)
+            config.getList(this::wrappingKeys.name)
         } catch (e: Throwable) {
-            throw IllegalStateException("Failed to get ${this::cfg.name}", e)
+            throw IllegalStateException("Failed to get ${this::wrappingKeys.name}", e)
+        }
+    }
+
+    val defaultWrappingKey: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        try {
+            config.getString(this::defaultWrappingKey.name)
+        } catch (e: Throwable) {
+            throw IllegalStateException("Failed to get ${this::defaultWrappingKey.name}", e)
         }
     }
 

--- a/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
+++ b/libs/crypto/crypto-config-impl/src/main/kotlin/net/corda/crypto/config/impl/CryptoHSMConfig.kt
@@ -30,14 +30,6 @@ class CryptoHSMConfig(private val config: SmartConfig) {
         }
     }
 
-    val supportedSchemes: List<String> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        try {
-            config.getStringList(this::supportedSchemes.name)
-        } catch (e: Throwable) {
-            throw IllegalStateException("Failed to get ${this::supportedSchemes.name}", e)
-        }
-    }
-
     val cfg: SmartConfig by lazy(LazyThreadSafetyMode.PUBLICATION) {
         try {
             config.getConfig(this::cfg.name)

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -46,7 +46,6 @@ class CryptoConfigUtilsTests {
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
         assertNull(softWorker.masterKeyAlias)
-        assertEquals(-1, softWorker.capacity)
         assertThat(softWorker.supportedSchemes).hasSize(8)
         assertThat(softWorker.supportedSchemes).contains(
             "CORDA.RSA",
@@ -97,7 +96,6 @@ class CryptoConfigUtilsTests {
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
         assertNull(softWorker.masterKeyAlias)
-        assertEquals(-1, softWorker.capacity)
         assertThat(softWorker.supportedSchemes).hasSize(8)
         assertThat(softWorker.supportedSchemes).contains(
             "CORDA.RSA",
@@ -217,9 +215,6 @@ class CryptoConfigUtilsTests {
         }
         assertThrows<IllegalStateException> {
             retryConfig.attemptTimeoutMills
-        }
-        assertThrows<IllegalStateException> {
-            config.capacity
         }
         assertThrows<IllegalStateException> {
             config.supportedSchemes

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -44,17 +44,6 @@ class CryptoConfigUtilsTests {
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
-        assertThat(softWorker.supportedSchemes).hasSize(8)
-        assertThat(softWorker.supportedSchemes).contains(
-            "CORDA.RSA",
-            "CORDA.ECDSA.SECP256R1",
-            "CORDA.ECDSA.SECP256K1",
-            "CORDA.EDDSA.ED25519",
-            "CORDA.X25519",
-            "CORDA.SM2",
-            "CORDA.GOST3410.GOST3411",
-            "CORDA.SPHINCS-256"
-        )
         val hsmCfg = softWorker.cfg
         val wrappingKey1 = hsmCfg.getConfigList("wrappingKeys")[0]
         assertEquals("master-salt", wrappingKey1.getString("salt"))
@@ -93,17 +82,6 @@ class CryptoConfigUtilsTests {
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
-        assertThat(softWorker.supportedSchemes).hasSize(8)
-        assertThat(softWorker.supportedSchemes).contains(
-            "CORDA.RSA",
-            "CORDA.ECDSA.SECP256R1",
-            "CORDA.ECDSA.SECP256K1",
-            "CORDA.EDDSA.ED25519",
-            "CORDA.X25519",
-            "CORDA.SM2",
-            "CORDA.GOST3410.GOST3411",
-            "CORDA.SPHINCS-256"
-        )
         val opsBusProcessor = config.opsBusProcessor()
         assertEquals(3, opsBusProcessor.maxAttempts)
         assertEquals(1, opsBusProcessor.waitBetweenMills.size)
@@ -212,9 +190,6 @@ class CryptoConfigUtilsTests {
         }
         assertThrows<IllegalStateException> {
             retryConfig.attemptTimeoutMills
-        }
-        assertThrows<IllegalStateException> {
-            config.supportedSchemes
         }
         assertThrows<IllegalStateException> {
             config.masterKeyPolicy

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -42,9 +42,8 @@ class CryptoConfigUtilsTests {
         assertEquals(60, signingService.cache.expireAfterAccessMins)
         assertEquals(10000, signingService.cache.maximumSize)
         val softWorker = config.hsm()
-        assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
-        assertEquals(3, softWorker.retry.maxAttempts)
-        assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
+        assertEquals(20000L, softWorker.retrying.attemptTimeoutMills)
+        assertEquals(3, softWorker.retrying.maxAttempts)
         val wrappingKey1 = softWorker.wrappingKeys[0] as ConfigObject
         assertEquals("master-salt", wrappingKey1["salt"]!!.unwrapped())
         assertEquals("master-passphrase", wrappingKey1["passphrase"]!!.unwrapped())
@@ -79,9 +78,8 @@ class CryptoConfigUtilsTests {
         assertEquals(60, signingService.cache.expireAfterAccessMins)
         assertEquals(10000, signingService.cache.maximumSize)
         val softWorker = config.hsm()
-        assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
-        assertEquals(3, softWorker.retry.maxAttempts)
-        assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
+        assertEquals(20000L, softWorker.retrying.attemptTimeoutMills)
+        assertEquals(3, softWorker.retrying.maxAttempts)
         val opsBusProcessor = config.opsBusProcessor()
         assertEquals(3, opsBusProcessor.maxAttempts)
         assertEquals(1, opsBusProcessor.waitBetweenMills.size)
@@ -182,7 +180,7 @@ class CryptoConfigUtilsTests {
     fun `CryptoHSMConfig should throw IllegalStateException when is empty`() {
         val config = CryptoHSMConfig(configFactory.create(ConfigFactory.empty()))
         assertThrows<IllegalStateException> {
-            config.retry
+            config.retrying
         }
         val retryConfig = CryptoHSMConfig.RetryConfig(configFactory.create(ConfigFactory.empty()))
         assertThrows<IllegalStateException> {
@@ -190,9 +188,6 @@ class CryptoConfigUtilsTests {
         }
         assertThrows<IllegalStateException> {
             retryConfig.attemptTimeoutMills
-        }
-        assertThrows<IllegalStateException> {
-            config.masterKeyPolicy
         }
         assertThrows<IllegalStateException> {
             config.wrappingKeys

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -68,7 +68,7 @@ class CryptoConfigUtilsTests {
         val config = createDefaultCryptoConfig("pass", "salt")
         val configJSON = config.root().render(ConfigRenderOptions.defaults())
         assertThat(configJSON.contains("passphrase"))
-        validator.validate(CRYPTO_CONFIG, Version(1, 0), config, false)
+        validator.validate(CRYPTO_CONFIG, Version(1, 0), config, true)
     }
 
     @Test

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 class CryptoConfigUtilsTests {
     companion object {
@@ -45,7 +44,6 @@ class CryptoConfigUtilsTests {
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
-        assertNull(softWorker.masterKeyAlias)
         assertThat(softWorker.supportedSchemes).hasSize(8)
         assertThat(softWorker.supportedSchemes).contains(
             "CORDA.RSA",
@@ -95,7 +93,6 @@ class CryptoConfigUtilsTests {
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
-        assertNull(softWorker.masterKeyAlias)
         assertThat(softWorker.supportedSchemes).hasSize(8)
         assertThat(softWorker.supportedSchemes).contains(
             "CORDA.RSA",

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -1,6 +1,7 @@
 package net.corda.crypto.config.impl
 
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigObject
 import com.typesafe.config.ConfigRenderOptions
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
@@ -44,11 +45,10 @@ class CryptoConfigUtilsTests {
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
-        val hsmCfg = softWorker.cfg
-        val wrappingKey1 = hsmCfg.getConfigList("wrappingKeys")[0]
-        assertEquals("master-salt", wrappingKey1.getString("salt"))
-        assertEquals("master-passphrase", wrappingKey1.getString("passphrase"))
-        assertEquals("root1", wrappingKey1.getString("alias"))
+        val wrappingKey1 = softWorker.wrappingKeys[0] as ConfigObject
+        assertEquals("master-salt", wrappingKey1["salt"]!!.unwrapped())
+        assertEquals("master-passphrase", wrappingKey1["passphrase"]!!.unwrapped())
+        assertEquals("root1", wrappingKey1["alias"]!!.unwrapped())
         val opsBusProcessor = config.opsBusProcessor()
         assertEquals(3, opsBusProcessor.maxAttempts)
         assertEquals(1, opsBusProcessor.waitBetweenMills.size)
@@ -195,7 +195,10 @@ class CryptoConfigUtilsTests {
             config.masterKeyPolicy
         }
         assertThrows<IllegalStateException> {
-            config.cfg
+            config.wrappingKeys
+        }
+        assertThrows<IllegalStateException> {
+            config.defaultWrappingKey
         }
     }
 

--- a/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
+++ b/libs/crypto/crypto-config-impl/src/test/kotlin/net/corda/crypto/config/impl/CryptoConfigUtilsTests.kt
@@ -44,9 +44,6 @@ class CryptoConfigUtilsTests {
         val softWorker = config.hsm()
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
-        assertThat(softWorker.categories).hasSize(1)
-        assertEquals("*", softWorker.categories[0].category)
-        assertEquals(PrivateKeyPolicy.WRAPPED, softWorker.categories[0].policy)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
         assertNull(softWorker.masterKeyAlias)
         assertEquals(-1, softWorker.capacity)
@@ -98,9 +95,6 @@ class CryptoConfigUtilsTests {
         val softWorker = config.hsm()
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
-        assertThat(softWorker.categories).hasSize(1)
-        assertEquals("*", softWorker.categories[0].category)
-        assertEquals(PrivateKeyPolicy.WRAPPED, softWorker.categories[0].policy)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
         assertNull(softWorker.masterKeyAlias)
         assertEquals(-1, softWorker.capacity)
@@ -217,22 +211,12 @@ class CryptoConfigUtilsTests {
         assertThrows<IllegalStateException> {
             config.retry
         }
-        val categoryConfig = CryptoHSMConfig.CategoryConfig(configFactory.create(ConfigFactory.empty()))
-        assertThrows<IllegalStateException> {
-            categoryConfig.category
-        }
-        assertThrows<IllegalStateException> {
-            categoryConfig.policy
-        }
         val retryConfig = CryptoHSMConfig.RetryConfig(configFactory.create(ConfigFactory.empty()))
         assertThrows<IllegalStateException> {
             retryConfig.maxAttempts
         }
         assertThrows<IllegalStateException> {
             retryConfig.attemptTimeoutMills
-        }
-        assertThrows<IllegalStateException> {
-            config.categories
         }
         assertThrows<IllegalStateException> {
             config.capacity

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -4,7 +4,6 @@ import com.github.stefanbirkner.systemlambda.SystemLambda
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import net.corda.crypto.config.impl.MasterKeyPolicy
-import net.corda.crypto.config.impl.PrivateKeyPolicy
 import net.corda.crypto.config.impl.flowBusProcessor
 import net.corda.crypto.config.impl.hsm
 import net.corda.crypto.config.impl.hsmRegistrationBusProcessor
@@ -158,9 +157,6 @@ class TestInitialConfigPluginCrypto {
         val softWorker = config.hsm()
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
-        assertThat(softWorker.categories).hasSize(1)
-        assertEquals("*", softWorker.categories[0].category)
-        assertEquals(PrivateKeyPolicy.WRAPPED, softWorker.categories[0].policy)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
         assertNull(softWorker.masterKeyAlias)
         assertEquals(-1, softWorker.capacity)

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -1,11 +1,9 @@
 package net.corda.cli.plugin.initialconfig
 
 import com.github.stefanbirkner.systemlambda.SystemLambda
-import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigList
 import com.typesafe.config.ConfigObject
-import net.corda.crypto.config.impl.MasterKeyPolicy
 import net.corda.crypto.config.impl.flowBusProcessor
 import net.corda.crypto.config.impl.hsm
 import net.corda.crypto.config.impl.hsmRegistrationBusProcessor
@@ -156,9 +154,8 @@ class TestInitialConfigPluginCrypto {
         assertEquals(60, signingService.cache.expireAfterAccessMins)
         assertEquals(10000, signingService.cache.maximumSize)
         val softWorker = config.hsm()
-        assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
-        assertEquals(3, softWorker.retry.maxAttempts)
-        assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
+        assertEquals(20000L, softWorker.retrying.attemptTimeoutMills)
+        assertEquals(3, softWorker.retrying.maxAttempts)
         wrappingKeyAssert(softWorker.wrappingKeys, smartConfigFactory)
         val opsBusProcessor = config.opsBusProcessor()
         assertEquals(3, opsBusProcessor.maxAttempts)

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -159,7 +159,6 @@ class TestInitialConfigPluginCrypto {
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
         assertNull(softWorker.masterKeyAlias)
-        assertEquals(-1, softWorker.capacity)
         assertThat(softWorker.supportedSchemes).hasSize(8)
         assertThat(softWorker.supportedSchemes).contains(
             "CORDA.RSA",

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -157,17 +157,6 @@ class TestInitialConfigPluginCrypto {
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
-        assertThat(softWorker.supportedSchemes).hasSize(8)
-        assertThat(softWorker.supportedSchemes).contains(
-            "CORDA.RSA",
-            "CORDA.ECDSA.SECP256R1",
-            "CORDA.ECDSA.SECP256K1",
-            "CORDA.EDDSA.ED25519",
-            "CORDA.X25519",
-            "CORDA.SM2",
-            "CORDA.GOST3410.GOST3411",
-            "CORDA.SPHINCS-256"
-        )
         val hsmCfg = softWorker.cfg
         wrappingKeyAssert(hsmCfg, smartConfigFactory)
         val opsBusProcessor = config.opsBusProcessor()

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -13,7 +13,6 @@ import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import picocli.CommandLine
 
@@ -158,7 +157,6 @@ class TestInitialConfigPluginCrypto {
         assertEquals(20000L, softWorker.retry.attemptTimeoutMills)
         assertEquals(3, softWorker.retry.maxAttempts)
         assertEquals(MasterKeyPolicy.UNIQUE, softWorker.masterKeyPolicy)
-        assertNull(softWorker.masterKeyAlias)
         assertThat(softWorker.supportedSchemes).hasSize(8)
         assertThat(softWorker.supportedSchemes).contains(
             "CORDA.RSA",


### PR DESCRIPTION
- aligns with having removed the following unused hsm configuration:
  - `hsm.categories`
  - `hsm.capacity`
  - `hsm.masterKeyAlias`
  - `hsm.supportedSchemes`
  - `hsm.masterKeyPolicy`
- aligns with having flattened `hsm.config` properties into `hsm`

api-os PR: [#1047](https://github.com/corda/corda-api/pull/1047)