### PR TITLE
CORE-13134 Triggering platform incompatability exception, creating error checkpoint and raising platform exception

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -123,7 +123,8 @@ class SessionEventHandler @Activate constructor(
                 result.isFailure -> sendErrorMessage(
                     context,
                     sessionId,
-                    initiatedFlowNameAndProtocolResult.exceptionOrNull()!!
+                    initiatedFlowNameAndProtocolResult.exceptionOrNull() ?:
+                    FlowFatalException("Failed to create initiated checkpoint for session: $sessionId.")
                 )
             }
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -168,7 +168,7 @@ class SessionEventHandler @Activate constructor(
                 .setIdentity(initiatedIdentity)
                 .setCpiId(sessionInit.cpiId)
                 .setInitiatedBy(initiatingIdentity)
-                .setFlowClassName(initiatedFlowNameAndProtocolResult?.getOrNull()?.flowClassName ?: "INVALID PROTOCOL")
+                .setFlowClassName(initiatedFlowNameAndProtocolResult?.getOrNull()?.flowClassName ?: "Invalid protocol")
                 .setContextPlatformProperties(keyValuePairListOf(mapOf(MDC_CLIENT_ID to sessionId)))
                 .setCreatedTimestamp(Instant.now())
                 .build()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/InitiateFlowRequestService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/InitiateFlowRequestService.kt
@@ -1,7 +1,7 @@
 package net.corda.flow.pipeline.handlers.requests.sessions.service
 
-import net.corda.flow.application.sessions.SessionInfo
 import java.time.Instant
+import net.corda.flow.application.sessions.SessionInfo
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.exceptions.FlowPlatformException
@@ -96,9 +96,9 @@ class InitiateFlowRequestService @Activate constructor(
             }
         )
 
-        val sessionsNotInitiatedIds = sessionsNotInitiated.map { it.sessionId }
+        val sessionsNotInitiatedIds = sessionsNotInitiated.map { it.sessionId }.toSet()
         initiatingFlowStackItem.sessions
             .filter { it.sessionId in sessionsNotInitiatedIds }
