### PR TITLE
ES-313: use latest Java 11 Azul Zulu base image

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -124,7 +124,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<String> baseImageTag =
-            getObjects().property(String).convention('11.0.15-11.56.19')
+            getObjects().property(String).convention('11')
 
     @Input
     final Property<String> subDir =

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -124,7 +124,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<String> baseImageTag =
-            getObjects().property(String).convention('11')
+            getObjects().property(String).convention('11.0.16.1-11.58.23')
 
     @Input
     final Property<String> subDir =

--- a/gradle.properties
+++ b/gradle.properties
@@ -126,7 +126,7 @@ jettyVersion = 9.4.51.v20230217
 compositeBuild=false
 cordaApiLocation=../corda-api
 cordaCliHostLocation=../corda-cli-plugin-host
-jibCoreVersion=0.22.0
+jibCoreVersion=0.23.0
 artifactoryPluginVersion = 4.28.2
 
 # PF4J


### PR DESCRIPTION
Bump the base image of workers to the newest Java11, which in turn uses a more up-to-date Ubuntu version `jammy-20230308`

Also updated the following

- Jib core 0.22 -> 0.23

Related corda-cll commit: https://github.com/corda/corda-cli-plugin-host/pull/159