### PR TITLE
CORE-12880 merkle proof execution time

### DIFF
--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -15,7 +15,6 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.extensions.merkle.MerkleTreeHashDigestProvider
 import net.corda.v5.crypto.merkle.MerkleProof
 import net.corda.v5.crypto.merkle.MerkleProofType
-import org.jetbrains.annotations.NotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -273,6 +273,8 @@ class MerkleTreeTest {
         runMerkelProofTest(treeSize)
     }
 
+    // This test should be run whenever the merkle tree implemenetation is changed. It is disabled on CI since 
+    // it can take 30 seconds.
     @Disabled
     @ParameterizedTest(name = "merkle proof tests for trees with extended sizes that run slow ({0} leaves)")
     @MethodSource("merkleProofExtendedTestSizes")

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
@@ -83,6 +84,9 @@ class MerkleTreeTest {
 
         @JvmStatic
         fun merkleProofTestSizes(): List<Int> = (1 until 12).toList()
+
+        @JvmStatic
+        fun merkleProofExtendedTestSizes(): List<Int> = (13 until 16).toList()
     }
 
     @Test
@@ -263,9 +267,20 @@ class MerkleTreeTest {
         assertNotEquals(tree1, tree2)
     }
 
-    @ParameterizedTest(name = "merkle proof tests for trees with {0} leaves")
+    @ParameterizedTest(name = "merkle proof tests for trees with sizes that run fast ({0} leaves)")
     @MethodSource("merkleProofTestSizes")
