### PR TITLE
CORE-12553 Corda CLI package `create-cpi` command outputs stacktrace if no truststore

### DIFF
--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
@@ -100,7 +100,12 @@ class CreateCpiV2 : Runnable {
 
         // Check input Cpb file is indeed a Cpb
         cpbPath?.let {
-            verifyIsValidCpbV2(it)
+            try {
+                verifyIsValidCpbV2(it)
+            } catch (e: Exception) {
+                System.err.println("Error verifying CPB: ${e.message}")
+                return@run
+            }
         }
 
         val outputName = determineOutputFileName(cpbPath)
@@ -130,18 +135,14 @@ class CreateCpiV2 : Runnable {
      * @throws IllegalArgumentException if it fails to verify Cpb V2
      */
     private fun verifyIsValidCpbV2(cpbPath: Path) {
-        try {
-            VerifierBuilder()
-                .type(PackageType.CPB)
-                .format(VerifierFactory.FORMAT_2)
-                .name(cpbPath.toString())
-                .inputStream(FileInputStream(cpbPath.toString()))
-                .trustedCerts(readCertificates(signingOptions.keyStoreFileName, signingOptions.keyStorePass))
-                .build()
-                .verify()
-        } catch (e: Exception) {
-            throw IllegalArgumentException("Cpb is invalid", e)
-        }
+        VerifierBuilder()
+            .type(PackageType.CPB)
+            .format(VerifierFactory.FORMAT_2)
+            .name(cpbPath.toString())
+            .inputStream(FileInputStream(cpbPath.toString()))
+            .trustedCerts(readCertificates(signingOptions.keyStoreFileName, signingOptions.keyStorePass))
+            .build()
+            .verify()
     }
 
     /**

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
@@ -306,9 +306,7 @@ Creates a CPI v2 from a CPB and GroupPolicy.json file.
         }
 
         assertFalse(cpiOutputFile.exists())
-        assertThat(outText).contains("java.lang.IllegalArgumentException: Cpb is invalid")
-        assertThat(outText).contains("net.corda.libs.packaging.core.exception.CordappManifestException: " +
-                "Manifest has invalid attribute \"Corda-CPB-Format\" value \"null\"")
+        assertThat(outText).contains("Error verifying CPB: Manifest has invalid attribute \"Corda-CPB-Format\" value \"null\"")
     }
 
     @Test

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiTest.kt
@@ -5,10 +5,8 @@ import net.corda.cli.plugins.packaging.TestSigningKeys.SIGNING_KEY_2
 import net.corda.cli.plugins.packaging.TestSigningKeys.SIGNING_KEY_2_ALIAS
 import net.corda.cli.plugins.packaging.TestUtils.captureStdErr
 import net.corda.libs.packaging.testutils.cpb.TestCpbV2Builder
-import net.corda.libs.packaging.testutils.cpk.TestCpkV2Builder
 import net.corda.utilities.exists
 import net.corda.utilities.inputStream
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -274,39 +272,6 @@ Creates a CPI v2 from a CPB and GroupPolicy.json file.
   -t, --tsa=<tsaUrl>         Time Stamping Authority (TSA) URL
       --upgrade=<cpiUpgrade> Allow upgrade without flow draining
 """, errText)
-    }
-
-    @Test
-    fun `cpi create tool aborts if its not a cpb before packing it into a cpi`() {
-        // Attempt to pack a Cpk into a Cpi - should fail since it's not a Cpb
-        val cpkBuilder = TestCpkV2Builder()
-        val cpkStream = cpkBuilder
-            .signers(CPK_SIGNER).build().inputStream()
-        val cpkPath = Path.of(tempDir.toString(), cpkBuilder.name)
-        Files.newOutputStream(cpkPath, StandardOpenOption.CREATE_NEW).use { outStream ->
-            cpkStream.use {
-                it.copyTo(outStream)
-            }
-        }
-
-        val cpiOutputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
-
-        val outText = captureStdErr {
-            CommandLine(app).execute (
-                "--cpb=${cpkPath}",
-                "--group-policy=${testGroupPolicy}",
-                "--file=$cpiOutputFile",
-                "--keystore=${testKeyStore}",
-                "--storepass=keystore password",
-                "--key=$SIGNING_KEY_2_ALIAS",
-                "--sig-file=${CPI_SIGNER_NAME}",
-                "--cpi-name=cpi name",
-                "--cpi-version=1.2.3"
-            )
-        }
-
-        assertFalse(cpiOutputFile.exists())
-        assertThat(outText).contains("Error verifying CPB: Manifest has invalid attribute \"Corda-CPB-Format\" value \"null\"")
     }
 
     @Test

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
@@ -12,6 +12,7 @@ import net.corda.cli.plugins.packaging.TestUtils.jarEntriesExistInCpx
 import net.corda.libs.packaging.testutils.cpb.TestCpbV2Builder
 import net.corda.libs.packaging.testutils.cpk.TestCpkV2Builder
 import net.corda.utilities.exists
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -243,13 +244,7 @@ class CreateCpiV2Test {
         }
 
         assertFalse(cpiOutputFile.exists())
-        assertTrue(outText.contains("java.lang.IllegalArgumentException: Cpb is invalid"))
-        assertTrue(
-            outText.contains(
-                "net.corda.libs.packaging.core.exception.CordappManifestException: " +
-                        "Manifest has invalid attribute \"Corda-CPB-Format\" value \"null\""
-            )
-        )
+        assertThat(outText).contains("Error verifying CPB: Manifest has invalid attribute \"Corda-CPB-Format\" value \"null\"")
     }
 
     @Test


### PR DESCRIPTION
- makes error message user-friendly by not including stack trace
- slightly modifies error message to be consistent with equivalent message in `verify` command
- removes duplicate test

**Error message** at failing to verify CPB **now looks like**: "_Error verifying CPB: ${error message}_"