### PR TITLE
CORE-13256 Remove evolvability tags from transaction output.

### DIFF
--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/factory/ConsensualSignedTransactionFactoryImpl.kt
@@ -14,7 +14,6 @@ import net.corda.ledger.consensual.data.transaction.verifier.verifyMetadata
 import net.corda.ledger.consensual.flow.impl.transaction.ConsensualSignedTransactionImpl
 import net.corda.ledger.consensual.flow.impl.transaction.verifier.ConsensualLedgerTransactionVerifier
 import net.corda.sandbox.type.UsedByFlow
-import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
@@ -43,8 +42,6 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
     private val transactionMetadataFactory: TransactionMetadataFactory,
     @Reference(service = WireTransactionFactory::class)
     private val wireTransactionFactory: WireTransactionFactory,
-    @Reference(service = CurrentSandboxGroupContext::class)
-    private val currentSandboxGroupContext: CurrentSandboxGroupContext,
     @Reference(service = JsonMarshallingService::class)
     private val jsonMarshallingService: JsonMarshallingService,
     @Reference(service = JsonValidator::class)
@@ -110,8 +107,6 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
         metadataBytes: ByteArray
     ): List<List<ByteArray>> {
 
-        val currentSandboxGroup = currentSandboxGroupContext.get().sandboxGroup
-
         val requiredSigningKeys = consensualTransactionBuilder
             .states
             .flatMap { it.participants }
@@ -133,15 +128,6 @@ class ConsensualSignedTransactionFactoryImpl @Activate constructor(
                     }
                     ConsensualComponentGroup.OUTPUT_STATES -> {
                         consensualTransactionBuilder.states.map { serializationService.serialize(it).bytes }
-                    }
-                    ConsensualComponentGroup.OUTPUT_STATE_TYPES -> {
-                        consensualTransactionBuilder.states.map {
-                            serializationService.serialize(
-                                currentSandboxGroup.getEvolvableTag(
-                                    it::class.java
-                                )
-                            ).bytes
-                        }
                     }
                 }
             }

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -191,7 +191,7 @@ class UtxoLedgerMessageProcessorTests {
         ).bytes
         val outputInfo = ctx.getSerializationService().serialize(
             UtxoOutputInfoComponent(
-                null, null, notaryX500Name, publicKeyExample, TestContractState::class.java.name, "contract tag"
+                null, null, notaryX500Name, publicKeyExample
             )
         ).bytes
         val wireTransactionFactory: WireTransactionFactory = ctx.getSandboxSingletonService()

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -542,10 +542,10 @@ class UtxoPersistenceServiceImplTest {
             listOf("group2_component1".toByteArray()),
             listOf(
                 UtxoOutputInfoComponent(
-                    null, null, notaryExampleName, notaryExampleKey, TestContractState1::class.java.name, "contract tag"
+                    null, null, notaryExampleName, notaryExampleKey
                 ).toBytes(),
                 UtxoOutputInfoComponent(
-                    null, null, notaryExampleName, notaryExampleKey, TestContractState2::class.java.name, "contract tag"
+                    null, null, notaryExampleName, notaryExampleKey
                 ).toBytes()
             ),
             listOf("group4_component1".toByteArray()),

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/tests/UtxoFilteredTransactionTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/tests/UtxoFilteredTransactionTest.kt
@@ -414,9 +414,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
             encumbrance = null,
             encumbranceGroupSize = null,
             notaryName = notaryX500Name,
-            notaryKey = publicKeyExample,
-            contractStateTag = UtxoStateClassExample::class.java.name,
-            contractTag = "contract tag"
+            notaryKey = publicKeyExample
         )
         return utxoSignedTransactionFactory.createExample(
             jsonMarshallingService,

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoFilteredTransactionAMQPSerializationTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoFilteredTransactionAMQPSerializationTest.kt
@@ -23,9 +23,7 @@ class UtxoFilteredTransactionAMQPSerializationTest : UtxoLedgerIntegrationTest()
             encumbrance = null,
             encumbranceGroupSize = null,
             notaryName = MemberX500Name("alice", "LDN", "GB"),
-            notaryKey = publicKeyExample,
-            contractStateTag = UtxoStateClassExample::class.java.name,
-            contractTag = "contract tag"
+            notaryKey = publicKeyExample
         )
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -158,9 +158,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
                 it.encumbranceGroup?.tag,
                 it.encumbranceGroup?.size,
                 utxoTransactionBuilder.notaryName!!,
