### PR TITLE
CORE-12911 Use only class bundle name for evolved classes

### DIFF
--- a/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkIdentifier.kt
+++ b/libs/packaging/packaging-core/src/main/kotlin/net/corda/libs/packaging/core/CpkIdentifier.kt
@@ -10,7 +10,7 @@ import net.corda.data.packaging.CpkIdentifier as CpkIdentifierAvro
 /**
  * Uniquely identifies a CPK archive
  *
- * @property name The Bundle-SymbolicName of the main bundle inside the CPK
+ * @property name The Corda-CPK-Cordapp-Name given to the CPK
  * @property version The Bundle-Version of the main bundle inside the CPK
  * @property signerSummaryHash The hash of concatenation of the sorted hashes of the public keys of the
  *              signers of the CPK, null if the CPK isn't signed

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2.kt
@@ -3,6 +3,7 @@ package net.corda.libs.packaging.internal.v2
 import net.corda.libs.packaging.Cpk
 import net.corda.libs.packaging.PackagingConstants.CPK_FORMAT_VERSION2_MAINBUNDLE_PLACEHOLDER
 import net.corda.libs.packaging.PackagingConstants.CPK_LIB_FOLDER_V2
+import net.corda.libs.packaging.PackagingConstants.CPK_NAME_ATTRIBUTE
 import net.corda.libs.packaging.core.CordappManifest
 import net.corda.libs.packaging.core.CpkIdentifier
 import net.corda.libs.packaging.core.CpkManifest
@@ -89,9 +90,12 @@ class CpkLoaderV2(
         // Read the configuration for the external channels
         val externalChannelsConfig = externalChannelsConfigLoader.read(cpkEntries)
 
+        // Corda-CPK-Cordapp-Name
+        val cordaCpkName = cordappManifest.attributes[CPK_NAME_ATTRIBUTE] ?: cordappManifest.bundleSymbolicName
+
         return CpkMetadata(
             cpkId = CpkIdentifier(
-                cordappManifest.bundleSymbolicName,
+                cordaCpkName,
                 cordappManifest.bundleVersion,
                 signerSummaryHash
             ),

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -43,13 +43,14 @@ internal class SandboxGroupImpl(
         }
     }
 
-    override val metadata: SortedMap<Bundle, CpkMetadata> =
-        unmodifiableSortedMap(cpkSandboxes.associateTo(TreeMap()) { cpk ->
-            cpk.mainBundle to cpk.cpkMetadata
-        })
+    override val metadata: SortedMap<Bundle, CpkMetadata> = unmodifiableSortedMap(cpkSandboxes.associateTo(TreeMap()) { cpk ->
+        cpk.mainBundle to cpk.cpkMetadata
+    })
 
     override fun loadClassFromPublicBundles(className: String): Class<*>? {
-        val clazz = publicSandboxes.flatMap(Sandbox::publicBundles).filterNot(Bundle::isFragment)
+        val clazz = publicSandboxes
+            .flatMap(Sandbox::publicBundles)
+            .filterNot(Bundle::isFragment)
             .mapNotNullTo(LinkedHashSet()) { bundle ->
                 try {
                     bundle.loadClass(className)
@@ -74,9 +75,8 @@ internal class SandboxGroupImpl(
                 null
             }
         }.singleOrNull()
-            ?: throw SandboxException("Class $className was not found in any sandbox in the sandbox group.").withSuppressed(
-                suppressed
-            )
+            ?: throw SandboxException("Class $className was not found in any sandbox in the sandbox group.")
+                .withSuppressed(suppressed)
     }
 
     override fun <T : Any> loadClassFromMainBundles(className: String, type: Class<T>): Class<out T> {

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -152,15 +152,18 @@ internal class SandboxGroupImpl(
      * bundle.
      */
     private fun getClassTag(klass: Class<*>, isStaticTag: Boolean): String {
-        val bundle = bundleUtils.getBundle(klass) ?: return classTagFactory.createSerialisedTag(isStaticTag, null, null)
+        val bundle = bundleUtils.getBundle(klass)
+            ?: return classTagFactory.createSerialisedTag(isStaticTag, null, null)
 
-        val publicSandbox = publicSandboxes.find { sandbox -> sandbox.containsBundle(bundle) }
+        val publicSandbox =
+            publicSandboxes.find { sandbox -> sandbox.containsBundle(bundle) }
         if (publicSandbox != null) {
             return classTagFactory.createSerialisedTag(isStaticTag, bundle, null)
         }
 
-        val cpkSandbox = cpkSandboxes.find { sandbox -> sandbox.containsBundle(bundle) }
-            ?: throw SandboxException("Bundle ${bundle.symbolicName} was not found in the sandbox group or in a public sandbox.")
+        val cpkSandbox =
+            cpkSandboxes.find { sandbox -> sandbox.containsBundle(bundle) }
+                ?: throw SandboxException("Bundle ${bundle.symbolicName} was not found in the sandbox group or in a public sandbox.")
         if (bundle in cpkSandbox.privateBundles && !isStaticTag) {
             throw SandboxException("Attempted to create evolvable class tag for cpk private bundle ${bundle.symbolicName}.")
         }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -122,7 +122,7 @@ internal class SandboxGroupImpl(
                 } ?: throw SandboxException(
                     "Class tag $serialisedClassTag did not match any sandbox in the sandbox group."
                 )
-                sandbox.loadClass(className, classTag.classBundleName) ?: throw SandboxException(
+                sandbox.loadClass(className, sandbox.mainBundle.symbolicName) ?: throw SandboxException(
                     "Class $className could not be loaded from bundle ${classTag.classBundleName} in sandbox ${sandbox.id}."
                 )
             }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -113,19 +113,12 @@ internal class SandboxGroupImpl(
                 val sandbox = when (classTag) {
                     is StaticTag -> cpkSandboxes.find { sandbox -> sandbox.cpkMetadata.fileChecksum == classTag.cpkFileHash }
                     is EvolvableTag -> {
-                        val sandbox = cpkSandboxes.find {
+                        cpkSandboxes.find {
                             it.cpkMetadata.cpkId.signerSummaryHash == classTag.cpkSignerSummaryHash
-                                    && it.mainBundle.symbolicName == classTag.mainBundleName
-                        }
-                        sandbox?.let {
-                            if (classTag.classBundleName != it.mainBundle.symbolicName) {
-                                throw SandboxException(
-                                    "Attempted to load class $className with an evolvable class tag from cpk private bundle " +
-                                            "${classTag.classBundleName}."
-                                )
-                            } else {
-                                it
-                            }
+                                    && it.mainBundle.symbolicName == classTag.classBundleName
+                            // In later versions of Corda 5 we should be finding a sandbox by trying to match its
+                            // Corda-CPK-Cordapp-Name to classTag.cordaCpkCordappName. Currently neither of those properties
+                            // are populated so we are matching by bundle symbolic versions.
                         }
                     }
                 } ?: throw SandboxException(

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -115,10 +115,8 @@ internal class SandboxGroupImpl(
                     is EvolvableTag -> {
                         cpkSandboxes.find {
                             it.cpkMetadata.cpkId.signerSummaryHash == classTag.cpkSignerSummaryHash
-                                    && it.mainBundle.symbolicName == classTag.classBundleName
-                            // In later versions of Corda 5 we should be finding a sandbox by trying to match its
-                            // Corda-CPK-Cordapp-Name to classTag.cordaCpkCordappName. Currently neither of those properties
-                            // are populated so we are matching by bundle symbolic versions.
+                                    && (it.cpkMetadata.cpkId.name == classTag.cordaCpkCordappName || // CPK given names match or
+                                        it.mainBundle.symbolicName == classTag.classBundleName) // symbolic names of class bundle match
                         }
                     }
                 } ?: throw SandboxException(

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -134,7 +134,7 @@ internal class SandboxGroupImpl(
                 publicSandboxes.asSequence().mapNotNull { publicSandbox ->
                     publicSandbox.loadClass(className, classTag.classBundleName)
                 }.firstOrNull() ?: throw SandboxException(
-                    "Class $className from bundle ${classTag.classBundleName} could not be loaded from any of the public " + "sandboxes."
+                    "Class $className from bundle ${classTag.classBundleName} could not be loaded from any of the public sandboxes."
                 )
             }
         }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/ClassTag.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/ClassTag.kt
@@ -33,13 +33,17 @@ internal abstract class StaticTag : ClassTag() {
 }
 
 /**
- * Identifies a sandboxed class based on the CPK's main bundle name and signers.
+ * Identifies a sandboxed class based on the CPK's name and signers. Classes tagged with this tag can evolve over subsequent
+ * versions of software so long as the changes are compatible with the evolution rules.
  *
- * @property mainBundleName The symbolic name of the main bundle of the CPK that the class if from.
+ * @property cordaCpkCordappName The name given to the CPK by the CorDapp developer which uniquely identifies it. This will
+ * be used for continuity purposes, the assumption being that a developer expects Corda to treat a class from a CPK with this
+ * cordaCpkCordappName as the same class type as any other with the same cordaCpkCordappName - generally to identify it between
+ * serialization and deserialization.
  * @property cpkSignerSummaryHash A summary hash of the hashes of the public keys that signed the CPK the class is from.
  */
 internal abstract class EvolvableTag : ClassTag() {
-    abstract val mainBundleName: String
+    abstract val cordaCpkCordappName: String
     abstract val cpkSignerSummaryHash: SecureHash?
 }
 

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImpl.kt
@@ -37,10 +37,13 @@ internal class ClassTagFactoryImpl : ClassTagFactory {
             if (isStaticTag) {
                 StaticTagImplV1(ClassType.CpkSandboxClass, bundleName, cpkSandbox.cpkMetadata.fileChecksum)
             } else {
-                val mainBundleName = cpkSandbox.mainBundle.symbolicName
+                // In later versions of Corda 5, cordaCpkCordappName will be populated from Corda-CPK-Cordapp-Name
+                // from the CPK metadata, and this will be modifiable by the CorDapp developer. Currently Corda-CPK-Cordapp-Name
+                // is always populated by the build system with the CPK symbolic bundle name, so we do that here too.
+                val cordaCpkCordappName = cpkSandbox.mainBundle.symbolicName
                 val signerSummaryHash = cpkSandbox.cpkMetadata.cpkId.signerSummaryHash
                 EvolvableTagImplV1(
-                    ClassType.CpkSandboxClass, bundleName, mainBundleName, signerSummaryHash
+                    ClassType.CpkSandboxClass, bundleName, cordaCpkCordappName, signerSummaryHash
                 )
             }
         }.serialise()

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImpl.kt
@@ -37,10 +37,7 @@ internal class ClassTagFactoryImpl : ClassTagFactory {
             if (isStaticTag) {
                 StaticTagImplV1(ClassType.CpkSandboxClass, bundleName, cpkSandbox.cpkMetadata.fileChecksum)
             } else {
-                // In later versions of Corda 5, cordaCpkCordappName will be populated from Corda-CPK-Cordapp-Name
-                // from the CPK metadata, and this will be modifiable by the CorDapp developer. Currently Corda-CPK-Cordapp-Name
-                // is always populated by the build system with the CPK symbolic bundle name, so we do that here too.
-                val cordaCpkCordappName = cpkSandbox.mainBundle.symbolicName
+                val cordaCpkCordappName = cpkSandbox.cpkMetadata.cpkId.name
                 val signerSummaryHash = cpkSandbox.cpkMetadata.cpkId.signerSummaryHash
                 EvolvableTagImplV1(
                     ClassType.CpkSandboxClass, bundleName, cordaCpkCordappName, signerSummaryHash

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/v1/EvolvableTagImplV1.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/v1/EvolvableTagImplV1.kt
@@ -16,14 +16,14 @@ import net.corda.v5.crypto.SecureHash
 internal data class EvolvableTagImplV1(
     override val classType: ClassType,
     override val classBundleName: String,
-    override val mainBundleName: String,
+    override val cordaCpkCordappName: String,
     override val cpkSignerSummaryHash: SecureHash?
 ) : EvolvableTag() {
     override val version: Int = ClassTagV1.VERSION
 
     companion object {
         private const val ENTRIES_LENGTH = 6
-        private const val MAIN_BUNDLE_NAME_IDX = 4
+        private const val CORDA_CPK_CORDAPP_NAME_IDX = 4
         private const val CPK_PUBLIC_KEY_HASHES_IDX = 5
 
         /** Deserialises an [EvolvableTagImplV1] class tag. */
@@ -48,7 +48,7 @@ internal data class EvolvableTagImplV1(
             return EvolvableTagImplV1(
                 classType,
                 classTagEntries[CLASS_BUNDLE_NAME_IDX],
-                classTagEntries[MAIN_BUNDLE_NAME_IDX],
+                classTagEntries[CORDA_CPK_CORDAPP_NAME_IDX],
                 cpkSignerSummaryHash
             )
         }
@@ -63,7 +63,7 @@ internal data class EvolvableTagImplV1(
         entries[CLASS_TAG_VERSION_IDX] = version
         entries[CLASS_TYPE_IDX] = classTypeToString(classType)
         entries[CLASS_BUNDLE_NAME_IDX] = classBundleName
-        entries[MAIN_BUNDLE_NAME_IDX] = mainBundleName
+        entries[CORDA_CPK_CORDAPP_NAME_IDX] = cordaCpkCordappName
         entries[CPK_PUBLIC_KEY_HASHES_IDX] = cpkSignerSummaryHash
 
         return entries.joinToString(CLASS_TAG_DELIMITER)

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
@@ -148,8 +148,13 @@ class SandboxGroupImplTests {
     }
 
     @Test
-    fun `returns CPK class identified by a static tag`() {
+    fun `returns CPK library class identified by a static tag`() {
         assertEquals(cpkLibraryClass, sandboxGroupImpl.getClass(cpkLibraryClass.name, CPK_STATIC_TAG))
+    }
+
+    @Test
+    fun `returns CPK main class identified by an evolvable tag`() {
+        assertEquals(cpkClass, sandboxGroupImpl.getClass(cpkClass.name, CPK_EVOLVABLE_TAG))
     }
 
     @Test
@@ -208,7 +213,7 @@ private class StaticTagImpl(
 private class EvolvableTagImpl(
     override val classType: ClassType,
     override val classBundleName: String,
-    override val mainBundleName: String,
+    override val cordaCpkCordappName: String,
     override val cpkSignerSummaryHash: SecureHash?
 ) : EvolvableTag() {
     override val version = 1
@@ -231,8 +236,8 @@ private class DummyClassTagFactory(cpkMetadata: CpkMetadata) : ClassTagFactory {
     private val cpkEvolvableTag =
         EvolvableTagImpl(
             ClassType.CpkSandboxClass,
-            CPK_LIBRARY_BUNDLE_NAME,
             CPK_MAIN_BUNDLE_NAME,
+            CORDA_CPK_CORDAPP_NAME,
             cpkMetadata.cpkId.signerSummaryHash
         )
 
@@ -248,7 +253,7 @@ private class DummyClassTagFactory(cpkMetadata: CpkMetadata) : ClassTagFactory {
         )
 
     private val invalidSignersEvolvableTag =
-        EvolvableTagImpl(ClassType.CpkSandboxClass, CPK_LIBRARY_BUNDLE_NAME, CPK_MAIN_BUNDLE_NAME, randomSecureHash())
+        EvolvableTagImpl(ClassType.CpkSandboxClass, CPK_LIBRARY_BUNDLE_NAME, CORDA_CPK_CORDAPP_NAME, randomSecureHash())
 
     override fun createSerialisedTag(
         isStaticTag: Boolean,

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
@@ -18,6 +18,7 @@ const val HASH_LENGTH = 32
 const val PUBLIC_BUNDLE_NAME = "public_bundle_symbolic_name"
 const val CPK_LIBRARY_BUNDLE_NAME = "cpk_library_bundle_symbolic_name"
 const val CPK_MAIN_BUNDLE_NAME = "cpk_main_bundle_symbolic_name"
+const val CORDA_CPK_CORDAPP_NAME = "cpk_cordapp_name"
 
 val random = Random(0)
 

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
@@ -48,7 +48,7 @@ fun mockBundle(
 
 /** Generates a mock CpkMetadata. */
 fun mockCpkMeta(): CpkMetadata {
-    val id = CpkIdentifier(random.nextInt().toString(), "1.0", randomSecureHash())
+    val id = CpkIdentifier(CORDA_CPK_CORDAPP_NAME, "1.0", randomSecureHash())
     val hash = randomSecureHash()
     return mock<CpkMetadata>().apply {
         whenever(this.cpkId).thenReturn(id)

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImplTests.kt
@@ -4,6 +4,7 @@ import net.corda.sandbox.SandboxException
 import net.corda.sandbox.internal.CLASS_TAG_DELIMITER
 import net.corda.sandbox.internal.CLASS_TAG_IDENTIFIER_IDX
 import net.corda.sandbox.internal.CLASS_TAG_VERSION_IDX
+import net.corda.sandbox.internal.CORDA_CPK_CORDAPP_NAME
 import net.corda.sandbox.internal.CPK_MAIN_BUNDLE_NAME
 import net.corda.sandbox.internal.ClassTagV1
 import net.corda.sandbox.internal.ClassTagV1.CLASS_TYPE_IDX
@@ -108,13 +109,10 @@ class ClassTagFactoryImplTests {
         val serialisedTag = classTagFactory.createSerialisedTag(false, mockBundle, mockSandbox)
         val classTag = classTagFactory.deserialise(serialisedTag)
 
-        // All evolvable tags set cordaCpkCordappName to the main bundle symbolic name presently
-        var cordaCpkCordappName = mockSandbox.mainBundle.symbolicName
-
         val expectedClassTag = EvolvableTagImplV1(
             ClassType.CpkSandboxClass,
             mockBundle.symbolicName,
-            cordaCpkCordappName,
+            CORDA_CPK_CORDAPP_NAME,
             mockCpkMetadata.cpkId.signerSummaryHash
         )
         assertEquals(expectedClassTag, classTag)

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImplTests.kt
@@ -108,10 +108,13 @@ class ClassTagFactoryImplTests {
         val serialisedTag = classTagFactory.createSerialisedTag(false, mockBundle, mockSandbox)
         val classTag = classTagFactory.deserialise(serialisedTag)
 
+        // All evolvable tags set cordaCpkCordappName to the main bundle symbolic name presently
+        var cordaCpkCordappName = mockSandbox.mainBundle.symbolicName
+
         val expectedClassTag = EvolvableTagImplV1(
             ClassType.CpkSandboxClass,
             mockBundle.symbolicName,
-            mockSandbox.mainBundle.symbolicName,
+            cordaCpkCordappName,
             mockCpkMetadata.cpkId.signerSummaryHash
         )
         assertEquals(expectedClassTag, classTag)

--- a/testing/cpbs/packaging-verification-app-v1/src/main/kotlin/com/r3/corda/testing/packagingverification/ReceiveTransferFlow.kt
+++ b/testing/cpbs/packaging-verification-app-v1/src/main/kotlin/com/r3/corda/testing/packagingverification/ReceiveTransferFlow.kt
@@ -4,6 +4,7 @@ import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.InitiatedBy
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import org.slf4j.LoggerFactory
 
@@ -16,6 +17,7 @@ class ReceiveTransferFlow : ResponderFlow {
     @CordaInject
     lateinit var utxoLedgerService: UtxoLedgerService
 
+    @Suspendable
     override fun call(session: FlowSession) {
         log.info("Receiving states")
 

--- a/testing/cpbs/packaging-verification-app-v1/src/main/kotlin/com/r3/corda/testing/packagingverification/ReportStatesFlow.kt
+++ b/testing/cpbs/packaging-verification-app-v1/src/main/kotlin/com/r3/corda/testing/packagingverification/ReportStatesFlow.kt
@@ -5,11 +5,13 @@ import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import com.r3.corda.testing.packagingverification.contract.SimpleState
+import net.corda.v5.base.annotations.Suspendable
 
 class ReportStatesFlow : ClientStartableFlow {
     @CordaInject
     lateinit var utxoLedgerService: UtxoLedgerService
 
+    @Suspendable
     override fun call(requestBody: ClientRequestBody): String {
         val unconsumedStates = utxoLedgerService.findUnconsumedStatesByType(SimpleState::class.java)
         val result = unconsumedStates.fold(0L) { acc, stateAndRef ->


### PR DESCRIPTION
Ultimately Corda 5 should use `Corda-CPK-Cordapp-Name` from the CPK metadata to identify a class type as being the same as another version of that class. See CORE-13259. This will be written in the evolvable tag. This change goes part way to supporting that in the evolvable tag.

Right now CorDapp developers cannot set this metadata, the gradle plugin always sets it to bundle symbolic name, so offering full support for `Corda-CPK-Cordapp-Name` is not yet possible. For Corda 5.0 we only use the class's bundle symbolic name to find sandboxes. Future versions of the platform will still write the class's bundle name and therefore be compatible with platforms running on 5.0.

We also write bundle symbolic name as `Corda-CPK-Cordapp-Name` in 5.0 meaning future versions of the platform reading that back will get a sensible answer - this is the same as the proposed default in future versions in fact.