### PR TITLE
CORE-12440: Improve Flow Tracing Capabilities

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -72,7 +72,7 @@ class CryptoFlowOpsBusProcessor(
 
             try {
                 if (Instant.now() >= expireAt) {
-                    logger.warn("Event ${request.request::class.java} for tenant ${request.context.tenantId} " +
+                    logger.warn("Event ${request.request::class.java.name} for tenant ${request.context.tenantId} " +
                             "is no longer valid, expired at $expireAt")
                     externalEventResponseFactory.transientError(
                         request.flowExternalEventContext,
@@ -84,7 +84,7 @@ class CryptoFlowOpsBusProcessor(
                     }
 
                     if (Instant.now() >= expireAt) {
-                        logger.warn("Event ${request.request::class.java} for tenant ${request.context.tenantId} " +
+                        logger.warn("Event ${request.request::class.java.name} for tenant ${request.context.tenantId} " +
                                 "is no longer valid, expired at $expireAt")
                         externalEventResponseFactory.transientError(
                             request.flowExternalEventContext,
@@ -99,7 +99,7 @@ class CryptoFlowOpsBusProcessor(
                 }
             } catch (throwable: Throwable) {
                 logger.error(
-                    "Failed to handle ${request.request::class.java} for tenant ${request.context.tenantId}",
+                    "Failed to handle ${request.request::class.java.name} for tenant ${request.context.tenantId}",
                     throwable
                 )
                 externalEventResponseFactory.platformError(request.flowExternalEventContext, throwable)

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -122,7 +122,6 @@ class CryptoFlowOpsBusProcessor(
                     tenantId = context.tenantId,
                     candidateKeys = request.keys
                 )
-
             is SignFlowCommand ->
                 cryptoOpsClient.signProxy(
                     tenantId = context.tenantId,
@@ -131,10 +130,8 @@ class CryptoFlowOpsBusProcessor(
                     data = request.bytes,
                     context = request.context
                 )
-
             is ByIdsFlowQuery ->
                 cryptoOpsClient.lookupKeysByFullIdsProxy(context.tenantId, request.fullKeyIds)
-
             else ->
                 throw IllegalArgumentException("Unknown request type ${request::class.java.name}")
         }

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -59,8 +59,6 @@ class CryptoFlowOpsBusProcessor(
             return null // cannot send any error back as have no idea where to send to
         }
 
-        logger.info("Handling ${request.request::class.java.name} for tenant ${request.context.tenantId}")
-
         val expireAt = getRequestExpireAt(request)
         val clientRequestId = request.flowExternalEventContext.contextProperties.toMap()[MDC_CLIENT_ID] ?: ""
         val mdc = mapOf(
@@ -70,6 +68,8 @@ class CryptoFlowOpsBusProcessor(
         )
 
         return withMDC(mdc) {
+            logger.info("Handling ${request.request::class.java.name} for tenant ${request.context.tenantId}")
+
             try {
                 if (Instant.now() >= expireAt) {
                     logger.warn("Event ${request.request::class.java} for tenant ${request.context.tenantId} " +

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
@@ -165,7 +165,7 @@ class FlowRestResourceImpl @Activate constructor(
             throw ForbiddenException(FlowRestExceptionConstants.FORBIDDEN.format(principal, startFlow.flowClassName))
         }
 
-        // TODO Platform properties to be populated correctly, for now a fixed 'account zero' is the only property
+        // TODO Platform properties to be populated correctly.
         // This is a placeholder which indicates access to everything, see CORE-6076
         val flowContextPlatformProperties = mapOf(
             "corda.account" to "account-zero",

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
@@ -40,6 +40,7 @@ import net.corda.rest.ws.DuplexChannel
 import net.corda.rest.ws.WebSocketValidationException
 import net.corda.schema.Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_STATUS_TOPIC
+import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.read.rest.extensions.getByHoldingIdentityShortHashOrThrow
 import net.corda.virtualnode.toAvro
@@ -166,7 +167,10 @@ class FlowRestResourceImpl @Activate constructor(
 
         // TODO Platform properties to be populated correctly, for now a fixed 'account zero' is the only property
         // This is a placeholder which indicates access to everything, see CORE-6076
-        val flowContextPlatformProperties = mapOf("corda.account" to "account-zero")
+        val flowContextPlatformProperties = mapOf(
+            "corda.account" to "account-zero",
+            MDC_CLIENT_ID to clientRequestId
+        )
         val startEvent =
             messageFactory.createStartFlowEvent(
                 clientRequestId,

--- a/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImplTest.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImplTest.kt
@@ -38,10 +38,11 @@ import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
@@ -191,9 +192,9 @@ class FlowRestResourceImplTest {
 
         val flowRestResource = createFlowRestResource()
 
-        assertThatThrownBy {
+        assertThrows<ResourceNotFoundException> {
             flowRestResource.getFlowStatus(VALID_SHORT_HASH, clientRequestId)
-        }.isInstanceOf(ResourceNotFoundException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, never()).getStatus(any(), any())
@@ -206,9 +207,9 @@ class FlowRestResourceImplTest {
     fun `get flow status throws bad request if short hash is invalid`(invalidShortHash: String) {
         val flowRestResource = createFlowRestResource()
 
-        assertThatThrownBy {
+        assertThrows<BadRequestException> {
             flowRestResource.getFlowStatus(invalidShortHash, "")
-        }.isInstanceOf(BadRequestException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, never()).getStatus(any(), any())
@@ -234,9 +235,9 @@ class FlowRestResourceImplTest {
 
         val flowRestResource = createFlowRestResource()
 
-        assertThatThrownBy {
+        assertThrows<ResourceNotFoundException> {
             flowRestResource.getMultipleFlowStatus(VALID_SHORT_HASH)
-        }.isInstanceOf(ResourceNotFoundException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, never()).getStatusesPerIdentity(any())
@@ -249,9 +250,9 @@ class FlowRestResourceImplTest {
     fun `get multiple flow status throws bad request if short hash is invalid`(invalidShortHash: String) {
         val flowRestResource = createFlowRestResource()
 
-        assertThatThrownBy {
+        assertThrows<BadRequestException> {
             flowRestResource.getMultipleFlowStatus(invalidShortHash)
-        }.isInstanceOf(BadRequestException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, never()).getStatusesPerIdentity(any())
@@ -279,7 +280,7 @@ class FlowRestResourceImplTest {
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(fatalErrorFunction, never()).invoke()
 
-        assertThat(platformPropertiesCaptor.firstValue[MDC_CLIENT_ID]).isEqualTo(clientRequestId)
+        assertEquals(clientRequestId, platformPropertiesCaptor.firstValue[MDC_CLIENT_ID])
     }
 
     @Test
@@ -290,18 +291,18 @@ class FlowRestResourceImplTest {
             getStubVirtualNode(flowStartOperationalStatus = OperationalStatus.INACTIVE)
         )
 
-        assertThatThrownBy {
+        assertThrows<OperationNotAllowedException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(OperationNotAllowedException::class.java)
+        }
     }
 
     @Test
     fun `start flow event fails when not initialized`() {
         val flowRestResource = createFlowRestResource(false)
 
-        assertThatThrownBy {
+        assertThrows<ServiceUnavailableException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(ServiceUnavailableException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
         verify(cpiInfoReadService, never()).get(any())
@@ -318,9 +319,9 @@ class FlowRestResourceImplTest {
     fun `start flow event throws bad request if short hash is invalid`(invalidShortHash: String) {
         val flowRestResource = createFlowRestResource()
 
-        assertThatThrownBy {
+        assertThrows<BadRequestException> {
             flowRestResource.startFlow(invalidShortHash, StartFlowParameters(clientRequestId, "", TestJsonObject()))
-        }.isInstanceOf(BadRequestException::class.java)
+        }
 
         verify(flowStatusCacheService, never()).getStatus(any(), any())
         verify(messageFactory, never()).createStartFlowEvent(any(), any(), any(), any(), any())
@@ -336,9 +337,9 @@ class FlowRestResourceImplTest {
 
         val flowRestResource = createFlowRestResource()
 
-        assertThatThrownBy {
+        assertThrows<ResourceNotFoundException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, "", TestJsonObject()))
-        }.isInstanceOf(ResourceNotFoundException::class.java)
+        }
 
         verify(flowStatusCacheService, never()).getStatus(any(), any())
         verify(messageFactory, never()).createStartFlowEvent(any(), any(), any(), any(), any())
@@ -353,9 +354,9 @@ class FlowRestResourceImplTest {
         val flowRestResource = createFlowRestResource()
 
         whenever(flowStatusCacheService.getStatus(any(), any())).thenReturn(mock())
-        assertThatThrownBy {
+        assertThrows<ResourceAlreadyExistsException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(ResourceAlreadyExistsException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -373,9 +374,9 @@ class FlowRestResourceImplTest {
 
         whenever(messageFactory.createFlowStatusResponse(any())).thenReturn(mock())
 
-        assertThatThrownBy {
+        assertThrows<InvalidInputDataException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters("requetsId", "invalid", TestJsonObject()))
-        }.isInstanceOf(InvalidInputDataException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -392,9 +393,9 @@ class FlowRestResourceImplTest {
         val flowRestResource = createFlowRestResource()
 
         doThrow(CordaMessageAPIIntermittentException("")).whenever(publisher).batchPublish(any())
-        assertThatThrownBy {
+        assertThrows<InternalServerException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(InternalServerException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -414,9 +415,9 @@ class FlowRestResourceImplTest {
             )
         })
 
-        assertThatThrownBy {
+        assertThrows<InternalServerException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(InternalServerException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -432,9 +433,9 @@ class FlowRestResourceImplTest {
         val flowRestResource = createFlowRestResource()
 
         doThrow(CordaMessageAPIFatalException("")).whenever(publisher).batchPublish(any())
-        assertThatThrownBy {
+        assertThrows<InternalServerException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(InternalServerException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -447,9 +448,9 @@ class FlowRestResourceImplTest {
         // flowRestResource should have marked itself as unable to start flows after fata error, which means throwing without
         // attempting to start the flow
 
-        assertThatThrownBy {
+        assertThrows<ServiceUnavailableException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(ServiceUnavailableException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -469,9 +470,9 @@ class FlowRestResourceImplTest {
             )
         })
 
-        assertThatThrownBy {
+        assertThrows<InternalServerException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(InternalServerException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -484,9 +485,9 @@ class FlowRestResourceImplTest {
         // flowRestResource should have marked itself as unable to start flows after fata error, which means throwing without
         // attempting to start the flow
 
-        assertThatThrownBy {
+        assertThrows<ServiceUnavailableException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(ServiceUnavailableException::class.java)
+        }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatus(any(), any())
@@ -511,7 +512,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(duplexChannel, times(1)).error(any())
-        assertThat(exceptionArgumentCaptor.firstValue.cause).isInstanceOf(ResourceNotFoundException::class.java)
+        assertInstanceOf(ResourceNotFoundException::class.java, exceptionArgumentCaptor.firstValue.cause)
         verify(fatalErrorFunction, never()).invoke()
     }
 
@@ -528,7 +529,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
         verify(duplexChannel, times(1)).error(any())
-        assertThat(exceptionArgumentCaptor.firstValue.cause).isInstanceOf(BadRequestException::class.java)
+        assertInstanceOf(BadRequestException::class.java, exceptionArgumentCaptor.firstValue.cause)
         verify(fatalErrorFunction, never()).invoke()
     }
 
@@ -543,9 +544,9 @@ class FlowRestResourceImplTest {
             )
         ).thenReturn(false)
 
-        assertThatThrownBy {
+        assertThrows<ForbiddenException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters(clientRequestId, FLOW1, TestJsonObject()))
-        }.isInstanceOf(ForbiddenException::class.java)
+        }
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(fatalErrorFunction, never()).invoke()
     }
@@ -556,8 +557,8 @@ class FlowRestResourceImplTest {
 
         whenever(messageFactory.createFlowStatusResponse(any())).thenReturn(mock())
 
-        assertThatThrownBy {
+        assertThrows<BadRequestException> {
             flowRestResource.startFlow(VALID_SHORT_HASH, StartFlowParameters("", FLOW1, TestJsonObject()))
-        }.isInstanceOf(BadRequestException::class.java)
+        }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -19,11 +19,12 @@ import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.flow.pipeline.sessions.FlowSessionManager
 import net.corda.flow.pipeline.sessions.protocol.FlowAndProtocolVersion
 import net.corda.flow.utils.KeyValueStore
-import net.corda.flow.utils.emptyKeyValuePairList
+import net.corda.flow.utils.keyValuePairListOf
 import net.corda.session.manager.Constants.Companion.FLOW_PROTOCOL
 import net.corda.session.manager.Constants.Companion.FLOW_PROTOCOL_VERSIONS_SUPPORTED
 import net.corda.session.manager.Constants.Companion.FLOW_PROTOCOL_VERSION_USED
 import net.corda.session.manager.SessionManager
+import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.debug
 import net.corda.utilities.trace
 import net.corda.virtualnode.toCorda
@@ -120,6 +121,7 @@ class SessionEventHandler @Activate constructor(
                     e
                 )
             }
+
             val flowAndProtocolVersion = protocolStore.responderForProtocol(requestedProtocolName, initiatorVersionsSupported, context)
             initiatedFlowNameAndProtocol = flowAndProtocolVersion
             FlowStartContext.newBuilder()
@@ -130,12 +132,12 @@ class SessionEventHandler @Activate constructor(
                 .setCpiId(sessionInit.cpiId)
                 .setInitiatedBy(initiatingIdentity)
                 .setFlowClassName(flowAndProtocolVersion.flowClassName)
-                .setContextPlatformProperties(emptyKeyValuePairList())
+                .setContextPlatformProperties(keyValuePairListOf(mapOf(MDC_CLIENT_ID to sessionId)))
                 .setCreatedTimestamp(Instant.now())
                 .build()
         }
 
-        //set initial session state so it can be found when trying to send the confirm message
+        //set initial session state, so it can be found when trying to send the confirmation message
         context.checkpoint.putSessionState(initialSessionState)
 
         sendConfirmMessage(initiatedFlowNameAndProtocol, requestedProtocolName, initiatorVersionsSupported, context, sessionId)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImpl.kt
@@ -8,6 +8,8 @@ import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.flow.state.checkpoint.FlowState
 import net.corda.data.flow.state.external.ExternalEventStateType
 import net.corda.flow.pipeline.FlowMDCService
+import net.corda.utilities.MDC_CLIENT_ID
+import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Component
 import org.slf4j.LoggerFactory
@@ -15,12 +17,10 @@ import org.slf4j.LoggerFactory
 @Component(service = [FlowMDCService::class])
 class FlowMDCServiceImpl : FlowMDCService {
     
-    private companion object {
-        const val MDC_FLOW_ID = "flow_id"
-        const val MDC_CLIENT_ID = "client_id"
-        const val MDC_VNODE_ID = "vnode_id"
-        const val MDC_SESSION_EVENT_ID = "session_event_id"
-        const val MDC_EXTERNAL_EVENT_ID = "external_event_id"
+    companion object {
+        const val MDC_FLOW_ID = "flow.id"
+        const val MDC_VNODE_ID = "vnode.id"
+        const val MDC_SESSION_EVENT_ID = "session.event.id"
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     
@@ -42,18 +42,18 @@ class FlowMDCServiceImpl : FlowMDCService {
                 val startKey = startContext.statusKey
                 val holdingIdentityShortHash = startKey.identity.toCorda().shortHash.toString()
                 mapOf(
-                    MDC_VNODE_ID to holdingIdentityShortHash,
+                    MDC_FLOW_ID to flowId,
                     MDC_CLIENT_ID to startContext.requestId,
-                    MDC_FLOW_ID to flowId
+                    MDC_VNODE_ID to holdingIdentityShortHash,
                 )
             }
             is SessionEvent -> {
                 //no checkpoint so this is either a SessionInit or a duplicate SessionEvent for an expired session
                 val holdingIdentityShortHash = payload.initiatedIdentity.toCorda().shortHash.toString()
                 mapOf(MDC_VNODE_ID to holdingIdentityShortHash,
+                    MDC_FLOW_ID to flowId,
                     MDC_CLIENT_ID to payload.sessionId,
                     MDC_SESSION_EVENT_ID to payload.sessionId,
-                    MDC_FLOW_ID to flowId
                 )
             }
             else -> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImpl.kt
@@ -10,6 +10,9 @@ import net.corda.data.flow.state.external.ExternalEventStateType
 import net.corda.flow.pipeline.FlowMDCService
 import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
+import net.corda.utilities.MDC_FLOW_ID
+import net.corda.utilities.MDC_SESSION_EVENT_ID
+import net.corda.utilities.MDC_VNODE_ID
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Component
 import org.slf4j.LoggerFactory
@@ -18,9 +21,6 @@ import org.slf4j.LoggerFactory
 class FlowMDCServiceImpl : FlowMDCService {
     
     companion object {
-        const val MDC_FLOW_ID = "flow.id"
-        const val MDC_VNODE_ID = "vnode.id"
-        const val MDC_SESSION_EVENT_ID = "session.event.id"
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
     

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImplTest.kt
@@ -19,17 +19,14 @@ import net.corda.test.flow.util.buildSessionEvent
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import net.corda.flow.pipeline.impl.FlowMDCServiceImpl.Companion.MDC_FLOW_ID
+import net.corda.flow.pipeline.impl.FlowMDCServiceImpl.Companion.MDC_VNODE_ID
+import net.corda.flow.pipeline.impl.FlowMDCServiceImpl.Companion.MDC_SESSION_EVENT_ID
+import net.corda.utilities.MDC_CLIENT_ID
+import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
 
 class FlowMDCServiceImplTest {
-
     private val flowMDCService = FlowMDCServiceImpl()
-
-    private val MDC_FLOW_ID = "flow_id"
-    private val MDC_CLIENT_ID = "client_id"
-    private val MDC_VNODE_ID = "vnode_id"
-    private val MDC_SESSION_EVENT_ID = "session_event_id"
-    private val MDC_EXTERNAL_EVENT_ID = "external_event_id"
-
     private val flowKey = "flowId"
     private val startRequestId = "requestId"
     private val sessionId = "sessionId"

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImplTest.kt
@@ -19,11 +19,11 @@ import net.corda.test.flow.util.buildSessionEvent
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import net.corda.flow.pipeline.impl.FlowMDCServiceImpl.Companion.MDC_FLOW_ID
-import net.corda.flow.pipeline.impl.FlowMDCServiceImpl.Companion.MDC_VNODE_ID
-import net.corda.flow.pipeline.impl.FlowMDCServiceImpl.Companion.MDC_SESSION_EVENT_ID
 import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
+import net.corda.utilities.MDC_FLOW_ID
+import net.corda.utilities.MDC_SESSION_EVENT_ID
+import net.corda.utilities.MDC_VNODE_ID
 
 class FlowMDCServiceImplTest {
     private val flowMDCService = FlowMDCServiceImpl()

--- a/components/ledger/ledger-verification/build.gradle
+++ b/components/ledger/ledger-verification/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     implementation project(':libs:crypto:cipher-suite')
     implementation project(':libs:flows:external-event-responses')
+    implementation project(':libs:flows:flow-utils')
     implementation project(':libs:ledger:ledger-common-data')
     implementation project(':libs:ledger:ledger-utxo-data')
     implementation project(':libs:ledger:ledger-utxo-transaction-verifier')

--- a/libs/flows/flow-utils/src/main/kotlin/net/corda/flow/utils/KeyValueStore.kt
+++ b/libs/flows/flow-utils/src/main/kotlin/net/corda/flow/utils/KeyValueStore.kt
@@ -41,12 +41,14 @@ fun keyValuePairListOf(map: Map<String, String>) = mutableKeyValuePairList().app
 /**
  * Transforms [KeyValuePairList] into map.
  */
-fun KeyValuePairList.toMap() = items.associate { it.key to it.value }
+fun KeyValuePairList.toMap() =
+    if (items != null) items.associate { it.key to it.value } else emptyMap()
 
 /**
  * Transforms [KeyValuePairList] into a mutable map.
  */
-fun KeyValuePairList.toMutableMap() = items.associateTo(mutableMapOf()) { it.key to it.value }
+fun KeyValuePairList.toMutableMap() =
+    if (items != null) items.associateTo(mutableMapOf()) { it.key to it.value } else mutableMapOf()
 
 /**
  * Creates a [KeyValuePairList] from an iterable container of objects of type [T] with keys
@@ -61,8 +63,8 @@ inline fun <reified T> Iterable<T>.toKeyValuePairList(prefix: String? = null): K
     return KeyValuePairList(
         this.filterNotNull()
             .mapIndexed { idx, value ->
-            KeyValuePair(listOf(keyPrefix, idx).joinToString("."), value.toString())
-        }
+                KeyValuePair(listOf(keyPrefix, idx).joinToString("."), value.toString())
+            }
     )
 }
 

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
@@ -7,6 +7,12 @@ import java.util.Collections
 import org.slf4j.Logger
 import org.slf4j.MDC
 
+/**
+ * Common MDC properties used across corda.
+ */
+const val MDC_CLIENT_ID = "corda.client.id"
+const val MDC_EXTERNAL_EVENT_ID = "corda.external.event.id"
+
 inline fun <T> logElapsedTime(label: String, logger: Logger, body: () -> T): T {
     // Use nanoTime as it's monotonic.
     val now = System.nanoTime()

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
@@ -8,6 +8,11 @@ import org.slf4j.Logger
 import org.slf4j.MDC
 
 /**
+ * Common logging Marker Names
+ */
+const val FLOW_TRACING_MARKER = "FLOW_TRACING"
+
+/**
  * Common MDC properties used across corda.
  */
 const val MDC_CLIENT_ID = "corda.client.id"

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
@@ -11,6 +11,9 @@ import org.slf4j.MDC
  * Common MDC properties used across corda.
  */
 const val MDC_CLIENT_ID = "corda.client.id"
+const val MDC_FLOW_ID = "flow.id"
+const val MDC_VNODE_ID = "vnode.id"
+const val MDC_SESSION_EVENT_ID = "session.event.id"
 const val MDC_EXTERNAL_EVENT_ID = "corda.external.event.id"
 
 inline fun <T> logElapsedTime(label: String, logger: Logger, body: () -> T): T {


### PR DESCRIPTION
Automatically add the 'clientRequestId' to the PlatformProperties so
the original request Id used by the client is always propagated across
workers for an entire flow execution.

- Include 'clientRequestId' within the MDC used by
  'EntityMessageProcessor'.
- Include 'clientRequestId' within the MDC used by 
  'PersistenceRequestProcessor'.
- Include 'clientRequestId' within the MDC used by
  'VerificationRequestProcessor'.
- Include 'clientRequestId' and 'externalEventId' within the MDC used
  by 'CryptoFlowOpsBusProcessor'.
- Update flow external event manager so it registers under INFO log
  level whenever external events are sent or received.
