### PR TITLE
CORE-4126 Refactoring KeyValueStore to prevent Quasar ASM from erroring classloader

### DIFF
--- a/libs/flows/flow-utils/build.gradle
+++ b/libs/flows/flow-utils/build.gradle
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'

--- a/libs/flows/flow-utils/src/main/java/net/corda/flow/utils/package-info.java
+++ b/libs/flows/flow-utils/src/main/java/net/corda/flow/utils/package-info.java
@@ -1,6 +1,4 @@
 @Export
-@QuasarIgnorePackage
 package net.corda.flow.utils;
 
-import co.paralleluniverse.quasar.annotations.QuasarIgnorePackage;
 import org.osgi.annotation.bundle.Export;

--- a/libs/flows/flow-utils/src/main/kotlin/net/corda/flow/utils/KeyValueStore.kt
+++ b/libs/flows/flow-utils/src/main/kotlin/net/corda/flow/utils/KeyValueStore.kt
@@ -79,11 +79,13 @@ inline fun <reified T> Iterable<T>.toKeyValuePairList(prefix: String? = null): K
 class KeyValueStore(private val backingList: KeyValuePairList = mutableKeyValuePairList()) {
 
     private fun KeyValuePairList.setValue(key: String, value: String) {
-        items.find { it.key == key }?.let {
-            it.value = value
-        } ?: run {
-            items.add(KeyValuePair(key, value))
+        for (item in items) {
+            if (item.key == key) {
+                item.value = value
+                return
+            }
         }
+        items.add(KeyValuePair(key, value))
     }
 
     operator fun set(key: String, value: String) = backingList.setValue(key, value)


### PR DESCRIPTION
This is a follow-up from https://github.com/corda/corda-runtime-os/pull/3698

Further investigation into the issue by @chrisr3 determined that the root cause of the issue described in [CORE-4126](https://r3-cev.atlassian.net/browse/CORE-4126) lies in how the ASM library, used by Quasar for bytecode instrumentation, builds the `StackMapTable` for the `KeyValuePairList::setValue()` extension function defined in `KeyValueStore` in such a way as to pull in superclass dependencies not present in the original bytecode.

Given these findings, I think it makes sense to implement a finer-grained solution rather than to throw a blanket `@QuasarIgnorePackage` over the affected package and call it a day.

Further details can be found in the original ticket.

[CORE-4126]: https://r3-cev.atlassian.net/browse/CORE-4126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