### PR TITLE
CORE-12788 do not throw a platform exception while already processing the result of a platform exception.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
@@ -105,7 +105,7 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
             if (expiryTime < now) {
                 val msg = "[${context.checkpoint.holdingIdentity.x500Name}] has failed to create a flow with counterparty: " +
                         "[${counterparty}] as the recipient doesn't exist in the network."
-                if (!doesCheckpointExist) {
+                if (doesCheckpointExist) {
                     context.checkpoint.putSessionState(sessionManager.errorSession(sessionState))
                     log.debug { "$msg. Throwing FlowPlatformException" }
                     throw FlowPlatformException(msg)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -2,7 +2,6 @@ package net.corda.flow.pipeline.impl
 
 import java.time.Instant
 import java.util.stream.Stream
-import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.mapper.FlowMapperEvent
@@ -341,26 +340,6 @@ class FlowGlobalPostProcessorImplTest {
             lastReceivedMessageTime = Instant.now().minusSeconds(86400)
         }
 
-        whenever(checkpoint.doesExist).thenReturn(false)
-        whenever(checkpoint.sessions).thenReturn(listOf(sessionState1, sessionState2, sessionState3))
-        whenever(checkpoint.holdingIdentity).thenReturn(HoldingIdentity(ALICE_X500_NAME, ""))
-
-        assertDoesNotThrow {
-            flowGlobalPostProcessor.postProcess(testContext)
-        }
-
-        verify(sessionManager, times(1)).errorSession(any())
-        verify(checkpoint, times(0)).putSessionState(any())
-    }
-
-    @Test
-    fun `Don't raise a error if counterparties cannot be confirmed within timeout window but there is already a pending platform error`() {
-        sessionState3.apply {
-            sessionStartTime = Instant.now().minusSeconds(86400)
-            lastReceivedMessageTime = Instant.now().minusSeconds(86400)
-        }
-
-        whenever(checkpoint.pendingPlatformError).thenReturn(ExceptionEnvelope())
         whenever(checkpoint.doesExist).thenReturn(false)
         whenever(checkpoint.sessions).thenReturn(listOf(sessionState1, sessionState2, sessionState3))
         whenever(checkpoint.holdingIdentity).thenReturn(HoldingIdentity(ALICE_X500_NAME, ""))

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -319,6 +319,7 @@ class FlowGlobalPostProcessorImplTest {
         assertThrows(FlowPlatformException::class.java) {
             flowGlobalPostProcessor.postProcess(testContext)
         }
+        verify(sessionManager, times(1)).errorSession(any())
     }
 
     @Test
@@ -353,6 +354,6 @@ class FlowGlobalPostProcessorImplTest {
             flowGlobalPostProcessor.postProcess(testContext)
         }
 
-        verify(sessionManager, times(1)).errorSession(any())
+        verify(sessionManager, never()).errorSession(any())
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -350,11 +350,9 @@ class FlowGlobalPostProcessorImplTest {
         whenever(checkpoint.sessions).thenReturn(listOf(sessionState1, sessionState2, sessionState3))
         whenever(checkpoint.holdingIdentity).thenReturn(HoldingIdentity(ALICE_X500_NAME, ""))
 
-        assertThrows(FlowPlatformException::class.java) {
-            flowGlobalPostProcessor.postProcess(testContext)
-        }
+        flowGlobalPostProcessor.postProcess(testContext)
         verify(sessionManager, times(0)).errorSession(any())
-        verify(checkpoint, times(1)).putSessionState(any())
+        verify(checkpoint, times(3)).putSessionState(any())
     }
 
     @Test


### PR DESCRIPTION
- Only validate that counterparty exists for sessions which are not in a terminated state
- Only update the checkpoint session state via `putSessionState()` when the checkpoint is not marked for deletion 

I think this pr highlights again that the way we handle session state updates is a bit confusing and requires refactoring. The `FlowCheckpoint` wrapper object manages the state of avro `Checkpoint`s. We deep copy the `FlowState` and assign sessionStates to a map. The `Flowcheckpoint` has a method for getting and updating the sessionStates to manage them and apply some validation to their updates.
However, The `SessionManager` updates the `SessionState`  objects in-situ. This means the flow engine can call `flowCheckpoint.getSessionState()`, perform an operation on it such as `updatedState = sessionManager.getMessagestoSend(sessionState)`, then decide not to call `flowCheckpoint.putSessionState(updatedState)`, but it will still get saved to the topic when `flowCheckpoint.toAvro()` is called. I will raise a JIRA to address this. 

As a consequence of the above point, this means the logic to verify that a couterparty exists will not be executed on all wakeups for sessions which have sent no data. This is because the getMessagesToSend() has updated the timestamps on SessionEvents based on the messageSesendWindow despite the messages not being sent (due to counterparty not being found), This may not be an issue as the counterparty validation window is set to be more than 2x larger than the resend window, but it may cause issues in the future.