### PR TITLE
CORE-12374: Create new helm pipeline

### DIFF
--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -91,6 +91,10 @@ pipeline {
     }
 }
 
+def gradleCmd() {
+    return isUnix() ? './gradlew' : './gradlew.bat'
+}
+
 def gradlewMinimumLogging(String... args) {
     def allArgs = args.join(' ')
     sh "${gradleCmd()} ${allArgs} \${GRADLE_ADDITIONAL_ARGS} \${GRADLE_PERFORMANCE_TUNING}"

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -31,6 +31,12 @@ pipeline {
         }
     }
 
+    environment {
+        GRADLE_ADDITIONAL_ARGS = ''
+        GRADLE_PERFORMANCE_TUNING = '--parallel --build-cache'
+        GRADLE_USER_HOME = "/host_tmp/gradle"
+    }
+
     stages {
         stage('Publishing') {
             parallel {
@@ -71,8 +77,6 @@ pipeline {
                         HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
                         HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
                         HELM_CHART_REPO_NAME = publishingUtils.getHelmRepo()
-                        GRADLE_ADDITIONAL_ARGS = ''
-                        GRADLE_PERFORMANCE_TUNING = '--parallel --build-cache'
                     }
                     steps {
                         script {

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -41,6 +41,10 @@ pipeline {
         BUILD_CACHE_USERNAME = "${env.BUILD_CACHE_CREDENTIALS_USR}"
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        VERSION_SUFFIX = publishingUtils.getVersionSuffix()
+        RELEASE_TYPE = publishingUtils.getReleaseType()
+        RELEASE_SUFFIX = publishingUtils.getReleaseSuffix()
+        RELEASE_VERSION = publishingUtils.getReleaseString()
     }
 
     stages {

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -99,7 +99,7 @@ pipeline {
             environment {
                 HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
                 HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
-                HELM_CHART_REPO = publishingUtils.getHelmRepo()
+                HELM_CHART_REPO_NAME = publishingUtils.getHelmRepo()
             }
             steps {
                 script {

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -44,77 +44,73 @@ pipeline {
     }
 
     stages {
-        stage('Publishing') {
-            parallel {
-                stage('Prepare Helm charts') {
-                    /*
-                    * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
-                    * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
-                    *
-                    * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
-                    * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
-                    * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
-                    */
-                    environment {
-                        HELM_CHART_VERSION = publishingUtils.getHelmChartVersion()
-                        HELM_CHART_APP_VERSION = getGradleProperty("version")
-                    }
-                    steps {
-                        script {
-                            publishingUtils.prepareHelmChart('artifactory-credentials')
-                        }
+        stage('Prepare Helm charts') {
+            /*
+            * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
+            * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
+            *
+            * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
+            * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
+            * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
+            */
+            environment {
+                HELM_CHART_VERSION = publishingUtils.getHelmChartVersion()
+                HELM_CHART_APP_VERSION = getGradleProperty("version")
+            }
+            steps {
+                script {
+                    publishingUtils.prepareHelmChart('artifactory-credentials')
+                }
+            }
+        }
+        stage('Publish / Publish Images') {
+            environment {
+                BASE_IMAGE = 'docker-remotes.software.r3.com/azul/zulu-openjdk'
+                BASE_IMAGE_TAG = '11.0.15-11.56.19'
+            }
+            steps {
+                script {
+                    gradlewMinimumLogging(
+                        'publishOSGiImage',
+                        '-PjibRemotePublish=true',
+                        "-PworkerBaseImageTag=${env.BASE_IMAGE_TAG}",
+                        "-PbaseImage=${env.BASE_IMAGE}",
+                        "-PuseDockerDaemon=false"
+                    )
+                }
+            }
+            post {
+                success {
+                    script{
+                        renderWidget("Release artifacts version: ${getGradleProperty("version")}")
                     }
                 }
-                stage('Publish / Publish Images') {
-                    environment {
-                        BASE_IMAGE = 'docker-remotes.software.r3.com/azul/zulu-openjdk'
-                        BASE_IMAGE_TAG = '11.0.15-11.56.19'
-                    }
-                    steps {
-                        script {
-                            gradlewMinimumLogging(
-                                'publishOSGiImage',
-                                '-PjibRemotePublish=true',
-                                "-PworkerBaseImageTag=${env.BASE_IMAGE_TAG}",
-                                "-PbaseImage=${env.BASE_IMAGE}",
-                                "-PuseDockerDaemon=false"
-                            )
-                        }
-                    }
-                    post {
-                        success {
-                            script{
-                                renderWidget("Release artifacts version: ${getGradleProperty("version")}")
-                            }
-                        }
-                    }
+            }
+        }
+        stage('Publish Helm Chart to Artifactory') {
+            /*
+            * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
+            * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
+            *
+            * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
+            * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
+            * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
+            */
+            environment {
+                HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
+                HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
+                HELM_CHART_REPO = publishingUtils.getHelmRepo()
+            }
+            steps {
+                script {
+                    publishingUtils.publishHelmCharts('artifactory-credentials')
                 }
-                stage('Publish Helm Chart to Artifactory') {
-                    /*
-                    * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
-                    * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
-                    *
-                    * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
-                    * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
-                    * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
-                    */
-                    environment {
-                        HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
-                        HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
-                        HELM_CHART_REPO = publishingUtils.getHelmRepo()
-                    }
-                    steps {
-                        script {
-                            publishingUtils.publishHelmCharts('artifactory-credentials')
-                        }
-                    }
-                    post {
-                        success {
-                            script{
-                                renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
-                                renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
-                            }
-                        }
+            }
+            post {
+                success {
+                    script{
+                        renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
+                        renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
                     }
                 }
             }

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -6,7 +6,6 @@ import com.r3.build.utils.PublishingUtils
 int cpus = 1
 BuildEnvironment buildEnvironment = BuildEnvironment.AMD64_LINUX
 
-@Field
 PublishingUtils publishingUtils = new PublishingUtils(this)
 
 pipeline {
@@ -82,6 +81,7 @@ pipeline {
                         success {
                             script{
                                 renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
+                                renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
                             }
                         }
                     }

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -49,14 +49,6 @@ pipeline {
 
     stages {
         stage('Prepare Helm charts') {
-            /*
-            * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
-            * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
-            *
-            * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
-            * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
-            * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
-            */
             environment {
                 HELM_CHART_VERSION = publishingUtils.getHelmChartVersion()
                 HELM_CHART_APP_VERSION = getGradleProperty("version")
@@ -97,8 +89,13 @@ pipeline {
             * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
             *
             * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
+            * e.g.  corda-os-docker-stable.software.r3.com/helm-charts/5.0.0.0-Beta3/corda
+            *
             * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
+            * e.g. corda-os-docker-unstable.software.r3.com/helm-charts/release/os/5.0/corda
+            *
             * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
+            * e.g. corda-os-docker-unstable.software.r3.com/helm-charts/PR-223/corda
             */
             environment {
                 HELM_REGISTRY = publishingUtils.getInternalRegistry(false)

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -35,6 +35,12 @@ pipeline {
         GRADLE_ADDITIONAL_ARGS = ''
         GRADLE_PERFORMANCE_TUNING = '--parallel --build-cache'
         GRADLE_USER_HOME = "/host_tmp/gradle"
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+        BUILD_CACHE_CREDENTIALS = credentials('gradle-ent-cache-credentials')
+        BUILD_CACHE_PASSWORD = "${env.BUILD_CACHE_CREDENTIALS_PSW}"
+        BUILD_CACHE_USERNAME = "${env.BUILD_CACHE_CREDENTIALS_USR}"
+        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
+        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
     }
 
     stages {

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -45,73 +45,75 @@ pipeline {
 
     stages {
         stage('Publishing') {
-            stage('Prepare Helm charts') {
-                /*
-                * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
-                * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
-                *
-                * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
-                * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
-                * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
-                */
-                environment {
-                    HELM_CHART_VERSION = publishingUtils.getHelmChartVersion()
-                    HELM_CHART_APP_VERSION = getGradleProperty("version")
-                }
-                steps {
-                    script {
-                        publishingUtils.prepareHelmChart('artifactory-credentials')
+            parallel {
+                stage('Prepare Helm charts') {
+                    /*
+                    * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
+                    * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
+                    *
+                    * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
+                    * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
+                    * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
+                    */
+                    environment {
+                        HELM_CHART_VERSION = publishingUtils.getHelmChartVersion()
+                        HELM_CHART_APP_VERSION = getGradleProperty("version")
                     }
-                }
-            }
-            stage('Publish / Publish Images') {
-                environment {
-                    BASE_IMAGE = 'docker-remotes.software.r3.com/azul/zulu-openjdk'
-                    BASE_IMAGE_TAG = '11.0.15-11.56.19'
-                }
-                steps {
-                    script {
-                        gradlewMinimumLogging(
-                            'publishOSGiImage',
-                            '-PjibRemotePublish=true',
-                            "-PworkerBaseImageTag=${env.BASE_IMAGE_TAG}",
-                            "-PbaseImage=${env.BASE_IMAGE}",
-                            "-PuseDockerDaemon=false"
-                        )
-                    }
-                }
-                post {
-                    success {
-                        script{
-                            renderWidget("Release artifacts version: ${getGradleProperty("version")}")
+                    steps {
+                        script {
+                            publishingUtils.prepareHelmChart('artifactory-credentials')
                         }
                     }
                 }
-            }
-            stage('Publish Helm Chart to Artifactory') {
-                /*
-                * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
-                * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
-                *
-                * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
-                * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
-                * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
-                */
-                environment {
-                    HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
-                    HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
-                    HELM_CHART_REPO = publishingUtils.getHelmRepo()
-                }
-                steps {
-                    script {
-                        publishingUtils.publishHelmCharts('artifactory-credentials')
+                stage('Publish / Publish Images') {
+                    environment {
+                        BASE_IMAGE = 'docker-remotes.software.r3.com/azul/zulu-openjdk'
+                        BASE_IMAGE_TAG = '11.0.15-11.56.19'
+                    }
+                    steps {
+                        script {
+                            gradlewMinimumLogging(
+                                'publishOSGiImage',
+                                '-PjibRemotePublish=true',
+                                "-PworkerBaseImageTag=${env.BASE_IMAGE_TAG}",
+                                "-PbaseImage=${env.BASE_IMAGE}",
+                                "-PuseDockerDaemon=false"
+                            )
+                        }
+                    }
+                    post {
+                        success {
+                            script{
+                                renderWidget("Release artifacts version: ${getGradleProperty("version")}")
+                            }
+                        }
                     }
                 }
-                post {
-                    success {
-                        script{
-                            renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
-                            renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
+                stage('Publish Helm Chart to Artifactory') {
+                    /*
+                    * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
+                    * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
+                    *
+                    * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
+                    * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
+                    * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
+                    */
+                    environment {
+                        HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
+                        HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
+                        HELM_CHART_REPO = publishingUtils.getHelmRepo()
+                    }
+                    steps {
+                        script {
+                            publishingUtils.publishHelmCharts('artifactory-credentials')
+                        }
+                    }
+                    post {
+                        success {
+                            script{
+                                renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
+                                renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
+                            }
                         }
                     }
                 }

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -113,9 +113,9 @@ pipeline {
             post {
                 success {
                     script{
-                        renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
-                        renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
-                        renderWidget("Published Corda helm chart OCI path: oci://$HELM_REGISTRY/${publishingUtils.getHelmRepo()}/corda")
+                        renderWidget("Published Corda helm chart version to Artifactory: ${env.HELM_CHART_VERSION}")
+                        renderWidget("Published Corda helm chart repo name: ${env.HELM_CHART_REPO_NAME}")
+                        renderWidget("Published Corda helm chart OCI path: oci://${env.HELM_REGISTRY}/${env.HELM_CHART_REPO_NAME}/corda")
                     }
                 }
             }

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -68,9 +68,11 @@ pipeline {
                     * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
                     */
                     environment {
-                        HELM_REGISTRY = publishingUtils.getInternalRegistry(config.corda5EnterpriseBuild)
+                        HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
                         HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
                         HELM_CHART_REPO_NAME = publishingUtils.getHelmRepo()
+                        GRADLE_ADDITIONAL_ARGS = ''
+                        GRADLE_PERFORMANCE_TUNING = '--parallel --build-cache'
                     }
                     steps {
                         script {

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -1,0 +1,92 @@
+#! groovy
+@Library('corda-shared-build-pipeline-steps@5.0.1') _
+import com.r3.build.enums.BuildEnvironment
+import com.r3.build.utils.PublishingUtils
+
+int cpus = 1
+BuildEnvironment buildEnvironment = BuildEnvironment.AMD64_LINUX
+
+@Field
+PublishingUtils publishingUtils = new PublishingUtils(this)
+
+pipeline {
+    agent {
+        kubernetes {
+            cloud "eks-e2e"
+            yaml kubernetesBuildAgentYaml('build', buildEnvironment, cpus)
+            idleMinutes 15
+            podRetention always()
+            nodeSelector ([
+                    "kubernetes.io/arch=${buildEnvironment.buildArchitecture.toString().toLowerCase()}",
+                    "kubernetes.io/os=${buildEnvironment.buildOperatingSystem.toString().toLowerCase()}",
+                    "role=jenkins-agent"
+            ].join(','))
+            label ([
+                    "kubernetes-build-agent",
+                    "${cpus}cpus",
+                    "${buildEnvironment.buildArchitecture.toString().toLowerCase()}",
+                    "${buildEnvironment.buildOperatingSystem.toString().toLowerCase()}"
+            ].join('-'))
+            showRawYaml false
+            defaultContainer 'build'
+        }
+    }
+
+    stages {
+        stage('Publishing') {
+            parallel {
+                stage('Publish / Publish Images') {
+                    environment {
+                        BASE_IMAGE = 'docker-remotes.software.r3.com/azul/zulu-openjdk'
+                        BASE_IMAGE_TAG = '11.0.15-11.56.19'
+                    }
+                    steps {
+                        script {
+                            gradlewMinimumLogging(
+                                'publishOSGiImage',
+                                '-PjibRemotePublish=true',
+                                "-PworkerBaseImageTag=${env.BASE_IMAGE_TAG}",
+                                "-PbaseImage=${env.BASE_IMAGE}",
+                                "-PuseDockerDaemon=false"
+                            )
+                        }
+                    }
+                    post {
+                        success {
+                            script{
+                                renderWidget("Release artifacts version: ${getGradleProperty("version")}")
+                            }
+                        }
+                    }
+                }
+                stage('Publish Helm Chart to Artifactory') {
+                    /*
+                    * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
+                    * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
+                    *
+                    * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
+                    * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
+                    * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
+                    */
+                    environment {
+                        HELM_REGISTRY = publishingUtils.getInternalRegistry(config.corda5EnterpriseBuild)
+                        HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
+                        HELM_CHART_REPO_NAME = publishingUtils.getHelmRepo()
+                    }
+                    steps {
+                        script {
+                            publishingUtils.publishHelmCharts('artifactory-credentials')
+                        }
+                    }
+                    post {
+                        success {
+                            script{
+                                renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -45,56 +45,73 @@ pipeline {
 
     stages {
         stage('Publishing') {
-            parallel {
-                stage('Publish / Publish Images') {
-                    environment {
-                        BASE_IMAGE = 'docker-remotes.software.r3.com/azul/zulu-openjdk'
-                        BASE_IMAGE_TAG = '11.0.15-11.56.19'
+            stage('Prepare Helm charts') {
+                /*
+                * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
+                * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
+                *
+                * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
+                * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
+                * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
+                */
+                environment {
+                    HELM_CHART_VERSION = publishingUtils.getHelmChartVersion()
+                    HELM_CHART_APP_VERSION = getGradleProperty("version")
+                }
+                steps {
+                    script {
+                        publishingUtils.prepareHelmChart('artifactory-credentials')
                     }
-                    steps {
-                        script {
-                            gradlewMinimumLogging(
-                                'publishOSGiImage',
-                                '-PjibRemotePublish=true',
-                                "-PworkerBaseImageTag=${env.BASE_IMAGE_TAG}",
-                                "-PbaseImage=${env.BASE_IMAGE}",
-                                "-PuseDockerDaemon=false"
-                            )
-                        }
+                }
+            }
+            stage('Publish / Publish Images') {
+                environment {
+                    BASE_IMAGE = 'docker-remotes.software.r3.com/azul/zulu-openjdk'
+                    BASE_IMAGE_TAG = '11.0.15-11.56.19'
+                }
+                steps {
+                    script {
+                        gradlewMinimumLogging(
+                            'publishOSGiImage',
+                            '-PjibRemotePublish=true',
+                            "-PworkerBaseImageTag=${env.BASE_IMAGE_TAG}",
+                            "-PbaseImage=${env.BASE_IMAGE}",
+                            "-PuseDockerDaemon=false"
+                        )
                     }
-                    post {
-                        success {
-                            script{
-                                renderWidget("Release artifacts version: ${getGradleProperty("version")}")
-                            }
+                }
+                post {
+                    success {
+                        script{
+                            renderWidget("Release artifacts version: ${getGradleProperty("version")}")
                         }
                     }
                 }
-                stage('Publish Helm Chart to Artifactory') {
-                    /*
-                    * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
-                    * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
-                    *
-                    * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
-                    * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
-                    * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
-                    */
-                    environment {
-                        HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
-                        HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
-                        HELM_CHART_REPO = publishingUtils.getHelmRepo()
+            }
+            stage('Publish Helm Chart to Artifactory') {
+                /*
+                * Depending on the situation, Helm charts are published to the following repositories with the given chart version:
+                * See {@link PublishingUtils#getHelmRepo()} for details on how helm chart repo name is generated
+                *
+                * Release tag          corda-os-docker-stable.software.r3.com/helm-charts/<branch-name>      <CHART_VERSION>
+                * Release/main branch  corda-os-docker-unstable.software.r3.com/helm-charts/<branch-name>    <CHART_VERSION>-beta.<TIMESTAMP>
+                * PR / feature branch  corda-os-docker-dev.software.r3.com/helm-charts/<branch-name>         <CHART_VERSION>-alpha.<TIMESTAMP>
+                */
+                environment {
+                    HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
+                    HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
+                    HELM_CHART_REPO = publishingUtils.getHelmRepo()
+                }
+                steps {
+                    script {
+                        publishingUtils.publishHelmCharts('artifactory-credentials')
                     }
-                    steps {
-                        script {
-                            publishingUtils.publishHelmCharts('artifactory-credentials')
-                        }
-                    }
-                    post {
-                        success {
-                            script{
-                                renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
-                                renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
-                            }
+                }
+                post {
+                    success {
+                        script{
+                            renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
+                            renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
                         }
                     }
                 }

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -90,3 +90,8 @@ pipeline {
         }
     }
 }
+
+def gradlewMinimumLogging(String... args) {
+    def allArgs = args.join(' ')
+    sh "${gradleCmd()} ${allArgs} \${GRADLE_ADDITIONAL_ARGS} \${GRADLE_PERFORMANCE_TUNING}"
+}

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -1,5 +1,6 @@
 #! groovy
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
+
 import com.r3.build.enums.BuildEnvironment
 import com.r3.build.utils.PublishingUtils
 
@@ -32,7 +33,6 @@ pipeline {
     }
 
     environment {
-        GRADLE_ADDITIONAL_ARGS = ''
         GRADLE_PERFORMANCE_TUNING = '--parallel --build-cache'
         GRADLE_USER_HOME = "/host_tmp/gradle"
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
@@ -115,6 +115,7 @@ pipeline {
                     script{
                         renderWidget("Published Corda helm chart version to Artifactory: ${publishingUtils.getHelmVersionFromYaml()}")
                         renderWidget("Published Corda helm chart repo name: ${publishingUtils.getHelmRepo()}")
+                        renderWidget("Published Corda helm chart OCI path: oci://$HELM_REGISTRY/${publishingUtils.getHelmRepo()}/corda")
                     }
                 }
             }
@@ -122,11 +123,7 @@ pipeline {
     }
 }
 
-def gradleCmd() {
-    return isUnix() ? './gradlew' : './gradlew.bat'
-}
-
 def gradlewMinimumLogging(String... args) {
     def allArgs = args.join(' ')
-    sh "${gradleCmd()} ${allArgs} \${GRADLE_ADDITIONAL_ARGS} \${GRADLE_PERFORMANCE_TUNING}"
+    sh "${isUnix() ? './gradlew' : './gradlew.bat'} ${allArgs} \${GRADLE_PERFORMANCE_TUNING}"
 }

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -82,7 +82,7 @@ pipeline {
                     environment {
                         HELM_REGISTRY = publishingUtils.getInternalRegistry(false)
                         HELM_CHART_VERSION = publishingUtils.getHelmVersionFromYaml()
-                        HELM_CHART_REPO_NAME = publishingUtils.getHelmRepo()
+                        HELM_CHART_REPO = publishingUtils.getHelmRepo()
                     }
                     steps {
                         script {


### PR DESCRIPTION
Added new file `Jenkinsfile_PublishHelmChart` to allow independent publishing of Helm charts without being tied to the PR gates of a repo.

This new job will _not_ be a PR gate but rather an on-demand utility job a developer may use to produce charts for a downstream consumer (non-functional tests etc.)

**Tested:** https://ci02.dev.r3.com/job/Corda5/job/Publish%20Helm%20Pipeline/job/PR-3614/