### PR TITLE
CORE-12189: Update VNode creation test utilities

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/VirtualNodeUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/VirtualNodeUtils.kt
@@ -2,8 +2,9 @@ package net.corda.e2etest.utilities
 
 import net.corda.utilities.minutes
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
 
-fun ClusterBuilder.awaitVirtualNodeOperationStatusCheck(requestId: String): String? {
+fun ClusterBuilder.awaitVirtualNodeOperationStatusCheck(requestId: String): String {
     val statusResponse = assertWithRetry {
         timeout(1.minutes)
         command { getVNodeStatus(requestId) }
@@ -29,4 +30,5 @@ fun ClusterBuilder.awaitVirtualNodeOperationStatusCheck(requestId: String): Stri
         .isEqualTo("SUCCEEDED")
 
     return  statusResponse.toJson()["resourceId"]?.textValue()
+        ?: fail("Virtual node status response did not include a resourceId field")
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/VirtualNodeUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/VirtualNodeUtils.kt
@@ -1,9 +1,11 @@
 package net.corda.e2etest.utilities
 
+import net.corda.utilities.minutes
 import org.assertj.core.api.Assertions.assertThat
 
 fun ClusterBuilder.awaitVirtualNodeOperationStatusCheck(requestId: String): String? {
     val statusResponse = assertWithRetry {
+        timeout(1.minutes)
         command { getVNodeStatus(requestId) }
         condition {
             if (it.code != 200) {


### PR DESCRIPTION
E2eCluster.createVirtualNode:
- Change timeout to 1 minute
- Use vnode create request ID to poll status and read holding ID from that response

ClusterBuilder.awaitVirtualNodeOperationStatusCheck:
- Change timeout to 1 minute
- Remove nullable from return type
