### PR TITLE
CORE-12774 - enable junit parallel execution

### DIFF
--- a/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/JavaSerialisationTest.kt
+++ b/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/JavaSerialisationTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InvalidClassException
@@ -12,6 +14,7 @@ import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.io.Serializable
 
+@Execution(ExecutionMode.SAME_THREAD)
 class JavaSerialisationTest {
 
     class Superhero(val name: String) : Serializable

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -115,6 +115,8 @@ tasks.register('smokeTest', Test) {
     testClassesDirs = project.sourceSets["smokeTest"].output.classesDirs
     classpath = project.sourceSets["smokeTest"].runtimeClasspath
 
+    systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
+
     def combinedWorker = project.getProperties().getOrDefault("isCombinedWorker",false)
     systemProperty "restEndpointUrl", project.getProperties().getOrDefault("restEndpointUrl","https://localhost:8888/")
 

--- a/build-benchmark.sh
+++ b/build-benchmark.sh
@@ -24,21 +24,21 @@ set -x
 
 echo "Using ${MAX_WORKERS} workers"
 
-#echo "Building without cache"
-#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache clean"
-#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
-#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
-#
-#echo "Building with cache"
-#gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache clean"
-#gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
-#gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_INCREMENTAL}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
-#
-#echo "(Incremental) Detekt without cache"
-#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache detekt"
+echo "Building without cache"
+gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache clean"
+gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
+gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
+
+echo "Building with cache"
+gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache clean"
+gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
+gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_INCREMENTAL}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
+
+echo "(Incremental) Detekt without cache"
+gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache detekt"
 
 echo "(Incremental) Testing without cache"
 gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache test"
 
-#echo "(Incremental) Testing without cache"
-#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache integrationTest"
+echo "(Incremental) Testing without cache"
+gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache integrationTest"

--- a/build-benchmark.sh
+++ b/build-benchmark.sh
@@ -3,7 +3,7 @@
 #
 MAX_WORKERS=4
 TAG_BENCHMARK="build-benchmark"    # Gradle build scan label prefix - should remain stable
-TAG_EXP="${TAG_BENCHMARK}-0001"    # Gradle build scan label suffix - can be incremented in case we want another set of benchmarks, for example to compare a before/after change
+TAG_EXP="${TAG_BENCHMARK}-0002-dries"    # Gradle build scan label suffix - can be incremented in case we want another set of benchmarks, for example to compare a before/after change
 
 TAG_CACHE="cache"
 TAG_NO_CACHE="no-cache"
@@ -24,21 +24,21 @@ set -x
 
 echo "Using ${MAX_WORKERS} workers"
 
-echo "Building without cache"
-gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache clean"
-gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
-gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
-
-echo "Building with cache"
-gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache clean"
-gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
-gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_INCREMENTAL}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
-
-echo "(Incremental) Detekt without cache"
-gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache detekt"
+#echo "Building without cache"
+#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache clean"
+#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_CLEAN}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
+#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache publishOSGiImage -PmultiArchSupport=false"
+#
+#echo "Building with cache"
+#gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache clean"
+#gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_CLEAN}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
+#gradle_run "${TAG_EXP}-${TAG_CACHE}-${TAG_INCREMENTAL}" "--build-cache publishOSGiImage -PmultiArchSupport=false"
+#
+#echo "(Incremental) Detekt without cache"
+#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache detekt"
 
 echo "(Incremental) Testing without cache"
 gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache test"
 
-echo "(Incremental) Testing without cache"
-gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache integrationTest"
+#echo "(Incremental) Testing without cache"
+#gradle_run "${TAG_EXP}-${TAG_NO_CACHE}-${TAG_INCREMENTAL}" "--no-build-cache integrationTest"

--- a/build.gradle
+++ b/build.gradle
@@ -70,13 +70,6 @@ allprojects {
                 systemProperty 'java.io.tmpdir', buildDir.absolutePath
                 jvmArgs '--illegal-access=deny'
             }
-
-            systemProperties([
-                    // Configuration parameters to execute top-level classes in parallel but methods in same thread
-                    'junit.jupiter.execution.parallel.enabled': 'true',
-                    'junit.jupiter.execution.parallel.mode.default': 'same_thread',
-                    'junit.jupiter.execution.parallel.mode.classes.default': 'concurrent',
-            ])
         }
     }
 
@@ -259,6 +252,15 @@ allprojects {
         }
     }
 
