### PR TITLE
CORE-9961: Add flow validation in pipeline for flow start operational status

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -172,25 +172,6 @@ class FlowServiceTestContext @Activate constructor(
         )
     }
 
-//    override fun virtualNode(cpiId: String, holdingId: HoldingIdentity, flowOperationalStatus: OperationalStatus) {
-//        val emptyUUID = UUID(0, 0)
-//
-//        virtualNodeInfoReadService.addOrUpdate(
-//            VirtualNodeInfo(
-//                holdingId.toCorda(),
-//                getCpiIdentifier(cpiId),
-//                emptyUUID,
-//                emptyUUID,
-//                emptyUUID,
-//                emptyUUID,
-//                emptyUUID,
-//                emptyUUID,
-//                timestamp = Instant.now(),
-//                flowOperationalStatus = flowOperationalStatus
-//            )
-//        )
-//    }
-
     override fun cpkMetadata(cpiId: String, cpkId: String, cpkChecksum: SecureHash) {
         val cordAppManifest = CordappManifest(
             "",

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -142,7 +142,14 @@ class FlowServiceTestContext @Activate constructor(
     override val initiatedIdentityMemberName: MemberX500Name
         get() = MemberX500Name.parse(sessionInitiatedIdentity!!.x500Name)
 
-    override fun virtualNode(cpiId: String, holdingId: HoldingIdentity, flowOperationalStatus: OperationalStatus) {
+    override fun virtualNode(
+        cpiId: String,
+        holdingId: HoldingIdentity,
+        flowP2pOperationalStatus: OperationalStatus,
+        flowStartOperationalStatus: OperationalStatus,
+        flowOperationalStatus: OperationalStatus,
+        vaultDbOperationalStatus: OperationalStatus
+    ) {
         val emptyUUID = UUID(0, 0)
 
         virtualNodeInfoReadService.addOrUpdate(
@@ -155,11 +162,34 @@ class FlowServiceTestContext @Activate constructor(
                 emptyUUID,
                 emptyUUID,
                 emptyUUID,
-                timestamp = Instant.now(),
-                flowOperationalStatus = flowOperationalStatus
+                emptyUUID,
+                flowP2pOperationalStatus = flowP2pOperationalStatus,
+                flowStartOperationalStatus = flowStartOperationalStatus,
+                flowOperationalStatus = flowOperationalStatus,
+                vaultDbOperationalStatus = vaultDbOperationalStatus,
+                timestamp = Instant.now()
             )
         )
     }
+
+//    override fun virtualNode(cpiId: String, holdingId: HoldingIdentity, flowOperationalStatus: OperationalStatus) {
+//        val emptyUUID = UUID(0, 0)
+//
+//        virtualNodeInfoReadService.addOrUpdate(
+//            VirtualNodeInfo(
+//                holdingId.toCorda(),
+//                getCpiIdentifier(cpiId),
+//                emptyUUID,
+//                emptyUUID,
+//                emptyUUID,
+//                emptyUUID,
+//                emptyUUID,
+//                emptyUUID,
+//                timestamp = Instant.now(),
+//                flowOperationalStatus = flowOperationalStatus
+//            )
+//        )
+//    }
 
     override fun cpkMetadata(cpiId: String, cpkId: String, cpkChecksum: SecureHash) {
         val cordAppManifest = CordappManifest(

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertions.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertions.kt
@@ -69,7 +69,13 @@ interface OutputAssertions {
 
     fun checkpointDoesNotHaveRetry()
 
-    fun flowStatus(state: FlowStates, result: String? = null, errorType: String? = null, errorMessage:String? = null)
+    fun flowStatus(
+        state: FlowStates,
+        result: String? = null,
+        errorType: String? = null,
+        errorMessage:String? = null,
+        flowTerminatedReason: String? = null
+    )
 
     fun nullStateRecord()
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -289,7 +289,6 @@ class OutputAssertionsImpl(
             assertNotNull(testRun.response)
             assertTrue(
                 testRun.response!!.responseEvents.any {
-                    println(it)
                     matchStatusRecord(flowId, state, result, errorType, errorMessage, flowTerminatedReason, it)
                 },
                 "Expected Flow Status: ${state}, result = ${result ?: "NA"}, errorType = ${errorType ?: "NA"}, error = ${errorMessage ?: "NA"}"
@@ -325,7 +324,7 @@ class OutputAssertionsImpl(
         return filteredEvents
     }
 
-    private fun  matchStatusRecord(
+    private fun matchStatusRecord(
         flowId: String,
         state: FlowStates,
         result: String?,

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -286,7 +286,6 @@ class OutputAssertionsImpl(
 
     override fun flowStatus(state: FlowStates, result: String?, errorType: String?, errorMessage: String?, flowTerminatedReason: String?) {
         asserts.add { testRun ->
-            println("flow response: ${testRun.response}")
             assertNotNull(testRun.response)
             assertTrue(
                 testRun.response!!.responseEvents.any {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -287,7 +287,6 @@ class OutputAssertionsImpl(
     override fun flowStatus(state: FlowStates, result: String?, errorType: String?, errorMessage: String?) {
 
         asserts.add { testRun ->
-            println("flow response: ${testRun.response}")
             assertNotNull(testRun.response)
             assertTrue(
                 testRun.response!!.responseEvents.any {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -285,7 +285,9 @@ class OutputAssertionsImpl(
     }
 
     override fun flowStatus(state: FlowStates, result: String?, errorType: String?, errorMessage: String?) {
+
         asserts.add { testRun ->
+            println("flow response: ${testRun.response}")
             assertNotNull(testRun.response)
             assertTrue(
                 testRun.response!!.responseEvents.any {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -284,13 +284,12 @@ class OutputAssertionsImpl(
         }
     }
 
-    override fun flowStatus(state: FlowStates, result: String?, errorType: String?, errorMessage: String?) {
-
+    override fun flowStatus(state: FlowStates, result: String?, errorType: String?, errorMessage: String?, flowTerminatedReason: String?) {
         asserts.add { testRun ->
             assertNotNull(testRun.response)
             assertTrue(
                 testRun.response!!.responseEvents.any {
-                    matchStatusRecord(flowId, state, result, errorType, errorMessage, null, it)
+                    matchStatusRecord(flowId, state, result, errorType, errorMessage, flowTerminatedReason, it)
                 },
                 "Expected Flow Status: ${state}, result = ${result ?: "NA"}, errorType = ${errorType ?: "NA"}, error = ${errorMessage ?: "NA"}"
             )
@@ -325,7 +324,7 @@ class OutputAssertionsImpl(
         return filteredEvents
     }
 
-    private fun matchStatusRecord(
+    private fun  matchStatusRecord(
         flowId: String,
         state: FlowStates,
         result: String?,

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -286,9 +286,11 @@ class OutputAssertionsImpl(
 
     override fun flowStatus(state: FlowStates, result: String?, errorType: String?, errorMessage: String?, flowTerminatedReason: String?) {
         asserts.add { testRun ->
+            println("flow response: ${testRun.response}")
             assertNotNull(testRun.response)
             assertTrue(
                 testRun.response!!.responseEvents.any {
+                    println(it)
                     matchStatusRecord(flowId, state, result, errorType, errorMessage, flowTerminatedReason, it)
                 },
                 "Expected Flow Status: ${state}, result = ${result ?: "NA"}, errorType = ${errorType ?: "NA"}, error = ${errorMessage ?: "NA"}"

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/StepSetup.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/StepSetup.kt
@@ -5,12 +5,22 @@ import net.corda.data.identity.HoldingIdentity
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.OperationalStatus
+import net.corda.virtualnode.VirtualNodeInfo
 
 interface StepSetup {
 
     val initiatedIdentityMemberName: MemberX500Name
 
-    fun virtualNode(cpiId: String, holdingId: HoldingIdentity, flowOperationalStatus: OperationalStatus = OperationalStatus.ACTIVE)
+//    fun virtualNode(cpiId: String, holdingId: HoldingIdentity, flowOperationalStatus: OperationalStatus = OperationalStatus.ACTIVE)
+
+    fun virtualNode(
+        cpiId: String,
+        holdingId: HoldingIdentity,
+        flowP2pOperationalStatus: OperationalStatus = VirtualNodeInfo.DEFAULT_INITIAL_STATE,
+        flowStartOperationalStatus: OperationalStatus = VirtualNodeInfo.DEFAULT_INITIAL_STATE,
+        flowOperationalStatus: OperationalStatus = VirtualNodeInfo.DEFAULT_INITIAL_STATE,
+        vaultDbOperationalStatus: OperationalStatus = VirtualNodeInfo.DEFAULT_INITIAL_STATE
+    )
 
     fun cpkMetadata(cpiId: String, cpkId: String, cpkChecksum: SecureHash)
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/StepSetup.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/StepSetup.kt
@@ -11,8 +11,6 @@ interface StepSetup {
 
     val initiatedIdentityMemberName: MemberX500Name
 
-//    fun virtualNode(cpiId: String, holdingId: HoldingIdentity, flowOperationalStatus: OperationalStatus = OperationalStatus.ACTIVE)
-
     fun virtualNode(
         cpiId: String,
         holdingId: HoldingIdentity,

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
@@ -81,7 +81,7 @@ class FlowKilledAcceptanceTest : FlowServiceTestBase() {
         }
 
         given {
-            virtualNode(CPI1, ALICE_HOLDING_IDENTITY, OperationalStatus.INACTIVE)
+            virtualNode(CPI1, ALICE_HOLDING_IDENTITY, flowOperationalStatus = OperationalStatus.INACTIVE)
         }
 
         `when` {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
@@ -19,7 +19,7 @@ class FlowKilledAcceptanceTest : FlowServiceTestBase() {
     fun beforeEach() {
         given {
             virtualNode(CPI1, ALICE_HOLDING_IDENTITY)
-            virtualNode(CPI1, BOB_HOLDING_IDENTITY, OperationalStatus.INACTIVE)
+            virtualNode(CPI1, BOB_HOLDING_IDENTITY, flowOperationalStatus=OperationalStatus.INACTIVE)
             cpkMetadata(CPI1, CPK1, CPK1_CHECKSUM)
             sandboxCpk(CPK1_CHECKSUM)
             membershipGroupFor(ALICE_HOLDING_IDENTITY)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
@@ -19,7 +19,7 @@ class FlowKilledAcceptanceTest : FlowServiceTestBase() {
     fun beforeEach() {
         given {
             virtualNode(CPI1, ALICE_HOLDING_IDENTITY)
-            virtualNode(CPI1, BOB_HOLDING_IDENTITY, flowOperationalStatus=OperationalStatus.INACTIVE)
+            virtualNode(CPI1, BOB_HOLDING_IDENTITY, flowOperationalStatus = OperationalStatus.INACTIVE)
             cpkMetadata(CPI1, CPK1, CPK1_CHECKSUM)
             sandboxCpk(CPK1_CHECKSUM)
             membershipGroupFor(ALICE_HOLDING_IDENTITY)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
@@ -70,7 +70,6 @@ class StartFlowTest : FlowServiceTestBase() {
 
         `when` {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, CHARLIE_HOLDING_IDENTITY, CPI1, "flow start data")
-                .suspendsWith(FlowIORequest.InitialCheckpoint)
         }
 
         then {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
@@ -5,6 +5,7 @@ import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.schema.configuration.FlowConfig
 import net.corda.virtualnode.OperationalStatus
+import net.corda.virtualnode.toCorda
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.Execution
@@ -76,11 +77,10 @@ class StartFlowTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 nullStateRecord()
                 noFlowEvents()
-//                flowStatus(
-//                    state = FlowStates.KILLED,
-//                    errorType = FlowProcessingExceptionTypes.FLOW_FAILED,
-//                    errorMessage = "'flowStartOperationalStatus is INACTIVE, new flows cannot be started for ${CHARLIE_HOLDING_IDENTITY.x500Name}"
-//                )
+                flowStatus(
+                    state = FlowStates.KILLED,
+                    flowTerminatedReason = "flowStartOperationalStatus is INACTIVE, new flows cannot be started for virtual node with shortHash ${CHARLIE_HOLDING_IDENTITY.toCorda().shortHash}"
+                )
             }
         }
     }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/StartFlowTest.kt
@@ -52,8 +52,13 @@ class StartFlowTest : FlowServiceTestBase() {
         }
     }
 
+
+    /**
+     * When a virtual node has an INACTIVE StartFlowOperationalStatus, it should throw a FlowMarkedForKillException and
+     * have a Killed status.
+     */
     @Test
-    fun `RPC Start Flow - Flow throws FlowMarkedForKillException if startFlowOperationalStatus is INACTIVE`() {
+    fun `Flow is marked as killed if startFlowOperationalStatus of vNode is INACTIVE`() {
 
         given {
             virtualNode(CPI1, CHARLIE_HOLDING_IDENTITY, flowStartOperationalStatus = OperationalStatus.INACTIVE)
@@ -71,11 +76,11 @@ class StartFlowTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 nullStateRecord()
                 noFlowEvents()
-                flowStatus(
-                    state = FlowStates.KILLED,
+//                flowStatus(
+//                    state = FlowStates.KILLED,
 //                    errorType = FlowProcessingExceptionTypes.FLOW_FAILED,
 //                    errorMessage = "'flowStartOperationalStatus is INACTIVE, new flows cannot be started for ${CHARLIE_HOLDING_IDENTITY.x500Name}"
-                )
+//                )
             }
         }
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
@@ -31,16 +31,6 @@ class StartFlowEventHandler @Activate constructor(
     override fun preProcess(context: FlowEventContext<StartFlow>): FlowEventContext<StartFlow> {
         log.info("Flow [${context.checkpoint.flowId}] started")
 
-        checkpointInitializer.initialize(
-            context.checkpoint,
-            WaitingFor(WaitingForStartFlow),
-            context.inputEventPayload.startContext.identity.toCorda(),
-        ) {
-            context.inputEventPayload.startContext
-        }
-
-        context.flowMetrics.flowStarted()
-
         val holdingIdentity = context.inputEventPayload.startContext.identity.toCorda()
         val virtualNodeInfo = virtualNodeInfoReadService.get(holdingIdentity)
 
@@ -50,6 +40,16 @@ class StartFlowEventHandler @Activate constructor(
                         "shortHash ${holdingIdentity.shortHash}"
             )
         }
+
+        checkpointInitializer.initialize(
+            context.checkpoint,
+            WaitingFor(WaitingForStartFlow),
+            context.inputEventPayload.startContext.identity.toCorda(),
+        ) {
+            context.inputEventPayload.startContext
+        }
+
+        context.flowMetrics.flowStarted()
 
         return context
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
@@ -31,16 +31,6 @@ class StartFlowEventHandler @Activate constructor(
     override fun preProcess(context: FlowEventContext<StartFlow>): FlowEventContext<StartFlow> {
         log.info("Flow [${context.checkpoint.flowId}] started")
 
-        val holdingIdentity = context.inputEventPayload.startContext.identity.toCorda()
-        val virtualNodeInfo = virtualNodeInfoReadService.get(holdingIdentity)
-
-        if (virtualNodeInfo?.flowStartOperationalStatus == OperationalStatus.INACTIVE) {
-            throw FlowMarkedForKillException(
-                "flowStartOperationalStatus is INACTIVE, new flows cannot be started for virtual node with " +
-                        "shortHash ${holdingIdentity.shortHash}"
-            )
-        }
-
         checkpointInitializer.initialize(
             context.checkpoint,
             WaitingFor(WaitingForStartFlow),
@@ -50,6 +40,16 @@ class StartFlowEventHandler @Activate constructor(
         }
 
         context.flowMetrics.flowStarted()
+
+        val holdingIdentity = context.inputEventPayload.startContext.identity.toCorda()
+        val virtualNodeInfo = virtualNodeInfoReadService.get(holdingIdentity)
+
+        if (virtualNodeInfo?.flowStartOperationalStatus == OperationalStatus.INACTIVE) {
+            throw FlowMarkedForKillException(
+                "flowStartOperationalStatus is INACTIVE, new flows cannot be started for virtual node with " +
+                        "shortHash ${holdingIdentity.shortHash}"
+            )
+        }
 
         return context
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
@@ -4,7 +4,10 @@ import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.pipeline.CheckpointInitializer
 import net.corda.flow.pipeline.events.FlowEventContext
+import net.corda.flow.pipeline.exceptions.FlowMarkedForKillException
 import net.corda.flow.pipeline.handlers.waiting.WaitingForStartFlow
+import net.corda.virtualnode.OperationalStatus
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -13,6 +16,8 @@ import org.slf4j.LoggerFactory
 
 @Component(service = [FlowEventHandler::class])
 class StartFlowEventHandler @Activate constructor(
+    @Reference(service = VirtualNodeInfoReadService::class)
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CheckpointInitializer::class)
     private val checkpointInitializer: CheckpointInitializer
 ) : FlowEventHandler<StartFlow> {
@@ -25,6 +30,17 @@ class StartFlowEventHandler @Activate constructor(
 
     override fun preProcess(context: FlowEventContext<StartFlow>): FlowEventContext<StartFlow> {
         log.info("Flow [${context.checkpoint.flowId}] started")
+
+        val holdingIdentity = context.inputEventPayload.startContext.identity.toCorda()
+        val virtualNodeInfo = virtualNodeInfoReadService.get(holdingIdentity)
+
+        if (virtualNodeInfo?.flowStartOperationalStatus == OperationalStatus.INACTIVE) {
+            throw FlowMarkedForKillException(
+                "flowStartOperationalStatus is INACTIVE, new flows cannot be started for virtual node with " +
+                        "shortHash ${holdingIdentity.shortHash}"
+            )
+        }
+
         checkpointInitializer.initialize(
             context.checkpoint,
             WaitingFor(WaitingForStartFlow),

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -1,12 +1,9 @@
 package net.corda.flow.pipeline.impl
 
-import net.corda.data.flow.FlowKey
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.mapper.ScheduleCleanup
-import net.corda.data.flow.event.session.SessionInit
 import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.flow.state.checkpoint.Checkpoint

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -194,7 +194,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             if (!checkpoint.doesExist) {
                 val flowKey = (context.inputEvent.payload as StartFlow).startContext.statusKey
                 val statusRecord = createFlowKilledStatusRecordWithoutCheckpoint(
-                    checkpoint, exception.message ?: "No exception message provided.", flowKey
+                    checkpoint.flowId, flowKey, exception.message ?: "No exception message provided."
                 )
 
                 return@withEscalation flowEventContextConverter.convert(
@@ -265,11 +265,15 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
         }
     }
 
-    private fun createFlowKilledStatusRecordWithoutCheckpoint(checkpoint: FlowCheckpoint, message: String?, flowKey: FlowKey): List<Record<*, *>> {
+    private fun createFlowKilledStatusRecordWithoutCheckpoint(
+        flowId: String,
+        flowKey: FlowKey,
+        message: String?,
+    ): List<Record<*, *>> {
         val status = FlowStatus().apply{
             key = flowKey
             flowStatus = FlowStates.KILLED
-            flowId = checkpoint.flowId
+            this.flowId = flowId
             processingTerminatedReason = message
         }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -280,7 +280,6 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
         return listOf(flowRecordFactory.createFlowStatusRecord(status))
     }
 
-
     private fun getScheduledCleanupExpiryTime(context: FlowEventContext<*>, now: Instant): Long {
         val flowCleanupTime = context.config.getLong(FlowConfig.SESSION_FLOW_CLEANUP_TIME)
         return now.plusMillis(flowCleanupTime).toEpochMilli()

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandlerTest.kt
@@ -10,6 +10,7 @@ import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -17,6 +18,7 @@ import org.mockito.kotlin.mock
 
 class StartFlowEventHandlerTest {
     private val holdingIdentity = BOB_X500_HOLDING_IDENTITY
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService>()
     private val startFlow = StartFlow(
         FlowStartContext().apply {
              identity = holdingIdentity
@@ -35,7 +37,7 @@ class StartFlowEventHandlerTest {
             holdingIdentity.toCorda(),
             contextExpected.checkpoint
         )
-        val handler = StartFlowEventHandler(fakeCheckpointInitializer)
+        val handler = StartFlowEventHandler(virtualNodeInfoReadService, fakeCheckpointInitializer)
         val actualContext = handler.preProcess(contextExpected)
         assertThat(actualContext).isEqualTo(contextExpected)
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
@@ -4,6 +4,8 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import java.lang.IllegalArgumentException
 import net.corda.data.flow.FlowKey
+import net.corda.data.flow.FlowStartContext
+import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.output.FlowStates
@@ -215,12 +217,13 @@ class FlowToBeKilledExceptionProcessingTest {
     fun `processing MarkedForKillException when checkpoint does not exist only outputs flow killed status record`() {
         whenever(checkpoint.doesExist).thenReturn(false)
 
-        val testContext = buildFlowEventContext(checkpoint, Any())
+        val inputEventPayload = StartFlow(FlowStartContext().apply {statusKey = flowKey}, "")
+
+        val testContext = buildFlowEventContext(checkpoint, inputEventPayload)
         val exception = FlowMarkedForKillException("reasoning")
         val contextCapture = argumentCaptor<FlowEventContext<*>>()
 
-        whenever(flowMessageFactory.createFlowKilledStatusMessage(any(), any())).thenReturn(flowKilledStatus)
-        whenever(flowRecordFactory.createFlowStatusRecord(flowKilledStatus)).thenReturn(flowKilledStatusRecord)
+        whenever(flowRecordFactory.createFlowStatusRecord(any())).thenReturn(flowKilledStatusRecord)
 
         whenever(flowEventContextConverter.convert(contextCapture.capture())).thenReturn(mockResponse)
 


### PR DESCRIPTION
This adds validation to `StartFlowEventHandler` to check that a virtualNode's `flowStartOperationalStatus` is ACTIVE. If not, a `FlowMarkedForKill` exception is thrown and the flow is killed. 

A test was added to `StartFlowTest` to cover this scenario. 