### PR TITLE
CORE-13288: Map errors correctly from the persistance client

### DIFF
--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/AbstractPersistenceClient.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/AbstractPersistenceClient.kt
@@ -63,16 +63,6 @@ abstract class AbstractPersistenceClient(
         )
     }
 
-    fun MembershipPersistenceRequest.execute(): Any? {
-        val result = this.operation {
-            Either.Left(it)
-        }.send()
-        return when (result) {
-            is Either.Left -> result.a
-            is Either.Right -> result.b
-        }
-    }
-
     override val isRunning: Boolean
         get() = coordinator.status == LifecycleStatus.UP
 

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
@@ -36,7 +36,6 @@ import net.corda.data.membership.db.response.command.PersistApprovalRuleResponse
 import net.corda.data.membership.db.response.command.PersistGroupParametersResponse
 import net.corda.data.membership.db.response.command.RevokePreAuthTokenResponse
 import net.corda.data.membership.db.response.command.SuspendMemberResponse
-import net.corda.data.membership.db.response.query.PersistenceFailedResponse
 import net.corda.data.membership.db.response.query.StaticNetworkInfoQueryResponse
 import net.corda.data.membership.db.response.query.UpdateMemberAndRegistrationRequestResponse
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
@@ -445,7 +444,6 @@ class MembershipPersistenceClientImpl(
     private fun nullToUnitConvertor(payload: Any?): Either<Unit, String> {
         return when (payload) {
             null -> Either.Left(Unit)
-            is PersistenceFailedResponse -> Either.Right(payload.errorMessage)
             else -> Either.Right("Unexpected response: $payload")
         }
     }
@@ -453,7 +451,6 @@ class MembershipPersistenceClientImpl(
     private inline fun <reified T, S> dataToResultConvertor(payload: Any?, toResult: (T) -> S): Either<S, String> {
         return when (payload) {
             is T -> Either.Left(toResult(payload))
-            is PersistenceFailedResponse -> Either.Right(payload.errorMessage)
             else -> Either.Right("Unexpected response: $payload")
         }
     }

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
@@ -6,8 +6,8 @@ import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.common.RegistrationRequestDetails
+import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipPersistenceRequest
 import net.corda.data.membership.db.request.query.MutualTlsListAllowedCertificates
 import net.corda.data.membership.db.request.query.QueryApprovalRules
@@ -23,7 +23,6 @@ import net.corda.data.membership.db.response.query.GroupPolicyQueryResponse
 import net.corda.data.membership.db.response.query.MemberInfoQueryResponse
 import net.corda.data.membership.db.response.query.MemberSignatureQueryResponse
 import net.corda.data.membership.db.response.query.MutualTlsListAllowedCertificatesResponse
-import net.corda.data.membership.db.response.query.PersistenceFailedResponse
 import net.corda.data.membership.db.response.query.PreAuthTokenQueryResponse
 import net.corda.data.membership.db.response.query.RegistrationRequestQueryResponse
 import net.corda.data.membership.db.response.query.RegistrationRequestsQueryResponse
@@ -38,6 +37,7 @@ import net.corda.membership.lib.toMap
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.persistence.client.MembershipQueryResult
 import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.utilities.Either
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.base.types.LayeredPropertyMap
@@ -49,8 +49,8 @@ import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.UUID
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 @Suppress("LongParameterList")
 @Component(service = [MembershipQueryClient::class])
@@ -60,7 +60,7 @@ class MembershipQueryClientImpl(
     configurationReadService: ConfigurationReadService,
     private val memberInfoFactory: MemberInfoFactory,
     clock: Clock,
-    private val layeredPropertyMapFactory: LayeredPropertyMapFactory
+    private val layeredPropertyMapFactory: LayeredPropertyMapFactory,
 ) : MembershipQueryClient, AbstractPersistenceClient(
     coordinatorFactory,
     LifecycleCoordinatorName.forComponent<MembershipQueryClient>(),
@@ -79,7 +79,7 @@ class MembershipQueryClientImpl(
         @Reference(service = MemberInfoFactory::class)
         memberInfoFactory: MemberInfoFactory,
         @Reference(service = LayeredPropertyMapFactory::class)
-        layeredPropertyMapFactory: LayeredPropertyMapFactory
+        layeredPropertyMapFactory: LayeredPropertyMapFactory,
     ) : this(coordinatorFactory, publisherFactory, configurationReadService, memberInfoFactory, UTCClock(), layeredPropertyMapFactory)
 
     private companion object {
@@ -96,32 +96,17 @@ class MembershipQueryClientImpl(
 
     override fun queryMemberInfo(
         viewOwningIdentity: HoldingIdentity,
-        queryFilter: Collection<HoldingIdentity>
+        queryFilter: Collection<HoldingIdentity>,
     ): MembershipQueryResult<Collection<MemberInfo>> {
         if (queryFilter.isNotEmpty()) {
             logger.info("Querying for member infos represented by ${queryFilter.size} holding identities")
         }
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
-            QueryMemberInfo(queryFilter.map { it.toAvro() })
-        ).execute()
-        return when (payload) {
-            is MemberInfoQueryResponse -> {
-                logger.info("Found ${payload.members.size} results.")
-                MembershipQueryResult.Success(
-                    payload.members.map { memberInfoFactory.create(it) }
-                )
-            }
-            is PersistenceFailedResponse -> {
-                val err = "Query failed because of: ${payload.errorMessage}"
-                logger.warn(err)
-                MembershipQueryResult.Failure(err)
-            }
-            else -> {
-                val err = "Query returned unexpected payload."
-                logger.warn(err)
-                MembershipQueryResult.Failure(err)
-            }
+            QueryMemberInfo(queryFilter.map { it.toAvro() }),
+        ).execute("query member info") { payload: MemberInfoQueryResponse ->
+            logger.info("Found ${payload.members.size} results.")
+            payload.members.map { memberInfoFactory.create(it) }
         }
     }
 
@@ -129,26 +114,11 @@ class MembershipQueryClientImpl(
         viewOwningIdentity: HoldingIdentity,
         registrationId: String,
     ): MembershipQueryResult<RegistrationRequestDetails?> {
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
-            QueryRegistrationRequest(registrationId)
-        ).execute()
-        return when (payload) {
-            is RegistrationRequestQueryResponse -> {
-                MembershipQueryResult.Success(
-                    payload.registrationRequest
-                )
-            }
-            is PersistenceFailedResponse -> {
-                val err = "Query failed because of: ${payload.errorMessage}"
-                logger.warn(err)
-                MembershipQueryResult.Failure(err)
-            }
-            else -> {
-                val err = "Query returned unexpected payload."
-                logger.warn(err)
-                MembershipQueryResult.Failure(err)
-            }
+            QueryRegistrationRequest(registrationId),
+        ).execute("retrieve registration request") { payload: RegistrationRequestQueryResponse ->
+            payload.registrationRequest
         }
     }
 
@@ -156,28 +126,13 @@ class MembershipQueryClientImpl(
         viewOwningIdentity: HoldingIdentity,
         requestSubjectX500Name: MemberX500Name?,
         statuses: List<RegistrationStatus>,
-        limit: Int?
+        limit: Int?,
     ): MembershipQueryResult<List<RegistrationRequestDetails>> {
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
-            QueryRegistrationRequests(requestSubjectX500Name?.toString(), statuses, limit)
-        ).execute()
-        return when (payload) {
-            is RegistrationRequestsQueryResponse -> {
-                MembershipQueryResult.Success(
-                    payload.registrationRequests
-                )
-            }
-            is PersistenceFailedResponse -> {
-                val err = "Query failed because of: ${payload.errorMessage}"
-                logger.warn(err)
-                MembershipQueryResult.Failure(err)
-            }
-            else -> {
-                val err = "Query returned unexpected payload."
-                logger.warn(err)
-                MembershipQueryResult.Failure(err)
-            }
+            QueryRegistrationRequests(requestSubjectX500Name?.toString(), statuses, limit),
+        ).execute("retrieve registration requests") { payload: RegistrationRequestsQueryResponse ->
+            payload.registrationRequests
         }
     }
 
@@ -188,61 +143,34 @@ class MembershipQueryClientImpl(
         if (holdingsIdentities.isEmpty()) {
             return MembershipQueryResult.Success(emptyMap())
         }
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
-            QueryMemberSignature(holdingsIdentities.map { it.toAvro() })
-        ).execute()
-        return when (payload) {
-            is MemberSignatureQueryResponse -> {
-                MembershipQueryResult.Success(
-                    payload.membersSignatures.associate { memberSignature ->
-                        memberSignature.holdingIdentity.toCorda() to
-                                (memberSignature.signature to memberSignature.signatureSpec)
-                    }
-                )
-            }
-            is PersistenceFailedResponse -> {
-                MembershipQueryResult.Failure("Failed to find members signatures: ${payload.errorMessage}")
-            }
-            else -> {
-                MembershipQueryResult.Failure("Failed to find members signatures, unexpected response: $payload")
+            QueryMemberSignature(holdingsIdentities.map { it.toAvro() }),
+        ).execute("find members signatures") { payload: MemberSignatureQueryResponse ->
+            payload.membersSignatures.associate { memberSignature ->
+                memberSignature.holdingIdentity.toCorda() to
+                    (memberSignature.signature to memberSignature.signatureSpec)
             }
         }
     }
 
     override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<Pair<LayeredPropertyMap, Long>> {
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
-            QueryGroupPolicy()
-        ).execute()
-        return when (payload) {
-            is GroupPolicyQueryResponse -> {
-                MembershipQueryResult.Success(
-                    layeredPropertyMapFactory.createMap(payload.properties.toMap()) to payload.version
-                )
-            }
-            else -> {
-                MembershipQueryResult.Failure("Failed to find group policy information.")
-            }
+            QueryGroupPolicy(),
+        ).execute("retrieve group policy") { payload: GroupPolicyQueryResponse ->
+            layeredPropertyMapFactory.createMap(payload.properties.toMap()) to payload.version
         }
     }
 
     override fun mutualTlsListAllowedCertificates(
-        mgmHoldingIdentity: HoldingIdentity
+        mgmHoldingIdentity: HoldingIdentity,
     ): MembershipQueryResult<Collection<String>> {
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(mgmHoldingIdentity.toAvro()),
-            MutualTlsListAllowedCertificates()
-        ).execute()
-        return when (payload) {
-            is MutualTlsListAllowedCertificatesResponse -> {
-                MembershipQueryResult.Success(
-                    payload.subjects,
-                )
-            }
-            else -> {
-                MembershipQueryResult.Failure("Failed to retrieve list of allowed certificates.")
-            }
+            MutualTlsListAllowedCertificates(),
+        ).execute("retrieve mutual TLS allowed certificates") { payload: MutualTlsListAllowedCertificatesResponse ->
+            payload.subjects
         }
     }
 
