### PR TITLE
CORE-13094: Properly delete previously installed version of `corda-cli`

### DIFF
--- a/tools/plugins/installScripts/install.ps1
+++ b/tools/plugins/installScripts/install.ps1
@@ -2,11 +2,14 @@ param ($addToPath)
 
 $cliHomeDir = "$ENV:UserProfile\.corda\cli"
 
+Write-Output "Removing previous cli version if exists"
+if(Test-Path -Path "$cliHomeDir") {
+    Write-Output "Deleting: $cliHomeDir"
+    Remove-Item "$cliHomeDir" -Recurse
+}
+
 Write-Output "Creating corda-cli dir at $cliHomeDir"
 New-Item -Path "$cliHomeDir" -ItemType "directory" -Force
-
-Write-Output "Removing previous cli version if exists"
-Remove-Item '$cliHomeDir\plugins' -Include *.jar
 
 Write-Output "Copying files and plugins"
 Copy-Item -Path ".\*" -Destination $cliHomeDir -Recurse

--- a/tools/plugins/installScripts/install.sh
+++ b/tools/plugins/installScripts/install.sh
@@ -4,11 +4,11 @@ zipdir=$(dirname $0)
 
 cliHome=~/.corda/cli/
 
+echo "Removing previous cli version if exists"
+rm -rf $cliHome
+
 echo "Creating corda-cli dir at cliHome"
 mkdir -p $cliHome
-
-echo "Removing previous cli version if exists"
-rm $cliHome/plugins/*.jar
 
 echo "Copying files and plugins"
 cp -R $zipdir/* $cliHome


### PR DESCRIPTION
Before installing a newer version