### PR TITLE
CORE-13235 Uniqueness checker in-flight double spend test

### DIFF
--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
@@ -580,7 +580,7 @@ class JPABackingStoreImplIntegrationTests {
 
         // This test is repeated a number of times due to in-flight double spends being a timing
         // issue that can be difficult to reproduce reliably
-        @RepeatedTest(100)
+        @RepeatedTest(10)
         fun `In-flight double spend is prevented using separate backing store instances executing in parallel`() {
             val numExecutors = 4
             val stateRefs = List(5) { UniquenessCheckStateRefImpl(SecureHashUtils.randomSecureHash(), it) }


### PR DESCRIPTION
### Summary

This PR adds an additional integration test case to verify that "in-flight" double spends cannot occur within the uniqueness checker, i.e. by attempting to spend the same state twice in parallel. In a real system, this would be when multiple DB workers are operating at the same time and different transactions are attempting to spend the same state in parallel, with their requests being processed by different workers.

Reproducing this scenario in practice is very difficult, so the integration test is performed at the backing store level, using multiple backing store instances and executing each in a separate thread. This allows for simultaneous database access. The test is also repeated 10 times to increase the chance of exposing any issues, as reproducing this issue reliably is difficult.

### Testing

To prove that the test will in fact detect double spends (which should never happen), the `JPABackingStoreEntities` code was intentionally broken to alter the SQL that checks for a blank consuming transaction id as part of the update expression. Confirmed that the test fails when this is done.