### PR TITLE
ES-161: [Build] Update Helm chart location in corda-runtime-os deploy.sh script

### DIFF
--- a/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
@@ -23,7 +23,7 @@ deploy() {
      --wait
 
    echo Installing corda image $DOCKER_IMAGE_VERSION into $namespace
-   helm upgrade --install corda -n $namespace oci://corda-os-docker-unstable.software.r3.com/helm-charts/corda \
+   helm upgrade --install corda -n $namespace oci://corda-os-docker.software.r3.com/helm-charts/release/os/5.0/corda \
      --set "imagePullSecrets={docker-registry-cred}" --set image.tag=$DOCKER_IMAGE_VERSION \
      --set image.registry="corda-os-docker.software.r3.com" --values $REPO_TOP_LEVEL_DIR/values.yaml \
      --values $REPO_TOP_LEVEL_DIR/debug.yaml --wait --version $CORDA_CHART_VERSION


### PR DESCRIPTION
In line with the change made here PR #3701 
The location of the Helm chart needs to be updated in the deploy.sh script 