### PR TITLE
CORE-12862 Unique notary service and MGM group ids on smoke test runs

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
@@ -2,7 +2,6 @@ package net.corda.applications.workers.smoketest.flow
 
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
-import net.corda.e2etest.utilities.GROUP_ID
 import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.awaitRpcFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
@@ -22,9 +21,10 @@ class AmqpSerializationTests {
         private const val AmqpSerializationTestFlow = "net.cordapp.testing.smoketests.flow.AmqpSerializationTestFlow"
 
         private val testRunUniqueId = UUID.randomUUID()
+        private val groupId = UUID.randomUUID().toString()
         private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
         private val bobX500 = "CN=Bob-${testRunUniqueId}, OU=Application, O=R3, L=London, C=GB"
-        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
+        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, groupId)
         private val staticMemberList = listOf(
             bobX500,
         )
@@ -36,7 +36,7 @@ class AmqpSerializationTests {
             conditionallyUploadCordaPackage(
                 cpiName,
                 TEST_CPB_LOCATION,
-                GROUP_ID,
+                groupId,
                 staticMemberList
             )
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import net.corda.applications.workers.smoketest.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.TEST_CPI_NAME
 import net.corda.e2etest.utilities.FlowStatus
-import net.corda.e2etest.utilities.GROUP_ID
 import net.corda.e2etest.utilities.RPC_FLOW_STATUS_FAILED
 import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.RpcSmokeTestInput
@@ -51,18 +50,19 @@ class FlowTests {
 
     companion object {
         private val testRunUniqueId = UUID.randomUUID()
+        private val groupId = UUID.randomUUID().toString()
         private val applicationCpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
         private val notaryCpiName = "${TEST_NOTARY_CPI_NAME}_$testRunUniqueId"
         private val aliceX500 = "CN=Alice-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
-        private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, GROUP_ID)
+        private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, groupId)
         private val bobX500 = "CN=Bob-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
-        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
+        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, groupId)
         private val davidX500 = "CN=David-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
-        private var davidHoldingId: String = getHoldingIdShortHash(davidX500, GROUP_ID)
+        private var davidHoldingId: String = getHoldingIdShortHash(davidX500, groupId)
         private val charlyX500 = "CN=Charley-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
-        private var charlieHoldingId: String = getHoldingIdShortHash(charlyX500, GROUP_ID)
+        private var charlieHoldingId: String = getHoldingIdShortHash(charlyX500, groupId)
         private val notaryX500 = "CN=Notary-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
