### PR TITLE
CORE-12543: Upgrade REST 3rd party library versions

### DIFF
--- a/applications/tools/p2p-test/app-simulator/build.gradle
+++ b/applications/tools/p2p-test/app-simulator/build.gradle
@@ -28,11 +28,6 @@ dependencies {
     implementation project(":libs:utilities")
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    constraints {
-        implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
-            because 'Required until jackson-dataformat-yaml use snake yaml 1.32 internally '
-        }
-    }
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation "org.postgresql:postgresql:$postgresDriverVersion"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -106,7 +106,7 @@ osgiTestJunit5Version=1.2.1
 postgresDriverVersion=42.5.1
 slingVersion=3.3.4
 
-# HTTP RPC dependency versions
+# REST dependency versions
 javalinVersion = 4.6.7
 swaggerVersion = 2.2.8
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
@@ -114,6 +114,7 @@ swaggeruiVersion = 4.18.2
 nimbusVersion = 9.43.1
 unirestVersion = 3.14.2
 jettyVersion = 9.4.51.v20230217
+
 # Enables the substitution of binaries for source code if it exists in expected location
 # Default behaviour is false.
 compositeBuild=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -112,7 +112,7 @@ swaggerVersion = 2.2.7
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
 swaggeruiVersion = 4.15.5
 nimbusVersion = 9.43.1
-unirestVersion = 3.14.1
+unirestVersion = 3.14.2
 jettyVersion = 9.4.49.v20220914
 # Enables the substitution of binaries for source code if it exists in expected location
 # Default behaviour is false.

--- a/gradle.properties
+++ b/gradle.properties
@@ -113,7 +113,7 @@ swaggerVersion = 2.2.7
 swaggeruiVersion = 4.15.5
 nimbusVersion = 9.43.1
 unirestVersion = 3.14.2
-jettyVersion = 9.4.49.v20220914
+jettyVersion = 9.4.51.v20230217
 # Enables the substitution of binaries for source code if it exists in expected location
 # Default behaviour is false.
 compositeBuild=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,7 +56,7 @@ felixSecurityVersion=2.8.3
 guavaVersion=30.1.1-jre
 hibernateVersion=5.6.14.Final
 hikariCpVersion=5.0.1
-jacksonVersion=2.14.1
+jacksonVersion=2.14.2
 jaxbVersion = 2.3.1
 jbossTransactionApiSpecVersion=1.1.1.Final
 jetbrainsAnnotationsVersion=13.0
@@ -108,7 +108,7 @@ slingVersion=3.3.4
 
 # HTTP RPC dependency versions
 javalinVersion = 4.6.7
-swaggerVersion = 2.2.9
+swaggerVersion = 2.2.8
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
 swaggeruiVersion = 4.18.2
 nimbusVersion = 9.43.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -108,9 +108,9 @@ slingVersion=3.3.4
 
 # HTTP RPC dependency versions
 javalinVersion = 4.6.7
-swaggerVersion = 2.2.7
+swaggerVersion = 2.2.9
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
-swaggeruiVersion = 4.15.5
+swaggeruiVersion = 4.18.2
 nimbusVersion = 9.43.1
 unirestVersion = 3.14.2
 jettyVersion = 9.4.51.v20230217

--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -31,18 +31,6 @@ dependencies {
     implementation "org.eclipse.jetty.websocket:websocket-server:$jettyVersion"
     implementation "org.eclipse.jetty.http2:http2-server:$jettyVersion"
     implementation "io.swagger.core.v3:swagger-core:$swaggerVersion"
-    constraints {
-        implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
-            because 'Required until jackson-dataformat-yaml use snake yaml 1.32 internally '
-        }
-    }
-    // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
-    // Constraints block can be removed when Swagger is upgraded to the next version
-    constraints {
-        implementation("com.fasterxml.jackson.core:$jacksonVersion") {
-            because 'sonatype-2021-4682'
-        }
-    }
 
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation project(":libs:rest:rest-common")

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/OptionalDependency.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/OptionalDependency.kt
@@ -12,7 +12,7 @@ enum class OptionalDependency(
     /**
      * Note: [version] must be aligned with [swaggeruiVersion] in Gradle properties
      */
-    SWAGGERUI("Swagger UI", "org.webjars", "swagger-ui", "4.15.5");
+    SWAGGERUI("Swagger UI", "org.webjars", "swagger-ui", "4.18.2");
 
     val symbolicName: String = "$groupId.$artifactId"
 }

--- a/testing/cpi-info-read-service-fake/build.gradle
+++ b/testing/cpi-info-read-service-fake/build.gradle
@@ -17,11 +17,6 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
 
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    constraints {
-        implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
-            because 'Required until jackson-dataformat-yaml use snake yaml 1.32 internally '
-        }
-    }
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
 
     testImplementation project(':libs:crypto:crypto-core')

--- a/testing/virtual-node-info-read-service-fake/build.gradle
+++ b/testing/virtual-node-info-read-service-fake/build.gradle
@@ -18,11 +18,6 @@ dependencies {
     implementation project(":components:reconciliation:reconciliation")
 
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    constraints {
-        implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
-            because 'Required until jackson-dataformat-yaml use snake yaml 1.32 internally '
-        }
-    }
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
 


### PR DESCRIPTION
com.konghq:unirest-java [3.14.1 -> 3.14.2]

com.konghq:unirest-objectmapper-jackson [3.14.1 -> 3.14.2]

com.nimbusds:oauth2-oidc-sdk [9.43.1 -> 10.7.1]  on latest 9.x.x version already

org.eclipse.jetty.websocket:websocket-client [9.4.49.v20220914 -> 9.4.51.v20230217]

org.eclipse.jetty.websocket:websocket-server [9.4.49.v20220914 -> 9.4.51.v20230217]

org.eclipse.jetty.websocket:websocket-servlet [9.4.49.v20220914 -> 11.0.14]

io.swagger.core.v3:swagger-core [2.2.7 -> 2.2.9] Can only update to v2.2.8 as version 2.2.9 introduces a direct dependency on SnakeYaml 2.0 which breaks other components where we have OSGi constrain [1.33, 2.0)

org.webjars:swagger-ui [4.15.5 -> 4.18.2]

com.fasterxml.jackson.core:jackson-annotations [2.14.1 -> 2.14.2]

com.fasterxml.jackson.core:jackson-core [2.14.1 -> 2.14.2]

com.fasterxml.jackson.core:jackson-databind [2.14.1 -> 2.14.2]

com.fasterxml.jackson.dataformat:jackson-dataformat-yaml [2.14.1 -> 2.14.2]

com.fasterxml.jackson.datatype:jackson-datatype-jsr310 [2.14.1 -> 2.14.2]

com.fasterxml.jackson.module:jackson-module-kotlin [2.14.1 -> 2.14.2]