### PR TITLE
CORE-9790: helm corda-lib support for Vault, and tidy up

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -379,7 +379,7 @@ a second init container to execute the output SQL to the relevant database
 
 {{- define "corda.generateAndExecuteSql" -}}
 {{- /* define 2 init containers, which run in sequence. First run corda-cli initial-config to generate some SQL, storing in a persistent volume called working-volume. Second is a postgres image which mounts the same persistent volume and executes the SQL. */ -}}  
-- name: {{ printf "%02d" .sequenceNumber }}-create-{{ .name }}
+- name: {{ printf "%02d-create-%s" .sequenceNumber .name }}
   image: {{ include "corda.bootstrapCliImage" . }}
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   {{- include "corda.bootstrapResources" . | nindent 2 }}
@@ -456,7 +456,7 @@ a second init container to execute the output SQL to the relevant database
     {{- if eq .environmentVariablePrefix "CRYPTO_DB_USER" -}}
       {{- include "corda.cryptoDbUserEnv" . | nindent 4 -}}
     {{- end }}
-- name: {{ printf "%02d" (add .sequenceNumber 1)}}-apply-{{ .name }}
+- name: {{ printf "%02d-apply-%s" (add .sequenceNumber 1) .name }}
   image: {{ include "corda.bootstrapDbClientImage" . }}
   imagePullPolicy: {{ .Values.imagePullPolicy }}
   {{- include "corda.bootstrapResources" . | nindent 2 }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -72,24 +72,6 @@ spec:
           {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
           {{- include "corda.clusterDbEnv" . | nindent 12 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto-config" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql" "sequenceNumber" 12) | nindent 8 }}
-        {{- if (((.Values).config).vault).url }} 
-        - name: 14-apply-db-secrets-to-vault
-          image: curlimages/curl:8.00.1
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: [ '--retry', '5', '--retry-max-time', '30', '--retry-all-errors', '--header', 'X-Vault-Token: {{ .Values.config.vault.token }}', '--request', 'POST', '--data', '{ "data": {"crypto": "$(CRYPTO_DB_USER_PASSWORD)", "vnodes": "$(DB_CLUSTER_PASSWORD)", "rbac": "$(RBAC_DB_USER_PASSWORD)"} }', '{{ .Values.config.vault.url }}/v1/secret/data/dbsecrets', '--verbose']
-          env:
-          {{ include "corda.rbacDbUserEnv" . | nindent 12 }}
-          {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
-          {{- include "corda.clusterDbEnv" . | nindent 12 }}
-        - name: 15-apply-crypto-secrets-to-vault
-          image: curlimages/curl:8.00.1
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: [ '--retry', '5', '--retry-max-time', '30', '--retry-all-errors', '--header', 'X-Vault-Token: {{ .Values.config.vault.token }}', '--request', 'POST', '--data', '{ "data": {"passphrase": "6SIgbxSKt6WpBcSifBUy4geKOGyyVDMIELQ/uj8k2P4=", "salt": "URSKJ/t6xNd/hu3XmQ6q57BVq3R0DNgQn75Hz/2SPf0="} }', '{{ .Values.config.vault.url }}/v1/secret/data/cryptosecrets', '--verbose']
-        {{- end }}
       volumes:
         - name: working-volume
           emptyDir: {}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -72,7 +72,7 @@ spec:
           {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
           {{- include "corda.clusterDbEnv" . | nindent 12 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto-config" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql" "sequenceNumber" 12) | nindent 8 }}
-        {{- if and (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") }} 
+        {{- if (((.Values).config).vault).url }} 
         - name: 14-apply-db-secrets-to-vault
           image: curlimages/curl:8.00.1
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -425,14 +425,14 @@ a second init container to execute the output SQL to the relevant database
          {{- end -}}         
          
          {{- if not (eq .name "rpc") -}}
-           {{- if and (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") (not (eq .name "crypto-config")) -}} 
+           {{- if and (((.Values).config).vault).url  (not (eq .name "crypto-config")) -}} 
              '-t', 'VAULT', '--vault-path', 'dbsecrets', '--key', {{ .name | quote }},
            {{- else -}}
              '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)",
            {{- end -}} 
          {{- end -}}
          
-         {{- if and (eq .name "crypto-config") (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") -}}
+         {{- if and (eq .name "crypto-config") (((.Values).config).vault).url  -}}
             '--vault-path', 'cryptosecrets', '-ks', 'salt', '-kp', 'passphrase',
          {{- end -}}
          

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -72,7 +72,7 @@ spec:
           {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
           {{- include "corda.clusterDbEnv" . | nindent 12 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto-config" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql" "sequenceNumber" 12) | nindent 8 }}
-        {{- if and (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") -}} 
+        {{- if and (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") }} 
         - name: 14-apply-db-secrets-to-vault
           image: curlimages/curl:8.00.1
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -425,15 +425,15 @@ a second init container to execute the output SQL to the relevant database
          {{- end -}}         
          
          {{- if not (eq .name "rpc") -}}
-           {{- if and (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") -}} 
-             '-t', 'VAULT', '--vault-path', 'dbsecrets', '--key', {{ .name }}
+           {{- if and (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") (not (eq .name "crypto-config")) -}} 
+             '-t', 'VAULT', '--vault-path', 'dbsecrets', '--key', {{ .name | quote }},
            {{- else -}}
              '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)",
            {{- end -}} 
          {{- end -}}
          
          {{- if and (eq .name "crypto-config") (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") -}}
-            '-v', 'cryptosecrets', '-ks', 'salt', '-kp', 'passphrase'
+            '--vault-path', 'cryptosecrets', '-ks', 'salt', '-kp', 'passphrase',
          {{- end -}}
          
          {{- " '-l'" -}}, '/tmp/working_dir']

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -72,7 +72,24 @@ spec:
           {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
           {{- include "corda.clusterDbEnv" . | nindent 12 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto-config" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql" "sequenceNumber" 12) | nindent 8 }}
-
+        {{- if and (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") -}} 
+        - name: 14-apply-db-secrets-to-vault
+          image: curlimages/curl:8.00.1
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
+          args: [ '--retry', '5', '--retry-max-time', '30', '--retry-all-errors', '--header', 'X-Vault-Token: {{ .Values.config.vault.token }}', '--request', 'POST', '--data', '{ "data": {"crypto": "$(CRYPTO_DB_USER_PASSWORD)", "vnodes": "$(DB_CLUSTER_PASSWORD)", "rbac": "$(RBAC_DB_USER_PASSWORD)"} }', '{{ .Values.config.vault.url }}/v1/secret/data/dbsecrets', '--verbose']
+          env:
+          {{ include "corda.rbacDbUserEnv" . | nindent 12 }}
+          {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
+          {{- include "corda.clusterDbEnv" . | nindent 12 }}
+        - name: 15-apply-crypto-secrets-to-vault
+          image: curlimages/curl:8.00.1
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
+          args: [ '--retry', '5', '--retry-max-time', '30', '--retry-all-errors', '--header', 'X-Vault-Token: {{ .Values.config.vault.token }}', '--request', 'POST', '--data', '{ "data": {"passphrase": "6SIgbxSKt6WpBcSifBUy4geKOGyyVDMIELQ/uj8k2P4=", "salt": "URSKJ/t6xNd/hu3XmQ6q57BVq3R0DNgQn75Hz/2SPf0="} }', '{{ .Values.config.vault.url }}/v1/secret/data/cryptosecrets', '--verbose']
+        {{- end }}
       volumes:
         - name: working-volume
           emptyDir: {}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -71,7 +71,7 @@ spec:
           {{ include "corda.rbacDbUserEnv" . | nindent 12 }}
           {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
           {{- include "corda.clusterDbEnv" . | nindent 12 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "quoteUser" "true" "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql") | nindent 8 }}
+        {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto-config" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "quoteUser" "true" "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql") | nindent 8 }}
 
       volumes:
         - name: working-volume

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -393,7 +393,7 @@ a second init container to execute the output SQL to the relevant database
          {{- /* request admin access in some cases, only when the optional admin argument to this function (named template) is specified as true */ -}}
          {{- if eq .name "vnodes" -}} '-a',{{- end -}}
          
-         {{- if (and (not (eq .name "db")) (not (eq .subCommand "create-crypto-config"))) -}}
+         {{- if and (not (eq .name "db")) (not (eq .name "crypto-config")) -}}
            {{- /* specify DB user - note that the quotes being optional is to preserve output while refactory, we can always safely quote */ -}}
            {{- "'-u'" -}}, '$({{ .environmentVariablePrefix -}}_USERNAME)',
          
@@ -413,6 +413,10 @@ a second init container to execute the output SQL to the relevant database
            {{- else -}}
              '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)",
            {{- end -}} 
+         {{- end -}}
+         
+         {{- if and (eq .name "crypto-config") (hasKey .Values "config") (hasKey .Values.config "vault") (hasKey .Values.config.vault "url") -}}
+            '-v', 'cryptosecrets', '-ks', 'salt', '-kp', 'passphrase'
          {{- end -}}
          
          {{- " '-l'" -}}, '/tmp/working_dir']

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -391,10 +391,6 @@ a second init container to execute the output SQL to the relevant database
   args: [ 'initial-config', '{{ .subCommand | default "create-db-config" }}',{{ " " -}}
   
          {{- /* request admin access in some cases, only when the optional admin argument to this function (named template) is specified as true */ -}}
-         {{- if (.admin | default false) -}} '-a',{{ " " -}}{{- end -}}
-  args: [ 'initial-config', '{{ .subCommand | default "create-db-config" }}',
- 
-         {{- /* request admin access when creating vnodes */ -}}
          {{- if eq .name "vnodes" -}} '-a',{{- end -}}
          
          {{- if (and (not (eq .name "db")) (not (eq .subCommand "create-crypto-config"))) -}}
@@ -436,7 +432,7 @@ a second init container to execute the output SQL to the relevant database
        {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
     {{- end -}}    
 
-    {{ include "corda.bootstrapCliEnv" . | nindent 4 -}}{{- /* set JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
+    {{- include "corda.bootstrapCliEnv" . | nindent 4 -}}{{- /* set JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
 
     {{- if or (eq .name "rbac") (eq .name "vnodes") }}
     {{ include "corda.rbacDbUserEnv" . | nindent 4 }}
@@ -450,7 +446,7 @@ a second init container to execute the output SQL to the relevant database
     {{- end -}}
     {{- if eq .environmentVariablePrefix "CRYPTO_DB_USER" -}}
       {{- include "corda.cryptoDbUserEnv" . | nindent 4 -}}
-    {{- end -}}
+    {{- end }}
 - name: apply-{{ .name }}
   image: {{ include "corda.bootstrapDbClientImage" . }}
   imagePullPolicy: {{ .Values.imagePullPolicy }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -44,8 +44,8 @@ spec:
         {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "Values" .Values "Chart" .Chart "Release" .Release "schema" "RBAC" "quoteUser" "true" "namePostfix" "schemas") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "rbac" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "quoteUser" "true") | nindent 8 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "vnodes" "longName" "virtual-nodes" "dbName" "rbac" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER") | nindent 8 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER" "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO") | nindent 8 }}                
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "rpc"  "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "REST_API_ADMIN" "quoteUser" "true" "quotePassword" "false" "schema" "RBAC"  "searchPath" "RBAC" "subCommand" "create-user-config" "namePostfix" "admin" "sqlFile" "rbac-config.sql") | nindent 8 }}
+        {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER" "quoteUser" "true" "schema" "CRYPTO") | nindent 8 }}                
+        {{- include "corda.generateAndExecuteSql" ( dict "name" "rpc"  "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "REST_API_ADMIN" "quoteUser" "true" "schema" "RBAC"  "searchPath" "RBAC" "subCommand" "create-user-config" "namePostfix" "admin" "sqlFile" "rbac-config.sql") | nindent 8 }}
         - name: create-db-users-and-grant
           image: {{ include "corda.bootstrapDbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -71,7 +71,7 @@ spec:
           {{ include "corda.rbacDbUserEnv" . | nindent 12 }}
           {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
           {{- include "corda.clusterDbEnv" . | nindent 12 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "quoteUser" "true" "quotePassword" "false" "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql") | nindent 8 }}
+        {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "quoteUser" "true" "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql") | nindent 8 }}
 
       volumes:
         - name: working-volume
@@ -398,7 +398,7 @@ a second init container to execute the output SQL to the relevant database
            {{- "'-u'" -}}, '$({{ .environmentVariablePrefix -}}_USERNAME)',
          
            {{- /* specify DB password - note again that the quotes being optional is to preserve output while refactory, we can always safely quote */ -}}   
-           {{- " '-p'" -}}, {{- if .quotePassword }} '{{- else -}} {{ " " -}}{{- end -}}$({{ .environmentVariablePrefix -}}_PASSWORD){{- if .quotePassword }}'{{- end -}},
+           {{- " '-p'" -}}, '$({{ .environmentVariablePrefix -}}_PASSWORD)',
          {{- end -}}           
          
          {{- if and (not (eq .name "rpc")) (not (eq .subCommand "create-crypto-config")) -}}

--- a/kubernetes-deploy.sh
+++ b/kubernetes-deploy.sh
@@ -1,4 +1,4 @@
-#! /bin/zsh
+#! /bin/bash
 
 # Set up Corda on Kubernetes; must be run from the root of corda-runtime-os
 

--- a/kubernetes-deploy.sh
+++ b/kubernetes-deploy.sh
@@ -4,9 +4,12 @@
 
 set -e
 
+# minikube users should do:
+#   eval $(minikube docker-env)
+
 ./gradlew publishOSGiImage
 
-# Currently the init containers are not repeatble, so ensure we start from scratch each time
+# Currently the init containers are not repeatable, so ensure we start from scratch each time
 kubectl delete namespace corda || echo corda namesapce already deleted?
 kubectl create namespace corda
 
@@ -15,9 +18,7 @@ helm install prereqs -n corda oci://registry-1.docker.io/corda/corda-dev-prereqs
 
 # Corda
 helm dependency build charts/corda
-helm upgrade --install corda -n corda charts/corda \
-  --values ../corda-runtime-os/values-prereqs.yaml \
-  --wait
+helm install corda -n corda charts/corda --values ./values-prereqs.yaml --wait
 
 # Port forwarding for convenience
 #nc localhost 8888

--- a/kubernetes-deploy.sh
+++ b/kubernetes-deploy.sh
@@ -1,5 +1,6 @@
 #! /bin/zsh
 
+# Currently the init containers are not repeatble, so ensure we start from scratch each time
 kubectl delete namespace corda
 kubectl create namespace corda
 

--- a/kubernetes-deploy.sh
+++ b/kubernetes-deploy.sh
@@ -1,0 +1,20 @@
+#! /bin/zsh
+
+kubectl delete namespace corda
+kubectl create namespace corda
+
+# Usual prereqs
+helm install prereqs -n corda --create-namespace oci://registry-1.docker.io/corda/corda-dev-prereqs --timeout 10m --wait
+
+# Corda
+helm dependency build ../corda5-runtime-os/charts/corda
+helm upgrade --install corda -n corda \
+  ../corda-runtime-os/charts/corda \
+  --values ../corda-runtime-os/values-prereqs.yaml \
+  --wait
+
+# Port forwarding for convenience
+#nc localhost 8888
+#nc localhost 5432
+#kubectl port-forward -n corda deploy/corda-corda-enterprise-rest-worker 8888 &
+#kubectl port-forward -n corda svc/prereqs-postgres 5432:5432 &

--- a/kubernetes-deploy.sh
+++ b/kubernetes-deploy.sh
@@ -11,7 +11,7 @@ kubectl delete namespace corda
 kubectl create namespace corda
 
 # Usual prereqs
-helm install prereqs -n corda --create-namespace oci://registry-1.docker.io/corda/corda-dev-prereqs --timeout 10m --wait
+helm install prereqs -n corda oci://registry-1.docker.io/corda/corda-dev-prereqs --timeout 10m --wait
 
 # Corda
 helm dependency build charts/corda

--- a/kubernetes-deploy.sh
+++ b/kubernetes-deploy.sh
@@ -4,10 +4,10 @@
 
 set -e
 
-./gradlew publishOSGiImage
+#./gradlew publishOSGiImage -PbaseImage=docker-remotes.software.r3.com/azul/zulu-openjdk
 
 # Currently the init containers are not repeatble, so ensure we start from scratch each time
-kubectl delete namespace corda
+kubectl delete namespace corda || echo corda namesapce already deleted?
 kubectl create namespace corda
 
 # Usual prereqs

--- a/kubernetes-deploy.sh
+++ b/kubernetes-deploy.sh
@@ -1,5 +1,11 @@
 #! /bin/zsh
 
+# Set up Corda on Kubernetes; must be run from the root of corda-runtime-os
+
+set -e
+
+./gradlew publishOSGiImage
+
 # Currently the init containers are not repeatble, so ensure we start from scratch each time
 kubectl delete namespace corda
 kubectl create namespace corda
@@ -8,9 +14,8 @@ kubectl create namespace corda
 helm install prereqs -n corda --create-namespace oci://registry-1.docker.io/corda/corda-dev-prereqs --timeout 10m --wait
 
 # Corda
-helm dependency build ../corda5-runtime-os/charts/corda
-helm upgrade --install corda -n corda \
-  ../corda-runtime-os/charts/corda \
+helm dependency build charts/corda
+helm upgrade --install corda -n corda charts/corda \
   --values ../corda-runtime-os/values-prereqs.yaml \
   --wait
 

--- a/kubernetes-deploy.sh
+++ b/kubernetes-deploy.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-#./gradlew publishOSGiImage -PbaseImage=docker-remotes.software.r3.com/azul/zulu-openjdk
+./gradlew publishOSGiImage
 
 # Currently the init containers are not repeatble, so ensure we start from scratch each time
 kubectl delete namespace corda || echo corda namesapce already deleted?


### PR DESCRIPTION
Support Hashicorp Vault for config secrets if it is configured, while preserving the Corda-native configruation system for non-Vault users. Tested for both Corda Open Source, and with https://github.com/corda/corda5-enterprise/pull/38 for Corda Enterprise. The enterprise/Vault scenario requires careful handling of secrets.

Add a sequence number prefix to each init container, so that they are listed in the right order and the ordering requirement is clear, since this initially confused me. This seems like a nice usability benefit for operators.

Add a short script to deploy to kubernetes in one go, respecting the prereqs chart and the requirement to delete namespaces.

In my earlier change I was careful to preserve all the idiosyncancies of the Helm output, so I knew that fiddly refactoring would have no impact on the Kubernetes resources that helm specifies. Now that's merged, we no longer need to preserve the exact whitespace and inconsistent use of quoting, so that allows the Helm chart to be simplified.