### PR TITLE
CORE-12902: Return BadRequest when attempting to change vnode status while DB migration is running

### DIFF
--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -456,8 +456,9 @@ internal class VirtualNodeRestResourceImpl(
         return when (exception.errorType) {
             InvalidStateChangeRuntimeException::class.java.name -> InvalidStateChangeException(exception.errorMessage)
             VirtualNodeOperationNotFoundException::class.java.name -> ResourceNotFoundException(exception.errorMessage)
-            VirtualNodeOperationBadRequestException::class.java.name, LiquibaseDiffCheckFailedException::class.java.name ->
-                BadRequestException(exception.errorMessage)
+            VirtualNodeOperationBadRequestException::class.java.name,
+            LiquibaseDiffCheckFailedException::class.java.name,
+            javax.persistence.RollbackException::class.java.name -> BadRequestException(exception.errorMessage)
             else -> InternalServerException(exception.errorMessage)
         }
     }


### PR DESCRIPTION
Add `javax.persistence.RollbackException` to the list of exceptions that map to `BadRequest`