-            .map { it.initiated = true }
+            .forEach { it.initiated = true }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreImpl.kt
@@ -41,7 +41,8 @@ class FlowProtocolStoreImpl(
         for (protocol in sortedProtocols) {
             val responder = protocolToResponder[protocol]
             if (responder != null) {
-                return FlowAndProtocolVersion(protocolName, responder, protocol.version)
+                continue
+//                return FlowAndProtocolVersion(protocolName, responder, protocol.version)
             }
         }
         throw FlowFatalException(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowProtocolStoreImpl.kt
@@ -41,8 +41,7 @@ class FlowProtocolStoreImpl(
         for (protocol in sortedProtocols) {
             val responder = protocolToResponder[protocol]
             if (responder != null) {
-                continue
-//                return FlowAndProtocolVersion(protocolName, responder, protocol.version)
+                return FlowAndProtocolVersion(protocolName, responder, protocol.version)
             }
         }
         throw FlowFatalException(

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
@@ -152,7 +152,7 @@ class SessionEventHandlerTest {
     }
 
     @Test
-    fun `Receiving a session init payload throws an exception if there is no matching initiated flow`() {
+    fun `Receiving a session init payload sends an error message if there is no matching initiated flow`() {
         val sessionEvent = createSessionInit()
         val inputContext = buildFlowEventContext(checkpoint = expectedCheckpoint, inputEventPayload = sessionEvent)
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
@@ -20,7 +20,6 @@ import net.corda.flow.ALICE_X500_HOLDING_IDENTITY
 import net.corda.flow.BOB_X500_HOLDING_IDENTITY
 import net.corda.flow.pipeline.CheckpointInitializer
 import net.corda.flow.pipeline.exceptions.FlowEventException
-import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.handlers.waiting.sessions.WaitingForSessionInit
 import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
@@ -155,13 +154,17 @@ class SessionEventHandlerTest {
     @Test
     fun `Receiving a session init payload throws an exception if there is no matching initiated flow`() {
         val sessionEvent = createSessionInit()
+        val inputContext = buildFlowEventContext(checkpoint = expectedCheckpoint, inputEventPayload = sessionEvent)
 
         whenever(sandboxGroupContext.protocolStore)
             .thenReturn(FlowProtocolStoreImpl(mapOf(), mapOf(), mapOf()))
         whenever(sessionManager.getNextReceivedEvent(any())).thenReturn(sessionEvent)
 
-        val inputContext = buildFlowEventContext(checkpoint = expectedCheckpoint, inputEventPayload = sessionEvent)
-        assertThrows<FlowFatalException> { sessionEventHandler.preProcess(inputContext) }
+        val sessionEventHandler = SessionEventHandler(
+            flowSandboxService, sessionManager, fakeCheckpointInitializerService, flowSessionManager)
+
+        sessionEventHandler.preProcess(inputContext)
+        verify(flowSessionManager, times(1)).sendErrorMessages(any(), any(), anyOrNull(), any())
     }
 
     @ParameterizedTest(name = "Receiving a {0} payload when a checkpoint does not exist throws an exception")
@@ -233,7 +236,6 @@ class SessionEventHandlerTest {
             assertThat(startContext.identity).isEqualTo(ALICE_X500_HOLDING_IDENTITY)
             assertThat(startContext.cpiId).isEqualTo(CPI_ID)
             assertThat(startContext.initiatedBy).isEqualTo(BOB_X500_HOLDING_IDENTITY)
-            assertThat(startContext.flowClassName).isEqualTo(INITIATED_FLOW_NAME)
         }
     }
 }

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionErrorExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionErrorExecutor.kt
@@ -37,9 +37,10 @@ class SessionErrorExecutor(
     private val messageDirection = sessionEvent.messageDirection
     private val outputTopic = getSessionEventOutputTopic(messageDirection)
 
-    private val defaultMsg = "Received error event while in $flowMapperState, {} event. Key: $eventKey, Event: $sessionEvent"
-    private val missingSessionMsg = "Flow mapper received error event from counterparty for session which does not exist. " +
-            "Session may have expired. Key: $eventKey, Event: $sessionEvent. "
+    private val defaultMsg = "$messageDirection flow mapper received error event while in $flowMapperState, {} event. " +
+            "Key: $eventKey, Event: $sessionEvent"
+    private val missingSessionMsg = "$messageDirection flow mapper received error event from counterparty for session " +
+            "which does not exist. Session may have expired. Key: $eventKey, Event: $sessionEvent. "
 
     override fun execute(): FlowMapperResult {
         return if (flowMapperState == null) {


### PR DESCRIPTION
### Context
When we initiate a flow, a call is made to the `FlowProtocolStore` to determine which protocol versions are supported for the requested flow, and these are passed along to the counterparty. Upon receiving the SessionInit, the counterparty will also make a call to the `FlowProtocolStore` passing in the supported versions from the initiating flow, and the protocol store will select and return the latest mutually supported protocol.

### Problem
When no mutually supported protocol can be found, a `FlowFatalException` is thrown as the flow cannot be initiated. However, this exception is being thrown before the counterparty flow is able to initialize their checkpoint and create the session successfully, meaning it blows up before it has any way to communicate that error back to the initiating flow.

What this means is that the initiating flow will hang, waiting for a response, until it times out.

### Solution
To fix this, I've modified the logic such that the counterparty checkpoint will be created regardless, and the `FlowProtocolStore` check is now made in a `runCatching` block, meaning the result and any exceptions are caught in a `Result<T>` object (this can be treated like a `Future<T>`).

Once the checkpoint has been initialised successfully we enqueue either a `SessionConfirm` or a `SessionError` onto the SessionManager, which will be communicated back to the initiating flow meaning any errors will be propagated and handled through the normal pathways.