### PR TITLE
CORE-12304 Cascade Intermittent Unavailability Caused by DB Worker Restart

### DIFF
--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
@@ -45,8 +45,9 @@ internal class ConfigProcessor(
                 addToCache(configSection, configuration)
             }
 
-            coordinator.postEvent(NewConfigReceived(config, isInitialConfig = true))
+            coordinator.postEvent(NewConfigReceived(config))
         }
+        coordinator.postEvent(ConfigOnSnapshotRun)
     }
 
     override fun onNext(

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
@@ -45,7 +45,7 @@ internal class ConfigProcessor(
                 addToCache(configSection, configuration)
             }
 
-            coordinator.postEvent(NewConfigReceived(config))
+            coordinator.postEvent(NewConfigReceived(config, isInitialConfig = true))
         }
     }
 

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
@@ -47,7 +47,7 @@ internal class ConfigProcessor(
 
             coordinator.postEvent(NewConfigReceived(config))
         }
-        coordinator.postEvent(ConfigOnSnapshotRun)
+        coordinator.postEvent(InitialConfigRead)
     }
 
     override fun onNext(

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadLifecycleEvents.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadLifecycleEvents.kt
@@ -25,7 +25,7 @@ internal class SetupConfigSubscription : LifecycleEvent
  *
  * @param config A map of changed keys to changed configuration.
  */
-internal data class NewConfigReceived(val config: Map<String, SmartConfig>) : LifecycleEvent
+internal data class NewConfigReceived(val config: Map<String, SmartConfig>, val isInitialConfig: Boolean = false) : LifecycleEvent
 
 /**
  * A new configuration change handler has been added by another component

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadLifecycleEvents.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadLifecycleEvents.kt
@@ -41,4 +41,4 @@ internal data class ConfigRegistrationAdd(val registration: ConfigurationChangeR
  */
 internal data class ConfigRegistrationRemove(val registration: ConfigurationChangeRegistration) : LifecycleEvent
 
-internal object ConfigOnSnapshotRun : LifecycleEvent
+internal object InitialConfigRead : LifecycleEvent

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadLifecycleEvents.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadLifecycleEvents.kt
@@ -25,7 +25,7 @@ internal class SetupConfigSubscription : LifecycleEvent
  *
  * @param config A map of changed keys to changed configuration.
  */
-internal data class NewConfigReceived(val config: Map<String, SmartConfig>, val isInitialConfig: Boolean = false) : LifecycleEvent
+internal data class NewConfigReceived(val config: Map<String, SmartConfig>) : LifecycleEvent
 
 /**
  * A new configuration change handler has been added by another component
@@ -40,3 +40,5 @@ internal data class ConfigRegistrationAdd(val registration: ConfigurationChangeR
  * @param registration The removed registration
  */
 internal data class ConfigRegistrationRemove(val registration: ConfigurationChangeRegistration) : LifecycleEvent
+
+internal object ConfigOnSnapshotRun : LifecycleEvent

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
@@ -86,7 +86,7 @@ internal class ConfigReadServiceEventHandler(
                 setupConfigSubscription(coordinator)
             }
 
-            is ConfigOnSnapshotRun -> {
+            is InitialConfigRead -> {
                 // Only set LifecycleStatus.UP for coordinator after the initial config is read from Kafka.
                 // This is to make sure config reconciler will not start reconciling before its
                 // kafka reader (config read service) has read the initial config from Kafka, otherwise

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
@@ -89,9 +89,10 @@ internal class ConfigReadServiceEventHandler(
                 }
                 publishAvroSchemas()
                 if (event.isInitialConfig) {
-                    // Only set LifecycleStatus.UP for coordinator after the config subscription onSnapshot
-                    // has run (initial config). This is to make sure config reconciler will not start
-                    // reconciling before its kafka reader (config read service) has read the initial config from Kafka.
+                    // Only set LifecycleStatus.UP for coordinator after the initial config is read from Kafka.
+                    // This is to make sure config reconciler will not start reconciling before its
+                    // kafka reader (config read service) has read the initial config from Kafka, otherwise
+                    // the config reconciler understands empty Kafka and tries to reconcile the full DB config.
                     coordinator.updateStatus(LifecycleStatus.UP)
                 }
                 registrations.forEach { it.invoke(event.config.keys, configuration) }

--- a/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigProcessorTest.kt
+++ b/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigProcessorTest.kt
@@ -53,9 +53,10 @@ class ConfigProcessorTest {
         val config = Configuration(CONFIG_STRING, SOURCE_CONFIG_STRING, 0, schemaVersion)
         val messagingConfig = Configuration(MESSAGING_CONFIG_STRING, MESSAGING_CONFIG_STRING, 0, schemaVersion)
         configProcessor.onSnapshot(mapOf("BAR" to config, MESSAGING_CONFIG to messagingConfig))
-        verify(coordinator).postEvent(capture(eventCaptor))
-        assertThat(eventCaptor.value is NewConfigReceived)
-        assertEquals(CONFIG_STRING.toSmartConfig(), (eventCaptor.value as NewConfigReceived).config["BAR"])
+        verify(coordinator, times(2)).postEvent(capture(eventCaptor))
+        assertThat(eventCaptor.allValues[0] is NewConfigReceived)
+        assertThat(eventCaptor.allValues[1] is InitialConfigRead)
+        assertEquals(CONFIG_STRING.toSmartConfig(), (eventCaptor.allValues[0] as NewConfigReceived).config["BAR"])
     }
 
     @Test
@@ -78,7 +79,7 @@ class ConfigProcessorTest {
         val bootconfig = BOOT_CONFIG_STRING.toSmartConfig()
         val configProcessor = ConfigProcessor(coordinator, smartConfigFactory, bootconfig, configMerger)
         configProcessor.onSnapshot(mapOf())
-        verify(coordinator, times(0)).postEvent(capture(eventCaptor))
+        verify(coordinator, times(1)).postEvent(any())
         verify(configMerger, times(0)).getMessagingConfig(bootconfig, null)
     }
 
@@ -90,7 +91,7 @@ class ConfigProcessorTest {
         val bootconfig = BOOT_CONFIG_STRING.toSmartConfig()
         val configProcessor = ConfigProcessor(coordinator, smartConfigFactory, bootconfig, configMerger)
         configProcessor.onSnapshot(mapOf())
-        verify(coordinator, times(1)).postEvent(capture(eventCaptor))
+        verify(coordinator, times(2)).postEvent(any())
         verify(configMerger, times(0)).getMessagingConfig(bootconfig, null)
         verify(configMerger, times(1)).getDbConfig(any(), anyOrNull())
     }

--- a/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandlerTest.kt
+++ b/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandlerTest.kt
@@ -141,6 +141,12 @@ internal class ConfigReadServiceEventHandlerTest {
             RegistrationStatusChangeEvent(configSubReg, LifecycleStatus.UP),
             coordinator
         )
+        verify(coordinator, times(0)).updateStatus(any(), any())
+
+        configReadServiceEventHandler.processEvent(
+            NewConfigReceived(mock(), true),
+            coordinator
+        )
         verify(coordinator).updateStatus(capture(lifecycleStatusCaptor), any())
         assertThat(lifecycleStatusCaptor.firstValue).isEqualTo(LifecycleStatus.UP)
     }

--- a/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandlerTest.kt
+++ b/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandlerTest.kt
@@ -144,7 +144,7 @@ internal class ConfigReadServiceEventHandlerTest {
         verify(coordinator, times(0)).updateStatus(any(), any())
 
         configReadServiceEventHandler.processEvent(
-            NewConfigReceived(mock(), true),
+            InitialConfigRead,
             coordinator
         )
         verify(coordinator).updateStatus(capture(lifecycleStatusCaptor), any())

--- a/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigurationReadServiceTest.kt
+++ b/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigurationReadServiceTest.kt
@@ -96,7 +96,7 @@ internal class ConfigurationReadServiceTest {
                     verificationWhenUp = {
                         verifyIsUp<ConfigurationReadService>()
                     },
-                    onUppingDependency = {
+                    onDependencyUp = {
                         configReadServiceCoordinator.postEvent(InitialConfigRead)
                     }
                 )

--- a/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigurationReadServiceTest.kt
+++ b/components/configuration/configuration-read-service-impl/src/test/kotlin/net/corda/configuration/read/impl/ConfigurationReadServiceTest.kt
@@ -84,7 +84,7 @@ internal class ConfigurationReadServiceTest {
             configReadServiceCoordinator.postEvent(SetupConfigSubscription())
             verifyIsDown<ConfigurationReadService>()
 
-            configReadServiceCoordinator.postEvent(NewConfigReceived(mock(), true))
+            configReadServiceCoordinator.postEvent(InitialConfigRead)
             verifyIsUp<ConfigurationReadService>()
 
             repeat(5) {
@@ -97,7 +97,7 @@ internal class ConfigurationReadServiceTest {
                         verifyIsUp<ConfigurationReadService>()
                     },
                     onUppingDependency = {
-                        configReadServiceCoordinator.postEvent(NewConfigReceived(mock(), true))
+                        configReadServiceCoordinator.postEvent(InitialConfigRead)
                     }
                 )
             }

--- a/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
+++ b/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
@@ -228,22 +228,26 @@ class LifecycleTest<T : Lifecycle>(
      * @param dependency the coordinator name of the dependency to toggle
      * @param verificationWhenDown can be used to assert expectations for once the dependency is down
      * @param verificationWhenUp can be used to assert expectations for once the dependency is back up
-     * @param onUppingDependency additional actions after [dependency] going up
+     * @param onDependencyDown additional actions after [dependency] going down
+     * @param onDependencyUp additional actions after [dependency] going up
      */
     fun toggleDependency(
         dependency: LifecycleCoordinatorName,
         verificationWhenDown: () -> Unit = {},
         verificationWhenUp: () -> Unit = {},
-        onUppingDependency: () -> Unit = {}
+        onDependencyDown: () -> Unit = {},
+        onDependencyUp: () -> Unit = {}
     ) {
-        bringDependencyDown(dependency)
-        verifyIsDown(dependency)
-        verificationWhenDown.invoke()
+        bringDependencyDown(dependency).also {
+            verifyIsDown(dependency)
+            onDependencyDown()
+            verificationWhenDown()
+        }
         bringDependencyUp(dependency).also {
             verifyIsUp(dependency)
-            onUppingDependency()
+            onDependencyUp()
+            verificationWhenUp()
         }
-        verificationWhenUp.invoke()
     }
 
     /**

--- a/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
+++ b/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
@@ -233,12 +233,15 @@ class LifecycleTest<T : Lifecycle>(
         dependency: LifecycleCoordinatorName,
         verificationWhenDown: () -> Unit = {},
         verificationWhenUp: () -> Unit = {},
+        onUppingDependency: () -> Unit = {}
     ) {
         bringDependencyDown(dependency)
         verifyIsDown(dependency)
         verificationWhenDown.invoke()
-        bringDependencyUp(dependency)
-        verifyIsUp(dependency)
+        bringDependencyUp(dependency).also {
+            verifyIsUp(dependency)
+            onUppingDependency()
+        }
         verificationWhenUp.invoke()
     }
 

--- a/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
+++ b/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
@@ -238,16 +238,15 @@ class LifecycleTest<T : Lifecycle>(
         onDependencyDown: () -> Unit = {},
         onDependencyUp: () -> Unit = {}
     ) {
-        bringDependencyDown(dependency).also {
-            verifyIsDown(dependency)
-            onDependencyDown()
-            verificationWhenDown()
-        }
-        bringDependencyUp(dependency).also {
-            verifyIsUp(dependency)
-            onDependencyUp()
-            verificationWhenUp()
-        }
+        bringDependencyDown(dependency)
+        verifyIsDown(dependency)
+        onDependencyDown()
+        verificationWhenDown()
+        
+        bringDependencyUp(dependency)
+        verifyIsUp(dependency)
+        onDependencyUp()
+        verificationWhenUp()
     }
 
     /**

--- a/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
+++ b/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
@@ -228,6 +228,7 @@ class LifecycleTest<T : Lifecycle>(
      * @param dependency the coordinator name of the dependency to toggle
      * @param verificationWhenDown can be used to assert expectations for once the dependency is down
      * @param verificationWhenUp can be used to assert expectations for once the dependency is back up
+     * @param onUppingDependency additional actions after [dependency] going up
      */
     fun toggleDependency(
         dependency: LifecycleCoordinatorName,


### PR DESCRIPTION
It seems there was a synchronization issue between `ConfigurationReadService` and Configuration reconciler. `ConfigurationReadService` holds a cache for caching the Configuration on Kafka. That cache is used by the Configuration reconciler to find the delta between Configuration on Kafka and Configuration in the database and then update Kafka with that delta. After adding Avro schema registry updating mechanism through Kafka as part of `ConfigurationReadService` bootstrapping process, it means `ConfigurationReadService` is now ready at a later point in time. So now, on DB worker restart the Configuration reconciler reader which is `ConfigurationReadService` has not yet read the Kafka Configuration, however marked as `UP`, which leads to the reconciler understand an empty Configuration on Kafka and therefore running a complete reconciliation with the database.

- Signals `ConfigurationReadService` as `UP` only after its `ConfigProcessor.onSnapshot` has run to make sure its cache has been populated with Kafka Configuration before reconciler uses it