### PR TITLE
CORE-12543: Updating REST dependencies, part 2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -109,7 +109,7 @@ javalinVersion = 4.6.7
 swaggerVersion = 2.2.9
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
 swaggeruiVersion = 4.18.2
-nimbusVersion = 10.7.2
+nimbusVersion = 10.8
 unirestVersion = 3.14.2
 jettyVersion = 9.4.51.v20230217
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -106,7 +106,7 @@ slingVersion=3.3.6
 
 # REST dependency versions
 javalinVersion = 4.6.7
-swaggerVersion = 2.2.8
+swaggerVersion = 2.2.9
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
 swaggeruiVersion = 4.18.2
 nimbusVersion = 10.7.2


### PR DESCRIPTION
Updated version of: 
- `swagger-core` to 2.2.9
- `nimbus` to 10.8