### PR TITLE
CORE-13593: Register Kryo's CordaClosureSerializer correctly to serialize Java lambdas.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -134,7 +134,7 @@ class FlowFiberImpl(
                 .withTag(CordaMetrics.Tag.FlowClass, getExecutionContext().flowCheckpoint.flowStartContext.flowClassName)
                 .build()
                 .recordCallable {
-                    getExecutionContext().sandboxGroupContext.checkpointSerializer.serialize(this)
+                    getExecutionContext().sandboxGroupContext.checkpointSerializer.serialize(fiber)
                 }!!
             flowCompletion.complete(FlowIORequest.FlowSuspended(ByteBuffer.wrap(fiberState), request, fiber.prepareForCaching()))
         }

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
@@ -104,8 +104,7 @@ class DefaultKryoCustomizer {
 
                 addDefaultSerializer(LinkedEntrySetSerializer.serializedType, LinkedEntrySetSerializer)
 
-                register(java.lang.invoke.SerializedLambda::class.java)
-                addDefaultSerializer(ClosureSerializer.Closure::class.java, CordaClosureSerializer)
+                register(ClosureSerializer.Closure::class.java, CordaClosureSerializer)
 
                 addDefaultSerializer(Throwable::class.java, object: BaseSerializerFactory<ThrowableSerializer<*>>() {
                     override fun newSerializer(kryo: Kryo, type: Class<*>) = ThrowableSerializer(kryo, type)

--- a/testing/kryo-serialization-testkit/src/main/kotlin/net/corda/kryoserialization/testkit/KryoTestUtils.kt
+++ b/testing/kryo-serialization-testkit/src/main/kotlin/net/corda/kryoserialization/testkit/KryoTestUtils.kt
@@ -44,7 +44,7 @@ fun mockSandboxGroup(taggedClasses: Set<Class<*>>): SandboxGroup {
         val tagCaptor = argumentCaptor<Class<*>>()
         whenever(getStaticTag(tagCaptor.capture())).thenAnswer {
             val clazz = tagCaptor.lastValue
-            if (clazz.isJvmClass && (bundleClasses.putIfAbsent(index.toString(), clazz) == null)) {
+            if ((clazz.isJvmClass || clazz.isLambda) && (bundleClasses.putIfAbsent(index.toString(), clazz) == null)) {
                 ++index
             }
             bundleClasses.keys.firstOrNull { value -> bundleClasses[value] == clazz }?.toString()
@@ -64,3 +64,6 @@ private val Class<*>.isJvmClass: Boolean
 
 private val Class<*>.isJavaType: Boolean
     get() = isPrimitive || name.startsWith("java.")
+
+private val Class<*>.isLambda: Boolean
+    get() = isSynthetic && name.contains('/')


### PR DESCRIPTION
We have not registered `CordaClosureSerializer` correctly, and so Kryo never attempts to use it for classes like:
```kotlin
class UtxoReceiveFinalityFlow(
    private val session: FlowSession,
    private val validator: UtxoTransactionValidator
) : SubFlow<UtxoSignedTransaction> {
```
where `validator` has a lambda value at runtime.

Register `CordaClosureSerializer` correctly. Also remove an unnecessary field from the `parkAndCustomSerialize` lambda.