### PR TITLE
CORE-13157 - Upgrade dependencies used by p2p

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ bouncycastleVersion=1.73
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
 cordaApiVersion=5.0.0.755-beta+
 
-disruptorVersion=3.4.2
+disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5
 felixScrVersion=2.2.6
@@ -69,7 +69,7 @@ liquibaseVersion = 4.19.0
 beanutilsVersion=1.9.4
 log4jVersion = 2.20.0
 micrometerVersion=1.11.0
-nettyVersion = 4.1.86.Final
+nettyVersion = 4.1.92.Final
 # com.networknt:json-schema-validator cannot be upgraded beyond 1.0.66 because it becomes dependent on com.ethlo.time which is not OSGi compatible.
 networkntJsonSchemaVersion = 1.0.66
 osgiCmVersion = 1.6.1


### PR DESCRIPTION
Upgrade `com.lmax:disruptor` and `io.netty:netty-codec-http`.