### PR TITLE
CORE-12748 and CORE-12749: Add Gradle constraint to resolve security vulnerabilities

### DIFF
--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
     implementation "io.javalin:javalin-osgi:$javalinVersion"
+    constraints {
+        implementation("org.eclipse.jetty:jetty-server:$jettyVersion") {
+            because 'Javalin uses an older version of Jetty which is exposed to CVE-2023-26048 and CVE-2023-26049. ' +
+                    'This might be resolved in the future versions of Javalin.'
+        }
+    }
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation ("io.micrometer:micrometer-core:0.1.0-SNAPSHOT") {
         // we don't need these in classpath, so excluding them to reduce dependencies.

--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -25,6 +25,12 @@ dependencies {
     implementation project(":libs:rest:rest-server")
     implementation "net.corda:corda-crypto"
     implementation "io.javalin:javalin-osgi:$javalinVersion"
+    constraints {
+        implementation("org.eclipse.jetty:jetty-server:$jettyVersion") {
+            because 'Javalin uses an older version of Jetty which is exposed to CVE-2023-26048 and CVE-2023-26049. ' +
+                    'This might be resolved in the future versions of Javalin.'
+        }
+    }
     implementation "com.nimbusds:oauth2-oidc-sdk:$nimbusVersion"
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.jcip-annotations:1.0_1"
     implementation "org.eclipse.jetty.websocket:websocket-servlet:$jettyVersion"


### PR DESCRIPTION
CVE-2023-26048 and CVE-2023-26049 on `jetty-server`