### PR TITLE
CORE-11704 Drop capabilities and use read-only FS

### DIFF
--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
@@ -34,6 +34,7 @@ class WorkerHelpers {
     companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val BOOT_CONFIG_PATH = "net/corda/applications/workers/workercommon/boot/corda.boot.json"
+        private val SENSITIVE_ARGS = setOf("-ddatabase.pass", "-spassphrase", "-msasl.jaas.config")
 
         /**
          * Parses the [args] into the [params].
@@ -201,11 +202,9 @@ class WorkerHelpers {
 
             val arguments = processInfo.arguments()
             if (arguments.isPresent) {
-                arguments.get().forEachIndexed { i, arg ->
-                    if ("-ddatabase.pass" !in arg && "-spassphrase" !in arg) {
-                        info("argument $i, $arg")
-                    }
-                }
+                arguments.get().map { arg -> SENSITIVE_ARGS.firstOrNull { arg.trim().startsWith(it) }
+                    .let { prefix -> if (prefix == null) arg else "$prefix=[REDACTED]" }
+                }.forEachIndexed { i, redactedArg -> info("argument $i, $redactedArg") }
             } else {
                 info("arguments: Null")
             }

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -255,8 +255,8 @@ abstract class DeployableContainerBuilder extends DefaultTask {
             builder.setEntrypoint(
                     "/bin/sh",
                     "-c",
-                    "exec java ${javaArgs.join(" ")} -jar " + CONTAINER_LOCATION + entryName + ".jar \$@",
-                    "\$@"
+                    "exec java ${javaArgs.join(" ")} -jar " + CONTAINER_LOCATION + entryName + ".jar \"\$@\"",
+                    "\"\$@\""
             )
         }
         if (!environment.get().empty) {

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -71,6 +71,10 @@ securityContext:
   runAsUser: 10001
   runAsGroup: 10002
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - "ALL"
 {{- end }}
 {{- end }}
 

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -175,7 +175,7 @@ spec:
               {{- if .debug.enabled }}
                 -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend={{ if .debug.suspend }}y{{ else }}n{{ end }}
               {{- end -}}
-              {{- if  .profiling.enabled }}
+              {{- if .profiling.enabled }}
                 -agentpath:/opt/override/libyjpagent.so=exceptions=disable,port=10045,listen=all,dir=/dumps/profile/snapshots,logdir=/dumps/profile/logs
               {{- end -}}
               {{- if $.Values.heapDumpOnOutOfMemoryError }}
@@ -184,9 +184,6 @@ spec:
               {{- end -}}
               {{- if .verifyInstrumentation }}
                 -Dco.paralleluniverse.fibers.verifyInstrumentation=true
-              {{- end -}}
-              {{- if $.Values.kafka.sasl.enabled }}
-                -Djava.security.auth.login.config=/etc/config/jaas.conf
               {{- end }}
           - name: LOG4J_CONFIG_FILE
             {{- if .logging.override }}
@@ -198,12 +195,51 @@ spec:
             value: {{ $.Values.logging.format | quote }}
           - name: CONSOLE_LOG_LEVEL
             value: {{ .logging.level | default $.Values.logging.level | quote }}
+          {{- if $.Values.kafka.sasl.enabled }}
+            {{- $username := .kafka.sasl.username }}
+          - name: SASL_USERNAME
+            {{- if $username.valueFrom.secretKeyRef.name }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $username.valueFrom.secretKeyRef.name | quote }}
+                key: {{ required (printf "Must specify %s.kafka.sasl.username.valueFrom.secretKeyRef.key" $worker) $username.valueFrom.secretKeyRef.key | quote }}
+            {{- else if $username.value }}
+            value: {{ $username.value | quote }}
+            {{- else if $.Values.kafka.sasl.username.valueFrom.secretKeyRef.name }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Values.kafka.sasl.username.valueFrom.secretKeyRef.name | quote }}
+                key: {{ required "Must specify kafka.sasl.username.valueFrom.secretKeyRef.key" $.Values.kafka.sasl.username.valueFrom.secretKeyRef.key | quote }}
+            {{- else }}
+            value: {{ required (printf "Must specify workers.%s.kafka.sasl.username.value, workers.%s.kafka.sasl.username.valueFrom.secretKeyRef.name, kafka.sasl.username.value, or kafka.sasl.username.valueFrom.secretKeyRef.name" $worker $worker) $.Values.kafka.sasl.username.value }}
+            {{- end }}
+            {{- $password := .kafka.sasl.password }}
+          - name: SASL_PASSWORD
+            {{- if $password.valueFrom.secretKeyRef.name }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $password.valueFrom.secretKeyRef.name | quote }}
+                key: {{ required (printf "Must specify %s.kafka.sasl.password.valueFrom.secretKeyRef.key" $worker) $password.valueFrom.secretKeyRef.key | quote }}
+            {{- else if $password.value }}
+            value: {{ $password.value | quote }}
+            {{- else if $.Values.kafka.sasl.password.valueFrom.secretKeyRef.name }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Values.kafka.sasl.password.valueFrom.secretKeyRef.name | quote }}
+                key: {{ required "Must specify kafka.sasl.password.valueFrom.secretKeyRef.key" $.Values.kafka.sasl.password.valueFrom.secretKeyRef.key | quote }}
+            {{- else }}
+            value: {{ required (printf "Must specify workers.%s.kafka.sasl.password.value, workers.%s.kafka.sasl.password.valueFrom.secretKeyRef.name, kafka.sasl.password.value, or kafka.sasl.password.valueFrom.secretKeyRef.name" $worker $worker) $.Values.kafka.sasl.password.value }}
+            {{- end }}
+          {{- end }}
         {{- include "corda.configSaltAndPassphraseEnv" $ | nindent 10 }}
         {{- if $optionalArgs.clusterDbAccess }}
         {{- include "corda.clusterDbEnv" $ | nindent 10 }}
         {{- end }}
         args:
           - "-mbootstrap.servers={{ include "corda.kafkaBootstrapServers" $ }}"
+          {{- if $.Values.kafka.sasl.enabled }}
+          - "-msasl.jaas.config=org.apache.kafka.common.security.{{- if eq $.Values.kafka.sasl.mechanism "PLAIN" }}plain.PlainLoginModule{{- else }}scram.ScramLoginModule{{- end }} required username=\"$(SASL_USERNAME)\" password=\"$(SASL_PASSWORD)\";"
+          {{- end }}
           - "--topic-prefix={{ $.Values.kafka.topicPrefix }}"
           {{- if $.Values.kafka.tls.enabled }}
           {{- if $.Values.kafka.sasl.enabled }}
@@ -238,14 +274,12 @@ spec:
           - {{ $arg | quote }}
           {{- end }}
         volumeMounts:
+          - mountPath: "/tmp"
+            name: "tmp"
+            readOnly: false
           {{- if and $.Values.kafka.tls.enabled $.Values.kafka.tls.truststore.valueFrom.secretKeyRef.name }}
           - mountPath: "/certs"
             name: "certs"
-            readOnly: true
-          {{- end }}
-          {{- if $.Values.kafka.sasl.enabled  }}
-          - mountPath: "/etc/config"
-            name: "jaas-conf"
             readOnly: true
           {{- end }}
           {{- if .tls }}
@@ -257,6 +291,7 @@ spec:
           - mountPath: /dumps
             name: dumps
             subPathExpr: $(K8S_POD_NAME)
+            readOnly: false
           {{- end }}
           {{- include "corda.log4jVolumeMount" $ | nindent 10 }}
         ports:
@@ -297,72 +332,9 @@ spec:
           failureThreshold: 20
           timeoutSeconds: 5
         {{- end }}
-      initContainers:
-        {{- if $.Values.kafka.sasl.enabled }}
-        - name: create-sasl-jaas-conf
-          image: {{ include "corda.workerImage" ( list $ . ) }}
-          imagePullPolicy:  {{ $.Values.imagePullPolicy }}
-          env:
-            {{- if $.Values.kafka.sasl.enabled }}
-              {{- $username := .kafka.sasl.username }}
-            - name: SASL_USERNAME
-              {{- if $username.valueFrom.secretKeyRef.name }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $username.valueFrom.secretKeyRef.name | quote }}
-                  key: {{ required (printf "Must specify %s.kafka.sasl.username.valueFrom.secretKeyRef.key" $worker) $username.valueFrom.secretKeyRef.key | quote }}
-              {{- else if $username.value }}
-              value: {{ $username.value | quote }}
-              {{- else if $.Values.kafka.sasl.username.valueFrom.secretKeyRef.name }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.kafka.sasl.username.valueFrom.secretKeyRef.name | quote }}
-                  key: {{ required "Must specify kafka.sasl.username.valueFrom.secretKeyRef.key" $.Values.kafka.sasl.username.valueFrom.secretKeyRef.key | quote }}
-              {{- else }}
-              value: {{ required (printf "Must specify workers.%s.kafka.sasl.username.value, workers.%s.kafka.sasl.username.valueFrom.secretKeyRef.name, kafka.sasl.username.value, or kafka.sasl.username.valueFrom.secretKeyRef.name" $worker $worker) $.Values.kafka.sasl.username.value }}
-              {{- end }}
-              {{- $password := .kafka.sasl.password }}
-            - name: SASL_PASSWORD
-              {{- if $password.valueFrom.secretKeyRef.name }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $password.valueFrom.secretKeyRef.name | quote }}
-                  key: {{ required (printf "Must specify %s.kafka.sasl.password.valueFrom.secretKeyRef.key" $worker) $password.valueFrom.secretKeyRef.key | quote }}
-              {{- else if $password.value }}
-              value: {{ $password.value | quote }}
-              {{- else if $.Values.kafka.sasl.password.valueFrom.secretKeyRef.name }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Values.kafka.sasl.password.valueFrom.secretKeyRef.name | quote }}
-                  key: {{ required "Must specify kafka.sasl.password.valueFrom.secretKeyRef.key" $.Values.kafka.sasl.password.valueFrom.secretKeyRef.key | quote }}
-              {{- else }}
-              value: {{ required (printf "Must specify workers.%s.kafka.sasl.password.value, workers.%s.kafka.sasl.password.valueFrom.secretKeyRef.name, kafka.sasl.password.value, or kafka.sasl.password.valueFrom.secretKeyRef.name" $worker $worker) $.Values.kafka.sasl.password.value }}
-              {{- end }}
-            {{- end }}
-          {{- include "corda.containerSecurityContext" $ | nindent 10 }}
-          command:
-          - /bin/bash
-          - -c
-          args:
-            - |
-                cat <<EOF > /etc/config/jaas.conf
-                KafkaClient {
-                    {{- if eq $.Values.kafka.sasl.mechanism "PLAIN" }}
-                    org.apache.kafka.common.security.plain.PlainLoginModule required
-                    {{- else }}
-                    org.apache.kafka.common.security.scram.ScramLoginModule required
-                    {{- end }}
-                    username="$SASL_USERNAME"
-                    password="$SASL_PASSWORD";
-                };
-                EOF
-          volumeMounts:
-          - mountPath: "/etc/config"
-            name: "jaas-conf"
-            readOnly: false
-          {{- include "corda.bootstrapResources" $ | nindent 10 }}
-        {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         {{- if and $.Values.kafka.tls.enabled $.Values.kafka.tls.truststore.valueFrom.secretKeyRef.name }}
         - name: certs
           secret:
@@ -383,10 +355,6 @@ spec:
               - key: {{ .tls.ca.secretKey | quote }}
                 path: "ca.crt"
         {{- end -}}
-        {{- if $.Values.kafka.sasl.enabled  }}
-        - name: jaas-conf
-          emptyDir: {}
-        {{- end }}
         {{- if $.Values.dumpHostPath }}
         - name: dumps
           hostPath:

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -236,6 +236,8 @@ spec:
         {{- include "corda.clusterDbEnv" $ | nindent 10 }}
         {{- end }}
         args:
+          - "--workspace-dir=/work"
+          - "--temp-dir=/tmp"
           - "-mbootstrap.servers={{ include "corda.kafkaBootstrapServers" $ }}"
           {{- if $.Values.kafka.sasl.enabled }}
           - "-msasl.jaas.config=org.apache.kafka.common.security.{{- if eq $.Values.kafka.sasl.mechanism "PLAIN" }}plain.PlainLoginModule{{- else }}scram.ScramLoginModule{{- end }} required username=\"$(SASL_USERNAME)\" password=\"$(SASL_PASSWORD)\";"
@@ -276,6 +278,9 @@ spec:
         volumeMounts:
           - mountPath: "/tmp"
             name: "tmp"
+            readOnly: false
+          - mountPath: "/work"
+            name: "work"
             readOnly: false
           {{- if and $.Values.kafka.tls.enabled $.Values.kafka.tls.truststore.valueFrom.secretKeyRef.name }}
           - mountPath: "/certs"
@@ -334,6 +339,8 @@ spec:
         {{- end }}
       volumes:
         - name: tmp
+          emptyDir: {}
+        - name: work
           emptyDir: {}
         {{- if and $.Values.kafka.tls.enabled $.Values.kafka.tls.truststore.valueFrom.secretKeyRef.name }}
         - name: certs


### PR DESCRIPTION
Drops all capabilities for containers. Sets root filesystem as read-only. Mounts `/tmp` and `/work` as writeable and sets `--workspace-dir` and `--temp-dir` on Corda workers). Worked out the required combination of quotes to allow us to pass in the SASL JAAS config directly as a Corda messaging argument rather than using the JVM JAAS config. This allowed the init container on the workers to be removed and ensures that the JAAS configuration is only usable by the Corda Kafka connections. Updated the worker helper so that the JAAS config is not logged (given it contains the credentials) but modified the behaviour so that at least some indication that the argument has been provided is output.

With a suitable set of overrides (e.g. to increase the number of replicas and set resource limits/requests) the YAML generated by the chart now gets a clean bill of health from Polaris.