### PR TITLE
CORE-8714 Set the Protocol and PKI mode after the InitiatorHandshake instead of the InitiatorHello

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/CryptoProtocolFactory.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/CryptoProtocolFactory.kt
@@ -12,8 +12,7 @@ internal class CryptoProtocolFactory: ProtocolFactory {
         return AuthenticationProtocolInitiator(sessionId, supportedModes, ourMaxMessageSize, ourPublicKey, groupId, mode)
     }
 
-    override fun createResponder(sessionId: String, supportedModes: Set<ProtocolMode>, ourMaxMessageSize: Int,
-                                 mode: CertificateCheckMode): AuthenticationProtocolResponder {
-        return AuthenticationProtocolResponder(sessionId, supportedModes, ourMaxMessageSize, mode)
+    override fun createResponder(sessionId: String, ourMaxMessageSize: Int): AuthenticationProtocolResponder {
+        return AuthenticationProtocolResponder(sessionId, ourMaxMessageSize)
     }
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/ProtocolFactory.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/ProtocolFactory.kt
@@ -10,6 +10,5 @@ internal interface ProtocolFactory {
     @Suppress("LongParameterList")
     fun createInitiator(sessionId: String, supportedModes: Set<ProtocolMode>, ourMaxMessageSize: Int,
                         ourPublicKey: PublicKey, groupId: String, mode: CertificateCheckMode): AuthenticationProtocolInitiator
-    fun createResponder(sessionId: String, supportedModes: Set<ProtocolMode>, ourMaxMessageSize: Int,
-                        mode: CertificateCheckMode): AuthenticationProtocolResponder
+    fun createResponder(sessionId: String, ourMaxMessageSize: Int): AuthenticationProtocolResponder
 }

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocol.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocol.kt
@@ -137,17 +137,14 @@ abstract class AuthenticationProtocol(private val certificateValidatorFactory: (
         expectedPeerPublicKey: PublicKey,
         messageName: String
     ) {
-        val certificateValidator = when(certificateCheckMode) {
-            is CertificateCheckMode.NoCertificate -> null
-            is CertificateCheckMode.CheckCertificate -> certificateValidatorFactory(
-                certificateCheckMode.revocationCheckMode,
-                certificateCheckMode.truststore,
-                certificateCheckMode.revocationChecker
-            )
-        }
-        if (certificateCheckMode != CertificateCheckMode.NoCertificate) {
+        if (certificateCheckMode is CertificateCheckMode.CheckCertificate) {
             if (peerCertificate != null) {
-                certificateValidator!!.validate(
+                val certificateValidator = certificateValidatorFactory(
+                    certificateCheckMode.revocationCheckMode,
+                    certificateCheckMode.truststore,
+                    certificateCheckMode.revocationChecker
+                )
+                certificateValidator.validate(
                     peerCertificate,
                     peerX500Name,
                     expectedPeerPublicKey

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocol.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocol.kt
@@ -41,6 +41,10 @@ import javax.crypto.KeyAgreement
 import javax.crypto.Mac
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
+import net.corda.crypto.utils.PemCertificate
+import net.corda.data.p2p.gateway.certificates.RevocationCheckRequest
+import net.corda.data.p2p.gateway.certificates.RevocationCheckResponse
+import net.corda.v5.base.types.MemberX500Name
 
 /**
  * A base, abstract class containing the core utilities for the session authentication protocol.
@@ -49,7 +53,9 @@ import javax.crypto.spec.SecretKeySpec
  *
  * For the detailed spec of the authentication protocol, refer to the corresponding design document.
  */
-abstract class AuthenticationProtocol(certificateCheckMode: CertificateCheckMode) {
+abstract class AuthenticationProtocol(private val certificateValidatorFactory: (revocationCheckMode: RevocationCheckMode,
+                                       pemTrustStore: List<PemCertificate>,
+                                       checkRevocation: (RevocationCheckRequest) -> RevocationCheckResponse) -> CertificateValidator){
     protected var myPrivateDHKey: PrivateKey? = null
     protected var myPublicDHKey: ByteArray? = null
     protected var peerPublicDHKey: PublicKey? = null
@@ -74,14 +80,7 @@ abstract class AuthenticationProtocol(certificateCheckMode: CertificateCheckMode
     protected val hmac = Mac.getInstance(HMAC_ALGO, provider)
     protected val aesCipher = Cipher.getInstance(CIPHER_ALGO, provider)
     protected val messageDigest = MessageDigest.getInstance(HASH_ALGO, provider)
-    protected val certificateValidator = when(certificateCheckMode) {
-        is CertificateCheckMode.NoCertificate -> null
-        is CertificateCheckMode.CheckCertificate -> CertificateValidator(
-            certificateCheckMode.revocationCheckMode,
-            certificateCheckMode.truststore,
-            certificateCheckMode.revocationChecker
-        )
-    }
+
     private val hkdfGenerator = HKDFBytesGenerator(messageDigest.convertToBCDigest())
 
     fun getSignature(signatureSpec: SignatureSpec): Signature {
@@ -129,6 +128,34 @@ abstract class AuthenticationProtocol(certificateCheckMode: CertificateCheckMode
                                                                     RESPONDER_SESSION_NONCE_INFO, CIPHER_NONCE_SIZE_BYTES)
 
         return SharedSessionSecrets(initiatorEncryptionKey, responderEncryptionKey, initiatorNonce, responderNonce)
+    }
+
+    protected fun validateCertificate(
+        certificateCheckMode: CertificateCheckMode,
+        peerCertificate: List<String>?,
+        peerX500Name: MemberX500Name,
+        expectedPeerPublicKey: PublicKey,
+        messageName: String
+    ) {
+        val certificateValidator = when(certificateCheckMode) {
+            is CertificateCheckMode.NoCertificate -> null
+            is CertificateCheckMode.CheckCertificate -> certificateValidatorFactory(
+                certificateCheckMode.revocationCheckMode,
+                certificateCheckMode.truststore,
+                certificateCheckMode.revocationChecker
+            )
+        }
+        if (certificateCheckMode != CertificateCheckMode.NoCertificate) {
+            if (peerCertificate != null) {
+                certificateValidator!!.validate(
+                    peerCertificate,
+                    peerX500Name,
+                    expectedPeerPublicKey
+                )
+            } else {
+                throw InvalidPeerCertificate("No peer certificate was sent in the $messageName.")
+            }
+        }
     }
 
     /**

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolResponder.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolResponder.kt
@@ -44,6 +44,7 @@ import kotlin.math.min
  * - [generateResponderHello]
  * - [generateHandshakeSecrets]
  * - [validatePeerHandshakeMessage]
+ * - [validateEncryptedExtensions]
  * - [generateOurHandshakeMessage]
  * - [getSession]
  *
@@ -210,6 +211,9 @@ class AuthenticationProtocolResponder(
         }
     }
 
+    /**
+     * Validates the protocol mode and certificate (if any).
+     */
     fun validateEncryptedExtensions(
         checkMode: CertificateCheckMode,
         supportedModes: Set<ProtocolMode>,

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
@@ -39,11 +39,7 @@ class AuthenticatedEncryptionSessionTest {
     // party B
     private val partyBMaxMessageSize = 1_500_000
     private val partyBSessionKey = keyPairGenerator.generateKeyPair()
-    private val authenticationProtocolB =
-        AuthenticationProtocolResponder(
-            sessionId,
-            setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION), partyBMaxMessageSize, CertificateCheckMode.NoCertificate
-        )
+    private val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
 
     @Test
     fun `session can be established between two parties and used for transmission of authenticated and encrypted data successfully`() {
@@ -73,10 +69,15 @@ class AuthenticatedEncryptionSessionTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(
                 partyASessionKey.public to SignatureSpecs.ECDSA_SHA256,
             ),
+        )
+
+        authenticationProtocolB.validateEncryptedExtensions(
+            CertificateCheckMode.NoCertificate,
+            setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
+            aliceX500Name
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -162,8 +163,13 @@ class AuthenticatedEncryptionSessionTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
+        )
+
+        authenticationProtocolB.validateEncryptedExtensions(
+            CertificateCheckMode.NoCertificate,
+            setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
+            aliceX500Name
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -255,8 +261,13 @@ class AuthenticatedEncryptionSessionTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
+        )
+
+        authenticationProtocolB.validateEncryptedExtensions(
+            CertificateCheckMode.NoCertificate,
+            setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
+            aliceX500Name
         )
 
         // Step 4: responder sending handshake message and initiator validating it.

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
@@ -40,9 +40,7 @@ class AuthenticatedSessionTest {
     // party B
     private val partyBMaxMessageSize = 1_500_000
     private val partyBSessionKey = keyPairGenerator.generateKeyPair()
-    private val authenticationProtocolB = AuthenticationProtocolResponder(
-        sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize, CertificateCheckMode.NoCertificate
-    )
+    private val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
 
     @Test
     fun `session can be established between two parties and used for transmission of authenticated data successfully`() {
@@ -72,8 +70,13 @@ class AuthenticatedSessionTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
+        )
+
+        authenticationProtocolB.validateEncryptedExtensions(
+            CertificateCheckMode.NoCertificate,
+            setOf(ProtocolMode.AUTHENTICATION_ONLY),
+            aliceX500Name
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -152,8 +155,13 @@ class AuthenticatedSessionTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
+        )
+
+        authenticationProtocolB.validateEncryptedExtensions(
+            CertificateCheckMode.NoCertificate,
+            setOf(ProtocolMode.AUTHENTICATION_ONLY),
+            aliceX500Name
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -223,8 +231,13 @@ class AuthenticatedSessionTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
+        )
+
+        authenticationProtocolB.validateEncryptedExtensions(
+            CertificateCheckMode.NoCertificate,
+            setOf(ProtocolMode.AUTHENTICATION_ONLY),
+            aliceX500Name
         )
 
         // Step 4: responder sending handshake message and initiator validating it.

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
@@ -46,17 +46,8 @@ class AuthenticationProtocolFailureTest {
     // party B
     private val partyBMaxMessageSize = 1_500_000
     private val partyBSessionKey = keyPairGenerator.generateKeyPair()
-    private val authenticationProtocolB =
-        AuthenticationProtocolResponder(
-            sessionId,
-            setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize, CertificateCheckMode.NoCertificate
-        )
-    private val certificateValidator = Mockito.mockConstruction(CertificateValidator::class.java)
-
-    @AfterEach
-    fun cleanUp() {
-        certificateValidator.close()
-    }
+    private val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
+    private val certificateValidator = mock<CertificateValidator>()
 
     @Test
     fun `session authentication fails if malicious actor changes initiator's handshake message`() {
@@ -90,7 +81,7 @@ class AuthenticationProtocolFailureTest {
         )
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                modifiedInitiatorHandshakeMessage, aliceX500Name, listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
+                modifiedInitiatorHandshakeMessage, listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -124,7 +115,7 @@ class AuthenticationProtocolFailureTest {
 
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                initiatorHandshakeMessage, aliceX500Name, listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
+                initiatorHandshakeMessage, listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
             )
         }
             .isInstanceOf(InvalidHandshakeMessageException::class.java)
@@ -159,7 +150,7 @@ class AuthenticationProtocolFailureTest {
         )
         assertThatThrownBy {
             authenticationProtocolB.validatePeerHandshakeMessage(
-                initiatorHandshakeMessage, aliceX500Name, listOf(wrongPublicKey to SignatureSpecs.ECDSA_SHA256)
+                initiatorHandshakeMessage, listOf(wrongPublicKey to SignatureSpecs.ECDSA_SHA256)
             )
         }
             .isInstanceOf(WrongPublicKeyHashException::class.java)
@@ -193,8 +184,13 @@ class AuthenticationProtocolFailureTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
+        )
+
+        authenticationProtocolB.validateEncryptedExtensions(
+            CertificateCheckMode.NoCertificate,
+            setOf(ProtocolMode.AUTHENTICATION_ONLY),
+            aliceX500Name
         )
 
         // Step 4: responder creating different signature than the one expected.
@@ -227,9 +223,7 @@ class AuthenticationProtocolFailureTest {
             sessionId,
             CertificateCheckMode.NoCertificate
         )
-        val authenticationProtocolB = AuthenticationProtocolResponder(
-            sessionId, setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION), partyBMaxMessageSize, CertificateCheckMode.NoCertificate
-        )
+        val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
 
         // Step 1: initiator sending hello message to responder.
         val initiatorHelloMsg = authenticationProtocolA.generateInitiatorHello()
@@ -255,11 +249,16 @@ class AuthenticationProtocolFailureTest {
             signingCallbackForA
         )
 
+        authenticationProtocolB.validatePeerHandshakeMessage(
+            initiatorHandshakeMessage,
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
+        )
+
         assertThrows<NoCommonModeError> {
-            authenticationProtocolB.validatePeerHandshakeMessage(
-                initiatorHandshakeMessage,
-                aliceX500Name,
-                listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
+            authenticationProtocolB.validateEncryptedExtensions(
+                CertificateCheckMode.NoCertificate,
+                setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
+                aliceX500Name
             )
         }
     }
@@ -276,12 +275,9 @@ class AuthenticationProtocolFailureTest {
             partyASessionKey.public,
             sessionId,
             certCheckMode
-        )
-        val authenticationProtocolB = AuthenticationProtocolResponder(
-            sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize, certCheckMode
-        )
-        val certificateValidatorResponder = certificateValidator.constructed()[1]!!
-        whenever(certificateValidatorResponder.validate(any(), any(), any()))
+        ) { _, _, _, -> certificateValidator }
+        val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
+        whenever(certificateValidator.validate(any(), any(), any()))
             .thenThrow(InvalidPeerCertificate("Invalid peer certificate"))
 
         // Step 1: initiator sending hello message to responder.
@@ -307,12 +303,12 @@ class AuthenticationProtocolFailureTest {
             ourCertificates,
             signingCallbackForA
         )
-
-        assertThrows<InvalidPeerCertificate> { authenticationProtocolB.validatePeerHandshakeMessage(
-                initiatorHandshakeMessage,
-                aliceX500Name,
-                listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
-            )
+        authenticationProtocolB.validatePeerHandshakeMessage(
+            initiatorHandshakeMessage,
+            listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256)
+        )
+        assertThrows<InvalidPeerCertificate> {
+            authenticationProtocolB.validateEncryptedExtensions(certCheckMode, setOf(ProtocolMode.AUTHENTICATION_ONLY), aliceX500Name)
         }
     }
 
@@ -320,6 +316,7 @@ class AuthenticationProtocolFailureTest {
     fun `session authentication fails if initiator certificate validation fails`() {
         val ourCertificates = listOf<String>()
         val certCheckMode = CertificateCheckMode.CheckCertificate(mock(), mock(), mock())
+        val certificateValidatorResponder = mock<CertificateValidator>()
 
         val authenticationProtocolA = AuthenticationProtocolInitiator(
             sessionId,
@@ -328,12 +325,11 @@ class AuthenticationProtocolFailureTest {
             partyASessionKey.public,
             sessionId,
             certCheckMode
-        )
-        val authenticationProtocolB = AuthenticationProtocolResponder(
-            sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize, certCheckMode
-        )
-        val certificateValidatorInitiator = certificateValidator.constructed()[0]!!
-        whenever(certificateValidatorInitiator.validate(any(), any(), any())).thenThrow(InvalidPeerCertificate(""))
+        ) { _, _, _, -> certificateValidator }
+        val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize) { _, _, _, ->
+            certificateValidatorResponder
+        }
+        whenever(certificateValidator.validate(any(), any(), any())).thenThrow(InvalidPeerCertificate(""))
 
         // Step 1: initiator sending hello message to responder.
         val initiatorHelloMsg = authenticationProtocolA.generateInitiatorHello()
@@ -361,9 +357,9 @@ class AuthenticationProtocolFailureTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
+        authenticationProtocolB.validateEncryptedExtensions(certCheckMode, setOf(ProtocolMode.AUTHENTICATION_ONLY), aliceX500Name)
 
         // Step 4: responder sending handshake message and initiator validating it.
         val signingCallbackForB = { data: ByteArray ->
@@ -397,9 +393,7 @@ class AuthenticationProtocolFailureTest {
             sessionId,
             CertificateCheckMode.NoCertificate
         )
-        val authenticationProtocolB = AuthenticationProtocolResponder(
-            sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize, certCheckMode
-        )
+        val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize) { _, _, _, -> certificateValidator }
 
         // Step 1: initiator sending hello message to responder.
         val initiatorHelloMsg = authenticationProtocolA.generateInitiatorHello()
@@ -424,12 +418,13 @@ class AuthenticationProtocolFailureTest {
             null,
             signingCallbackForA
         )
-
-        assertThrows<InvalidPeerCertificate> { authenticationProtocolB.validatePeerHandshakeMessage(
+        authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
         )
+
+        assertThrows<InvalidPeerCertificate> {
+            authenticationProtocolB.validateEncryptedExtensions(certCheckMode, setOf(ProtocolMode.AUTHENTICATION_ONLY), aliceX500Name)
         }
     }
 
@@ -445,10 +440,8 @@ class AuthenticationProtocolFailureTest {
             partyASessionKey.public,
             sessionId,
             certCheckMode
-        )
-        val authenticationProtocolB = AuthenticationProtocolResponder(
-            sessionId, setOf(ProtocolMode.AUTHENTICATION_ONLY), partyBMaxMessageSize, CertificateCheckMode.NoCertificate
-        )
+        ) { _, _, _, -> certificateValidator }
+        val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
 
         // Step 1: initiator sending hello message to responder.
         val initiatorHelloMsg = authenticationProtocolA.generateInitiatorHello()
@@ -476,8 +469,12 @@ class AuthenticationProtocolFailureTest {
 
         authenticationProtocolB.validatePeerHandshakeMessage(
             initiatorHandshakeMessage,
-            aliceX500Name,
             listOf(partyASessionKey.public to SignatureSpecs.ECDSA_SHA256),
+        )
+        authenticationProtocolB.validateEncryptedExtensions(
+            CertificateCheckMode.NoCertificate,
+            setOf(ProtocolMode.AUTHENTICATION_ONLY),
+            aliceX500Name
         )
 
         // Step 4: responder sending handshake message and initiator validating it.

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
@@ -6,10 +6,8 @@ import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolTest.kt
@@ -9,15 +9,12 @@ import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.Signature
 import java.util.UUID
-import net.corda.data.p2p.gateway.certificates.RevocationCheckRequest
-import net.corda.data.p2p.gateway.certificates.RevocationCheckResponse
 
 class AuthenticationProtocolTest {
 


### PR DESCRIPTION
We only know the initiator's identity after we have received the `InitiatorHandshake` message. The previous behaviour was looking for any identity in the same group and then using that to look up the group policy. This will cause problems once updating the parts of the group policy used by the Link Manager is supported. e.g. Reregistering and updating the protocol mode.

To do this I added a new step into the responders authentication protocol `VALIDATED_ENCRYPTED_EXTENSIONS`. This step comes after validating the `InititaorHandshake` message. I moved selecting and checking for a valid protocol mode and   validating the certificate from validating the initiator handshake message, to this new stage.

I left in the group policy lookup when processing the `InitiatorHello` message, this is only used to lookup the network type (Corda 5 or Corda 4). We could consider hard coding it to Corda 5 