### PR TITLE
CORE-12881: crypto ops client test share fixtures

### DIFF
--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponent.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponent.kt
@@ -62,13 +62,14 @@ class CryptoOpsClientComponent @Activate constructor(
     ),
     configKeys = setOf(MESSAGING_CONFIG, CRYPTO_CONFIG)
 ), CryptoOpsClient, CryptoOpsProxyClient {
+    @Suppress("LongParameterList")
     constructor(
         coordinatorFactory: LifecycleCoordinatorFactory,
         publisherFactory: PublisherFactory,
         schemeMetadata: CipherSchemeMetadata,
         configurationReadService: ConfigurationReadService,
         digestService: PlatformDigestService,
-        retriesLimit: Int,
+        retriesLimit: Int = 3,
     ) : this(
         coordinatorFactory,
         publisherFactory,

--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/CryptoOpsClientImpl.kt
@@ -54,7 +54,8 @@ import java.util.UUID
 class CryptoOpsClientImpl(
     private val schemeMetadata: CipherSchemeMetadata,
     private val sender: RPCSender<RpcOpsRequest, RpcOpsResponse>,
-    private val digestService: PlatformDigestService
+    private val digestService: PlatformDigestService,
+    private val rpcRetries: Int = 3,
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
@@ -414,9 +415,8 @@ class CryptoOpsClientImpl(
         timeout: Duration,
         respClazz: Class<RESPONSE>,
         allowNoContentValue: Boolean = false,
-        retries: Int = 3
     ): RESPONSE? = try {
-        val response = retry(retries, logger) {
+        val response = retry(rpcRetries, logger) {
             sender.sendRequest(this).getOrThrow(timeout)
         }
         check(

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -98,22 +98,8 @@ class CryptoOpsClientComponentTests {
             }
         )
         private val schemeMetadata = CipherSchemeMetadataImpl()
-
-    }
-    private lateinit var sender: TestRPCSender<RpcOpsRequest, RpcOpsResponse>
-    private lateinit var coordinatorFactory: TestLifecycleCoordinatorFactoryImpl
-    private lateinit var configurationReadService: TestConfigurationReadService
-    private lateinit var publisherFactory: PublisherFactory
-    private lateinit var component: CryptoOpsClientComponent
-
-    @BeforeEach
-    fun setup() {
-        coordinatorFactory = TestLifecycleCoordinatorFactoryImpl()
-        sender = TestRPCSender(coordinatorFactory)
-        publisherFactory = mock {
-            on { createRPCSender<RpcOpsRequest, RpcOpsResponse>(any(), any()) } doReturn sender
-        }
-        configurationReadService = TestConfigurationReadService(
+        private val coordinatorFactory = TestLifecycleCoordinatorFactoryImpl()
+        private val configurationReadService: TestConfigurationReadService = TestConfigurationReadService(
             coordinatorFactory
         ).also {
             it.start()
@@ -121,7 +107,19 @@ class CryptoOpsClientComponentTests {
                 assertTrue(it.isRunning)
             }
         }
-        component = CryptoOpsClientComponent(
+        private val sender = TestRPCSender(coordinatorFactory)
+        private val publisherFactory = mock<PublisherFactory> {
+            on { createRPCSender<RpcOpsRequest, RpcOpsResponse>(any(), any()) } doReturn sender
+        }
+        private val configurationReadService = TestConfigurationReadService(
+            coordinatorFactory
+        ).also {
+            it.start()
+            eventually {
+                assertTrue(it.isRunning)
+            }
+        }
+        private val component = CryptoOpsClientComponent(
             coordinatorFactory = coordinatorFactory,
             publisherFactory = publisherFactory,
             schemeMetadata = schemeMetadata,

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -77,9 +77,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
+val schemeMetadata = CipherSchemeMetadataImpl()
 
 private class ExecutionContext {
-    val schemeMetadata = CipherSchemeMetadataImpl()
     val coordinatorFactory = TestLifecycleCoordinatorFactoryImpl()
     val configurationReadService: TestConfigurationReadService = TestConfigurationReadService(
         coordinatorFactory
@@ -121,9 +121,7 @@ class CryptoOpsClientComponentTests {
             }
         )
         private val context = ExecutionContext()
-        private val schemeMetadata = context.schemeMetadata
         private val coordinatorFactory = context.coordinatorFactory
-        private val configurationReadService = context.configurationReadService
         private val sender = context.sender
         private val component = context.component
     }

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -1,7 +1,6 @@
 package net.corda.crypto.client.impl
 
 import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
-import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
 import net.corda.crypto.cipher.suite.SignatureSpecs
 import net.corda.crypto.cipher.suite.publicKeyId
@@ -64,7 +63,6 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -86,13 +86,20 @@ class CryptoOpsClientComponentTests {
         @JvmStatic
         fun knownCordaRPCAPIResponderExceptions(): List<Class<*>> =
             exceptionFactories.keys.map { Class.forName(it) }
-    }
 
-    private lateinit var knownTenantId: String
-    private lateinit var knownAlias: String
-    private lateinit var knownOperationContext: Map<String, String>
-    private lateinit var knownRawOperationContext: KeyValuePairList
-    private lateinit var schemeMetadata: CipherSchemeMetadata
+        private val knownTenantId = toHex(UUID.randomUUID().toString().toByteArray().sha256Bytes()).take(12)
+        private val knownAlias = UUID.randomUUID().toString()
+        private val knownOperationContext = mapOf(
+            UUID.randomUUID().toString() to UUID.randomUUID().toString()
+        )
+        private val knownRawOperationContext = KeyValuePairList(
+            knownOperationContext.map {
+                KeyValuePair(it.key, it.value)
+            }
+        )
+        private val schemeMetadata = CipherSchemeMetadataImpl()
+
+    }
     private lateinit var sender: TestRPCSender<RpcOpsRequest, RpcOpsResponse>
     private lateinit var coordinatorFactory: TestLifecycleCoordinatorFactoryImpl
     private lateinit var configurationReadService: TestConfigurationReadService
@@ -101,17 +108,6 @@ class CryptoOpsClientComponentTests {
 
     @BeforeEach
     fun setup() {
-        knownTenantId = toHex(UUID.randomUUID().toString().toByteArray().sha256Bytes()).take(12)
-        knownAlias = UUID.randomUUID().toString()
-        knownOperationContext = mapOf(
-            UUID.randomUUID().toString() to UUID.randomUUID().toString()
-        )
-        knownRawOperationContext = KeyValuePairList(
-            knownOperationContext.map {
-                KeyValuePair(it.key, it.value)
-            }
-        )
-        schemeMetadata = CipherSchemeMetadataImpl()
         coordinatorFactory = TestLifecycleCoordinatorFactoryImpl()
         sender = TestRPCSender(coordinatorFactory)
         publisherFactory = mock {

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/CryptoOpsClientComponentTests.kt
@@ -118,7 +118,7 @@ class TestExecutionContext {
         schemeMetadata = schemeMetadata,
         configurationReadService = configurationReadService,
         digestService = mock(),
-        rpcRetries = 0
+        0
     )
 }
 

--- a/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/RetryUtils.kt
+++ b/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/RetryUtils.kt
@@ -5,16 +5,20 @@ import kotlin.math.pow
 import kotlin.math.roundToLong
 
 inline fun <R> retry(numRetries: Int, logger: Logger, block: () -> R): R {
-    var firstException: Exception? = null
-    for (i in 0..numRetries) {
-        try {
-            return block()
-        } catch (e: Exception) {
-            logger.warn("Exception occurred in retry block (invocation: ${i+1}, retries left: ${numRetries-i}): $e")
-            if (firstException == null)
-                firstException = e
-            Thread.sleep((1000 * 1.0.pow(i+1)).roundToLong())
+    if (numRetries == 0) {
+        return block()
+    } else {
+        var firstException: Exception? = null
+        for (i in 0..numRetries) {
+            try {
+                return block()
+            } catch (e: Exception) {
+                logger.warn("Exception occurred in retry block (invocation: ${i + 1}, retries left: ${numRetries - i}): $e")
+                if (firstException == null)
+                    firstException = e
+                Thread.sleep((1000 * 1.0.pow(i + 1)).roundToLong())
+            }
         }
+        throw firstException!!
     }
-    throw firstException!!
 }

--- a/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/RetryUtils.kt
+++ b/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/RetryUtils.kt
@@ -4,21 +4,20 @@ import org.slf4j.Logger
 import kotlin.math.pow
 import kotlin.math.roundToLong
 
+@Suppress("NestedBlockDepth")
 inline fun <R> retry(numRetries: Int, logger: Logger, block: () -> R): R {
-    if (numRetries == 0) {
-        return block()
-    } else {
-        var firstException: Exception? = null
-        for (i in 0..numRetries) {
-            try {
-                return block()
-            } catch (e: Exception) {
-                logger.warn("Exception occurred in retry block (invocation: ${i + 1}, retries left: ${numRetries - i}): $e")
-                if (firstException == null)
-                    firstException = e
-                Thread.sleep((1000 * 1.0.pow(i + 1)).roundToLong())
-            }
+    var firstException: Exception? = null
+    var i = 0
+    while (true) {
+        if (i > 0) Thread.sleep((1000 * 1.0.pow(i + 1)).roundToLong())
+        try {
+            return block()
+        } catch (e: Exception) {
+            logger.warn("Exception occurred in retry block (invocation: ${i + 1}, retries left: ${numRetries - i}): $e")
+            if (firstException == null)
+                firstException = e
         }
-        throw firstException!!
+        i += 1
+        if (i >= numRetries) throw firstException!!
     }
 }


### PR DESCRIPTION
Allow retries to be configurable for CryptoOpsClientComponent, but not fixed.

The motivation for this is simply to significantly decreate test execution time, saving about 5 seconds on my machine, i.e. double the speed of the test. The absolute time saving should be more on Jenkins. See https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4449697918/Unit+Test+Execution+Time+findings

On my machine, CryptoOpsClientComponentTests takes 7.6s now. That seems to be mostly test set up. Baseline 5.1 tests take 39.7s.

