### PR TITLE
CORE-11959: make lifecycle being down cause retries in crypto flow ops

### DIFF
--- a/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/AbstractComponent.kt
+++ b/components/crypto/crypto-component-core-impl/src/main/kotlin/net/corda/crypto/component/impl/AbstractComponent.kt
@@ -1,5 +1,6 @@
 package net.corda.crypto.component.impl
 
+import net.corda.crypto.core.AbstractComponentNotReadyException
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -38,7 +39,7 @@ abstract class AbstractComponent<IMPL : AbstractComponent.AbstractImpl>(
         get() {
             val tmp = _impl
             if (tmp == null || lifecycleCoordinator.status != LifecycleStatus.UP) {
-                throw IllegalStateException("Component $myName is not ready.")
+                throw AbstractComponentNotReadyException("Component $myName is not ready.")
             }
             return tmp
         }

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -104,6 +104,14 @@ class CryptoFlowOpsBusProcessor(
     }
 
     private fun handleRequest(request: Any, context: CryptoRequestContext): Any {
+        // What about if cryptoOpsClient has gone to DOWN or ERROR out at this point? 
+        // Then CryptoOpsClientComponent will throw AbstractComponentNotReadyFunction, and the retry logic
+        // will keep repeating it until timeout or the cryptoOpsClient potentially comes back. 
+
+        // For example, if we get an UnknownHostException from Kafka client code then the crypto ops client
+        // will be marked as DOWN or ERROR (depending on what catches it; certainly if it made it to the top of the
+        // TreadLooper it will cause the status to go to ERROR)
+
         return when (request) {
             is FilterMyKeysFlowQuery ->
                 cryptoOpsClient.filterMyKeysProxy(

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/AbstractComponentNotReadyException.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/AbstractComponentNotReadyException.kt
@@ -1,0 +1,3 @@
+package net.corda.crypto.core
+
+class AbstractComponentNotReadyException(message: String) : IllegalStateException(message)

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoExceptionsUtils.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoExceptionsUtils.kt
@@ -17,6 +17,10 @@ val RETRYABLE_EXCEPTIONS = setOf(
 
 fun Throwable.isRecoverable(): Boolean =
     when (this) {
+        // AbstractComponentNotReadyException is thrown when lifecycle is goes away from up on an abstract component, 
+        // e.g. due to a transient or permanent error; we retry since it may come up later, and if it stays down
+        // long enough we will get restarted and this code may have more luck in the new process
+        is AbstractComponentNotReadyException -> true
         is TimeoutException -> true
         is CryptoException -> isRecoverable
         else -> when {


### PR DESCRIPTION
To that end, make the error thrown by AbstractComponent when invoking operations on components in state DOWN or ERROR be a specific type, since it was IllegalStateException and we don't know if it is appropriate to retry this.

I believe there are situations where errors may not be recoverable, and we will rely on the operator, often via Kubernets, to restart the worker, e.g. because the health check is returning negative. However, if we error out from the CryptoOpsClient into CryptoFlowOpsBusProcessor, then a platform error will be reported to the flow. If we wait, maybe we can proceed either after the service is restarted (e.g. by Kubernetes) or if the lifecycle goes UP again some other way. For instance, if we get a UnknownHostException from Kafka and put CryptoOpsClient down, then without this change we will error out a bunch of flows. With this change, we will wait until the service is restarted and then maybe succeed (if the TTL hasn't expired), or potentially we can have some additional retry logic that marks the CryptoOpsClient UP again when Kafka comes back. 

Long term, we may remove the `AbstractComponent` abstraction, and that takes work in each component that uses it, so this is a short term small fix to improve robustness in 5.0.