### PR TITLE
ES-175: remove external publishing for simulator and it's dependencies

### DIFF
--- a/libs/configuration/configuration-core/build.gradle
+++ b/libs/configuration/configuration-core/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Configuration Library'

--- a/libs/crypto/cipher-suite-impl/build.gradle
+++ b/libs/crypto/cipher-suite-impl/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Cipher suite default implementation'

--- a/libs/crypto/cipher-suite/build.gradle
+++ b/libs/crypto/cipher-suite/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Corda Cipher Suite'

--- a/libs/crypto/crypto-core/build.gradle
+++ b/libs/crypto/crypto-core/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Crypto core'

--- a/libs/crypto/crypto-impl/build.gradle
+++ b/libs/crypto/crypto-impl/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Common crypto implementation'

--- a/libs/crypto/crypto-serialization-impl/build.gradle
+++ b/libs/crypto/crypto-serialization-impl/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Crypto serialization'

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -1,14 +1,6 @@
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
-    id 'corda.javadoc-generation'
-}
-
-// Temporary measure for DP2, required as a transitive dependency by simulator modules
-// This code marks this module as to be published externally.
-// TODO To be revisited prior to beta program.
-ext {
-    releasable = true
 }
 
 description 'Database Admin Implementation'

--- a/libs/db/db-admin/build.gradle
+++ b/libs/db/db-admin/build.gradle
@@ -1,15 +1,8 @@
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
-    id 'corda.javadoc-generation'
 }
 
-// Temporary measure for DP2, required as a transitive dependency by simulator modules
-// This code marks this module as to be published externally.
-// TODO To be revisited prior to beta program.
-ext {
-    releasable = true
-}
 
 description 'Database Admin API'
 

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -7,11 +7,6 @@ import static com.gradle.enterprise.gradleplugin.test.JUnitXmlDialect.GENERIC
 plugins {
     id 'corda.common-publishing'
     id 'biz.aQute.bnd.builder'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description "Bare bones Kotlin reflection within an OSGi framework."

--- a/libs/layered-property-map/build.gradle
+++ b/libs/layered-property-map/build.gradle
@@ -2,11 +2,6 @@ plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
     id 'corda.osgi-test-conventions'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Layered property map internal API and implementation'

--- a/libs/packaging/packaging-core/build.gradle
+++ b/libs/packaging/packaging-core/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Packaging Interfaces and Data Classes'

--- a/libs/packaging/packaging/build.gradle
+++ b/libs/packaging/packaging/build.gradle
@@ -3,11 +3,6 @@ import aQute.bnd.version.MavenVersion
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Corda Packaging'

--- a/libs/sandbox-types/build.gradle
+++ b/libs/sandbox-types/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Corda Sandbox Types'

--- a/libs/sandbox/build.gradle
+++ b/libs/sandbox/build.gradle
@@ -2,11 +2,6 @@ plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
     id 'org.jetbrains.kotlin.jvm'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Corda Sandbox'

--- a/libs/serialization/json-serializers/build.gradle
+++ b/libs/serialization/json-serializers/build.gradle
@@ -1,15 +1,9 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Corda Common JSON serializers'
-
 
 dependencies {
     compileOnly "org.osgi:osgi.annotation"

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -4,12 +4,6 @@ plugins {
     id 'corda.osgi-test-conventions'
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
-}
-
-
-ext {
-    releasable = true
 }
 
 description 'Corda AMQP serialization library'

--- a/libs/serialization/serialization-encoding/build.gradle
+++ b/libs/serialization/serialization-encoding/build.gradle
@@ -4,10 +4,6 @@ plugins {
     id 'corda.javadoc-generation'
 }
 
-ext {
-    releasable = true
-}
-
 description 'Corda Serialization encoding'
 
 configurations {

--- a/libs/serialization/serialization-internal/build.gradle
+++ b/libs/serialization/serialization-internal/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-library'
     id 'corda.common-publishing'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 description 'Corda Serialization Internal API'

--- a/libs/utilities/build.gradle
+++ b/libs/utilities/build.gradle
@@ -1,13 +1,9 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
 }
 description 'Utilities'
 
-ext {
-    releasable = true
-}
 
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'corda.common-publishing'
     id 'net.corda.plugins.cordapp-cpb2'
-    id 'corda.javadoc-generation'
 }
 
 description 'Corda Non-Validating Notary Plugin Server'

--- a/simulator/api/build.gradle
+++ b/simulator/api/build.gradle
@@ -1,11 +1,6 @@
 
 plugins {
     id 'corda.common-publishing'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 dependencies {

--- a/simulator/runtime/build.gradle
+++ b/simulator/runtime/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-publishing'
     id 'corda.common-library'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 dependencies {

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -1,11 +1,6 @@
 plugins {
     id 'corda.common-publishing'
     id 'java'
-    id 'corda.javadoc-generation'
-}
-
-ext {
-    releasable = true
 }
 
 group 'net.corda.cli.deployment'


### PR DESCRIPTION
Use of the `simulator` module in CSDE brought in multiple runtime dependencies which over the course of development required us to make several corda-runtime-os jars publicly available. 

With the retirement of simulator, this should be corrected.

- Remove `releasable = true` extensions block from these modules, this property signals to our internal publishing gradle plugin to pick up these modules for external publishing.
- Remove `corda.javadoc-generation` from these modules also, which is a BuildSrc plugin that controls JavaDoc generation this was only added as a requirement of Maven Central upload, now that we are no longer externally releasing these modules this can also be removed, this will have an added benefit of less build activity needed on CI runs.

