### PR TITLE
CORE-9731 Block non-custom property updates to re-registration context

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
@@ -33,7 +33,6 @@ import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.configuration.MembershipConfig.TtlsConfig.UPDATE_TO_PENDING_AUTO_APPROVAL
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.membership.MemberContext
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
@@ -209,6 +208,4 @@ internal class ProcessMemberVerificationResponseHandler(
     }
 
     class InvalidPreAuthTokenException(msg: String) : CordaRuntimeException(msg)
-
-    private fun MemberContext.toMap() = entries.associate { it.key to it.value }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -15,6 +15,7 @@ import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandle
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
 import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
@@ -60,7 +61,6 @@ internal class StartRegistrationHandler(
 ) : RegistrationHandler<StartRegistration> {
 
     private companion object {
-        const val CUSTOM_KEY_PREFIX = "ext."
         val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
@@ -131,7 +131,7 @@ internal class StartRegistrationHandler(
                     .filterNot { it.key.startsWith(CUSTOM_KEY_PREFIX) }
                 validateRegistrationRequest(
                     diff.isEmpty()
-                ) { "Only custom fields with the 'ext.' prefix may be updated during re-registration." }
+                ) { "Only custom fields with the '$CUSTOM_KEY_PREFIX' prefix may be updated during re-registration." }
             }
 
             // The group ID matches the group ID of the MGM

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -412,7 +412,7 @@ class DynamicMemberRegistrationService @Activate constructor(
             member: HoldingIdentity,
             roles: Collection<MemberRole>,
             notaryKeys: List<KeyDetails>,
-            previousContext: Map<String, String>?,
+            previousRegistrationContext: Map<String, String>?,
         ): Map<String, String> {
             val cpi = virtualNodeInfoReadService.get(member)?.cpiIdentifier
                 ?: throw CordaRuntimeException("Could not find virtual node info for member ${member.shortHash}")
@@ -433,7 +433,7 @@ class DynamicMemberRegistrationService @Activate constructor(
             )
             val roleContext = roles.toMemberInfo { notaryKeys }
             val optionalContext = mapOf(MEMBER_CPI_SIGNER_HASH to cpi.signerSummaryHash.toString())
-            val result = filteredContext +
+            val newRegistrationContext = filteredContext +
                     sessionKeyContext +
                     ledgerKeyContext +
                     additionalContext +
@@ -441,8 +441,8 @@ class DynamicMemberRegistrationService @Activate constructor(
                     optionalContext +
                     tlsSubject
 
-            previousContext?.let { previous ->
-                ((result.entries - previous.entries) + (previous.entries - result.entries)).filterNot {
+            previousRegistrationContext?.let { previous ->
+                ((newRegistrationContext.entries - previous.entries) + (previous.entries - newRegistrationContext.entries)).filterNot {
                     it.key.startsWith(CUSTOM_KEY_PREFIX)
                 }.apply {
                     require(isEmpty()) {
@@ -454,7 +454,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                 }
             }
 
-            return result
+            return newRegistrationContext
         }
 
         private fun getTlsSubject(member: HoldingIdentity) : Map<String, String> {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -26,6 +26,7 @@ import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequestHeader
 import net.corda.data.p2p.app.AppMessage
+import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.data.p2p.app.UnauthenticatedMessage
 import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.libs.configuration.helper.getConfig
@@ -314,7 +315,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                     ?: throw IllegalArgumentException("Failed to look up MGM information.")
 
                 val serialInfo = context[SERIAL]?.toLong()
-                    ?: groupReader.lookup(member.x500Name)?.serial
+                    ?: groupReader.lookup(member.x500Name, MembershipStatusFilter.ACTIVE_OR_SUSPENDED)?.serial
                     ?: 0
 
                 val message = MembershipRegistrationRequest(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/RegistrationContextCustomFieldsVerifier.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/verifiers/RegistrationContextCustomFieldsVerifier.kt
@@ -1,9 +1,10 @@
 package net.corda.membership.impl.registration.dynamic.verifiers
 
+import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
+
 internal class RegistrationContextCustomFieldsVerifier {
 
     private companion object {
-        const val CUSTOM_KEY_PREFIX = "ext."
         const val MAX_VALUE_LENGTH = 256
         const val MAX_KEY_LENGTH = 128
         const val MAX_CUSTOM_FIELDS = 100

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -124,6 +124,11 @@ class MemberInfoExtension {
         const val ROLES_PREFIX = "corda.roles"
 
         /**
+         * Prefix for custom properties
+         */
+        const val CUSTOM_KEY_PREFIX = "ext"
+
+        /**
          * Notary role name
          */
         const val NOTARY_ROLE = "notary"

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/RegistrationUtils.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/RegistrationUtils.kt
@@ -3,6 +3,7 @@ package net.corda.membership.lib
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.v5.base.types.LayeredPropertyMap
+import net.corda.v5.membership.MemberContext
 
 /**
  * Transforms [KeyValuePairList] into map.
@@ -30,4 +31,9 @@ fun LayeredPropertyMap.toWire(): KeyValuePairList {
         }
     )
 }
+
+/**
+ * Transforms [MemberContext] into map.
+ */
+fun MemberContext.toMap() = entries.associate { it.key to it.value }
 


### PR DESCRIPTION
This change compares the member-provided contexts from a member's existing MemberInfo and the proposed MemberInfo during re-registration, and only allows changes to be made to custom properties with the 'ext.' prefix. This check is performed on the member as well as the MGM side.