### PR TITLE
CORE-13288: Disable MGM tests

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
@@ -25,6 +25,7 @@ import java.nio.file.Path
 /**
  * Three clusters are required for running this test. See `resources/RunNetworkTests.md` for more details.
  */
+@Disabled("CORE-13288: Tests are disabled until there is a solution in place")
 class MultiClusterDynamicNetworkTest {
     @TempDir
     lateinit var tempDir: Path

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
@@ -16,10 +16,12 @@ import net.corda.applications.workers.rest.utils.onboardMgm
 import net.corda.applications.workers.rest.utils.setSslConfiguration
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@Disabled("CORE-13288: Tests are disabled until there is a solution in place")
 class SessionCertificateTest {
     @TempDir
     lateinit var tempDir: Path

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@Disabled("CORE-13288: Tests are disabled until there is a solution in place")
 class SingleClusterDynamicNetworkTest {
     @TempDir
     lateinit var tempDir: Path

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/StaticNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/StaticNetworkTest.kt
@@ -20,6 +20,7 @@ import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.TimeUnit
 
+@Disabled("CORE-13288: Tests are disabled until there is a solution in place")
 class StaticNetworkTest {
     @TempDir
     lateinit var tempDir: Path


### PR DESCRIPTION
This change will disable the flaky MGM tests to allow others to progress while investigating alternative solutions.