+    tasks.named('test', Test) {
+        systemProperties([
+            // Configuration parameters to execute top-level classes in parallel but methods in same thread
+            'junit.jupiter.execution.parallel.enabled'                 : 'true',
+            'junit.jupiter.execution.parallel.mode.default'            : 'same_thread',
+            'junit.jupiter.execution.parallel.mode.classes.default'    : 'concurrent',
+        ])
+    }
+
     tasks.register('integrationTest', Test) {
         inputs.property('postgresHost', postgresHost)
         inputs.property('postgresDb', postgresDb)
@@ -271,6 +273,8 @@ allprojects {
 
         testClassesDirs = project.sourceSets["integrationTest"].output.classesDirs
         classpath = project.sourceSets["integrationTest"].runtimeClasspath
+
+        systemProperty 'junit.jupiter.execution.parallel.enabled', 'false'
 
         systemProperty 'postgresHost', postgresHost
         systemProperty 'postgresDb', postgresDb

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,13 @@ allprojects {
                 systemProperty 'java.io.tmpdir', buildDir.absolutePath
                 jvmArgs '--illegal-access=deny'
             }
+
+            systemProperties([
+                    // Configuration parameters to execute top-level classes in parallel but methods in same thread
+                    'junit.jupiter.execution.parallel.enabled': 'true',
+                    'junit.jupiter.execution.parallel.mode.default': 'same_thread',
+                    'junit.jupiter.execution.parallel.mode.classes.default': 'concurrent',
+            ])
         }
     }
 

--- a/components/configuration/configuration-rest-resource-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/ConfigRestResourceImplTests.kt
+++ b/components/configuration/configuration-rest-resource-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/ConfigRestResourceImplTests.kt
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -42,6 +44,7 @@ data class TestJsonObject(override val escapedJson: String = "") : JsonObject
 /**
  * Tests of [ConfigRestResourceImpl].
  */