-                utxoTransactionBuilder.notaryKey!!,
-                currentSandboxGroup.getEvolvableTag(it.contractStateType),
-                currentSandboxGroup.getEvolvableTag(it.contractType)
+                utxoTransactionBuilder.notaryKey!!
             )
         }
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionTestBase.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionTestBase.kt
@@ -52,8 +52,8 @@ open class UtxoFilteredTransactionTestBase {
         val signerKey1 = mock<PublicKey>()
         val signerKey2 = mock<PublicKey>()
 
-        val outputInfo1 = UtxoOutputInfoComponent(null, null, notaryName, notaryKey, "", "")
-        val outputInfo2 = UtxoOutputInfoComponent("three", 3, notaryName, notaryKey, "", "")
+        val outputInfo1 = UtxoOutputInfoComponent(null, null, notaryName, notaryKey)
+        val outputInfo2 = UtxoOutputInfoComponent("three", 3, notaryName, notaryKey)
     }
 
     lateinit var wireTransaction: WireTransaction

--- a/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
@@ -19,7 +19,6 @@ import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
-import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.ledger.utxo.verification.CordaPackageSummary
 import net.corda.ledger.utxo.verification.TransactionVerificationRequest
 import net.corda.ledger.utxo.verification.TransactionVerificationResponse
@@ -247,7 +246,7 @@ class VerificationRequestProcessorTest {
 
         val outputInfo = ctx.getSerializationService().serialize(
             UtxoOutputInfoComponent(
-                null, null, NOTARY_X500_NAME, PUBLIC_KEY, outputState::class.java.canonicalName, "contract tag"
+                null, null, NOTARY_X500_NAME, PUBLIC_KEY
             )
         ).bytes
 

--- a/libs/ledger/ledger-consensual-data/src/main/kotlin/net/corda/ledger/consensual/data/transaction/ConsensualComponentGroup.kt
+++ b/libs/ledger/ledger-consensual-data/src/main/kotlin/net/corda/ledger/consensual/data/transaction/ConsensualComponentGroup.kt
@@ -14,7 +14,6 @@ import java.time.Instant
  * @property TIMESTAMP The timestamp parameter component group. Ordinal = 1.
  * @property SIGNATORIES The required signing keys component group. Ordinal = 2.
  * @property OUTPUT_STATES The output states component group. Ordinal = 3.
- * @property OUTPUT_STATE_TYPES The output state types component group. Ordinal = 4.
  */
 
 enum class ConsensualComponentGroup {
@@ -22,14 +21,12 @@ enum class ConsensualComponentGroup {
               // [net.corda.ledger.common.impl.transaction.WireTransactionImplKt.ALL_LEDGER_METADATA_COMPONENT_GROUP_ID]
     TIMESTAMP,
     SIGNATORIES,
-    OUTPUT_STATES,
-    OUTPUT_STATE_TYPES
+    OUTPUT_STATES
 }
 
 val consensualComponentGroupStructure = listOf(
     listOf("metadata"),
     listOf(Instant::class.java.name),
     listOf(PublicKey::class.java.name),
-    listOf(ConsensualState::class.java.name),
-    listOf("OutputInfo"),
+    listOf(ConsensualState::class.java.name)
 )

--- a/libs/ledger/ledger-consensual-data/src/main/kotlin/net/corda/ledger/consensual/data/transaction/ConsensualLedgerTransactionImpl.kt
+++ b/libs/ledger/ledger-consensual-data/src/main/kotlin/net/corda/ledger/consensual/data/transaction/ConsensualLedgerTransactionImpl.kt
@@ -17,12 +17,6 @@ class ConsensualLedgerTransactionImpl(
 
     init {
         verifyMetadata(wireTransaction.metadata)
-        check(
-            wireTransaction.componentGroupLists[ConsensualComponentGroup.OUTPUT_STATES.ordinal].size ==
-                    wireTransaction.componentGroupLists[ConsensualComponentGroup.OUTPUT_STATE_TYPES.ordinal].size
-        ) {
-            "The length of the output states and output state types component groups needs to be the same."
-        }
     }
 
     override fun equals(other: Any?): Boolean {

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoOutputInfoComponent.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoOutputInfoComponent.kt
@@ -9,7 +9,5 @@ data class UtxoOutputInfoComponent(
     val encumbrance: String?,
     val encumbranceGroupSize: Int?,
     val notaryName: MemberX500Name,
-    val notaryKey: PublicKey,
-    val contractStateTag: String,
-    val contractTag: String
+    val notaryKey: PublicKey
 )

--- a/testing/ledger/ledger-consensual-base-test/src/main/kotlin/net/corda/ledger/consensual/test/ConsensualLedgerTest.kt
+++ b/testing/ledger/ledger-consensual-base-test/src/main/kotlin/net/corda/ledger/consensual/test/ConsensualLedgerTest.kt
@@ -16,7 +16,6 @@ abstract class ConsensualLedgerTest : CommonLedgerTest() {
         fakeTransactionSignatureService(),
         transactionMetadataFactory,
         wireTransactionFactory,
-        currentSandboxGroupContext,
         jsonMarshallingService,
         jsonValidator
     )


### PR DESCRIPTION
The tags were added to UtxoOutputInfo and Consensual transactions, but they are completely redundant as they are part of the AMQP serialized data.