### PR TITLE
CORE-13168: Check whether the Kotlin metadata is compatible with the library.

### DIFF
--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    testCompileOnly "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
+    testCompileOnly 'org.jetbrains:annotations'
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
     testRuntimeOnly "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinMetadataVersion"

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinClassImpl.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinClassImpl.kt
@@ -380,6 +380,7 @@ private fun <T : Any> Metadata.forKotlinType(
         is KotlinClassMetadata.Class -> KotlinClassImpl.KmClassType(clazz, klazz, pool, km.toKmClass())
         is KotlinClassMetadata.FileFacade -> KotlinClassImpl.KmPackageType(clazz, klazz, pool, km.toKmPackage())
         is KotlinClassMetadata.MultiFileClassPart -> KotlinClassImpl.KmPackageType(clazz, klazz, pool, km.toKmPackage())
+        null -> throw IllegalArgumentException("Incompatible Kotlin metadata version '${metadataVersion.joinToString(".")}'.")
         else -> throw IllegalArgumentException("Unsupported Kotlin class type: $km")
     }
 }

--- a/osgi-framework-api/build.gradle
+++ b/osgi-framework-api/build.gradle
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     compileOnly platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly 'org.osgi:osgi.core'
-    compileOnly "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
+    compileOnly 'org.jetbrains:annotations'
 }


### PR DESCRIPTION
The Kotlin metadata library returns `null` if the class data it was asked to read is incompatible. Check for this explicitly and return an informative error message as required.

Ultimately, supporting multiple versions of Kotlin will require supporting multiple versions of the metadata library too.