### PR TITLE
CORE-9070: use corda micrometer fork

### DIFF
--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -38,12 +38,12 @@ dependencies {
         }
     }
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation ("io.micrometer:micrometer-core:0.1.0-SNAPSHOT") {
+    implementation ("net.corda.micrometer:micrometer-core:$micrometerVersion") {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
         exclude group: 'org.latencyutils', module: 'LatencyUtils'
     }
-    implementation "io.micrometer:micrometer-registry-prometheus:0.1.0-SNAPSHOT"
+    implementation "net.corda.micrometer:micrometer-registry-prometheus:$micrometerVersion"
 
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly "org.apache.commons:commons-lang3:$commonsLangVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -206,11 +206,11 @@ allprojects {
             exclusiveContent {
                 forRepository {
                     maven {
-                        url "$artifactoryContextUrl/corda-dependencies-dev"
+                        url "$artifactoryContextUrl/corda-dependencies"
                     }
                 }
                 filter {
-                    includeGroup 'io.micrometer'
+                    includeGroup 'net.corda.micrometer'
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -201,8 +201,8 @@ allprojects {
                 }
             }
 
-            // NOTE: this needs to be removed once Micrometer contains OSGi metadata
-            //   https://github.com/micrometer-metrics/micrometer/pull/3457
+            // NOTE: this block needs to be removed once Micrometer release 1.11.0 
+            // and code in this project is updated to use this version rather than the forked version.
             exclusiveContent {
                 forRepository {
                     maven {

--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -17,7 +17,7 @@ quasar {
         'com.networknt.schema**',
         'com.typesafe.**',
         'de.javakaffee.kryoserializers**',
-        'io.micrometer.**',
+        'net.corda.micrometer.**',
         'javax.**',
         'kotlin**',
         'org.apache.**',

--- a/gradle.properties
+++ b/gradle.properties
@@ -69,7 +69,7 @@ liquibaseVersion = 4.19.0
 # Needed by Liquibase:
 beanutilsVersion=1.9.4
 log4jVersion = 2.20.0
-micrometerVersion=0.1.0-SNAPSHOT
+micrometerVersion=1.11.0
 nettyVersion = 4.1.86.Final
 # com.networknt:json-schema-validator cannot be upgraded beyond 1.0.66 because it becomes dependent on com.ethlo.time which is not OSGi compatible.
 networkntJsonSchemaVersion = 1.0.66

--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
-    api ("io.micrometer:micrometer-core:$micrometerVersion") {
+    api ("net.corda.micrometer:micrometer-core:$micrometerVersion") {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.latencyutils', module: 'LatencyUtils'
     }


### PR DESCRIPTION
Use our published fork of `micrometer`, which repackages this [RC 1.11.0 ](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.11.0-RC1,)as 1.11.0 under `net.corda.micrometer`. 

We use this as a recent contribution to the micrometer repo By @driessamyn has added OSGi support, however, this has not been released in a GA version as yet.

This should be replaced with the real micrometre artifacts once micrometre 1.11.0 GA is released. 