### PR TITLE
CORE-12498 Vault named query parsing escape special characters

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -14,23 +14,21 @@ import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
 import net.corda.orm.utils.transaction
 import net.corda.persistence.common.exceptions.NullParameterException
-import net.corda.sandbox.type.UsedByPersistence
 import net.corda.utilities.serialization.deserialize
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
-import org.osgi.service.component.annotations.Activate
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import javax.persistence.EntityManagerFactory
 import javax.persistence.Tuple
 
-class VaultNamedQueryExecutorImpl @Activate constructor(
+class VaultNamedQueryExecutorImpl(
     private val entityManagerFactory: EntityManagerFactory,
     private val registry: VaultNamedQueryRegistry,
     private val serializationService: SerializationService
-) : VaultNamedQueryExecutor, UsedByPersistence {
+) : VaultNamedQueryExecutor {
 
     private companion object {
         const val UTXO_VISIBLE_TX_TABLE = "utxo_visible_transaction_state"

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/parsing/converters/PostgresVaultNamedQueryConverter.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/parsing/converters/PostgresVaultNamedQueryConverter.kt
@@ -60,8 +60,8 @@ class PostgresVaultNamedQueryConverter : VaultNamedQueryConverter {
                     }
                     output.append(")")
                 }
-                is JsonKeyExists -> output.append(" ? ")
-                is JsonCast -> output.append("::${token.value}")
+                is JsonKeyExists -> output.append(" \\?\\? ")
+                is JsonCast -> output.append("\\:\\:${token.value}")
                 is Like -> output.append(" LIKE ")
                 is ParameterEnd -> output.append(", ")
                 else -> throw IllegalArgumentException("Invalid token in expression - $token")

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
@@ -45,10 +45,10 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
 
     @Suppress("MaxLineLength")
     private val opsPattern = Regex(
-        """(?<op>(->>)|[+-/*=?]|<(=)?|>(=)?|==|!(=)?|(\\\?\\\?)|(?i)\bas\b|(?i)\bfrom\b|(?i)\bselect\b|(?i)\bwhere\b|(?i)\band\b|(?i)\bor\b|(?i)\bis null\b|(?i)\bis not null\b|(?i)\bin\b|(?i)\blike\b)"""
+        """(?<op>(->>)|[+-/*=?]|<(=)?|>(=)?|==|!(=)?|(?i)\bas\b|(?i)\bfrom\b|(?i)\bselect\b|(?i)\bwhere\b|(?i)\band\b|(?i)\bor\b|(?i)\bis null\b|(?i)\bis not null\b|(?i)\bin\b|(?i)\blike\b)"""
     )
 
-    private val jsonCastPattern = Regex("""\\:\\:(?<cast>.*?)((->>)|[+*=]|&&|\|\||<(=)?|>(=)?|==|!(=)?|\s|$)""")
+    private val jsonCastPattern = Regex("""::(?<cast>.*?)((->>)|[+*=]|&&|\|\||<(=)?|>(=)?|==|!(=)?|\s|$)""")
 
     private val parameterPattern = Regex("""(?<parameter>:[^:]\S+)""")
 
@@ -156,7 +156,7 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
             "AND" -> And()
             "=" -> Equals()
             "IN" -> In()
-            "\\?\\?" -> JsonKeyExists()
+            "?" -> JsonKeyExists()
             "LIKE" -> Like()
             else -> throw IllegalArgumentException("Unknown keyword '$keyword'")
         }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
@@ -45,10 +45,10 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
 
     @Suppress("MaxLineLength")
     private val opsPattern = Regex(
-        """(?<op>(->>)|[+-/*=?]|<(=)?|>(=)?|==|!(=)?|(?i)\bas\b|(?i)\bfrom\b|(?i)\bselect\b|(?i)\bwhere\b|(?i)\band\b|(?i)\bor\b|(?i)\bis null\b|(?i)\bis not null\b|(?i)\bin\b|(?i)\blike\b)"""
+        """(?<op>(->>)|[+-/*=?]|<(=)?|>(=)?|==|!(=)?|(\\\?\\\?)|(?i)\bas\b|(?i)\bfrom\b|(?i)\bselect\b|(?i)\bwhere\b|(?i)\band\b|(?i)\bor\b|(?i)\bis null\b|(?i)\bis not null\b|(?i)\bin\b|(?i)\blike\b)"""
     )
 
-    private val jsonCastPattern = Regex("""::(?<cast>.*?)((->>)|[+*=]|&&|\|\||<(=)?|>(=)?|==|!(=)?|\s|$)""")
+    private val jsonCastPattern = Regex("""\\:\\:(?<cast>.*?)((->>)|[+*=]|&&|\|\||<(=)?|>(=)?|==|!(=)?|\s|$)""")
 
     private val parameterPattern = Regex("""(?<parameter>:[^:]\S+)""")
 
@@ -156,9 +156,9 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
             "AND" -> And()
             "=" -> Equals()
             "IN" -> In()
-            "?" -> JsonKeyExists()
+            "\\?\\?" -> JsonKeyExists()
             "LIKE" -> Like()
-            else -> throw IllegalArgumentException("Unknown keyword $keyword")
+            else -> throw IllegalArgumentException("Unknown keyword '$keyword'")
         }
     }
 }

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/PostgresVaultNamedQueryParserIntegrationTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/PostgresVaultNamedQueryParserIntegrationTest.kt
@@ -32,30 +32,29 @@ class PostgresVaultNamedQueryParserIntegrationTest {
                     "WHERE \"field name\" ->> \"json property\" = 'some_value'",
                     "WHERE \"field name\" ->> \"json property\" = 'some_value'"
                 ),
