### PR TITLE
CORE-9467: Add trim() to parse version parameter of flow protocol

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -154,7 +154,7 @@ class SessionEventHandler @Activate constructor(
                         "missing from SessionInit"
             )
         }
-        return Pair(requestedProtocolName, initiatorVersionsSupportedProp.split(",").map { it.toInt() })
+        return Pair(requestedProtocolName, initiatorVersionsSupportedProp.split(",").map { it.trim().toInt() })
     }
 
     private fun sendConfirmMessage(


### PR DESCRIPTION
This was causing an error when flows were called that were compatible across multiple versions. 

e.g.
`@InitiatingFlow(protocol = "upgrade-compatibility-test-protocol", version=[1, 2])`

This code was trying to parse ' 2' (with a space) into an int and failing. Adding a trim() fixes this. 

Error in logs:
`2023-04-13 14:35:12.904 [Thread-102] WARN  net.corda.flow.pipeline.impl.FlowEventExceptionProcessorImpl {client_id=667b9495-0043-460b-92d1-8a3152c97c35-INITIATED, flow_id=2048f552-a092-49c5-ab1e-54b14e71bc08, session_event_id=667b9495-0043-460b-92d1-8a3152c97c35-INITIATED, vnode_id=36CC10CF008B} - Unexpected exception while processing flow, the flow will be sent to the DLQ
java.lang.NumberFormatException: For input string: " 2"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[?:?]
	at java.lang.Integer.parseInt(Integer.java:638) ~[?:?]
	at java.lang.Integer.parseInt(Integer.java:770) ~[?:?]
	at net.corda.flow.pipeline.handlers.events.SessionEventHandler.getProtocolInfo(SessionEventHandler.kt:157) ~[?:?]
	at net.corda.flow.pipeline.handlers.events.SessionEventHandler.createInitiatedFlowCheckpoint(SessionEventHandler.kt:104) ~[?:?]
	at net.corda.flow.pipeline.handlers.events.SessionEventHandler.preProcess(SessionEventHandler.kt:74) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventPipelineImpl.eventPreProcessing(FlowEventPipelineImpl.kt:76) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventPipelineImpl.eventPreProcessing(FlowEventPipelineImpl.kt:37) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventProcessorImpl.getFlowPipelineResponse(FlowEventProcessorImpl.kt:81) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventProcessorImpl.access$getFlowPipelineResponse(FlowEventProcessorImpl.kt:23) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventProcessorImpl$onNext$1.invoke(FlowEventProcessorImpl.kt:52) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventProcessorImpl$onNext$1.invoke(FlowEventProcessorImpl.kt:51) ~[?:?]
	at net.corda.utilities.LogUtilsKt.withMDC(LogUtils.kt:61) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventProcessorImpl.onNext(FlowEventProcessorImpl.kt:51) ~[?:?]
	at net.corda.flow.pipeline.impl.FlowEventProcessorImpl.onNext(FlowEventProcessorImpl.kt:23) ~[?:?]
	at net.corda.messaging.subscription.StateAndEventSubscriptionImpl$getUpdatesForEvent$future$1$1.invoke(StateAndEventSubscriptionImpl.kt:310) ~[?:?]
	at net.corda.messaging.subscription.consumer.StateAndEventConsumerImpl.waitForFunctionToFinish$lambda$21(StateAndEventConsumerImpl.kt:243) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700) [?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]`