### PR TITLE
CORE-11807 stop and close should not be called together. Only close is required when wanting to stop and close.

### DIFF
--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
@@ -1,5 +1,9 @@
 package net.corda.lifecycle.impl
 
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import net.corda.lifecycle.CustomEvent
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.LifecycleCoordinator
@@ -19,10 +23,6 @@ import net.corda.lifecycle.registry.LifecycleRegistryException
 import net.corda.utilities.trace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
 
 
 /**
@@ -273,7 +273,6 @@ class LifecycleCoordinatorImpl(
             logger.trace { "$name: Closing coordinator" }
             postInternalEvent(StopEvent())
             postInternalEvent(CloseCoordinator())
-            registry.removeCoordinator(name)
         }
     }
 }

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
@@ -1,5 +1,7 @@
 package net.corda.lifecycle.impl
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledFuture
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.ErrorEvent
 import net.corda.lifecycle.LifecycleCoordinator
@@ -16,8 +18,6 @@ import net.corda.lifecycle.registry.LifecycleRegistryException
 import net.corda.utilities.debug
 import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ScheduledFuture
 
 /**
  * Perform processing of lifecycle events.
@@ -219,6 +219,7 @@ internal class LifecycleProcessor(
         state.registrations.clear()
         closeManagedResources(null)
         managedResources.clear()
+        registry.removeCoordinator(name)
         return true
     }
 

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleProcessorTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleProcessorTest.kt
@@ -1,5 +1,8 @@
 package net.corda.lifecycle.impl
 
+import java.util.concurrent.Delayed
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.ErrorEvent
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -28,9 +31,6 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import java.util.concurrent.Delayed
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
 
 class LifecycleProcessorTest {
 
@@ -663,13 +663,15 @@ class LifecycleProcessorTest {
     }
 
     @Test
-    fun `processClose will close all the timers`() {
+    fun `processClose will close all the timers and remove from registry`() {
         val state: LifecycleStateManager = mock()
+        val registry = mock<LifecycleRegistryCoordinatorAccess>()
+
         whenever(state.nextBatch()).thenReturn(listOf(CloseCoordinator()))
-        val processor = LifecycleProcessor(NAME, state, mock(), mock(), mock())
+        val processor = LifecycleProcessor(NAME, state, registry, mock(), mock())
 
         processor.processEvents(mock(), mock())
-
+        verify(registry, times(1)).removeCoordinator(any())
         verify(state).cancelAllTimer()
     }
 

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/RPCSenderImpl.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/RPCSenderImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.emulation.publisher
 
+import java.util.concurrent.CompletableFuture
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
@@ -7,7 +8,6 @@ import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.messaging.emulation.rpc.RPCTopicService
-import java.util.concurrent.CompletableFuture
 
 class RPCSenderImpl<REQUEST, RESPONSE>(
     private val rpcConfig: RPCConfig<REQUEST, RESPONSE>,
@@ -32,8 +32,6 @@ class RPCSenderImpl<REQUEST, RESPONSE>(
 
     override fun close() {
         running = false
-        lifecycleCoordinator.updateStatus(LifecycleStatus.DOWN)
-        lifecycleCoordinator.stop()
         lifecycleCoordinator.close()
     }
 

--- a/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/publisher/RPCSenderImplTest.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/publisher/RPCSenderImplTest.kt
@@ -69,6 +69,7 @@ class RPCSenderImplTest {
 
         verify(lifecycleCoordinator, times(1)).close()
         verify(lifecycleCoordinator, never()).stop()
+        verify(lifecycleCoordinator, never()).updateStatus(any(), any())
     }
 
     private fun getConfig(): RPCConfig<String, String> {

--- a/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/publisher/RPCSenderImplTest.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/publisher/RPCSenderImplTest.kt
@@ -1,5 +1,7 @@
 package net.corda.messaging.emulation.publisher
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.messaging.api.exception.CordaRPCAPISenderException
@@ -11,10 +13,9 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.atomic.AtomicInteger
 
 class RPCSenderImplTest {
     private val rpcTopicService: RPCTopicService = mock()
@@ -53,6 +54,21 @@ class RPCSenderImplTest {
         Assertions.assertThat(requestCompletion).isInstanceOf(CompletableFuture::class.java)
 
         verify(rpcTopicService, times(1)).publish("test", request, requestCompletion)
+    }
+
+    @Test
+    fun `Close should call close and not stop`() {
+        val rpcSender = RPCSenderImpl(
+            getConfig(),
+            rpcTopicService,
+            lifecycleCoordinatorFactory,
+            clientIdCounter.getAndIncrement().toString()
+        )
+
+        rpcSender.close()
+
+        verify(lifecycleCoordinator, times(1)).close()
+        verify(lifecycleCoordinator, never()).stop()
     }
 
     private fun getConfig(): RPCConfig<String, String> {


### PR DESCRIPTION
the implementation of close is will post and internal stop event and then remove the coordinator from the registry.
stop() posts an internal stop event. 

Given that close and stop both post stop events there is no need to call both as this causes warnings. there is also no need to post DOWN as this is done already as part of close.

Additionall there is a race condition within the coordinator close logic. close() will post events to its own processor to process in order on a different thread, such as CloseCoordinator(). Then the coordinator will remove itself from the registry. This means it will usually remove itself from the registry before it processed the CloseCoordinator event fully. When it tries to update its status in the registry in CloseCoordinator handler it will fail and log a warning. Moved the registry removal to the CloseCoordinator handler