-                Arguments.of("WHERE (field ->> property)::int = 5", "WHERE (field ->> property)::int = 5"),
-                Arguments.of("WHERE (field ->> property)::int != 5", "WHERE (field ->> property)::int != 5"),
-                Arguments.of("WHERE (field ->> property)::int < 5", "WHERE (field ->> property)::int < 5"),
-                Arguments.of("WHERE (field ->> property)::int <= 5", "WHERE (field ->> property)::int <= 5"),
-                Arguments.of("WHERE (field ->> property)::int > 5", "WHERE (field ->> property)::int > 5"),
-                Arguments.of("WHERE (field ->> property)::int >= 5", "WHERE (field ->> property)::int >= 5"),
-                Arguments.of("WHERE (field ->> property)::int <= :value", "WHERE (field ->> property)::int <= :value"),
-                Arguments.of("WHERE (field ->> property)::int = 1234.5678900", "WHERE (field ->> property)::int = 1234.5678900"),
-
+                Arguments.of("WHERE (field ->> property)\\:\\:int = 5", "WHERE (field ->> property)\\:\\:int = 5"),
+                Arguments.of("WHERE (field ->> property)\\:\\:int != 5", "WHERE (field ->> property)\\:\\:int != 5"),
+                Arguments.of("WHERE (field ->> property)\\:\\:int < 5", "WHERE (field ->> property)\\:\\:int < 5"),
+                Arguments.of("WHERE (field ->> property)\\:\\:int <= 5", "WHERE (field ->> property)\\:\\:int <= 5"),
+                Arguments.of("WHERE (field ->> property)\\:\\:int > 5", "WHERE (field ->> property)\\:\\:int > 5"),
+                Arguments.of("WHERE (field ->> property)\\:\\:int >= 5", "WHERE (field ->> property)\\:\\:int >= 5"),
+                Arguments.of("WHERE (field ->> property)\\:\\:int <= :value", "WHERE (field ->> property)\\:\\:int <= :value"),
+                Arguments.of("WHERE (field ->> property)\\:\\:int = 1234.5678900", "WHERE (field ->> property)\\:\\:int = 1234.5678900"),
                 Arguments.of(
-                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value'",
-                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value'"
+                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value?'",
+                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value?'"
                 ),
                 Arguments.of(
                     "WHERE field ->> property = 'some_value' OR field ->> property2 = 'another value'",
                     "WHERE field ->> property = 'some_value' OR field ->> property2 = 'another value'"
                 ),
                 Arguments.of(
-                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value' OR field ->> property3 = 'third property'",
-                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value' OR field ->> property3 = 'third property'"
+                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value' OR field ->> property3 = 'third property?'",
+                    "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value' OR field ->> property3 = 'third property?'"
                 ),
                 Arguments.of(
-                    "WHERE (field ->> property = 'some_value' AND field ->> property2 = 'another value') OR field ->> property3 = 'third property'",
-                    "WHERE (field ->> property = 'some_value' AND field ->> property2 = 'another value') OR field ->> property3 = 'third property'"
+                    "WHERE (field ->> property = 'some_value' AND field ->> property2 = 'another value') OR field ->> property3 = 'third property?'",
+                    "WHERE (field ->> property = 'some_value' AND field ->> property2 = 'another value') OR field ->> property3 = 'third property?'"
                 ),
                 Arguments.of(
                     "WHERE field ->> property = 'some_value' AND (field ->> property2 = 'another value') OR field ->> property3 = 'third property')",
@@ -79,21 +78,22 @@ class PostgresVaultNamedQueryParserIntegrationTest {
                     "WHERE (field ->> property LIKE '%hello there%')",
                     "WHERE (field ->> property LIKE '%hello there%')"
                 ),
+                Arguments.of("WHERE field \\?\\? property", "WHERE field \\?\\? property"),
                 Arguments.of(
                     """
                         where
                             ("custom"->>'salary'='10'
-                            and (custom ->> 'salary')::int>9.00000000
+                            and (custom ->> 'salary')\:\:int>9.00000000
                             or custom ->> 'field with space' is null)
                     """,
-                    "WHERE (\"custom\" ->> 'salary' = '10' AND (custom ->> 'salary')::int > 9.00000000 OR custom ->> 'field with space' IS NULL)"
+                    "WHERE (\"custom\" ->> 'salary' = '10' AND (custom ->> 'salary')\\:\\:int > 9.00000000 OR custom ->> 'field with space' IS NULL)"
                 ),
                 Arguments.of(
                     """WHERE custom ->> 'TestUtxoState.testField' = :testField
                         |AND custom ->> 'Corda.participants' IN :participants
-                        |AND custom?:contractStateType
+                        |AND custom\?\?:contractStateType
                         |AND created > :created""".trimMargin(),
-                    "WHERE custom ->> 'TestUtxoState.testField' = :testField AND custom ->> 'Corda.participants' IN :participants AND custom ? :contractStateType AND created > :created"
+                    "WHERE custom ->> 'TestUtxoState.testField' = :testField AND custom ->> 'Corda.participants' IN :participants AND custom \\?\\? :contractStateType AND created > :created"
                 )
             )
         }

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/PostgresVaultNamedQueryParserIntegrationTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/PostgresVaultNamedQueryParserIntegrationTest.kt
@@ -32,14 +32,14 @@ class PostgresVaultNamedQueryParserIntegrationTest {
                     "WHERE \"field name\" ->> \"json property\" = 'some_value'",
                     "WHERE \"field name\" ->> \"json property\" = 'some_value'"
                 ),
