### PR TITLE
CORE-12404 The hardcoded interop-group interim solution will not contain some indetities.

### DIFF
--- a/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropAliasProcessor.kt
+++ b/components/interop/interop-service/src/main/kotlin/net/corda/interop/InteropAliasProcessor.kt
@@ -113,6 +113,14 @@ class InteropAliasProcessor(
             )
             return Record(Schemas.P2P.P2P_HOSTED_IDENTITIES_TOPIC, holdingIdentity.shortHash.value, hostedIdentity)
         }
+
+        fun commonNameOrUnitStartsWith(name: MemberX500Name, letters: List<String>): Boolean {
+            val commonName = name.commonName
+            return letters.any {
+                (commonName != null && (commonName.startsWith(it, ignoreCase = true))
+                        || (name.organization.startsWith(it, ignoreCase = true)))
+            }
+        }
     }
 
     override fun onNext(
@@ -141,6 +149,10 @@ class InteropAliasProcessor(
 
     private fun addEntry(entry: HostedIdentityEntry) {
         val info = entry.holdingIdentity.toCorda()
+        if (commonNameOrUnitStartsWith(info.x500Name, listOf("D", "E", "F"))) {
+            logger.info("Skipped adding alias for=${info.x500Name}")
+            return
+        }
         identityMappingCache[entry.holdingIdentity.x500Name.toString()] = info
         val newIdentity = entry
         val holdIdentity = newIdentity.holdingIdentity.toCorda()


### PR DESCRIPTION
The hard-coded interop-group interim solution be amended to so that a small subset of members e.g.  Dave, Elon, Freddie are not automatically added to it - implemented as: if x500Name organization (O) or common name (CN) starts with "D", "E" or "F" (lower or upper case), then no aliases will be created for those identities,
in the logs for FlowWorker, this will be recorded as "Skipped adding alias for=[x500Name]", e.g.:
```
% kubectl logs corda-flow-worker-7cf7847f9d-tqw9c | grep Skipped
Defaulted container "corda-flow-worker" out of: corda-flow-worker, create-sasl-jaas-conf (init)
08:48:15.610 [compacted subscription thread interop_alias_translator-p2p.hosted.identities] INFO  net.corda.interop.InteropAliasProcessor {} - Skipped adding alias for=O=Freddie, L=London, C=GB
```
In the deployment script, add name to the second group, here added `C=GB, L=London, O=Freddie"`:
```
cpi=demo2
identity1=("C=GB, L=London, O=Bob" "C=GB, L=London, O=Freddie")
```
Also when creating group policy add new `--name` entry: `"--name=${identity1[1]}"` full new line:
```
./build/generatedScripts/corda-cli.sh mgm groupPolicy "--name=${identity1[0]}" "--name=${identity1[1]}" --endpoint-protocol=1 --endpoint="http://localhost:1080" > "../register-member/$groupPolicyFile.json"

```
