### PR TITLE
CORE-13459: Allow kotlin-osgi-bundle to load as a synthetic contract CPK.

### DIFF
--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
@@ -80,7 +80,7 @@ class CpkChunksKafkaReader(
     }
 
     private fun onAllChunksReceived(cpkChecksum: SecureHash, chunks: SortedSet<CpkChunkId>) {
-        cpkChunksFileManager.assembleCpk(cpkChecksum, chunks)?.let { cpkPath ->
+        cpkChunksFileManager.assembleCpk(cpkChecksum, chunks)?.also { cpkPath ->
             val cpk = Files.newInputStream(cpkPath).use { inStream ->
                 CpkReader.readCpk(inStream, cpkPartsDir)
             }

--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkType.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkType.kt
@@ -8,11 +8,17 @@ import net.corda.data.packaging.CpkType as CpkTypeAvro
  * of the Corda runtime itself (and don't need to be resolved during dependency resolution)
  * and those that are not
  */
-enum class CpkType constructor(private val text : String?) : Comparable<CpkType> {
-    CORDA_API("corda-api"), UNKNOWN(null);
+enum class CpkType(private val text: String?) : Comparable<CpkType> {
+    CORDA_API("corda-api"), UNKNOWN(null), SYNTHETIC(null);
 
     companion object{
-        private val map = values().associateBy(CpkType::text)
+        private val map = buildMap {
+            for (cpkType in values()) {
+                cpkType.text?.also { text ->
+                    this[text] = cpkType
+                }
+            }
+        }
 
         /**
          * Parses [CpkType] from a [String], if the [String] cannot be parsed this function returns [CpkType.UNKNOWN]
@@ -31,5 +37,6 @@ enum class CpkType constructor(private val text : String?) : Comparable<CpkType>
     fun toAvro(): CpkTypeAvro = when (this) {
         UNKNOWN -> CpkTypeAvro.UNKNOWN
         CORDA_API -> CpkTypeAvro.CORDA_API
+        SYNTHETIC -> CpkTypeAvro.UNKNOWN
     }
 }

--- a/libs/packaging/packaging/build.gradle
+++ b/libs/packaging/packaging/build.gradle
@@ -31,7 +31,8 @@ configurations {
 }
 
 dependencies {
-    compileOnly "org.osgi:osgi.annotation"
+    compileOnly 'org.osgi:osgi.annotation'
+    compileOnly 'org.osgi:osgi.core'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     api platform("net.corda:corda-api:$cordaApiVersion")
@@ -43,7 +44,7 @@ dependencies {
 
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:utilities')
-    implementation project(":libs:packaging:packaging-core")
+    implementation project(':libs:packaging:packaging-core')
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
 
     testImplementation 'org.osgi:osgi.core'
@@ -51,8 +52,8 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation project(':libs:crypto:cipher-suite')
-    testImplementation project(":testing:test-utilities")
-    testImplementation project(":testing:packaging-test-utilities")
+    testImplementation project(':testing:test-utilities')
+    testImplementation project(':testing:packaging-test-utilities')
 
     // TODO:  We're pulling in some code (flows) from corda5 dev preview to build test cpks for our tests.
     // TODO:  This should be re-visited when more of the cordapp APIs are imported into this repo.

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkReader.kt
@@ -5,11 +5,14 @@ import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.UnknownFormatVersionException
 import net.corda.libs.packaging.internal.FormatVersionReader
 import net.corda.libs.packaging.internal.v2.CpkLoaderV2
+import org.osgi.framework.Constants.BUNDLE_SYMBOLICNAME
 import java.io.InputStream
 import java.nio.file.Path
+import java.util.Collections.singletonList
 import java.util.jar.JarInputStream
 
 object CpkReader {
+    private val SYNTHETIC_CONTRACTS = singletonList("org.jetbrains.kotlin.osgi-bundle")
     private val version2 = CpkFormatVersion(2, 0)
 
     fun readCpk(
@@ -27,10 +30,14 @@ object CpkReader {
         val manifest = JarInputStream(buffer.inputStream()).use(JarInputStream::getManifest)
             ?: throw CordappManifestException("No manifest in Jar file")
 
-        // Choose correct implementation to read this version
-        return when (val formatVersion = FormatVersionReader.readCpkFormatVersion(manifest)) {
-            version2 -> CpkLoaderV2().loadCPK(buffer, cacheDir, cpkLocation, verifySignature, cpkFileName)
-            else -> throw UnknownFormatVersionException("Unknown Corda-CPK-Format - \"$formatVersion\"")
+        return if (manifest.mainAttributes.getValue(BUNDLE_SYMBOLICNAME) in SYNTHETIC_CONTRACTS) {
+            CpkLoaderV2().loadAsSyntheticContract(buffer, cacheDir, cpkFileName)
+        } else {
+            // Choose correct implementation to read this version
+            when (val formatVersion = FormatVersionReader.readCpkFormatVersion(manifest)) {
+                version2 -> CpkLoaderV2().loadCPK(buffer, cacheDir, cpkLocation, verifySignature, cpkFileName)
+                else -> throw UnknownFormatVersionException("Unknown Corda-CPK-Format - \"$formatVersion\"")
+            }
         }
     }
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
@@ -12,6 +12,8 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * An implementation of [Sandbox].
  *
+ * @param id A unique identifier for this sandbox.
+ * @param publicBundles The set of [Bundle]s exposed to other sandboxes.
  * @param privateBundles The set of non-public [Bundle]s in this sandbox
  */
 internal open class SandboxImpl(
@@ -19,6 +21,9 @@ internal open class SandboxImpl(
     final override val publicBundles: Set<Bundle>,
     final override val privateBundles: Set<Bundle>
 ) : Sandbox {
+    constructor(publicBundles: Set<Bundle>, privateBundles: Set<Bundle>)
+        : this(UUID.randomUUID(), publicBundles, privateBundles)
+
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     // The other sandboxes whose services, bundles and events this sandbox can receive.

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
@@ -12,16 +12,10 @@ import org.osgi.framework.wiring.BundleWiring
 import org.osgi.framework.wiring.FrameworkWiring
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.runtime.ServiceComponentRuntime
 
 /** Handles bundle operations for the `SandboxCreationService` and the `SandboxContextService`. */
 @Component(service = [BundleUtils::class])
-internal class BundleUtils @Activate constructor(
-    @Reference
-    private val serviceComponentRuntime: ServiceComponentRuntime,
-    private val bundleContext: BundleContext
-) {
+internal class BundleUtils @Activate constructor(private val bundleContext: BundleContext) {
     private val systemBundle = bundleContext.getBundle(SYSTEM_BUNDLE_ID)
     private val arrayType = "\\[++(([BCDFIJSZ])|L([^;]++);)".toRegex()
 
@@ -82,14 +76,6 @@ internal class BundleUtils @Activate constructor(
             throw ClassNotFoundException(className)
         }
     }
-
-    /**
-     * Returns the bundle from which [serviceComponentRuntime] is loaded, or null if there is no such bundle.
-     *
-     * This exists to simplify mocking - we can provide one mock for recovering the `ServiceComponentRuntime` bundle
-     * during `SandboxServiceImpl` initialisation, and another mock for general retrieval of bundles based on classes.
-     */
-    fun getServiceRuntimeComponentBundle(): Bundle? = FrameworkUtil.getBundle(serviceComponentRuntime::class.java)
 
     /** Returns the list of all installed bundles. */
     val allBundles get() = bundleContext.bundles.toList()

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxCreationService.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxCreationService.kt
@@ -10,8 +10,15 @@ import org.osgi.framework.Bundle
  * * CPK sandboxes are created from previously-installed CPKs
  */
 interface SandboxCreationService {
-    /** Creates a new public sandbox, containing the given [publicBundles] and [privateBundles]. */
-    fun createPublicSandbox(publicBundles: Iterable<Bundle>, privateBundles: Iterable<Bundle>)
+    /**
+     * Creates a new public sandbox, containing the given [mandatoryPublicBundles],
+     * [optionalPublicBundles] and [privateBundles].
+     */
+    fun createPublicSandboxes(
+        mandatoryPublicBundles: Set<Bundle>,
+        optionalPublicBundles: Set<Bundle>,
+        privateBundles: Set<Bundle>
+    )
 
     /**
      * Creates a new [SandboxGroup] in the [securityDomain] containing a sandbox for each of the [cpks].


### PR DESCRIPTION
Allow CPBs to include their own `kotlin-osgi-bundle` as a pseudo-contract CPK so that they no longer need to use Corda's `kotlin-osgi-bundle` version. This will allow CPBs greater flexibility in which version of Kotlin they can use.

_Note:_ AMQP serialization still requires that a CorDapp's Kotlin classes can be analysed by Corda's `kotlinx-metadata-jvm` library. 