### PR TITLE
CORE-13610 Add requirement for limit to not be 0

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/NamedParameterizedQuery.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/NamedParameterizedQuery.kt
@@ -24,7 +24,7 @@ class NamedParameterizedQuery<R : Any>(
 ) : ParameterizedQuery<R> {
 
     override fun setLimit(limit: Int): ParameterizedQuery<R> {
-        require (limit >= 0) { "Limit cannot be negative" }
+        require (limit > 0) { "Limit cannot be negative or zero" }
         this.limit = limit
         return this
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/PagedFindQuery.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/PagedFindQuery.kt
@@ -20,7 +20,7 @@ class PagedFindQuery<R : Any>(
 ) : PagedQuery<R> {
 
     override fun setLimit(limit: Int): PagedQuery<R> {
-        require (limit >= 0) { "Limit cannot be negative" }
+        require (limit > 0) { "Limit cannot be negative or zero" }
         this.limit = limit
         return this
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/NamedParameterizedQueryTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/NamedParameterizedQueryTest.kt
@@ -71,6 +71,11 @@ class NamedParameterizedQueryTest {
     }
 
     @Test
+    fun `setLimit cannot be zero`() {
+        assertThatThrownBy { query.setLimit(0) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
     fun `setOffset cannot be negative`() {
         assertThatThrownBy { query.setOffset(-1) }.isInstanceOf(IllegalArgumentException::class.java)
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/PagedFindQueryTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/PagedFindQueryTest.kt
@@ -69,6 +69,11 @@ class PagedFindQueryTest {
     }
 
     @Test
+    fun `setLimit cannot be zero`() {
+        assertThatThrownBy { query.setLimit(0) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
     fun `setOffset cannot be negative`() {
         assertThatThrownBy { query.setOffset(-1) }.isInstanceOf(IllegalArgumentException::class.java)
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -28,7 +28,7 @@ class VaultNamedParameterizedQueryImpl<T>(
     }
 
     override fun setLimit(limit: Int): VaultNamedParameterizedQuery<T> {
-        require (limit >= 0) { "Limit cannot be negative" }
+        require (limit > 0) { "Limit cannot be negative or zero" }
         this.limit = limit
         return this
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -81,6 +81,11 @@ class VaultNamedParameterizedQueryImplTest {
     }
 
     @Test
+    fun `setLimit cannot be zero`() {
+        assertThatThrownBy { query.setLimit(0) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
     fun `setOffset cannot be negative`() {
         assertThatThrownBy { query.setOffset(-1) }.isInstanceOf(IllegalArgumentException::class.java)
     }


### PR DESCRIPTION
### Overview

Hibernate has a weird behaviour of fetching every record if the limit is zero.
We want to make sure users can't encounter that behaviour and add a requirement gate before even reaching Hibernate.