### PR TITLE
CORE-12499 Enforce the usage of the latest group parameters when finalizing transactions.

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityBaseV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityBaseV1.kt
@@ -111,7 +111,7 @@ abstract class UtxoFinalityBaseV1 : SubFlow<UtxoSignedTransaction> {
     @Suspendable
     protected fun verifyTransaction(signedTransaction: UtxoSignedTransaction) {
         try {
-            transactionVerificationService.verify(signedTransaction.toLedgerTransaction())
+            transactionVerificationService.initialVerify(signedTransaction.toLedgerTransaction())
         } catch(e: Exception){
             persistInvalidTransaction(signedTransaction)
             throw e

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationService.kt
@@ -16,4 +16,16 @@ interface UtxoLedgerTransactionVerificationService {
      */
     @Suspendable
     fun verify(transaction: UtxoLedgerTransaction)
+
+    /**
+     * Verify UTXO ledger transaction initially in Finality flow.
+     * (It calls the normal verify as well.)
+     *
+     * @param transaction UTXO ledger transaction.
+     *
+     * @throws [TransactionVerificationException] in case of unsuccessful verification
+     */
+    @Suspendable
+    fun initialVerify(transaction: UtxoLedgerTransaction)
+
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
@@ -130,6 +130,7 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
             "Membership group parameters hash cannot be found in the transaction metadata."
         }
     }
+
     private fun transactionVerificationFlowTimer(): Timer {
         return CordaMetrics.Metric.Ledger.TransactionVerificationFlowTime
             .builder()

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoLedgerTransactionVerificationServiceImpl.kt
@@ -76,12 +76,23 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    private fun fetchAndVerifySignedGroupParameters(transaction: UtxoLedgerTransaction): SignedGroupParameters {
-        val membershipGroupParametersHashString =
-            (transaction.metadata as TransactionMetadataInternal).getMembershipGroupParametersHash()
-        requireNotNull(membershipGroupParametersHashString) {
-            "Membership group parameters hash cannot be found in the transaction metadata."
+    override fun initialVerify(transaction: UtxoLedgerTransaction) {
+        verifyCurrenGroupParametersUsed(transaction)
+        verify(transaction)
+    }
+
+    private fun verifyCurrenGroupParametersUsed(transaction: UtxoLedgerTransaction){
+        check(
+            transaction.getMembershipGroupParametersHash() ==
+                    currentGroupParametersService.get().hash.toString()
+        ) {
+            "Transactions can be created only with the latest membership group parameters."
         }
+    }
+
+    @Suspendable
+    private fun fetchAndVerifySignedGroupParameters(transaction: UtxoLedgerTransaction): SignedGroupParameters {
+        val membershipGroupParametersHashString = transaction.getMembershipGroupParametersHash()
 
         val currentGroupParameters = currentGroupParametersService.get()
         val signedGroupParameters =
@@ -114,6 +125,11 @@ class UtxoLedgerTransactionVerificationServiceImpl @Activate constructor(
 
     private fun serialize(payload: Any) = ByteBuffer.wrap(serializationService.serialize(payload).bytes)
 
+    private fun UtxoLedgerTransaction.getMembershipGroupParametersHash(): String {
+        return requireNotNull((metadata as TransactionMetadataInternal).getMembershipGroupParametersHash()) {
+            "Membership group parameters hash cannot be found in the transaction metadata."
+        }
+    }
     private fun transactionVerificationFlowTimer(): Timer {
         return CordaMetrics.Metric.Ledger.TransactionVerificationFlowTime
             .builder()

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -219,7 +219,7 @@ class UtxoFinalityFlowV1Test {
 
     @Test
     fun `called with an invalid transaction initially throws and persists as invalid`() {
-        whenever(transactionVerificationService.verify(any())).thenThrow(
+        whenever(transactionVerificationService.initialVerify(any())).thenThrow(
             TransactionVerificationException(
                 TX_ID, TransactionVerificationStatus.INVALID, null, "Verification error"
             )

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -172,7 +172,7 @@ class UtxoReceiveFinalityFlowV1Test {
 
     @Test
     fun `receiving an invalid transaction initially throws and persists as invalid`() {
-        whenever(transactionVerificationService.verify(any())).thenThrow(
+        whenever(transactionVerificationService.initialVerify(any())).thenThrow(
             TransactionVerificationException(
                 ID,
                 TransactionVerificationStatus.INVALID,
@@ -428,7 +428,7 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(ledgerTransaction.outputStateAndRefs).thenReturn(listOf(getExampleInvalidStateAndRefImpl()))
         whenever(signedTransaction.inputStateRefs).thenReturn(listOf(mock()))
         whenever(signedTransaction.referenceStateRefs).thenReturn(listOf(mock()))
-        whenever(transactionVerificationService.verify(any())).thenThrow(
+        whenever(transactionVerificationService.initialVerify(any())).thenThrow(
             TransactionVerificationException(
                 ID,
                 TransactionVerificationStatus.INVALID,


### PR DESCRIPTION
CORE-12499 Enforce the usage of the latest group parameters when finalizing transactions.