### PR TITLE
CORE-13150 - Clarify default value for statuses in member lookup API

### DIFF
--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MemberLookupRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MemberLookupRestResource.kt
@@ -39,8 +39,8 @@ interface MemberLookupRestResource : RestResource {
      * @param locality Optional. Locality (L) attribute of the X.500 name to filter members by.
      * @param state Optional. State (ST) attribute of the X.500 name to filter members by.
      * @param country Optional. Country (C) attribute of the X.500 name to filter members by.
-     * @param statuses Optional. List of statuses ("ACTIVE", "SUSPENDED") to filter members by. Only an MGM can view
-     * suspended members.
+     * @param statuses Optional. List of statuses ("ACTIVE", "SUSPENDED") to filter members by.
+     * By default, only ACTIVE members are filtered. Only an MGM can view suspended members.
      *
      * @return List of active and pending members matching the criteria as [RestMemberInfoList].
      */
@@ -90,8 +90,8 @@ interface MemberLookupRestResource : RestResource {
         )
         country: String? = null,
         @RestQueryParameter(
-            description = "List of statuses (\"ACTIVE\", \"SUSPENDED\") to filter members by. Only an " +
-                    "MGM can view suspended members.",
+            description = "List of statuses (\"ACTIVE\", \"SUSPENDED\") to filter members by. " +
+                    "By default, only ACTIVE members are filtered. Only an MGM can view suspended members.",
             required = false,
         )
         statuses: List<String> = listOf(MemberInfoExtension.MEMBER_STATUS_ACTIVE),

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -1775,7 +1775,7 @@
         }, {
           "name" : "statuses",
           "in" : "query",
-          "description" : "List of statuses (\"ACTIVE\", \"SUSPENDED\") to filter members by. Only an MGM can view suspended members.",
+          "description" : "List of statuses (\"ACTIVE\", \"SUSPENDED\") to filter members by. By default, only ACTIVE members are filtered. Only an MGM can view suspended members.",
           "required" : false,
           "schema" : {
             "uniqueItems" : false,


### PR DESCRIPTION
Add a clarification for the default value for statuses on the member lookup API. 