### PR TITLE
CORE-9790: refactor helm bootstrap to reduce repetition

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -41,7 +41,7 @@ spec:
             - mountPath: /tmp/working_dir
               name: working-volume
       initContainers:
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
+        {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "Values" .Values "Chart" .Chart "Release" .Release "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "rbac" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "vnodes" "longName" "virtual-nodes" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER" "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO") | nindent 8 }}                

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -66,8 +66,8 @@ spec:
               name: working-volume
           env:
           {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
-        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "rbac" "clusterDb" "false" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
-        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "vnodes" "longName" "virtual-nodes" "admin" "true" "clusterDb" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
+        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "rbac" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
+        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "vnodes" "longName" "virtual-nodes" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
         {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER" "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO") | nindent 8 }}                
         {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "rpc"  "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "REST_API_ADMIN" "quoteUser" "true" "quotePassword" "false" "schema" "RBAC"  "searchPath" "RBAC" "command" "create-user-config" "namePostfix" "admin" "sqlFile" "rbac-config.sql") | nindent 8 }}
         - name: create-db-users-and-grant
@@ -467,15 +467,18 @@ a second init container to execute the output SQL to the relevant database
     {{- if or (eq .name "rbac") (eq .name "crypto")  (eq .name "vnodes") -}}
        {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
     {{- end -}}    
+
     {{- /* TODO remove this special case, it is just that the old template has these declarations later */ -}}
     {{- if not (eq .name "rpc") -}}
       {{ include "corda.bootstrapCliEnv" . | nindent 4 -}}{{- /* set JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
     {{- end -}}
+
     {{- if or (eq .name "rbac") (eq .name "vnodes") }}
     {{ include "corda.rbacDbUserEnv" . | nindent 4 }}
     {{- end -}}
-    {{- /* TODO remove this and use the name instead */ -}}
-    {{- if eq .clusterDb "true" -}}
+    
+
+    {{- if eq .name "vnodes" -}}
       {{ include "corda.clusterDbEnv" . | nindent 4 -}}
     {{- end -}}
     {{- if eq .name "rpc" -}}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -459,7 +459,7 @@ SQL to the relevant database
     {{- end -}}    
     {{- /* TODO remove this special case, it is just that the old template has these declarations later */ -}}
     {{- if not (eq .name "rpc") -}}
-      {{ include "corda.bootstrapCliEnv" . | nindent 4 -}} {{- /* set JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
+      {{ include "corda.bootstrapCliEnv" . | nindent 4 -}}{{- /* set JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
     {{- end -}}
     {{- if or (eq .name "rbac") (eq .name "vnodes") }}
     {{ include "corda.rbacDbUserEnv" . | nindent 4 }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -41,35 +41,11 @@ spec:
             - mountPath: /tmp/working_dir
               name: working-volume
       initContainers:
-        - name: create-db-schemas
-          image: {{ include "corda.bootstrapCliImage" . }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: [ 'database', 'spec', '-g', 'config:{{ .Values.db.cluster.schema }},rbac:{{ .Values.bootstrap.db.rbac.schema }},crypto:{{ .Values.bootstrap.db.crypto.schema }}', '-c', '-l', '/tmp/working_dir', '--jdbc-url', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}', '-u', $(PGUSER), '-p', $(PGPASSWORD) ]
-          workingDir: /tmp/working_dir
-          volumeMounts:
-            - mountPath: /tmp/working_dir
-              name: working-volume
-            {{ include "corda.log4jVolumeMount" . | nindent 12 }}
-          env:
-            {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
-            {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
-        - name: apply-db-schemas
-          image: {{ include "corda.bootstrapDbClientImage" . }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          command: [ 'sh', '-c', 'for f in /tmp/working_dir/*.sql; do psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f "$f" --dbname {{ include "corda.clusterDbName" . }}; done' ]
-          volumeMounts:
-            - mountPath: /tmp/working_dir
-              name: working-volume
-          env:
-          {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
+        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "db" "command" "database" "subCommand" "spec" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
         {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "rbac" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
         {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "vnodes" "longName" "virtual-nodes" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
         {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER" "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO") | nindent 8 }}                
-        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "rpc"  "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "REST_API_ADMIN" "quoteUser" "true" "quotePassword" "false" "schema" "RBAC"  "searchPath" "RBAC" "command" "create-user-config" "namePostfix" "admin" "sqlFile" "rbac-config.sql") | nindent 8 }}
+        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "rpc"  "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "REST_API_ADMIN" "quoteUser" "true" "quotePassword" "false" "schema" "RBAC"  "searchPath" "RBAC" "subCommand" "create-user-config" "namePostfix" "admin" "sqlFile" "rbac-config.sql") | nindent 8 }}
         - name: create-db-users-and-grant
           image: {{ include "corda.bootstrapDbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -95,7 +71,7 @@ spec:
           {{ include "corda.rbacDbUserEnv" . | nindent 12 }}
           {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
           {{- include "corda.clusterDbEnv" . | nindent 12 }}
-        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "crypto" "command" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql") | nindent 8 }}
+        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "crypto" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql") | nindent 8 }}
 
       volumes:
         - name: working-volume
@@ -404,17 +380,17 @@ a second init container to execute the output SQL to the relevant database
 
 {{- define "corda.bootstrapInitialConfigGenerateAndApply" -}}
 {{- /* define 2 init containers, which run in sequence. First run corda-cli initial-config to generate some SQL, storing in a persistent volume called working-volume. Second is a postgres image which mounts the same persistent volume and executes the SQL. */ -}}  
-- name: create-initial-{{ .name }}-{{ .namePostfix | default "db-config" }}
+- name: create-{{- if not (eq .name "db") -}}initial-{{- end -}}{{ .name }}-{{ .namePostfix | default "db-config" }}
   image: {{ include "corda.bootstrapCliImage" . }}
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   {{- include "corda.bootstrapResources" . | nindent 2 }}
   {{- include "corda.containerSecurityContext" . | nindent 2 }}
-  args: [ 'initial-config', '{{ .command | default "create-db-config" }}',{{ " " -}}
+  args: [ '{{ .command | default "initial-config"}}', '{{ .subCommand | default "create-db-config" }}',{{ " " -}}
   
          {{- /* request admin access in some cases, onl when the optional admin argument to this function (named tempalte) is specified as true */ -}}
          {{- if eq (.admin | default "false") "true" -}} '-a',{{ " " -}}{{- end -}}
          
-         {{- if not (eq .command "create-crypto-config") -}}
+         {{- if (and (not (eq .name "db")) (not (eq .subCommand "create-crypto-config"))) -}}
            {{- /* specify DB user - note that the quotes being optional is to preserve output while refactory, we can always safely quote */ -}}
            {{- "'-u'" -}},{{ " " -}}{{- if .quoteUser }}'{{- end -}} $({{ .environmentVariablePrefix -}}_USERNAME){{- if .quoteUser }}'{{- end -}},
          
@@ -422,15 +398,17 @@ a second init container to execute the output SQL to the relevant database
            {{- " '-p'" -}}, {{- if .quotePassword }} '{{- else -}} {{ " " -}}{{- end -}}$({{ .environmentVariablePrefix -}}_PASSWORD){{- if .quotePassword }}'{{- end -}},
          {{- end -}}           
          
-         {{- if and (not (eq .name "rpc")) (not (eq .command "create-crypto-config")) -}}
+         {{- if and (not (eq .name "rpc")) (not (eq .subCommand "create-crypto-config")) (not (eq .name "db")) -}}
              {{- " '--name'" -}}, 'corda-{{ .longName | default .name }}', 
              {{- " '--jdbc-url'" -}}, 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}', 
              {{- " '--jdbc-pool-max-size'" -}}, {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, {{- " " -}}
          {{- end -}}         
-         {{- if (not (eq .name "rpc")) -}}
+         
+         {{- if (and (not (eq .name "rpc")) (not (eq .name "db"))) -}}
              {{- "'--salt'" -}}, "$(SALT)", '--passphrase', "$(PASSPHRASE)", 
          {{- end -}}
                   
+         
          {{- " '-l'" -}}, '/tmp/working_dir']
   workingDir: /tmp/working_dir
   volumeMounts:
@@ -457,13 +435,12 @@ a second init container to execute the output SQL to the relevant database
     {{ include "corda.rbacDbUserEnv" . | nindent 4 }}
     {{- end -}}
     
-
     {{- if eq .name "vnodes" -}}
       {{ include "corda.clusterDbEnv" . | nindent 4 -}}
     {{- end -}}
     {{- if eq .name "rpc" -}}
       {{- include "corda.restApiAdminSecretEnv" . | nindent 4 }}
-    {{- else if (and (not (or (eq .name "vnodes") (eq .name "rbac"))) (not (eq .command "create-crypto-config"))) -}}
+    {{- else if (and (not (or (eq .name "vnodes") (eq .name "rbac") (eq .name "db"))) (not (eq .subCommand "create-crypto-config"))) -}}
     {{ "\n    " -}} {{- /* legacy whitespace compliance */ -}}
     {{- end -}}
     {{- if eq .environmentVariablePrefix "CRYPTO_DB_USER" -}}
@@ -475,12 +452,12 @@ a second init container to execute the output SQL to the relevant database
       {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
       {{ include "corda.bootstrapCliEnv" . | nindent 4  -}} {{- /* JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
     {{- end }}
-- name: apply-initial-{{ .name }}-{{ .namePostfix | default "db-config" }}
+- name: apply-{{- if not (eq .name "db") -}}initial-{{- end -}}{{ .name }}-{{ .namePostfix | default "db-config" }}
   image: {{ include "corda.bootstrapDbClientImage" . }}
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   {{- include "corda.bootstrapResources" . | nindent 2 }}
   {{- include "corda.containerSecurityContext" . | nindent 2 }}
-  command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/{{ .sqlFile | default "db-config.sql" }} --dbname "dbname={{ include "corda.clusterDbName" . }} options=--search_path={{ .searchPath | default .Values.db.cluster.schema }}"' ]
+  command: [ 'sh', '-c',{{- if eq .name "db" }} 'for f in /tmp/working_dir/*.sql; do psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f "$f" --dbname {{ include "corda.clusterDbName" . }}; done'{{- else }} 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/{{ .sqlFile | default "db-config.sql" }} --dbname "dbname={{ include "corda.clusterDbName" . }} options=--search_path={{ .searchPath | default .Values.db.cluster.schema }}"' {{- end }} ]
   volumeMounts:
     - mountPath: /tmp/working_dir
       name: working-volume

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -66,34 +66,8 @@ spec:
               name: working-volume
           env:
           {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
-        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "rbac-db-config" "Values" .Values "Chart" .Chart "Release" .Release) | nindent 8 }}
-        - name: create-initial-vnodes-db-config
-          image: {{ include "corda.bootstrapCliImage" . }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: [ 'initial-config', 'create-db-config', '-a', '-u', $(DB_CLUSTER_USERNAME), '-p', $(DB_CLUSTER_PASSWORD), '--name', 'corda-virtual-nodes', '--jdbc-url', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}', '--jdbc-pool-max-size', {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
-          workingDir: /tmp/working_dir
-          volumeMounts:
-            - mountPath: /tmp/working_dir
-              name: working-volume
-            {{ include "corda.log4jVolumeMount" . | nindent 12 }}
-          env:
-            {{ include "corda.configSaltAndPassphraseEnv" . | nindent 12 }}
-            {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
-            {{ include "corda.rbacDbUserEnv" . | nindent 12 }}
-            {{- include "corda.clusterDbEnv" . | nindent 12 }}
-        - name: apply-initial-vnodes-db-config
-          image: {{ include "corda.bootstrapDbClientImage" . }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          command: [ 'sh', '-c', 'psql -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/working_dir/db-config.sql --dbname "dbname={{ include "corda.clusterDbName" . }} options=--search_path={{ .Values.db.cluster.schema }}"' ]
-          volumeMounts:
-            - mountPath: /tmp/working_dir
-              name: working-volume
-          env:
-          {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
+        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "rbac" "clusterDb" "false" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
+        {{- include "corda.bootstrapInitialConfigGenerateAndApply" ( dict "name" "vnodes" "longName" "virtual-nodes" "admin" "true" "clusterDb" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
         - name: create-initial-crypto-db-config
           image: {{ include "corda.bootstrapCliImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -501,12 +475,13 @@ Bootstrap declaration to declare an initial container for running corda-cli init
 SQL to the relevant database
 */}}
 {{- define "corda.bootstrapInitialConfigGenerateAndApply" -}}
-- name: create-initial-{{ .name }}
+- name: create-initial-{{ .name }}-db-config
   image: {{ include "corda.bootstrapCliImage" . }}
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   {{- include "corda.bootstrapResources" . | nindent 2 }}
   {{- include "corda.containerSecurityContext" . | nindent 2 }}
-  args: [ 'initial-config', 'create-db-config', '-u', '$(RBAC_DB_USER_USERNAME)', '-p', $(RBAC_DB_USER_PASSWORD), '--name', 'corda-rbac', '--jdbc-url', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}?currentSchema={{ .Values.bootstrap.db.rbac.schema }}', '--jdbc-pool-max-size', {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
+  args: [ 'initial-config', 'create-db-config',{{ " " -}}
+         {{- if eq (.admin | default "false") "true" -}} '-a',{{ " " -}}{{- end -}} '-u',{{ " " -}}{{- if .quoteUser }}'{{- end -}}$({{ .environmentVariablePrefix -}}_USERNAME){{- if .quoteUser }}'{{- end -}}, '-p', $({{ .environmentVariablePrefix -}}_PASSWORD), '--name', 'corda-{{ .longName | default .name }}', '--jdbc-url', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}', '--jdbc-pool-max-size', {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)", '-l', '/tmp/working_dir']
   workingDir: /tmp/working_dir
   volumeMounts:
     - mountPath: /tmp/working_dir
@@ -516,7 +491,10 @@ SQL to the relevant database
     {{ include "corda.configSaltAndPassphraseEnv" . | nindent 4 }}
     {{ include "corda.bootstrapCliEnv" . | nindent 4 }}
     {{ include "corda.rbacDbUserEnv" . | nindent 4 }}
-- name: apply-initial-rbac-db-config
+    {{- if eq .clusterDb "true" -}}
+    {{ include "corda.clusterDbEnv" . | nindent 4 -}}
+    {{- end }}
+- name: apply-initial-{{ .name }}-db-config
   image: {{ include "corda.bootstrapDbClientImage" . }}
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   {{- include "corda.bootstrapResources" . | nindent 2 }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -41,7 +41,7 @@ spec:
             - mountPath: /tmp/working_dir
               name: working-volume
       initContainers:
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "command" "database" "subCommand" "spec" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
+        {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "subCommand" "spec" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "rbac" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "vnodes" "longName" "virtual-nodes" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER" "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO") | nindent 8 }}                

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -391,7 +391,7 @@ a second init container to execute the output SQL to the relevant database
   args: [ 'initial-config', '{{ .subCommand | default "create-db-config" }}',{{ " " -}}
   
          {{- /* request admin access in some cases, only when the optional admin argument to this function (named template) is specified as true */ -}}
-         {{- if eq (.admin | default "false") "true" -}} '-a',{{ " " -}}{{- end -}}
+         {{- if (.admin | default false) -}} '-a',{{ " " -}}{{- end -}}
          
          {{- if (and (not (eq .name "db")) (not (eq .subCommand "create-crypto-config"))) -}}
            {{- /* specify DB user - note that the quotes being optional is to preserve output while refactory, we can always safely quote */ -}}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -501,7 +501,7 @@ Bootstrap declaration to declare an initial container for running corda-cli init
 SQL to the relevant database
 */}}
 {{- define "corda.bootstrapInitialConfigGenerateAndApply" -}}
-- name: create-initial-rbac-db-config
+- name: create-initial-{{ .name }}
   image: {{ include "corda.bootstrapCliImage" . }}
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   {{- include "corda.bootstrapResources" . | nindent 2 }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -470,11 +470,11 @@ SQL to the relevant database
     {{- end -}}
     {{- if eq .name "rpc" -}}
       {{- include "corda.restApiAdminSecretEnv" . | nindent 4 }}
-    {{- else if not (eq .name "vnodes") -}}
+    {{- else if not (or (eq .name "vnodes") (eq .name "rbac")) -}}
     {{ "\n    " -}} {{- /* legacy whitespace compliance */ -}}
     {{- end -}}
     {{- if eq .environmentVariablePrefix "CRYPTO_DB_USER" -}}
-      {{- include "corda.cryptoDbUserEnv" . | nindent 4 }}
+      {{- include "corda.cryptoDbUserEnv" . | nindent 4 -}}
     {{- end -}}
     {{- /* TODO remove this special case, it is just that the old template has these declarations later */ -}}
     {{- if (eq .name "rpc") -}}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -43,7 +43,7 @@ spec:
       initContainers:
         {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "Values" .Values "Chart" .Chart "Release" .Release "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "rbac" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "vnodes" "longName" "virtual-nodes" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
+        {{- include "corda.generateAndExecuteSql" ( dict "name" "vnodes" "longName" "virtual-nodes" "dbName" "rbac" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER" "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO") | nindent 8 }}                
         {{- include "corda.generateAndExecuteSql" ( dict "name" "rpc"  "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "REST_API_ADMIN" "quoteUser" "true" "quotePassword" "false" "schema" "RBAC"  "searchPath" "RBAC" "subCommand" "create-user-config" "namePostfix" "admin" "sqlFile" "rbac-config.sql") | nindent 8 }}
         - name: create-db-users-and-grant
@@ -404,7 +404,7 @@ a second init container to execute the output SQL to the relevant database
          {{- if and (not (eq .name "rpc")) (not (eq .subCommand "create-crypto-config")) -}}
              {{- " '--name'" -}}, 'corda-{{ .longName | default .name }}', 
              {{- " '--jdbc-url'" -}}, 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}', 
-             {{- " '--jdbc-pool-max-size'" -}}, {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, {{- " " -}}
+             {{- " '--jdbc-pool-max-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxSize | quote }}, {{- " " -}}
          {{- end -}}         
          
          {{- if not (eq .name "rpc") -}}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -108,7 +108,7 @@ spec:
             {{ include "corda.log4jVolumeMount" . | nindent 12 }}
           env:
             {{ include "corda.configSaltAndPassphraseEnv" . | nindent 12 }}
-            {{ include "corda.bootstrapCliEnv" . | nindent 12 }} 
+            {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
         - name: apply-initial-crypto-worker-config
           image: {{ include "corda.bootstrapDbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -454,7 +454,7 @@ SQL to the relevant database
     {{- if not (eq .mode "admin") -}}
       {{ include "corda.configSaltAndPassphraseEnv" . | nindent 4 -}}
     {{- end -}}
-    {{- if or (eq .name "rbac") -}}
+    {{- if or (eq .name "rbac") (eq .name "crypto") -}}
        {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
     {{- end -}}    
     {{- /* TODO remove this special case, it is just that the old template has these declarations later */ -}}
@@ -463,7 +463,7 @@ SQL to the relevant database
     {{- end -}}
     {{- if or (eq .name "rbac") (eq .name "vnodes") }}
     {{ include "corda.rbacDbUserEnv" . | nindent 4 }}
-    {{- end }}
+    {{- end -}}
     {{- /* TODO remove this and use the name instead */ -}}
     {{- if eq .clusterDb "true" -}}
       {{ include "corda.clusterDbEnv" . | nindent 4 -}}
@@ -474,12 +474,12 @@ SQL to the relevant database
     {{ "\n    " -}} {{- /* legacy whitespace compliance */ -}}
     {{- end -}}
     {{- if eq .environmentVariablePrefix "CRYPTO_DB_USER" -}}
-    {{- include "corda.cryptoDbUserEnv" . | nindent 4 }}
+      {{- include "corda.cryptoDbUserEnv" . | nindent 4 }}
     {{- end -}}
     {{- /* TODO remove this special case, it is just that the old template has these declarations later */ -}}
     {{- if (eq .name "rpc") -}}
-    {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
-    {{ include "corda.bootstrapCliEnv" . | nindent 4  -}} {{- /* JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
+      {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
+      {{ include "corda.bootstrapCliEnv" . | nindent 4  -}} {{- /* JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
     {{- end }}
 - name: apply-initial-{{ .name }}-{{ .mode | default "db-config" }}
   image: {{ include "corda.bootstrapDbClientImage" . }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -454,7 +454,7 @@ SQL to the relevant database
     {{- if not (eq .mode "admin") -}}
       {{ include "corda.configSaltAndPassphraseEnv" . | nindent 4 -}}
     {{- end -}}
-    {{- if or (eq .name "rbac") (eq .name "crypto") -}}
+    {{- if or (eq .name "rbac") (eq .name "crypto")  (eq .name "vnodes") -}}
        {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
     {{- end -}}    
     {{- /* TODO remove this special case, it is just that the old template has these declarations later */ -}}
@@ -470,7 +470,7 @@ SQL to the relevant database
     {{- end -}}
     {{- if eq .name "rpc" -}}
       {{- include "corda.restApiAdminSecretEnv" . | nindent 4 }}
-    {{- else -}}
+    {{- else if not (eq .name "vnodes") -}}
     {{ "\n    " -}} {{- /* legacy whitespace compliance */ -}}
     {{- end -}}
     {{- if eq .environmentVariablePrefix "CRYPTO_DB_USER" -}}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -390,7 +390,7 @@ a second init container to execute the output SQL to the relevant database
   {{- else }}
   args: [ 'initial-config', '{{ .subCommand | default "create-db-config" }}',{{ " " -}}
   
-         {{- /* request admin access in some cases, onl when the optional admin argument to this function (named tempalte) is specified as true */ -}}
+         {{- /* request admin access in some cases, only when the optional admin argument to this function (named template) is specified as true */ -}}
          {{- if eq (.admin | default "false") "true" -}} '-a',{{ " " -}}{{- end -}}
          
          {{- if (and (not (eq .name "db")) (not (eq .subCommand "create-crypto-config"))) -}}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -401,7 +401,7 @@ a second init container to execute the output SQL to the relevant database
            {{- " '-p'" -}}, {{- if .quotePassword }} '{{- else -}} {{ " " -}}{{- end -}}$({{ .environmentVariablePrefix -}}_PASSWORD){{- if .quotePassword }}'{{- end -}},
          {{- end -}}           
          
-         {{- if and (not (eq .name "rpc")) (not (eq .subCommand "create-crypto-config")) (not (eq .name "db")) -}}
+         {{- if and (not (eq .name "rpc")) (not (eq .subCommand "create-crypto-config")) -}}
              {{- " '--name'" -}}, 'corda-{{ .longName | default .name }}', 
              {{- " '--jdbc-url'" -}}, 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}', 
              {{- " '--jdbc-pool-max-size'" -}}, {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, {{- " " -}}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -41,7 +41,7 @@ spec:
             - mountPath: /tmp/working_dir
               name: working-volume
       initContainers:
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "subCommand" "spec" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
+        {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "rbac" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "vnodes" "longName" "virtual-nodes" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER" "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO") | nindent 8 }}                

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -407,7 +407,7 @@ a second init container to execute the output SQL to the relevant database
              {{- " '--jdbc-pool-max-size'" -}}, {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }}, {{- " " -}}
          {{- end -}}         
          
-         {{- if (and (not (eq .name "rpc")) (not (eq .name "db"))) -}}
+         {{- if not (eq .name "rpc") -}}
              {{- "'--salt'" -}}, "$(SALT)", '--passphrase', "$(PASSPHRASE)", 
          {{- end -}}
                   


### PR DESCRIPTION
Previously we had 6 instances of a pattern where we run corda-cli to make some SQL, then run another container to execute it. This was hard to maintain, so used a new named template to go from 6 to 1 copy of the declarations. 

To verify this produces the exact same output, I used `helm template` and then diffed the output against the old run. The differences are only in the random elements.

This exercise has revealed various unnecessary consistencies in the whitespace, quoting and naming. For now, I've got conditionals that preserve the inconsistencies, and we should make this big change, then remove the inconsistencies in later work.