### PR TITLE
CORE-9483 Enabling sending of primitive types across sessions

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/PersistenceServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/PersistenceServiceImpl.kt
@@ -1,6 +1,13 @@
 package net.corda.flow.application.persistence
 
-import net.corda.flow.application.persistence.external.events.*
+import net.corda.flow.application.persistence.external.events.FindExternalEventFactory
+import net.corda.flow.application.persistence.external.events.FindParameters
+import net.corda.flow.application.persistence.external.events.MergeExternalEventFactory
+import net.corda.flow.application.persistence.external.events.MergeParameters
+import net.corda.flow.application.persistence.external.events.PersistExternalEventFactory
+import net.corda.flow.application.persistence.external.events.PersistParameters
+import net.corda.flow.application.persistence.external.events.RemoveExternalEventFactory
+import net.corda.flow.application.persistence.external.events.RemoveParameters
 import net.corda.flow.application.persistence.query.PagedQueryFactory
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.sandbox.type.UsedByFlow

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/PersistenceServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/PersistenceServiceImpl.kt
@@ -1,14 +1,6 @@
 package net.corda.flow.application.persistence
 
-import java.nio.ByteBuffer
-import net.corda.flow.application.persistence.external.events.FindExternalEventFactory
-import net.corda.flow.application.persistence.external.events.FindParameters
-import net.corda.flow.application.persistence.external.events.MergeExternalEventFactory
-import net.corda.flow.application.persistence.external.events.MergeParameters
-import net.corda.flow.application.persistence.external.events.PersistExternalEventFactory
-import net.corda.flow.application.persistence.external.events.PersistParameters
-import net.corda.flow.application.persistence.external.events.RemoveExternalEventFactory
-import net.corda.flow.application.persistence.external.events.RemoveParameters
+import net.corda.flow.application.persistence.external.events.*
 import net.corda.flow.application.persistence.query.PagedQueryFactory
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.sandbox.type.UsedByFlow
@@ -22,6 +14,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import java.nio.ByteBuffer
 
 @Suppress("TooManyFunctions")
 @Component(service = [ PersistenceService::class, UsedByFlow::class ], scope = PROTOTYPE)
