### PR TITLE
CORE-12769 Move the JSON factory create to try-catch

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -245,16 +245,15 @@ class UtxoPersistenceServiceImpl(
     ): String {
         val jsonMap = factoryStorage.getFactoriesForClass(contractState).associate {
 
-            val jsonToParse = @Suppress("unchecked_cast")
-            (it as ContractStateVaultJsonFactory<ContractState>)
-                .create(contractState, jsonMarshallingService)
-                .ifBlank { "{}" } // Default to "{}" if the provided factory returns empty string to avoid exception
-
             it.stateType.name to try {
+                val jsonToParse = @Suppress("unchecked_cast")
+                (it as ContractStateVaultJsonFactory<ContractState>)
+                    .create(contractState, jsonMarshallingService)
+                    .ifBlank { "{}" } // Default to "{}" if the provided factory returns empty string to avoid exception
                 jsonMarshallingService.parse(jsonToParse, Any::class.java)
             } catch (e: Exception) {
-                log.warn("Error while processing factory for class: ${it.stateType.name}. " +
-                        "JSON that could not be processed: $jsonToParse. Defaulting to empty JSON.")
+                // We can't log the JSON string here because the logic might have failed before we have a JSON
+                log.warn("Error while processing factory for class: ${it.stateType.name}. Defaulting to empty JSON.")
                 jsonMarshallingService.parse("{}", Any::class.java)
             }
         }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -245,15 +245,22 @@ class UtxoPersistenceServiceImpl(
     ): String {
         val jsonMap = factoryStorage.getFactoriesForClass(contractState).associate {
 
-            it.stateType.name to try {
-                val jsonToParse = @Suppress("unchecked_cast")
+            val jsonToParse = try {
+                @Suppress("unchecked_cast")
                 (it as ContractStateVaultJsonFactory<ContractState>)
                     .create(contractState, jsonMarshallingService)
                     .ifBlank { "{}" } // Default to "{}" if the provided factory returns empty string to avoid exception
+            } catch (e: Exception) {
+                // We can't log the JSON string here because the failed before we have a JSON
+                log.warn("Error while processing factory for class: ${it.stateType.name}. Defaulting to empty JSON.")
+                "{}"
+            }
+
+            it.stateType.name to try {
                 jsonMarshallingService.parse(jsonToParse, Any::class.java)
             } catch (e: Exception) {
-                // We can't log the JSON string here because the logic might have failed before we have a JSON
-                log.warn("Error while processing factory for class: ${it.stateType.name}. Defaulting to empty JSON.")
+                log.warn("Error while processing factory for class: ${it.stateType.name}. " +
+                        "JSON that could not be processed: $jsonToParse. Defaulting to empty JSON.")
                 jsonMarshallingService.parse("{}", Any::class.java)
             }
         }


### PR DESCRIPTION
### Problem overview

If the user decides to throw an exception in their `ContractStateVaultJsonFactory` implementation, or return `null` (Java only) then our logic will fill as the calling of the `create()` function is not part of the try-catch block.

### Solution

Move the `ContractStateVaultJsonFactory.create()` call to the try catch block. This way we can't log the JSON in the warn log because we might not even have a JSON. It would be possible to split this into two and have two try-catches. One for `JsonProcessingException` and one for `Exception` in general, it's probably not worth it though.