### PR TITLE
CORE-4126 Adding @QuasarIgnorePackage directive to :flow:utils to prevent issues with avro classloading

### DIFF
--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -88,15 +88,3 @@ dependencies {
 
     integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
 }
-
-def jar = tasks.named('jar', Jar) {
-    archiveBaseName = 'corda-flow-service'
-
-    bundle {
-        bnd """\
-Import-Package:\
-    org.apache.avro.specific,\
-    *
-"""
-    }
-}

--- a/libs/flows/utils/build.gradle
+++ b/libs/flows/utils/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
@@ -13,13 +14,3 @@ dependencies {
 }
 
 description 'Flow related utilities'
-
-def jar = tasks.named('jar', Jar) {
-    bundle {
-        bnd """\
-Import-Package:\
-    org.apache.avro.specific,\
-    *
-"""
-    }
-}

--- a/libs/flows/utils/src/main/java/net/corda/flow/utils/package-info.java
+++ b/libs/flows/utils/src/main/java/net/corda/flow/utils/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnorePackage
 package net.corda.flow.utils;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnorePackage;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
This PR addresses [CORE-4126](https://r3-cev.atlassian.net/browse/CORE-4126)

### Context
Following some changes last year to add flow sessions, we began to see issues with Avro's SpecificRecordBase at runtime:
```
java.lang.ClassNotFoundException: org.apache.avro.specific.SpecificRecordBase not found by [...]
```
even though it was correctly defined and included. To workaround this issue, the following script was added to the `build.gradle` in the affected areas:
```
def jar = tasks.named('jar', Jar) {
    archiveBaseName = 'corda-flow-service'

    bundle {
        bnd """\
Import-Package:\
    org.apache.avro.specific,\
    *
"""
    }
}
```
Essentially what we're doing here is running the build process as standard, and then manually importing in the `org.apache.avro.specific` package afterwards.

### Solution
Taking a look at this error, I believe the root cause lies in the interaction between Quasar and Avro objects. The dynamic loading and bytecode instrumentation carried out by Quasar causes issues with the classloading of Avro object; this is why we had to carry out the normal build process and then manually import the package after the fact.

I was able to reproduce the error seen in `:libs:flows:utils` by removing the workaround script, and I’ve since resolved it by adding a `@QuasarIgnorePackage` directive to `net.corda.flow.utils` (and perhaps we can reduce the scope of this directive if we find that causes issues). I haven’t been able to reproduce the issue in `:flow:flow-service` as yet, so it may be that this change fixes both areas.

[CORE-4126]: https://r3-cev.atlassian.net/browse/CORE-4126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