@@ -36,7 +29,6 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun <R : Any> find(entityClass: Class<R>, primaryKey: Any): R? {
-        requireBoxedType(entityClass)
         return wrapWithPersistenceException {
             externalEventExecutor.execute(
                 FindExternalEventFactory::class.java,
@@ -47,7 +39,6 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun <R : Any> find(entityClass: Class<R>, primaryKeys: List<*>): List<R> {
-        requireBoxedType(entityClass)
         return wrapWithPersistenceException {
             externalEventExecutor.execute(
                 FindExternalEventFactory::class.java,
@@ -58,13 +49,11 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun <R : Any> findAll(entityClass: Class<R>): PagedQuery<R> {
-        requireBoxedType(entityClass)
         return pagedQueryFactory.createPagedFindQuery(entityClass)
     }
 
     @Suspendable
     override fun <R : Any> merge(entity: R): R? {
-        requireBoxedType(entity.javaClass)
         return wrapWithPersistenceException {
             externalEventExecutor.execute(
                 MergeExternalEventFactory::class.java,
@@ -76,7 +65,6 @@ class PersistenceServiceImpl @Activate constructor(
     @Suspendable
     override fun <R : Any> merge(entities: List<R>): List<R> {
         return if (entities.isNotEmpty()) {
-            requireBoxedType(entities)
             val mergedEntities = wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     MergeExternalEventFactory::class.java,
@@ -96,7 +84,6 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun persist(entity: Any) {
-        requireBoxedType(entity.javaClass)
         wrapWithPersistenceException {
             externalEventExecutor.execute(
                 PersistExternalEventFactory::class.java,
@@ -108,7 +95,6 @@ class PersistenceServiceImpl @Activate constructor(
     @Suspendable
     override fun persist(entities: List<*>) {
         if (entities.isNotEmpty()) {
-            requireBoxedType(entities)
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     PersistExternalEventFactory::class.java,
@@ -120,7 +106,6 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun remove(entity: Any) {
-        requireBoxedType(entity.javaClass)
         wrapWithPersistenceException {
             externalEventExecutor.execute(
                 RemoveExternalEventFactory::class.java,
@@ -132,7 +117,6 @@ class PersistenceServiceImpl @Activate constructor(
     @Suspendable
     override fun remove(entities: List<*>) {
         if (entities.isNotEmpty()) {
-            requireBoxedType(entities)
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     RemoveExternalEventFactory::class.java,
@@ -147,23 +131,7 @@ class PersistenceServiceImpl @Activate constructor(
         queryName: String,
         entityClass: Class<T>
     ): ParameterizedQuery<T> {
-        requireBoxedType(entityClass)
         return pagedQueryFactory.createNamedParameterizedQuery(queryName, entityClass)
-    }
-
-    /**
-     * Required to prevent class cast exceptions during AMQP serialization of primitive types.
-     */
-    private fun requireBoxedType(type: Class<*>) {
-        require(!type.isPrimitive) { "Cannot perform persistence operation on primitive type ${type.name}" }
-    }
-
-    private fun requireBoxedType(objects: List<*>) {
-        for (obj in objects) {
-            if (obj != null) {
-                requireBoxedType(obj.javaClass)
-            }
-        }
     }
 
     private fun serialize(payload: Any): ByteBuffer {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowMessagingImpl.kt
@@ -25,7 +25,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
-import java.util.*
+import java.util.UUID
 
 @Suppress("TooManyFunctions")
 @Component(service = [FlowMessaging::class, UsedByFlow::class], scope = PROTOTYPE)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
@@ -100,7 +100,6 @@ class FlowSessionImpl(
     @Suspendable
     override fun <R : Any> sendAndReceive(receiveType: Class<R>, payload: Any): R {
         verifySessionStatusNotErrorOrClose(sourceSessionId, flowFiberService)
-        requireBoxedType(receiveType)
         val request = FlowIORequest.SendAndReceive(mapOf(getSessionInfo() to serialize(payload)))
         val received = fiber.suspend(request)
         setSessionConfirmed()
@@ -110,7 +109,6 @@ class FlowSessionImpl(
     @Suspendable
     override fun <R : Any> receive(receiveType: Class<R>): R {
         verifySessionStatusNotErrorOrClose(sourceSessionId, flowFiberService)
-        requireBoxedType(receiveType)
         val request = FlowIORequest.Receive(setOf(getSessionInfo()))
         val received = fiber.suspend(request)
         setSessionConfirmed()
@@ -133,13 +131,6 @@ class FlowSessionImpl(
         } else {
             log.debug { "Ignoring close on uninitiated session: $sourceSessionId" }
         }
-    }
-
-    /**
-     * Required to prevent class cast exceptions during AMQP serialization of primitive types.
-     */
-    private fun requireBoxedType(type: Class<*>) {
-        require(!type.isPrimitive) { "Cannot receive primitive type $type" }
     }
 
     private fun serialize(payload: Any): ByteArray {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
@@ -103,7 +103,14 @@ class FlowSessionImpl(
         val request = FlowIORequest.SendAndReceive(mapOf(getSessionInfo() to serialize(payload)))
         val received = fiber.suspend(request)
         setSessionConfirmed()
-        return deserializeReceivedPayload(received, receiveType)
+
+        // We could call `.kotlin.javaObjectType` on non-primitive types too, and it would have no effect,
+        // but this check is added for clarity of intent
+        return if (receiveType.isPrimitive) {
+            deserializeReceivedPayload(received, receiveType.kotlin.javaObjectType)
+        } else {
+            deserializeReceivedPayload(received, receiveType)
+        }
     }
 
     @Suspendable
@@ -112,7 +119,14 @@ class FlowSessionImpl(
         val request = FlowIORequest.Receive(setOf(getSessionInfo()))
         val received = fiber.suspend(request)
         setSessionConfirmed()
-        return deserializeReceivedPayload(received, receiveType)
+
+        // We could call `.kotlin.javaObjectType` on non-primitive types too, and it would have no effect,
+        // but this check is added for clarity of intent
+        return if (receiveType.isPrimitive) {
+            deserializeReceivedPayload(received, receiveType.kotlin.javaObjectType)
+        } else {
+            deserializeReceivedPayload(received, receiveType)
+        }
     }
     @Suspendable
     override fun send(payload: Any) {

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -116,24 +116,4 @@ public class FlowSessionImplJavaTest {
         when(flowSandboxGroupContext.getCheckpointSerializer()).thenReturn(checkpointSerializer);
         when(flowFiberService.getExecutingFiber()).thenReturn(flowFiber);
     }
-
-    @Test
-    public void passingABoxedTypeToSendAndReceiveWillNotThrowAnException() {
-        session.sendAndReceive(Integer.class, 1);
-    }
-
-    @Test
-    public void passingAPrimitiveReceiveTypeToSendAndReceiveWillThrowAnException() {
-        assertThrows(IllegalArgumentException.class, () -> session.sendAndReceive(int.class, 1));
-    }
-
-    @Test
-    public void passingABoxedTypeToReceiveWillNotThrowAnException() {
-        session.receive(Integer.class);
-    }
-
-    @Test
-    public void passingAPrimitiveReceiveTypeToReceiveWillThrowAnException() {
-        assertThrows(IllegalArgumentException.class, () -> session.receive(int.class));
-    }
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -47,6 +47,17 @@ internal class SandboxGroupImpl(
         cpk.mainBundle to cpk.cpkMetadata
     })
 
+    private val primitiveTypes = mapOf(
+        "boolean" to Boolean::class.javaPrimitiveType,
+        "byte" to Byte::class.javaPrimitiveType,
+        "char" to Char::class.javaPrimitiveType,
+        "short" to Short::class.javaPrimitiveType,
+        "int" to Int::class.javaPrimitiveType,
+        "long" to Long::class.javaPrimitiveType,
+        "float" to Float::class.javaPrimitiveType,
+        "double" to Double::class.javaPrimitiveType
+    )
+
     override fun loadClassFromPublicBundles(className: String): Class<*>? {
         val clazz = publicSandboxes
             .flatMap(Sandbox::publicBundles)
@@ -101,7 +112,8 @@ internal class SandboxGroupImpl(
         return when (classTag.classType) {
             ClassType.NonBundleClass -> {
                 try {
-                    bundleUtils.loadClassFromSystemBundle(className)
+                    primitiveTypes.getOrDefault(className, null)
+                        ?: bundleUtils.loadClassFromSystemBundle(className)
                 } catch (e: ClassNotFoundException) {
                     throw SandboxException(
                         "Class $className was not from a bundle, and could not be found in the system classloader."

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -286,7 +286,6 @@ class SerializationOutputTests {
         assertTrue(AMQPTypeIdentifiers.isPrimitive(Short::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(UnsignedShort::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(Int::class.java))
-        assertTrue(AMQPTypeIdentifiers.isPrimitive(Integer::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(UnsignedInteger::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(Long::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(UnsignedLong::class.java))

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -51,7 +51,16 @@ import java.io.NotSerializableException
 import java.math.BigDecimal
 import java.time.DayOfWeek
 import java.time.Month
-import java.util.*
+import java.util.Currency
+import java.util.Date
+import java.util.EnumMap
+import java.util.NavigableMap
+import java.util.Objects
+import java.util.Random
+import java.util.SortedSet
+import java.util.TreeMap
+import java.util.TreeSet
+import java.util.UUID
 
 object AckWrapper {
     @CordaSerializable

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -51,16 +51,7 @@ import java.io.NotSerializableException
 import java.math.BigDecimal
 import java.time.DayOfWeek
 import java.time.Month
-import java.util.Currency
-import java.util.Date
-import java.util.EnumMap
-import java.util.NavigableMap
-import java.util.Objects
-import java.util.Random
-import java.util.SortedSet
-import java.util.TreeMap
-import java.util.TreeSet
-import java.util.UUID
+import java.util.*
 
 object AckWrapper {
     @CordaSerializable
@@ -286,6 +277,7 @@ class SerializationOutputTests {
         assertTrue(AMQPTypeIdentifiers.isPrimitive(Short::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(UnsignedShort::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(Int::class.java))
+        assertTrue(AMQPTypeIdentifiers.isPrimitive(Integer::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(UnsignedInteger::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(Long::class.java))
         assertTrue(AMQPTypeIdentifiers.isPrimitive(UnsignedLong::class.java))
@@ -311,6 +303,26 @@ class SerializationOutputTests {
     @Test
     fun `test float`() {
         val obj = TestFloat(10.0F)
+        serdes(obj)
+    }
+
+    @Test
+    fun `test primitive float`() {
+        val obj = 10.0f
+        serdes(obj)
+    }
+
+    @Test
+    fun `test primitive int`() {
+        val obj = 5
+        assert(obj.javaClass == Int::class.java)
+        serdes(obj)
+    }
+
+    @Test
+    fun `test boxed integer`() {
+        val obj = Integer.valueOf(5)
+        assert(obj.javaClass == Integer::class.java)
         serdes(obj)
     }
 

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -307,23 +307,59 @@ class SerializationOutputTests {
     }
 
     @Test
-    fun `test primitive float`() {
-        val obj = 10.0f
-        serdes(obj)
+    fun `test primitive boolean`() {
+        val input = true
+        val output = serdes(input)
+        assertEquals(input, output)
+    }
+
+    @Test
+    fun `test primitive byte`() {
+        val input: Byte = 1
+        val output = serdes(input)
+        assertEquals(input, output)
+    }
+
+    @Test
+    fun `test primitive char`() {
+        val input: Char = 'a'
+        val output = serdes(input)
+        assertEquals(input, output)
+    }
+
+    @Test
+    fun `test primitive short`() {
+        val input: Short = 10
+        val output = serdes(input)
+        assertEquals(input, output)
     }
 
     @Test
     fun `test primitive int`() {
-        val obj = 5
-        assert(obj.javaClass == Int::class.java)
-        serdes(obj)
+        val input = 5
+        val output = serdes(input)
+        assertEquals(input, output)
     }
 
     @Test
-    fun `test boxed integer`() {
-        val obj = Integer.valueOf(5)
-        assert(obj.javaClass == Integer::class.java)
-        serdes(obj)
+    fun `test primitive long`() {
+        val input: Long = 10000000000
+        val output = serdes(input)
+        assertEquals(input, output)
+    }
+
+    @Test
+    fun `test primitive float`() {
+        val input = 10.0f
+        val output = serdes(input)
+        assertEquals(input, output)
+    }
+
+    @Test
+    fun `test primitive double`() {
+        val input = 3.14
+        val output = serdes(input)
+        assertEquals(input, output)
     }
 
     @Test

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
@@ -65,7 +65,6 @@ abstract class BlockingQueueFlowSession(
      */
     override fun <R : Any> receive(receiveType: Class<R>): R {
         state.closedCheck()
-        requireBoxedType(receiveType)
         val start = configuration.clock.instant()
         while (true) {
             checkTimeout(start)
@@ -91,10 +90,6 @@ abstract class BlockingQueueFlowSession(
         }
     }
 
-    private fun requireBoxedType(type: Class<*>) {
-        require(!type.isPrimitive) { "Cannot receive primitive type $type" }
-    }
-
     /**
      * @param receiveType The class of the received payload.
      * @param payload The payload to send.
@@ -103,7 +98,6 @@ abstract class BlockingQueueFlowSession(
      * @see [BlockingQueueFlowSession.receive] for details of thrown exceptions.
      */
     override fun <R : Any> sendAndReceive(receiveType: Class<R>, payload: Any): R {
-        requireBoxedType(receiveType)
         send(payload)
         return receive(receiveType)
     }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
@@ -130,12 +130,10 @@ class ConcurrentFlowMessaging(
      * Not yet implemented.
      */
     override fun <R : Any> receiveAll(receiveType: Class<out R>, sessions: Set<FlowSession>): List<R> {
-        requireBoxedType(receiveType)
         return sessions.map { it.receive(receiveType) }
     }
 
     override fun receiveAllMap(sessions: Map<FlowSession, Class<out Any>>): Map<FlowSession, Any> {
-        sessions.mapKeys { requireBoxedType(it.value) }
         return sessions.mapValues { it.key.receive(it.value) }
     }
 
@@ -145,10 +143,6 @@ class ConcurrentFlowMessaging(
 
     override fun sendAllMap(payloadsPerSession: Map<FlowSession, Any>) {
         payloadsPerSession.keys.forEach { it.send(payloadsPerSession[it]!!) }
-    }
-
-    private fun requireBoxedType(type: Class<*>) {
-        require(!type.isPrimitive) { "Cannot receive primitive type $type" }
     }
 
     override fun close() {


### PR DESCRIPTION
This PR addresses [CORE-9483](https://r3-cev.atlassian.net/browse/CORE-9483).

## Background:
Due to some errors observed in Corda 4 when serialising primitive types in flow sessions, the function `requireBoxedType(type: Class<*>) { require(!type.isPrimitive) }` was added to a number of classes to assert that a passed parameter was **not** a primitive type. Today, this function is causing failures when we try to pass integers through FlowMessaging as Kotlin autoboxing is converting the **boxed** `java.lang.Integer`/`kotlin.Int` to the primitive `int` which then fails the `requireBoxedType()` check.

## Findings:
When we remove the `requireBoxedType()` check, the sending of primitive types fails for two reasons:

### Autoboxing
It's important to note that, unlike Java, Kotlin has no primitive types; instead, all primitive types (e.g., boolean, float, int) are represented by boxed classes. When Kotlin code is compiled to JVM bytecode, all Kotlin variables are compiled to Java variables and it is up to the compiler to determine whether they become the boxed (class) or unboxed (primitive) equivalent.

To send data between flows, we use the `send()`, `receive()`, and `sendAndReceive()` functions on the FlowSession class (or equivalent functions in FlowMessaging). The `send(payload: Any)` function accepts a payload of `Any` type, serialises it using an AMQP serialiser, and sends the resulting bytes to the designated counterparty.

To receive data, we use the `receive(receiveType: Class<R>)` function, which takes a type token `receiveType` representing the expected class of the received data. The function waits for a send event from the counterparty flow and attempts to deserialise the received payload to the specified class type.

The issue here is that the `Any` parameter in `send()` will cause passed arguments to be implicit cast to their boxed representation at runtime, meaning that a passed `int` will be cast to a `Java.lang.Integer` before being serialised and sent. The generic type parameter `Class<R>` in `send()` does not do such casting, and so upon receiving the serialised `Java.lang.Integer` at runtime we attempt to deserialise it as a primitive `int` causing the following exception:
```
java.io.NotSerializableException: Internal deserialization failure: java.lang.ClassCastException: Cannot cast java.lang.Integer to int 
```
[java.io.NotSerializableException.txt](https://github.com/corda/corda-runtime-os/files/11450822/java.io.NotSerializableException.txt)

### Kryo Serialization / Class Loading
When we call `receive()` on a flow, we persist a `FlowIORequest` into the flow fiber and suspend the fiber, waiting for the expected message to be received. This suspension was triggering a Kryo serialisation/deserialisation of the flow which was tripping up when trying to load the `int` 'class' from the system class loader as there is no class to load for an `int` primitive, resulting in the following:
```
com.esotericsoftware.kryo.KryoException: net.corda.sandbox.SandboxException: Class int was not from a bundle, and could not be found in the system classloader.
```
[KryoException- net.corda.sandbox.SandboxException.txt](https://github.com/corda/corda-runtime-os/files/11450817/KryoException-.net.corda.sandbox.SandboxException.txt)

## Solution:
### Autoboxing
We can assume that any primitive value will be autoboxed before serialization, and deserialize it as such on receipt with the following check:
```
return if (receiveType.isPrimitive) {
    deserializeReceivedPayload(received, receiveType.kotlin.javaObjectType)
} else {
    deserializeReceivedPayload(received, receiveType)
}
```
> (Note: We could call the deserialiser with `receiveType.kotlin.javaObjectType` in all cases – it would simply be a no-op on boxed classes – but I felt this conditional check made the intent more clear).

This check makes sure we pass the class type of the boxed representation to the deserialiser. The return type, `R`, will ensure that the returned value is implicit cast to whichever representation the `receive()` function was called with, either boxed or primitive. 

We could also solve this by modifying the API of `send()` and `sendAndReceive()` to prevent autoboxing, but this solution doesn't require any modifications to the API.

### Kryo Serialization / Class Loading
Flow class loading is delegated through the `GroupSandboxImpl`; I've modified this delegator so that when it is called with a primitive, e.g. `int` or `float`, it will directly return the Java `Class` wrapper for that primitive from a mapping:
```
private val primitiveTypes = mapOf(
    "boolean" to Boolean::class.javaPrimitiveType,
    "byte" to Byte::class.javaPrimitiveType,
    "short" to Short::class.javaPrimitiveType,
    ...
)
```
### Miscellanious
Special handling was also added to `DeserializationInput` for `char` types, as they go through a widening conversion to an `Integer` type in-transit. More info on this can be found in comments below.

## Testing
As of now, I've written unit tests for AMQP serialisation/deserialisation of primitive types, and I've performed manual E2E testing of flows with primitive types. I'll add automated E2E and integration testing of the new behaviour.

[CORE-9483]: https://r3-cev.atlassian.net/browse/CORE-9483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