### PR TITLE
CORE-12441 Disable object referencing in AMQP serialization

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -178,8 +178,8 @@ class ConsensualLedgerMessageProcessorTests {
         assertThat(entityResponse.results).hasSize(1)
         val retrievedTransaction = ctx.deserialize<SignedTransactionContainer>(entityResponse.results.first())
         assertThat(retrievedTransaction).isEqualTo(transaction)
-        // todo Enable with CORE-12441
-        // assertThat(entityResponse.results.first()).isEqualTo(serializedTransaction)
+        // todo re-check with CORE-12472
+        assertThat(entityResponse.results.first()).isEqualTo(serializedTransaction)
     }
 
     private fun createTestTransaction(ctx: SandboxGroupContext): SignedTransactionContainer {

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
@@ -1,6 +1,6 @@
 package net.corda.sandbox.serialization.amqp
 
-import net.corda.internal.serialization.AMQP_P2P_CONTEXT
+import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
 import net.corda.internal.serialization.SerializationServiceImpl
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.SerializationOutput
@@ -77,7 +77,7 @@ class AMQPSerializationProvider @Activate constructor(
         val serializationService = SerializationServiceImpl(
             serializationOutput,
             deserializationInput,
-            AMQP_P2P_CONTEXT.withSandboxGroup(context.sandboxGroup)
+            AMQP_STORAGE_CONTEXT.withSandboxGroup(context.sandboxGroup) //todo double check in CORE-12472
         )
 
         context.putObjectByKey(AMQP_SERIALIZATION_SERVICE, serializationService)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
@@ -17,7 +17,7 @@ import net.corda.serialization.SerializationContext
 val AMQP_STORAGE_CONTEXT = SerializationContextImpl(
         amqpMagic,
         emptyMap(),
-        true,
+        true, // todo should not this be false? CORE-12472
         SerializationContext.UseCase.Storage,
         null,
         AlwaysAcceptEncodingAllowList

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
@@ -17,7 +17,7 @@ import net.corda.serialization.SerializationContext
 val AMQP_STORAGE_CONTEXT = SerializationContextImpl(
         amqpMagic,
         emptyMap(),
-        true, // todo should not this be false? CORE-12472
+        false, // todo double check in CORE-12472
         SerializationContext.UseCase.Storage,
         null,
         AlwaysAcceptEncodingAllowList

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
@@ -15,10 +15,10 @@ import net.corda.serialization.SerializationContext
  */
 
 val AMQP_STORAGE_CONTEXT = SerializationContextImpl(
-        preferredSerializationVersion = amqpMagic,
-        properties = emptyMap(),
-        objectReferencesEnabled = false, // todo double check in CORE-12472
-        useCase = SerializationContext.UseCase.Storage,
-        encoding = null,
-        encodingAllowList = AlwaysAcceptEncodingAllowList
+    preferredSerializationVersion = amqpMagic,
+    properties = emptyMap(),
+    objectReferencesEnabled = false,
+    useCase = SerializationContext.UseCase.Storage,
+    encoding = null,
+    encodingAllowList = AlwaysAcceptEncodingAllowList
 )

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/ServerContexts.kt
@@ -15,10 +15,10 @@ import net.corda.serialization.SerializationContext
  */
 
 val AMQP_STORAGE_CONTEXT = SerializationContextImpl(
-        amqpMagic,
-        emptyMap(),
-        false, // todo double check in CORE-12472
-        SerializationContext.UseCase.Storage,
-        null,
-        AlwaysAcceptEncodingAllowList
+        preferredSerializationVersion = amqpMagic,
+        properties = emptyMap(),
+        objectReferencesEnabled = false, // todo double check in CORE-12472
+        useCase = SerializationContext.UseCase.Storage,
+        encoding = null,
+        encodingAllowList = AlwaysAcceptEncodingAllowList
 )

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
@@ -9,7 +9,7 @@ import net.corda.serialization.SerializationEncoding
 val AMQP_P2P_CONTEXT = SerializationContextImpl(
         amqpMagic,
         emptyMap(),
-        true,
+        false, //todo revert this to true in CORE-12472
         SerializationContext.UseCase.P2P,
         null
 )

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
@@ -7,11 +7,11 @@ import net.corda.serialization.SerializationContext
 import net.corda.serialization.SerializationEncoding
 
 val AMQP_P2P_CONTEXT = SerializationContextImpl(
-        preferredSerializationVersion = amqpMagic,
-        properties = emptyMap(),
-        objectReferencesEnabled = true, //todo double check in CORE-12472
-        useCase = SerializationContext.UseCase.P2P,
-        encoding = null
+    preferredSerializationVersion = amqpMagic,
+    properties = emptyMap(),
+    objectReferencesEnabled = true,
+    useCase = SerializationContext.UseCase.P2P,
+    encoding = null
 )
 
 object AlwaysAcceptEncodingAllowList : EncodingAllowList {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
@@ -9,7 +9,7 @@ import net.corda.serialization.SerializationEncoding
 val AMQP_P2P_CONTEXT = SerializationContextImpl(
         amqpMagic,
         emptyMap(),
-        false, //todo revert this to true in CORE-12472
+        true, //todo double check in CORE-12472
         SerializationContext.UseCase.P2P,
         null
 )

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SharedContexts.kt
@@ -7,11 +7,11 @@ import net.corda.serialization.SerializationContext
 import net.corda.serialization.SerializationEncoding
 
 val AMQP_P2P_CONTEXT = SerializationContextImpl(
-        amqpMagic,
-        emptyMap(),
-        true, //todo double check in CORE-12472
-        SerializationContext.UseCase.P2P,
-        null
+        preferredSerializationVersion = amqpMagic,
+        properties = emptyMap(),
+        objectReferencesEnabled = true, //todo double check in CORE-12472
+        useCase = SerializationContext.UseCase.P2P,
+        encoding = null
 )
 
 object AlwaysAcceptEncodingAllowList : EncodingAllowList {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
@@ -148,14 +148,18 @@ open class SerializationOutput constructor(
             putTypeToMetadata(serializer.type, context)
         }
 
-        val retrievedRefCount = objectHistory[obj]
-        if (!context.objectReferencesEnabled || retrievedRefCount == null) {
+
+        val retrievedRefCount = if (context.objectReferencesEnabled) {
+            objectHistory[obj]
+        } else {
+            null
+        }
+        if (retrievedRefCount == null) {
             serializer.writeObject(obj, data, type, this, context, debugIndent)
             // Important to do it after serialization such that dependent object will have preceding reference numbers
             // assigned to them first as they will be first read from the stream on receiving end.
             // Skip for primitive types as they are too small and overhead of referencing them will be much higher than their content
 
-            // todo CORE-12472 is this needed if referencing is disabled?
             if (serializerFactory.isSuitableForObjectReference(obj.javaClass)) {
                 objectHistory[obj] = objectHistory.size
             }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
@@ -149,11 +149,13 @@ open class SerializationOutput constructor(
         }
 
         val retrievedRefCount = objectHistory[obj]
-        if (retrievedRefCount == null) {
+        if (!context.objectReferencesEnabled || retrievedRefCount == null) {
             serializer.writeObject(obj, data, type, this, context, debugIndent)
             // Important to do it after serialization such that dependent object will have preceding reference numbers
             // assigned to them first as they will be first read from the stream on receiving end.
             // Skip for primitive types as they are too small and overhead of referencing them will be much higher than their content
+
+            // todo CORE-12472 is this needed if referencing is disabled?
             if (serializerFactory.isSuitableForObjectReference(obj.javaClass)) {
                 objectHistory[obj] = objectHistory.size
             }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -39,7 +39,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
@@ -695,7 +694,6 @@ class SerializationOutputTests {
     @CordaSerializable
     data class ParentContainer(val left: SimpleContainer, val right: Container)
 
-    @Disabled // todo re-enable with CORE-12472
     @Test
     fun `test object referenced multiple times`() {
         val simple = SimpleContainer("Fred", "Ginger")
@@ -703,7 +701,8 @@ class SerializationOutputTests {
         assertSame(parentContainer.left, parentContainer.right)
 
         val parentCopy = serdes(parentContainer)
-        assertSame(parentCopy.left, parentCopy.right)
+        // todo remvert to assertSame in CORE-12472
+        assertNotSame(parentCopy.left, parentCopy.right)
     }
 
     @CordaSerializable
@@ -725,7 +724,6 @@ class SerializationOutputTests {
     @CordaSerializable
     data class Vic(val a: List<String>, val b: List<String>)
 
-    @Disabled // todo re-enable with CORE-12472
     @Test
     fun `test generics ignored from graph logic`() {
         val a = listOf("a", "b")
@@ -734,7 +732,8 @@ class SerializationOutputTests {
         val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val objCopy = serdes(obj, factory, factory2)
-        assertSame(objCopy.a, objCopy.b)
+        // todo revert to assertSame in CORE-12472
+        assertNotSame(objCopy.a, objCopy.b)
     }
 
     class Spike private constructor(val a: String) {

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -701,7 +701,7 @@ class SerializationOutputTests {
         assertSame(parentContainer.left, parentContainer.right)
 
         val parentCopy = serdes(parentContainer)
-        // todo remvert to assertSame in CORE-12472
+        // todo revert to assertSame in CORE-12472
         assertNotSame(parentCopy.left, parentCopy.right)
     }
 

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNotSame
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
@@ -694,6 +695,7 @@ class SerializationOutputTests {
     @CordaSerializable
     data class ParentContainer(val left: SimpleContainer, val right: Container)
 
+    @Disabled // todo re-enable with CORE-12472
     @Test
     fun `test object referenced multiple times`() {
         val simple = SimpleContainer("Fred", "Ginger")
@@ -723,6 +725,7 @@ class SerializationOutputTests {
     @CordaSerializable
     data class Vic(val a: List<String>, val b: List<String>)
 
+    @Disabled // todo re-enable with CORE-12472
     @Test
     fun `test generics ignored from graph logic`() {
         val a = listOf("a", "b")


### PR DESCRIPTION
Make serialization more stable as a default to support storing use cases.
On longer term, messaging and storing serialization needs to be reworked properly. (https://r3-cev.atlassian.net/browse/CORE-12472)