### PR TITLE
CORE-11162: Remove source and destination from inbound unauthenticated messages

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -3,7 +3,7 @@ package net.corda.p2p.gateway.messaging.internal
 import io.netty.handler.codec.http.HttpResponseStatus
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.p2p.LinkInMessage
-import net.corda.data.p2p.app.UnauthenticatedMessage
+import net.corda.data.p2p.app.InboundUnauthenticatedMessage
 import net.corda.data.p2p.crypto.AuthenticatedDataMessage
 import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
 import net.corda.data.p2p.crypto.InitiatorHandshakeMessage
@@ -127,7 +127,7 @@ internal class InboundMessageHandler(
         logger.debug("Received and processing message ${gatewayMessage.id} of type ${p2pMessage.payload.javaClass} from ${request.source}")
         val response = GatewayResponse(gatewayMessage.id)
         when (p2pMessage.payload) {
-            is UnauthenticatedMessage -> {
+            is InboundUnauthenticatedMessage -> {
                 p2pInPublisher.publish(listOf(Record(LINK_IN_TOPIC, generateKey(), p2pMessage)))
                 httpWriter.write(HttpResponseStatus.OK, request.source, avroSchemaRegistry.serialize(response).array())
             }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
@@ -2,7 +2,6 @@ package net.corda.p2p.gateway.messaging.internal
 
 import io.netty.handler.codec.http.HttpResponseStatus
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.data.identity.HoldingIdentity
 import net.corda.data.p2p.gateway.GatewayMessage
 import net.corda.data.p2p.gateway.GatewayResponse
 import net.corda.libs.configuration.SmartConfigImpl
@@ -17,8 +16,8 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.data.p2p.LinkInMessage
-import net.corda.data.p2p.app.UnauthenticatedMessage
-import net.corda.data.p2p.app.UnauthenticatedMessageHeader
+import net.corda.data.p2p.app.InboundUnauthenticatedMessage
+import net.corda.data.p2p.app.InboundUnauthenticatedMessageHeader
 import net.corda.data.p2p.crypto.AuthenticatedDataMessage
 import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
 import net.corda.data.p2p.crypto.CommonHeader
@@ -504,10 +503,8 @@ class InboundMessageHandlerTest {
         source = InitiatorHandshakeIdentity(ByteBuffer.wrap(byteArrayOf()), "some-group")
     }.build()
 
-    private fun unauthenticatedP2PMessage(content: String) = UnauthenticatedMessage.newBuilder().apply {
-        header = UnauthenticatedMessageHeader(
-            HoldingIdentity("A", "B"),
-            HoldingIdentity("C", "D"),
+    private fun unauthenticatedP2PMessage(content: String) = InboundUnauthenticatedMessage.newBuilder().apply {
+        header = InboundUnauthenticatedMessageHeader(
             "subsystem",
             "messageId",
         )

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandlerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandlerTest.kt
@@ -19,8 +19,8 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.data.p2p.LinkOutHeader
 import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.NetworkType
-import net.corda.data.p2p.app.UnauthenticatedMessage
-import net.corda.data.p2p.app.UnauthenticatedMessageHeader
+import net.corda.data.p2p.app.InboundUnauthenticatedMessage
+import net.corda.data.p2p.app.InboundUnauthenticatedMessageHeader
 import net.corda.p2p.gateway.messaging.ConnectionConfiguration
 import net.corda.p2p.gateway.messaging.DynamicKeyStore
 import net.corda.p2p.gateway.messaging.ReconfigurableConnectionManager
@@ -176,10 +176,8 @@ class OutboundMessageHandlerTest {
 
     @Test
     fun `onNext will write message to the client and return completed future`() {
-        val msgPayload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val msgPayload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -211,10 +209,8 @@ class OutboundMessageHandlerTest {
     @Test
     fun `onNext will throw an exception if the handler is not ready`() {
         handlerStarted = false
-        val payload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val payload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -236,10 +232,8 @@ class OutboundMessageHandlerTest {
 
     @Test
     fun `onNext will use the correct destination info for CORDA5`() {
-        val payload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val payload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -287,10 +281,8 @@ class OutboundMessageHandlerTest {
         }
         whenever(commonComponents.dynamicKeyStore).doReturn(dynamicKeyStore)
         whenever(gatewayConfigReader.constructed().first().sslConfiguration).doReturn(sslConfig)
-        val payload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val payload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -338,10 +330,8 @@ class OutboundMessageHandlerTest {
         }
         whenever(commonComponents.dynamicKeyStore).doReturn(dynamicKeyStore)
         whenever(gatewayConfigReader.constructed().first().sslConfiguration).doReturn(sslConfig)
-        val payload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val payload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -365,10 +355,8 @@ class OutboundMessageHandlerTest {
 
     @Test
     fun `onNext will use the correct destination info for CORDA4`() {
-        val payload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val payload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -403,10 +391,8 @@ class OutboundMessageHandlerTest {
 
     @Test
     fun `onNext will not send anything for invalid arguments`() {
-        val payload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val payload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -430,10 +416,8 @@ class OutboundMessageHandlerTest {
 
     @Test
     fun `onNext will not send anything for invalid URL`() {
-        val msgPayload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val msgPayload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -454,10 +438,8 @@ class OutboundMessageHandlerTest {
 
     @Test
     fun `onNext will not send anything for wrong scheme URL`() {
-        val msgPayload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val msgPayload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -478,10 +460,8 @@ class OutboundMessageHandlerTest {
 
     @Test
     fun `onNext will get the trust store from the trust store map`() {
-        val payload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val payload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -515,10 +495,8 @@ class OutboundMessageHandlerTest {
                 // simulate scenario where no response is received.
             }
         }
-        val msgPayload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val msgPayload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -555,10 +533,8 @@ class OutboundMessageHandlerTest {
                 CompletableFuture.failedFuture(RuntimeException("some error happened"))
             }
         }
-        val msgPayload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val msgPayload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -600,10 +576,8 @@ class OutboundMessageHandlerTest {
                 CompletableFuture.completedFuture(response)
             }
         }
-        val msgPayload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val msgPayload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )
@@ -643,10 +617,8 @@ class OutboundMessageHandlerTest {
                 CompletableFuture.completedFuture(response)
             }
         }
-        val msgPayload = UnauthenticatedMessage.newBuilder().apply {
-            header = UnauthenticatedMessageHeader(
-                HoldingIdentity("A", "B"),
-                HoldingIdentity("C", "D"),
+        val msgPayload = InboundUnauthenticatedMessage.newBuilder().apply {
+            header = InboundUnauthenticatedMessageHeader(
                 "subsystem",
                 "messageId",
             )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
@@ -8,8 +8,8 @@ import net.corda.data.p2p.LinkOutHeader
 import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.MessageAck
 import net.corda.data.p2p.NetworkType
+import net.corda.data.p2p.app.InboundUnauthenticatedMessage
 import net.corda.data.p2p.app.MembershipStatusFilter
-import net.corda.data.p2p.app.UnauthenticatedMessage
 import net.corda.data.p2p.crypto.AuthenticatedDataMessage
 import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
 import net.corda.membership.grouppolicy.GroupPolicyProvider
@@ -174,12 +174,11 @@ class MessageConverter {
         }
 
         fun linkOutFromUnauthenticatedMessage(
-            message: UnauthenticatedMessage,
+            message: InboundUnauthenticatedMessage,
+            source: HoldingIdentity,
             destMemberInfo: MemberInfo,
             groupPolicy: GroupPolicy,
         ): LinkOutMessage {
-            val source = message.header.source.toCorda()
-
             return createLinkOutMessage(
                 message,
                 source,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -296,20 +296,25 @@ internal class InboundMessageProcessor(
     }
 
     private fun recordInboundMessagesMetric(message: InboundUnauthenticatedMessage) {
-        message.header.let {
-            recordInboundMessagesMetric("***", "***", "***",
-                it.subsystem, message::class.java.simpleName)
-        }
+        recordInboundMessagesMetric(null, null, null,
+            message.header.subsystem, message::class.java.simpleName)
     }
 
-    private fun recordInboundMessagesMetric(source: String, dest: String, group: String, subsystem: String, messageType: String) {
-        CordaMetrics.Metric.InboundMessageCount.builder()
-            .withTag(CordaMetrics.Tag.SourceVirtualNode, source)
-            .withTag(CordaMetrics.Tag.DestinationVirtualNode, dest)
-            .withTag(CordaMetrics.Tag.MembershipGroup, group)
-            .withTag(CordaMetrics.Tag.MessagingSubsystem, subsystem)
-            .withTag(CordaMetrics.Tag.MessageType, messageType)
-            .build().increment()
+    private fun recordInboundMessagesMetric(source: String?, dest: String?, group: String?, subsystem: String, messageType: String) {
+        val builder = CordaMetrics.Metric.InboundMessageCount.builder()
+        listOf(
+            CordaMetrics.Tag.SourceVirtualNode to source,
+            CordaMetrics.Tag.DestinationVirtualNode to dest,
+            CordaMetrics.Tag.MembershipGroup to group,
+            CordaMetrics.Tag.MessagingSubsystem to subsystem,
+            CordaMetrics.Tag.MessageType to messageType,
+        ).forEach {
+            val value = it.second
+            if (value != null) {
+                builder.withTag(it.first, value)
+            }
+        }
+        builder.build().increment()
     }
 
     private fun <T> checkAllowedCommunication(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -5,7 +5,9 @@ import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.data.p2p.SessionPartitions
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.AuthenticatedMessage
-import net.corda.data.p2p.app.UnauthenticatedMessage
+import net.corda.data.p2p.app.InboundUnauthenticatedMessage
+import net.corda.data.p2p.app.InboundUnauthenticatedMessageHeader
+import net.corda.data.p2p.app.OutboundUnauthenticatedMessage
 import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.data.p2p.markers.Component
 import net.corda.data.p2p.markers.LinkManagerDiscardedMarker
@@ -106,7 +108,7 @@ internal class OutboundMessageProcessor(
                 processAuthenticatedMessage(AuthenticatedMessageAndKey(message, event.key))
                     .also { recordOutboundMessagesMetric(message) }
             }
-            is UnauthenticatedMessage -> {
+            is OutboundUnauthenticatedMessage -> {
                 processUnauthenticatedMessage(message)
                     .also { recordOutboundMessagesMetric(message) }
             }
@@ -170,7 +172,7 @@ internal class OutboundMessageProcessor(
         return outResult ?: inResult
     }
 
-    private fun processUnauthenticatedMessage(message: UnauthenticatedMessage): List<Record<String, *>> {
+    private fun processUnauthenticatedMessage(message: OutboundUnauthenticatedMessage): List<Record<String, *>> {
         logger.debug { "Processing outbound message ${message.header.messageId} to ${message.header.destination}." }
 
         val discardReason = checkSourceAndDestinationValid(
@@ -189,8 +191,15 @@ internal class OutboundMessageProcessor(
             message.header.source.toCorda(),
             message.header.destination.toCorda()
         )
+        val inboundMessage = InboundUnauthenticatedMessage(
+            InboundUnauthenticatedMessageHeader(
+                message.header.subsystem,
+                message.header.messageId,
+            ),
+            message.payload,
+        )
         if (linkManagerHostingMap.isHostedLocally(message.header.destination.toCorda())) {
-            return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(message)))
+            return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(inboundMessage)))
         } else if (destMemberInfo != null) {
             val source = message.header.source.toCorda()
             val groupPolicy = groupPolicyProvider.getGroupPolicy(source)
@@ -202,7 +211,7 @@ internal class OutboundMessageProcessor(
                 return emptyList()
             }
 
-            val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(message, destMemberInfo, groupPolicy)
+            val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(inboundMessage, source, destMemberInfo, groupPolicy)
             return listOf(Record(Schemas.P2P.LINK_OUT_TOPIC, LinkManager.generateKey(), linkOutMessage))
         } else {
             logger.warn("Trying to send unauthenticated message ${message.header.messageId} from ${message.header.source.toCorda()} " +
@@ -370,7 +379,7 @@ internal class OutboundMessageProcessor(
         }
     }
 
-    private fun recordOutboundMessagesMetric(message: UnauthenticatedMessage) {
+    private fun recordOutboundMessagesMetric(message: OutboundUnauthenticatedMessage) {
         message.header.let {
             recordOutboundMessagesMetric(it.source.x500Name, it.destination.x500Name, it.source.groupId,
                 it.subsystem, message::class.java.simpleName)

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessor.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessor.kt
@@ -10,7 +10,7 @@ import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.p2p.VerificationResponse
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.AuthenticatedMessage
-import net.corda.data.p2p.app.UnauthenticatedMessage
+import net.corda.data.p2p.app.InboundUnauthenticatedMessage
 import net.corda.membership.impl.p2p.handler.MembershipPackageHandler
 import net.corda.membership.impl.p2p.handler.MembershipSyncRequestHandler
 import net.corda.membership.impl.p2p.handler.MessageHandler
@@ -102,22 +102,22 @@ class MembershipP2PProcessor(
 
     private fun Any.isMembershipSubsystem(): Boolean {
         return (this as? AuthenticatedMessage)?.isMembershipSubsystem() ?: false
-                || (this as? UnauthenticatedMessage)?.isMembershipSubsystem() ?: false
+                || (this as? InboundUnauthenticatedMessage)?.isMembershipSubsystem() ?: false
     }
 
     private fun AuthenticatedMessage.isMembershipSubsystem() = header.subsystem == MEMBERSHIP_P2P_SUBSYSTEM
-    private fun UnauthenticatedMessage.isMembershipSubsystem() = header.subsystem == MEMBERSHIP_P2P_SUBSYSTEM
+    private fun InboundUnauthenticatedMessage.isMembershipSubsystem() = header.subsystem == MEMBERSHIP_P2P_SUBSYSTEM
 
     private val Any.header: Any
         get() = (this as? AuthenticatedMessage)?.header
-            ?: (this as? UnauthenticatedMessage)?.header
+            ?: (this as? InboundUnauthenticatedMessage)?.header
             ?: throw UnsupportedOperationException(
                 "Tried to get header from message other than AuthenticatedMessage or UnauthenticatedMessage."
             )
 
     private val Any.payload: ByteBuffer
         get() = (this as? AuthenticatedMessage)?.payload
-            ?: (this as? UnauthenticatedMessage)?.payload
+            ?: (this as? InboundUnauthenticatedMessage)?.payload
             ?: throw UnsupportedOperationException(
                 "Tried to get payload from message other than AuthenticatedMessage or UnauthenticatedMessage."
             )

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/RegistrationRequestHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/RegistrationRequestHandler.kt
@@ -2,11 +2,12 @@ package net.corda.membership.impl.p2p.handler
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.hes.StableKeyPairDecryptor
+import net.corda.data.KeyValuePairList
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.StartRegistration
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
-import net.corda.data.p2p.app.UnauthenticatedMessageHeader
+import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.ecdhKey
 import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
 import net.corda.membership.read.MembershipGroupReaderProvider
@@ -14,7 +15,10 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
@@ -31,23 +35,29 @@ internal class RegistrationRequestHandler(
     }
 
     override fun invokeUnauthenticatedMessage(
-        header: UnauthenticatedMessageHeader,
         payload: ByteBuffer
     ): Record<String, RegistrationCommand>? {
         try {
             logger.info("Received registration request. Issuing StartRegistration command.")
-            val registrationRequest = avroSchemaRegistry.deserialize<MembershipRegistrationRequest>(
-                ByteBuffer.wrap(decryptPayload(payload, header.destination.toCorda()))
+            val (registrationRequest, mgm) = decryptPayload(payload)
+            val memberName = avroSchemaRegistry.deserialize<KeyValuePairList>(registrationRequest.memberContext)
+                .items
+                .firstOrNull { it.key == MemberInfoExtension.PARTY_NAME }
+                ?.value
+                ?: throw CordaRuntimeException("Invalid registration context - missing member name")
+            val member = HoldingIdentity(
+                MemberX500Name.parse(memberName),
+                mgm.groupId,
             )
             val registrationId = registrationRequest.registrationId
             return Record(
                 REGISTRATION_COMMAND_TOPIC,
-                "$registrationId-${header.destination.toCorda().shortHash}",
+                "$registrationId-${mgm.shortHash}",
                 RegistrationCommand(
                     StartRegistration(
-                        header.destination,
-                        header.source,
-                        registrationRequest
+                        mgm.toAvro(),
+                        member.toAvro(),
+                        registrationRequest,
                     )
                 )
             )
@@ -58,19 +68,23 @@ internal class RegistrationRequestHandler(
     }
 
     /** Decrypts the received encrypted registration request received from member. */
-    private fun decryptPayload(payload: ByteBuffer, mgm: HoldingIdentity): ByteArray {
+    private fun decryptPayload(payload: ByteBuffer): Pair<MembershipRegistrationRequest, HoldingIdentity> {
         val request = avroSchemaRegistry.deserialize<UnauthenticatedRegistrationRequest>(payload)
         val reqHeader = request.header
+        val mgm = reqHeader.mgm.toCorda()
         val memberKey = keyEncodingService.decodePublicKey(reqHeader.key)
         val mgmKey = getECDHKey(mgm)
-        return stableKeyPairDecryptor.decrypt(
+        val requestPayload = stableKeyPairDecryptor.decrypt(
             mgm.shortHash.value,
             reqHeader.salt.array(),
             mgmKey,
             memberKey,
             request.payload.array(),
-            reqHeader.aad.array()
+            reqHeader.aad.array(),
         )
+        return avroSchemaRegistry.deserialize<MembershipRegistrationRequest>(
+            ByteBuffer.wrap(requestPayload),
+        ) to mgm
     }
 
     /** Retrieves the MGM's ECDH key required for decrypting the message. */

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/UnauthenticatedMessageHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/UnauthenticatedMessageHandler.kt
@@ -1,19 +1,12 @@
 package net.corda.membership.impl.p2p.handler
 
 import net.corda.messaging.api.records.Record
-import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import java.nio.ByteBuffer
 
 internal abstract class UnauthenticatedMessageHandler : MessageHandler {
     override fun invoke(header: Any, payload: ByteBuffer): Record<*, *>? {
-        if (header is UnauthenticatedMessageHeader) {
-            return invokeUnauthenticatedMessage(header, payload)
-        } else {
-            throw UnsupportedOperationException(
-                "Handler does not support message type. Only UnauthenticatedMessage is allowed."
-            )
-        }
+        return invokeUnauthenticatedMessage(payload)
     }
 
-    abstract fun invokeUnauthenticatedMessage(header: UnauthenticatedMessageHeader, payload: ByteBuffer): Record<*, *>?
+    abstract fun invokeUnauthenticatedMessage(payload: ByteBuffer): Record<*, *>?
 }

--- a/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessorTest.kt
+++ b/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessorTest.kt
@@ -24,11 +24,12 @@ import net.corda.data.membership.p2p.VerificationResponse
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.AuthenticatedMessage
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.data.p2p.app.InboundUnauthenticatedMessage
+import net.corda.data.p2p.app.InboundUnauthenticatedMessageHeader
 import net.corda.data.p2p.app.MembershipStatusFilter
-import net.corda.data.p2p.app.UnauthenticatedMessage
-import net.corda.data.p2p.app.UnauthenticatedMessageHeader
 import net.corda.data.sync.BloomFilter
 import net.corda.membership.impl.p2p.MembershipP2PProcessor.Companion.MEMBERSHIP_P2P_SUBSYSTEM
+import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.ecdhKey
 import net.corda.membership.lib.MemberInfoExtension.Companion.isMgm
 import net.corda.membership.read.MembershipGroupReader
@@ -37,6 +38,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.Schemas.Membership.SYNCHRONIZATION_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
+import net.corda.schema.registry.deserialize
 import net.corda.test.util.time.TestClock
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
@@ -88,17 +90,17 @@ class MembershipP2PProcessorTest {
     private val registrationReqMsgPayload = registrationRequest.toByteBuffer()
     private val memberKey: PublicKey = mock()
     private val memberKeyPem = "-----BEGIN PUBLIC KEY-----encoded-memberKey-----END PUBLIC KEY-----"
+    private val groupId = "1f5e558c-dd87-438f-a57f-21e69c1e0b88"
+    private val mgm = HoldingIdentity("C=GB, L=London, O=MGM", groupId)
     private val unauthenticatedRegistrationRequest = UnauthenticatedRegistrationRequest(
         UnauthenticatedRegistrationRequestHeader(
-            ByteBuffer.wrap(SALT_BYTES), ByteBuffer.wrap(AAD_BYTES), memberKeyPem
+            mgm, ByteBuffer.wrap(SALT_BYTES), ByteBuffer.wrap(AAD_BYTES), memberKeyPem
         ),
         registrationReqMsgPayload
     )
     private val unauthenticatedRegMsgPayload = unauthenticatedRegistrationRequest.toByteBuffer()
-    private val groupId = "1f5e558c-dd87-438f-a57f-21e69c1e0b88"
     private val member = HoldingIdentity("C=GB, L=London, O=Alice", groupId)
     private val mgmKey: PublicKey = mock()
-    private val mgm = HoldingIdentity("C=GB, L=London, O=MGM", groupId)
     private val memberProvidedContext: MemberContext = mock()
     private val mgmProvidedContext: MGMContext = mock()
     private val mgmInfo: MemberInfo = mock {
@@ -107,7 +109,6 @@ class MembershipP2PProcessorTest {
         on { ecdhKey } doReturn mgmKey
         on { isMgm } doReturn true
     }
-
     private val verificationRequest = VerificationRequest(
         registrationId,
         KeyValuePairList(listOf(KeyValuePair("A", "B")))
@@ -183,6 +184,15 @@ class MembershipP2PProcessorTest {
 
     @Test
     fun `Registration request as unauthenticated message is processed as expected`() {
+        val context = KeyValuePairList(
+            listOf(
+                KeyValuePair(
+                    MemberInfoExtension.PARTY_NAME,
+                    member.x500Name,
+                ),
+            ),
+        )
+        whenever(avroSchemaRegistry.deserialize<KeyValuePairList>(memberContext)).doReturn(context)
         val result = processUnauthMsgPayload(unauthenticatedRegMsgPayload)
 
         with(result) {
@@ -197,8 +207,8 @@ class MembershipP2PProcessorTest {
                 val value = this.first().value as RegistrationCommand
                 it.assertThat(value.command).isInstanceOf(StartRegistration::class.java)
                 val command = value.command as StartRegistration
-                it.assertThat(command.destination).isEqualTo(mgm)
-                it.assertThat(command.source).isEqualTo(member)
+                it.assertThat(command.destination.toCorda()).isEqualTo(mgm.toCorda())
+                it.assertThat(command.source.toCorda()).isEqualTo(member.toCorda())
                 it.assertThat(command.memberRegistrationRequest).isEqualTo(registrationRequest)
             }
         }
@@ -206,16 +216,8 @@ class MembershipP2PProcessorTest {
 
     @Test
     fun `Registration request on a non-membership subsystem returns no output records`() {
-        val result = processUnauthMsgPayload(unauthenticatedRegMsgPayload, mgm, member, "BAD_SUBSYSTEM")
+        val result = processUnauthMsgPayload(unauthenticatedRegMsgPayload, "BAD_SUBSYSTEM")
         assertThat(result).isEmpty()
-    }
-
-    @Test
-    fun `Registration request as authenticated message throws exception`() {
-        val appMessage = createAuthMsg(unauthenticatedRegMsgPayload)
-        assertThrows<UnsupportedOperationException> {
-            membershipP2PProcessor.onNext(listOf(Record(TOPIC, KEY, appMessage)))
-        }
     }
 
     @Test
@@ -273,7 +275,7 @@ class MembershipP2PProcessorTest {
 
     @Test
     fun `Verification request as unauthenticated message throws exception`() {
-        val appMessage = createUnauthMsg(verificationReqMsgPayload, member, mgm)
+        val appMessage = createUnauthMsg(verificationReqMsgPayload)
         assertThrows<UnsupportedOperationException> {
             membershipP2PProcessor.onNext(listOf(Record(TOPIC, KEY, appMessage)))
         }
@@ -338,20 +340,16 @@ class MembershipP2PProcessorTest {
 
     private fun createUnauthMsg(
         payload: ByteBuffer,
-        destination: HoldingIdentity =mgm,
-        source: HoldingIdentity = member,
         subsystem: String = MEMBERSHIP_P2P_SUBSYSTEM
     ) = with(payload) {
         mockPayloadDeserialization()
-        asUnauthenticatedAppMessagePayload(destination, source, subsystem)
+        asUnauthenticatedAppMessagePayload(subsystem)
     }
     private fun processUnauthMsgPayload(
         payload: ByteBuffer,
-        destination: HoldingIdentity = mgm,
-        source: HoldingIdentity = member,
         subsystem: String = MEMBERSHIP_P2P_SUBSYSTEM
     ) = membershipP2PProcessor.onNext(
-        listOf(Record(TOPIC, KEY, createUnauthMsg(payload, destination, source, subsystem)))
+        listOf(Record(TOPIC, KEY, createUnauthMsg(payload, subsystem)))
     )
 
     private fun createAuthMsg(payload: ByteBuffer, destination: HoldingIdentity = mgm, source: HoldingIdentity = member) =
@@ -368,14 +366,12 @@ class MembershipP2PProcessorTest {
     )
 
     private fun ByteBuffer.asUnauthenticatedAppMessagePayload(
-        destination: HoldingIdentity = mgm,
-        source: HoldingIdentity = member,
         subsystem: String = MEMBERSHIP_P2P_SUBSYSTEM
     ): AppMessage {
         return AppMessage(
-            UnauthenticatedMessage(
-                UnauthenticatedMessageHeader(
-                    destination, source, subsystem, "messageId"
+            InboundUnauthenticatedMessage(
+                InboundUnauthenticatedMessageHeader(
+                    subsystem, "messageId"
                 ),
                 this
             )

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/MemberRegistrationIntegrationTest.kt
@@ -16,7 +16,7 @@ import net.corda.data.config.ConfigurationSchemaVersion
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
 import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.UnauthenticatedMessage
+import net.corda.data.p2p.app.OutboundUnauthenticatedMessage
 import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.packaging.core.CpiIdentifier
@@ -308,7 +308,7 @@ class MemberRegistrationIntegrationTest {
                 .isNotNull
                 .isInstanceOf(AppMessage::class.java)
 
-            with(result!!.second["message"] as UnauthenticatedMessage) {
+            with(result!!.second["message"] as OutboundUnauthenticatedMessage) {
                 it.assertThat(this.header.destination.x500Name).isEqualTo(mgmName.toString())
                 it.assertThat(this.header.destination.groupId).isEqualTo(groupId)
                 it.assertThat(this.header.source.x500Name).isEqualTo(memberName.toString())

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -24,7 +24,7 @@ import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.data.p2p.app.AppMessage
-import net.corda.data.p2p.app.UnauthenticatedMessage
+import net.corda.data.p2p.app.OutboundUnauthenticatedMessage
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.platform.PlatformInfoProvider
@@ -411,7 +411,7 @@ class DynamicMemberRegistrationServiceTest {
                 it.assertThat(publishedMessage.topic).isEqualTo(Schemas.P2P.P2P_OUT_TOPIC)
                 it.assertThat(publishedMessage.key).isEqualTo(memberId.value)
                 val unauthenticatedMessagePublished =
-                    (publishedMessage.value as AppMessage).message as UnauthenticatedMessage
+                    (publishedMessage.value as AppMessage).message as OutboundUnauthenticatedMessage
                 it.assertThat(unauthenticatedMessagePublished.header.source).isEqualTo(member.toAvro())
                 it.assertThat(unauthenticatedMessagePublished.header.destination).isEqualTo(mgm.toAvro())
                 it.assertThat(unauthenticatedMessagePublished.payload).isEqualTo(ByteBuffer.wrap(UNAUTH_REQUEST_BYTES))

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.755-beta+
+cordaApiVersion=5.0.0.756-alpha-1683021069914
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.756-alpha-1683021069914
+cordaApiVersion=5.0.0.756-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
API pull request in https://github.com/corda/corda-api/pull/1079.

This pull request split the unauthenticated messages into inbound (without source and destination) and outbound (with source and destination).

The link manager will convert the outbound to inbound, and the Gateway will only be aware of the inbound messages.

The registration request handler will get the MGM from the request header and the member from the registration context (and not from the message header).

It was tested by registering using a single cluster and multiple clusters.

