### PR TITLE
CORE-11838: Upgrade to Felix Security 2.8.4.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5
 felixScrVersion=2.2.6
-felixSecurityVersion=2.8.3
+felixSecurityVersion=2.8.4
 guavaVersion=30.1.1-jre
 # Hibernate cannot be upgraded to 6.x due to missing OSGi support
 hibernateVersion=5.6.15.Final


### PR DESCRIPTION
This prevents OSGi permissions objects being leaked whenever bundles are unloaded from the framework. It should also mean that fewer permissions objects are created in the first place!

See [FELIX-6591](https://issues.apache.org/jira/browse/FELIX-6591).