### PR TITLE
CORE-12857 Allow resetting of `VaultNamedParameterizedQuery` parameters

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -140,7 +140,15 @@ class UtxoLedgerServiceImpl @Activate constructor(
 
     @Suspendable
     override fun <R> query(queryName: String, resultClass: Class<R>): VaultNamedParameterizedQuery<R> {
-        return VaultNamedParameterizedQueryImpl(queryName, externalEventExecutor, serializationService, resultClass)
+        return VaultNamedParameterizedQueryImpl(
+            queryName,
+            externalEventExecutor,
+            serializationService,
+            parameters = mutableMapOf(),
+            limit = Int.MAX_VALUE,
+            offset = 0,
+            resultClass
+        )
     }
 
     // Retrieve notary client plugin class for specified notary service identity. This is done in

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer
 import java.time.Instant
 
 // TODO CORE-12032 use delegation to create this class
+@Suppress("LongParameterList")
 class VaultNamedParameterizedQueryImpl<T>(
     private val queryName: String,
     private val externalEventExecutor: ExternalEventExecutor,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -16,6 +16,9 @@ class VaultNamedParameterizedQueryImpl<T>(
     private val queryName: String,
     private val externalEventExecutor: ExternalEventExecutor,
     private val serializationService: SerializationService,
+    private var parameters: MutableMap<String, Any>,
+    private var limit: Int,
+    private var offset: Int,
     private val resultClass: Class<T>
 ) : VaultNamedParameterizedQuery<T> {
 
@@ -23,33 +26,25 @@ class VaultNamedParameterizedQueryImpl<T>(
         const val TIMESTAMP_LIMIT_PARAM_NAME = "Corda_TimestampLimit"
     }
 
-    private var limit: Int? = null
-    private var offset: Int? = null
-    private val queryParams = mutableMapOf<String, Any>()
-
     override fun setLimit(limit: Int): VaultNamedParameterizedQuery<T> {
-        require(this.limit == null) { "Limit is already set." }
+        require (limit >= 0) { "Limit cannot be negative" }
         this.limit = limit
         return this
     }
 
     override fun setOffset(offset: Int): VaultNamedParameterizedQuery<T> {
-        require(this.offset == null) { "Offset is already set." }
+        require (offset >= 0) { "Offset cannot be negative" }
         this.offset = offset
         return this
     }
 
     override fun setParameter(name: String, value: Any): VaultNamedParameterizedQuery<T> {
-        require(queryParams[name] == null) { "Parameter with key $name is already set." }
-        queryParams[name] = value
+        parameters[name] = value
         return this
     }
 
     override fun setParameters(parameters: MutableMap<String, Any>): VaultNamedParameterizedQuery<T> {
-        val existingParams = (queryParams - parameters).map { it.key }
-
-        require(existingParams.isEmpty()) { "Parameters with keys: $existingParams are already set." }
-        queryParams.putAll(parameters)
+        this.parameters = parameters.toMutableMap()
         return this
     }
 
@@ -57,13 +52,6 @@ class VaultNamedParameterizedQueryImpl<T>(
     override fun execute(): PagedQuery.ResultSet<T> {
         val offsetValue = offset
         val limitValue = limit
-
-        require(offsetValue != null && offsetValue >= 0) {
-            "Offset needs to be provided and needs to be a positive number to execute the query."
-        }
-        require(limitValue != null && limitValue > 0) {
-            "Limit needs to be provided and needs to be a positive number to execute the query."
-        }
 
         getCreatedTimestampLimit()?.let {
             require(it <= Instant.now()) {
@@ -73,7 +61,7 @@ class VaultNamedParameterizedQueryImpl<T>(
 
         val results = externalEventExecutor.execute(
             VaultNamedQueryExternalEventFactory::class.java,
-            VaultNamedQueryEventParams(queryName, getSerializedParameters(queryParams), offsetValue, limitValue)
+            VaultNamedQueryEventParams(queryName, getSerializedParameters(parameters), offsetValue, limitValue)
         )
 
         return ResultSetImpl(
@@ -84,11 +72,11 @@ class VaultNamedParameterizedQueryImpl<T>(
     override fun setCreatedTimestampLimit(timestampLimit: Instant): VaultNamedParameterizedQuery<T> {
         require(timestampLimit <= Instant.now()) { "Timestamp limit must not be in the future." }
 
-        queryParams[TIMESTAMP_LIMIT_PARAM_NAME] = timestampLimit
+        parameters[TIMESTAMP_LIMIT_PARAM_NAME] = timestampLimit
         return this
     }
 
-    private fun getCreatedTimestampLimit() = queryParams[TIMESTAMP_LIMIT_PARAM_NAME] as? Instant
+    private fun getCreatedTimestampLimit() = parameters[TIMESTAMP_LIMIT_PARAM_NAME] as? Instant
 
     private fun getSerializedParameters(parameters: Map<String, Any>) : Map<String, ByteBuffer> {
         return parameters.mapValues {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -19,50 +19,24 @@ import java.time.Instant
 class VaultNamedParameterizedQueryImplTest {
 
     @Test
-    fun `Vault named parameterized query cannot set the same parameter twice`() {
+    fun `Vault named parameterized query can set parameters multiple times`() {
         val query = createQuery()
-
         query.setParameter("dummy", "dummy")
-
-        val ex = assertThrows<IllegalArgumentException> {
-            query.setParameter("dummy", "dummy")
-        }
-
-        assertThat(ex).hasStackTraceContaining("Parameter with key dummy is already set.")
+        query.setParameter("dummy", "dummy1")
     }
 
     @Test
-    fun `Vault named parameterized query cannot set parameters from map if any of the parameters already set`() {
+    fun `Vault named parameterized query can set parameters using map`() {
         val query = createQuery()
-
         query.setParameter("dummy", "dummy")
-
-        val ex = assertThrows<IllegalArgumentException> {
-            query.setParameters(mapOf("dummy" to "dummy", "dummy2" to "dummy2"))
-        }
-
-        assertThat(ex).hasStackTraceContaining("Parameters with keys: [dummy] are already set.")
-
-        query.setParameter("dummy2", "dummy2")
-
-        val ex2 = assertThrows<IllegalArgumentException> {
-            query.setParameters(mapOf("dummy" to "dummy", "dummy2" to "dummy2"))
-        }
-
-        assertThat(ex2).hasStackTraceContaining("Parameters with keys: [dummy, dummy2] are already set.")
+        query.setParameters(mapOf("dummy" to "dummy1"))
     }
 
     @Test
-    fun `Vault named parameterized query cannot set offset twice`() {
+    fun `Vault named parameterized query can set offset multiple times`() {
         val query = createQuery()
-
         query.setOffset(100)
-
-        val ex = assertThrows<IllegalArgumentException> {
-            query.setOffset(100)
-        }
-
-        assertThat(ex).hasStackTraceContaining("Offset is already set.")
+        query.setOffset(101)
     }
 
     @Test
@@ -74,33 +48,6 @@ class VaultNamedParameterizedQueryImplTest {
         }
 
         assertThat(ex).hasStackTraceContaining("Timestamp limit must not be in the future.")
-    }
-
-    @Test
-    fun `Vault named parameterized query cannot be executed without a valid offset`() {
-        val query = createQuery()
-
-        val ex = assertThrows<IllegalArgumentException> {
-            query.execute()
-        }
-
-        assertThat(ex).hasStackTraceContaining(
-            "Offset needs to be provided and needs to be a positive number to execute the query."
-        )
-    }
-
-    @Test
-    fun `Vault named parameterized query cannot be executed without a valid limit`() {
-        val query = createQuery()
-        query.setOffset(0)
-
-        val ex = assertThrows<IllegalArgumentException> {
-            query.execute()
-        }
-
-        assertThat(ex).hasStackTraceContaining(
-            "Limit needs to be provided and needs to be a positive number to execute the query."
-        )
     }
 
     @Test
@@ -135,6 +82,9 @@ class VaultNamedParameterizedQueryImplTest {
             "DUMMY",
             mockExternalEventExecutor,
             mockSerializationService,
+            parameters = mutableMapOf(),
+            limit = Int.MAX_VALUE,
+            offset = 0,
             String::class.java
         )
     }


### PR DESCRIPTION
Allow `VaultNamedParameterizedQuery`'s `offset`, `limit` and `parameters` to be set multiple times.

This keeps it following the same behaviour as `NamedParameterizedQuery`.