### PR TITLE
CORE-13373: Add "eviction listeners" to SandboxGroupContextCache.

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/VNodeService.kt
@@ -42,7 +42,7 @@ class VNodeServiceImpl @Activate constructor(
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     init {
-        sandboxGroupContextComponent.initCaches(1)
+        sandboxGroupContextComponent.resizeCaches(1)
     }
 
     override fun loadVirtualNode(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeSandboxGroupContextComponent.kt
@@ -10,7 +10,13 @@ import net.corda.flow.pipeline.sessions.protocol.FlowAndProtocolVersion
 import net.corda.flow.pipeline.sessions.protocol.FlowProtocolStore
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.sandbox.SandboxGroup
-import net.corda.sandboxgroupcontext.*
+import net.corda.sandboxgroupcontext.MutableSandboxGroupContext
+import net.corda.sandboxgroupcontext.RequireSandboxAMQP
+import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.sandboxgroupcontext.SandboxGroupContextInitializer
+import net.corda.sandboxgroupcontext.SandboxGroupType
+import net.corda.sandboxgroupcontext.VirtualNodeContext
+import net.corda.sandboxgroupcontext.service.EvictionListener
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.serialization.checkpoint.CheckpointSerializer
 import net.corda.v5.application.flows.Flow
@@ -27,6 +33,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking
 class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
 
     private val availableCpk = mutableSetOf<SecureHash>()
+    private val evictionListeners = SandboxGroupType.values().associateWith { linkedSetOf<EvictionListener>() }
     private var initiatingToInitiatedFlowsMap: Map<String, Pair<String, String>> = mapOf()
 
     fun putCpk(cpkFileChecksum: SecureHash) {
@@ -65,7 +72,7 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
         return cpkChecksums.any { availableCpk.contains(it) }
     }
 
-    override fun initCache(type: SandboxGroupType, capacity: Long) {
+    override fun resizeCache(type: SandboxGroupType, capacity: Long) {
         TODO("Not yet implemented")
     }
 
@@ -79,6 +86,20 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
 
     override fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>? {
         TODO("Not yet implemented")
+    }
+
+    override fun addEvictionListener(type: SandboxGroupType, listener: EvictionListener): Boolean {
+        val listeners = evictionListeners[type] ?: return false
+        return synchronized(listeners) {
+            listeners.add(listener)
+        }
+    }
+
+    override fun removeEvictionListener(type: SandboxGroupType, listener: EvictionListener): Boolean {
+        val listeners = evictionListeners[type] ?: return false
+        return synchronized(listeners) {
+            listeners.remove(listener)
+        }
     }
 
     override val isRunning: Boolean
@@ -198,7 +219,7 @@ class FakeSandboxGroupContextComponent : SandboxGroupContextComponent {
 
         override fun responderForProtocol(protocolName: String, supportedVersions: Collection<Int>, context: FlowEventContext<*>): FlowAndProtocolVersion {
             val flowClass = responderForProtocol[protocolName] ?: throw IllegalArgumentException("No responder configured for $protocolName")
-            return FlowAndProtocolVersion(protocolName, flowClass,1, )
+            return FlowAndProtocolVersion(protocolName, flowClass, 1)
         }
 
         override fun protocolsForInitiator(initiator: String, context: FlowEventContext<*>): Pair<String, List<Int>> {

--- a/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/helpers/VirtualNodeService.kt
+++ b/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/helpers/VirtualNodeService.kt
@@ -28,7 +28,7 @@ class VirtualNodeService @Activate constructor(
     }
 
     init {
-        sandboxGroupContextComponent.initCaches(2)
+        sandboxGroupContextComponent.resizeCaches(2)
     }
 
     fun load(resourceName: String): VirtualNodeInfo {

--- a/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/integrationTest/kotlin/net/corda/sandboxgroupcontext/test/VirtualNodeService.kt
@@ -45,7 +45,7 @@ class VirtualNodeService @Activate constructor(
     }
     init {
         // setting cache size to 2 as some tests require 2 concurrent sandboxes for validating they don't overlap
-        sandboxGroupContextComponent.initCaches(2)
+        sandboxGroupContextComponent.resizeCaches(2)
     }
 
     private val vnodes = mutableMapOf<SandboxGroupContext, VirtualNodeInfo>()

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheControl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheControl.kt
@@ -1,17 +1,11 @@
 package net.corda.sandboxgroupcontext.service
 
 import net.corda.sandboxgroupcontext.SandboxGroupType
-import net.corda.sandboxgroupcontext.VirtualNodeContext
-import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
-interface CacheControl {
-    fun initCaches(capacity: Long) = SandboxGroupType.values().forEach { initCache(it, capacity) }
+interface CacheControl : CacheEviction {
+    fun resizeCaches(capacity: Long) = SandboxGroupType.values().forEach { resizeCache(it, capacity) }
+    fun resizeCache(type: SandboxGroupType, capacity: Long)
 
-    fun initCache(type: SandboxGroupType, capacity: Long)
     fun flushCache(): CompletableFuture<*>
-    fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
-
-    @Throws(InterruptedException::class)
-    fun waitFor(completion: CompletableFuture<*>, duration: Duration): Boolean
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheEviction.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/CacheEviction.kt
@@ -1,0 +1,16 @@
+package net.corda.sandboxgroupcontext.service
+
+import net.corda.sandboxgroupcontext.SandboxGroupType
+import net.corda.sandboxgroupcontext.VirtualNodeContext
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+
+interface CacheEviction {
+    fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
+
+    @Throws(InterruptedException::class)
+    fun waitFor(completion: CompletableFuture<*>, duration: Duration): Boolean
+
+    fun addEvictionListener(type: SandboxGroupType, listener: EvictionListener): Boolean
+    fun removeEvictionListener(type: SandboxGroupType, listener: EvictionListener): Boolean
+}

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/EvictionListener.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/EvictionListener.kt
@@ -1,0 +1,15 @@
+package net.corda.sandboxgroupcontext.service
+
+import net.corda.sandboxgroupcontext.VirtualNodeContext
+
+fun interface EvictionListener {
+    /**
+     * Invoked when the [VirtualNodeContext] is evicted from
+     * [SandboxGroupContextCache][net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextCache].
+     * Its sandbox is still active at this point, and will be closed when no longer referenced.
+     *
+     * We don't pass a reference to the [SandboxGroupContext][net.corda.sandboxgroupcontext.SandboxGroupContext]
+     * itself here simply because we don't need to yet. And also because we are waiting for people to _stop_ using it.
+     */
+    fun onEviction(vnc: VirtualNodeContext)
+}

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCache.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCache.kt
@@ -1,22 +1,19 @@
 package net.corda.sandboxgroupcontext.service.impl
 
-import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
+import net.corda.sandboxgroupcontext.service.CacheEviction
 
-interface SandboxGroupContextCache : AutoCloseable {
+interface SandboxGroupContextCache : CacheEviction, AutoCloseable {
     val capacities: Map<SandboxGroupType, Long>
-    fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
+
     fun get(
         virtualNodeContext: VirtualNodeContext,
         createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
     ): SandboxGroupContext
 
-    fun resize(sandboxGroupType: SandboxGroupType, newCapacity: Long): SandboxGroupContextCache
+    fun resize(sandboxGroupType: SandboxGroupType, newCapacity: Long)
     fun flush(): CompletableFuture<*>
-
-    @Throws(InterruptedException::class)
-    fun waitFor(completion: CompletableFuture<*>, duration: Duration): Boolean
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -24,6 +24,7 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.sandboxgroupcontext.putObjectByKey
 import net.corda.sandboxgroupcontext.service.CacheControl
+import net.corda.sandboxgroupcontext.service.EvictionListener
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash
 import org.osgi.framework.Bundle
@@ -70,6 +71,7 @@ typealias SatisfiedServiceReferences = Map<String, SortedMap<ServiceReference<*>
  * This is a per-process service, but it must return the "same instance" for a given [VirtualNodeContext]
  * in EVERY process.
  */
+@Suppress("TooManyFunctions")
 @Component(service = [ SandboxGroupContextService::class ])
 @RequireSandboxCrypto
 @RequireSandboxHooks
@@ -114,37 +116,14 @@ class SandboxGroupContextServiceImpl @Activate constructor(
                 logger.debug("Ignoring exception", e)
             }
         }
-
-        private val DUMMY_CACHE = object : SandboxGroupContextCache {
-            override val capacities: Map<SandboxGroupType, Long>
-                get() = SandboxGroupType.values().associateWith { 0 }
-
-            override fun remove(virtualNodeContext: VirtualNodeContext)
-                = throw IllegalStateException("remove: SandboxGroupContextService is not ready.")
-
-            override fun get(
-                virtualNodeContext: VirtualNodeContext,
-                createFunction: (VirtualNodeContext) -> CloseableSandboxGroupContext
-            ) = throw IllegalStateException("get: SandboxGroupContextService is not ready.")
-
-            override fun resize(sandboxGroupType: SandboxGroupType, newCapacity: Long): SandboxGroupContextCache {
-                val newCapacities = capacities.toMutableMap()
-                newCapacities[sandboxGroupType] = newCapacity
-                return SandboxGroupContextCacheImpl(newCapacities)
-            }
-
-            override fun waitFor(completion: CompletableFuture<*>, duration: Duration) = true
-            override fun flush() = CompletableFuture.completedFuture(true)
-            override fun close() {}
-        }
     }
 
-    private var cache: SandboxGroupContextCache = DUMMY_CACHE
+    private val cache = SandboxGroupContextCacheImpl(0)
 
-    override fun initCache(type: SandboxGroupType, capacity: Long) {
+    override fun resizeCache(type: SandboxGroupType, capacity: Long) {
         if (capacity != cache.capacities[type]) {
             logger.info("Changing Sandbox cache capacity for type {} from {} to {}", type, cache.capacities[type], capacity)
-            cache = cache.resize(type, capacity)
+            cache.resize(type, capacity)
         }
     }
 
@@ -159,6 +138,14 @@ class SandboxGroupContextServiceImpl @Activate constructor(
 
     override fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>? {
         return cache.remove(virtualNodeContext)
+    }
+
+    override fun addEvictionListener(type: SandboxGroupType, listener: EvictionListener): Boolean {
+        return cache.addEvictionListener(type, listener)
+    }
+
+    override fun removeEvictionListener(type: SandboxGroupType, listener: EvictionListener): Boolean {
+        return cache.removeEvictionListener(type, listener)
     }
 
     override fun getOrCreate(

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/impl/SandboxGroupContextServiceImplTest.kt
@@ -6,6 +6,7 @@ import net.corda.libs.packaging.Cpk
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.putUniqueObject
+import net.corda.sandboxgroupcontext.service.EvictionListener
 import net.corda.sandboxgroupcontext.service.impl.SandboxGroupContextServiceImpl
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.v5.crypto.SecureHash
@@ -15,8 +16,10 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.runtime.ServiceComponentRuntime
 
@@ -67,7 +70,7 @@ class SandboxGroupContextServiceImplTest {
             scr,
             bundleContext
         )
-        service.initCaches(1)
+        service.resizeCaches(1)
         virtualNodeContext = createVirtualNodeContextForFlow(
             holdingIdentity,
             cpks.mapTo(mutableSetOf()) { it.metadata.fileChecksum }
@@ -147,7 +150,7 @@ class SandboxGroupContextServiceImplTest {
         val cpkService = CpkReadServiceFake(cpks1 + cpks2 + cpks3)
 
         val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext).apply {
-            initCaches(1)
+            resizeCaches(1)
         }
 
         val dog1 = Dog("Rover", "Woof!")
@@ -194,17 +197,34 @@ class SandboxGroupContextServiceImplTest {
     @Test
     fun `remove removes from cache`() {
         val holdingIdentity1 = createTestHoldingIdentity("CN=Foo, O=Foo Corp, L=LDN, C=GB", "bar")
-        val cpks1 = setOf(Helpers.mockTrivialCpk("MAIN1", "example", "1.0.0"))
+        val cpkChecksum = parseSecureHash("DUMMY:1234567890abcdef")
+        val cpks1 = setOf(Helpers.mockTrivialCpk("MAIN1", "example", "1.0.0", cpkChecksum))
         val ctx1 = createVirtualNodeContextForFlow(
             holdingIdentity1,
-            cpks1.map { parseSecureHash("DUMMY:1234567890abcdef") }.toSet()
+            cpks1.mapTo(linkedSetOf()) { cpkChecksum }
         )
         val sandboxCreationService = Helpers.mockSandboxCreationService(listOf(cpks1))
         val cpkService = CpkReadServiceFake(cpks1)
-        val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext)
+        val flowEvictionListener = mock<EvictionListener>()
+        val persistenceEvictionListener = mock<EvictionListener>()
+        val verificationEvictionListener = mock<EvictionListener>()
+        val service = SandboxGroupContextServiceImpl(sandboxCreationService, cpkService, scr, bundleContext).apply {
+            resizeCache(SandboxGroupType.FLOW, 1)
+            assertTrue(addEvictionListener(SandboxGroupType.FLOW, flowEvictionListener))
+            assertTrue(addEvictionListener(SandboxGroupType.PERSISTENCE, persistenceEvictionListener))
+            assertTrue(addEvictionListener(SandboxGroupType.VERIFICATION, verificationEvictionListener))
+        }
+        service.getOrCreate(ctx1) { _, _ -> AutoCloseable {} }
 
-        val ex = assertThrows<IllegalStateException> { service.remove(ctx1) }
-        assertThat(ex).hasMessageStartingWith("remove: ")
+        val completion = service.remove(ctx1)
+        assertThat(completion)
+            .isNotNull
+            .isNotDone
+        assertThat(service.remove(ctx1))
+            .isNull()
+        verify(flowEvictionListener).onEviction(ctx1)
+        verify(persistenceEvictionListener, never()).onEviction(any())
+        verify(verificationEvictionListener, never()).onEviction(any())
     }
 
     @Test

--- a/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImplTest.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/test/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImplTest.kt
@@ -64,9 +64,9 @@ class SandboxGroupContextComponentImplTest {
             mock()
         )
 
-        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.FLOW), eq(4))
-        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.PERSISTENCE), eq(3))
-        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.VERIFICATION), eq(2))
+        verify(sandboxGroupContextService).resizeCache(eq(SandboxGroupType.FLOW), eq(4))
+        verify(sandboxGroupContextService).resizeCache(eq(SandboxGroupType.PERSISTENCE), eq(3))
+        verify(sandboxGroupContextService).resizeCache(eq(SandboxGroupType.VERIFICATION), eq(2))
     }
 
     @Test
@@ -95,8 +95,8 @@ class SandboxGroupContextComponentImplTest {
             mock()
         )
 
-        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.FLOW), eq(SANDBOX_CACHE_SIZE_DEFAULT))
-        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.PERSISTENCE), eq(SANDBOX_CACHE_SIZE_DEFAULT))
-        verify(sandboxGroupContextService).initCache(eq(SandboxGroupType.VERIFICATION), eq(SANDBOX_CACHE_SIZE_DEFAULT))
+        verify(sandboxGroupContextService).resizeCache(eq(SandboxGroupType.FLOW), eq(SANDBOX_CACHE_SIZE_DEFAULT))
+        verify(sandboxGroupContextService).resizeCache(eq(SandboxGroupType.PERSISTENCE), eq(SANDBOX_CACHE_SIZE_DEFAULT))
+        verify(sandboxGroupContextService).resizeCache(eq(SandboxGroupType.VERIFICATION), eq(SANDBOX_CACHE_SIZE_DEFAULT))
     }
 }

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
@@ -40,7 +40,7 @@ class VirtualNodeService @Activate constructor(
     private var connectionCounter = AtomicInteger(0)
 
     init {
-        sandboxGroupContextComponent.initCaches(2)
+        sandboxGroupContextComponent.resizeCaches(2)
     }
 
     fun load(resourceName: String): VirtualNodeInfo {

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
@@ -4,6 +4,7 @@ import net.corda.sandboxgroupcontext.SandboxGroupContextService
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheControl
+import net.corda.sandboxgroupcontext.service.EvictionListener
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.testing.sandboxes.SandboxSetup
 import org.osgi.service.component.annotations.Activate
@@ -23,11 +24,12 @@ class SandboxGroupContextComponentImpl @Activate constructor(
 ) : SandboxGroupContextComponent, SandboxGroupContextService by sandboxGroupContextService {
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    override val isRunning: Boolean = true
+    override val isRunning: Boolean
+        get() = true
 
-    override fun initCache(type: SandboxGroupType, capacity: Long) {
+    override fun resizeCache(type: SandboxGroupType, capacity: Long) {
         (sandboxGroupContextService as? CacheControl
-            ?: throw IllegalStateException("Cannot initialize sandbox cache")).initCache(type, capacity)
+            ?: throw IllegalStateException("Cannot initialize sandbox cache")).resizeCache(type, capacity)
     }
 
     override fun remove(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>? {
@@ -44,6 +46,16 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     override fun waitFor(completion: CompletableFuture<*>, duration: Duration): Boolean {
         return (sandboxGroupContextService as? CacheControl
             ?: throw IllegalStateException("Cannot wait for sandbox cache to flush")).waitFor(completion, duration)
+    }
+
+    override fun addEvictionListener(type: SandboxGroupType, listener: EvictionListener): Boolean {
+        return (sandboxGroupContextService as? CacheControl
+            ?: throw IllegalStateException("Failed to add eviction listener")).addEvictionListener(type, listener)
+    }
+
+    override fun removeEvictionListener(type: SandboxGroupType, listener: EvictionListener): Boolean {
+        return (sandboxGroupContextService as? CacheControl
+            ?: throw IllegalStateException("Failed to remove eviction listener")).removeEvictionListener(type, listener)
     }
 
     override fun start() {

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
@@ -36,7 +36,7 @@ class VirtualNodeServiceImpl @Activate constructor(
     }
 
     init {
-        sandboxGroupContextComponent.initCaches(1)
+        sandboxGroupContextComponent.resizeCaches(1)
     }
 
     override fun loadVirtualNode(resourceName: String): VirtualNodeInfo {


### PR DESCRIPTION
Allow sandboxing components to register "eviction listeners" which are invoked when sandboxes are evicted from the `SandboxGroupContextCache`.

Also simplify the cache handling, now that `SandboxGroupContextCache` can be resized _without_ recreating it.