### PR TITLE
CORE-13129: Remove org.osgi.framework.bsnversion property from OSGi tests.

### DIFF
--- a/components/membership/registration-impl/test.bndrun
+++ b/components/membership/registration-impl/test.bndrun
@@ -43,7 +43,6 @@
     begin=-1
 
 -runproperties: \
-    org.osgi.framework.bsnversion=multiple,\
     org.slf4j.simpleLogger.defaultLogLevel=info,\
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\

--- a/components/membership/synchronisation-impl/test.bndrun
+++ b/components/membership/synchronisation-impl/test.bndrun
@@ -46,7 +46,6 @@
     begin=-1
 
 -runproperties: \
-    org.osgi.framework.bsnversion=multiple,\
     org.slf4j.simpleLogger.defaultLogLevel=info,\
     org.slf4j.simpleLogger.showShortLogName=true,\
     org.slf4j.simpleLogger.showThreadName=false,\


### PR DESCRIPTION
This property allows the OSGi framework to contain multiple bundles with the same (`Bundle-SymbolicName`, `Bundle-Version`), which is not how our applications are configured to behave.