### PR TITLE
CORE-9633 `DigitalSignatureMetadata.properties` should be deterministically serialized

### DIFF
--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializationScheme.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/AMQPSerializationScheme.kt
@@ -16,6 +16,7 @@ import net.corda.internal.serialization.amqp.custom.CertPathSerializer
 import net.corda.internal.serialization.amqp.custom.ClassSerializer
 import net.corda.internal.serialization.amqp.custom.CurrencySerializer
 import net.corda.internal.serialization.amqp.custom.DayOfWeekSerializer
+import net.corda.internal.serialization.amqp.custom.DigitalSignatureMetadataSerializer
 import net.corda.internal.serialization.amqp.custom.DurationSerializer
 import net.corda.internal.serialization.amqp.custom.EnumSetSerializer
 import net.corda.internal.serialization.amqp.custom.InputStreamSerializer
@@ -149,5 +150,6 @@ fun registerCustomSerializers(factory: SerializerFactory) {
         register(AlgorithmParameterSpecSerializer(), this)
         register(PSSParameterSpecSerializer(), this)
         register(MGF1ParameterSpecSerializer(), this)
+        register(DigitalSignatureMetadataSerializer(), this)
     }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/DigitalSignatureMetadataSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/DigitalSignatureMetadataSerializer.kt
