### PR TITLE
CORE-12501 JsonLayout -> JsonTemplateLayout

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,6 +11,7 @@ def artifactoryContextUrl = constants.getProperty('artifactoryContextUrl')
 def jibCoreVersion = constants.getProperty('jibCoreVersion')
 def internalPublishVersion = constants.getProperty('internalPublishVersion')
 def gradleEnterpriseVersion = constants.getProperty('gradleEnterpriseVersion')
+def log4jVersion = constants.getProperty('log4jVersion')
 
 dependencies {
     implementation "biz.aQute.bnd:biz.aQute.bnd.gradle:$bndVersion"
@@ -18,6 +19,8 @@ dependencies {
 
     implementation "com.google.cloud.tools:jib-core:$jibCoreVersion"
     implementation "com.gradle:gradle-enterprise-gradle-plugin:$gradleEnterpriseVersion"
+
+    implementation "org.apache.logging.log4j:log4j-core:$log4jVersion"
 
     if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('cordaArtifactoryUsername')) {
         implementation "com.r3.internal.gradle.plugins:publish:$internalPublishVersion"

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -5,6 +5,7 @@ import java.util.jar.Attributes
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import javax.inject.Inject
+import org.apache.logging.log4j.core.config.plugins.processor.PluginCache;
 
 import static java.util.stream.Collectors.toSet
 import static org.osgi.framework.Constants.BUNDLE_MANIFESTVERSION
@@ -458,6 +459,26 @@ TaskProvider<JavaAgentFile> javaAgentFileTask =  tasks.register("javaAgentFile",
     javaAgents = osgiRun.javaAgents
 }
 
+def mergeLog4j2Plugins = tasks.register('mergeLog4j2Plugins') {
+    dependsOn configurations.bootstrapClasspath
+    inputs.files(configurations.bootstrapClasspath.collect { it.isDirectory() ? it : zipTree(it) })
+    def outputDir = layout.buildDirectory.dir('log4j')
+    outputs.dir(outputDir)
+
+    doLast {
+        def inputFiles = inputs.files.getFiles().findAll { it.name == 'Log4j2Plugins.dat' }.collect { it.toURI().toURL() }
+        if (inputFiles) {
+            def combinedCache = new PluginCache()
+            combinedCache.loadCacheFiles(Collections.enumeration(inputFiles))
+            def outputFile = outputDir.get().file('META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat').asFile
+            outputFile.parentFile.mkdirs()
+            try (OutputStream out = new FileOutputStream(outputFile)) {
+                combinedCache.writeCache(out)
+            }
+        }
+    }
+}
+
 def appJar = tasks.register('appJar', Jar) {
     inputs.files(configurations.bootstrapClasspath).withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.property('addOpensAttribute', osgiRun.addOpensAttribute)
@@ -490,10 +511,14 @@ def appJar = tasks.register('appJar', Jar) {
     into("META-INF/") {
         from(javaAgentFileTask)
     }
-    from{ configurations.bootstrapClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    from{ configurations.bootstrapClasspath.collect { it.isDirectory() ? it : zipTree(it) } } {
+        // Exclude the Log4J2 plugins caches as the merged version is included from mergeLog4J2Plugins
+        eachFile { if (it.name == "Log4j2Plugins.dat") { it.exclude() } }
+    }
     from(createApplicationBundlesFile.flatMap { it.applicationBundleFile })
     from(cordaAssembleSystemPackagesExtraTask)
     from(writeFrameworkPropertyFile)
+    from(mergeLog4j2Plugins)
     into('bundles') {
         from(defineApplicationBundles.map { it.applicationBundles }) {
             eachFile { FileCopyDetails fileCopyDetails ->

--- a/charts/corda/log4j2.xml
+++ b/charts/corda/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="json" target="SYSTEM_OUT">
-            <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" />
+            <JsonTemplateLayout eventTemplateUri="classpath:JsonLayout.json"/>
         </Console>
         <Console name="text" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} %X - %msg%n"/>

--- a/osgi-framework-bootstrap/build.gradle
+++ b/osgi-framework-bootstrap/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation "org.slf4j:jul-to-slf4j:$slf4jVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.framework:$felixVersion"
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+    runtimeOnly "org.apache.logging.log4j:log4j-layout-template-json:$log4jVersion"
 
     // Jackson dependencies for JSON formatted logs
     runtimeOnly "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"


### PR DESCRIPTION
Switches JSON format logging from using the deprecated `JSONLayout` to `JsonTemplateLayout` with the `JsonLayout` template. On the whole, the output should be identical but the way in which exceptions are serialized changes which we hope will address issues with the use of reflection and the security manager.

The PR is made infinitely more complicated by the fact that the `log4j-layout-template-json` dependency brings with it a second `META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat` file. Normally Log4J would expect to read both files from their respective JARs but when we combine them into a single worker JAR, it only sees one. The `mergeLog4j2Plugins` task is therefore added to merge together the two files into one using Log4J's `PluginCache` class.