### PR TITLE
CORE-12888: Simplify sandbox visibility rules.

### DIFF
--- a/libs/sandbox-internal/build.gradle
+++ b/libs/sandbox-internal/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     testRuntimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
     testRuntimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     testRuntimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
     cpbs project(path: 'sandbox-cpk-one', configuration: 'cordaCPB')
     cpbs project(path: 'sandbox-cpk-three', configuration: 'cordaCPB')

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -122,8 +122,6 @@ internal class SandboxServiceImpl @Activate constructor(
             lookedAtSandbox === lookingSandbox -> true
             // Does only one of the bundles belong to a sandbox?
             lookedAtSandbox == null || lookingSandbox == null -> false
-            // Is the looked-at bundle a public bundle in a public sandbox?
-            lookedAtBundle in publicSandboxes.flatMap { sandbox -> sandbox.publicBundles } -> true
             // Does the looking sandbox not have visibility of the looked at sandbox?
             !lookingSandbox.hasVisibility(lookedAtSandbox) -> false
             // Is the looked-at bundle a public bundle in the looked-at sandbox?
@@ -221,6 +219,7 @@ internal class SandboxServiceImpl @Activate constructor(
 
         newSandboxes.forEach { newSandbox ->
             // Each sandbox requires visibility of the sandboxes of the other CPKs and of the public sandboxes.
+            newSandbox.grantVisibility(publicSandboxes)
             newSandbox.grantVisibility(newSandboxes - newSandbox)
         }
 

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -288,8 +288,8 @@ class SandboxServiceImplTests {
         val sandboxOne = (sandboxGroupOne as SandboxGroupInternal).cpkSandboxes.single()
         val sandboxTwo = (sandboxGroupTwo as SandboxGroupInternal).cpkSandboxes.single()
 
-        val sandboxOneBundles = startedBundles.filter { bundle -> sandboxOne.containsBundle(bundle) }
-        val sandboxTwoBundles = startedBundles.filter { bundle -> sandboxTwo.containsBundle(bundle) }
+        val sandboxOneBundles = startedBundles.filter(sandboxOne::containsBundle)
+        val sandboxTwoBundles = startedBundles.filter(sandboxTwo::containsBundle)
 
         sandboxOneBundles.forEach { sandboxOneBundle ->
             sandboxTwoBundles.forEach { sandboxTwoBundle ->
@@ -305,8 +305,8 @@ class SandboxServiceImplTests {
         val sandboxOne = sandboxes[0] as SandboxImpl
         val sandboxTwo = sandboxes[1] as SandboxImpl
 
-        val sandboxOneBundles = startedBundles.filter { bundle -> sandboxOne.containsBundle(bundle) }
-        val sandboxTwoBundles = startedBundles.filter { bundle -> sandboxTwo.containsBundle(bundle) }
+        val sandboxOneBundles = startedBundles.filter(sandboxOne::containsBundle)
+        val sandboxTwoBundles = startedBundles.filter(sandboxTwo::containsBundle)
         val sandboxTwoPublicBundles = sandboxTwoBundles.filterTo(HashSet()) { bundle -> bundle in sandboxTwo.publicBundles }
         val sandboxTwoPrivateBundles = sandboxTwoBundles - sandboxTwoPublicBundles
 
@@ -327,8 +327,8 @@ class SandboxServiceImplTests {
         val sandboxOne = sandboxes[0] as CpkSandboxImpl
         val sandboxTwo = sandboxes[1] as CpkSandboxImpl
 
-        val sandboxOneBundles = startedBundles.filter { bundle -> sandboxOne.containsBundle(bundle) }
-        val sandboxTwoBundles = startedBundles.filter { bundle -> sandboxTwo.containsBundle(bundle) }
+        val sandboxOneBundles = startedBundles.filter(sandboxOne::containsBundle)
+        val sandboxTwoBundles = startedBundles.filter(sandboxTwo::containsBundle)
         val sandboxTwoMainBundle = sandboxTwo.mainBundle
         val sandboxTwoLibraryBundles = sandboxTwoBundles - sandboxTwoMainBundle
 
@@ -363,17 +363,19 @@ class SandboxServiceImplTests {
 
     @Test
     fun `a bundle only has visibility of public bundles in public sandboxes`() {
-        val publicMockBundle = mockBundle()
-        val privateMockBundle = mockBundle()
-        sandboxService.createPublicSandbox(setOf(publicMockBundle), setOf(privateMockBundle))
+        val publicPlatformBundle = mockBundle("public-platform-bundle")
+        val privatePlatformBundle = mockBundle("private-platform-bundle")
+        sandboxService.createPublicSandbox(setOf(publicPlatformBundle), setOf(privatePlatformBundle))
 
         val sandboxGroup = sandboxService.createSandboxGroup(setOf(cpkTwo))
         val sandbox = (sandboxGroup as SandboxGroupInternal).cpkSandboxes.single() as SandboxImpl
-        val sandboxBundles = startedBundles.filter { bundle -> sandbox.containsBundle(bundle) }
+        val sandboxBundles = startedBundles.filter(sandbox::containsBundle)
 
         sandboxBundles.forEach { sandboxOneBundle ->
-            assertTrue(sandboxService.hasVisibility(sandboxOneBundle, publicMockBundle))
-            assertFalse(sandboxService.hasVisibility(sandboxOneBundle, privateMockBundle))
+            assertTrue(sandboxService.hasVisibility(sandboxOneBundle, publicPlatformBundle))
+            assertFalse(sandboxService.hasVisibility(sandboxOneBundle, privatePlatformBundle))
+            assertFalse(sandboxService.hasVisibility(publicPlatformBundle, sandboxOneBundle))
+            assertFalse(sandboxService.hasVisibility(privatePlatformBundle, sandboxOneBundle))
         }
     }
 

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
@@ -7,6 +7,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.osgi.framework.Bundle
+import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
 import org.osgi.framework.Version
 import kotlin.math.abs
 import kotlin.random.Random
@@ -26,14 +27,22 @@ fun mockBundle(
     klass: Class<*>? = null,
     bundleLocation: String = random.nextInt().toString()
 ) = mock<Bundle>().apply {
-    whenever(bundleId).thenReturn(nextLong())
+    val bundleVersion = Version.parseVersion("${abs(random.nextInt())}.${abs(random.nextInt())}")
+    val id = if ("org.apache.felix.framework" == bundleSymbolicName) {
+        SYSTEM_BUNDLE_ID
+    } else {
+        nextLong()
+    }
+    val description = "Bundle[BSN=$bundleSymbolicName, ID=$id]"
+    whenever(bundleId).thenReturn(id)
     whenever(symbolicName).thenReturn(bundleSymbolicName)
-    whenever(version).thenReturn(Version.parseVersion("${abs(random.nextInt())}.${abs(random.nextInt())}"))
+    whenever(version).thenReturn(bundleVersion)
     whenever(loadClass(any())).then { answer ->
         val requestedClass = answer.arguments.single()
         if (klass?.name == requestedClass) klass else throw ClassNotFoundException()
     }
     whenever(location).thenReturn(bundleLocation)
+    whenever(toString()).thenReturn(description)
 }
 
 /** Generates a mock CpkMetadata. */


### PR DESCRIPTION
Explicitly grant public sandbox visibility to a CPK sandbox. Update the tests to demonstrate that sandbox visibility is correct.