### PR TITLE
CORE-12417 MGM Admin API

### DIFF
--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
@@ -149,6 +149,11 @@ class MGMResourceClientImpl @Activate constructor(
             reason: String?,
         )
 
+        fun forceDeclineRegistrationRequest(
+            holdingIdentityShortHash: ShortHash,
+            requestId: UUID,
+        )
+
         fun suspendMember(
             holdingIdentityShortHash: ShortHash, memberX500Name: MemberX500Name, serialNumber: Long?, reason: String?
         )
@@ -232,6 +237,9 @@ class MGMResourceClientImpl @Activate constructor(
     override fun reviewRegistrationRequest(
         holdingIdentityShortHash: ShortHash, requestId: UUID, approve: Boolean, reason: String?
     ) = impl.reviewRegistrationRequest(holdingIdentityShortHash, requestId, approve, reason)
+
+    override fun forceDeclineRegistrationRequest(holdingIdentityShortHash: ShortHash, requestId: UUID) =
+        impl.forceDeclineRegistrationRequest(holdingIdentityShortHash, requestId)
 
     override fun suspendMember(
         holdingIdentityShortHash: ShortHash, memberX500Name: MemberX500Name, serialNumber: Long?, reason: String?
@@ -342,6 +350,10 @@ class MGMResourceClientImpl @Activate constructor(
 
         override fun reviewRegistrationRequest(
             holdingIdentityShortHash: ShortHash, requestId: UUID, approve: Boolean, reason: String?
+        ) = throw IllegalStateException(ERROR_MSG)
+
+        override fun forceDeclineRegistrationRequest(
+            holdingIdentityShortHash: ShortHash, requestId: UUID
         ) = throw IllegalStateException(ERROR_MSG)
 
         override fun suspendMember(
@@ -537,6 +549,11 @@ class MGMResourceClientImpl @Activate constructor(
             } else {
                 publishApprovalDecision(DeclineRegistration(reason ?: ""), holdingIdentityShortHash, requestId.toString())
             }
+        }
+
+        override fun forceDeclineRegistrationRequest(holdingIdentityShortHash: ShortHash, requestId: UUID) {
+            mgmHoldingIdentity(holdingIdentityShortHash)
+            publishApprovalDecision(DeclineRegistration(""), holdingIdentityShortHash, requestId.toString())
         }
 
         override fun suspendMember(

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
@@ -563,6 +563,10 @@ class MGMResourceClientImpl @Activate constructor(
 
             logger.info("Force declining registration request with ID='$requestId' and status='${requestStatus.registrationStatus}'.")
 
+            require(!setOf(RegistrationStatus.APPROVED, RegistrationStatus.DECLINED).contains(requestStatus.registrationStatus))
+            { "The registration process for request '$requestId' has been completed, so this request cannot be force " +
+                    "declined. Refer to the docs on Member Suspension to suspend approved members." }
+
             publishRegistrationCommand(
                 DeclineRegistration(FORCE_DECLINE_MESSAGE),
                 requestStatus.memberProvidedContext.items.first { it.key == PARTY_NAME }.value,

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
@@ -983,6 +983,28 @@ class MGMResourceClientTest {
         }
 
         @Test
+        fun `forceDeclineRegistrationRequest should fail for completed requests`() {
+            val mockStatus = mock<RegistrationRequestDetails> {
+                on { registrationStatus } doReturn RegistrationStatus.APPROVED
+                on { memberProvidedContext } doReturn KeyValuePairList(listOf(KeyValuePair(PARTY_NAME, memberName.toString())))
+            }
+            whenever(membershipQueryClient.queryRegistrationRequest(any(), any())).doReturn(
+                MembershipQueryResult.Success(mockStatus)
+            )
+            mgmResourceClient.start()
+            setUpRpcSender(null)
+
+            assertThrows<IllegalArgumentException> {
+                mgmResourceClient.forceDeclineRegistrationRequest(
+                    shortHash,
+                    REQUEST_ID.uuid(),
+                )
+            }
+            verify(publisher, never()).publish(any())
+            mgmResourceClient.stop()
+        }
+
+        @Test
         fun `forceDeclineRegistrationRequest should fail if the MGM cannot be found`() {
             mgmResourceClient.start()
             setUpRpcSender(null)

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
@@ -6,6 +6,8 @@ import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.impl.converter.PublicKeyConverter
+import net.corda.data.KeyValuePair
+import net.corda.data.KeyValuePairList
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.ApproveRegistration
@@ -39,6 +41,7 @@ import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.membership.lib.EndpointInfoFactory
 import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.id
 import net.corda.membership.lib.approval.ApprovalRuleParams
 import net.corda.membership.lib.impl.MemberInfoFactoryImpl
@@ -104,11 +107,12 @@ class MGMResourceClientTest {
         const val REQUEST_ID = "b305129b-8c92-4092-b3a2-e6d452ce2b01"
         const val SERIAL = 1L
         const val REASON = "test"
+        const val GROUP = "DEFAULT_MEMBER_GROUP_ID"
 
         val RULE_TYPE = ApprovalRuleType.STANDARD
         val memberName = MemberX500Name.parse("CN=Bob,O=Bob,OU=Unit1,L=London,ST=State1,C=GB")
         val mgmX500Name = MemberX500Name.parse("CN=Alice,OU=Unit1,O=Alice,L=London,ST=State1,C=GB")
-        val holdingIdentity = createTestHoldingIdentity(mgmX500Name.toString(), "DEFAULT_MEMBER_GROUP_ID")
+        val holdingIdentity = createTestHoldingIdentity(mgmX500Name.toString(), GROUP)
         val shortHash = ShortHash.of(HOLDING_IDENTITY_STRING)
         val clock = TestClock(Instant.ofEpochSecond(100))
 
@@ -164,9 +168,9 @@ class MGMResourceClientTest {
     @Suppress("SpreadOperator")
     private fun createMemberInfo(name: String, isMgm: Boolean = true): MemberInfo = memberInfoFactory.create(
         sortedMapOf(
-            MemberInfoExtension.PARTY_NAME to name,
+            PARTY_NAME to name,
             String.format(MemberInfoExtension.PARTY_SESSION_KEYS, 0) to KNOWN_KEY,
-            MemberInfoExtension.GROUP_ID to "DEFAULT_MEMBER_GROUP_ID",
+            MemberInfoExtension.GROUP_ID to GROUP,
             *convertPublicKeys().toTypedArray(),
             *convertEndpoints().toTypedArray(),
             MemberInfoExtension.SOFTWARE_VERSION to "5.0.0",
@@ -794,6 +798,7 @@ class MGMResourceClientTest {
             whenever(publisher.publish(any())).doReturn(listOf(CompletableFuture.completedFuture(Unit)))
             val mockStatus = mock<RegistrationRequestDetails> {
                 on { registrationStatus } doReturn RegistrationStatus.PENDING_MANUAL_APPROVAL
+                on { memberProvidedContext } doReturn KeyValuePairList(listOf(KeyValuePair(PARTY_NAME, memberName.toString())))
             }
             whenever(membershipQueryClient.queryRegistrationRequest(any(), any())).doReturn(
                 MembershipQueryResult.Success(mockStatus)
@@ -811,7 +816,7 @@ class MGMResourceClientTest {
                 listOf(
                     Record(
                         Schemas.Membership.REGISTRATION_COMMAND_TOPIC,
-                        "$REQUEST_ID-$shortHash",
+                        "$memberName-$GROUP",
                         RegistrationCommand(ApproveRegistration())
                     )
                 )
@@ -825,6 +830,7 @@ class MGMResourceClientTest {
             whenever(publisher.publish(any())).doReturn(listOf(CompletableFuture.completedFuture(Unit)))
             val mockStatus = mock<RegistrationRequestDetails> {
                 on { registrationStatus } doReturn RegistrationStatus.PENDING_MANUAL_APPROVAL
+                on { memberProvidedContext } doReturn KeyValuePairList(listOf(KeyValuePair(PARTY_NAME, memberName.toString())))
             }
             whenever(membershipQueryClient.queryRegistrationRequest(any(), any())).doReturn(
                 MembershipQueryResult.Success(mockStatus)
@@ -844,7 +850,7 @@ class MGMResourceClientTest {
                 listOf(
                     Record(
                         Schemas.Membership.REGISTRATION_COMMAND_TOPIC,
-                        "$REQUEST_ID-$shortHash",
+                        "$memberName-$GROUP",
                         RegistrationCommand(DeclineRegistration(reason))
                     )
                 )
@@ -951,6 +957,7 @@ class MGMResourceClientTest {
             whenever(publisher.publish(any())).doReturn(listOf(CompletableFuture.completedFuture(Unit)))
             val mockStatus = mock<RegistrationRequestDetails> {
                 on { registrationStatus } doReturn RegistrationStatus.PENDING_MEMBER_VERIFICATION
+                on { memberProvidedContext } doReturn KeyValuePairList(listOf(KeyValuePair(PARTY_NAME, memberName.toString())))
             }
             whenever(membershipQueryClient.queryRegistrationRequest(any(), any())).doReturn(
                 MembershipQueryResult.Success(mockStatus)
@@ -967,7 +974,7 @@ class MGMResourceClientTest {
                 listOf(
                     Record(
                         Schemas.Membership.REGISTRATION_COMMAND_TOPIC,
-                        "$REQUEST_ID-$shortHash",
+                        "$memberName-$GROUP",
                         RegistrationCommand(DeclineRegistration("Force declined by MGM"))
                     )
                 )

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
@@ -983,7 +983,7 @@ class MGMResourceClientTest {
         }
 
         @Test
-        fun `forceDeclineRegistrationRequest should fail if the member cannot be found`() {
+        fun `forceDeclineRegistrationRequest should fail if the MGM cannot be found`() {
             mgmResourceClient.start()
             setUpRpcSender(null)
 
@@ -997,7 +997,7 @@ class MGMResourceClientTest {
         }
 
         @Test
-        fun `forceDeclineRegistrationRequest should fail if the member cannot be read`() {
+        fun `forceDeclineRegistrationRequest should fail if the MGM cannot be read`() {
             mgmResourceClient.start()
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
@@ -1012,7 +1012,7 @@ class MGMResourceClientTest {
         }
 
         @Test
-        fun `forceDeclineRegistrationRequest should fail if the member is not the MGM`() {
+        fun `forceDeclineRegistrationRequest should fail if holding identity ID does not belong to the MGM`() {
             mgmResourceClient.start()
             setUpRpcSender(null)
             val mgmContext = mock<MGMContext>()

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
@@ -178,7 +178,15 @@ interface MGMResourceClient : Lifecycle {
     )
 
     /**
-     * TODO
+     * Force decline a registration request that may be stuck or displaying some other unexpected behaviour. This
+     * method should only be used under exceptional circumstances.
+     *
+     * @param holdingIdentityShortHash The holding identity ID of the MGM of the membership group.
+     * @param requestId ID of the registration request.
+     *
+     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
+     * @throws [IllegalArgumentException] If the request is not found.
      */
     @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class, IllegalArgumentException::class)
     fun forceDeclineRegistrationRequest(

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
@@ -178,15 +178,15 @@ interface MGMResourceClient : Lifecycle {
     )
 
     /**
-     * Force decline a registration request that may be stuck or displaying some other unexpected behaviour. This
-     * method should only be used under exceptional circumstances.
+     * Force decline an in-progress registration request that may be stuck or displaying some other unexpected
+     * behaviour. This method should only be used under exceptional circumstances.
      *
      * @param holdingIdentityShortHash The holding identity ID of the MGM of the membership group.
      * @param requestId ID of the registration request.
      *
      * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
-     * @throws [IllegalArgumentException] If the request is not found.
+     * @throws [IllegalArgumentException] If the request is not found, or has already been approved/declined.
      */
     @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class, IllegalArgumentException::class)
     fun forceDeclineRegistrationRequest(

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
@@ -16,6 +16,7 @@ import kotlin.jvm.Throws
 /**
  * The MGM ops client to perform group operations.
  */
+@Suppress("TooManyFunctions")
 interface MGMResourceClient : Lifecycle {
 
     /**
@@ -174,6 +175,15 @@ interface MGMResourceClient : Lifecycle {
         requestId: UUID,
         approve: Boolean,
         reason: String? = null,
+    )
+
+    /**
+     * TODO
+     */
+    @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class, IllegalArgumentException::class)
+    fun forceDeclineRegistrationRequest(
+        holdingIdentityShortHash: ShortHash,
+        requestId: UUID,
     )
 
     /**

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
@@ -1,0 +1,117 @@
+package net.corda.membership.impl.rest.v1
+
+import net.corda.crypto.core.ShortHash
+import net.corda.lifecycle.Lifecycle
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.MGMResourceClient
+import net.corda.membership.client.MemberNotAnMgmException
+import net.corda.membership.impl.rest.v1.lifecycle.RestResourceLifecycleHandler
+import net.corda.membership.rest.v1.MGMAdminRestResource
+import net.corda.messaging.api.exception.CordaRPCAPIPartitionException
+import net.corda.rest.PluggableRestResource
+import net.corda.rest.exception.InvalidInputDataException
+import net.corda.rest.exception.ResourceNotFoundException
+import net.corda.rest.exception.ServiceUnavailableException
+import net.corda.virtualnode.read.rest.extensions.parseOrThrow
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+@Component(service = [PluggableRestResource::class])
+class MGMAdminRestResourceImpl @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    coordinatorFactory: LifecycleCoordinatorFactory,
+    @Reference(service = MGMResourceClient::class)
+    private val mgmResourceClient: MGMResourceClient
+) : MGMAdminRestResource, PluggableRestResource<MGMAdminRestResource>, Lifecycle {
+
+    private companion object {
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    private interface InnerMGMAdminRestResource {
+        fun forceDeclineRegistrationRequest(holdingIdentityShortHash: String, requestId: String)
+    }
+
+    override val targetInterface: Class<MGMAdminRestResource> = MGMAdminRestResource::class.java
+
+    override val protocolVersion = 1
+
+    private var impl: InnerMGMAdminRestResource = InactiveImpl
+
+    private val coordinatorName = LifecycleCoordinatorName.forComponent<MGMAdminRestResource>(protocolVersion.toString())
+
+    private val lifecycleHandler = RestResourceLifecycleHandler(
+        ::activate,
+        ::deactivate,
+        setOf()
+    )
+
+    private val coordinator = coordinatorFactory.createCoordinator(coordinatorName, lifecycleHandler)
+
+    override val isRunning: Boolean
+        get() = coordinator.isRunning
+
+    override fun start() {
+        coordinator.start()
+    }
+
+    override fun stop() {
+        coordinator.stop()
+    }
+
+    override fun forceDeclineRegistrationRequest(holdingIdentityShortHash: String, requestId: String) =
+        impl.forceDeclineRegistrationRequest(holdingIdentityShortHash, requestId)
+
+    fun activate(reason: String) {
+        impl = ActiveImpl()
+        coordinator.updateStatus(LifecycleStatus.UP, reason)
+    }
+
+    fun deactivate(reason: String) {
+        coordinator.updateStatus(LifecycleStatus.DOWN, reason)
+        impl = InactiveImpl
+    }
+
+    private object InactiveImpl : InnerMGMAdminRestResource {
+
+        private fun <T> throwNotRunningException(): T {
+            throw ServiceUnavailableException(
+                "${MGMAdminRestResourceImpl::class.java.simpleName} is not running. Operation cannot be fulfilled."
+            )
+        }
+
+        override fun forceDeclineRegistrationRequest(holdingIdentityShortHash: String, requestId: String): Unit =
+            throwNotRunningException()
+    }
+
+    private inner class ActiveImpl : InnerMGMAdminRestResource {
+        override fun forceDeclineRegistrationRequest(holdingIdentityShortHash: String, requestId: String) {
+            try {
+                mgmResourceClient.forceDeclineRegistrationRequest(
+                    ShortHash.parseOrThrow(holdingIdentityShortHash),
+                    UUID.fromString(requestId)
+                )
+            } catch (e: CouldNotFindMemberException) {
+                throw ResourceNotFoundException("Holding Identity", holdingIdentityShortHash)
+            } catch (e: MemberNotAnMgmException) {
+                throw InvalidInputDataException(
+                    details = mapOf("holdingIdentityShortHash" to holdingIdentityShortHash),
+                    message = "Member with holding identity $holdingIdentityShortHash is not an MGM.",
+                )
+            } catch (e: CordaRPCAPIPartitionException) {
+                throw ServiceUnavailableException("Could not perform operation for $holdingIdentityShortHash: Repartition Event!")
+            } catch (e: IllegalArgumentException) {
+                throw InvalidInputDataException(
+                    details = mapOf("registrationRequestId" to requestId),
+                    message = "requestId is not a valid registration request ID."
+                )
+            }
+        }
+    }
+}

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
@@ -21,7 +21,6 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
-import java.util.UUID
 
 @Component(service = [PluggableRestResource::class])
 class MGMAdminRestResourceImpl @Activate constructor(
@@ -111,17 +110,6 @@ class MGMAdminRestResourceImpl @Activate constructor(
                 throw ServiceUnavailableException("Could not perform operation for $holdingIdentityShortHash: Repartition Event!")
             } catch (e: IllegalArgumentException) {
                 throw BadRequestException("${e.message}")
-            }
-        }
-
-        private fun parseRegistrationRequestId(requestId: String): UUID {
-            return try {
-                UUID.fromString(requestId)
-            } catch (e: IllegalArgumentException) {
-                throw InvalidInputDataException(
-                    details = mapOf("registrationRequestId" to requestId),
-                    message = "requestId is not a valid registration request ID."
-                )
             }
         }
     }

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -660,17 +660,6 @@ class MGMRestResourceImpl internal constructor(
             }
         }
 
-        private fun parseRegistrationRequestId(requestId: String): UUID {
-            return try {
-                UUID.fromString(requestId)
-            } catch (e: IllegalArgumentException) {
-                throw InvalidInputDataException(
-                    details = mapOf("registrationRequestId" to requestId),
-                    message = "requestId is not a valid registration request ID."
-                )
-            }
-        }
-
         private fun parseX500Name(keyName: String, x500Name: String): MemberX500Name {
             return try {
                 MemberX500Name.parse(x500Name)

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MembershipRestUtils.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MembershipRestUtils.kt
@@ -1,0 +1,15 @@
+package net.corda.membership.impl.rest.v1
+
+import net.corda.rest.exception.InvalidInputDataException
+import java.util.UUID
+
+internal fun parseRegistrationRequestId(requestId: String): UUID {
+    return try {
+        UUID.fromString(requestId)
+    } catch (e: IllegalArgumentException) {
+        throw InvalidInputDataException(
+            details = mapOf("registrationRequestId" to requestId),
+            message = "'$requestId' is not a valid registration request ID."
+        )
+    }
+}

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
@@ -1,0 +1,142 @@
+package net.corda.membership.impl.rest.v1
+
+import net.corda.crypto.core.ShortHash
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.MGMResourceClient
+import net.corda.membership.client.MemberNotAnMgmException
+import net.corda.rest.exception.BadRequestException
+import net.corda.rest.exception.InvalidInputDataException
+import net.corda.rest.exception.ResourceNotFoundException
+import net.corda.rest.exception.ServiceUnavailableException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.UUID
+import kotlin.test.assertFailsWith
+
+class MGMAdminRestResourceTest {
+    private companion object {
+        const val HOLDING_IDENTITY_ID = "111213141500"
+        const val INVALID_SHORT_HASH = "ABS09234745D"
+        const val REQUEST_ID = "b305129b-8c92-4092-b3a2-e6d452ce2b01"
+
+        fun String.shortHash() = ShortHash.of(this)
+        fun String.uuid(): UUID = UUID.fromString(this)
+    }
+
+    private var coordinatorIsRunning = false
+    private val coordinator = mock<LifecycleCoordinator> {
+        on { isRunning } doAnswer { coordinatorIsRunning }
+        on { start() } doAnswer { coordinatorIsRunning = true }
+        on { stop() } doAnswer { coordinatorIsRunning = false }
+    }
+
+    private val lifecycleCoordinatorFactory = mock<LifecycleCoordinatorFactory> {
+        on { createCoordinator(any(), any()) } doReturn coordinator
+    }
+
+    private val mgmResourceClient = mock<MGMResourceClient>()
+
+    private val mgmAdminRestResource = MGMAdminRestResourceImpl(
+        lifecycleCoordinatorFactory,
+        mgmResourceClient
+    )
+
+    private fun startService() {
+        mgmAdminRestResource.start()
+        mgmAdminRestResource.activate("")
+    }
+
+    private fun stopService() {
+        mgmAdminRestResource.deactivate("")
+        mgmAdminRestResource.stop()
+    }
+
+    @Test
+    fun `starting and stopping the service succeeds`() {
+        mgmAdminRestResource.start()
+        assertTrue(mgmAdminRestResource.isRunning)
+        mgmAdminRestResource.stop()
+        assertFalse(mgmAdminRestResource.isRunning)
+    }
+
+    @Test
+    fun `operation fails when svc is not running`() {
+        val ex = assertFailsWith<ServiceUnavailableException> {
+            mgmAdminRestResource.forceDeclineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)
+        }
+        assertEquals("MGMAdminRestResourceImpl is not running. Operation cannot be fulfilled.", ex.message)
+    }
+
+    @Nested
+    inner class ForceDeclineRegistrationRequestTests {
+        @BeforeEach
+        fun setUp() = startService()
+
+        @AfterEach
+        fun tearDown() = stopService()
+
+        @Test
+        fun `forceDeclineRegistrationRequest delegates correctly to MGM resource client`() {
+            mgmAdminRestResource.forceDeclineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)
+
+            verify(mgmResourceClient).forceDeclineRegistrationRequest(
+                HOLDING_IDENTITY_ID.shortHash(), REQUEST_ID.uuid()
+            )
+        }
+
+        @Test
+        fun `forceDeclineRegistrationRequest throws resource not found for invalid member`() {
+            whenever(mgmResourceClient.forceDeclineRegistrationRequest(
+                HOLDING_IDENTITY_ID.shortHash(), REQUEST_ID.uuid()
+            )).doThrow(mock<CouldNotFindMemberException>())
+
+            assertThrows<ResourceNotFoundException> {
+                mgmAdminRestResource.forceDeclineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)
+            }
+        }
+
+        @Test
+        fun `forceDeclineRegistrationRequest throws invalid input for non MGM member`() {
+            whenever(mgmResourceClient.forceDeclineRegistrationRequest(
+                HOLDING_IDENTITY_ID.shortHash(), REQUEST_ID.uuid()
+            )).doThrow(mock<MemberNotAnMgmException>())
+
+            assertThrows<InvalidInputDataException> {
+                mgmAdminRestResource.forceDeclineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)
+            }
+        }
+
+        @Test
+        fun `forceDeclineRegistrationRequest throws bad request if short hash is invalid`() {
+            assertThrows<BadRequestException> {
+                mgmAdminRestResource.forceDeclineRegistrationRequest(INVALID_SHORT_HASH, REQUEST_ID)
+            }
+        }
+
+        @Test
+        fun `forceDeclineRegistrationRequest throws bad request if request is not found`() {
+            whenever(mgmResourceClient.forceDeclineRegistrationRequest(
+                HOLDING_IDENTITY_ID.shortHash(), REQUEST_ID.uuid()
+            )).doThrow(mock<IllegalArgumentException>())
+
+            assertThrows<BadRequestException> {
+                mgmAdminRestResource.forceDeclineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)
+            }
+        }
+    }
+}

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
@@ -129,7 +129,7 @@ class MGMAdminRestResourceTest {
         }
 
         @Test
-        fun `forceDeclineRegistrationRequest throws bad request if request is not found`() {
+        fun `forceDeclineRegistrationRequest throws bad request if request is not found or already completed`() {
             whenever(mgmResourceClient.forceDeclineRegistrationRequest(
                 HOLDING_IDENTITY_ID.shortHash(), REQUEST_ID.uuid()
             )).doThrow(mock<IllegalArgumentException>())

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -7,20 +7,38 @@ import net.corda.rest.annotations.HttpRestResource
 import net.corda.rest.annotations.RestPathParameter
 
 /**
- * TODO
+ * The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership
+ * group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a
+ * specific set of CorDapps. The API allows you to perform actions such as force decline registration requests which
+ * may be displaying unexpected behaviour. This API should only be used under exceptional circumstances.
  */
 @HttpRestResource(
     name = "MGM Admin API",
-    description = "",
+    description = "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership " +
+            "groups. A membership group is a logical grouping of a number of Corda Identities to communicate and " +
+            "transact with one another with a specific set of CorDapps. The API allows you to perform actions such as" +
+            " force decline registration requests which may be displaying unexpected behaviour. This API should only " +
+            "be used under exceptional circumstances.",
     path = "admin"
 )
 interface MGMAdminRestResource : RestResource {
     /**
-     * TODO
+     * The [forceDeclineRegistrationRequest] method enables you to force decline a registration request that may be
+     * stuck or displaying some other unexpected behaviour. This method should only be used under exceptional
+     * circumstances.
+     *
+     * Example usage:
+     * ```
+     * mgmOps.forceDeclineRegistrationRequest("58B6030FABDD", "3B9A266F96E2")
+     * ```
+     *
+     * @param holdingIdentityShortHash The holding identity ID of the MGM of the membership group.
+     * @param requestId ID of the registration request.
      */
     @HttpPOST(
         path = "{holdingIdentityShortHash}/decline",
-        description = ""
+        description = "This method enables you to force decline a registration request that may be stuck or " +
+                "displaying some other unexpected behaviour."
     )
     fun forceDeclineRegistrationRequest(
         @RestPathParameter(

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -1,0 +1,35 @@
+package net.corda.membership.rest.v1
+
+import net.corda.rest.RestResource
+import net.corda.rest.annotations.ClientRequestBodyParameter
+import net.corda.rest.annotations.HttpPOST
+import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestPathParameter
+
+/**
+ * TODO
+ */
+@HttpRestResource(
+    name = "MGM Admin API",
+    description = "",
+    path = "admin"
+)
+interface MGMAdminRestResource : RestResource {
+    /**
+     * TODO
+     */
+    @HttpPOST(
+        path = "{holdingIdentityShortHash}/decline",
+        description = ""
+    )
+    fun forceDeclineRegistrationRequest(
+        @RestPathParameter(
+            description = "The holding identity ID of the MGM of the membership group"
+        )
+        holdingIdentityShortHash: String,
+        @ClientRequestBodyParameter(
+            description = "ID of the registration request"
+        )
+        requestId: String
+    )
+}

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -8,8 +8,8 @@ import net.corda.rest.annotations.RestPathParameter
 /**
  * The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership
  * group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a
- * specific set of CorDapps. The API allows you to perform actions such as force decline registration requests which
- * may be displaying unexpected behaviour. This API should only be used under exceptional circumstances.
+ * specific set of CorDapps. The API allows the MGM to perform actions such as force decline registration requests which
+ * may be displaying unexpected behaviour. This API should only be used by the MGM and under exceptional circumstances.
  */
 @HttpRestResource(
     name = "MGM Admin API",

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -36,7 +36,7 @@ interface MGMAdminRestResource : RestResource {
      * @param requestId ID of the registration request.
      */
     @HttpPOST(
-        path = "{holdingIdentityShortHash}/decline",
+        path = "{holdingIdentityShortHash}/force-decline/{requestId}",
         description = "This method enables you to force decline a registration request that may be stuck or " +
                 "displaying some other unexpected behaviour."
     )
@@ -45,7 +45,7 @@ interface MGMAdminRestResource : RestResource {
             description = "The holding identity ID of the MGM of the membership group"
         )
         holdingIdentityShortHash: String,
-        @ClientRequestBodyParameter(
+        @RestPathParameter(
             description = "ID of the registration request"
         )
         requestId: String

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -1,7 +1,6 @@
 package net.corda.membership.rest.v1
 
 import net.corda.rest.RestResource
-import net.corda.rest.annotations.ClientRequestBodyParameter
 import net.corda.rest.annotations.HttpPOST
 import net.corda.rest.annotations.HttpRestResource
 import net.corda.rest.annotations.RestPathParameter

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -15,16 +15,16 @@ import net.corda.rest.annotations.RestPathParameter
     name = "MGM Admin API",
     description = "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership " +
             "groups. A membership group is a logical grouping of a number of Corda Identities to communicate and " +
-            "transact with one another with a specific set of CorDapps. The API allows you to perform actions such as" +
-            " force decline registration requests which may be displaying unexpected behaviour. This API should only " +
-            "be used under exceptional circumstances.",
+            "transact with one another with a specific set of CorDapps. The API allows the MGM to perform actions " +
+            "such as force decline registration requests which may be displaying unexpected behaviour. This API " +
+            "should only be used by the MGM under exceptional circumstances.",
     path = "mgmadmin"
 )
 interface MGMAdminRestResource : RestResource {
     /**
-     * The [forceDeclineRegistrationRequest] method enables you to force decline a registration request that may be
-     * stuck or displaying some other unexpected behaviour. This method should only be used under exceptional
-     * circumstances.
+     * The [forceDeclineRegistrationRequest] method enables you to force decline an in-progress registration request
+     * that may be stuck or displaying some other unexpected behaviour. This method should only be used under
+     * exceptional circumstances.
      *
      * Example usage:
      * ```
@@ -36,8 +36,8 @@ interface MGMAdminRestResource : RestResource {
      */
     @HttpPOST(
         path = "{holdingIdentityShortHash}/force-decline/{requestId}",
-        description = "This method enables you to force decline a registration request that may be stuck or " +
-                "displaying some other unexpected behaviour."
+        description = "This method enables you to force decline an in-progress registration request that may be stuck" +
+                " or displaying some other unexpected behaviour."
     )
     fun forceDeclineRegistrationRequest(
         @RestPathParameter(

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -18,7 +18,7 @@ import net.corda.rest.annotations.RestPathParameter
             "transact with one another with a specific set of CorDapps. The API allows you to perform actions such as" +
             " force decline registration requests which may be displaying unexpected behaviour. This API should only " +
             "be used under exceptional circumstances.",
-    path = "admin"
+    path = "mgmadmin"
 )
 interface MGMAdminRestResource : RestResource {
     /**

--- a/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/OpenApiCompatibilityTest.kt
+++ b/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/OpenApiCompatibilityTest.kt
@@ -19,6 +19,7 @@ import net.corda.libs.virtualnode.maintenance.endpoints.v1.VirtualNodeMaintenanc
 import net.corda.membership.rest.v1.CertificatesRestResource
 import net.corda.membership.rest.v1.HsmRestResource
 import net.corda.membership.rest.v1.KeysRestResource
+import net.corda.membership.rest.v1.MGMAdminRestResource
 import net.corda.membership.rest.v1.MGMRestResource
 import net.corda.membership.rest.v1.MemberLookupRestResource
 import net.corda.membership.rest.v1.MemberRegistrationRestResource
@@ -55,6 +56,7 @@ class OpenApiCompatibilityTest {
             MemberLookupRestResource::class.java, // MGM
             MemberRegistrationRestResource::class.java, // MGM
             MGMRestResource::class.java, // MGM
+            MGMAdminRestResource::class.java, // MGM
             NetworkRestResource::class.java, // MGM
             PermissionEndpoint::class.java, // REST
             RoleEndpoint::class.java, // REST
@@ -63,7 +65,7 @@ class OpenApiCompatibilityTest {
         )
 
         // `cardinality` is not equal to `importantRestResources.size` as there might be some test RestResource as well
-        @InjectService(service = PluggableRestResource::class, cardinality = 16, timeout = 10_000)
+        @InjectService(service = PluggableRestResource::class, cardinality = 17, timeout = 10_000)
         lateinit var dynamicRestResources: List<RestResource>
 
         @InjectService(service = RestServerFactory::class, timeout = 10_000)

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -40,7 +40,7 @@
     "description" : "The MGM API consists of a number of endpoints used to manage membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows you to generate the group policy for a membership group, required for new members to join the group."
   }, {
     "name" : "MGM Admin API",
-    "description" : "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows you to perform actions such as force decline registration requests which may be displaying unexpected behaviour. This API should only be used under exceptional circumstances."
+    "description" : "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows the MGM to perform actions such as force decline registration requests which may be displaying unexpected behaviour. This API should only be used by the MGM under exceptional circumstances."
   }, {
     "name" : "Member Lookup API",
     "description" : "The Member Lookup API consists of endpoints used to look up information related to membership groups."
@@ -2844,7 +2844,7 @@
     "/mgmadmin/{holdingidentityshorthash}/force-decline/{requestid}" : {
       "post" : {
         "tags" : [ "MGM Admin API" ],
-        "description" : "This method enables you to force decline a registration request that may be stuck or displaying some other unexpected behaviour.",
+        "description" : "This method enables you to force decline an in-progress registration request that may be stuck or displaying some other unexpected behaviour.",
         "operationId" : "post_mgmadmin__holdingidentityshorthash__force_decline__requestid_",
         "parameters" : [ {
           "name" : "holdingidentityshorthash",

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -67,76 +67,6 @@
     "description" : "The Virtual Node Maintenance API consists of a series of endpoints used for virtual node management.Warning: Using these endpoints could be highly disruptive, so great care should be taken when using them."
   } ],
   "paths" : {
-    "/admin/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "MGM Admin API" ],
-        "description" : "",
-        "operationId" : "get_admin_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/admin/{holdingidentityshorthash}/force-decline/{requestid}" : {
-      "post" : {
-        "tags" : [ "MGM Admin API" ],
-        "description" : "This method enables you to force decline a registration request that may be stuck or displaying some other unexpected behaviour.",
-        "operationId" : "post_admin__holdingidentityshorthash__force_decline__requestid_",
-        "parameters" : [ {
-          "name" : "holdingidentityshorthash",
-          "in" : "path",
-          "description" : "The holding identity ID of the MGM of the membership group",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The holding identity ID of the MGM of the membership group",
-            "nullable" : false,
-            "example" : "string"
-          }
-        }, {
-          "name" : "requestid",
-          "in" : "path",
-          "description" : "ID of the registration request",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "ID of the registration request",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Success"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/certificates/cluster/{usage}" : {
       "get" : {
         "tags" : [ "Certificates API" ],
@@ -2872,6 +2802,76 @@
                 }
               }
             }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
+    "/mgmadmin/getprotocolversion" : {
+      "get" : {
+        "tags" : [ "MGM Admin API" ],
+        "description" : "",
+        "operationId" : "get_mgmadmin_getprotocolversion",
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "An integer value specifying the version of the endpoint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "integer",
+                  "format" : "int32",
+                  "nullable" : false,
+                  "example" : 0
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
+    "/mgmadmin/{holdingidentityshorthash}/force-decline/{requestid}" : {
+      "post" : {
+        "tags" : [ "MGM Admin API" ],
+        "description" : "This method enables you to force decline a registration request that may be stuck or displaying some other unexpected behaviour.",
+        "operationId" : "post_mgmadmin__holdingidentityshorthash__force_decline__requestid_",
+        "parameters" : [ {
+          "name" : "holdingidentityshorthash",
+          "in" : "path",
+          "description" : "The holding identity ID of the MGM of the membership group",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The holding identity ID of the MGM of the membership group",
+            "nullable" : false,
+            "example" : "string"
+          }
+        }, {
+          "name" : "requestid",
+          "in" : "path",
+          "description" : "ID of the registration request",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "ID of the registration request",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Success"
           },
           "401" : {
             "description" : "Unauthorized"

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -39,6 +39,9 @@
     "name" : "MGM API",
     "description" : "The MGM API consists of a number of endpoints used to manage membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows you to generate the group policy for a membership group, required for new members to join the group."
   }, {
+    "name" : "MGM Admin API",
+    "description" : "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows you to perform actions such as force decline registration requests which may be displaying unexpected behaviour. This API should only be used under exceptional circumstances."
+  }, {
     "name" : "Member Lookup API",
     "description" : "The Member Lookup API consists of endpoints used to look up information related to membership groups."
   }, {
@@ -64,6 +67,84 @@
     "description" : "The Virtual Node Maintenance API consists of a series of endpoints used for virtual node management.Warning: Using these endpoints could be highly disruptive, so great care should be taken when using them."
   } ],
   "paths" : {
+    "/admin/getprotocolversion" : {
+      "get" : {
+        "tags" : [ "MGM Admin API" ],
+        "description" : "",
+        "operationId" : "get_admin_getprotocolversion",
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "An integer value specifying the version of the endpoint",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "integer",
+                  "format" : "int32",
+                  "nullable" : false,
+                  "example" : 0
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
+    "/admin/{holdingidentityshorthash}/decline" : {
+      "post" : {
+        "tags" : [ "MGM Admin API" ],
+        "description" : "This method enables you to force decline a registration request that may be stuck or displaying some other unexpected behaviour.",
+        "operationId" : "post_admin__holdingidentityshorthash__decline",
+        "parameters" : [ {
+          "name" : "holdingidentityshorthash",
+          "in" : "path",
+          "description" : "The holding identity ID of the MGM of the membership group",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The holding identity ID of the MGM of the membership group",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "description" : "requestBody",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "type" : "object",
+                "properties" : {
+                  "requestId" : {
+                    "type" : "string",
+                    "description" : "ID of the registration request",
+                    "nullable" : false,
+                    "example" : "string"
+                  }
+                }
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Success"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
     "/certificates/cluster/{usage}" : {
       "get" : {
         "tags" : [ "Certificates API" ],

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -96,11 +96,11 @@
         }
       }
     },
-    "/admin/{holdingidentityshorthash}/decline" : {
+    "/admin/{holdingidentityshorthash}/force-decline/{requestid}" : {
       "post" : {
         "tags" : [ "MGM Admin API" ],
         "description" : "This method enables you to force decline a registration request that may be stuck or displaying some other unexpected behaviour.",
-        "operationId" : "post_admin__holdingidentityshorthash__decline",
+        "operationId" : "post_admin__holdingidentityshorthash__force_decline__requestid_",
         "parameters" : [ {
           "name" : "holdingidentityshorthash",
           "in" : "path",
@@ -112,26 +112,18 @@
             "nullable" : false,
             "example" : "string"
           }
+        }, {
+          "name" : "requestid",
+          "in" : "path",
+          "description" : "ID of the registration request",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "ID of the registration request",
+            "nullable" : false,
+            "example" : "string"
+          }
         } ],
-        "requestBody" : {
-          "description" : "requestBody",
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "object",
-                "properties" : {
-                  "requestId" : {
-                    "type" : "string",
-                    "description" : "ID of the registration request",
-                    "nullable" : false,
-                    "example" : "string"
-                  }
-                }
-              }
-            }
-          },
-          "required" : true
-        },
         "responses" : {
           "200" : {
             "description" : "Success"


### PR DESCRIPTION
Introduces the MGM Admin API, which allows you to perform actions such as force decline registration requests which may be stuck or displaying some other unexpected behaviour. This API is intended for use by the MGM under exceptional circumstances only. Force decline only works on in-progress requests (use member suspension for completed requests).

Also fixes a bug which broke the manual approve/decline functionality by correcting the key which is used while publishing those commands.

Endpoints:
1. Force decline a registration request
```bash
REQUEST_ID=<REQUEST ID>
curl --insecure -u admin:admin -X POST $API_URL/mgmadmin/$MGM_HOLDING_ID/force-decline/$REQUEST_ID
```

Test:
- Create request
<img width="1782" alt="Screenshot 2023-04-19 at 10 46 05" src="https://user-images.githubusercontent.com/17948697/233043392-dba988c6-35aa-481c-bc2d-73f6678804ec.png">

- Force decline:
<img width="1792" alt="Screenshot 2023-04-19 at 10 46 33" src="https://user-images.githubusercontent.com/17948697/233043425-d706c665-777b-42a3-9508-b1a617608c6a.png">
