### PR TITLE
CORE-13349 Remove redundant `HsmRestResource.assignHsm` REST endpoint

### DIFF
--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImpl.kt
@@ -76,21 +76,6 @@ class HsmRestResourceImpl @Activate constructor(
         }
     }
 
-    override fun assignHsm(tenantId: String, category: String): HsmAssociationInfo {
-        verifyTenantId(tenantId)
-        return tryWithExceptionHandling(
-            logger,
-            "Assign HSM",
-            untranslatedExceptions = setOf(ResourceNotFoundException::class.java)
-        ) {
-            hsmRegistrationClient.assignHSM(
-                tenantId,
-                category.toCategory(),
-                emptyMap()
-            ).expose()
-        }
-    }
-
     override val targetInterface = HsmRestResource::class.java
 
     override val protocolVersion = 1

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImplTest.kt
@@ -2,21 +2,19 @@ package net.corda.membership.impl.rest.v1
 
 import net.corda.crypto.client.hsm.HSMRegistrationClient
 import net.corda.crypto.core.CryptoConsts.Categories.CI
-import net.corda.crypto.core.CryptoConsts.Categories.LEDGER
 import net.corda.crypto.core.CryptoConsts.Categories.NOTARY
 import net.corda.crypto.core.CryptoConsts.Categories.TLS
 import net.corda.crypto.core.CryptoTenants.P2P
-import net.corda.crypto.core.CryptoTenants.REST
 import net.corda.crypto.core.ShortHash
 import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
-import net.corda.rest.exception.BadRequestException
-import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleEventHandler
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.membership.rest.v1.types.response.HsmAssociationInfo
+import net.corda.rest.exception.BadRequestException
+import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -127,68 +125,6 @@ class HsmRestResourceImplTest {
                     deprecatedAt = 0
                 ),
             )
-        }
-
-        @Test
-        fun `assignHsm will return the data`() {
-            whenever(hsmRegistrationClient.assignHSM(tenantId, LEDGER, emptyMap())).doReturn(
-                HSMAssociationInfo(
-                    "id1",
-                    tenantId,
-                    "hsm-id",
-                    LEDGER,
-                    "master-key-alias",
-                    0,
-                )
-            )
-
-            val hsm = ops.assignHsm(tenantId, LEDGER)
-
-            assertThat(hsm).isEqualTo(
-                HsmAssociationInfo(
-                    id = "id1",
-                    hsmId = "hsm-id",
-                    category = LEDGER,
-                    masterKeyAlias = "master-key-alias",
-                    deprecatedAt = 0
-                ),
-            )
-        }
-
-        @Test
-        fun `assignHsm verify the tenantId`() {
-            whenever(hsmRegistrationClient.assignHSM(tenantId, LEDGER, emptyMap())).doReturn(
-                HSMAssociationInfo(
-                    "id1",
-                    tenantId,
-                    "hsm-id",
-                    LEDGER,
-                    "master-key-alias",
-                    0,
-                )
-            )
-
-            ops.assignHsm(tenantId, LEDGER)
-
-            verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(tenantIdShortHash)
-        }
-
-        @Test
-        fun `assignHsm will not verify the tenantId from REST tenant`() {
-            whenever(hsmRegistrationClient.assignHSM(REST, LEDGER, emptyMap())).doReturn(
-                HSMAssociationInfo(
-                    "id1",
-                    REST,
-                    "hsm-id",
-                    LEDGER,
-                    "master-key-alias",
-                    0,
-                )
-            )
-
-            ops.assignHsm(REST, LEDGER)
-
-            verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(tenantIdShortHash)
         }
 
         @Test

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
@@ -98,44 +98,4 @@ interface HsmRestResource : RestResource {
                 " 'NOTARY', 'SESSION_INIT', 'TLS', or 'JWT_KEY'")
         category: String
     ): HsmAssociationInfo
-
-    /**
-     * The [assignHsm] method enables you to assign a hardware-backed HSM to the tenant for the specified category.
-     *
-     * Example usage:
-     * ```
-     * hsmOps.assignHsm(tenantId = "58B6030FABDD", category = "LEDGER")
-     *
-     * hsmOps.assignHsm(tenantId = "rest", category = "LEDGER")
-     * ```
-     *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
-     * @param category The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT',
-     * 'TLS', or 'JWT_KEY'.
-     *
-     * @return Information on the newly assigned HSM.
-     */
-    @HttpPOST(
-        path = "{tenantId}/{category}",
-        description = "This method enables you to assign a hardware-backed HSM to the tenant for the specified " +
-                "category.",
-        responseDescription = """
-            The HSM association details including:
-            id: the unique identifier of the HSM association
-            hsmId: the HSM identifier included into the association
-            category: the category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT', 
-                'TLS', or 'JWT_KEY'
-            masterKeyAlias: optional master key alias to be used on HSM
-            deprecatedAt: time when the association was deprecated, epoch time in seconds; 
-                value of 0 means the association is active"""
-    )
-    fun assignHsm(
-        @RestPathParameter(description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST")
-        tenantId: String,
-        @RestPathParameter(description = "The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER'," +
-                " 'NOTARY', 'SESSION_INIT', 'TLS', or 'JWT_KEY'")
-        category: String
-    ): HsmAssociationInfo
 }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -1148,52 +1148,6 @@
             "description" : "Forbidden"
           }
         }
-      },
-      "post" : {
-        "tags" : [ "HSM API" ],
-        "description" : "This method enables you to assign a hardware-backed HSM to the tenant for the specified category.",
-        "operationId" : "post_hsm__tenantid___category_",
-        "parameters" : [ {
-          "name" : "tenantid",
-          "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
-            "nullable" : false,
-            "example" : "string"
-          }
-        }, {
-          "name" : "category",
-          "in" : "path",
-          "description" : "The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT', 'TLS', or 'JWT_KEY'",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT', 'TLS', or 'JWT_KEY'",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "\n            The HSM association details including:\n            id: the unique identifier of the HSM association\n            hsmId: the HSM identifier included into the association\n            category: the category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT', \n                'TLS', or 'JWT_KEY'\n            masterKeyAlias: optional master key alias to be used on HSM\n            deprecatedAt: time when the association was deprecated, epoch time in seconds; \n                value of 0 means the association is active",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/HsmAssociationInfo"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
       }
     },
     "/keys/getprotocolversion" : {


### PR DESCRIPTION
This PR removes the `assignHSM` endpoint as Hardware HSMs are not supported.
We have confirmed with QA that this endpoint isn't used as part of any tests or automation. The `assignSoftHsm` endpoint is the only one applicable to Corda 5.0.