+@Execution(ExecutionMode.SAME_THREAD)
 class ConfigRestResourceImplTests {
     companion object {
         private const val actor = "test_principal"

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/AvroSealedClassTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/AvroSealedClassTest.kt
@@ -7,8 +7,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.kotlin.mock
 
+@Isolated("These tests use logs for behaviour assertion, so can only be run in isolation.")
+@Execution(ExecutionMode.SAME_THREAD)
 class AvroSealedClassTest {
 
     companion object {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/MessageConverterTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/MessageConverterTest.kt
@@ -25,12 +25,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import java.nio.ByteBuffer
 
+@Isolated("These tests use logs for behaviour assertion, so can only be run in isolation.")
+@Execution(ExecutionMode.SAME_THREAD)
 class MessageConverterTest {
 
     companion object {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTrackerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTrackerTest.kt
@@ -28,6 +28,9 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -41,6 +44,8 @@ import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.util.UUID
 
+@Isolated("These tests use logs for behaviour assertion, so can only be run in isolation.")
+@Execution(ExecutionMode.SAME_THREAD)
 class DeliveryTrackerTest {
 
     companion object {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
@@ -29,6 +29,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -42,6 +45,8 @@ import org.mockito.kotlin.whenever
 import java.security.KeyPairGenerator
 import java.util.UUID
 
+@Isolated("These tests use logs for behaviour assertion, so can only be run in isolation.")
+@Execution(ExecutionMode.SAME_THREAD)
 class InMemorySessionReplayerTest {
 
     private companion object {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/ReplaySchedulerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/ReplaySchedulerTest.kt
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
@@ -26,6 +29,8 @@ import org.mockito.kotlin.whenever
 import java.time.Duration
 import java.util.UUID
 
+@Isolated("These tests use logs for behaviour assertion, so can only be run in isolation.")
+@Execution(ExecutionMode.SAME_THREAD)
 class ReplaySchedulerTest {
 
     private companion object {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
@@ -49,6 +49,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
@@ -60,6 +63,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 
+@Isolated("These tests use logs for behaviour assertion, so can only be run in isolation.")
+@Execution(ExecutionMode.SAME_THREAD)
 class InboundMessageProcessorTest {
     companion object {
         private const val SESSION_ID = "Session"

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/OutboundSessionPoolTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/OutboundSessionPoolTest.kt
@@ -6,9 +6,14 @@ import net.corda.p2p.linkmanager.utilities.LoggingInterceptor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@Isolated("These tests use logs for behaviour assertion, so can only be run in isolation.")
+@Execution(ExecutionMode.SAME_THREAD)
 class OutboundSessionPoolTest {
 
     companion object {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -76,6 +76,9 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
@@ -99,6 +102,8 @@ import java.time.Instant
 import java.util.Collections
 import java.util.concurrent.CompletableFuture
 
+@Isolated("These tests use logs for behaviour assertion, so can only be run in isolation.")
+@Execution(ExecutionMode.SAME_THREAD)
 class SessionManagerTest {
 
     private companion object {

--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/subscription/MemberListProcessorTest.kt
@@ -1,5 +1,6 @@
 package net.corda.membership.impl.read.subscription
 
+import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.impl.converter.PublicKeyConverter
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
@@ -13,6 +14,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PEND
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
@@ -26,15 +28,13 @@ import net.corda.membership.lib.impl.converter.EndpointInfoConverter
 import net.corda.membership.lib.impl.converter.MemberNotaryDetailsConverter
 import net.corda.messaging.api.records.Record
 import net.corda.test.util.time.TestClock
-import net.corda.crypto.cipher.suite.CipherSchemeMetadata
-import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
@@ -46,128 +46,129 @@ import java.time.Instant
 
 class MemberListProcessorTest {
     companion object {
-        private val clock = TestClock(Instant.ofEpochSecond(100))
-        private val keyEncodingService: CipherSchemeMetadata = mock()
-        private val knownKey: PublicKey = mock()
         private const val knownKeyAsString = "12345"
-        private val modifiedTime = clock.instant()
-        private val endpointInfoFactory: EndpointInfoFactory = mock {
-            on { create(any(), any()) } doAnswer { invocation ->
-                mock {
-                    on { this.url } doReturn invocation.getArgument(0)
-                    on { this.protocolVersion } doReturn invocation.getArgument(1)
-                }
+    }
+
+    private val clock = TestClock(Instant.ofEpochSecond(100))
+    private val keyEncodingService: CipherSchemeMetadata = mock()
+    private val knownKey: PublicKey = mock()
+
+    private val modifiedTime = clock.instant()
+    private val endpointInfoFactory: EndpointInfoFactory = mock {
+        on { create(any(), any()) } doAnswer { invocation ->
+            mock {
+                on { this.url } doReturn invocation.getArgument(0)
+                on { this.protocolVersion } doReturn invocation.getArgument(1)
             }
         }
-        private val endpoints = listOf(
-            endpointInfoFactory.create("https://corda5.r3.com:10000"),
-            endpointInfoFactory.create("https://corda5.r3.com:10001", 10)
+    }
+    private val endpoints = listOf(
+        endpointInfoFactory.create("https://corda5.r3.com:10000"),
+        endpointInfoFactory.create("https://corda5.r3.com:10001", 10)
+    )
+    private val ledgerKeys = listOf(knownKey, knownKey)
+    private lateinit var memberInfoFactory: MemberInfoFactory
+    private val converters = listOf(
+        EndpointInfoConverter(),
+        MemberNotaryDetailsConverter(keyEncodingService),
+        PublicKeyConverter(keyEncodingService),
+    )
+
+    private lateinit var alice: MemberInfo
+    private lateinit var aliceIdentity: HoldingIdentity
+    private lateinit var bob: MemberInfo
+    private lateinit var bobIdentity: HoldingIdentity
+    private lateinit var charlie: MemberInfo
+    private lateinit var charlieIdentity: HoldingIdentity
+
+    private lateinit var memberListProcessor: MemberListProcessor
+    private lateinit var memberListFromTopic: Map<String, PersistentMemberInfo>
+
+    private lateinit var membershipGroupReadCache: MembershipGroupReadCache
+
+    @Suppress("SpreadOperator")
+    private fun createTestMemberInfo(x500Name: String, status: String): MemberInfo = memberInfoFactory.create(
+        sortedMapOf(
+            PARTY_NAME to x500Name,
+            String.format(PARTY_SESSION_KEYS, 0) to knownKeyAsString,
+            GROUP_ID to "DEFAULT_MEMBER_GROUP_ID",
+            *convertPublicKeys().toTypedArray(),
+            *convertEndpoints().toTypedArray(),
+            SOFTWARE_VERSION to "5.0.0",
+            PLATFORM_VERSION to "5000",
+        ),
+        sortedMapOf(
+            STATUS to status,
+            MODIFIED_TIME to modifiedTime.toString(),
+            SERIAL to "1",
         )
-        private val ledgerKeys = listOf(knownKey, knownKey)
-        private lateinit var memberInfoFactory: MemberInfoFactory
-        private val converters = listOf(
-            EndpointInfoConverter(),
-            MemberNotaryDetailsConverter(keyEncodingService),
-            PublicKeyConverter(keyEncodingService),
-        )
 
-        private lateinit var alice: MemberInfo
-        private lateinit var aliceIdentity: HoldingIdentity
-        private lateinit var bob: MemberInfo
-        private lateinit var bobIdentity: HoldingIdentity
-        private lateinit var charlie: MemberInfo
-        private lateinit var charlieIdentity: HoldingIdentity
+    )
 
-        private lateinit var memberListProcessor: MemberListProcessor
-        private lateinit var memberListFromTopic: Map<String, PersistentMemberInfo>
-
-        private lateinit var membershipGroupReadCache: MembershipGroupReadCache
-
-        @Suppress("SpreadOperator")
-        private fun createTestMemberInfo(x500Name: String, status: String): MemberInfo = memberInfoFactory.create(
-            sortedMapOf(
-                PARTY_NAME to x500Name,
-                String.format(PARTY_SESSION_KEYS, 0) to knownKeyAsString,
-                GROUP_ID to "DEFAULT_MEMBER_GROUP_ID",
-                *convertPublicKeys().toTypedArray(),
-                *convertEndpoints().toTypedArray(),
-                SOFTWARE_VERSION to "5.0.0",
-                PLATFORM_VERSION to "5000",
-            ),
-            sortedMapOf(
-                STATUS to status,
-                MODIFIED_TIME to modifiedTime.toString(),
-                SERIAL to "1",
-            )
-
-        )
-
-        private fun convertToTestTopicData(
-            memberInfoList: List<MemberInfo>,
-            selfOwned: Boolean = false
-        ): Map<String, PersistentMemberInfo> {
-            val topicData = mutableMapOf<String, PersistentMemberInfo>()
-            memberInfoList.forEach { member ->
-                val holdingIdentity = HoldingIdentity(member.name, member.groupId)
-                if (!selfOwned && holdingIdentity != aliceIdentity) {
-                    topicData[aliceIdentity.shortHash.value + holdingIdentity.shortHash.value] = PersistentMemberInfo(
-                        aliceIdentity.toAvro(),
-                        member.memberProvidedContext.toAvro(),
-                        member.mgmProvidedContext.toAvro()
-                    )
-                }
-                topicData[holdingIdentity.shortHash.value] = PersistentMemberInfo(
-                    holdingIdentity.toAvro(),
+    private fun convertToTestTopicData(
+        memberInfoList: List<MemberInfo>,
+        selfOwned: Boolean = false,
+    ): Map<String, PersistentMemberInfo> {
+        val topicData = mutableMapOf<String, PersistentMemberInfo>()
+        memberInfoList.forEach { member ->
+            val holdingIdentity = HoldingIdentity(member.name, member.groupId)
+            if (!selfOwned && holdingIdentity != aliceIdentity) {
+                topicData[aliceIdentity.shortHash.value + holdingIdentity.shortHash.value] = PersistentMemberInfo(
+                    aliceIdentity.toAvro(),
                     member.memberProvidedContext.toAvro(),
                     member.mgmProvidedContext.toAvro()
                 )
             }
-            return topicData
+            topicData[holdingIdentity.shortHash.value] = PersistentMemberInfo(
+                holdingIdentity.toAvro(),
+                member.memberProvidedContext.toAvro(),
+                member.mgmProvidedContext.toAvro()
+            )
         }
+        return topicData
+    }
 
-        private fun convertEndpoints(): List<Pair<String, String>> {
-            val result = mutableListOf<Pair<String, String>>()
-            for (index in endpoints.indices) {
-                result.add(
-                    Pair(
-                        String.format(URL_KEY, index),
-                        endpoints[index].url
-                    )
+    private fun convertEndpoints(): List<Pair<String, String>> {
+        val result = mutableListOf<Pair<String, String>>()
+        for (index in endpoints.indices) {
+            result.add(
+                Pair(
+                    String.format(URL_KEY, index),
+                    endpoints[index].url
                 )
-                result.add(
-                    Pair(
-                        String.format(PROTOCOL_VERSION, index),
-                        endpoints[index].protocolVersion.toString()
-                    )
+            )
+            result.add(
+                Pair(
+                    String.format(PROTOCOL_VERSION, index),
+                    endpoints[index].protocolVersion.toString()
                 )
-            }
-            return result
+            )
+        }
+        return result
+    }
+
+    private fun convertPublicKeys(): List<Pair<String, String>> =
+        ledgerKeys.mapIndexed { index, ledgerKey ->
+            String.format(
+                LEDGER_KEYS_KEY,
+                index
+            ) to keyEncodingService.encodeAsString(ledgerKey)
         }
 
-        private fun convertPublicKeys(): List<Pair<String, String>> =
-            ledgerKeys.mapIndexed { index, ledgerKey ->
-                String.format(
-                    LEDGER_KEYS_KEY,
-                    index
-                ) to keyEncodingService.encodeAsString(ledgerKey)
-            }
-
-        @JvmStatic
-        @BeforeAll
-        fun setUp() {
-            memberInfoFactory = MemberInfoFactoryImpl(LayeredPropertyMapMocks.createFactory(converters))
-            membershipGroupReadCache = MembershipGroupReadCache.Impl()
-            memberListProcessor = MemberListProcessor(membershipGroupReadCache, memberInfoFactory)
-            whenever(keyEncodingService.decodePublicKey(knownKeyAsString)).thenReturn(knownKey)
-            whenever(keyEncodingService.encodeAsString(knownKey)).thenReturn(knownKeyAsString)
-            alice = createTestMemberInfo("O=Alice,L=London,C=GB", MEMBER_STATUS_PENDING)
-            aliceIdentity = HoldingIdentity(alice.name, alice.groupId)
-            bob = createTestMemberInfo("O=Bob,L=London,C=GB", MEMBER_STATUS_ACTIVE)
-            bobIdentity = HoldingIdentity(bob.name, bob.groupId)
-            charlie = createTestMemberInfo("O=Charlie,L=London,C=GB", MEMBER_STATUS_SUSPENDED)
-            charlieIdentity = HoldingIdentity(charlie.name, charlie.groupId)
-            memberListFromTopic = convertToTestTopicData(listOf(alice, bob, charlie))
-        }
+    @BeforeEach
+    fun setUp() {
+        memberInfoFactory = MemberInfoFactoryImpl(LayeredPropertyMapMocks.createFactory(converters))
+        membershipGroupReadCache = MembershipGroupReadCache.Impl()
+        memberListProcessor = MemberListProcessor(membershipGroupReadCache, memberInfoFactory)
+        whenever(keyEncodingService.decodePublicKey(knownKeyAsString)).thenReturn(knownKey)
+        whenever(keyEncodingService.encodeAsString(knownKey)).thenReturn(knownKeyAsString)
+        alice = createTestMemberInfo("O=Alice,L=London,C=GB", MEMBER_STATUS_PENDING)
+        aliceIdentity = HoldingIdentity(alice.name, alice.groupId)
+        bob = createTestMemberInfo("O=Bob,L=London,C=GB", MEMBER_STATUS_ACTIVE)
+        bobIdentity = HoldingIdentity(bob.name, bob.groupId)
+        charlie = createTestMemberInfo("O=Charlie,L=London,C=GB", MEMBER_STATUS_SUSPENDED)
+        charlieIdentity = HoldingIdentity(charlie.name, charlie.groupId)
+        memberListFromTopic = convertToTestTopicData(listOf(alice, bob, charlie))
     }
 
     @AfterEach

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -107,6 +107,8 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito
@@ -131,6 +133,7 @@ import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import javax.security.auth.x500.X500Principal
 
+@Execution(ExecutionMode.SAME_THREAD)
 class DynamicMemberRegistrationServiceTest {
     private companion object {
         const val SESSION_KEY = "1234"

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextCacheTest.kt
@@ -14,6 +14,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
@@ -26,6 +29,8 @@ import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
 @Suppress("ExplicitGarbageCollectionCall")
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated
 class SandboxGroupContextCacheTest {
     private companion object {
         private const val TIMEOUT = 60L

--- a/libs/crypto/delegated-signing/src/test/kotlin/net/corda/crypto/delegated/signing/DelegatedSignatureTest.kt
+++ b/libs/crypto/delegated-signing/src/test/kotlin/net/corda/crypto/delegated/signing/DelegatedSignatureTest.kt
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
@@ -21,6 +24,8 @@ import java.security.Security
 import java.security.Signature
 import java.security.spec.AlgorithmParameterSpec
 
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated
 class DelegatedSignatureTest {
     companion object {
         private const val name = "Test-name"

--- a/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionContractVerifierTest.kt
+++ b/libs/ledger/ledger-utxo-transaction-verifier/src/test/kotlin/net/corda/ledger/utxo/transaction/verifier/UtxoLedgerTransactionContractVerifierTest.kt
@@ -18,12 +18,15 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.security.PublicKey
 
+@Execution(ExecutionMode.SAME_THREAD)
 class UtxoLedgerTransactionContractVerifierTest {
 
     private companion object {

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
@@ -15,6 +15,8 @@ import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.mockito.ArgumentCaptor
 import org.mockito.Mock
 import org.mockito.kotlin.any
@@ -25,6 +27,7 @@ import org.mockito.kotlin.whenever
 import java.time.Duration
 import java.time.Instant
 
+@Execution(ExecutionMode.SAME_THREAD)
 internal class DBCordaConsumerImplTest {
 
     companion object {

--- a/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationServiceTest.kt
+++ b/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/RbacBasicAuthenticationServiceTest.kt
@@ -16,9 +16,6 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionEntityTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoTransactionEntityTest.kt
@@ -10,8 +10,11 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import java.time.Instant
 
+@Execution(ExecutionMode.SAME_THREAD)
 class UtxoTransactionEntityTest {
 
     private val member = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSessionTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSessionTest.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeoutException
 import kotlin.concurrent.thread
 
 
-@Timeout(value = 5, unit = TimeUnit.SECONDS)
+@Timeout(value = 15, unit = TimeUnit.SECONDS)
 class BlockingQueueFlowSessionTest {
 
     private val sender = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/persistence/DbPersistenceServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/persistence/DbPersistenceServiceTest.kt
@@ -7,8 +7,11 @@ import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import java.util.UUID
 
+@Execution(ExecutionMode.SAME_THREAD)
 class DbPersistenceServiceTest {
 
     private val member = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/serialization/BaseSerializationServiceTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/serialization/BaseSerializationServiceTest.kt
@@ -8,8 +8,10 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.instanceOf
 import org.hamcrest.Matchers.`is`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Isolated
 import java.security.PublicKey
 
+@Isolated
 class BaseSerializationServiceTest {
 
     companion object {

--- a/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/rpc/RPCTopicServiceImplTest.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/rpc/RPCTopicServiceImplTest.kt
@@ -64,7 +64,7 @@ class RPCTopicServiceImplTest {
     }
 
     @Test
-    @Timeout(1)
+    @Timeout(3)
     fun `requests succeed when listeners handles requests`() {
         val executorService = Executors.newSingleThreadExecutor()
         val service = RPCTopicServiceImpl(executorService)
@@ -80,7 +80,7 @@ class RPCTopicServiceImplTest {
     }
 
     @Test
-    @Timeout(1)
+    @Timeout(3)
     fun `requests failed when listeners cancel`() {
         val executorService = Executors.newSingleThreadExecutor()
         val service = RPCTopicServiceImpl(executorService)
@@ -97,7 +97,7 @@ class RPCTopicServiceImplTest {
     }
 
     @Test
-    @Timeout(1)
+    @Timeout(3)
     fun `requests failed when listeners complete with exception`() {
         val executorService = Executors.newSingleThreadExecutor()
         val service = RPCTopicServiceImpl(executorService)
@@ -114,7 +114,7 @@ class RPCTopicServiceImplTest {
     }
 
     @Test
-    @Timeout(1)
+    @Timeout(3)
     fun `requests failed when listeners throw an exception`() {
         val executorService = Executors.newSingleThreadExecutor()
         val service = RPCTopicServiceImpl(executorService)
@@ -131,7 +131,7 @@ class RPCTopicServiceImplTest {
     }
 
     @Test
-    @Timeout(1)
+    @Timeout(3)
     fun `requests on topics with multiple listeners are distributed on round-robin basis`() {
         val executorService = Executors.newSingleThreadExecutor()
         val service = RPCTopicServiceImpl(executorService)
@@ -166,7 +166,7 @@ class RPCTopicServiceImplTest {
     }
 
     @Test
-    @Timeout(1)
+    @Timeout(3)
     fun `when listener removed from a topic work distributed to remaining`() {
         val executorService = Executors.newSingleThreadExecutor()
         val service = RPCTopicServiceImpl(executorService)

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPlugin.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPlugin.kt
@@ -3,8 +3,13 @@ package net.corda.cli.plugin.initialconfig
 import com.github.stefanbirkner.systemlambda.SystemLambda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import picocli.CommandLine
 
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated("Tests using tapSystemErrNormalized cannot run in parallel.")
 class TestInitialConfigPlugin {
 
     @Test

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -16,9 +16,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import picocli.CommandLine
 
 @Execution(ExecutionMode.SAME_THREAD)
+@Isolated("Tests using tapSystemErrNormalized cannot run in parallel.")
 class TestInitialConfigPluginCrypto {
     @Test
     fun `Should output missing options`() {

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -14,8 +14,11 @@ import net.corda.libs.configuration.secret.EncryptionSecretsServiceFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import picocli.CommandLine
 
+@Execution(ExecutionMode.SAME_THREAD)
 class TestInitialConfigPluginCrypto {
     @Test
     fun `Should output missing options`() {

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
@@ -3,8 +3,13 @@ package net.corda.cli.plugin.initialconfig
 import com.github.stefanbirkner.systemlambda.SystemLambda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import picocli.CommandLine
 
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated("Tests using tapSystemErrNormalized cannot run in parallel.")
 class TestInitialConfigPluginDb {
     @Test
     fun testDbConfigCreationMissingOptions() {

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginUser.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginUser.kt
@@ -4,8 +4,13 @@ import com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemErrNormalized
 import com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import picocli.CommandLine
 
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated("Tests using tapSystemOutNormalized cannot run in parallel.")
 class TestInitialConfigPluginUser {
 
     @Test

--- a/tools/plugins/mgm/src/test/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicyTest.kt
+++ b/tools/plugins/mgm/src/test/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicyTest.kt
@@ -13,11 +13,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import picocli.CommandLine
 import java.nio.file.Files
 import java.nio.file.Path
 
 @Execution(ExecutionMode.SAME_THREAD)
+@Isolated("Tests using tapSystemErrAndOutNormalized cannot run in parallel.")
 class GenerateGroupPolicyTest {
 
     @Test

--- a/tools/plugins/mgm/src/test/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicyTest.kt
+++ b/tools/plugins/mgm/src/test/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicyTest.kt
@@ -172,7 +172,8 @@ class GenerateGroupPolicyTest {
     }
 
     @Test
-    fun `YAML file with 'memberNames' is correctly parsed to generate group policy with specified member information`(@TempDir tempDir: Path) {
+    fun `YAML file with 'memberNames' is correctly parsed to generate group policy with specified member information`(
+        @TempDir tempDir: Path) {
         val app = GenerateGroupPolicy()
         val filePath = Files.createFile(tempDir.resolve("src.yaml"))
         filePath.toFile().writeText(

--- a/tools/plugins/mgm/src/test/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicyTest.kt
+++ b/tools/plugins/mgm/src/test/kotlin/net/corda/cli/plugins/mgm/GenerateGroupPolicyTest.kt
@@ -11,14 +11,14 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import picocli.CommandLine
 import java.nio.file.Files
 import java.nio.file.Path
 
+@Execution(ExecutionMode.SAME_THREAD)
 class GenerateGroupPolicyTest {
-
-    @TempDir
-    lateinit var tempDir: Path
 
     @Test
     fun `command generates and prints GroupPolicy to output as correctly formatted JSON`() {
@@ -105,6 +105,7 @@ class GenerateGroupPolicyTest {
                 "--endpoint-protocol=5"
             )
         }.apply {
+            println(this)
             memberList(this).forEach {
                 assertTrue(it["name"].asText().contains("C=GB, L=London, O=Member"))
                 assertEquals("ACTIVE", it["memberStatus"].asText())
@@ -126,7 +127,7 @@ class GenerateGroupPolicyTest {
     }
 
     @Test
-    fun `if file type is not JSON or YAML (YML), exception is thrown`() {
+    fun `if file type is not JSON or YAML (YML), exception is thrown`(@TempDir tempDir: Path) {
         val app = GenerateGroupPolicy()
         val filePath = Files.createFile(tempDir.resolve("src.txt"))
         tapSystemErrAndOutNormalized {
@@ -137,7 +138,7 @@ class GenerateGroupPolicyTest {
     }
 
     @Test
-    fun `JSON file with 'members' is correctly parsed to generate group policy with specified member information`() {
+    fun `JSON file with 'members' is correctly parsed to generate group policy with specified member information`(@TempDir tempDir: Path) {
         val app = GenerateGroupPolicy()
         val filePath = Files.createFile(tempDir.resolve("src.json"))
         filePath.toFile().writeText(
@@ -169,7 +170,7 @@ class GenerateGroupPolicyTest {
     }
 
     @Test
-    fun `YAML file with 'memberNames' is correctly parsed to generate group policy with specified member information`() {
+    fun `YAML file with 'memberNames' is correctly parsed to generate group policy with specified member information`(@TempDir tempDir: Path) {
         val app = GenerateGroupPolicy()
         val filePath = Files.createFile(tempDir.resolve("src.yaml"))
         filePath.toFile().writeText(
@@ -191,7 +192,7 @@ class GenerateGroupPolicyTest {
     }
 
     @Test
-    fun `exception is thrown when the input file has both 'members' and 'memberNames' blocks`() {
+    fun `exception is thrown when the input file has both 'members' and 'memberNames' blocks`(@TempDir tempDir: Path) {
         val app = GenerateGroupPolicy()
         val filePath = Files.createFile(tempDir.resolve("src.yaml"))
         filePath.toFile().writeText(
@@ -217,7 +218,7 @@ class GenerateGroupPolicyTest {
     }
 
     @Test
-    fun `exception is thrown when the input file is empty`() {
+    fun `exception is thrown when the input file is empty`(@TempDir tempDir: Path) {
         val app = GenerateGroupPolicy()
         val filePath = Files.createFile(tempDir.resolve("src.yaml"))
 
@@ -229,7 +230,7 @@ class GenerateGroupPolicyTest {
     }
 
     @Test
-    fun `exception is thrown if file specifies 'members' or 'memberNames' but no endpoint information`() {
+    fun `exception is thrown if file specifies 'members' or 'memberNames' but no endpoint information`(@TempDir tempDir: Path) {
         val app = GenerateGroupPolicy()
         val filePath1 = Files.createFile(tempDir.resolve("src.yaml"))
         filePath1.toFile().writeText("memberNames: [\"C=GB, L=London, O=Member1\", \"C=GB, L=London, O=Member2\"]")

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import picocli.CommandLine
 import picocli.CommandLine.Help
 import java.io.ByteArrayInputStream
@@ -29,6 +30,7 @@ import java.util.jar.JarEntry
 import java.util.jar.JarInputStream
 
 @Execution(ExecutionMode.SAME_THREAD)
+@Isolated("Tests using tapSystemErrNormalized cannot run in parallel.")
 class CreateCpiTest {
     companion object {
         const val CPI_FILE_NAME = "output.cpi"

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import picocli.CommandLine
 import picocli.CommandLine.Help
 import java.io.ByteArrayInputStream
@@ -26,6 +28,7 @@ import java.nio.file.StandardOpenOption
 import java.util.jar.JarEntry
 import java.util.jar.JarInputStream
 
+@Execution(ExecutionMode.SAME_THREAD)
 class CreateCpiTest {
     companion object {
         const val CPI_FILE_NAME = "output.cpi"

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
@@ -18,10 +18,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import picocli.CommandLine
 import java.io.ByteArrayInputStream
 import java.io.File
 
+@Execution(ExecutionMode.SAME_THREAD)
 class CreateCpiV2Test {
 
     companion object {

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
@@ -24,9 +24,6 @@ import java.io.File
 
 class CreateCpiV2Test {
 
-    @TempDir
-    lateinit var tempDir: Path
-
     companion object {
 
         // Share cpb across all tests since we only read it and not modify it to save disk writes
@@ -76,7 +73,7 @@ class CreateCpiV2Test {
     }
 
     @Test
-    fun `cpi v2 contains cpb, manifest, signature files and GroupPolicy file`() {
+    fun `cpi v2 contains cpb, manifest, signature files and GroupPolicy file`(@TempDir tempDir: Path) {
         val outputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
         CommandLine(CreateCpiV2()).execute (
             "--cpb=${cpbPath}",
@@ -105,7 +102,7 @@ class CreateCpiV2Test {
     }
 
     @Test
-    fun `cpi v2 contains manifest attributes`() {
+    fun `cpi v2 contains manifest attributes`(@TempDir tempDir: Path) {
         val cpiOutputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
         CommandLine(CreateCpiV2()).execute (
             "--cpb=${cpbPath}",
@@ -132,7 +129,7 @@ class CreateCpiV2Test {
     }
 
     @Test
-    fun `cpi v2 can create CPI with only Group Policy and no CPB`() {
+    fun `cpi v2 can create CPI with only Group Policy and no CPB`(@TempDir tempDir: Path) {
         val cpiOutputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
         val errText = TestUtils.captureStdErr {
             CommandLine(CreateCpiV2()).execute (
@@ -174,7 +171,7 @@ class CreateCpiV2Test {
     }
 
     @Test
-    fun `cpi create tool handles group policy passed through standard input`() {
+    fun `cpi create tool handles group policy passed through standard input`(@TempDir tempDir: Path) {
         val outputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
         val groupPolicyString = File(testGroupPolicy.toString()).readText(Charsets.UTF_8)
 
@@ -214,7 +211,7 @@ class CreateCpiV2Test {
     }
 
     @Test
-    fun `cpi create tool aborts if its not a cpb before packing it into a cpi`() {
+    fun `cpi create tool aborts if its not a cpb before packing it into a cpi`(@TempDir tempDir: Path) {
         // Attempt to pack a Cpk into a Cpi - should fail since it's not a Cpb
         val cpkBuilder = TestCpkV2Builder()
         val cpkStream = cpkBuilder
@@ -253,7 +250,7 @@ class CreateCpiV2Test {
     }
 
     @Test
-    fun `cpi create tool aborts if its group policy is invalid`() {
+    fun `cpi create tool aborts if its group policy is invalid`(@TempDir tempDir: Path) {
         val outputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
 
         val errText = TestUtils.captureStdErr {

--- a/tools/plugins/secret-config/src/test/kotlin/net/corda/cli/plugin/secretconfig/TestSecretConfigPlugin.kt
+++ b/tools/plugins/secret-config/src/test/kotlin/net/corda/cli/plugin/secretconfig/TestSecretConfigPlugin.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.jupiter.api.parallel.Isolated
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -13,6 +14,7 @@ import picocli.CommandLine
 import java.util.stream.Stream
 
 @Execution(ExecutionMode.SAME_THREAD)
+@Isolated("Tests using tapSystemErrNormalized cannot run in parallel.")
 class TestSecretConfigPlugin {
     @Test
     fun `create CORDA type secret Config`() {

--- a/tools/plugins/secret-config/src/test/kotlin/net/corda/cli/plugin/secretconfig/TestSecretConfigPlugin.kt
+++ b/tools/plugins/secret-config/src/test/kotlin/net/corda/cli/plugin/secretconfig/TestSecretConfigPlugin.kt
@@ -4,12 +4,15 @@ import com.github.stefanbirkner.systemlambda.SystemLambda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import picocli.CommandLine
 import java.util.stream.Stream
 
+@Execution(ExecutionMode.SAME_THREAD)
 class TestSecretConfigPlugin {
     @Test
     fun `create CORDA type secret Config`() {


### PR DESCRIPTION
Enable parallel using the JUnit support for this. 

Some unit tests did not support this because they assume each test class is instantiated from new whenever any test is run. These were fixed by either fixing up the test (when that was obvious), or forcing all tests in a class to run in a sequence, or marking the test class as isolated, or a combination of the above.

Full details: https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4449927237/Dev+Friction+L+D+Event+-+Parallelising+JUnit+Tests