### PR TITLE
CORE-8956 check notary whitelisted

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
@@ -45,7 +45,8 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
     @Suspendable
     override fun verify(transaction: UtxoLedgerTransaction) {
 
-        verifyNotary(transaction)
+        val signedGroupParameters = fetchAndVerifySignedGroupParameters(transaction)
+        verifyNotaryAllowed(transaction, signedGroupParameters)
 
         val verificationResult = externalEventExecutor.execute(
             TransactionVerificationExternalEventFactory::class.java,
@@ -66,13 +67,7 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    private fun verifyNotary(transaction: UtxoLedgerTransaction) {
-        val signedGroupParameters = fetchSignedGroupParameters(transaction)
-        verifyNotaryAllowed(transaction, signedGroupParameters)
-    }
-
-    @Suspendable
-    private fun fetchSignedGroupParameters(transaction: UtxoLedgerTransaction): SignedGroupParameters {
+    private fun fetchAndVerifySignedGroupParameters(transaction: UtxoLedgerTransaction): SignedGroupParameters {
         val membershipGroupParametersHashString =
             (transaction.metadata as TransactionMetadataInternal).getMembershipGroupParametersHash()
         requireNotNull(membershipGroupParametersHashString) {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
@@ -11,6 +11,7 @@ import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPers
 import net.corda.ledger.utxo.flow.impl.transaction.verifier.external.events.TransactionVerificationExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.transaction.verifier.external.events.TransactionVerificationParameters
 import net.corda.ledger.utxo.transaction.verifier.SignedGroupParametersVerifier
+import net.corda.membership.lib.SignedGroupParameters
 import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.serialization.SerializationService
@@ -24,8 +25,8 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 import java.nio.ByteBuffer
 
 @Component(
-    service = [ UtxoLedgerTransactionVerificationService::class, UsedByFlow::class ],
-    property = [ CORDA_SYSTEM_SERVICE ],
+    service = [UtxoLedgerTransactionVerificationService::class, UsedByFlow::class],
+    property = [CORDA_SYSTEM_SERVICE],
     scope = PROTOTYPE
 )
 class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
@@ -43,24 +44,9 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
 
     @Suspendable
     override fun verify(transaction: UtxoLedgerTransaction) {
-        val membershipGroupParametersHashString =
-            (transaction.metadata as TransactionMetadataInternal).getMembershipGroupParametersHash()
-        // todo CORE-8956, CORE-8958 requireNotNull
-        if (membershipGroupParametersHashString != null) {
-            val currentGroupParameters = currentGroupParametersService.get()
-            val signedGroupParameters =
-                if (currentGroupParameters.hash.toString() == membershipGroupParametersHashString) {
-                    currentGroupParameters
-                } else {
-                    val membershipGroupParametersHash = parseSecureHash(membershipGroupParametersHashString)
-                    utxoLedgerGroupParametersPersistenceService.find(membershipGroupParametersHash)
-                }
-            signedGroupParametersVerifier.verify(
-                transaction,
-                signedGroupParameters,
-                currentGroupParametersService.getMgmKeys()
-            )
-        }
+
+        verifyNotary(transaction)
+
         val verificationResult = externalEventExecutor.execute(
             TransactionVerificationExternalEventFactory::class.java,
             TransactionVerificationParameters(
@@ -77,6 +63,37 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
                 verificationResult.errorMessage
             )
         }
+    }
+
+    private fun verifyNotary(transaction: UtxoLedgerTransaction) {
+        val signedGroupParameters = fetchSignedGroupParameters(transaction)
+        verifyNotaryAllowed(transaction, signedGroupParameters)
+    }
+
+    private fun fetchSignedGroupParameters(transaction: UtxoLedgerTransaction): SignedGroupParameters {
+        val membershipGroupParametersHashString =
+            (transaction.metadata as TransactionMetadataInternal).getMembershipGroupParametersHash()
+        requireNotNull(membershipGroupParametersHashString) {
+            "Membership group parameters hash cannot be found in the transaction metadata."
+        }
+
+        val currentGroupParameters = currentGroupParametersService.get()
+        val signedGroupParameters =
+            if (currentGroupParameters.hash.toString() == membershipGroupParametersHashString) {
+                currentGroupParameters
+            } else {
+                val membershipGroupParametersHash = parseSecureHash(membershipGroupParametersHashString)
+                utxoLedgerGroupParametersPersistenceService.find(membershipGroupParametersHash)
+            }
+        requireNotNull(signedGroupParameters) {
+            "Signed group parameters $membershipGroupParametersHashString related to the transaction ${transaction.id} cannot be accessed."
+        }
+        signedGroupParametersVerifier.verify(
+            transaction,
+            signedGroupParameters,
+            currentGroupParametersService.getMgmKeys()
+        )
+        return signedGroupParameters
     }
 
     private fun UtxoLedgerTransaction.toContainer() =

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
@@ -65,11 +65,13 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
         }
     }
 
+    @Suspendable
     private fun verifyNotary(transaction: UtxoLedgerTransaction) {
         val signedGroupParameters = fetchSignedGroupParameters(transaction)
         verifyNotaryAllowed(transaction, signedGroupParameters)
     }
 
+    @Suspendable
     private fun fetchSignedGroupParameters(transaction: UtxoLedgerTransaction): SignedGroupParameters {
         val membershipGroupParametersHashString =
             (transaction.metadata as TransactionMetadataInternal).getMembershipGroupParametersHash()

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifier.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifier.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.transaction.verifier
 
+import net.corda.crypto.cipher.suite.publicKeyId
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.membership.lib.SignedGroupParameters
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
@@ -24,9 +25,10 @@ fun verifyNotaryAllowed(transaction: UtxoLedgerTransaction, signedGroupParameter
     }
 
     val notaryCandidate = checkNotNull(allowedNotaries.singleOrNull { it.name == transaction.notaryName }) {
-        "Notary of the transaction is not listed in the available notaries."
+        "Notary of the transaction (${transaction.notaryName}) is not listed in the available notaries."
     }
     check(notaryCandidate.publicKey == transaction.notaryKey) {
-        "Notary key of the transaction is not matching against the related notary in Signed Group Parameters."
+        "Notary key of the transaction (${transaction.notaryKey.publicKeyId()} is not matching against " +
+                "the related notary (${notaryCandidate.publicKey.publicKeyId()} in Signed Group Parameters."
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifier.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifier.kt
@@ -1,0 +1,24 @@
+package net.corda.ledger.utxo.flow.impl.transaction.verifier
+
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
+import net.corda.membership.lib.SignedGroupParameters
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
+
+fun verifyNotaryAllowed(transaction: UtxoLedgerTransaction, signedGroupParameters: SignedGroupParameters) {
+    val txNotaryPublicKey = transaction.notaryKey
+    val txNotaryName = transaction.notaryName
+    val allowedNotaries = signedGroupParameters.notaries
+
+    val txGroupParametersHash = (transaction.metadata as TransactionMetadataInternal).getMembershipGroupParametersHash()
+    check(txGroupParametersHash == signedGroupParameters.hash.toString()) {
+        "Membership group parameters (${signedGroupParameters.hash}) is not the one associated to the transaction " +
+                " in its metadata ($txGroupParametersHash)."
+    }
+
+    checkNotNull(
+        allowedNotaries.firstOrNull { it.publicKey == txNotaryPublicKey }
+            ?: allowedNotaries.firstOrNull { it.name == txNotaryName }
+    ) {
+        "Notary of the transaction is not listed in the available notaries."
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifier.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifier.kt
@@ -5,8 +5,6 @@ import net.corda.membership.lib.SignedGroupParameters
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 
 fun verifyNotaryAllowed(transaction: UtxoLedgerTransaction, signedGroupParameters: SignedGroupParameters) {
-    val txNotaryPublicKey = transaction.notaryKey
-    val txNotaryName = transaction.notaryName
     val allowedNotaries = signedGroupParameters.notaries
 
     val txGroupParametersHash = (transaction.metadata as TransactionMetadataInternal).getMembershipGroupParametersHash()
@@ -16,8 +14,8 @@ fun verifyNotaryAllowed(transaction: UtxoLedgerTransaction, signedGroupParameter
     }
 
     checkNotNull(
-        allowedNotaries.firstOrNull { it.publicKey == txNotaryPublicKey }
-            ?: allowedNotaries.firstOrNull { it.name == txNotaryName }
+        allowedNotaries.firstOrNull { it.publicKey == transaction.notaryKey }
+            ?: allowedNotaries.firstOrNull { it.name == transaction.notaryName }
     ) {
         "Notary of the transaction is not listed in the available notaries."
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoTransactionBuilderVerifier.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoTransactionBuilderVerifier.kt
@@ -32,7 +32,6 @@ class UtxoTransactionBuilderVerifier(
         verifyNoDuplicateInputsOrReferences(transactionBuilder.inputStateRefs, transactionBuilder.referenceStateRefs)
         verifyNoInputAndReferenceOverlap(transactionBuilder.inputStateRefs, transactionBuilder.referenceStateRefs)
         verifyCommands(transactionBuilder.commands)
-        verifyNotaryIsWhitelisted()
     }
 
     private fun verifyNotary() {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImplTest.kt
@@ -1,16 +1,22 @@
 package net.corda.ledger.utxo.flow.impl.transaction.verifier
 
+import net.corda.crypto.core.parseSecureHash
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.internal.serialization.SerializedBytesImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationResult
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
+import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.verifier.external.events.TransactionVerificationExternalEventFactory
 import net.corda.ledger.utxo.test.mockCurrentGroupParametersService
+import net.corda.ledger.utxo.testkit.notaryX500Name
+import net.corda.membership.lib.SignedGroupParameters
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.membership.NotaryInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -34,18 +40,27 @@ class UtxoLedgerTransactionVerificationServiceImplTest {
     private val serializationService = mock<SerializationService>()
     private lateinit var verificationService: UtxoLedgerTransactionVerificationServiceImpl
     private val argumentCaptor = argumentCaptor<Class<TransactionVerificationExternalEventFactory>>()
+    private val mockUtxoLedgerGroupParametersPersistenceService = mock<UtxoLedgerGroupParametersPersistenceService>()
+    private val mockSignedGroupParameters = mock<SignedGroupParameters>()
+    private val notaryInfo = mock<NotaryInfo>()
+    private val groupParametersHash = parseSecureHash("algo:1234")
 
     @BeforeEach
     fun setup() {
         verificationService = UtxoLedgerTransactionVerificationServiceImpl(
             externalEventExecutor,
             serializationService,
-            mock(),
+            mockUtxoLedgerGroupParametersPersistenceService,
             mockCurrentGroupParametersService(),
             mock()
         )
 
         whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
+        whenever(mockUtxoLedgerGroupParametersPersistenceService.find(any())).thenReturn(mockSignedGroupParameters)
+        whenever(notaryInfo.name).thenReturn(notaryX500Name)
+        whenever(notaryInfo.publicKey).thenReturn(publicKeyExample)
+        whenever(mockSignedGroupParameters.notaries).thenReturn(listOf(notaryInfo))
+        whenever(mockSignedGroupParameters.hash).thenReturn(groupParametersHash)
     }
 
     @Test
@@ -67,9 +82,11 @@ class UtxoLedgerTransactionVerificationServiceImplTest {
         val transactionMetadata = mock<TransactionMetadataInternal>()
         whenever(transaction.wireTransaction).thenReturn(wireTransaction)
         whenever(transaction.metadata).thenReturn(transactionMetadata)
+        whenever(transaction.notaryKey).thenReturn(publicKeyExample)
+        whenever(transaction.notaryName).thenReturn(notaryX500Name)
         whenever(wireTransaction.metadata).thenReturn(transactionMetadata)
         whenever(transactionMetadata.getCpkMetadata()).thenReturn(listOf(mock()))
-        whenever(transactionMetadata.getMembershipGroupParametersHash()).thenReturn("SHA-X:1234")
+        whenever(transactionMetadata.getMembershipGroupParametersHash()).thenReturn(groupParametersHash.toString())
 
         assertDoesNotThrow {
             verificationService.verify(transaction)
@@ -100,9 +117,11 @@ class UtxoLedgerTransactionVerificationServiceImplTest {
         whenever(transaction.id).thenReturn(transactionId)
         whenever(transaction.wireTransaction).thenReturn(wireTransaction)
         whenever(transaction.metadata).thenReturn(transactionMetadata)
+        whenever(transaction.notaryKey).thenReturn(publicKeyExample)
+        whenever(transaction.notaryName).thenReturn(notaryX500Name)
         whenever(wireTransaction.metadata).thenReturn(transactionMetadata)
         whenever(transactionMetadata.getCpkMetadata()).thenReturn(listOf(mock()))
-        whenever(transactionMetadata.getMembershipGroupParametersHash()).thenReturn("SHA-X:1234")
+        whenever(transactionMetadata.getMembershipGroupParametersHash()).thenReturn(groupParametersHash.toString())
 
         val exception = assertThrows<TransactionVerificationException> {
             verificationService.verify(transaction)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifierTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifierTest.kt
@@ -58,14 +58,25 @@ class UtxoNotaryVerifierTest {
     }
 
     @Test
-    fun `verifyNotaryAllowed does not throw if any keys matches`() {
+    fun `verifyNotaryAllowed throws if only key matches, but not the name`() {
         whenever(notary1.publicKey).thenReturn(publicKeyExample)
-        assertDoesNotThrow { verifyNotaryAllowed(transaction, signedGroupParameters) }
+        assertThatThrownBy { verifyNotaryAllowed(transaction, signedGroupParameters) }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Notary of the transaction is not listed in the available notaries.")
     }
 
     @Test
-    fun `verifyNotaryAllowed does not throw if any names matches`() {
+    fun `verifyNotaryAllowed throws if only name matches, but not the key`() {
         whenever(notary1.name).thenReturn(notaryX500Name)
+        assertThatThrownBy { verifyNotaryAllowed(transaction, signedGroupParameters) }
+            .isExactlyInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("Notary key of the transaction is not matching against the related notary in Signed Group Parameters.")
+    }
+
+    @Test
+    fun `verifyNotaryAllowed does not throw if both key and name matches`() {
+        whenever(notary1.name).thenReturn(notaryX500Name)
+        whenever(notary1.publicKey).thenReturn(publicKeyExample)
         assertDoesNotThrow { verifyNotaryAllowed(transaction, signedGroupParameters) }
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifierTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoNotaryVerifierTest.kt
@@ -54,7 +54,7 @@ class UtxoNotaryVerifierTest {
     fun `verifyNotaryAllowed throws if no keys or names matches`() {
         assertThatThrownBy { verifyNotaryAllowed(transaction, signedGroupParameters) }
             .isExactlyInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Notary of the transaction is not listed in the available notaries.")
+            .hasMessageContaining("is not listed in the available notaries.")
     }
 
     @Test
@@ -62,7 +62,7 @@ class UtxoNotaryVerifierTest {
         whenever(notary1.publicKey).thenReturn(publicKeyExample)
         assertThatThrownBy { verifyNotaryAllowed(transaction, signedGroupParameters) }
             .isExactlyInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Notary of the transaction is not listed in the available notaries.")
+            .hasMessageContaining("is not listed in the available notaries.")
     }
 
     @Test
@@ -70,7 +70,7 @@ class UtxoNotaryVerifierTest {
         whenever(notary1.name).thenReturn(notaryX500Name)
         assertThatThrownBy { verifyNotaryAllowed(transaction, signedGroupParameters) }
             .isExactlyInstanceOf(IllegalStateException::class.java)
-            .hasMessageContaining("Notary key of the transaction is not matching against the related notary in Signed Group Parameters.")
+            .hasMessageContaining("is not matching against the related notary")
     }
 
     @Test

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoTransactionBuilderVerifierTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoTransactionBuilderVerifierTest.kt
@@ -136,11 +136,6 @@ class UtxoTransactionBuilderVerifierTest {
     }
 
     @Test
-    fun `throws an exception if the notary is not allowed`() {
-        // TODO CORE-8956 Check the notary is in the group parameters whitelist
-    }
-
-    @Test
     fun `throws an exception if the same input state appears twice`() {
         whenever(transactionBuilder.inputStateRefs).thenReturn(listOf(stateRef, stateRef))
         assertThatThrownBy { verifier.verify() }

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifier.kt
@@ -52,7 +52,6 @@ class UtxoLedgerTransactionVerifier(
         check(allInputs.first().notaryName == transaction.notaryName) {
             "Input and reference states' notaries need to be the same as the $subjectClass's notary."
         }
-        // TODO CORE-8958 check rotated notaries
     }
 
     private fun verifyInputsAreOlderThanOutputs() {

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifier.kt
@@ -46,11 +46,10 @@ class UtxoLedgerTransactionVerifier(
         if (allInputs.isEmpty()) {
             return
         }
-        check(allInputs.map { Pair(it.notaryName, it.notaryKey) }.distinct().size == 1) {
+        check(allInputs.map { it.notaryName }.distinct().size == 1) {
             "Input and reference states' notaries need to be the same."
         }
-        check(allInputs.first().notaryName == transaction.notaryName
-                && allInputs.first().notaryKey == transaction.notaryKey ) {
+        check(allInputs.first().notaryName == transaction.notaryName) {
             "Input and reference states' notaries need to be the same as the $subjectClass's notary."
         }
         // TODO CORE-8958 check rotated notaries

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifier.kt
@@ -33,7 +33,6 @@ class UtxoLedgerTransactionVerifier(
         verifyNoDuplicateInputsOrReferences(transaction.inputStateRefs, transaction.referenceStateRefs)
         verifyNoInputAndReferenceOverlap(transaction.inputStateRefs, transaction.referenceStateRefs)
         verifyCommands(transaction.commands)
-        verifyNotaryIsWhitelisted()
 
         /**
          * These checks require backchain resolution.

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionVerifier.kt
@@ -41,7 +41,6 @@ abstract class UtxoTransactionVerifier {
         }
     }
 
-
     protected fun verifyCommands(commands: List<Command>) {
         check(commands.isNotEmpty()) {
             "At least one command must be applied to the current $subjectClass."

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionVerifier.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/main/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoTransactionVerifier.kt
@@ -47,8 +47,4 @@ abstract class UtxoTransactionVerifier {
             "At least one command must be applied to the current $subjectClass."
         }
     }
-
-    protected fun verifyNotaryIsWhitelisted() {
-        // TODO CORE-8956 Check the notary is in the group parameters whitelist
-    }
 }

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
@@ -160,7 +160,7 @@ class UtxoLedgerTransactionVerifierTest {
     }
 
     @Test
-    fun `does not throw when input and reference states don't have the same notary keys passed into the verification (but the names are still the same)`() {
+    fun `does not throw when input and reference states have different notary keys passed into verification (names are the same)`() {
         whenever(inputTransactionState.notaryKey).thenReturn(anotherPublicKeyExample)
         whenever(referenceTransactionState.notaryKey).thenReturn(anotherPublicKeyExample)
         assertDoesNotThrow { verifier.verify() }

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
@@ -132,11 +132,6 @@ class UtxoLedgerTransactionVerifierTest {
     }
 
     @Test
-    fun `throws an exception if the notary is not allowed`() {
-        // TODO CORE-8956 Check the notary is in the group parameters whitelist
-    }
-
-    @Test
     fun `throws an exception when input and reference states don't have the same notary`() {
         whenever(inputTransactionState.notaryName).thenReturn(notaryX500Name)
         whenever(inputTransactionState.notaryKey).thenReturn(publicKeyExample)

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
@@ -22,6 +22,7 @@ import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.security.PublicKey
@@ -132,25 +133,36 @@ class UtxoLedgerTransactionVerifierTest {
     }
 
     @Test
-    fun `throws an exception when input and reference states don't have the same notary`() {
+    fun `throws an exception when input and reference states don't have the same notary (names are different)`() {
         whenever(inputTransactionState.notaryName).thenReturn(notaryX500Name)
-        whenever(inputTransactionState.notaryKey).thenReturn(publicKeyExample)
         whenever(referenceTransactionState.notaryName).thenReturn(anotherNotaryX500Name)
-        whenever(referenceTransactionState.notaryKey).thenReturn(anotherPublicKeyExample)
         assertThatThrownBy { verifier.verify() }
             .isExactlyInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("Input and reference states' notaries need to be the same.")
     }
 
     @Test
-    fun `throws an exception when input and reference states don't have the same notary passed into the verification`() {
-        whenever(inputTransactionState.notaryName).thenReturn(anotherNotaryX500Name)
-        whenever(inputTransactionState.notaryKey).thenReturn(anotherPublicKeyExample)
-        whenever(referenceTransactionState.notaryName).thenReturn(anotherNotaryX500Name)
+    fun `does not throw when input and reference states don't have the same notary keys (but the names are still the same)`() {
+        whenever(inputTransactionState.notaryKey).thenReturn(publicKeyExample)
         whenever(referenceTransactionState.notaryKey).thenReturn(anotherPublicKeyExample)
+        assertDoesNotThrow { verifier.verify() }
+    }
+
+
+    @Test
+    fun `throws an exception when input and reference states don't have the same notary passed into the verification (names are different)`() {
+        whenever(inputTransactionState.notaryName).thenReturn(anotherNotaryX500Name)
+        whenever(referenceTransactionState.notaryName).thenReturn(anotherNotaryX500Name)
         assertThatThrownBy { verifier.verify() }
             .isExactlyInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("Input and reference states' notaries need to be the same as the UtxoLedgerTransaction's notary")
+    }
+
+    @Test
+    fun `does not throw when input and reference states don't have the same notary keys passed into the verification (but the names are still the same)`() {
+        whenever(inputTransactionState.notaryKey).thenReturn(anotherPublicKeyExample)
+        whenever(referenceTransactionState.notaryKey).thenReturn(anotherPublicKeyExample)
+        assertDoesNotThrow { verifier.verify() }
     }
 
     @Test

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
@@ -27,6 +27,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.security.PublicKey
 
+@Suppress("MaxLineLength")
 class UtxoLedgerTransactionVerifierTest {
 
     private val transaction = mock<UtxoLedgerTransaction>()

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionVerifierTest.kt
@@ -27,7 +27,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.security.PublicKey
 
-@Suppress("MaxLineLength")
 class UtxoLedgerTransactionVerifierTest {
 
     private val transaction = mock<UtxoLedgerTransaction>()
@@ -151,7 +150,7 @@ class UtxoLedgerTransactionVerifierTest {
 
 
     @Test
-    fun `throws an exception when input and reference states don't have the same notary passed into the verification (names are different)`() {
+    fun `throws an exception when input and reference states don't have the same notary passed into verification (names are different)`() {
         whenever(inputTransactionState.notaryName).thenReturn(anotherNotaryX500Name)
         whenever(referenceTransactionState.notaryName).thenReturn(anotherNotaryX500Name)
         assertThatThrownBy { verifier.verify() }


### PR DESCRIPTION
* CORE-8956 check if notary is whitelisted. It gets triggered in both sides of finality and also on tx creation time.
* Fix notary comparison in `verifyInputNotaries()`. (Public keys are not checked anymore, to support key rotation.)