### PR TITLE
CORE-13137: Fix incorrect AMQP serialization test for WireTransaction.

### DIFF
--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImpl.kt
@@ -17,6 +17,7 @@ import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE_REQUIRED
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 import java.util.function.Predicate
 
@@ -26,7 +27,7 @@ import java.util.function.Predicate
     scope = PROTOTYPE,
 )
 class FilteredTransactionFactoryImpl @Activate constructor(
-    @Reference(service = JsonMarshallingService::class)
+    @Reference(service = JsonMarshallingService::class, scope = PROTOTYPE_REQUIRED)
     private val jsonMarshallingService: JsonMarshallingService,
     @Reference(service = MerkleTreeProvider::class)
     private val merkleTreeProvider: MerkleTreeProvider,

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/serializer/amqp/FilteredTransactionSerializer.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/serializer/amqp/FilteredTransactionSerializer.kt
@@ -14,6 +14,7 @@ import net.corda.v5.crypto.merkle.MerkleProof
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE_REQUIRED
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
@@ -22,7 +23,7 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
     scope = PROTOTYPE
 )
 class FilteredTransactionSerializer @Activate constructor(
-    @Reference(service = JsonMarshallingService::class)
+    @Reference(service = JsonMarshallingService::class, scope = PROTOTYPE_REQUIRED)
     private val jsonMarshallingService: JsonMarshallingService,
     @Reference(service = MerkleTreeProvider::class)
     private val merkleTreeProvider: MerkleTreeProvider

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
@@ -26,6 +26,7 @@ import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE_REQUIRED
 import org.osgi.service.component.annotations.ServiceScope
 import java.time.Instant
 
@@ -45,9 +46,9 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
     private val wireTransactionFactory: WireTransactionFactory,
     @Reference(service = CurrentSandboxGroupContext::class)
     private val currentSandboxGroupContext: CurrentSandboxGroupContext,
-    @Reference(service = JsonMarshallingService::class)
+    @Reference(service = JsonMarshallingService::class, scope = PROTOTYPE_REQUIRED)
     private val jsonMarshallingService: JsonMarshallingService,
-    @Reference(service = JsonValidator::class)
+    @Reference(service = JsonValidator::class, scope = PROTOTYPE_REQUIRED)
     private val jsonValidator: JsonValidator,
 ) : ConsensualSignedTransactionFactory, UsedByFlow, SingletonSerializeAsToken {
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -33,6 +33,7 @@ import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE_REQUIRED
 import org.osgi.service.component.annotations.ServiceScope
 import java.security.PublicKey
 
@@ -43,9 +44,9 @@ import java.security.PublicKey
 class UtxoSignedTransactionFactoryImpl @Activate constructor(
     @Reference(service = CurrentSandboxGroupContext::class)
     private val currentSandboxGroupContext: CurrentSandboxGroupContext,
-    @Reference(service = JsonMarshallingService::class)
+    @Reference(service = JsonMarshallingService::class, scope = PROTOTYPE_REQUIRED)
     private val jsonMarshallingService: JsonMarshallingService,
-    @Reference(service = JsonValidator::class)
+    @Reference(service = JsonValidator::class, scope = PROTOTYPE_REQUIRED)
     private val jsonValidator: JsonValidator,
     @Reference(service = SerializationService::class)
     private val serializationService: SerializationService,

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/AMQPSerializationTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/AMQPSerializationTest.kt
@@ -1,12 +1,10 @@
 package net.corda.sandboxgroupcontext.test
 
-import net.corda.common.json.validation.JsonValidator
 import java.lang.invoke.MethodHandles
 import java.nio.file.Path
 import java.security.KeyPairGenerator
 import kotlin.reflect.full.primaryConstructor
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
-import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.crypto.core.parseSecureHash
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.testkit.getWireTransactionExample
@@ -18,11 +16,10 @@ import net.corda.sandboxgroupcontext.RequireSandboxAMQP.AMQP_SERIALIZATION_SERVI
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.getObjectByKey
+import net.corda.sandboxgroupcontext.getSandboxSingletonService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
-import net.corda.v5.application.crypto.DigestService
-import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.types.MemberX500Name
@@ -69,18 +66,6 @@ class AMQPSerializationTest {
 
     @InjectService(timeout = TIMEOUT_MILLIS)
     lateinit var cipherSchemeMetadata: CipherSchemeMetadata
-
-    @InjectService(timeout = TIMEOUT_MILLIS)
-    lateinit var merkleTreeProvider: MerkleTreeProvider
-
-    @InjectService(timeout = TIMEOUT_MILLIS)
-    lateinit var digestService: DigestService
-
-    @InjectService(timeout = TIMEOUT_MILLIS)
-    lateinit var jsonMarshallingService: JsonMarshallingService
-
-    @InjectService(timeout = TIMEOUT_MILLIS)
-    lateinit var jsonValidator: JsonValidator
 
     @RegisterExtension
     private val lifecycle = AllTestsLifecycle()
@@ -230,10 +215,11 @@ class AMQPSerializationTest {
             val serializationService = ctx.getSerializationService()
 
             origWireTx = getWireTransactionExample(
-                digestService,
-                merkleTreeProvider,
-                jsonMarshallingService,
-                jsonValidator)
+                digestService = ctx.getSandboxSingletonService(),
+                merkleTreeProvider = ctx.getSandboxSingletonService(),
+                jsonMarshallingService = ctx.getSandboxSingletonService(),
+                jsonValidator = ctx.getSandboxSingletonService()
+            )
 
             serializedBytes = serializationService.serialize(origWireTx!!)
         }

--- a/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/JsonMarshallingServiceImpl.kt
+++ b/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/JsonMarshallingServiceImpl.kt
@@ -18,6 +18,7 @@ import net.corda.common.json.serializers.SerializationCustomizer
 import net.corda.crypto.core.parseSecureHash
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
+import net.corda.sandbox.type.UsedByVerification
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.marshalling.json.JsonDeserializer
 import net.corda.v5.application.marshalling.json.JsonSerializer
@@ -35,9 +36,12 @@ import java.util.Collections.unmodifiableMap
  * Simple implementation, requires alignment with other serialization such as that used
  * in the HTTP library
  */
-@Component(service = [ JsonMarshallingService::class, UsedByFlow::class, UsedByPersistence::class ], scope = PROTOTYPE)
+@Component(
+    service = [ JsonMarshallingService::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
+    scope = PROTOTYPE
+)
 class JsonMarshallingServiceImpl : JsonMarshallingService,
-    UsedByFlow, UsedByPersistence, SingletonSerializeAsToken, SerializationCustomizer {
+    UsedByFlow, UsedByPersistence, UsedByVerification, SingletonSerializeAsToken, SerializationCustomizer {
     private companion object {
         private const val INITIAL_SIZE = 16
         private const val MAX_SIZE = 200

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/factory/WireTransactionFactoryImpl.kt
@@ -4,24 +4,26 @@ import net.corda.common.json.validation.JsonValidator
 import net.corda.common.json.validation.WrappedJsonSchema
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
+import net.corda.ledger.common.data.transaction.PrivacySalt
 import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
+import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
+import net.corda.sandbox.type.UsedByVerification
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.marshalling.JsonMarshallingService
-import net.corda.ledger.common.data.transaction.PrivacySalt
-import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE_REQUIRED
 import org.osgi.service.component.annotations.ServiceScope
 
 @Component(
-    service = [WireTransactionFactory::class, UsedByFlow::class, UsedByPersistence::class],
+    service = [ WireTransactionFactory::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
     scope = ServiceScope.PROTOTYPE
 )
 @Suppress("LongParameterList")
@@ -30,13 +32,13 @@ class WireTransactionFactoryImpl @Activate constructor(
     private val merkleTreeProvider: MerkleTreeProvider,
     @Reference(service = DigestService::class)
     private val digestService: DigestService,
-    @Reference(service = JsonMarshallingService::class)
+    @Reference(service = JsonMarshallingService::class, scope = PROTOTYPE_REQUIRED)
     private val jsonMarshallingService: JsonMarshallingService,
-    @Reference(service = JsonValidator::class)
+    @Reference(service = JsonValidator::class, scope = PROTOTYPE_REQUIRED)
     private val jsonValidator: JsonValidator,
     @Reference(service = CipherSchemeMetadata::class)
     private val cipherSchemeMetadata: CipherSchemeMetadata
-) : WireTransactionFactory, UsedByFlow, UsedByPersistence, SingletonSerializeAsToken {
+) : WireTransactionFactory, UsedByFlow, UsedByPersistence, UsedByVerification, SingletonSerializeAsToken {
 
     private val metadataSchema: WrappedJsonSchema by lazy {
         jsonValidator.parseSchema(getSchema(TransactionMetadataImpl.SCHEMA_PATH))

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/serializer/amqp/WireTransactionSerializer.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/serializer/amqp/WireTransactionSerializer.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.common.data.transaction.serializer.amqp
 
+import net.corda.ledger.common.data.transaction.PrivacySalt
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
 import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
@@ -9,7 +10,6 @@ import net.corda.sandbox.type.UsedByVerification
 import net.corda.serialization.BaseProxySerializer
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.ledger.common.data.transaction.PrivacySalt
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference

--- a/libs/serialization/json-validator/src/main/kotlin/net/corda/common/json/validation/impl/JsonValidatorImpl.kt
+++ b/libs/serialization/json-validator/src/main/kotlin/net/corda/common/json/validation/impl/JsonValidatorImpl.kt
@@ -8,15 +8,19 @@ import net.corda.common.json.validation.JsonValidator
 import net.corda.common.json.validation.WrappedJsonSchema
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
+import net.corda.sandbox.type.UsedByVerification
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.erdtman.jcs.JsonCanonicalizer
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.ServiceScope
 import java.io.InputStream
 
-@Component(service = [ JsonValidator::class, UsedByFlow::class, UsedByPersistence::class ], scope = ServiceScope.PROTOTYPE)
+@Component(
+    service = [ JsonValidator::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
+    scope = ServiceScope.PROTOTYPE
+)
 class JsonValidatorImpl: JsonValidator,
-    UsedByFlow, UsedByPersistence, SingletonSerializeAsToken {
+    UsedByFlow, UsedByPersistence, UsedByVerification, SingletonSerializeAsToken {
 
     override fun validate(json: String, wrappedSchema: WrappedJsonSchema) {
         val errors = validateSchema(json, wrappedSchema)

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/CustomSerializerRegistry.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/CustomSerializerRegistry.kt
@@ -111,14 +111,14 @@ class CachingCustomSerializerRegistry(
         sandboxGroup: SandboxGroup
     ) : this(descriptorBasedSerializerRegistry, emptySet(), sandboxGroup)
 
-    companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    private companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override val customSerializerNames: List<String>
         get() = customSerializers.map { serializer ->
             if (serializer is CorDappCustomSerializer) serializer.toString()
-            else "${serializer::class.java} - Classloader: ${serializer::class.java.classLoader}"
+            else "$serializer - Classloader: ${serializer::class.java.classLoader}"
         }
 
     private data class CustomSerializerIdentifier(val actualTypeIdentifier: TypeIdentifier, val declaredTypeIdentifier: TypeIdentifier)


### PR DESCRIPTION
`@InjectService` can only inject a platform service. You must therefore acquire a reference to a sandbox service from the `SandboxGroupContext`, as otherwise the test becomes meaningless.

Note that `WireTransactionSerializer` requires a `WireTransactionFactory`, which only exists in `FLOW` and `PERSISTENCE` sandboxes. As does the `JsonValidator` service, as it happens. Therefore there is no point declaring `WireTransactionSerializer` as `UsedForVerification`, which means `testSerializeAndDeserializeWireTransaction` should only execute for `FLOW` and `PERSISTENCE` sandboxes.

The fact that this test used to pass for `VERIFICATION` sandboxes demonstrates my earlier point about incorrect usage of `@InjectService` making tests meaningless.

---
It appears that `VERIFICATION` sandboxes also require the following services:
- `WireTransactionFactory`
- `WireTransactionSerializer`
- `JsonMarshallingService`
- `JsonValidator`

as otherwise `VerificationRequestProcessorTest` fails. Declare all of these components as `UsedByVerification` so that `testSerializeAndDeserializeWireTransaction` can also pass for all sandbox types.

_It is critical that sandboxes use their own instance of `JsonMarshallingService` so that CPKs can be unloaded without leaking memory._ So declare these references as `PROTOTYPE_REQUIRED` to prevent them accidentally being satisfied by the platform's `JsonMarshallingService`.