### PR TITLE
CORE-12505: fix SSO Docker Hub issue when building worker images

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -208,6 +208,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         JibContainerBuilder builder = null
 
         if (useDaemon.get()) {
+
             logger.info("Daemon available")
             def imageName = "${baseImageTag.get().empty ? baseImageName.get() : "${baseImageName.get()}:${baseImageTag.get()}"}"
             if (imageName.endsWith("-local")) {
@@ -218,7 +219,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
                 builder = setCredentialsOnBaseImage(builder)
             } else {
                 logger.info("Resolving base image ${baseImageName.get()}: ${baseImageTag.get()} from remote repo")
-                    builder = Jib.from(imageName)
+                builder = setCredentialsOnBaseImage(builder)
             }
         } else {  // CI use case
             logger.info("No daemon available")

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -208,7 +208,6 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         JibContainerBuilder builder = null
 
         if (useDaemon.get()) {
-
             logger.info("Daemon available")
             def imageName = "${baseImageTag.get().empty ? baseImageName.get() : "${baseImageName.get()}:${baseImageTag.get()}"}"
             if (imageName.endsWith("-local")) {


### PR DESCRIPTION
`setCredentialsOnBaseImage` is not set on the base image resulting in the Docker Hub rate limit imposed on users despite setting the needed credentials.

This fix ensures users who have set valid creds for `DOCKER_HUB_USERNAME` and `DOCKER_HUB_PASSWORD` environment variables are not subject to Docker Hubs rate limit of 100 pulls per 6 hours per IP For anonymous users.

