### PR TITLE
CORE-11665: Change LiquibaseDiffCheckFailedException error handling to return Bad Request

### DIFF
--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -20,6 +20,7 @@ import net.corda.libs.configuration.helper.getConfig
 import net.corda.libs.external.messaging.serialization.ExternalMessagingRouteConfigSerializerImpl
 import net.corda.libs.virtualnode.common.constant.VirtualNodeStateTransitions
 import net.corda.libs.virtualnode.common.exception.InvalidStateChangeRuntimeException
+import net.corda.libs.virtualnode.common.exception.LiquibaseDiffCheckFailedException
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationBadRequestException
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundException
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
@@ -455,7 +456,8 @@ internal class VirtualNodeRestResourceImpl(
         return when (exception.errorType) {
             InvalidStateChangeRuntimeException::class.java.name -> InvalidStateChangeException(exception.errorMessage)
             VirtualNodeOperationNotFoundException::class.java.name -> ResourceNotFoundException(exception.errorMessage)
-            VirtualNodeOperationBadRequestException::class.java.name -> BadRequestException(exception.errorMessage)
+            VirtualNodeOperationBadRequestException::class.java.name, LiquibaseDiffCheckFailedException::class.java.name ->
+                BadRequestException(exception.errorMessage)
             else -> InternalServerException(exception.errorMessage)
         }
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -1,9 +1,5 @@
 package net.corda.virtualnode.write.db.impl.writer.asyncoperation.handlers
 
-import java.time.Instant
-import java.util.UUID
-import javax.persistence.EntityManager
-import javax.persistence.EntityManagerFactory
 import net.corda.crypto.core.ShortHash
 import net.corda.data.virtualnode.VirtualNodeUpgradeRequest
 import net.corda.libs.cpi.datamodel.CpkDbChangeLog
@@ -11,6 +7,7 @@ import net.corda.libs.cpi.datamodel.repository.CpkDbChangeLogRepository
 import net.corda.libs.cpi.datamodel.repository.CpkDbChangeLogRepositoryImpl
 import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGenerator
 import net.corda.libs.packaging.core.CpiMetadata
+import net.corda.libs.virtualnode.common.exception.LiquibaseDiffCheckFailedException
 import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationStateDto
 import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationType
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepository
@@ -27,10 +24,13 @@ import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeEntityRepository
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.MigrationUtility
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.VirtualNodeAsyncOperationHandler
-import net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception.LiquibaseDiffCheckFailedException
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception.MigrationsFailedException
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception.VirtualNodeUpgradeRejectedException
 import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
 
 @Suppress("LongParameterList")
 internal class VirtualNodeUpgradeOperationHandler(

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/utility/MigrationUtilityImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/utility/MigrationUtilityImpl.kt
@@ -1,17 +1,17 @@
 package net.corda.virtualnode.write.db.impl.writer.asyncoperation.utility
 
 import net.corda.crypto.core.ShortHash
-import java.util.UUID
 import net.corda.db.admin.LiquibaseSchemaMigrator
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.core.CloseableDataSource
 import net.corda.libs.cpi.datamodel.CpkDbChangeLog
+import net.corda.libs.virtualnode.common.exception.LiquibaseDiffCheckFailedException
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbChangeLog
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.MigrationUtility
-import net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception.LiquibaseDiffCheckFailedException
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 internal class MigrationUtilityImpl(
     private val dbConnectionManager: DbConnectionManager,

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandlerTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandlerTest.kt
@@ -1,10 +1,5 @@
 package net.corda.virtualnode.write.db.impl.tests.writer.asyncoperation.handlers
 
-import java.time.Instant
-import java.util.UUID
-import javax.persistence.EntityManager
-import javax.persistence.EntityManagerFactory
-import javax.persistence.EntityTransaction
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.ShortHash
 import net.corda.data.virtualnode.VirtualNodeUpgradeRequest
@@ -14,6 +9,7 @@ import net.corda.libs.cpi.datamodel.repository.CpkDbChangeLogRepository
 import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGenerator
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
+import net.corda.libs.virtualnode.common.exception.LiquibaseDiffCheckFailedException
 import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationStateDto
 import net.corda.libs.virtualnode.datamodel.dto.VirtualNodeOperationType
 import net.corda.libs.virtualnode.datamodel.repository.VirtualNodeRepository
@@ -29,7 +25,6 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeEntityRepository
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.MigrationUtility
-import net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception.LiquibaseDiffCheckFailedException
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.handlers.VirtualNodeUpgradeOperationHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -42,6 +37,11 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.UUID
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+import javax.persistence.EntityTransaction
 
 class VirtualNodeUpgradeOperationHandlerTest {
     private val oldVirtualNodeEntityRepository = mock<VirtualNodeEntityRepository>()

--- a/libs/virtual-node/virtual-node-common/src/main/kotlin/net/corda/libs/virtualnode/common/exception/LiquibaseDiffCheckFailedException.kt
+++ b/libs/virtual-node/virtual-node-common/src/main/kotlin/net/corda/libs/virtualnode/common/exception/LiquibaseDiffCheckFailedException.kt
@@ -1,4 +1,4 @@
-package net.corda.virtualnode.write.db.impl.writer.asyncoperation.exception
+package net.corda.libs.virtualnode.common.exception
 
 import java.lang.Exception
 import net.corda.v5.base.exceptions.CordaRuntimeException


### PR DESCRIPTION
* Move `LiquibaseDiffCheckFailedException` info `virtual-node-common` so it is visible to `virtual-node-rest-service-impl`
* Add `LiquibaseDiffCheckFailedException` to list of exception `VirtualNodeRestResourceImpl.handleFailure` understands, return Bad Request HTTP status