### PR TITLE
CORE-12422 - Flow External Messaging - Dev Testing Issues

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkDbWriterFactoryImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkDbWriterFactoryImpl.kt
@@ -133,7 +133,8 @@ class ChunkDbWriterFactoryImpl(
         val cpiCacheDir = tempPathProvider.getOrCreate(bootConfig, CPI_CACHE_DIR)
         val cpiPartsDir = tempPathProvider.getOrCreate(bootConfig, CPI_PARTS_DIR)
         val membershipSchemaValidator = membershipSchemaValidatorFactory.createValidator()
-        val externalChannelsConfigValidator = ExternalChannelsConfigValidatorImpl(configurationValidatorFactory.createCordappConfigValidator())
+        val externalChannelsConfigValidator =
+            ExternalChannelsConfigValidatorImpl(configurationValidatorFactory.createCordappConfigValidator())
         val validator = CpiValidatorImpl(
             statusPublisher,
             chunkPersistence,

--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkDbWriterFactoryImpl.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/ChunkDbWriterFactoryImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.chunking.db.impl
 
+import javax.persistence.EntityManagerFactory
 import net.corda.chunking.RequestId
 import net.corda.chunking.db.ChunkDbWriter
 import net.corda.chunking.db.ChunkDbWriterFactory
@@ -8,9 +9,11 @@ import net.corda.chunking.db.impl.persistence.StatusPublisher
 import net.corda.chunking.db.impl.persistence.database.DatabaseChunkPersistence
 import net.corda.chunking.db.impl.persistence.database.DatabaseCpiPersistence
 import net.corda.chunking.db.impl.validation.CpiValidatorImpl
+import net.corda.chunking.db.impl.validation.ExternalChannelsConfigValidatorImpl
 import net.corda.cpiinfo.write.CpiInfoWriteService
 import net.corda.data.chunking.Chunk
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.validation.ConfigurationValidatorFactory
 import net.corda.membership.certificate.service.CertificatesService
 import net.corda.membership.group.policy.validation.MembershipGroupPolicyValidator
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
@@ -28,9 +31,6 @@ import net.corda.utilities.time.UTCClock
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import javax.persistence.EntityManagerFactory
-import net.corda.chunking.db.impl.validation.ExternalChannelsConfigValidatorImpl
-import net.corda.libs.configuration.validation.ConfigurationValidatorFactory
 
 @Suppress("UNUSED", "LongParameterList")
 @Component(service = [ChunkDbWriterFactory::class])
@@ -133,7 +133,7 @@ class ChunkDbWriterFactoryImpl(
         val cpiCacheDir = tempPathProvider.getOrCreate(bootConfig, CPI_CACHE_DIR)
         val cpiPartsDir = tempPathProvider.getOrCreate(bootConfig, CPI_PARTS_DIR)
         val membershipSchemaValidator = membershipSchemaValidatorFactory.createValidator()
-        val externalChannelsConfigValidator = ExternalChannelsConfigValidatorImpl(configurationValidatorFactory.createConfigValidator())
+        val externalChannelsConfigValidator = ExternalChannelsConfigValidatorImpl(configurationValidatorFactory.createCordappConfigValidator())
         val validator = CpiValidatorImpl(
             statusPublisher,
             chunkPersistence,

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterFactoryTests.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/VirtualNodeWriterFactoryTests.kt
@@ -54,7 +54,7 @@ class VirtualNodeWriterFactoryTests {
             ConfigFactory.empty()
                 .withValue(
                     ExternalMessagingConfig.EXTERNAL_MESSAGING_RECEIVE_TOPIC_PATTERN,
-                    ConfigValueFactory.fromAnyRef("ext.\$HOLDING_ID\$.\$CHANNEL_NAME\$.receive")
+                    ConfigValueFactory.fromAnyRef("ext.\$HOLDING_ID.\$CHANNEL_NAME.receive")
                 )
                 .withValue(ExternalMessagingConfig.EXTERNAL_MESSAGING_ACTIVE, ConfigValueFactory.fromAnyRef(true))
                 .withValue(

--- a/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
+++ b/libs/external-messaging/src/main/kotlin/net/corda/libs/external/messaging/ExternalMessagingRouteConfigGeneratorImpl.kt
@@ -37,8 +37,8 @@ class ExternalMessagingRouteConfigGeneratorImpl(
                 val defaultConfig = externalMessagingConfigProvider.getDefaults()
                 val topicPattern = defaultConfig.receiveTopicPattern
 
-                    .replace("\$HOLDING_ID\$", holdingId.shortHash.toString())
-                    .replace("\$CHANNEL_NAME\$", channelConfig.name)
+                    .replace("\$HOLDING_ID", holdingId.shortHash.toString())
+                    .replace("\$CHANNEL_NAME", channelConfig.name)
 
                 Route(
                     channelConfig.name,

--- a/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingRouteConfigGeneratorTest.kt
+++ b/libs/external-messaging/src/test/kotlin/net/corda/libs/external/messaging/test/ExternalMessagingRouteConfigGeneratorTest.kt
@@ -97,7 +97,7 @@ class ExternalMessagingRouteConfigGeneratorTest {
     fun `ensure the route configuration is generated correctly`() {
 
         val smartConfig =
-            genExternalMsgConfig("ext.\$HOLDING_ID\$.\$CHANNEL_NAME\$.receive", false, InactiveResponseType.IGNORE)
+            genExternalMsgConfig("ext.\$HOLDING_ID.\$CHANNEL_NAME.receive", false, InactiveResponseType.IGNORE)
 
         val externalMessagingRouteConfigGenerator =
             ExternalMessagingRouteConfigGeneratorImpl(

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -1,9 +1,9 @@
 package net.corda.virtualnode
 
-import net.corda.data.virtualnode.VirtualNodeOperationalState
-import net.corda.libs.packaging.core.CpiIdentifier
 import java.time.Instant
 import java.util.UUID
+import net.corda.data.virtualnode.VirtualNodeOperationalState
+import net.corda.libs.packaging.core.CpiIdentifier
 
 /**
  * Contains information relevant to a particular virtual node (a CPI and a holding identity).
@@ -77,6 +77,7 @@ fun VirtualNodeInfo.toAvro(): VirtualNodeInfoAvro =
             .setFlowOperationalStatus(flowOperationalStatus.toAvro())
             .setVaultDbOperationalStatus(vaultDbOperationalStatus.toAvro())
             .setOperationInProgress(operationInProgress)
+            .setExternalMessagingRouteConfig(externalMessagingRouteConfig)
             .setVersion(version)
             .setTimestamp(timestamp)
             .build()

--- a/testing/cpbs/test-cordapp/src/main/resources/config/external-channels.json
+++ b/testing/cpbs/test-cordapp/src/main/resources/config/external-channels.json
@@ -1,0 +1,8 @@
+{
+  "channels": [
+    {
+      "name": "external_app",
+      "type": "SEND"
+    }
+  ]
+}


### PR DESCRIPTION
Updated the class `ChunkDbWriterFactoryImpl` so that the correct configuration validator is created. Added the `external-channels.json` file to the smoke tests so that if the wrong validator is created, the smoke test will fail.

Changed the template replacement code to use a single $ prefix.

Added the map of the `externalMessagingRouteConfig` field of the Avro object in the .toAvro() method on net.corda.virtualnode.VirtualNodeInfo.