### PR TITLE
CORE-12539 - Liquibase dependency updates

### DIFF
--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -180,7 +180,9 @@ class PersistenceServiceInternalTests {
             )
         )
 
-        lbm.updateDb(dbConnectionManager.getDataSource(animalDbConnection.first).connection, cl)
+        dbConnectionManager.getDataSource(animalDbConnection.first).connection.use {
+            lbm.updateDb(it, cl)
+        }
 
         entityManagerFactory = dbConnectionManager.createEntityManagerFactory(
             animalDbConnection.first,
@@ -247,7 +249,9 @@ class PersistenceServiceInternalTests {
                 ),
             )
         )
-        lbm.updateDb(myDbConnectionManager.getDataSource(animalDbConnection.first).connection, cl)
+        myDbConnectionManager.getDataSource(animalDbConnection.first).connection.use {
+            lbm.updateDb(it, cl)
+        }
 
         // create dog using dog-aware sandbox
         val dog = sandboxOne.createDog("Stray", owner = "Not Known")

--- a/gradle.properties
+++ b/gradle.properties
@@ -54,7 +54,7 @@ felixSecurityVersion=2.8.3
 # NOTE: Guava cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.
 guavaVersion=30.1.1-jre
-hibernateVersion=5.6.14.Final
+hibernateVersion=5.6.15.Final
 hikariCpVersion=5.0.1
 jacksonVersion=2.14.2
 jaxbVersion = 2.3.1
@@ -65,7 +65,7 @@ kafkaClientVersion=3.3.1_1
 #  Check with one of the group leads before changing.
 kryoVersion = 5.4.0
 kryoSerializersVersion = 0.45
-liquibaseVersion = 4.18.0
+liquibaseVersion = 4.21.1
 # Needed by Liquibase:
 beanutilsVersion=1.9.4
 log4jVersion = 2.20.0

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -20,6 +20,14 @@ dependencies {
     implementation "org.slf4j:slf4j-api"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     implementation "org.liquibase:liquibase-core:$liquibaseVersion"
+    constraints {
+        implementation("org.yaml:snakeyaml") {
+            version {
+                strictly("1.33")
+            }
+            because("Required until jackson upgrades to 2.0")
+        }
+    }
 
     api project(":libs:db:db-admin")
 

--- a/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
+++ b/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
@@ -1,6 +1,6 @@
 package net.corda.db.admin.impl
 
-import liquibase.exception.ChangeLogParseException
+import liquibase.exception.CommandExecutionException
 import net.corda.db.core.InMemoryDataSourceFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -143,9 +143,10 @@ class LiquibaseSchemaMigratorImplTest {
                 )
             )
         )
-        val e = assertThrows<ChangeLogParseException> {
+        val e = assertThrows<CommandExecutionException> {
             lbm.updateDb(ds.connection, cl)
         }
+        assertThat(e).hasMessageContaining("ChangeLogParseException")
         assertThat(e).hasMessageContaining("IllegalArgumentException")
         assertThat(e).hasMessageContaining("mysteryclass")
     }

--- a/libs/db/db-admin-impl/src/test/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorTest.kt
+++ b/libs/db/db-admin-impl/src/test/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorTest.kt
@@ -2,6 +2,9 @@ package net.corda.db.admin.impl
 
 import liquibase.Contexts
 import liquibase.Liquibase
+import liquibase.command.CommandArgumentDefinition
+import liquibase.command.CommandScope
+import liquibase.command.core.UpdateCommandStep
 import liquibase.database.Database
 import liquibase.database.DatabaseConnection
 import liquibase.resource.ResourceAccessor
@@ -9,7 +12,9 @@ import net.corda.db.admin.DbChange
 import net.corda.db.admin.LiquibaseSchemaMigrator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.check
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -21,7 +26,11 @@ import java.sql.Connection
 class LiquibaseSchemaMigratorTest {
     private val connection = mock<Connection>()
     private val dbChange = mock<DbChange>()
-    private val lb = mock<Liquibase>()
+    private val lb = mock<Liquibase>() {
+        on { database } doReturn (mock())
+        on { changeLogFile } doReturn ( "changeLog" )
+        on { changeLogParameters } doReturn (mock())
+    }
     private val lbFactory = mock<(String, ResourceAccessor, Database) -> Liquibase> {
         on { invoke(any(), any(), any()) } doReturn (lb)
     }
@@ -32,10 +41,20 @@ class LiquibaseSchemaMigratorTest {
     private val dbFactory = mock<(connection: Connection) -> Database> {
         on { invoke(any()) } doReturn (db)
     }
+    private val commandScope = mock<CommandScope>() { cs ->
+        on { addArgumentValue(anyString(), any()) } doReturn cs
+        on { addArgumentValue(any<CommandArgumentDefinition<Any>>(), anyOrNull()) } doReturn cs
+        on { execute() } doReturn mock()
+
+    }
+
+    private val commandScopeFactory = mock<(commandNames: Array<String>) -> CommandScope> {
+        on { invoke(any()) } doReturn (commandScope)
+    }
     private val writer = mock<Writer>()
 
     private val migrator: LiquibaseSchemaMigrator =
-        LiquibaseSchemaMigratorImpl(lbFactory, dbFactory)
+        LiquibaseSchemaMigratorImpl(lbFactory, dbFactory, commandScopeFactory)
 
     @Test
     fun `when updateDb create LB object`() {
@@ -54,7 +73,7 @@ class LiquibaseSchemaMigratorTest {
     @Test
     fun `when updateDb call Liquibase API`() {
         migrator.updateDb(connection, dbChange)
-        verify(lb).update(any<Contexts>())
+        verify(commandScopeFactory).invoke(UpdateCommandStep.COMMAND_NAME)
     }
 
     @Test

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -81,6 +81,7 @@ dependencies {
 
     runtimeOnly project(":libs:application:application-impl")
     runtimeOnly project(':libs:crypto:cipher-suite-impl')
+    runtimeOnly project(':libs:db:db-admin-impl')
     runtimeOnly project(':libs:db:db-orm-impl')
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly project(':libs:membership:membership-impl')
@@ -96,7 +97,6 @@ dependencies {
 
     runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
     runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
-    runtimeOnly "org.liquibase:liquibase-core:$liquibaseVersion"
     // NOTE: this is needed by Liquibase but for some reason not picked up automatically.
     runtimeOnly "commons-beanutils:commons-beanutils:$beanutilsVersion"
 


### PR DESCRIPTION
DB dependency updates.

Abandoning this change for now because:

- Issues with some of the tests suggest a race condition/timing issue with migration. E.g. this build: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-runtime-os/detail/PR-3628/11/tests/ shows the migration not having completed when executing the rest of the test.
- The new "Structured Logging" seems to be writing a lot of logs to stdout instead of the logger. E.g:
```
Apr 18, 2023 9:40:36 AM liquibase.util
INFO: -------------------------------
Apr 18, 2023 9:40:36 AM liquibase.util
INFO: Total change sets:            4


UPDATE SUMMARY
Run:                          0
Previously run:               4
Filtered out:                 0
-------------------------------
Total change sets:            4

Apr 18, 2023 9:40:36 AM liquibase.util
INFO: Update summary generated
Apr 18, 2023 9:40:36 AM liquibase.lockservice
INFO: Successfully released change log lock
Apr 18, 2023 9:40:36 AM liquibase.lockservice
INFO: Successfully released change log lock
Apr 18, 2023 9:40:36 AM liquibase.command
INFO: Command execution complete
```

https://r3-cev.atlassian.net/browse/CORE-12612 created to track this.