-        private val notaryHoldingId: String = getHoldingIdShortHash(notaryX500, GROUP_ID)
+        private val notaryHoldingId: String = getHoldingIdShortHash(notaryX500, groupId)
         private val staticMemberList = listOf(
             aliceX500,
             bobX500,
@@ -103,13 +103,13 @@ class FlowTests {
         internal fun beforeAll() {
             // Upload test flows if not already uploaded
             conditionallyUploadCordaPackage(
-                applicationCpiName, TEST_CPB_LOCATION, GROUP_ID, staticMemberList
+                applicationCpiName, TEST_CPB_LOCATION, groupId, staticMemberList
             )
             // Upload notary server CPB
             conditionallyUploadCordaPackage(
                 notaryCpiName,
                 TEST_NOTARY_CPB_LOCATION,
-                GROUP_ID,
+                groupId,
                 staticMemberList
             )
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/ConsensualLedgerTests.kt
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import net.corda.crypto.core.parseSecureHash
-import net.corda.e2etest.utilities.GROUP_ID
 import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.awaitRpcFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
@@ -42,15 +41,16 @@ class ConsensualLedgerTests {
     }
 
     private val testRunUniqueId = UUID.randomUUID()
+    private val groupId = UUID.randomUUID().toString()
     private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
 
     private val aliceX500 = "CN=Alice-${testRunUniqueId}, OU=Application, O=R3, L=London, C=GB"
     private val bobX500 = "CN=Bob-${testRunUniqueId}, OU=Application, O=R3, L=London, C=GB"
     private val charlieX500 = "CN=Charlie-${testRunUniqueId}, OU=Application, O=R3, L=London, C=GB"
 
-    private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, GROUP_ID)
-    private val bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
-    private val charlieHoldingId: String = getHoldingIdShortHash(charlieX500, GROUP_ID)
+    private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, groupId)
+    private val bobHoldingId: String = getHoldingIdShortHash(bobX500, groupId)
+    private val charlieHoldingId: String = getHoldingIdShortHash(charlieX500, groupId)
 
     private val staticMemberList = listOf(
         aliceX500,
@@ -63,7 +63,7 @@ class ConsensualLedgerTests {
         conditionallyUploadCordaPackage(
             cpiName,
             TEST_CPB_LOCATION,
-            GROUP_ID,
+            groupId,
             staticMemberList
         )
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
@@ -3,7 +3,6 @@ package net.corda.applications.workers.smoketest.ledger
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import net.corda.e2etest.utilities.GROUP_ID
 import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
@@ -39,6 +38,7 @@ class UtxoLedgerTests {
     }
 
     private val testRunUniqueId = UUID.randomUUID()
+    private val groupId = UUID.randomUUID().toString()
     private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
     private val notaryCpiName = "${TEST_NOTARY_CPI_NAME}_$testRunUniqueId"
 
@@ -47,10 +47,10 @@ class UtxoLedgerTests {
     private val charlieX500 = "CN=Charlie-${testRunUniqueId}, OU=Application, O=R3, L=London, C=GB"
     private val notaryX500 = "CN=Notary-${testRunUniqueId}, OU=Application, O=R3, L=London, C=GB"
 
-    private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, GROUP_ID)
-    private val bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
-    private val charlieHoldingId: String = getHoldingIdShortHash(charlieX500, GROUP_ID)
-    private val notaryHoldingId: String = getHoldingIdShortHash(notaryX500, GROUP_ID)
+    private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, groupId)
+    private val bobHoldingId: String = getHoldingIdShortHash(bobX500, groupId)
+    private val charlieHoldingId: String = getHoldingIdShortHash(charlieX500, groupId)
+    private val notaryHoldingId: String = getHoldingIdShortHash(notaryX500, groupId)
 
     private val staticMemberList = listOf(
         aliceX500,
@@ -64,13 +64,13 @@ class UtxoLedgerTests {
         conditionallyUploadCordaPackage(
             cpiName,
             TEST_CPB_LOCATION,
-            GROUP_ID,
+            groupId,
             staticMemberList
         )
         conditionallyUploadCordaPackage(
             notaryCpiName,
             TEST_NOTARY_CPB_LOCATION,
-            GROUP_ID,
+            groupId,
             staticMemberList
         )
 
@@ -239,4 +239,3 @@ class UtxoLedgerTests {
 
     data class CustomQueryFlowResponse(val results: List<String>)
 }
-

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRpcTest.kt
@@ -9,7 +9,6 @@ import net.corda.applications.workers.smoketest.VNODE_UPGRADE_TEST_CPI_V2
 import net.corda.e2etest.utilities.CLUSTER_URI
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT
 import net.corda.e2etest.utilities.ClusterBuilder
-import net.corda.e2etest.utilities.GROUP_ID
 import net.corda.e2etest.utilities.PASSWORD
 import net.corda.e2etest.utilities.USERNAME
 import net.corda.e2etest.utilities.assertWithRetry
@@ -54,10 +53,11 @@ class VirtualNodeRpcTest {
         private const val EXPECTED_ERROR_CPB_INSTEAD_OF_CPI = "Invalid CPI.  Unknown Corda-CPI-Format - \"1.0\""
 
         private val testRunUniqueId = UUID.randomUUID()
+        private val groupId = UUID.randomUUID().toString()
         private val aliceX500 = "CN=Alice-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
         private val bobX500 = "CN=Bob-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
-        private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, GROUP_ID)
-        private val bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
+        private val aliceHoldingId: String = getHoldingIdShortHash(aliceX500, groupId)
+        private val bobHoldingId: String = getHoldingIdShortHash(bobX500, groupId)
         private val staticMemberList = listOf(
             aliceX500,
             bobX500
@@ -125,7 +125,7 @@ class VirtualNodeRpcTest {
         cpiName: String,
         cpiVersion: String = "1.0.0.0-SNAPSHOT"
     ): String {
-        val requestId = cpiUpload(cpbLocation, GROUP_ID, staticMemberList, cpiName, cpiVersion)
+        val requestId = cpiUpload(cpbLocation, groupId, staticMemberList, cpiName, cpiVersion)
             .let { it.toJson()["id"].textValue() }
         assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
@@ -235,7 +235,7 @@ class VirtualNodeRpcTest {
             val cpiJson = json["cpis"].first { it["id"]["cpiName"].textValue() == cpiName }
 
             val groupPolicyJson = cpiJson["groupPolicy"].textValue().toJson()
-            assertThat(groupPolicyJson["groupId"].textValue()).isEqualTo(GROUP_ID)
+            assertThat(groupPolicyJson["groupId"].textValue()).isEqualTo(groupId)
         }
     }
 
@@ -417,7 +417,7 @@ class VirtualNodeRpcTest {
 
             val requestId = forceCpiUpload(
                 TEST_CPB_LOCATION,
-                GROUP_ID,
+                groupId,
                 staticMemberList,
                 cpiName
             ).let { it.toJson()["id"].textValue() }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -7,7 +7,6 @@ import net.corda.applications.workers.smoketest.websocket.client.SmokeTestWebsoc
 import net.corda.applications.workers.smoketest.websocket.client.useWebsocketConnection
 import net.corda.e2etest.utilities.CLUSTER_URI
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT
-import net.corda.e2etest.utilities.GROUP_ID
 import net.corda.e2etest.utilities.PASSWORD
 import net.corda.e2etest.utilities.RpcSmokeTestInput
 import net.corda.e2etest.utilities.SMOKE_TEST_CLASS_NAME
@@ -37,9 +36,10 @@ class FlowStatusFeedSmokeTest {
 
     private companion object {
         private val testRunUniqueId = UUID.randomUUID()
+        private val groupId = UUID.randomUUID().toString()
         private val cpiName = "${TEST_CPI_NAME}_$testRunUniqueId"
         private val bobX500 = "CN=Bob-$testRunUniqueId, OU=Application, O=R3, L=London, C=GB"
-        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, GROUP_ID)
+        private var bobHoldingId: String = getHoldingIdShortHash(bobX500, groupId)
         private val staticMemberList = listOf(
             bobX500,
         )
@@ -66,7 +66,7 @@ class FlowStatusFeedSmokeTest {
             conditionallyUploadCordaPackage(
                 cpiName,
                 TEST_CPB_LOCATION,
-                GROUP_ID,
+                groupId,
                 staticMemberList
             )
 

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -146,13 +146,12 @@ class ClusterBuilder {
     private fun registerMemberBody() =
         """{ "context": { "corda.key.scheme" : "CORDA.ECDSA.SECP256R1" } }""".trimMargin()
 
-    // TODO CORE-7248 Review once plugin loading logic is added
-    private fun registerNotaryBody() =
+    private fun registerNotaryBody(holdingIdShortHash: String) =
         """{ 
             |  "context": { 
             |    "corda.key.scheme" : "CORDA.ECDSA.SECP256R1", 
             |    "corda.roles.0" : "notary",
-            |    "corda.notary.service.name" : "O=MyNotaryService, L=London, C=GB",
+            |    "corda.notary.service.name" : "O=MyNotaryService-${holdingIdShortHash}, L=London, C=GB",
             |    "corda.notary.service.flow.protocol.name" : "com.r3.corda.notary.plugin.nonvalidating",
             |    "corda.notary.service.flow.protocol.version.0" : "1"
             |   } 
@@ -178,12 +177,16 @@ class ClusterBuilder {
     fun getVNodeStatus(requestId: String) = client!!.get("/api/v1/virtualnode/status/$requestId")
 
     /**
-     * Register a member to the network
+     * Register a member to the network.
+     *
+     * KNOWN LIMITATION: Registering a notary static member will currently always provision a new
+     * notary service. This is fine for now as we only support a 1-1 mapping from notary service to
+     * notary vnode. It will need revisiting when 1-* is supported.
      */
     fun registerStaticMember(holdingIdShortHash: String, isNotary: Boolean = false) =
         register(
             holdingIdShortHash,
-            if (isNotary) registerNotaryBody() else registerMemberBody()
+            if (isNotary) registerNotaryBody(holdingIdShortHash) else registerMemberBody()
         )
 
     fun register(holdingIdShortHash: String, registrationContext: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/Utils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/Utils.kt
@@ -16,7 +16,6 @@ import java.util.concurrent.TimeoutException
 
 const val USERNAME = "admin"
 val PASSWORD = System.getenv("INITIAL_ADMIN_USER_PASSWORD") ?: "admin"
-const val GROUP_ID = "7c5d6948-e17b-44e7-9d1c-fa4a3f667cad"
 val testRunUniqueId: UUID = UUID.randomUUID()
 
 // Code signer certificate


### PR DESCRIPTION
Previously, the notary service name was hard-coded to a fixed string. This meant that repeated runs of the smoke tests against the same database would re-use the notary service identity. This had the unintended effect of adding more notary virtual nodes to the existing service identity, rather than provisioning a new service identity on each test run.

Aside from this currently being an unrealistic setup, composite keys (used to aggregate the keys of notary virtual nodes) have a maximum number of leaves. Repeated test runs could eventually fail due to hitting this limit. To address this, this PR generates a new UUID for the notary service on each test run.

Making this change also revealed that in many cases, the MGM group id is also reused between test runs. This led to some flows failing due to the fact that the above change would result in multiple notary services on a network, which some CorDapps cannot handle. This change therefore also makes a similar change to the MGM group id, ensuring a new id is used on each test run.

See https://github.com/corda/corda-e2e-tests/pull/74 for the corresponding E2E test change.