### PR TITLE
CORE-12443: Avoid creating unused secrets

### DIFF
--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -26,6 +26,7 @@
     ( dict "salt" ( dict "generate" 32 ) "passphrase" ( dict "generate" 32 ) )
   )
 }}
+{{- if .Values.bootstrap.db.enabled }}
 {{- include "corda.secret"
   ( list
     $
@@ -46,6 +47,7 @@
     ( dict "cleanup" true )
   )
 }}
+{{- end }}
 {{- include "corda.secret"
   ( list
     $

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -48,6 +48,7 @@
   )
 }}
 {{- end }}
+{{- if or (.Values.bootstrap.db.enabled) (and (.Values.bootstrap.rbac.enabled) (and (or (.Values.bootstrap.restApiAdmin.username.value) (.Values.bootstrap.restApiAdmin.username.valueFrom.secretKeyRef.name)) (or (.Values.bootstrap.restApiAdmin.password.value) (.Values.bootstrap.restApiAdmin.password.valueFrom.secretKeyRef.name)))) }}
 {{- include "corda.secret"
   ( list
     $
@@ -57,6 +58,7 @@
     ( dict "username" ( dict "required" true ) "password" ( dict "generate" 12 ) )
   )
 }}
+{{- end }}
 {{- if not .Values.workers.rest.tls.secretName }}
 {{- $altNames := list }}
 {{- if .Values.workers.rest.tls.generation }}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -59,7 +59,7 @@
   )
 }}
 {{ else if .Values.bootstrap.rbac.enabled }}
-{{- fail "please set credentials for restApiAdmin secret or disable bootstrap RBAC" }}
+{{- fail "credentials for restApiAdmin must be provided to bootstrap RBAC if DB bootstrap is disabled" }}
 {{- end }}
 {{- if not .Values.workers.rest.tls.secretName }}
 {{- $altNames := list }}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -58,6 +58,8 @@
     ( dict "username" ( dict "required" true ) "password" ( dict "generate" 12 ) )
   )
 }}
+{{ else if .Values.bootstrap.rbac.enabled }}
+{{- fail "please set credentials for restApiAdmin secret or disable bootstrap RBAC" }}
 {{- end }}
 {{- if not .Values.workers.rest.tls.secretName }}
 {{- $altNames := list }}


### PR DESCRIPTION
The Corda Helm chart creates the `-rbac-db` , `-crypto-db`, and `-rest-api-admin` secrets even when there is no bootstrapping enabled to consume them. This is potentially confusing, not least for the last of these where the Helm chart notes will indicate that this secret contains the API credentials when the API is actually using those stored in the database.