### PR TITLE
CORE-12808: Add new metrics for batch sizes, poll timings and commit timings to state and event pattern

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/constants/MetricsConstants.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/constants/MetricsConstants.kt
@@ -1,0 +1,18 @@
+package net.corda.messaging.constants
+
+object MetricsConstants {
+    // Pattern types, to use with MessagePatternType tag
+    const val PUB_SUB_PATTERN_TYPE = "PubSub"
+    const val COMPACTED_PATTERN_TYPE = "Compacted"
+    const val DURABLE_PATTERN_TYPE = "Durable"
+    const val RPC_PATTERN_TYPE = "RPC"
+    const val STATE_AND_EVENT_PATTERN_TYPE = "StateAndEvent"
+
+    // Operation types, to use with OperationName tag
+    const val ON_NEXT_OPERATION = "onNext"
+    const val ON_SNAPSHOT_OPERATION = "onSnapshot"
+    const val RPC_SENDER_OPERATION = "rpcSender"
+    const val RPC_RESPONDER_OPERATION = "rpcResponder"
+    const val EVENT_POLL_OPERATION = "eventPoll"
+    const val STATE_POLL_OPERATION = "statePoll"
+}

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
@@ -26,6 +26,7 @@ import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.config.ResolvedSubscriptionConfig
+import net.corda.messaging.constants.MetricsConstants
 import net.corda.messaging.subscription.ThreadLooper
 import net.corda.messaging.subscription.consumer.listener.RPCConsumerRebalanceListener
 import net.corda.messaging.utils.FutureTracker
@@ -70,9 +71,9 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
     )
 
     private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, "RPC")
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.RPC_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, "rpcSender")
+        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.RPC_SENDER_OPERATION)
         .build()
 
     private val errorMsg = "Failed to read records from group ${config.group}, topic ${config.topic}"

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImpl.kt
@@ -13,6 +13,7 @@ import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.processor.CompactedProcessor
 import net.corda.messaging.api.subscription.CompactedSubscription
 import net.corda.messaging.config.ResolvedSubscriptionConfig
+import net.corda.messaging.constants.MetricsConstants
 import net.corda.messaging.subscription.factory.MapFactory
 import net.corda.messaging.utils.toRecord
 import net.corda.metrics.CordaMetrics
@@ -37,15 +38,15 @@ internal class CompactedSubscriptionImpl<K : Any, V : Any>(
     private var latestValues: MutableMap<K, V>? = null
 
     private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, "Compacted")
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.COMPACTED_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, "onNext")
+        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.ON_NEXT_OPERATION)
         .build()
 
     private val snapshotMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, "Compacted")
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.COMPACTED_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, "onSnapshot")
+        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.ON_SNAPSHOT_OPERATION)
         .build()
 
     override fun close() = threadLooper.close()

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
@@ -21,6 +21,7 @@ import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.listener.PartitionAssignmentListener
 import net.corda.messaging.config.ResolvedSubscriptionConfig
+import net.corda.messaging.constants.MetricsConstants
 import net.corda.messaging.subscription.consumer.listener.ForwardingRebalanceListener
 import net.corda.messaging.subscription.consumer.listener.LoggingConsumerRebalanceListener
 import net.corda.messaging.utils.toCordaProducerRecords
@@ -67,9 +68,9 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
             "${config.clientId}."
 
     private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, "Durable")
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.DURABLE_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, "onNext")
+        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.ON_NEXT_OPERATION)
         .build()
 
     override val isRunning: Boolean

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
@@ -13,6 +13,7 @@ import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.processor.PubSubProcessor
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.config.ResolvedSubscriptionConfig
+import net.corda.messaging.constants.MetricsConstants
 import net.corda.messaging.subscription.consumer.listener.PubSubConsumerRebalanceListener
 import net.corda.messaging.utils.toRecord
 import net.corda.metrics.CordaMetrics
@@ -49,9 +50,9 @@ internal class PubSubSubscriptionImpl<K : Any, V : Any>(
             "topic ${config.topic}."
 
     private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, "PubSub")
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.PUB_SUB_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, "onNext")
+        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.ON_NEXT_OPERATION)
         .build()
 
     override val isRunning: Boolean

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
@@ -27,6 +27,7 @@ import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.processor.RPCResponderProcessor
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.config.ResolvedSubscriptionConfig
+import net.corda.messaging.constants.MetricsConstants
 import net.corda.metrics.CordaMetrics
 import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
