### PR TITLE
CORE-12468: Configure flow-worker not to instrument VERIFICATION sandboxes.

### DIFF
--- a/applications/workers/release/flow-worker/build.gradle
+++ b/applications/workers/release/flow-worker/build.gradle
@@ -12,6 +12,10 @@ osgiRun {
     )
 }
 
+quasar {
+    excludeLocations = [ 'VERIFICATION/*' ]
+}
+
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -51,7 +51,6 @@ dependencies {
     implementation project(":libs:virtual-node:virtual-node-datamodel")
     implementation project(":libs:virtual-node:virtual-node-info")
     implementation project(":libs:virtual-node:cpi-datamodel")
-    implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-db-schema'

--- a/processors/flow-processor/build.gradle
+++ b/processors/flow-processor/build.gradle
@@ -3,17 +3,15 @@ plugins {
     id 'corda.common-library'
 }
 
+description 'Flow Worker Processor'
+
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    compileOnly "org.osgi:org.osgi.service.cm:$osgiCmVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-ledger-utxo'
@@ -34,11 +32,6 @@ dependencies {
     implementation project(':libs:utilities')
     implementation project(':libs:virtual-node:sandbox-group-context')
     implementation project(":notary-plugins:notary-plugin-common")
-    implementation project(":osgi-framework-api")
-
-    runtimeOnly 'javax.persistence:javax.persistence-api'
-    runtimeOnly "net.corda:corda-avro-schema"
-
 
     runtimeOnly project(":components:configuration:configuration-read-service-impl")
     runtimeOnly project(":components:flow:flow-service")
@@ -76,5 +69,3 @@ dependencies {
     runtimeOnly project(":libs:serialization:serialization-kryo")
 
 }
-
-description 'Flow Worker Processor'

--- a/processors/link-manager-processor/build.gradle
+++ b/processors/link-manager-processor/build.gradle
@@ -3,17 +3,16 @@ plugins {
     id 'corda.common-library'
 }
 
+description 'Link Manager Processor'
+
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    compileOnly "org.osgi:org.osgi.service.cm:$osgiCmVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
@@ -25,13 +24,13 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:messaging:messaging')
     implementation project(':libs:utilities')
-    implementation project(':osgi-framework-api')
     implementation project(":components:membership:group-policy")
     implementation project(":components:crypto:crypto-client")
     implementation project(":components:membership:membership-group-read")
     implementation project(":components:membership:membership-persistence-client")
+    implementation project(':components:virtual-node:virtual-node-info-read-service')
+    implementation project(":components:virtual-node:cpi-info-read-service")
 
-    runtimeOnly 'net.corda:corda-avro-schema'
     runtimeOnly project(":components:crypto:crypto-client-impl")
     runtimeOnly project(':components:configuration:configuration-read-service-impl')
     runtimeOnly project(':libs:messaging:messaging-impl')
@@ -44,8 +43,4 @@ dependencies {
     runtimeOnly project(":libs:layered-property-map")
     runtimeOnly project(":libs:crypto:crypto-impl")
     runtimeOnly project(":components:membership:membership-group-read-impl")
-    implementation project(':components:virtual-node:virtual-node-info-read-service')
-    implementation project(":components:virtual-node:cpi-info-read-service")
 }
-
-description 'Link Manager Processor'

--- a/processors/verification-processor/build.gradle
+++ b/processors/verification-processor/build.gradle
@@ -3,29 +3,25 @@ plugins {
     id 'corda.common-library'
 }
 
+description 'Verification Processor'
+
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    compileOnly "org.osgi:org.osgi.service.cm:$osgiCmVersion"
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
+    api project(':libs:configuration:configuration-core')
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "info.picocli:picocli:$picocliVersion"
     implementation 'org.slf4j:slf4j-api'
-    implementation 'net.corda:corda-base'
 
-    implementation project(":components:configuration:configuration-read-service")
-    implementation project(":components:ledger:ledger-verification")
+    implementation project(':components:configuration:configuration-read-service')
+    implementation project(':components:ledger:ledger-verification')
+    implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:utilities')
 
-    runtimeOnly "net.corda:corda-avro-schema"
-
-    runtimeOnly project(":components:configuration:configuration-read-service-impl")
-    runtimeOnly project(":libs:lifecycle:lifecycle-impl")
-    runtimeOnly project(":libs:sandbox-internal")
+    runtimeOnly project(':components:configuration:configuration-read-service-impl')
+    runtimeOnly project(':libs:lifecycle:lifecycle-impl')
 }
 
-description 'Verification Processor'

--- a/processors/verification-processor/src/main/java/net/corda/processors/verification/package-info.java
+++ b/processors/verification-processor/src/main/java/net/corda/processors/verification/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.processors.verification;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Quasar must not instrument either the flow-worker's verification processor or the VERIFICATION sandboxes.

Also remove a large number of completely superfluous dependencies _(picocli??!?)_ from the processors.