-    fun `merkle proofs`(treeSize: Int) {
+    fun `merkle proofs fast`(treeSize: Int) {
+        runMerkelProofTest(treeSize)
+    }
+
+    @Disabled
+    @ParameterizedTest(name = "merkle proof tests for trees with extended sizes that run slow ({0} leaves)")
+    @MethodSource("merkleProofExtendedTestSizes")
+    fun `merkle proofs slow `(treeSize: Int) {
+        runMerkelProofTest(treeSize)
+    }
+
+    private fun runMerkelProofTest(treeSize: Int) {
         val hashProvider = trivialHashDigestProvider
         val leafData = (0 until treeSize).map { it.toByteArray() }
         val merkleTree = MerkleTreeImpl.createMerkleTree(leafData, hashProvider)

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -6,6 +6,7 @@ import net.corda.cipher.suite.impl.PlatformDigestServiceImpl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.bytes
+import net.corda.crypto.core.concatByteArrays
 import net.corda.crypto.core.toByteArray
 import net.corda.crypto.merkle.impl.mocks.getZeroHash
 import net.corda.v5.application.crypto.DigestService
@@ -14,6 +15,7 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.extensions.merkle.MerkleTreeHashDigestProvider
 import net.corda.v5.crypto.merkle.MerkleProof
 import net.corda.v5.crypto.merkle.MerkleProofType
+import org.jetbrains.annotations.NotNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
@@ -36,7 +38,25 @@ class MerkleTreeTest {
         private lateinit var nonceHashDigestProvider: NonceHashDigestProvider
         private lateinit var nonceHashDigestProviderVerify: NonceHashDigestProvider
         private lateinit var secureRandom: SecureRandom
+        private val trivialHashDigestProvider = object : MerkleTreeHashDigestProvider {
+            private val ZERO_BYTE = ByteArray(1) { 0 }
+            private val ONE_BYTE = ByteArray(1) { 1 }
+            private fun hash(b: ByteArray): SecureHash {
+                var acc = 0L
+                for (c in b) acc += c.toLong()
+                return SecureHashImpl("byteadd", acc.toByteArray())
+            }
 
+            override fun getDigestAlgorithmName(): DigestAlgorithmName = DigestAlgorithmName("add")
+            override fun leafNonce(index: Int): ByteArray? = null
+            override fun leafHash(index: Int, nonce: ByteArray?, bytes: ByteArray): SecureHash {
+                return hash(concatByteArrays(ZERO_BYTE, bytes))
+            }
+
+            override fun nodeHash(depth: Int, left: SecureHash, right: SecureHash): SecureHash {
+                return hash(concatByteArrays(ONE_BYTE, left.serialize(), right.serialize()))
+            }
+        }
 
         @BeforeAll
         @JvmStatic
@@ -52,7 +72,7 @@ class MerkleTreeTest {
         }
 
         @JvmStatic
-        fun supportedDigestProviders(): List<MerkleTreeHashDigestProvider>{
+        fun supportedDigestProviders(): List<MerkleTreeHashDigestProvider> {
             return listOf(
                 DefaultHashDigestProvider(digestAlgorithm, digestService),
                 TweakableHashDigestProvider(digestAlgorithm, digestService, "0".toByteArray(), "1".toByteArray()),
@@ -63,7 +83,7 @@ class MerkleTreeTest {
         }
 
         @JvmStatic
-        fun merkleProofTestSizes(): List<Int> = (1 until 16).toList()
+        fun merkleProofTestSizes(): List<Int> = (1 until 12).toList()
     }
 
     @Test
@@ -71,10 +91,10 @@ class MerkleTreeTest {
         assertDoesNotThrow {
             TweakableHashDigestProvider(digestAlgorithm, digestService, "0".toByteArray(), "1".toByteArray())
         }
-        assertThrows(IllegalArgumentException::class.java)  {
+        assertThrows(IllegalArgumentException::class.java) {
             TweakableHashDigestProvider(digestAlgorithm, digestService, "".toByteArray(), "1".toByteArray())
         }
-        assertThrows(IllegalArgumentException::class.java)  {
+        assertThrows(IllegalArgumentException::class.java) {
             TweakableHashDigestProvider(digestAlgorithm, digestService, "0".toByteArray(), "".toByteArray())
         }
     }
@@ -247,8 +267,9 @@ class MerkleTreeTest {
     @ParameterizedTest(name = "merkle proof tests for trees with {0} leaves")
     @MethodSource("merkleProofTestSizes")
     fun `merkle proofs`(treeSize: Int) {
+        val hashProvider = trivialHashDigestProvider
         val leafData = (0 until treeSize).map { it.toByteArray() }
-        val merkleTree = MerkleTreeImpl.createMerkleTree(leafData, nonceHashDigestProvider)
+        val merkleTree = MerkleTreeImpl.createMerkleTree(leafData, hashProvider)
 
         if (merkleTree.leaves.isNotEmpty()) {
             // Should not build proof for empty list
@@ -287,19 +308,20 @@ class MerkleTreeTest {
             val proof = merkleTree.createAuditProof(powerSet)
 
             // The original root can be reconstructed from the proof
-            assertTrue(proof.verify(root, nonceHashDigestProviderVerify))
+            assertEquals(proof.calculateRoot(hashProvider), merkleTree.root)
+            assertTrue(proof.verify(root, hashProvider))
 
             // Wrong root should not be accepted.
             val wrongRootBytes = root.bytes
             wrongRootBytes[0] = wrongRootBytes[0] xor 1
             val wrongRootHash = SecureHashImpl(DigestAlgorithmName.SHA2_256D.name, wrongRootBytes)
-            assertFalse(proof.verify(wrongRootHash, nonceHashDigestProviderVerify))
+            assertFalse(proof.verify(wrongRootHash, hashProvider))
 
             // We break the leaves one by one. All of them should break the proof.
             for (leaf in proof.leaves) {
                 val data = leaf.leafData
                 data[0] = data[0] xor 1
-                assertFalse ( proof.verify(root, nonceHashDigestProviderVerify))
+                assertFalse(proof.verify(root, hashProvider))
                 data[0] = data[0] xor 1
             }
 
@@ -309,9 +331,9 @@ class MerkleTreeTest {
                 val badHashBytes = badHashes[j].bytes
                 badHashBytes[0] = badHashBytes[0] xor 1
                 badHashes[j] = SecureHashImpl(DigestAlgorithmName.SHA2_256D.name, badHashBytes)
-                val badProof : MerkleProof =
+                val badProof: MerkleProof =
                     MerkleProofImpl(MerkleProofType.AUDIT, proof.treeSize, proof.leaves, badHashes)
-                assertFalse(badProof.verify(root, nonceHashDigestProviderVerify))
+                assertFalse(badProof.verify(root, hashProvider))
             }
 
             // We add one extra hash which breaks the proof.
@@ -321,7 +343,7 @@ class MerkleTreeTest {
                         digestAlgorithm
                     )
                 )
-            assertFalse( badProof1.verify(root, nonceHashDigestProviderVerify))
+            assertFalse(badProof1.verify(root, hashProvider))
 
             // We remove one hash which breaks the proof.
             if (proof.hashes.size > 1) {
@@ -332,7 +354,7 @@ class MerkleTreeTest {
                         proof.leaves,
                         proof.hashes.take(proof.hashes.size - 1)
                     )
-                assertFalse( badProof2.verify(root, nonceHashDigestProviderVerify))
+                assertFalse(badProof2.verify(root, hashProvider))
             }
 
             // We remove one leaf which breaks the proof.
@@ -344,21 +366,22 @@ class MerkleTreeTest {
                         proof.leaves.take(proof.leaves.size - 1),
                         proof.hashes
                     )
-                assertFalse( badProof3.verify(root, nonceHashDigestProviderVerify))
+                assertFalse(badProof3.verify(root, hashProvider))
             }
 
             // If there are leaves not have been added yet
             val notInProofLeaves = (0 until treeSize).filter { (i in powerSet) }
             if (notInProofLeaves.isNotEmpty()) {
                 val extraIndex = notInProofLeaves.first()
-                val extraLeaf = IndexedMerkleLeafImpl(extraIndex,
-                    nonceHashDigestProvider.leafNonce(extraIndex),
+                val extraLeaf = IndexedMerkleLeafImpl(
+                    extraIndex,
+                    trivialHashDigestProvider.leafNonce(extraIndex),
                     merkleTree.leaves[extraIndex]
                 )
                 // We add one leaf which breaks the proof.
                 val badProof4: MerkleProof =
                     MerkleProofImpl(MerkleProofType.AUDIT, proof.treeSize, proof.leaves + extraLeaf, proof.hashes)
-                assertFalse( badProof4.verify(root, nonceHashDigestProviderVerify))
+                assertFalse(badProof4.verify(root, hashProvider))
 
                 // We replace one leaf which breaks the proof.
                 val badProof5: MerkleProof =
@@ -368,14 +391,14 @@ class MerkleTreeTest {
                         proof.leaves.dropLast(1) + extraLeaf,
                         proof.hashes
                     )
-                assertFalse( badProof5.verify(root, nonceHashDigestProviderVerify))
+                assertFalse(badProof5.verify(root, hashProvider))
 
             }
 
             // We duplicate one leaf which breaks the proof.
             val badProof6: MerkleProof =
                 MerkleProofImpl(MerkleProofType.AUDIT, proof.treeSize, proof.leaves + proof.leaves.last(), proof.hashes)
-            assertFalse( badProof6.verify(root, nonceHashDigestProviderVerify))
+            assertFalse(badProof6.verify(root, hashProvider))
 
         }
     }


### PR DESCRIPTION
Reduce test time from 22 seconds to 0.5 seconds by:
- Using a cheap and non-cryptographic hash function for Merkle tree tests.
- Test only up to 11 leafs rather than 15, since it gets slow due to the exponential growth of the test time. 

Both changes have about the same contribution to speeding up the tests.

If anyone can demonstrate any regressions caught by testing up to 15 but not at 11 then maybe we should move the larger tree tests to an e2e test run periodically on the release branch. But short of a demonstratble problem it feels like a waste of electricity.