### PR TITLE
ES-379 Investigate use of unstable tags to skip certain tests on the main CI using Junit tags for e2e tests

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
@@ -26,7 +26,6 @@ import java.nio.file.Path
 /**
  * Three clusters are required for running this test. See `resources/RunNetworkTests.md` for more details.
  */
-@Tag("Unstable")
 class MultiClusterDynamicNetworkTest {
     @TempDir
     lateinit var tempDir: Path
@@ -62,6 +61,7 @@ class MultiClusterDynamicNetworkTest {
         assertThat(clusterC.members).hasSize(1)
     }
 
+    @Tag("Unstable")
     @Test
     fun `Create mgm and allow members to join the group - one way TLS`() {
         onboardMultiClusterGroup(false)

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
@@ -18,6 +18,7 @@ import net.corda.applications.workers.rest.utils.setSslConfiguration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -25,7 +26,7 @@ import java.nio.file.Path
 /**
  * Three clusters are required for running this test. See `resources/RunNetworkTests.md` for more details.
  */
-@Disabled("CORE-13288: Tests are disabled until there is a solution in place")
+@Tag("Unstable")
 class MultiClusterDynamicNetworkTest {
     @TempDir
     lateinit var tempDir: Path

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
@@ -17,11 +17,12 @@ import net.corda.applications.workers.rest.utils.setSslConfiguration
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
-@Disabled("CORE-13288: Tests are disabled until there is a solution in place")
+@Tag("Unstable")
 class SessionCertificateTest {
     @TempDir
     lateinit var tempDir: Path

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
-@Tag("Unstable")
+
 class SessionCertificateTest {
     @TempDir
     lateinit var tempDir: Path
@@ -57,6 +57,7 @@ class SessionCertificateTest {
     }
 
     @Test
+    @Tag("Unstable")
     fun `Create mgm and allow members to join the group`() {
         onboardMultiClusterGroup()
     }

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
@@ -13,6 +13,7 @@ import net.corda.applications.workers.rest.utils.getMemberName
 import net.corda.applications.workers.rest.utils.onboardMembers
 import net.corda.applications.workers.rest.utils.onboardMgm
 import net.corda.data.identity.HoldingIdentity
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -42,6 +43,7 @@ class SingleClusterDynamicNetworkTest {
     (as this one will cover that use case as well)
     To run it locally while disabled follow the instruction in resources/RunP2PTest.md:
      */
+    @Disabled("Is disabled and can be run manually until CORE-6079 is complete.")
     @Test
     fun `Onboard group and check p2p connectivity`() {
         val groupId = onboardSingleClusterGroup()

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
-@Tag("Unstable")
 class SingleClusterDynamicNetworkTest {
     @TempDir
     lateinit var tempDir: Path
@@ -32,6 +31,7 @@ class SingleClusterDynamicNetworkTest {
 
     private val mgm = cordaCluster.createTestMember("Mgm")
 
+    @Tag("Unstable")
     @Test
     fun `Create mgm and allow members to join the group`() {
         onboardSingleClusterGroup()

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
@@ -13,12 +13,12 @@ import net.corda.applications.workers.rest.utils.getMemberName
 import net.corda.applications.workers.rest.utils.onboardMembers
 import net.corda.applications.workers.rest.utils.onboardMgm
 import net.corda.data.identity.HoldingIdentity
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
-@Disabled("CORE-13288: Tests are disabled until there is a solution in place")
+@Tag("Unstable")
 class SingleClusterDynamicNetworkTest {
     @TempDir
     lateinit var tempDir: Path
@@ -42,7 +42,6 @@ class SingleClusterDynamicNetworkTest {
     (as this one will cover that use case as well)
     To run it locally while disabled follow the instruction in resources/RunP2PTest.md:
      */
-    @Disabled("Is disabled and can be run manually until CORE-6079 is complete.")
     @Test
     fun `Onboard group and check p2p connectivity`() {
         val groupId = onboardSingleClusterGroup()

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/StaticNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/StaticNetworkTest.kt
@@ -13,6 +13,7 @@ import net.corda.applications.workers.rest.utils.getMemberName
 import net.corda.applications.workers.rest.utils.onboardStaticMembers
 import net.corda.data.identity.HoldingIdentity
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.io.TempDir
@@ -20,7 +21,7 @@ import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-@Disabled("CORE-13288: Tests are disabled until there is a solution in place")
+@Tag("Unstable")
 class StaticNetworkTest {
     @TempDir
     lateinit var tempDir: Path

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/StaticNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/StaticNetworkTest.kt
@@ -21,7 +21,6 @@ import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.TimeUnit
 
-@Tag("Unstable")
 class StaticNetworkTest {
     @TempDir
     lateinit var tempDir: Path
@@ -32,6 +31,7 @@ class StaticNetworkTest {
         addMembers((3..4).map { createTestMember("Member$it") })
     }
 
+    @Tag("Unstable")
     @Test
     fun `register members`() {
         onboardStaticGroup(tempDir)


### PR DESCRIPTION
mark `MultiClusterDynamicNetworkTest`, `SessionCertificateTest`, `SingleClusterDynamicNetworkTest`, and `StaticNetworkTest` as _Unstable_ with junit Tags, this means they will be skipped by main CI / PR gates a separate "catch-all" job will be implemented to execute these.

Companion PR  https://github.com/corda/corda-shared-build-pipeline-steps/pull/766