### PR TITLE
CORE-3819: Remove unused OSGi dependencies from Notary CPK.

### DIFF
--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/build.gradle
@@ -23,9 +23,6 @@ dependencies {
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-notary-plugin'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-
-    cordaProvided "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
-    cordaProvided "org.osgi:osgi.core"
     cordaProvided 'org.slf4j:slf4j-api'
 
     // Common package pulled in as transitive dependency through API


### PR DESCRIPTION
These OSGi dependencies are not used and do not belong here. They need to be removed.