### PR TITLE
CORE-13099 performance tracing

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowMessagingImpl.kt
@@ -7,7 +7,6 @@ import net.corda.flow.application.serialization.SerializationServiceInternal
 import net.corda.flow.application.sessions.FlowSessionInternal
 import net.corda.flow.application.sessions.SessionInfo
 import net.corda.flow.application.sessions.factory.FlowSessionFactory
-import net.corda.flow.application.sessions.impl.FlowSessionImpl
 import net.corda.flow.application.versioning.impl.sessions.VersionReceivingFlowSession
 import net.corda.flow.application.versioning.impl.sessions.VersionSendingFlowSession
 import net.corda.flow.fiber.FlowFiber
@@ -61,7 +60,7 @@ class FlowMessagingImpl @Activate constructor(
 
     @Suspendable
     override fun <R : Any> receiveAll(receiveType: Class<out R>, sessions: Set<FlowSession>): List<R> {
-        log.trace("ReceiveAll started [${sessions.map{ it.counterparty}}]")
+        log.trace("ReceiveAll started [${sessions.map { it.counterparty }}]")
         requireBoxedType(receiveType)
 
         @Suppress("unchecked_cast")
@@ -89,13 +88,13 @@ class FlowMessagingImpl @Activate constructor(
         val request = FlowIORequest.Receive(sessions = sessionsToReceiveFrom.map { it.getSessionInfo() }.toSet())
         val received = fiber.suspend(request)
         setSessionsAsConfirmed(flowSessionInternals)
-        log.trace("ReceiveAll returning [${sessions.map{ it.counterparty}}]")
+        log.trace("ReceiveAll returning [${sessions.map { it.counterparty }}]")
         return deserializeReceivedPayload(received, receiveType) + versionReceivingFlowSessionPayloads.values
     }
 
     @Suspendable
     override fun receiveAllMap(sessions: Map<FlowSession, Class<out Any>>): Map<FlowSession, Any> {
-        log.trace("ReceiveAllMap started [${sessions.keys.map{ it.counterparty}}]")
+        log.trace("ReceiveAllMap started [${sessions.keys.map { it.counterparty }}]")
         val flowSessionInternals = sessions.mapKeys {
             requireBoxedType(it.value)
             it.key as FlowSessionInternal
@@ -129,13 +128,13 @@ class FlowMessagingImpl @Activate constructor(
 
         val received = fiber.suspend(request)
         setSessionsAsConfirmed(flowSessionInternals.keys)
-        log.trace("ReceiveAllMap returning [${sessions.keys.map{ it.counterparty}}]")
+        log.trace("ReceiveAllMap returning [${sessions.keys.map { it.counterparty }}]")
         return deserializeReceivedPayload(received, sessionsToReceiveFrom) + versionReceivingFlowSessionPayloads
     }
 
     @Suspendable
     override fun sendAll(payload: Any, sessions: Set<FlowSession>) {
-        log.trace("SendAll started [${sessions.map{ it.counterparty}}]")
+        log.trace("SendAll started [${sessions.map { it.counterparty }}]")
         requireBoxedType(payload::class.java)
         if (sessions.isEmpty()) {
             return
@@ -152,7 +151,7 @@ class FlowMessagingImpl @Activate constructor(
         }
         fiber.suspend(FlowIORequest.Send(sessionToPayload))
         setSessionsAsConfirmed(flowSessionInternals)
-        log.trace("SendAll returning [${sessions.map{ it.counterparty}}]")
+        log.trace("SendAll returning [${sessions.map { it.counterparty }}]")
     }
 
     @Suspendable
@@ -160,7 +159,7 @@ class FlowMessagingImpl @Activate constructor(
         if (payloadsPerSession.isEmpty()) {
             return
         }
-        log.trace("sendAllMap started [${payloadsPerSession.keys.map{ it.counterparty}}]")
+        log.trace("sendAllMap started [${payloadsPerSession.keys.map { it.counterparty }}]")
         val sessionPayload = payloadsPerSession.map { (session, payload) ->
             requireBoxedType(payload::class.java)
             val flowSessionInternal = session as FlowSessionInternal
@@ -173,7 +172,7 @@ class FlowMessagingImpl @Activate constructor(
         fiber.suspend(FlowIORequest.Send(sessionPayload))
         @Suppress("unchecked_cast")
         setSessionsAsConfirmed(payloadsPerSession.keys as Set<FlowSessionInternal>)
-        log.trace("sendAllMap returning [${payloadsPerSession.keys.map{ it.counterparty}}]")
+        log.trace("sendAllMap returning [${payloadsPerSession.keys.map { it.counterparty }}]")
     }
 
     private fun setSessionsAsConfirmed(flowSessionInternals: Set<FlowSessionInternal>) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
@@ -99,29 +99,35 @@ class FlowSessionImpl(
 
     @Suspendable
     override fun <R : Any> sendAndReceive(receiveType: Class<R>, payload: Any): R {
+        log.trace("SendAndReceive started [${getCounterparty()}]")
         verifySessionStatusNotErrorOrClose(sourceSessionId, flowFiberService)
         requireBoxedType(receiveType)
         val request = FlowIORequest.SendAndReceive(mapOf(getSessionInfo() to serialize(payload)))
         val received = fiber.suspend(request)
         setSessionConfirmed()
+        log.trace("SendAndReceive returning [${getCounterparty()}]")
         return deserializeReceivedPayload(received, receiveType)
     }
 
     @Suspendable
     override fun <R : Any> receive(receiveType: Class<R>): R {
+        log.trace("Receive started [${getCounterparty()}]")
         verifySessionStatusNotErrorOrClose(sourceSessionId, flowFiberService)
         requireBoxedType(receiveType)
         val request = FlowIORequest.Receive(setOf(getSessionInfo()))
         val received = fiber.suspend(request)
         setSessionConfirmed()
+        log.trace("Receive returning [${getCounterparty()}]")
         return deserializeReceivedPayload(received, receiveType)
     }
     @Suspendable
     override fun send(payload: Any) {
+        log.trace("Send started [${getCounterparty()}]")
         verifySessionStatusNotErrorOrClose(sourceSessionId, flowFiberService)
         val request =
             FlowIORequest.Send(mapOf(getSessionInfo() to serialize(payload)))
         fiber.suspend(request)
+        log.trace("Send returning [${getCounterparty()}]")
         setSessionConfirmed()
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImpl.kt
@@ -83,7 +83,12 @@ class ExternalEventManagerImpl(
         externalEventResponse: ExternalEventResponse
     ): ExternalEventState {
         val requestId = externalEventResponse.requestId
-        log.info(flowTraceMarker, "Processing response for external event with id '{}'", requestId)
+        log.info(
+            flowTraceMarker,
+            "Processing response for external event with id '{}' factory '{}'",
+            requestId,
+            externalEventState.factoryClassName
+        )
 
         if (requestId == externalEventState.requestId) {
             log.debug { "External event response with id $requestId matched last sent request" }
@@ -202,7 +207,13 @@ class ExternalEventManagerImpl(
         val eventToSend = externalEventState.eventToSend
         eventToSend.timestamp = instant
         externalEventState.sendTimestamp = instant.plusMillis(config.getLong(FlowConfig.EXTERNAL_EVENT_MESSAGE_RESEND_WINDOW))
-        log.info(flowTraceMarker, "Dispatching external event with id '{}' to '{}'", externalEventState.requestId, eventToSend.topic)
+        log.info(
+            flowTraceMarker,
+            "Dispatching external event with id '{}' to '{}' factory '{}'",
+            externalEventState.requestId,
+            eventToSend.topic,
+            externalEventState.factoryClassName
+        )
 
         return externalEventState to Record(eventToSend.topic, eventToSend.key.array(), eventToSend.payload.array())
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/external/events/impl/executor/ExternalEventExecutorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/external/events/impl/executor/ExternalEventExecutorImpl.kt
@@ -11,12 +11,18 @@ import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @Component(service = [ExternalEventExecutor::class, SingletonSerializeAsToken::class])
 class ExternalEventExecutorImpl @Activate constructor(
     @Reference(service = FlowFiberService::class)
     private val flowFiberService: FlowFiberService
 ) : ExternalEventExecutor, SingletonSerializeAsToken {
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
 
     @Suspendable
     override fun <PARAMETERS : Any, RESPONSE : Any, RESUME> execute(
@@ -26,6 +32,7 @@ class ExternalEventExecutorImpl @Activate constructor(
     ): RESUME {
         @Suppress("unchecked_cast")
         return with(flowFiberService.getExecutingFiber()) {
+            log.trace("Suspend for ${factoryClass.name}")
             suspend(
                 FlowIORequest.ExternalEvent(
                     requestId,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -120,11 +120,13 @@ class FlowFiberImpl(
         this.suspensionOutcome = suspensionOutcome
         this.flowCompletion = CompletableFuture<FlowIORequest<*>>()
         unparkDeserialized(this, scheduler)
+        log.trace("Resume: ${getExecutionContext().flowCheckpoint.flowStartContext.flowClassName}")
         return flowCompletion
     }
 
     @Suspendable
     override fun <SUSPENDRETURN> suspend(request: FlowIORequest<SUSPENDRETURN>): SUSPENDRETURN {
+        log.trace("Suspend: ${getExecutionContext().flowCheckpoint.flowStartContext.flowClassName} ${request.javaClass.name}")
         removeCurrentSandboxGroupContext()
         parkAndCustomSerialize { _ ->
             resetLoggingContext()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -126,7 +126,10 @@ class FlowFiberImpl(
 
     @Suspendable
     override fun <SUSPENDRETURN> suspend(request: FlowIORequest<SUSPENDRETURN>): SUSPENDRETURN {
-        log.trace("Suspend: ${getExecutionContext().flowCheckpoint.flowStartContext.flowClassName} ${request.javaClass.name}")
+        log.trace(
+            "Suspend: ${getExecutionContext().flowCheckpoint.flowStartContext.flowClassName} " +
+                    "${request.javaClass.name}"
+        )
         removeCurrentSandboxGroupContext()
         parkAndCustomSerialize { _ ->
             resetLoggingContext()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
@@ -24,7 +24,7 @@ class StartFlowEventHandler @Activate constructor(
     override val type = StartFlow::class.java
 
     override fun preProcess(context: FlowEventContext<StartFlow>): FlowEventContext<StartFlow> {
-        log.info("Flow [${context.checkpoint.flowId}] started")
+        log.info("Flow [${context.checkpoint.flowId}, ${context.inputEventPayload.startContext.flowClassName}] started")
         checkpointInitializer.initialize(
             context.checkpoint,
             WaitingFor(WaitingForStartFlow),

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
@@ -42,7 +42,7 @@ class FlowFinishedRequestHandler @Activate constructor(
         val status = flowMessageFactory.createFlowCompleteStatusMessage(checkpoint, request.result)
         val records = getRecords(flowRecordFactory, context, status)
 
-        log.info("Flow [${checkpoint.flowId}] completed successfully")
+        log.info("Flow [${checkpoint.flowId}, ${context.checkpoint.flowStartContext.flowClassName}] completed successfully")
         checkpoint.markDeleted()
         return context.copy(outputRecords = context.outputRecords + records)
     }

--- a/osgi-framework-bootstrap/src/main/resources/log4j2-performance-tracing.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2-performance-tracing.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} %X - %msg%n"/>
+        </Console>
+
+        <RollingFile name="App"
+                     fileName="logs/corda.log"
+                     filePattern="logs/corda.%d{MM-dd-yyyy}.%i.log"
+                     ignoreExceptions="false">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} %X - %msg%n"/>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+                <TimeBasedTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="10 MB" />
+            </Policies>
+            <DefaultRolloverStrategy>
+                <Delete basePath="logs/">
+                    <IfFileName glob="logs/corda.*.log">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="500 MB" />
+                            <IfAccumulatedFileCount exceeds="10" />
+                        </IfAny>
+                    </IfFileName>
+                    <IfLastModified age="7d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
+
+        <RollingFile name="PerformanceTracing"
+                     fileName="logs/performance.log"
+                     filePattern="logs/performance.%d{MM-dd-yyyy}.%i.log"
+                     ignoreExceptions="false">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} %X - %msg%n"/>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+                <TimeBasedTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="100 MB" />
+            </Policies>
+            <DefaultRolloverStrategy>
+                <Delete basePath="logs/">
+                    <IfFileName glob="logs/performance.*.log">
+                        <IfAny>
+                            <IfAccumulatedFileSize exceeds="500 MB" />
+                            <IfAccumulatedFileCount exceeds="10" />
+                        </IfAny>
+                    </IfFileName>
+                    <IfLastModified age="7d" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
+
+    </Appenders>
+    <Loggers>
+        <logger name="Console">
+            <AppenderRef ref="Console" level="info"/>
+        </logger>
+
+        <!-- log warn only for these 3rd party libs -->
+        <Logger name="com.zaxxer.hikari" level="warn" />
+        <Logger name="io.javalin.Javalin" level="warn" />
+        <Logger name="org.apache.aries.spifly" level="warn" />
+        <Logger name="org.apache.kafka" level="warn" />
+        <Logger name="org.eclipse.jetty" level="warn" />
+        <Logger name="org.hibernate" level="warn" />
+        <Logger name="org.pf4j" level="warn" />
+
+        <!-- default to warn only for OSGi logging -->
+        <Logger name="net.corda.osgi.framework.OSGiFrameworkWrap" level="warn" />
+
+        <root level="debug">
+            <AppenderRef ref="App" level="info"/>
+        </root>
+
+        <logger name="net.corda.flow.fiber.FlowFiberImpl" level="trace">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+        <logger name="net.corda.flow.external.events.impl.executor.ExternalEventExecutorImpl" level="trace">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+        <logger name="net.corda.flow.application.services.impl.FlowEngineImpl" level="trace">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+        <logger name="net.corda.flow.application.services.impl.FlowMessagingImpl" level="trace">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+        <logger name="net.corda.flow.application.sessions.impl.FlowSessionImpl" level="trace">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+        <logger name="net.corda.flow.external.events.impl.ExternalEventManagerImpl" level="info">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+        <logger name="net.corda.flow.pipeline.handlers.events.StartFlowEventHandler" level="info">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+        <logger name="net.corda.flow.pipeline.handlers.requests.FlowFinishedRequestHandler" level="info">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+        <logger name="net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCacheImpl" level="info">
+            <AppenderRef ref="PerformanceTracing"/>
+        </logger>
+
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
* CORE-13099 Adding new trace logs around performance-related events. (suspend, resume, start sub-flows, external events.)
* CORE-13099 Enrich a few existing log entries with external event-specific details.
* CORE-13099 Alternative lo config to gather performance tracing logs.

Questions:
* Are these the best points to log? Is anything important missing? Anything duplicated?
* Do we want to keep this non-merged maybe? Can it have a significant negative performance impact?