### PR TITLE
CORE-12304 Try improve `ConfigProcessor` logging

### DIFF
--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
@@ -46,10 +46,9 @@ internal class ConfigProcessor(
 
                 logger.info("onSnapshot - Received configuration for key $configKey")
                 logger.debug {
-                    config[configKey]!!.let {
-                        "$configKey configuration: " +
-                                it.toSafeConfig().root().render(ConfigRenderOptions.concise().setFormatted(true))
-                    }
+                    "$configKey configuration: " +
+                            config[configKey]!!.toSafeConfig().root()
+                                .render(ConfigRenderOptions.concise().setFormatted(true))
                 }
             }
 

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
@@ -46,7 +46,7 @@ internal class ConfigProcessor(
 
                 logger.info("onSnapshot - Received configuration for key $configKey")
                 logger.debug {
-                    configuration.toSmartConfig().let {
+                    config[configKey]!!.let {
                         "$configKey configuration: " +
                                 it.toSafeConfig().root().render(ConfigRenderOptions.concise().setFormatted(true))
                     }

--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigProcessor.kt
@@ -44,7 +44,7 @@ internal class ConfigProcessor(
             currentData.forEach { (configKey, configuration: Configuration) ->
                 addToCache(configKey, configuration)
 
-                logger.info("onSnapshot - Received configuration for key $configKey")
+                logger.info("Received initial configuration for key $configKey")
                 logger.debug {
                     "$configKey configuration: " +
                             config[configKey]!!.toSafeConfig().root()
@@ -67,7 +67,7 @@ internal class ConfigProcessor(
         if (newConfig != null) {
             val config = mergeConfigs(currentData)
             val newConfigKey = newRecord.key
-            logger.info("onNext - Received configuration for key $newConfigKey")
+            logger.info("Received new configuration for key $newConfigKey")
             logger.debug {
                 "$newConfigKey configuration: " +
                         newConfig.toSafeConfig().root().render(ConfigRenderOptions.concise().setFormatted(true))


### PR DESCRIPTION
Updates received configuration `INFO` logging to look like:

- Adds logging on receiving (initial) configuration through `ConfigProcessor.onSnapshot`:

  ![image](https://user-images.githubusercontent.com/15893565/232890499-e32a2554-6746-42a3-a03d-953e5787cdcd.png)

- Updates logging on receiving (new) configuration through `ConfigProcessor.onNext`:
  
  ![image](https://user-images.githubusercontent.com/15893565/232895579-ccff8922-eae1-42e2-953a-f19547ee5855.png)
  
