### PR TITLE
CORE-12668: Change error message when flow fails due to counterparty being in maintenance mode

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionDataWaitingForHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionDataWaitingForHandler.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.pipeline.handlers.waiting.sessions
 
-import net.corda.data.ExceptionEnvelope
 import java.nio.ByteBuffer
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionError

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionDataWaitingForHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/waiting/sessions/SessionDataWaitingForHandler.kt
@@ -48,7 +48,7 @@ class SessionDataWaitingForHandler @Activate constructor(
                 flowSessionManager.getSessionsWithNextMessageClose(checkpoint, waitingFor.sessionIds - receivedSessions)
             val terminatedSessions = erroredSessions + closingSessionEvents
 
-            val sessionErrorMsg = ((context.inputEvent.payload as SessionEvent).payload as? SessionError)?.errorMessage.toString()
+            val sessionErrorMsg = ((context.inputEvent.payload as? SessionEvent)?.payload as? SessionError)?.errorMessage.toString()
 
             when {
                 unconfirmedSessions.isNotEmpty() -> FlowContinuation.Continue

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionErrorExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionErrorExecutor.kt
@@ -61,6 +61,7 @@ class SessionErrorExecutor(
                 log.warn(errorMsg + "Forwarding event.")
                 flowMapperState.status = FlowMapperStateType.ERROR
                 if (messageDirection == MessageDirection.OUTBOUND) {
+                    val errorMessage = (sessionEvent.payload as SessionError).errorMessage?.errorMessage
                     FlowMapperResult(
                         flowMapperState, listOf(
                             createP2PRecord(
@@ -68,7 +69,7 @@ class SessionErrorExecutor(
                                 SessionError(
                                     ExceptionEnvelope(
                                         "FlowMapper-SessionError",
-                                        "Received SessionError with sessionId $sessionId"
+                                         "Received SessionError with sessionId $sessionId, Error: $errorMessage"
                                     )
                                 ),
                                 instant,

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionErrorExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionErrorExecutor.kt
@@ -61,7 +61,7 @@ class SessionErrorExecutor(
                 log.warn(errorMsg + "Forwarding event.")
                 flowMapperState.status = FlowMapperStateType.ERROR
                 if (messageDirection == MessageDirection.OUTBOUND) {
-                    val errorMessage = (sessionEvent.payload as SessionError).errorMessage?.errorMessage
+                    val errorMessage = (sessionEvent.payload as? SessionError)?.errorMessage?.errorMessage
                     FlowMapperResult(
                         flowMapperState, listOf(
                             createP2PRecord(


### PR DESCRIPTION
When a in initiatingFlow tries to trigger a responder flow from a Virtual Node that is in maintenance mode, it fails. If the flow status of the initiating flow is checked, there is no details of the reason for the failure. 

This change passes the error message generated in the responder flow "Flow operational status is INACTIVE" through to the status of the initiating flow. 