### PR TITLE
CORE-13024: remove old test that is covered in e2e test repo

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
@@ -15,7 +15,6 @@ import net.corda.e2etest.utilities.assertWithRetry
 import net.corda.e2etest.utilities.awaitRpcFlowFinished
 import net.corda.e2etest.utilities.awaitVirtualNodeOperationStatusCheck
 import net.corda.e2etest.utilities.cluster
-import net.corda.e2etest.utilities.getFlowStatus
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.startRpcFlow
 import net.corda.e2etest.utilities.toJson
@@ -37,7 +36,7 @@ import java.util.UUID
  */
 @Order(10)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
-class VirtualNodeRpcTest {
+class VirtualNodeRestTest {
     companion object {
         // Some simple test failure messages
         private const val ERROR_CPI_NOT_UPLOADED =
@@ -323,33 +322,6 @@ class VirtualNodeRpcTest {
                             response.toJson()["holdingIdentity"]["x500Name"].textValue().contains(aliceX500)
                 }
             }
-        }
-    }
-
-    @Test
-    @Order(62)
-    fun `set virtual node state`() {
-        cluster {
-            endpoint(
-                CLUSTER_URI,
-                USERNAME,
-                PASSWORD
-            )
-            val vnodesWithStates: List<Pair<String, String>> = vNodeList().toJson()["virtualNodes"].map {
-                it["holdingIdentity"]["shortHash"].textValue() to it["flowP2pOperationalStatus"].textValue()
-            }
-
-            val (vnodeId, oldState) = vnodesWithStates.last()
-            val newState = "maintenance"
-
-            eventuallyUpdateVirtualNodeState(vnodeId, newState, "INACTIVE")
-
-            val className = "com.r3.corda.testing.smoketests.virtualnode.ReturnAStringFlow"
-            val requestId = startRpcFlow(aliceHoldingId, emptyMap(), className, 405)
-            getFlowStatus(aliceHoldingId, requestId, 404)
-
-
-            eventuallyUpdateVirtualNodeState(vnodeId, oldState, "ACTIVE")
         }
     }
 


### PR DESCRIPTION
This removes a test that is present in the e2e test repo and might have become flakey here. 

It also renames VirtualNodeRpcTest to VirtualNodeRestTest. 