### PR TITLE
ES-122 set chart version to 5.0.0

### DIFF
--- a/applications/tools/p2p-test/app-simulator/charts/app-simulator-db/Chart.yaml
+++ b/applications/tools/p2p-test/app-simulator/charts/app-simulator-db/Chart.yaml
@@ -3,8 +3,8 @@ name: app-simulator-db
 description: A Helm chart for installing the database used by app-simulator
 
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 5.0.0
+appVersion: "5.0.0"
 
 dependencies:
   - name: postgresql

--- a/applications/tools/p2p-test/app-simulator/charts/app-simulator/Chart.yaml
+++ b/applications/tools/p2p-test/app-simulator/charts/app-simulator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 5.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/applications/tools/p2p-test/app-simulator/scripts/settings.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/settings.sh
@@ -5,7 +5,7 @@
 NAMESPACE_PREFIX="${USER//./}"
 
 # Chart and Docker Image versions to deploy
-CORDA_CHART_VERSION="^0.1.0-beta"
+CORDA_CHART_VERSION="^5.0.0-beta"
 if [ -z $DOCKER_IMAGE_VERSION ]; then
   DOCKER_IMAGE_VERSION=$(curl -u $CORDA_ARTIFACTORY_USERNAME:$CORDA_ARTIFACTORY_PASSWORD  https://corda-os-docker-unstable.software.r3.com:/v2/corda-os-p2p-link-manager-worker/tags/list | jq -r -M '.["tags"] | map(select(contains("5.0.0.0-beta"))) | sort | reverse | .[0]')
 fi

--- a/charts/corda-lib/Chart.yaml
+++ b/charts/corda-lib/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 5.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/corda/Chart.yaml
+++ b/charts/corda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 5.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "unstable"
 
 dependencies:
   - name: "corda-lib"
-    version: "0.1.0"
+    version: "5.0.0"
     repository: "file://../corda-lib"


### PR DESCRIPTION
Set our Corda chart version to `5.0.0` prior to GA we currently override this dynamically when building releases.

- Downstream consumers also to be updated (associated PRs to follow which will be linked here) 

ENT PR:
https://github.com/corda/corda5-enterprise/pull/42

Shared lib:
https://github.com/corda/corda-shared-build-pipeline-steps/pull/729