### PR TITLE
CORE-12868: Upgrade to Kryo 5.5.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,8 +51,6 @@ felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5
 felixScrVersion=2.2.6
 felixSecurityVersion=2.8.3
-# NOTE: Guava cannot easily be upgraded as it needs a Quasar change.
-#  Check with one of the group leads before changing.
 guavaVersion=30.1.1-jre
 hibernateVersion=5.6.15.Final
 hikariCpVersion=5.0.1
@@ -63,7 +61,7 @@ jetbrainsAnnotationsVersion=13.0
 kafkaClientVersion=3.3.1_1
 # NOTE: Kryo cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.
-kryoVersion = 5.4.0
+kryoVersion = 5.5.0
 kryoSerializersVersion = 0.45
 liquibaseVersion = 4.19.0
 # Needed by Liquibase:
@@ -80,7 +78,7 @@ osgiUtilFunctionVersion = 1.2.0
 osgiUtilPromiseVersion = 1.3.0
 picocliVersion = 4.7.0
 protonjVersion=0.33.0
-quasarVersion = 0.9.0_r3-20230424.080917-12
+quasarVersion = 0.9.0_r3-SNAPSHOT
 reflectAsmVersion = 1.11.9
 slf4jVersion=1.7.36
 snappyVersion=0.4


### PR DESCRIPTION
Upgrade Kryo 5.4.0 -> 5.5.0.

Note that Quasar no longer depends on Guava, as of [CORE-5878](https://r3-cev.atlassian.net/browse/CORE-5878).

[CORE-5878]: https://r3-cev.atlassian.net/browse/CORE-5878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