### PR TITLE
CORE-12580 Represent visible states as Map

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -581,10 +581,10 @@ class UtxoPersistenceServiceImplTest {
         override val cpkMetadata: List<CordaPackageSummary>
             get() = (transactionContainer.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
 
-        override fun getProducedStates(): List<StateAndRef<ContractState>> {
-            return listOf(
-                stateAndRef<TestContract>(TestContractState1(), id, 0),
-                stateAndRef<TestContract>(TestContractState2(), id, 1)
+        override fun getVisibleStates(): Map<Int, StateAndRef<ContractState>> {
+            return mapOf(
+                0 to stateAndRef<TestContract>(TestContractState1(), id, 0),
+                1 to stateAndRef<TestContract>(TestContractState2(), id, 1)
             )
         }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoTransactionReader.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoTransactionReader.kt
@@ -27,7 +27,7 @@ interface UtxoTransactionReader {
 
     val visibleStatesIndexes: List<Int>
 
-    fun getProducedStates(): List<StateAndRef<ContractState>>
+    fun getVisibleStates(): Map<Int, StateAndRef<ContractState>>
 
     fun getConsumedStates(persistenceService: UtxoPersistenceService): List<StateAndRef<ContractState>>
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistTransactionRequestHandler.kt
@@ -36,7 +36,7 @@ class UtxoPersistTransactionRequestHandler @Suppress("LongParameterList") constr
         val outputTokenRecords = if (isTransactionVerified) {
             utxoOutputRecordFactory.getTokenCacheChangeEventRecords(
                 holdingIdentity,
-                transaction.getProducedStates().toTokens(tokenObservers),
+                transaction.getVisibleStates().values.toList().toTokens(tokenObservers),
                 transaction.getConsumedStates(persistenceService).toTokens(tokenObservers)
             )
         } else {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
@@ -88,7 +88,7 @@ class UtxoTransactionReaderImpl(
     override val cpkMetadata: List<CordaPackageSummary>
         get() = (signedTransaction.wireTransaction.metadata as TransactionMetadataInternal).getCpkMetadata()
 
-    override fun getProducedStates(): List<StateAndRef<ContractState>> {
+    override fun getVisibleStates(): Map<Int, StateAndRef<ContractState>> {
         val visibleStatesSet = visibleStatesIndexes.toSet()
         return rawGroupLists[UtxoComponentGroup.OUTPUTS.ordinal]
             .zip(rawGroupLists[UtxoComponentGroup.OUTPUTS_INFO.ordinal])
@@ -100,9 +100,8 @@ class UtxoTransactionReaderImpl(
                     serializer.deserialize<ContractState>(value.first),
                     serializer.deserialize<UtxoOutputInfoComponent>(value.second)
                 )
-            }
-            .map { (index, state, info) ->
-                StateAndRefImpl(
+            }.associate { (index, state, info) ->
+                index to StateAndRefImpl(
                     state = TransactionStateImpl(state, info.notaryName, info.notaryKey, info.getEncumbranceGroup()),
                     ref = StateRef(id, index)
                 )

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
@@ -82,8 +82,8 @@ class UtxoPersistenceServiceImplTest {
 
     @Test
     fun `Persisting a transaction while JSON parsing fails will result in an empty JSON string being stored`() {
-        val tx = createMockTransaction(listOf(
-            createStateAndRef(InvalidState())
+        val tx = createMockTransaction(mapOf(
+            0 to createStateAndRef(InvalidState())
         ))
 
         persistenceService.persistTransaction(tx)
@@ -123,8 +123,8 @@ class UtxoPersistenceServiceImplTest {
             UTCClock()
         )
 
-        val tx = createMockTransaction(listOf(
-            createStateAndRef(EmptyState())
+        val tx = createMockTransaction(mapOf(
+            0 to createStateAndRef(EmptyState())
         ))
 
         singlePersistenceService.persistTransaction(tx)
@@ -147,8 +147,8 @@ class UtxoPersistenceServiceImplTest {
 
     @Test
     fun `Persisting a transaction with multiple JSON factories will result in a combined JSON string being stored`() {
-        val tx = createMockTransaction(listOf(
-            createStateAndRef(DummyState("DUMMY"))
+        val tx = createMockTransaction(mapOf(
+            0 to createStateAndRef(DummyState("DUMMY"))
         ))
 
         persistenceService.persistTransaction(tx)
@@ -173,8 +173,8 @@ class UtxoPersistenceServiceImplTest {
 
     @Test
     fun `Persisting a transaction while no JSON factory is present for the given type will result in using the ContractState factory`() {
-        val tx = createMockTransaction(listOf(
-            createStateAndRef(ContractState { emptyList() }) // State that has no specific factory
+        val tx = createMockTransaction(mapOf(
+            0 to createStateAndRef(ContractState { emptyList() }) // State that has no specific factory
         ))
 
         persistenceService.persistTransaction(tx)
@@ -205,8 +205,8 @@ class UtxoPersistenceServiceImplTest {
             UTCClock()
         )
 
-        val tx = createMockTransaction(listOf(
-            createStateAndRef(ContractState { emptyList() })
+        val tx = createMockTransaction(mapOf(
+            0 to createStateAndRef(ContractState { emptyList() })
         ))
 
         emptyPersistenceService.persistTransaction(tx)
@@ -217,7 +217,7 @@ class UtxoPersistenceServiceImplTest {
         assertThat(persisted.value.json).isEqualTo("{}")
     }
 
-    private fun createMockTransaction(producedStates: List<StateAndRef<ContractState>>): UtxoTransactionReader {
+    private fun createMockTransaction(producedStates: Map<Int, StateAndRef<ContractState>>): UtxoTransactionReader {
         return mock {
             on { getConsumedStateRefs() } doReturn emptyList()
             on { rawGroupLists } doReturn emptyList()
@@ -227,7 +227,7 @@ class UtxoPersistenceServiceImplTest {
             on { id } doReturn randomSecureHash()
             on { privacySalt } doReturn mockPrivacySalt
             on { account } doReturn ""
-            on { getProducedStates() } doReturn producedStates
+            on { getVisibleStates() } doReturn producedStates
         }
     }
 


### PR DESCRIPTION
When filtering the `producedStates` list, the indices will not follow and that way when accessing the list with a `visibleStateIndex` it might produce an out of bound error.

Representing `producedStates` as a map where the key is an index will fix this issue.