@@ -50,9 +51,9 @@ internal class RPCSubscriptionImpl<REQUEST : Any, RESPONSE : Any>(
     private val errorMsg = "Failed to read records from group ${config.group}, topic ${config.topic}"
 
     private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, "RPC")
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.RPC_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, "rpcResponder")
+        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.RPC_RESPONDER_OPERATION)
         .build()
 
     val isRunning: Boolean

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -17,6 +17,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.StateAndEventSubscription
 import net.corda.messaging.api.subscription.listener.StateAndEventListener
 import net.corda.messaging.config.ResolvedSubscriptionConfig
+import net.corda.messaging.constants.MetricsConstants
 import net.corda.messaging.subscription.consumer.StateAndEventConsumer
 import net.corda.messaging.subscription.consumer.builder.StateAndEventBuilder
 import net.corda.messaging.subscription.consumer.listener.StateAndEventConsumerRebalanceListener
@@ -77,9 +78,19 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
             "producerClientId ${config.clientId}."
 
     private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, "StateAndEvent")
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, "onNext")
+        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.ON_NEXT_OPERATION)
+        .build()
+
+    private val batchSizeHistogram = CordaMetrics.Metric.MessageBatchSize.builder()
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
+        .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
+        .build()
+
+    private val commitTimer = CordaMetrics.Metric.MessageCommitTime.builder()
+        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
+        .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
         .build()
 
     /**
@@ -180,7 +191,9 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
                 var rebalanceOccurred = false
                 val batches = getEventsByBatch(stateAndEventConsumer.pollEvents()).iterator()
                 while (!rebalanceOccurred && batches.hasNext()) {
-                    rebalanceOccurred = tryProcessBatchOfEvents(batches.next())
+                    val batch = batches.next()
+                    batchSizeHistogram.record(batch.size.toDouble())
+                    rebalanceOccurred = tryProcessBatchOfEvents(batch)
                 }
                 keepProcessing = false // We only want to do one batch at a time
             } catch (ex: Exception) {
@@ -223,20 +236,22 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
             }
         }
 
-        producer.beginTransaction()
-        producer.sendRecords(outputRecords.toCordaProducerRecords())
-        if (deadLetterRecords.isNotEmpty()) {
-            producer.sendRecords(deadLetterRecords.map {
-                CordaProducerRecord(
-                    getStateAndEventDLQTopic(eventTopic),
-                    UUID.randomUUID().toString(),
-                    it
-                )
-            })
-            deadLetterRecords.clear()
+        commitTimer.recordCallable {
+            producer.beginTransaction()
+            producer.sendRecords(outputRecords.toCordaProducerRecords())
+            if (deadLetterRecords.isNotEmpty()) {
+                producer.sendRecords(deadLetterRecords.map {
+                    CordaProducerRecord(
+                        getStateAndEventDLQTopic(eventTopic),
+                        UUID.randomUUID().toString(),
+                        it
+                    )
+                })
+                deadLetterRecords.clear()
+            }
+            producer.sendRecordOffsetsToTransaction(eventConsumer, events.map { it })
+            producer.commitTransaction()
         }
-        producer.sendRecordOffsetsToTransaction(eventConsumer, events.map { it })
-        producer.commitTransaction()
         log.debug { "Processing events(keys: ${events.joinToString { it.key.toString() }}, size: ${events.size}) complete." }
 
         stateAndEventConsumer.updateInMemoryStatePostCommit(updatedStates, clock)

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -43,6 +43,21 @@ object CordaMetrics {
         object MessageProcessorTime : Metric<Timer>("messaging.processor.time", CordaMetrics::timer)
 
         /**
+         * The size of batches of messages received in a poll from the message bus.
+         */
+        object MessageBatchSize : Metric<DistributionSummary>("messaging.batch.size", Metrics::summary)
+
+        /**
+         * The time taken to commit a processed batch of messages back to the bus.
+         */
+        object MessageCommitTime : Metric<Timer>("messaging.commit.time", CordaMetrics::timer)
+
+        /**
+         * The time blocking inside a poll call waiting for messages from the bus.
+         */
+        object MessagePollTime : Metric<Timer>("messaging.poll.time", CordaMetrics::timer)
+
+        /**
          * Time it took for a flow to complete sucessfully or to error.
          */
         object FlowRunTime : Metric<Timer>("flow.run.time", CordaMetrics::timer)


### PR DESCRIPTION
Add new metrics to the state and event message pattern. This should be useful to help measure flow performance, by understanding where most time is spent during a single loop of polling for events, processing those events, and writing the resulting messages back to Kafka.

The added metrics are:
- State poll timer, indicating how much time was spent in the state poll
- Event poll timer, indicating how much time was spent in the event poll
- Batch size, indicating how many events were processed by the pattern in a single batch before poll was called again
- Commit time, indicating how long it took to write all output messages back to the bus, along with the new offsets on the event topic

Additionally, some cleanup around existing metrics has been done to ensure string constants are consistent across the patterns library.