### PR TITLE
CORE-11656 Add validations to `DigestServiceImpl.parseSecureHash`

### DIFF
--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
@@ -3,8 +3,8 @@ package net.corda.cipher.suite.impl
 import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.crypto.core.DigestAlgorithmFactoryProvider
 import net.corda.crypto.core.SecureHashImpl
-import net.corda.crypto.core.parseDigestAlgoName
-import net.corda.crypto.core.parseHexString
+import net.corda.crypto.core.parseSecureHashAlgoName
+import net.corda.crypto.core.parseSecureHashHexString
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
@@ -63,10 +63,10 @@ class DigestServiceImpl @Activate constructor(
         try {
             platformDigestService.parseSecureHash(algoNameAndHexString)
         } catch (e: IllegalArgumentException) {
-            val digestName = parseDigestAlgoName(algoNameAndHexString)
+            val digestName = parseSecureHashAlgoName(algoNameAndHexString)
             lookForCustomAlgorithm(DigestAlgorithmName(digestName))?.let {
                 val digestHexStringLength = it.digestLength * 2
-                val hexString = parseHexString(algoNameAndHexString)
+                val hexString = parseSecureHashHexString(algoNameAndHexString)
                 require(digestHexStringLength == hexString.length) {
                     "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength is not met by hex string: \"$hexString\""
                 }

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
@@ -68,7 +68,8 @@ class DigestServiceImpl @Activate constructor(
                 val digestHexStringLength = it.digestLength * 2
                 val hexString = parseSecureHashHexString(algoNameAndHexString)
                 require(digestHexStringLength == hexString.length) {
-                    "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength is not met by hex string: \"$hexString\""
+                    "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength " +
+                            "is not met by hex string: \"$hexString\""
                 }
                 SecureHashImpl(digestName, ByteArrays.parseAsHex(hexString))
             } ?: throw e

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
@@ -68,7 +68,7 @@ class DigestServiceImpl @Activate constructor(
                 val digestHexStringLength = it.digestLength * 2
                 val hexString = parseSecureHashHexString(algoNameAndHexString)
                 require(digestHexStringLength == hexString.length) {
-                    "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength " +
+                    "Digest algorithm's: \"$digestName\" required hex string length: $digestHexStringLength " +
                             "is not met by hex string: \"$hexString\""
                 }
                 SecureHashImpl(digestName, ByteArrays.parseAsHex(hexString))

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/DigestServiceImpl.kt
@@ -4,11 +4,12 @@ import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.crypto.core.DigestAlgorithmFactoryProvider
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.parseDigestAlgoName
-import net.corda.crypto.core.parseSecureHash
+import net.corda.crypto.core.parseHexString
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
 import net.corda.v5.application.crypto.DigestService
+import net.corda.v5.base.util.ByteArrays
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.extensions.DigestAlgorithm
@@ -65,7 +66,11 @@ class DigestServiceImpl @Activate constructor(
             val digestName = parseDigestAlgoName(algoNameAndHexString)
             lookForCustomAlgorithm(DigestAlgorithmName(digestName))?.let {
                 val digestHexStringLength = it.digestLength * 2
-                parseSecureHash(algoNameAndHexString, digestHexStringLength)
+                val hexString = parseHexString(algoNameAndHexString)
+                require(digestHexStringLength == hexString.length) {
+                    "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength is not met by hex string: \"$hexString\""
+                }
+                SecureHashImpl(digestName, ByteArrays.parseAsHex(hexString))
             } ?: throw e
         }
 

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
@@ -50,7 +50,8 @@ class PlatformDigestServiceImpl @Activate constructor(
         val digestHexStringLength = digestLength(DigestAlgorithmName(digestName)) * 2
         val hexString = parseSecureHashHexString(algoNameAndHexString)
         require(digestHexStringLength == hexString.length) {
-            "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength is not met by hex string: \"$hexString\""
+            "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength " +
+                    "is not met by hex string: \"$hexString\""
         }
         return SecureHashImpl(digestName, ByteArrays.parseAsHex(hexString))
     }

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
@@ -50,7 +50,7 @@ class PlatformDigestServiceImpl @Activate constructor(
         val digestHexStringLength = digestLength(DigestAlgorithmName(digestName)) * 2
         val hexString = parseSecureHashHexString(algoNameAndHexString)
         require(digestHexStringLength == hexString.length) {
-            "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength " +
+            "Digest algorithm's: \"$digestName\" required hex string length: $digestHexStringLength " +
                     "is not met by hex string: \"$hexString\""
         }
         return SecureHashImpl(digestName, ByteArrays.parseAsHex(hexString))

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
@@ -3,8 +3,8 @@ package net.corda.cipher.suite.impl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.crypto.core.SecureHashImpl
-import net.corda.crypto.core.parseDigestAlgoName
-import net.corda.crypto.core.parseHexString
+import net.corda.crypto.core.parseSecureHashAlgoName
+import net.corda.crypto.core.parseSecureHashHexString
 import net.corda.crypto.impl.DoubleSHA256DigestFactory
 import net.corda.v5.base.util.ByteArrays
 import net.corda.v5.crypto.DigestAlgorithmName
@@ -45,10 +45,10 @@ class PlatformDigestServiceImpl @Activate constructor(
     }
 
     override fun parseSecureHash(algoNameAndHexString: String): SecureHash {
-        val digestName = parseDigestAlgoName(algoNameAndHexString)
+        val digestName = parseSecureHashAlgoName(algoNameAndHexString)
         // `digestLength` throws if algorithm not found/ not supported
         val digestHexStringLength = digestLength(DigestAlgorithmName(digestName)) * 2
-        val hexString = parseHexString(algoNameAndHexString)
+        val hexString = parseSecureHashHexString(algoNameAndHexString)
         require(digestHexStringLength == hexString.length) {
             "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength is not met by hex string: \"$hexString\""
         }

--- a/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
+++ b/libs/crypto/cipher-suite-impl/src/main/kotlin/net/corda/cipher/suite/impl/PlatformDigestServiceImpl.kt
@@ -4,8 +4,9 @@ import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.parseDigestAlgoName
-import net.corda.crypto.core.parseSecureHash
+import net.corda.crypto.core.parseHexString
 import net.corda.crypto.impl.DoubleSHA256DigestFactory
+import net.corda.v5.base.util.ByteArrays
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.extensions.DigestAlgorithm
@@ -47,7 +48,11 @@ class PlatformDigestServiceImpl @Activate constructor(
         val digestName = parseDigestAlgoName(algoNameAndHexString)
         // `digestLength` throws if algorithm not found/ not supported
         val digestHexStringLength = digestLength(DigestAlgorithmName(digestName)) * 2
-        return parseSecureHash(algoNameAndHexString, digestHexStringLength)
+        val hexString = parseHexString(algoNameAndHexString)
+        require(digestHexStringLength == hexString.length) {
+            "Required algorithm's: \"$digestName\" hex string length: $digestHexStringLength is not met by hex string: \"$hexString\""
+        }
+        return SecureHashImpl(digestName, ByteArrays.parseAsHex(hexString))
     }
 
     override fun digestLength(platformDigestName: DigestAlgorithmName): Int =

--- a/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/DigestServiceImplTest.kt
+++ b/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/DigestServiceImplTest.kt
@@ -3,10 +3,14 @@ package net.corda.cipher.suite.impl
 import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.crypto.core.DigestAlgorithmFactoryProvider
 import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
+import net.corda.v5.base.util.ByteArrays
 import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.extensions.DigestAlgorithm
 import net.corda.v5.crypto.extensions.DigestAlgorithmFactory
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -14,6 +18,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.io.InputStream
+import kotlin.random.Random
 
 // DigestServiceImpl is basically a wrapper around `PlatformDigestServiceImpl` so main hashing functionality
 // is tested in `PlatformDigestServiceImplTest`. Here we will only assert wrapping behavior
@@ -30,6 +35,7 @@ class DigestServiceImplTest {
         whenever(it.hash(any<InputStream>(), any())).thenThrow(IllegalArgumentException())
         whenever(it.hash(any<ByteArray>(), any())).thenThrow(IllegalArgumentException())
         whenever(it.digestLength(any())).thenThrow(IllegalArgumentException())
+        whenever(it.parseSecureHash(any())).thenThrow(IllegalArgumentException())
     }
 
     private lateinit var customFactoriesProvider: DigestAlgorithmFactoryProvider
@@ -76,5 +82,26 @@ class DigestServiceImplTest {
         assertEquals(expectedDummySecureHash, hash0)
         assertEquals(expectedDummySecureHash, hash1)
         assertEquals(DUMMY_DIGEST_LENGTH, hashLength)
+    }
+
+    @Test
+    fun `parses secure hash of custom digest algorithm`() {
+        val digestAlgorithmFactory = object : DigestAlgorithmFactory {
+            override fun getAlgorithm() = "CUSTOM_DIGEST"
+            override fun getInstance() =
+                object : DigestAlgorithm {
+                    override fun getAlgorithm() = "CUSTOM_DIGEST"
+                    override fun getDigestLength() = 64
+                    override fun digest(inputStream: InputStream) = throw UnsupportedOperationException()
+                    override fun digest(bytes: ByteArray) = throw UnsupportedOperationException()
+                }
+        }
+        whenever(customFactoriesProvider.get("CUSTOM_DIGEST")).thenReturn(digestAlgorithmFactory)
+
+        val hashBytes = Random.nextBytes(64)
+        val algoNameAndHexString = "CUSTOM_DIGEST${SecureHash.DELIMITER}${ByteArrays.toHexString(hashBytes)}"
+        val secureHash = digestServiceImpl.parseSecureHash(algoNameAndHexString)
+        assertEquals("CUSTOM_DIGEST", secureHash.algorithm)
+        assertTrue(hashBytes.contentEquals(secureHash.bytes))
     }
 }

--- a/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/DigestServiceImplTest.kt
+++ b/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/DigestServiceImplTest.kt
@@ -30,7 +30,7 @@ class DigestServiceImplTest {
         val DUMMY_BYTES = byteArrayOf(0x01, 0x02, 0x03)
     }
 
-    private val digestService = mock<PlatformDigestService>().also {
+    private val platformDigestService = mock<PlatformDigestService>().also {
         // DigestService throwing to impersonate digest algorithm not found in platform digest algorithms
         whenever(it.hash(any<InputStream>(), any())).thenThrow(IllegalArgumentException())
         whenever(it.hash(any<ByteArray>(), any())).thenThrow(IllegalArgumentException())
@@ -39,24 +39,24 @@ class DigestServiceImplTest {
     }
 
     private lateinit var customFactoriesProvider: DigestAlgorithmFactoryProvider
-    private lateinit var digestServiceImpl: DigestServiceImpl
+    private lateinit var digestService: DigestServiceImpl
 
     @BeforeEach
     fun setUp() {
         customFactoriesProvider = mock()
-        digestServiceImpl = DigestServiceImpl(digestService, customFactoriesProvider)
+        digestService = DigestServiceImpl(platformDigestService, customFactoriesProvider)
     }
 
     @Test
     fun `throws IllegalArgumentException, if digest algorithm not found`() {
         assertThrows<IllegalArgumentException> {
-            digestServiceImpl.hash(DUMMY_BYTES, DigestAlgorithmName(DUMMY_DIGEST))
+            digestService.hash(DUMMY_BYTES, DigestAlgorithmName(DUMMY_DIGEST))
         }
         assertThrows<IllegalArgumentException> {
-            digestServiceImpl.hash(DUMMY_BYTES.inputStream(), DigestAlgorithmName(DUMMY_DIGEST))
+            digestService.hash(DUMMY_BYTES.inputStream(), DigestAlgorithmName(DUMMY_DIGEST))
         }
         assertThrows<IllegalArgumentException> {
-            digestServiceImpl.digestLength(DigestAlgorithmName(DUMMY_DIGEST))
+            digestService.digestLength(DigestAlgorithmName(DUMMY_DIGEST))
         }
     }
 
@@ -74,9 +74,9 @@ class DigestServiceImplTest {
         }
         whenever(customFactoriesProvider.get(DUMMY_DIGEST)).thenReturn(digestAlgorithmFactory)
 
-        val hash0 = digestServiceImpl.hash(DUMMY_BYTES, DigestAlgorithmName(DUMMY_DIGEST))
-        val hash1 = digestServiceImpl.hash(DUMMY_BYTES.inputStream(), DigestAlgorithmName(DUMMY_DIGEST))
-        val hashLength = digestServiceImpl.digestLength(DigestAlgorithmName(DUMMY_DIGEST))
+        val hash0 = digestService.hash(DUMMY_BYTES, DigestAlgorithmName(DUMMY_DIGEST))
+        val hash1 = digestService.hash(DUMMY_BYTES.inputStream(), DigestAlgorithmName(DUMMY_DIGEST))
+        val hashLength = digestService.digestLength(DigestAlgorithmName(DUMMY_DIGEST))
 
         val expectedDummySecureHash = SecureHashImpl(DUMMY_DIGEST, DUMMY_BYTES)
         assertEquals(expectedDummySecureHash, hash0)
@@ -100,7 +100,7 @@ class DigestServiceImplTest {
 
         val hashBytes = Random.nextBytes(64)
         val algoNameAndHexString = "CUSTOM_DIGEST${SecureHash.DELIMITER}${ByteArrays.toHexString(hashBytes)}"
-        val secureHash = digestServiceImpl.parseSecureHash(algoNameAndHexString)
+        val secureHash = digestService.parseSecureHash(algoNameAndHexString)
         assertEquals("CUSTOM_DIGEST", secureHash.algorithm)
         assertTrue(hashBytes.contentEquals(secureHash.bytes))
     }

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/PlatformDigestService.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/PlatformDigestService.kt
@@ -38,6 +38,9 @@ interface PlatformDigestService {
      * @param algoNameAndHexString The algorithm name followed by the hex string form of the digest,
      *                             separated by colon (':')
      *                             e.g. SHA-256:98AF8725385586B41FEFF205B4E05A000823F78B5F8F5C02439CE8F67A781D90.
+     *
+     * @throws IllegalArgumentException if the digest algorithm is not supported or if the hex string length does not
+     *                                  meet the algorithm's digest length.
      */
     fun parseSecureHash(algoNameAndHexString: String): SecureHash
 

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/PlatformDigestService.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/PlatformDigestService.kt
@@ -30,6 +30,18 @@ interface PlatformDigestService {
     fun hash(inputStream : InputStream, platformDigestName: DigestAlgorithmName): SecureHash
 
     /**
+     * Parses a secure hash in string form into a [SecureHash].
+     *
+     * A valid secure hash string should be containing the algorithm and hexadecimal representation of the bytes
+     * separated by the colon character (':') ([net.corda.v5.crypto.SecureHash.DELIMITER]).
+     *
+     * @param algoNameAndHexString The algorithm name followed by the hex string form of the digest,
+     *                             separated by colon (':')
+     *                             e.g. SHA-256:98AF8725385586B41FEFF205B4E05A000823F78B5F8F5C02439CE8F67A781D90.
+     */
+    fun parseSecureHash(algoNameAndHexString: String): SecureHash
+
+    /**
      * Returns the [DigestAlgorithmName] digest length in bytes.
      *
      * @param platformDigestName The digest algorithm to get the digest length for, looked up in platform supported

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
@@ -38,18 +38,21 @@ fun parseDigestAlgoName(algoNameAndHexString: String): String {
     return algoNameAndHexString.substring(0, idx)
 }
 
-fun parseSecureHash(algoNameAndHexString: String, expectedLength: Int? = null): SecureHash {
+fun parseHexString(algoNameAndHexString: String): String {
+    val idx = algoNameAndHexString.indexOf(DELIMITER)
+    if (idx == -1) {
+        throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")
+    }
+    return algoNameAndHexString.substring(idx + 1)
+}
+
+fun parseSecureHash(algoNameAndHexString: String): SecureHash {
     val idx = algoNameAndHexString.indexOf(DELIMITER)
     return if (idx == -1) {
         throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")
     } else {
         val algorithm = algoNameAndHexString.substring(0, idx)
         val value = algoNameAndHexString.substring(idx + 1)
-        expectedLength?.let {
-            require(it == value.length) {
-                "Required hex string length: $it for algo: \"$algorithm\" is not met by the provided hex string: \"$value\""
-            }
-        }
         val data = ByteArrays.parseAsHex(value)
         SecureHashImpl(algorithm, data)
     }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
@@ -30,7 +30,7 @@ class SecureHashImpl(
     override fun toString() = "$algorithm$DELIMITER${toHexString()}"
 }
 
-fun parseDigestAlgoName(algoNameAndHexString: String): String {
+fun parseSecureHashAlgoName(algoNameAndHexString: String): String {
     val idx = algoNameAndHexString.indexOf(DELIMITER)
     if (idx == -1) {
         throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")
@@ -38,7 +38,7 @@ fun parseDigestAlgoName(algoNameAndHexString: String): String {
     return algoNameAndHexString.substring(0, idx)
 }
 
-fun parseHexString(algoNameAndHexString: String): String {
+fun parseSecureHashHexString(algoNameAndHexString: String): String {
     val idx = algoNameAndHexString.indexOf(DELIMITER)
     if (idx == -1) {
         throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
@@ -38,14 +38,14 @@ fun parseDigestAlgoName(algoNameAndHexString: String): String {
     return algoNameAndHexString.substring(0, idx)
 }
 
-fun parseSecureHash(algoNameAndHexString: String, hexStringLength: Int? = null): SecureHash {
+fun parseSecureHash(algoNameAndHexString: String, expectedLength: Int? = null): SecureHash {
     val idx = algoNameAndHexString.indexOf(DELIMITER)
     return if (idx == -1) {
         throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")
     } else {
         val algorithm = algoNameAndHexString.substring(0, idx)
         val value = algoNameAndHexString.substring(idx + 1)
-        hexStringLength?.let {
+        expectedLength?.let {
             require(it == value.length) {
                 "Required hex string length: $it for algo: \"$algorithm\" is not met by the provided hex string: \"$value\""
             }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
@@ -39,23 +39,15 @@ fun parseSecureHashAlgoName(algoNameAndHexString: String): String {
 }
 
 fun parseSecureHashHexString(algoNameAndHexString: String): String {
-    val idx = algoNameAndHexString.indexOf(DELIMITER)
-    if (idx == -1) {
-        throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")
-    }
-    return algoNameAndHexString.substring(idx + 1)
+    val algoName = parseSecureHashAlgoName(algoNameAndHexString)
+    return algoNameAndHexString.substring(algoName.length + 1)
 }
 
 fun parseSecureHash(algoNameAndHexString: String): SecureHash {
-    val idx = algoNameAndHexString.indexOf(DELIMITER)
-    return if (idx == -1) {
-        throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")
-    } else {
-        val algorithm = algoNameAndHexString.substring(0, idx)
-        val value = algoNameAndHexString.substring(idx + 1)
-        val data = ByteArrays.parseAsHex(value)
-        SecureHashImpl(algorithm, data)
-    }
+    val algoName = parseSecureHashAlgoName(algoNameAndHexString)
+    val hexString = algoNameAndHexString.substring(algoName.length + 1)
+    val data = ByteArrays.parseAsHex(hexString)
+    return SecureHashImpl(algoName, data)
 }
 
 val SecureHash.bytes: ByteArray

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
@@ -30,13 +30,26 @@ class SecureHashImpl(
     override fun toString() = "$algorithm$DELIMITER${toHexString()}"
 }
 
-fun parseSecureHash(algoNameAndHexString: String): SecureHash {
+fun parseDigestAlgoName(algoNameAndHexString: String): String {
+    val idx = algoNameAndHexString.indexOf(DELIMITER)
+    if (idx == -1) {
+        throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")
+    }
+    return algoNameAndHexString.substring(0, idx)
+}
+
+fun parseSecureHash(algoNameAndHexString: String, hexStringLength: Int? = null): SecureHash {
     val idx = algoNameAndHexString.indexOf(DELIMITER)
     return if (idx == -1) {
         throw IllegalArgumentException("Provided string: $algoNameAndHexString should be of format algorithm:hexadecimal")
     } else {
         val algorithm = algoNameAndHexString.substring(0, idx)
         val value = algoNameAndHexString.substring(idx + 1)
+        hexStringLength?.let {
+            require(it == value.length) {
+                "Required hex string length: $it for algo: \"$algorithm\" is not met by the provided hex string: \"$value\""
+            }
+        }
         val data = ByteArrays.parseAsHex(value)
         SecureHashImpl(algorithm, data)
     }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/SecureHashImpl.kt
@@ -46,8 +46,7 @@ fun parseSecureHashHexString(algoNameAndHexString: String): String {
 fun parseSecureHash(algoNameAndHexString: String): SecureHash {
     val algoName = parseSecureHashAlgoName(algoNameAndHexString)
     val hexString = algoNameAndHexString.substring(algoName.length + 1)
-    val data = ByteArrays.parseAsHex(hexString)
-    return SecureHashImpl(algoName, data)
+    return SecureHashImpl(algoName, ByteArrays.parseAsHex(hexString))
 }
 
 val SecureHash.bytes: ByteArray

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/SignatureSpecUtilsTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/SignatureSpecUtilsTests.kt
@@ -89,6 +89,10 @@ class SignatureSpecUtilsTests {
             return SecureHashImpl(platformDigestName.name, messageDigest.digest())
         }
 
+        override fun parseSecureHash(algoNameAndHexString: String): SecureHash {
+            TODO("Not yet implemented")
+        }
+
         override fun digestLength(platformDigestName: DigestAlgorithmName): Int =
             MessageDigest.getInstance(platformDigestName.name).digestLength
 

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/tests/legacy/DigestServiceImpl.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/tests/legacy/DigestServiceImpl.kt
@@ -29,6 +29,10 @@ class DigestServiceImpl : PlatformDigestService {
         return SecureHashImpl(platformDigestName.name, messageDigest.digest())
     }
 
+    override fun parseSecureHash(algoNameAndHexString: String): SecureHash {
+        TODO("Not yet implemented")
+    }
+
     override fun digestLength(platformDigestName: DigestAlgorithmName): Int {
         return digestFor(platformDigestName).digestLength
     }


### PR DESCRIPTION
- adds validations on secure hash parsing; that 1. digest algorithm is supported and 2. the hex value of the hash is of the expected length:
  - adds `PlatformDigestService.parseSecureHash` to delegate for platform digest algorithms validations
  - adds custom algorithms validations in `DigestServiceImpl.parseSecureHash`