### PR TITLE
CORE-12714 Improve Avro schema registration logging

### DIFF
--- a/libs/schema-registry/schema-registry-impl/src/main/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImpl.kt
+++ b/libs/schema-registry/schema-registry-impl/src/main/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImpl.kt
@@ -198,7 +198,7 @@ class AvroSchemaRegistryImpl(
                 // deserializing into, so we can search this list to find a name match.
                 compiledSchemaFingerprintsByClazz.keys.firstOrNull { it.name == schema.fullName }?.let { classFromSchema ->
                     clazzByFingerprint.putIfAbsent(fingerprint, classFromSchema)
-                } ?: log.info("Cannot find $clazz in schema registry, this schema will be ignored")
+                } ?: log.info("Attempt to register Avro schema for unknown class ${schema.fullName}, this schema will be ignored")
                 // Do not populate any other maps here, they are reserved for compile time classes
             } else {
                 // Class is known at compile time

--- a/libs/schema-registry/schema-registry-impl/src/test/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImplTest.kt
+++ b/libs/schema-registry/schema-registry-impl/src/test/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImplTest.kt
@@ -164,12 +164,11 @@ internal class AvroSchemaRegistryImplTest {
         val unknownClassTypeSchema = Schema.Parser()
             .parse(
                 "{\"type\":\"record\"," +
-                        "\"name\":\"AvroMessageWeHaveNoClassFor\"," +
-                        "\"namespace\":\"net.corda.data.test\"," +
-                        "\"fields\":[{\"name\":\"flags\",\"type\":\"int\"}]}"
+                    "\"name\":\"AvroMessageWeHaveNoClassFor\"," +
+                    "\"namespace\":\"net.corda.data.test\"," +
+                    "\"fields\":[{\"name\":\"flags\",\"type\":\"int\"}]}"
             )
-
-        registry.addSchemaOnly(unknownClassTypeSchema)
+        
         assertDoesNotThrow { registry.addSchemaOnly(unknownClassTypeSchema) }
     }
 

--- a/libs/schema-registry/schema-registry-impl/src/test/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImplTest.kt
+++ b/libs/schema-registry/schema-registry-impl/src/test/kotlin/net/corda/schema/registry/impl/AvroSchemaRegistryImplTest.kt
@@ -18,6 +18,7 @@ import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -155,6 +156,21 @@ internal class AvroSchemaRegistryImplTest {
 
         val decoded = registry.deserialize<TestMessage>(encoded)
         assertThat(nonAvroMessage).isEqualTo(decoded)
+    }
+
+    @Test
+    fun `schema for class which is unknown at compile time is safely ignored without error`() {
+        val registry = AvroSchemaRegistryImpl()
+        val unknownClassTypeSchema = Schema.Parser()
+            .parse(
+                "{\"type\":\"record\"," +
+                        "\"name\":\"AvroMessageWeHaveNoClassFor\"," +
+                        "\"namespace\":\"net.corda.data.test\"," +
+                        "\"fields\":[{\"name\":\"flags\",\"type\":\"int\"}]}"
+            )
+
+        registry.addSchemaOnly(unknownClassTypeSchema)
+        assertDoesNotThrow { registry.addSchemaOnly(unknownClassTypeSchema) }
     }
 
     @Test


### PR DESCRIPTION
Logging was displaying `null` in all case because incorrect variable was being logged. Also added a test to exercise this path through the code.