### PR TITLE
CORE-12867 `LazyStateAndRefImpl` serialization errors

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/state/serializer/kryo/LazyStateAndRefImplKryoSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/state/serializer/kryo/LazyStateAndRefImplKryoSerializer.kt
@@ -1,0 +1,60 @@
+package net.corda.ledger.utxo.flow.impl.state.serializer.kryo
+
+import net.corda.ledger.utxo.data.state.LazyStateAndRefImpl
+import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.serialization.checkpoint.CheckpointInput
+import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
+import net.corda.serialization.checkpoint.CheckpointOutput
+import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.ledger.utxo.StateAndRef
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import kotlin.reflect.jvm.isAccessible
+
+@Component(
+    service = [CheckpointInternalCustomSerializer::class, UsedByFlow::class],
+    property = [CORDA_UNINJECTABLE_SERVICE],
+    scope = PROTOTYPE
+)
+class LazyStateAndRefImplKryoSerializer @Activate constructor(
+    @Reference(service = SerializationService::class)
+    private val serialisationService: SerializationService,
+) : CheckpointInternalCustomSerializer<LazyStateAndRefImpl<*>>, UsedByFlow {
+
+    private companion object {
+        const val NOT_INITIALIZED = 0
+        const val INITIALIZED = 1
+    }
+
+    override val type: Class<LazyStateAndRefImpl<*>> get() = LazyStateAndRefImpl::class.java
+
+    override fun write(output: CheckpointOutput, obj: LazyStateAndRefImpl<*>) {
+        output.writeClassAndObject(obj.serializedStateAndRef)
+        val delegate = obj::stateAndRef
+            .also { property -> property.isAccessible = true }
+            .getDelegate()
+        @Suppress("UNCHECKED_CAST")
+        if ((delegate as Lazy<StateAndRef<*>>).isInitialized()) {
+            output.writeInt(INITIALIZED)
+            output.writeClassAndObject(obj.stateAndRef)
+        } else {
+            output.writeInt(NOT_INITIALIZED)
+        }
+    }
+
+    override fun read(input: CheckpointInput, type: Class<out LazyStateAndRefImpl<*>>): LazyStateAndRefImpl<*> {
+        val serializedStateAndRef = input.readClassAndObject() as UtxoTransactionOutputDto
+        val deserializedStateAndRef = when (input.readInt()) {
+            0 -> null
+            1 -> input.readClassAndObject() as StateAndRef<*>
+            else -> throw IllegalArgumentException(
+                "${LazyStateAndRefImpl::class.java} was previously serialized incorrectly and cannot be deserialized"
+            )
+        }
+        return LazyStateAndRefImpl(serializedStateAndRef, deserializedStateAndRef, serialisationService)
+    }
+}

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/state/LazyStateAndRefImpl.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/state/LazyStateAndRefImpl.kt
@@ -25,10 +25,12 @@ import java.lang.Exception
 @CordaSerializable
 data class LazyStateAndRefImpl<out T : ContractState>(
     val serializedStateAndRef: UtxoTransactionOutputDto,
+    val deserializedStateAndRef: StateAndRef<@UnsafeVariance T>?,
     private val serializationService: SerializationService
 ) : StateAndRef<@UnsafeVariance T> {
-    private val stateAndRef: StateAndRef<@UnsafeVariance T> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        serializedStateAndRef.deserializeToStateAndRef(serializationService)
+
+    val stateAndRef: StateAndRef<@UnsafeVariance T> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        deserializedStateAndRef ?: serializedStateAndRef.deserializeToStateAndRef<T>(serializationService)
     }
 
     override fun getState(): TransactionState<@UnsafeVariance T> {

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/state/serializer/amqp/LazyStateAndRefImplSerializer.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/state/serializer/amqp/LazyStateAndRefImplSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.utxo.data.state.LazyStateAndRefImpl
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
 import net.corda.serialization.BaseProxySerializer
 import net.corda.serialization.InternalCustomSerializer
@@ -16,14 +17,14 @@ import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
-    service = [InternalCustomSerializer::class, UsedByFlow::class, UsedByVerification::class],
+    service = [InternalCustomSerializer::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class],
     property = [CORDA_UNINJECTABLE_SERVICE],
     scope = PROTOTYPE
 )
 class LazyStateAndRefSerializer @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serializationService: SerializationService
-): BaseProxySerializer<LazyStateAndRefImpl<ContractState>, LazyStateAndRefImplProxy>(), UsedByFlow, UsedByVerification {
+): BaseProxySerializer<LazyStateAndRefImpl<ContractState>, LazyStateAndRefImplProxy>(), UsedByFlow, UsedByPersistence, UsedByVerification {
     private companion object {
         private const val VERSION_1 = 1
     }

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoTransactionOutputDto.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoTransactionOutputDto.kt
@@ -30,6 +30,7 @@ data class UtxoTransactionOutputDto(
     fun <T : ContractState> toStateAndRef(serializationService: SerializationService) =
         LazyStateAndRefImpl<T>(
             this,
+            null,
             serializationService
         )
 }


### PR DESCRIPTION
Include `LazyStateAndRefImplSerializer` in the persistence sandbox.

Add `LazyStateAndRefImplKryoSerializer` to serialize `LazyStateAndRefImpl` within flows. Without this an error is thrown when trying to serialize its `lazy` field.