@@ -1,0 +1,35 @@
+package net.corda.internal.serialization.amqp.custom
+
+import net.corda.serialization.BaseProxySerializer
+import net.corda.v5.application.crypto.DigitalSignatureMetadata
+import net.corda.v5.crypto.SignatureSpec
+import java.time.Instant
+import java.util.SortedMap
+
+class DigitalSignatureMetadataSerializer :
+    BaseProxySerializer<DigitalSignatureMetadata, DigitalSignatureMetadataSerializer.DigitalSignatureMetadataProxy>() {
+
+    data class DigitalSignatureMetadataProxy(
+        val timestamp: Instant,
+        val signatureSpec: SignatureSpec,
+        val properties: SortedMap<String, String>
+    )
+
+    override fun toProxy(obj: DigitalSignatureMetadata): DigitalSignatureMetadataProxy =
+        DigitalSignatureMetadataProxy(
+            obj.timestamp,
+            obj.signatureSpec,
+            obj.properties.toSortedMap()
+        )
+
+    override fun fromProxy(proxy: DigitalSignatureMetadataProxy): DigitalSignatureMetadata =
+        DigitalSignatureMetadata(
+            proxy.timestamp,
+            proxy.signatureSpec,
+            proxy.properties
+        )
+
+    override val proxyType = DigitalSignatureMetadataProxy::class.java
+    override val type = DigitalSignatureMetadata::class.java
+    override val withInheritance = false
+}

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/DigitalSignatureMetadataTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/DigitalSignatureMetadataTest.kt
@@ -54,23 +54,23 @@ class DigitalSignatureMetadataTest {
     @Test
     fun `DigitalSignatureMetadata properties round trip serializes deterministically`() {
         val digitalSignatureProperties1 = hashMapOf<String, String>()
-        (0 until 1000).forEach {
-            digitalSignatureProperties1["$it"] = "$it"
+        for (i in 0 until 1000) {
+            digitalSignatureProperties1["$i"] = "$i"
         }
 
         val digitalSignatureProperties2 = hashMapOf<String, String>()
         val addedEntriesKeys = arrayListOf<String>()
         val removedEntriesKeys = arrayListOf<String>()
         val skippedEntriesKeys = arrayListOf<String>()
-        (0 until 1000).forEach {
+        for (i in 0 until 1000) {
             when (Random.nextInt(3)) {
                 ADD -> {
-                    digitalSignatureProperties2["$it"] = "$it"
-                    addedEntriesKeys.add("$it")
+                    digitalSignatureProperties2["$i"] = "$i"
+                    addedEntriesKeys.add("$i")
                 }
 
                 REMOVE -> {
-                    skippedEntriesKeys.add("$it")
+                    skippedEntriesKeys.add("$i")
                     if (addedEntriesKeys.size > 0) {
                         val removedEntry = addedEntriesKeys.removeAt(Random.nextInt(addedEntriesKeys.size))
                         digitalSignatureProperties2.remove(removedEntry)
@@ -80,7 +80,7 @@ class DigitalSignatureMetadataTest {
                 }
 
                 SKIP -> {
-                    skippedEntriesKeys.add("$it")
+                    skippedEntriesKeys.add("$i")
                 }
             }
         }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/DigitalSignatureMetadataTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/DigitalSignatureMetadataTest.kt
@@ -1,0 +1,78 @@
+package net.corda.internal.serialization.amqp.custom
+
+import net.corda.crypto.cipher.suite.SignatureSpecs
+import net.corda.internal.serialization.amqp.ReusableSerialiseDeserializeAssert
+import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.testutils.serialize
+import net.corda.v5.application.crypto.DigitalSignatureMetadata
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class DigitalSignatureMetadataTest {
+    companion object {
+        const val MAP_CAPACITY = 2
+        const val MAP_LOAD_FACTOR = 3.00f
+    }
+
+    @Test
+    fun `DigitalSignatureMetadata serializes deterministically`() {
+        // We are creating below 2 maps with 2 buckets each to easily reproduce equal maps i.e.
+        // same elements but different iteration through them and thus different serializations.
+
+        val digitalSignatureProperties1 = java.util.HashMap<String, String>(MAP_CAPACITY, MAP_LOAD_FACTOR)
+        // Iterating through digitalSignatureProperties1 keys looks like:
+        // 0, 2, 4, 1, 3, 5
+        digitalSignatureProperties1["0"] = "v0"
+        digitalSignatureProperties1["1"] = "v1"
+        digitalSignatureProperties1["2"] = "v2"
+        digitalSignatureProperties1["3"] = "v3"
+        digitalSignatureProperties1["4"] = "v4"
+        digitalSignatureProperties1["5"] = "v5"
+
+        val digitalSignatureProperties2 = java.util.HashMap<String, String>(MAP_CAPACITY, MAP_LOAD_FACTOR)
+        // Iterating through digitalSignatureProperties2 keys looks like:
+        // 2, 4, 0, 5, 1, 3
+        digitalSignatureProperties2["5"] = "v5"
+        digitalSignatureProperties2["1"] = "v1"
+        digitalSignatureProperties2["2"] = "v2"
+        digitalSignatureProperties2["3"] = "v3"
+        digitalSignatureProperties2["4"] = "v4"
+        digitalSignatureProperties2["0"] = "v0"
+
+        // The two maps are equal
+        assertEquals(digitalSignatureProperties1, digitalSignatureProperties2)
+
+        val instant = Instant.now()
+        val signatureSpec = SignatureSpecs.RSA_SHA256
+
+        val digitalSignatureMetadata1 =
+            DigitalSignatureMetadata(
+                instant,
+                signatureSpec,
+                digitalSignatureProperties1
+            )
+
+        val digitalSignatureMetadata2 =
+            DigitalSignatureMetadata(
+                instant,
+                signatureSpec,
+                digitalSignatureProperties2
+            )
+
+        // The two maps serializations are different due to the different order their values are iterated through
+        val bytes1 =
+            SerializationOutput(ReusableSerialiseDeserializeAssert.factory)
+                .serialize(digitalSignatureMetadata1)
+
+        val bytes2 =
+            SerializationOutput(ReusableSerialiseDeserializeAssert.factory)
+                .serialize(digitalSignatureMetadata2)
+
+        // With `DigitalSignatureMetadataSerializer` we make their serializations equal by
+        // converting DigitalSignatureMetadata.properties into a sorted map first and then serialize that instead.
+        assertEquals(bytes1, bytes2)
+        ReusableSerialiseDeserializeAssert.serializeDeserializeAssert(digitalSignatureMetadata1)
+        ReusableSerialiseDeserializeAssert.serializeDeserializeAssert(digitalSignatureMetadata2)
+    }
+}

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/DigitalSignatureMetadataTest.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/custom/DigitalSignatureMetadataTest.kt
@@ -52,7 +52,7 @@ class DigitalSignatureMetadataTest {
     }
 
     @Test
-    fun `DigitalSignatureMetadata round trip serializes deterministically`() {
+    fun `DigitalSignatureMetadata properties round trip serializes deterministically`() {
         val digitalSignatureProperties1 = hashMapOf<String, String>()
         (0 until 1000).forEach {
             digitalSignatureProperties1["$it"] = "$it"


### PR DESCRIPTION
`DigitalSignatureMetadata.properties` which is of type `Map<String, String>` is getting serialized as part of `DigitalSignatureMetadata` and gets signed alongside actual payload. It can be that two `DigitalSignatureMetadata` may be equal meaning their `DigitalSignatureMetadata.properties` are equal but `DigitalSignatureMetadata.properties` iteration order might be different leading to different serializations and therefore different signatures.

- Adds a custom AMQP serializer for `DigitalSignatureMetadata` to convert `DigitalSignatureMetadata.properties` to a `SortedMap` before serializing it, thus making equal maps but with different iteration orders over their entries serialize deterministically. 