### PR TITLE
ES-371/Update license to Apache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -163,5 +163,5 @@ gradleEnterpriseUrl = https://gradle.dev.r3.com
 snykVersion = 0.4
 
 # License
-licenseName = Corda Pre-Release Software License Agreement
-licenseUrl = https://www.corda.net/wp-content/uploads/2022/09/Corda-Pre-Release-Software-License-Agreement.pdf
+licenseName = The Apache License, Version 2.0
+licenseUrl = http://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
As part of the C5 build process a license file is injected into the pom.xml of a produced Jar this license file is specified as part of the gradle.properties of each repo the current license properties are not correct / outdated and should be updated pre GA