-                Arguments.of("WHERE (field ->> property)\\:\\:int = 5", "WHERE (field ->> property)\\:\\:int = 5"),
-                Arguments.of("WHERE (field ->> property)\\:\\:int != 5", "WHERE (field ->> property)\\:\\:int != 5"),
-                Arguments.of("WHERE (field ->> property)\\:\\:int < 5", "WHERE (field ->> property)\\:\\:int < 5"),
-                Arguments.of("WHERE (field ->> property)\\:\\:int <= 5", "WHERE (field ->> property)\\:\\:int <= 5"),
-                Arguments.of("WHERE (field ->> property)\\:\\:int > 5", "WHERE (field ->> property)\\:\\:int > 5"),
-                Arguments.of("WHERE (field ->> property)\\:\\:int >= 5", "WHERE (field ->> property)\\:\\:int >= 5"),
-                Arguments.of("WHERE (field ->> property)\\:\\:int <= :value", "WHERE (field ->> property)\\:\\:int <= :value"),
-                Arguments.of("WHERE (field ->> property)\\:\\:int = 1234.5678900", "WHERE (field ->> property)\\:\\:int = 1234.5678900"),
+                Arguments.of("WHERE (field ->> property)::int = 5", "WHERE (field ->> property)\\:\\:int = 5"),
+                Arguments.of("WHERE (field ->> property)::int != 5", "WHERE (field ->> property)\\:\\:int != 5"),
+                Arguments.of("WHERE (field ->> property)::int < 5", "WHERE (field ->> property)\\:\\:int < 5"),
+                Arguments.of("WHERE (field ->> property)::int <= 5", "WHERE (field ->> property)\\:\\:int <= 5"),
+                Arguments.of("WHERE (field ->> property)::int > 5", "WHERE (field ->> property)\\:\\:int > 5"),
+                Arguments.of("WHERE (field ->> property)::int >= 5", "WHERE (field ->> property)\\:\\:int >= 5"),
+                Arguments.of("WHERE (field ->> property)::int <= :value", "WHERE (field ->> property)\\:\\:int <= :value"),
+                Arguments.of("WHERE (field ->> property)::int = 1234.5678900", "WHERE (field ->> property)\\:\\:int = 1234.5678900"),
                 Arguments.of(
                     "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value?'",
                     "WHERE field ->> property = 'some_value' AND field ->> property2 = 'another value?'"
@@ -78,12 +78,12 @@ class PostgresVaultNamedQueryParserIntegrationTest {
                     "WHERE (field ->> property LIKE '%hello there%')",
                     "WHERE (field ->> property LIKE '%hello there%')"
                 ),
-                Arguments.of("WHERE field \\?\\? property", "WHERE field \\?\\? property"),
+                Arguments.of("WHERE field ? property", "WHERE field \\?\\? property"),
                 Arguments.of(
                     """
                         where
                             ("custom"->>'salary'='10'
-                            and (custom ->> 'salary')\:\:int>9.00000000
+                            and (custom ->> 'salary')::int>9.00000000
                             or custom ->> 'field with space' is null)
                     """,
                     "WHERE (\"custom\" ->> 'salary' = '10' AND (custom ->> 'salary')\\:\\:int > 9.00000000 OR custom ->> 'field with space' IS NULL)"
@@ -91,7 +91,7 @@ class PostgresVaultNamedQueryParserIntegrationTest {
                 Arguments.of(
                     """WHERE custom ->> 'TestUtxoState.testField' = :testField
                         |AND custom ->> 'Corda.participants' IN :participants
-                        |AND custom\?\?:contractStateType
+                        |AND custom?:contractStateType
                         |AND created > :created""".trimMargin(),
                     "WHERE custom ->> 'TestUtxoState.testField' = :testField AND custom ->> 'Corda.participants' IN :participants AND custom \\?\\? :contractStateType AND created > :created"
                 )

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverterTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/converters/PostgresVaultNamedQueryConverterTest.kt
@@ -214,14 +214,14 @@ class PostgresVaultNamedQueryConverterTest {
     fun `JsonCast is appended directly to the output with no spaces`() {
         val expression = listOf(JsonCast("int"))
         postgresVaultNamedQueryParser.convert(output, expression)
-        assertThat(output.toString()).isEqualTo("::int")
+        assertThat(output.toString()).isEqualTo("\\:\\:int")
     }
 
     @Test
     fun `JsonKeyExists is appended to the output with a space on either side`() {
         val expression = listOf(JsonKeyExists())
         postgresVaultNamedQueryParser.convert(output, expression)
-        assertThat(output.toString()).isEqualTo(" ? ")
+        assertThat(output.toString()).isEqualTo(" \\?\\? ")
     }
 
     @Test

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParserTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParserTest.kt
@@ -103,7 +103,7 @@ class PostgresVaultNamedQueryExpressionParserTest {
 
     @Test
     fun `parameter name is parsed as Parameter`() {
-        val expression = expressionParser.parse(":parameter ARE 123 :another_one nAmEs != :with-dashes ::int ->> is null is not null")
+        val expression = expressionParser.parse(":parameter ARE 123 :another_one nAmEs != :with-dashes \\:\\:int ->> is null is not null")
         assertThat(expression.filterIsInstance<Parameter>()).hasSize(3)
         assertThat(expression)
             .contains(Parameter(":parameter"), Index.atIndex(0))
@@ -324,10 +324,10 @@ class PostgresVaultNamedQueryExpressionParserTest {
 
     @Test
     fun `json cast to is parsed as JsonCast`() {
-        val expression = expressionParser.parse("::int::int::int ::date ::string->> ::int=5 ::int>5 z::intz<=1 != ->> is null is not null")
+        val expression = expressionParser.parse("\\:\\:int\\:\\:int\\:\\:int \\:\\:date \\:\\:string->> \\:\\:int=5 \\:\\:int>5 z\\:\\:intz<=1 != ->> is null is not null")
         assertThat(expression.filterIsInstance<JsonCast>()).hasSize(6)
         assertThat(expression)
-            .contains(JsonCast("int::int::int"), Index.atIndex(0))
+            .contains(JsonCast("int\\:\\:int\\:\\:int"), Index.atIndex(0))
             .contains(JsonCast("date"), Index.atIndex(1))
             .contains(JsonCast("string"), Index.atIndex(2))
             .contains(JsonCast("int"), Index.atIndex(4))
@@ -337,7 +337,7 @@ class PostgresVaultNamedQueryExpressionParserTest {
 
     @Test
     fun `json key exist is parsed as JsonKeyExists`() {
-        val expression = expressionParser.parse("??? ? ->> ? ? z?z ->> is null is not null")
+        val expression = expressionParser.parse("\\?\\?\\?\\?\\?\\? \\?\\? ->> \\?\\? \\?\\? z\\?\\?z ->> is null is not null")
         assertThat(expression.filterIsInstance<JsonKeyExists>()).hasSize(7)
         assertThat(expression)
             .contains(JsonKeyExists(), Index.atIndex(0))

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParserTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParserTest.kt
@@ -103,7 +103,7 @@ class PostgresVaultNamedQueryExpressionParserTest {
 
     @Test
     fun `parameter name is parsed as Parameter`() {
-        val expression = expressionParser.parse(":parameter ARE 123 :another_one nAmEs != :with-dashes \\:\\:int ->> is null is not null")
+        val expression = expressionParser.parse(":parameter ARE 123 :another_one nAmEs != :with-dashes ::int ->> is null is not null")
         assertThat(expression.filterIsInstance<Parameter>()).hasSize(3)
         assertThat(expression)
             .contains(Parameter(":parameter"), Index.atIndex(0))
@@ -324,10 +324,10 @@ class PostgresVaultNamedQueryExpressionParserTest {
 
     @Test
     fun `json cast to is parsed as JsonCast`() {
-        val expression = expressionParser.parse("\\:\\:int\\:\\:int\\:\\:int \\:\\:date \\:\\:string->> \\:\\:int=5 \\:\\:int>5 z\\:\\:intz<=1 != ->> is null is not null")
+        val expression = expressionParser.parse("::int::int::int ::date ::string->> ::int=5 ::int>5 z::intz<=1 != ->> is null is not null")
         assertThat(expression.filterIsInstance<JsonCast>()).hasSize(6)
         assertThat(expression)
-            .contains(JsonCast("int\\:\\:int\\:\\:int"), Index.atIndex(0))
+            .contains(JsonCast("int::int::int"), Index.atIndex(0))
             .contains(JsonCast("date"), Index.atIndex(1))
             .contains(JsonCast("string"), Index.atIndex(2))
             .contains(JsonCast("int"), Index.atIndex(4))
@@ -337,7 +337,7 @@ class PostgresVaultNamedQueryExpressionParserTest {
 
     @Test
     fun `json key exist is parsed as JsonKeyExists`() {
-        val expression = expressionParser.parse("\\?\\?\\?\\?\\?\\? \\?\\? ->> \\?\\? \\?\\? z\\?\\?z ->> is null is not null")
+        val expression = expressionParser.parse("??? ? ->> ? ? z?z ->> is null is not null")
         assertThat(expression.filterIsInstance<JsonKeyExists>()).hasSize(7)
         assertThat(expression)
             .contains(JsonKeyExists(), Index.atIndex(0))


### PR DESCRIPTION
`?` and `::` need to be used in Postgres JSON queries; however, they
cause parameter issues when creating the native query and execution
errors when executing them.

To bypass these errors, these characters must be escaped in the executed
query.

We have decided to keep our queries tidy, so the escaping has been hidden
within our parsing code. This means that developers write `?` and `::` 
into their query strings, and we translate them into `\\?\\?` and `\\:\\:` 
respectively.