### PR TITLE
CORE-11960 Capture the originator of a notarization request

### DIFF
--- a/components/uniqueness/backing-store-impl/src/backingStoreBenchmark/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplBenchmark.kt
+++ b/components/uniqueness/backing-store-impl/src/backingStoreBenchmark/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplBenchmark.kt
@@ -75,6 +75,8 @@ class JPABackingStoreImplBenchmark {
     private var currentTestExecTimeMs = 0L
     private val resultsMap = TreeMap<String, Int>()
 
+    private val originatorX500Name = "C=GB, L=London, O=Alice"
+
     private lateinit var holdingIdentity: HoldingIdentity
     private lateinit var backingStore: BackingStore
     private lateinit var testClock: AutoTickTestClock
@@ -90,8 +92,8 @@ class JPABackingStoreImplBenchmark {
         // An entirely new database is created for each test case, to ensure performance is not
         // impacted between different test cases
         holdingIdentity = createTestHoldingIdentity(
-            "C=GB, L=London, O=Alice", UUID.randomUUID().toString())
-         val holdingIdentityDbName =
+            "C=GB, L=London, O=NotaryRep1", UUID.randomUUID().toString())
+        val holdingIdentityDbName =
             VirtualNodeDbType.UNIQUENESS.getSchemaName(holdingIdentity.shortHash)
 
         val databaseInstaller = DatabaseInstaller(
@@ -247,6 +249,7 @@ class JPABackingStoreImplBenchmark {
                         UniquenessCheckRequestInternal(
                             txId,
                             txId.toString(),
+                            originatorX500Name,
                             emptyList(),
                             emptyList(),
                             0,

--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntitiesIntegrationTest.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntitiesIntegrationTest.kt
@@ -33,6 +33,8 @@ class JPABackingStoreEntitiesIntegrationTest {
     private val testClock =
         AutoTickTestClock(Instant.now().truncatedTo(ChronoUnit.MILLIS), Duration.ofMillis(1))
 
+    private val originatorX500Name = "C=GB, L=London, O=Alice"
+
     private companion object {
         private const val MIGRATION_FILE_LOCATION =
             "net/corda/db/schema/vnode-uniqueness/migration/vnode-uniqueness-creation-v1.0.xml"
@@ -122,6 +124,7 @@ class JPABackingStoreEntitiesIntegrationTest {
         val txDetails = UniquenessTransactionDetailEntity(
             txId.algorithm,
             txId.bytes,
+            originatorX500Name,
             testClock.instant(),
             testClock.instant(),
             RESULT_ACCEPTED_REPRESENTATION
@@ -187,6 +190,7 @@ class JPABackingStoreEntitiesIntegrationTest {
             UniquenessTransactionDetailEntity(
                 txId.algorithm,
                 txId.bytes,
+                originatorX500Name,
                 testClock.instant(),
                 testClock.instant(),
                 RESULT_ACCEPTED_REPRESENTATION),

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntities.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntities.kt
@@ -1,5 +1,6 @@
 package net.corda.uniqueness.backingstore.impl
 
+import net.corda.uniqueness.datamodel.common.UniquenessConstants.ORIGINATOR_X500_NAME_LENGTH
 import net.corda.uniqueness.datamodel.common.UniquenessConstants.TRANSACTION_ID_ALGO_LENGTH
 import net.corda.uniqueness.datamodel.common.UniquenessConstants.TRANSACTION_ID_LENGTH
 import net.corda.uniqueness.datamodel.common.UniquenessConstants.REJECTED_TRANSACTION_ERROR_DETAILS_LENGTH
@@ -156,6 +157,7 @@ internal class UniquenessStateDetailEntity(
 )
 
 @IdClass(UniquenessTxAlgoIdKey::class)
+@Suppress("LongParameterList")
 internal class UniquenessTransactionDetailEntity(
     @Id
     @Column(name = "tx_id_algo", length = TRANSACTION_ID_ALGO_LENGTH, nullable = false)
@@ -164,6 +166,9 @@ internal class UniquenessTransactionDetailEntity(
     @Id
     @Column(name = "tx_id", length = TRANSACTION_ID_LENGTH, nullable = false)
     val txId: ByteArray,
+
+    @Column(name = "originator_x500_name", length = ORIGINATOR_X500_NAME_LENGTH, nullable = false)
+    val originatorX500Name: String,
 
     @Column(name = "expiry_datetime", nullable = false)
     val expiryDateTime: Instant,
@@ -180,6 +185,7 @@ internal class UniquenessTransactionDetailEntity(
 
         if (txIdAlgo != other.txIdAlgo) return false
         if (!txId.contentEquals(other.txId)) return false
+        if (originatorX500Name != other.originatorX500Name) return false
         if (expiryDateTime != other.expiryDateTime) return false
         if (result != other.result) return false
 

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -408,6 +408,7 @@ open class JPABackingStoreImpl @Activate constructor(
                         UniquenessTransactionDetailEntity(
                             request.txId.algorithm,
                             request.txId.bytes,
+                            request.originatorX500Name,
                             request.timeWindowUpperBound,
                             result.resultTimestamp,
                             result.toCharacterRepresentation()

--- a/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImpl.kt
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImpl.kt
@@ -35,6 +35,7 @@ class LedgerUniquenessCheckerClientServiceImpl @Activate constructor(
     @Suspendable
     override fun requestUniquenessCheck(
         txId: String,
+        originatorX500Name: String,
         inputStates: List<String>,
         referenceStates: List<String>,
         numOutputStates: Int,
@@ -49,6 +50,7 @@ class LedgerUniquenessCheckerClientServiceImpl @Activate constructor(
             UniquenessCheckExternalEventFactory::class.java,
             UniquenessCheckExternalEventParams(
                 txId,
+                originatorX500Name,
                 inputStates,
                 referenceStates,
                 numOutputStates,

--- a/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/UniquenessCheckClientExternalEventFactory.kt
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/UniquenessCheckClientExternalEventFactory.kt
@@ -41,6 +41,7 @@ class UniquenessCheckExternalEventFactory @Activate constructor():
         checkpoint.holdingIdentity.toAvro(),
         context,
         params.txId,
+        params.originatorX500Name,
         params.inputStates,
         params.referenceStates,
         params.numOutputStates,
@@ -51,6 +52,7 @@ class UniquenessCheckExternalEventFactory @Activate constructor():
 
 data class UniquenessCheckExternalEventParams(
     val txId: String,
+    val originatorX500Name: String,
     val inputStates: List<String>,
     val referenceStates: List<String>,
     val numOutputStates: Int,

--- a/components/uniqueness/uniqueness-checker-client-service-impl/src/test/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImplTest.kt
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/src/test/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImplTest.kt
@@ -24,6 +24,7 @@ class LedgerUniquenessCheckerClientServiceImplTest {
 
     private companion object {
         val dummyTxId = SecureHashUtils.randomSecureHash()
+        val originatorX500Name = "C=GB, L=London, O=Alice"
     }
 
     private val argumentCaptor = argumentCaptor<Class<out UniquenessCheckExternalEventFactory>>()
@@ -34,6 +35,7 @@ class LedgerUniquenessCheckerClientServiceImplTest {
             uniquenessCheckResult = UniquenessCheckResultSuccessImpl(Instant.now())
         ).requestUniquenessCheck(
             dummyTxId.toString(),
+            originatorX500Name,
             emptyList(),
             emptyList(),
             5,
@@ -53,6 +55,7 @@ class LedgerUniquenessCheckerClientServiceImplTest {
             )
         ).requestUniquenessCheck(
             dummyTxId.toString(),
+            originatorX500Name,
             emptyList(),
             emptyList(),
             5,

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/osgitests/MessageBusIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/osgitests/MessageBusIntegrationTests.kt
@@ -164,8 +164,10 @@ class MessageBusIntegrationTests {
 
     private val groupId = UUID.randomUUID().toString()
 
-    private val defaultHoldingIdentity = createTestHoldingIdentity(
-        "C=GB, L=London, O=Alice", groupId).toAvro()
+    private val defaultNotaryVNodeHoldingIdentity = createTestHoldingIdentity(
+        "C=GB, L=London, O=NotaryRep1", groupId).toAvro()
+
+    private val defaultOriginatorX500Name = "C=GB, L=London, O=Alice"
 
     // We don't use Instant.MAX because this appears to cause a long overflow in Avro
     private val defaultTimeWindowUpperBound: Instant =
@@ -179,13 +181,14 @@ class MessageBusIntegrationTests {
             : UniquenessCheckRequestAvro.Builder =
         UniquenessCheckRequestAvro.newBuilder(
             UniquenessCheckRequestAvro(
-                defaultHoldingIdentity,
+                defaultNotaryVNodeHoldingIdentity,
                 ExternalEventContext(
                     UUID.randomUUID().toString(),
                     UUID.randomUUID().toString(),
                     KeyValuePairList(emptyList())
                 ),
                 txId.toString(),
+                defaultOriginatorX500Name,
                 emptyList(),
                 emptyList(),
                 0,

--- a/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
@@ -92,6 +92,8 @@ class UniquenessCheckerImplDBIntegrationTests {
     private val noDbHoldingIdentityDbName =
         VirtualNodeDbType.UNIQUENESS.getSchemaName(noDbHoldingIdentity.shortHash)
 
+    private val originatorX500Name = "C=GB, L=London, O=David"
+
     // We don't use Instant.MAX because this appears to cause a long overflow in Avro
     private val defaultTimeWindowUpperBound: Instant =
         LocalDate.of(2200, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC)
@@ -109,6 +111,7 @@ class UniquenessCheckerImplDBIntegrationTests {
                 defaultHoldingIdentity.toAvro(),
                 ExternalEventContext(),
                 txId.toString(),
+                originatorX500Name,
                 emptyList(),
                 emptyList(),
                 0,

--- a/components/uniqueness/uniqueness-checker-impl/src/test/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/test/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplTests.kt
@@ -59,8 +59,10 @@ class UniquenessCheckerImplTests {
     private val groupId = UUID.randomUUID().toString()
 
     // Default holding id used in most tests
-    private val defaultHoldingIdentity = createTestHoldingIdentity(
-        "C=GB, L=London, O=Alice", groupId).toAvro()
+    private val defaultNotaryVNodeHoldingIdentity = createTestHoldingIdentity(
+        "C=GB, L=London, O=NotaryRep1", groupId).toAvro()
+
+    private val originatorX500Name = "C=GB, L=London, O=Alice"
 
     // We don't use Instant.MAX because this appears to cause a long overflow in Avro
     private val defaultTimeWindowUpperBound: Instant =
@@ -77,9 +79,10 @@ class UniquenessCheckerImplTests {
     private fun newRequestBuilder(txId: SecureHash = randomSecureHash()): UniquenessCheckRequestAvro.Builder =
         UniquenessCheckRequestAvro.newBuilder(
             UniquenessCheckRequestAvro(
-                defaultHoldingIdentity,
+                defaultNotaryVNodeHoldingIdentity,
                 ExternalEventContext(),
                 txId.toString(),
+                originatorX500Name,
                 emptyList(),
                 emptyList(),
                 0,

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.72
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.750-beta+
+cordaApiVersion=5.0.0.751-beta+
 
 disruptorVersion=3.4.2
 felixConfigAdminVersion=1.9.26

--- a/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/common/UniquenessConstants.kt
+++ b/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/common/UniquenessConstants.kt
@@ -10,21 +10,30 @@ object UniquenessConstants {
     /**
      * Specifies the maximum supported transaction algorithm length.
      *
-     * CHANGING THIS VALUE WILL CHANGE THE SIZE OF DATABASE FIELDS STORING TRANSACTION ALGORITHM IDS
+     * THIS VALUE MUST MATCH THE SIZE SPECIFIED IN THE CORDA-API LIQUIBASE SCHEMA DEFINITION
      */
     const val TRANSACTION_ID_ALGO_LENGTH = 8
 
     /**
      * Specifies the maximum supported transaction hash length.
      *
-     * CHANGING THIS VALUE WILL CHANGE THE SIZE OF DATABASE FIELDS STORING TRANSACTION IDS
+     * THIS VALUE MUST MATCH THE SIZE SPECIFIED IN THE CORDA-API LIQUIBASE SCHEMA DEFINITION
      */
     const val TRANSACTION_ID_LENGTH = 64
 
     /**
+     * Specifies the maximum supported length of the x500 name of a party requesting notarization.
+     * This is deliberately large, relying on application logic to enforce an assumed shorter
+     * maximum length.
+     *
+     * THIS VALUE MUST MATCH THE SIZE SPECIFIED IN THE CORDA-API LIQUIBASE SCHEMA DEFINITION
+     */
+    const val ORIGINATOR_X500_NAME_LENGTH = 1024
+
+    /**
      * Specifies the maximum supported rejected transaction error details length.
      *
-     * CHANGING THIS VALUE WILL CHANGE THE SIZE LIMIT OF REJECTED TRANSACTION ERROR DETAILS
+     * THIS VALUE MUST MATCH THE SIZE SPECIFIED IN THE CORDA-API LIQUIBASE SCHEMA DEFINITION
      */
     const val REJECTED_TRANSACTION_ERROR_DETAILS_LENGTH = 1024
 

--- a/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/internal/UniquenessCheckRequestInternal.kt
+++ b/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/internal/UniquenessCheckRequestInternal.kt
@@ -15,6 +15,7 @@ import java.time.Instant
 data class UniquenessCheckRequestInternal constructor(
     val txId: SecureHash,
     val rawTxId: String,
+    val originatorX500Name: String,
     val inputStates: List<UniquenessCheckStateRef>,
     val referenceStates: List<UniquenessCheckStateRef>,
     val numOutputStates: Int,
@@ -45,6 +46,7 @@ data class UniquenessCheckRequestInternal constructor(
                 return UniquenessCheckRequestInternal(
                     parseSecureHash(txId),
                     txId,
+                    originatorX500Name,
                     inputStates?.map { it.toStateRef() } ?: emptyList(),
                     referenceStates?.map { it.toStateRef() } ?: emptyList(),
                     numOutputStates,

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -81,6 +81,7 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
 
             val uniquenessResult = clientService.requestUniquenessCheck(
                 txDetails.id.toString(),
+                session.counterparty.toString(),
                 txDetails.inputs.map { it.toString() },
                 txDetails.references.map { it.toString() },
                 txDetails.numOutputs,

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -413,11 +413,11 @@ class NonValidatingNotaryServerFlowImplTest {
     }
 
     private fun mockThrowErrorUniquenessCheckClientService() = mock<LedgerUniquenessCheckerClientService> {
-        on { requestUniquenessCheck(any(), any(), any(), any(), any(), any()) } doThrow
+        on { requestUniquenessCheck(any(), any(), any(), any(), any(), any(), any()) } doThrow
                 IllegalArgumentException("Uniqueness checker cannot be reached")
     }
 
     private fun mockUniquenessClientService(response: UniquenessCheckResult) = mock<LedgerUniquenessCheckerClientService> {
-        on { requestUniquenessCheck(any(), any(), any(), any(), any(), any()) } doReturn response
+        on { requestUniquenessCheck(any(), any(), any(), any(), any(), any(), any()) } doReturn response
     }
 }


### PR DESCRIPTION
### Summary

This PR adds the ability to capture the name of the originator of a notarization request to be captured in the uniqueness database for a notary virtual node for audit purposes. This change also has corresponding extensions to the DB schema and internal API, see https://github.com/corda/corda-api/pull/1048

### Testing

Automated test cases have been updated to specify an originating x500 name where applicable. As part of running smoke tests, also manually verified that the new DB field is being populated correctly in the uniqueness DB:

![image](https://user-images.githubusercontent.com/4272763/231737262-e611ebc8-b7e8-472d-848c-f42404b1f10f.png)