### PR TITLE
ES-358: remove hard coded combined worker version from combined worker e2e test start up

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -85,7 +85,7 @@ pipeline {
         } 			
         stage('start combined worker') {       
             environment {
-                JAR_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.0.0.0-*.jar"
+                JAR_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar"
                 JDBC_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/drivers"
                 REST_TLS_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/tls/rest/rest_worker.pfx"
                 VM_PARAMETERS = "-Dco.paralleluniverse.fibers.verifyInstrumentation=true"


### PR DESCRIPTION
When reading the combined worker from the build dir to start the worker process, don't hard code the version, as this leads to issues when creating new branches with different versions. This directory will only ever contain 1 version of the combined worker so just wildcard the path 