@@ -250,7 +178,7 @@ class MembershipQueryClientImpl(
         mgmHoldingIdentity: HoldingIdentity,
         ownerX500Name: MemberX500Name?,
         preAuthTokenId: UUID?,
-        viewInactive: Boolean
+        viewInactive: Boolean,
     ): MembershipQueryResult<List<PreAuthToken>> {
         val statuses = if (viewInactive) {
             PreAuthTokenStatus.values().toList()
@@ -259,46 +187,57 @@ class MembershipQueryClientImpl(
         }
         val ownerX500NameString = ownerX500Name?.let { ownerX500Name.toString() }
         val preAuthTokenIdString = preAuthTokenId?.let { preAuthTokenId.toString() }
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(mgmHoldingIdentity.toAvro()),
-            QueryPreAuthToken(ownerX500NameString, preAuthTokenIdString, statuses)
-        ).execute()
-        return when (payload) {
-            is PreAuthTokenQueryResponse -> {
-                MembershipQueryResult.Success(
-                    payload.tokens,
-                )
-            }
-            else -> {
-                MembershipQueryResult.Failure("Failed to query for pre auth tokens.")
-            }
+            QueryPreAuthToken(ownerX500NameString, preAuthTokenIdString, statuses),
+        ).execute("query for pre auth tokens") { payload: PreAuthTokenQueryResponse ->
+            payload.tokens
         }
     }
 
     override fun getApprovalRules(
         viewOwningIdentity: HoldingIdentity,
-        ruleType: ApprovalRuleType
+        ruleType: ApprovalRuleType,
     ): MembershipQueryResult<Collection<ApprovalRuleDetails>> {
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(viewOwningIdentity.toAvro()),
-            QueryApprovalRules(ruleType)
-        ).execute()
-        return when (payload) {
-            is ApprovalRulesQueryResponse -> MembershipQueryResult.Success(payload.rules)
-            else -> MembershipQueryResult.Failure("Failed to retrieve approval rules.")
+            QueryApprovalRules(ruleType),
+        ).execute("retrieve approval rules") { payload: ApprovalRulesQueryResponse ->
+            payload.rules
         }
     }
 
     override fun queryStaticNetworkInfo(
-        groupId: String
+        groupId: String,
     ): MembershipQueryResult<StaticNetworkInfo> {
-        val payload = MembershipPersistenceRequest(
+        return MembershipPersistenceRequest(
             buildMembershipRequestContext(),
-            QueryStaticNetworkInfo(groupId)
-        ).execute()
-        return when (payload) {
-            is StaticNetworkInfoQueryResponse -> MembershipQueryResult.Success(payload.info)
-            else -> MembershipQueryResult.Failure("Failed to retrieve static network configuration.")
+            QueryStaticNetworkInfo(groupId),
+        ).execute("retrieve static network") { payload: StaticNetworkInfoQueryResponse ->
+            payload.info
+        }
+    }
+
+    private inline fun <reified T, E> MembershipPersistenceRequest.execute(
+        operationName: String,
+        crossinline convert: (T) -> E,
+    ): MembershipQueryResult<E> {
+        val result = this.operation {
+            if (it is T) {
+                Either.Left(it)
+            } else {
+                Either.Right(
+                    "Query returned unexpected payload. Got ${it?.javaClass} while waiting for ${T::class.java}",
+                )
+            }
+        }.send()
+        return when (result) {
+            is Either.Left -> MembershipQueryResult.Success(convert(result.a))
+            is Either.Right -> {
+                val err = "Failed to $operationName: ${result.b}."
+                logger.warn(err)
+                MembershipQueryResult.Failure(err)
+            }
         }
     }
 }


### PR DESCRIPTION
The persistence client mapped the error results wrong, which caused all errors to be logged as: `Query returned unexpected payload.` which is not helpful. This change fixes that issue.

See https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-combined-worker-e2e-tests/job/release%252Fos%252F5.0/2470/artifact/workerLogs.txt for an exmple