### PR TITLE
CORE-10100: AWS KMS Integration - copy JCE Provider classes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,7 @@ caffeineVersion = 3.1.6
 commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
+awsSdkVersion= 2.20.59
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT

--- a/tools/plugins/package/build.gradle
+++ b/tools/plugins/package/build.gradle
@@ -13,7 +13,11 @@ ext {
 group 'net.corda.cli.deployment'
 
 dependencies {
+    compileOnly "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
+
+    implementation platform("software.amazon.awssdk:bom:$awsSdkVersion")
+    implementation 'software.amazon.awssdk:kms'
 
     implementation project(':libs:packaging:packaging-verify')
     implementation project(':libs:membership:schema-validation')

--- a/tools/plugins/package/build.gradle
+++ b/tools/plugins/package/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     implementation platform("software.amazon.awssdk:bom:$awsSdkVersion")
     implementation 'software.amazon.awssdk:kms'
+    implementation 'software.amazon.awssdk:sso'
 
     implementation project(':libs:packaging:packaging-verify')
     implementation project(':libs:membership:schema-validation')

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKey.java
@@ -1,0 +1,9 @@
+package software.amazon.awssdk.services.kms.jce.provider;
+
+import java.security.Key;
+
+public interface KmsKey extends Key {
+
+    String getId();
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKey.java
@@ -1,4 +1,4 @@
-package software.amazon.awssdk.services.kms.jce.provider;
+package net.corda.cli.plugins.packaging.aws.kms;
 
 import java.security.Key;
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKeyStore.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKeyStore.java
@@ -1,0 +1,139 @@
+package software.amazon.awssdk.services.kms.jce.provider;
+
+import software.amazon.awssdk.services.kms.jce.provider.ec.KmsECKeyFactory;
+import software.amazon.awssdk.services.kms.jce.provider.rsa.KmsRSAKeyFactory;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.AliasListEntry;
+import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
+import software.amazon.awssdk.services.kms.model.ListAliasesRequest;
+import software.amazon.awssdk.services.kms.model.ListAliasesResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class KmsKeyStore extends KeyStoreSpi {
+
+    @NonNull
+    private final KmsClient kmsClient;
+
+    @Override
+    public Enumeration<String> engineAliases() {
+        return Collections.enumeration(getAliases().stream().map(AliasListEntry::aliasName).collect(Collectors.toSet()));
+    }
+
+    @Override
+    public boolean engineContainsAlias(String alias) {
+        String prefixedAlias = getPrefixedAlias(alias);
+        return getAliases().stream().filter(e -> e.aliasName().equals(prefixedAlias)).findAny().isPresent();
+    }
+
+    @Override
+    public int engineSize() {
+        return getAliases().size();
+    }
+
+    @Override
+    public Key engineGetKey(String alias, char[] chars) throws NoSuchAlgorithmException, UnrecoverableKeyException {
+        String prefixedAlias = getPrefixedAlias(alias);
+        AliasListEntry aliasListEntry = getAliases().stream().filter(e -> e.aliasName().equals(prefixedAlias)).findAny().orElse(null);
+        if (aliasListEntry == null) return null;
+
+        DescribeKeyResponse describeKeyResponse = kmsClient.describeKey(builder -> builder.keyId(aliasListEntry.targetKeyId()));
+        if (!describeKeyResponse.keyMetadata().hasSigningAlgorithms()) {
+            throw new IllegalStateException("Unsupported Key type. Only signing keys are supported.");
+        }
+
+        boolean rsa = describeKeyResponse.keyMetadata().signingAlgorithmsAsStrings().stream().filter(a -> a.startsWith("RSA")).findAny().isPresent();
+        return rsa ? KmsRSAKeyFactory.getPrivateKey(describeKeyResponse.keyMetadata().keyId()) : KmsECKeyFactory.getPrivateKey(describeKeyResponse.keyMetadata().keyId());
+    }
+
+    private String getPrefixedAlias(String alias) {
+        return alias.startsWith("alias/") ? alias : "alias/" + alias;
+    }
+
+    private Set<AliasListEntry> getAliases() {
+        ListAliasesResponse listAliasesResponse = null;
+        String marker = null;
+        Set<AliasListEntry> aliases = new HashSet<>();
+
+        do {
+            listAliasesResponse = kmsClient.listAliases(ListAliasesRequest.builder().marker(marker).build());
+            aliases.addAll(listAliasesResponse.aliases());
+            marker = listAliasesResponse.nextMarker();
+        } while (listAliasesResponse.truncated());
+
+        return aliases;
+    }
+
+    @Override
+    public void engineLoad(InputStream inputStream, char[] chars) throws IOException, NoSuchAlgorithmException, CertificateException {
+    }
+
+    /*
+    UNSUPPORTED OPERATIONS
+     */
+
+    @Override
+    public Certificate[] engineGetCertificateChain(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Certificate engineGetCertificate(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date engineGetCreationDate(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void engineSetKeyEntry(String s, Key key, char[] chars, Certificate[] certificates) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void engineSetKeyEntry(String s, byte[] bytes, Certificate[] certificates) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void engineSetCertificateEntry(String s, Certificate certificate) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void engineDeleteEntry(String s) throws KeyStoreException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean engineIsKeyEntry(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean engineIsCertificateEntry(String s) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String engineGetCertificateAlias(Certificate certificate) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void engineStore(OutputStream outputStream, char[] chars) throws IOException, NoSuchAlgorithmException, CertificateException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKeyStore.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKeyStore.java
@@ -1,9 +1,9 @@
-package software.amazon.awssdk.services.kms.jce.provider;
+package net.corda.cli.plugins.packaging.aws.kms;
 
-import software.amazon.awssdk.services.kms.jce.provider.ec.KmsECKeyFactory;
-import software.amazon.awssdk.services.kms.jce.provider.rsa.KmsRSAKeyFactory;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import net.corda.cli.plugins.packaging.aws.kms.ec.KmsECKeyFactory;
+import net.corda.cli.plugins.packaging.aws.kms.rsa.KmsRSAKeyFactory;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.AliasListEntry;
 import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
@@ -13,10 +13,18 @@ import software.amazon.awssdk.services.kms.model.ListAliasesResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.security.*;
+import java.security.Key;
+import java.security.KeyStoreException;
+import java.security.KeyStoreSpi;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKeyStore.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsKeyStore.java
@@ -1,9 +1,8 @@
 package net.corda.cli.plugins.packaging.aws.kms;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import net.corda.cli.plugins.packaging.aws.kms.ec.KmsECKeyFactory;
 import net.corda.cli.plugins.packaging.aws.kms.rsa.KmsRSAKeyFactory;
+import org.jetbrains.annotations.NotNull;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.AliasListEntry;
 import software.amazon.awssdk.services.kms.model.DescribeKeyResponse;
@@ -24,14 +23,19 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
 public class KmsKeyStore extends KeyStoreSpi {
 
-    @NonNull
+    @NotNull
     private final KmsClient kmsClient;
+
+    public KmsKeyStore(KmsClient kmsClient) {
+        Objects.requireNonNull(kmsClient);
+        this.kmsClient = kmsClient;
+    }
 
     @Override
     public Enumeration<String> engineAliases() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsProvider.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsProvider.java
@@ -1,0 +1,54 @@
+package software.amazon.awssdk.services.kms.jce.provider;
+
+import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSignature;
+import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
+import lombok.NonNull;
+import software.amazon.awssdk.services.kms.KmsClient;
+
+import java.security.Provider;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+public class KmsProvider extends Provider {
+
+    public KmsProvider(@NonNull KmsClient kmsClient) {
+        super("KMS", "software.amazon.awssdk.services.kms.jce", "AWS KMS Provider");
+        registerSignatures(kmsClient);
+    }
+
+    private void registerSignatures(final KmsClient kmsClient) {
+        this.putService(new KmsKeyStoreService(this, kmsClient));
+        Stream.of(KmsSigningAlgorithm.values()).forEach(s -> this.putService(new KmsSignatureProviderService(this, kmsClient, s)));
+    }
+
+    private static class KmsKeyStoreService extends Service {
+
+        private final KmsClient kmsClient;
+
+        public KmsKeyStoreService(Provider provider, KmsClient kmsClient) {
+            super(provider, "KeyStore", "KMS", KmsKeyStore.class.getName(), Collections.emptyList(), Collections.emptyMap());
+            this.kmsClient = kmsClient;
+        }
+
+        public Object newInstance(Object constructorParameter) {
+            return new KmsKeyStore(kmsClient);
+        }
+    }
+
+    private static class KmsSignatureProviderService extends Service {
+
+        private final KmsClient kmsClient;
+        private final KmsSigningAlgorithm kmsSigningAlgorithm;
+
+        public KmsSignatureProviderService(Provider provider, KmsClient kmsClient, KmsSigningAlgorithm kmsSigningAlgorithm) {
+            super(provider, "Signature", kmsSigningAlgorithm.getAlgorithm(), KmsSignature.class.getName(), Collections.emptyList(), Collections.emptyMap());
+            this.kmsClient = kmsClient;
+            this.kmsSigningAlgorithm = kmsSigningAlgorithm;
+        }
+
+        public Object newInstance(Object constructorParameter) {
+            return new KmsSignature(kmsClient, kmsSigningAlgorithm);
+        }
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsProvider.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsProvider.java
@@ -1,6 +1,8 @@
 package net.corda.cli.plugins.packaging.aws.kms;
 
 import lombok.NonNull;
+import net.corda.cli.plugins.packaging.aws.kms.signature.KmsSignature;
+import net.corda.cli.plugins.packaging.aws.kms.signature.KmsSigningAlgorithm;
 import software.amazon.awssdk.services.kms.KmsClient;
 
 import java.security.Provider;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsProvider.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsProvider.java
@@ -1,18 +1,20 @@
 package net.corda.cli.plugins.packaging.aws.kms;
 
-import lombok.NonNull;
 import net.corda.cli.plugins.packaging.aws.kms.signature.KmsSignature;
 import net.corda.cli.plugins.packaging.aws.kms.signature.KmsSigningAlgorithm;
+import org.jetbrains.annotations.NotNull;
 import software.amazon.awssdk.services.kms.KmsClient;
 
 import java.security.Provider;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 public class KmsProvider extends Provider {
 
-    public KmsProvider(@NonNull KmsClient kmsClient) {
+    public KmsProvider(@NotNull KmsClient kmsClient) {
         super("KMS", "software.amazon.awssdk.services.kms.jce", "AWS KMS Provider");
+        Objects.requireNonNull(kmsClient);
         registerSignatures(kmsClient);
     }
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsProvider.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsProvider.java
@@ -1,7 +1,5 @@
-package software.amazon.awssdk.services.kms.jce.provider;
+package net.corda.cli.plugins.packaging.aws.kms;
 
-import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSignature;
-import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
 import lombok.NonNull;
 import software.amazon.awssdk.services.kms.KmsClient;
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsPublicKey.java
@@ -1,0 +1,9 @@
+package software.amazon.awssdk.services.kms.jce.provider;
+
+import java.security.PublicKey;
+
+public interface KmsPublicKey extends KmsKey {
+
+    PublicKey getPublicKey();
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/KmsPublicKey.java
@@ -1,4 +1,4 @@
-package software.amazon.awssdk.services.kms.jce.provider;
+package net.corda.cli.plugins.packaging.aws.kms;
 
 import java.security.PublicKey;
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/README.md
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/README.md
@@ -1,2 +1,6 @@
-The AWS KMS package is used for the KMS integration into Corda-cli tool.
-The classes are copied from https://github.com/aws-samples/aws-kms-jce and Lombok dependency is removed.
+The AWS KMS Java package contains JCE Provider classes (https://github.com/aws-samples/aws-kms-jce).
+They are useful for AWS KMS integration into `corda-cli` tool as they provide important interaction with KMS which
+cannot be achieved via AWS CLI.
+Original classes contain Lombok dependency, which was removed.
+
+Examples on how to use JCE Provider can be found in the original repo https://github.com/aws-samples/aws-kms-jce.

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/README.md
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/README.md
@@ -1,0 +1,2 @@
+The AWS KMS package is used for the KMS integration into Corda-cli tool.
+The classes are copied from https://github.com/aws-samples/aws-kms-jce and Lombok dependency is removed.

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
@@ -1,0 +1,79 @@
+package software.amazon.awssdk.services.kms.jce.provider.ec;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.X509EncodedKeySpec;
+
+public abstract class KmsECKeyFactory {
+
+    /**
+     * Retrieve KMS KeyPair reference (Private Key / Public Key) based on the keyId informed.
+     * Also fetch the real Public Key from KMS.
+     * Use only when it is necessary the real Public Key.
+     *
+     * @param kmsClient
+     * @param keyId
+     * @return
+     */
+    public static KeyPair getKeyPair(@NonNull KmsClient kmsClient, @NonNull String keyId) {
+        return new KeyPair(getPublicKey(kmsClient, keyId), getPrivateKey(keyId));
+    }
+
+    /**
+     * Retrieve KMS KeyPair reference (Private Key / Public Key) based on the keyId informed.
+     * The real Public Key is not fetched.
+     *
+     * @param keyId
+     * @return
+     */
+    public static KeyPair getKeyPair(@NonNull String keyId) {
+        return new KeyPair(getPublicKey(keyId), getPrivateKey(keyId));
+    }
+
+    /**
+     * Retrieve KMS Private Key reference based on the keyId informed.
+     *
+     * @param keyId
+     * @return
+     */
+    public static KmsECPrivateKey getPrivateKey(@NonNull String keyId) {
+        return new KmsECPrivateKey(keyId);
+    }
+
+    /**
+     * Retrieve KMS Public Key reference based on the keyId informed.
+     *
+     * @param keyId
+     * @return
+     */
+    public static KmsECPublicKey getPublicKey(@NonNull String keyId) {
+        return new KmsECPublicKey(keyId, null);
+    }
+
+    /**
+     * Retrieve KMS Public Key reference based on the keyId informed.
+     * Also fetch the real Public Key from KMS.
+     * Use only when it is necessary the real Public Key.
+     *
+     * @param kmsClient
+     * @param keyId
+     * @return
+     */
+    @SneakyThrows
+    public static KmsECPublicKey getPublicKey(@NonNull KmsClient kmsClient, @NonNull String keyId) {
+        GetPublicKeyRequest getPublicKeyRequest = GetPublicKeyRequest.builder().keyId(keyId).build();
+        GetPublicKeyResponse getPublicKeyResponse = kmsClient.getPublicKey(getPublicKeyRequest);
+
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(getPublicKeyResponse.publicKey().asByteArray());
+        KeyFactory keyFactory = KeyFactory.getInstance("EC");
+        return new KmsECPublicKey(keyId, (ECPublicKey) keyFactory.generatePublic(keySpec));
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
@@ -1,6 +1,6 @@
 package net.corda.cli.plugins.packaging.aws.kms.ec;
 
-import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Objects;
 
 public abstract class KmsECKeyFactory {
 
@@ -23,7 +24,9 @@ public abstract class KmsECKeyFactory {
      * @param keyId
      * @return
      */
-    public static KeyPair getKeyPair(@NonNull KmsClient kmsClient, @NonNull String keyId) {
+    public static KeyPair getKeyPair(@NotNull KmsClient kmsClient, @NotNull String keyId) {
+        Objects.requireNonNull(kmsClient);
+        Objects.requireNonNull(keyId);
         return new KeyPair(getPublicKey(kmsClient, keyId), getPrivateKey(keyId));
     }
 
@@ -34,7 +37,8 @@ public abstract class KmsECKeyFactory {
      * @param keyId
      * @return
      */
-    public static KeyPair getKeyPair(@NonNull String keyId) {
+    public static KeyPair getKeyPair(@NotNull String keyId) {
+        Objects.requireNonNull(keyId);
         return new KeyPair(getPublicKey(keyId), getPrivateKey(keyId));
     }
 
@@ -44,7 +48,8 @@ public abstract class KmsECKeyFactory {
      * @param keyId
      * @return
      */
-    public static KmsECPrivateKey getPrivateKey(@NonNull String keyId) {
+    public static KmsECPrivateKey getPrivateKey(@NotNull String keyId) {
+        Objects.requireNonNull(keyId);
         return new KmsECPrivateKey(keyId);
     }
 
@@ -54,7 +59,8 @@ public abstract class KmsECKeyFactory {
      * @param keyId
      * @return
      */
-    public static KmsECPublicKey getPublicKey(@NonNull String keyId) {
+    public static KmsECPublicKey getPublicKey(@NotNull String keyId) {
+        Objects.requireNonNull(keyId);
         return new KmsECPublicKey(keyId, null);
     }
 
@@ -67,7 +73,9 @@ public abstract class KmsECKeyFactory {
      * @param keyId
      * @return
      */
-    public static KmsECPublicKey getPublicKey(@NonNull KmsClient kmsClient, @NonNull String keyId) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    public static KmsECPublicKey getPublicKey(@NotNull KmsClient kmsClient, @NotNull String keyId) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        Objects.requireNonNull(kmsClient);
+        Objects.requireNonNull(keyId);
         GetPublicKeyRequest getPublicKeyRequest = GetPublicKeyRequest.builder().keyId(keyId).build();
         GetPublicKeyResponse getPublicKeyResponse = kmsClient.getPublicKey(getPublicKeyRequest);
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
@@ -1,4 +1,4 @@
-package software.amazon.awssdk.services.kms.jce.provider.ec;
+package net.corda.cli.plugins.packaging.aws.kms.ec;
 
 import lombok.NonNull;
 import lombok.SneakyThrows;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
@@ -24,7 +24,7 @@ public abstract class KmsECKeyFactory {
      * @param keyId
      * @return
      */
-    public static KeyPair getKeyPair(@NotNull KmsClient kmsClient, @NotNull String keyId) {
+    public static KeyPair getKeyPair(@NotNull KmsClient kmsClient, @NotNull String keyId) throws NoSuchAlgorithmException, InvalidKeySpecException {
         Objects.requireNonNull(kmsClient);
         Objects.requireNonNull(keyId);
         return new KeyPair(getPublicKey(kmsClient, keyId), getPrivateKey(keyId));

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECKeyFactory.java
@@ -1,14 +1,15 @@
 package net.corda.cli.plugins.packaging.aws.kms.ec;
 
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPublicKey;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 
 public abstract class KmsECKeyFactory {
@@ -66,8 +67,7 @@ public abstract class KmsECKeyFactory {
      * @param keyId
      * @return
      */
-    @SneakyThrows
-    public static KmsECPublicKey getPublicKey(@NonNull KmsClient kmsClient, @NonNull String keyId) {
+    public static KmsECPublicKey getPublicKey(@NonNull KmsClient kmsClient, @NonNull String keyId) throws NoSuchAlgorithmException, InvalidKeySpecException {
         GetPublicKeyRequest getPublicKeyRequest = GetPublicKeyRequest.builder().keyId(keyId).build();
         GetPublicKeyResponse getPublicKeyResponse = kmsClient.getPublicKey(getPublicKeyRequest);
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
@@ -1,0 +1,37 @@
+package software.amazon.awssdk.services.kms.jce.provider.ec;
+
+import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigInteger;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECParameterSpec;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class KmsECPrivateKey implements KmsKey, ECPrivateKey {
+
+    @NonNull
+    private final String id;
+    private final String algorithm = "EC";
+    private final String format = "PKCS#8";
+
+    @Override
+    public BigInteger getS() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ECParameterSpec getParams() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
@@ -1,10 +1,10 @@
-package software.amazon.awssdk.services.kms.jce.provider.ec;
+package net.corda.cli.plugins.packaging.aws.kms.ec;
 
-import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
 
 import java.math.BigInteger;
 import java.security.interfaces.ECPrivateKey;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
@@ -3,7 +3,7 @@ package net.corda.cli.plugins.packaging.aws.kms.ec;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
+import net.corda.cli.plugins.packaging.aws.kms.KmsKey;
 
 import java.math.BigInteger;
 import java.security.interfaces.ECPrivateKey;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
@@ -1,7 +1,6 @@
 package net.corda.cli.plugins.packaging.aws.kms.ec;
 
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
@@ -10,7 +9,6 @@ import java.math.BigInteger;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.ECParameterSpec;
 
-@Getter
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KmsECPrivateKey implements KmsKey, ECPrivateKey {
 
@@ -18,6 +16,21 @@ public class KmsECPrivateKey implements KmsKey, ECPrivateKey {
     private final String id;
     private final String algorithm = "EC";
     private final String format = "PKCS#8";
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    @Override
+    public String getFormat() {
+        return format;
+    }
 
     @Override
     public BigInteger getS() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPrivateKey.java
@@ -1,21 +1,24 @@
 package net.corda.cli.plugins.packaging.aws.kms.ec;
 
-import lombok.AccessLevel;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import net.corda.cli.plugins.packaging.aws.kms.KmsKey;
+import org.jetbrains.annotations.NotNull;
 
 import java.math.BigInteger;
 import java.security.interfaces.ECPrivateKey;
 import java.security.spec.ECParameterSpec;
+import java.util.Objects;
 
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KmsECPrivateKey implements KmsKey, ECPrivateKey {
 
-    @NonNull
+    @NotNull
     private final String id;
     private final String algorithm = "EC";
     private final String format = "PKCS#8";
+
+    public KmsECPrivateKey(String id) {
+        Objects.requireNonNull(id);
+        this.id = id;
+    }
 
     @Override
     public String getId() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
@@ -1,0 +1,46 @@
+package software.amazon.awssdk.services.kms.jce.provider.ec;
+
+import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class KmsECPublicKey implements KmsPublicKey, ECPublicKey {
+
+    @NonNull
+    private final String id;
+    private final ECPublicKey publicKey;
+
+    @Override
+    public ECPoint getW() {
+        return publicKey.getW();
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return publicKey.getAlgorithm();
+    }
+
+    @Override
+    public String getFormat() {
+        return publicKey.getFormat();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return publicKey.getEncoded();
+    }
+
+    @Override
+    public ECParameterSpec getParams() {
+        return publicKey.getParams();
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
@@ -1,20 +1,24 @@
 package net.corda.cli.plugins.packaging.aws.kms.ec;
 
-import lombok.AccessLevel;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import net.corda.cli.plugins.packaging.aws.kms.KmsPublicKey;
+import org.jetbrains.annotations.NotNull;
 
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
+import java.util.Objects;
 
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KmsECPublicKey implements KmsPublicKey, ECPublicKey {
 
-    @NonNull
+    @NotNull
     private final String id;
     private final ECPublicKey publicKey;
+
+    public KmsECPublicKey(String id, ECPublicKey publicKey) {
+        Objects.requireNonNull(id);
+        this.id = id;
+        this.publicKey = publicKey;
+    }
 
     public String getId() {
         return id;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
@@ -1,7 +1,6 @@
 package net.corda.cli.plugins.packaging.aws.kms.ec;
 
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
@@ -10,13 +9,21 @@ import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 
-@Getter
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KmsECPublicKey implements KmsPublicKey, ECPublicKey {
 
     @NonNull
     private final String id;
     private final ECPublicKey publicKey;
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public ECPublicKey getPublicKey() {
+        return publicKey;
+    }
 
     @Override
     public ECPoint getW() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
@@ -1,10 +1,10 @@
-package software.amazon.awssdk.services.kms.jce.provider.ec;
+package net.corda.cli.plugins.packaging.aws.kms.ec;
 
-import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
 
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/ec/KmsECPublicKey.java
@@ -3,7 +3,7 @@ package net.corda.cli.plugins.packaging.aws.kms.ec;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
+import net.corda.cli.plugins.packaging.aws.kms.KmsPublicKey;
 
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
@@ -1,0 +1,79 @@
+package software.amazon.awssdk.services.kms.jce.provider.rsa;
+
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.X509EncodedKeySpec;
+
+public abstract class KmsRSAKeyFactory {
+
+    /**
+     * Retrieve KMS KeyPair reference (Private Key / Public Key) based on the keyId informed.
+     * Also fetch the real Public Key from KMS.
+     * Use only when it is necessary the real Public Key.
+     *
+     * @param kmsClient
+     * @param keyId
+     * @return
+     */
+    public static KeyPair getKeyPair(@NonNull KmsClient kmsClient, @NonNull String keyId) {
+        return new KeyPair(getPublicKey(kmsClient, keyId), getPrivateKey(keyId));
+    }
+
+    /**
+     * Retrieve KMS KeyPair reference (Private Key / Public Key) based on the keyId informed.
+     * The real Public Key is not fetched.
+     *
+     * @param keyId
+     * @return
+     */
+    public static KeyPair getKeyPair(@NonNull String keyId) {
+        return new KeyPair(getPublicKey(keyId), getPrivateKey(keyId));
+    }
+
+    /**
+     * Retrieve KMS Private Key reference based on the keyId informed.
+     *
+     * @param keyId
+     * @return
+     */
+    public static KmsRSAPrivateKey getPrivateKey(@NonNull String keyId) {
+        return new KmsRSAPrivateKey(keyId);
+    }
+
+    /**
+     * Retrieve KMS Public Key reference based on the keyId informed.
+     *
+     * @param keyId
+     * @return
+     */
+    public static KmsRSAPublicKey getPublicKey(@NonNull String keyId) {
+        return new KmsRSAPublicKey(keyId, null);
+    }
+
+    /**
+     * Retrieve KMS Public Key reference based on the keyId informed.
+     * Also fetch the real Public Key from KMS.
+     * Use only when it is necessary the real Public Key.
+     *
+     * @param kmsClient
+     * @param keyId
+     * @return
+     */
+    @SneakyThrows
+    public static KmsRSAPublicKey getPublicKey(@NonNull KmsClient kmsClient, @NonNull String keyId) {
+        GetPublicKeyRequest getPublicKeyRequest = GetPublicKeyRequest.builder().keyId(keyId).build();
+        GetPublicKeyResponse getPublicKeyResponse = kmsClient.getPublicKey(getPublicKeyRequest);
+
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(getPublicKeyResponse.publicKey().asByteArray());
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return new KmsRSAPublicKey(keyId, (RSAPublicKey) keyFactory.generatePublic(keySpec));
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
@@ -24,7 +24,7 @@ public abstract class KmsRSAKeyFactory {
      * @param keyId
      * @return
      */
-    public static KeyPair getKeyPair(@NotNull KmsClient kmsClient, @NotNull String keyId) {
+    public static KeyPair getKeyPair(@NotNull KmsClient kmsClient, @NotNull String keyId) throws NoSuchAlgorithmException, InvalidKeySpecException {
         Objects.requireNonNull(kmsClient);
         Objects.requireNonNull(keyId);
         return new KeyPair(getPublicKey(kmsClient, keyId), getPrivateKey(keyId));

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
@@ -1,14 +1,15 @@
 package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
 import lombok.NonNull;
-import lombok.SneakyThrows;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 
 public abstract class KmsRSAKeyFactory {
@@ -66,8 +67,7 @@ public abstract class KmsRSAKeyFactory {
      * @param keyId
      * @return
      */
-    @SneakyThrows
-    public static KmsRSAPublicKey getPublicKey(@NonNull KmsClient kmsClient, @NonNull String keyId) {
+    public static KmsRSAPublicKey getPublicKey(@NonNull KmsClient kmsClient, @NonNull String keyId) throws NoSuchAlgorithmException, InvalidKeySpecException {
         GetPublicKeyRequest getPublicKeyRequest = GetPublicKeyRequest.builder().keyId(keyId).build();
         GetPublicKeyResponse getPublicKeyResponse = kmsClient.getPublicKey(getPublicKeyRequest);
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
@@ -1,6 +1,6 @@
 package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
-import lombok.NonNull;
+import org.jetbrains.annotations.NotNull;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Objects;
 
 public abstract class KmsRSAKeyFactory {
 
@@ -23,7 +24,9 @@ public abstract class KmsRSAKeyFactory {
      * @param keyId
      * @return
      */
-    public static KeyPair getKeyPair(@NonNull KmsClient kmsClient, @NonNull String keyId) {
+    public static KeyPair getKeyPair(@NotNull KmsClient kmsClient, @NotNull String keyId) {
+        Objects.requireNonNull(kmsClient);
+        Objects.requireNonNull(keyId);
         return new KeyPair(getPublicKey(kmsClient, keyId), getPrivateKey(keyId));
     }
 
@@ -34,7 +37,8 @@ public abstract class KmsRSAKeyFactory {
      * @param keyId
      * @return
      */
-    public static KeyPair getKeyPair(@NonNull String keyId) {
+    public static KeyPair getKeyPair(@NotNull String keyId) {
+        Objects.requireNonNull(keyId);
         return new KeyPair(getPublicKey(keyId), getPrivateKey(keyId));
     }
 
@@ -44,7 +48,8 @@ public abstract class KmsRSAKeyFactory {
      * @param keyId
      * @return
      */
-    public static KmsRSAPrivateKey getPrivateKey(@NonNull String keyId) {
+    public static KmsRSAPrivateKey getPrivateKey(@NotNull String keyId) {
+        Objects.requireNonNull(keyId);
         return new KmsRSAPrivateKey(keyId);
     }
 
@@ -54,7 +59,8 @@ public abstract class KmsRSAKeyFactory {
      * @param keyId
      * @return
      */
-    public static KmsRSAPublicKey getPublicKey(@NonNull String keyId) {
+    public static KmsRSAPublicKey getPublicKey(@NotNull String keyId) {
+        Objects.requireNonNull(keyId);
         return new KmsRSAPublicKey(keyId, null);
     }
 
@@ -67,7 +73,9 @@ public abstract class KmsRSAKeyFactory {
      * @param keyId
      * @return
      */
-    public static KmsRSAPublicKey getPublicKey(@NonNull KmsClient kmsClient, @NonNull String keyId) throws NoSuchAlgorithmException, InvalidKeySpecException {
+    public static KmsRSAPublicKey getPublicKey(@NotNull KmsClient kmsClient, @NotNull String keyId) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        Objects.requireNonNull(kmsClient);
+        Objects.requireNonNull(keyId);
         GetPublicKeyRequest getPublicKeyRequest = GetPublicKeyRequest.builder().keyId(keyId).build();
         GetPublicKeyResponse getPublicKeyResponse = kmsClient.getPublicKey(getPublicKeyRequest);
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAKeyFactory.java
@@ -1,4 +1,4 @@
-package software.amazon.awssdk.services.kms.jce.provider.rsa;
+package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
 import lombok.NonNull;
 import lombok.SneakyThrows;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
@@ -1,0 +1,36 @@
+package software.amazon.awssdk.services.kms.jce.provider.rsa;
+
+import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigInteger;
+import java.security.interfaces.RSAPrivateKey;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class KmsRSAPrivateKey implements KmsKey, RSAPrivateKey {
+
+    @NonNull
+    private final String id;
+    private final String algorithm = "RSA";
+    private final String format = "X.509";
+
+    @Override
+    public BigInteger getPrivateExponent() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BigInteger getModulus() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
@@ -3,7 +3,7 @@ package net.corda.cli.plugins.packaging.aws.kms.rsa;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
+import net.corda.cli.plugins.packaging.aws.kms.KmsKey;
 
 import java.math.BigInteger;
 import java.security.interfaces.RSAPrivateKey;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
@@ -1,7 +1,6 @@
 package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
@@ -9,7 +8,6 @@ import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
 import java.math.BigInteger;
 import java.security.interfaces.RSAPrivateKey;
 
-@Getter
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KmsRSAPrivateKey implements KmsKey, RSAPrivateKey {
 
@@ -17,6 +15,21 @@ public class KmsRSAPrivateKey implements KmsKey, RSAPrivateKey {
     private final String id;
     private final String algorithm = "RSA";
     private final String format = "X.509";
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    @Override
+    public String getFormat() {
+        return format;
+    }
 
     @Override
     public BigInteger getPrivateExponent() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
@@ -1,10 +1,10 @@
-package software.amazon.awssdk.services.kms.jce.provider.rsa;
+package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
-import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
 
 import java.math.BigInteger;
 import java.security.interfaces.RSAPrivateKey;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPrivateKey.java
@@ -1,20 +1,23 @@
 package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
-import lombok.AccessLevel;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import net.corda.cli.plugins.packaging.aws.kms.KmsKey;
+import org.jetbrains.annotations.NotNull;
 
 import java.math.BigInteger;
 import java.security.interfaces.RSAPrivateKey;
+import java.util.Objects;
 
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KmsRSAPrivateKey implements KmsKey, RSAPrivateKey {
 
-    @NonNull
+    @NotNull
     private final String id;
     private final String algorithm = "RSA";
     private final String format = "X.509";
+
+    public KmsRSAPrivateKey(String id) {
+        Objects.requireNonNull(id);
+        this.id = id;
+    }
 
     @Override
     public String getId() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
@@ -1,0 +1,45 @@
+package software.amazon.awssdk.services.kms.jce.provider.rsa;
+
+import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigInteger;
+import java.security.interfaces.RSAPublicKey;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class KmsRSAPublicKey implements KmsPublicKey, RSAPublicKey {
+
+    @NonNull
+    private final String id;
+    private final RSAPublicKey publicKey;
+
+    @Override
+    public BigInteger getPublicExponent() {
+        return publicKey.getPublicExponent();
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return publicKey.getAlgorithm();
+    }
+
+    @Override
+    public String getFormat() {
+        return publicKey.getFormat();
+    }
+
+    @Override
+    public byte[] getEncoded() {
+        return publicKey.getEncoded();
+    }
+
+    @Override
+    public BigInteger getModulus() {
+        return publicKey.getModulus();
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
@@ -3,7 +3,7 @@ package net.corda.cli.plugins.packaging.aws.kms.rsa;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
+import net.corda.cli.plugins.packaging.aws.kms.KmsPublicKey;
 
 import java.math.BigInteger;
 import java.security.interfaces.RSAPublicKey;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
@@ -1,7 +1,6 @@
 package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
@@ -9,13 +8,21 @@ import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
 import java.math.BigInteger;
 import java.security.interfaces.RSAPublicKey;
 
-@Getter
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KmsRSAPublicKey implements KmsPublicKey, RSAPublicKey {
 
     @NonNull
     private final String id;
     private final RSAPublicKey publicKey;
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public RSAPublicKey getPublicKey() {
+        return publicKey;
+    }
 
     @Override
     public BigInteger getPublicExponent() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
@@ -1,10 +1,10 @@
-package software.amazon.awssdk.services.kms.jce.provider.rsa;
+package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
-import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.kms.jce.provider.KmsPublicKey;
 
 import java.math.BigInteger;
 import java.security.interfaces.RSAPublicKey;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/rsa/KmsRSAPublicKey.java
@@ -1,19 +1,23 @@
 package net.corda.cli.plugins.packaging.aws.kms.rsa;
 
-import lombok.AccessLevel;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import net.corda.cli.plugins.packaging.aws.kms.KmsPublicKey;
+import org.jetbrains.annotations.NotNull;
 
 import java.math.BigInteger;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Objects;
 
-@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class KmsRSAPublicKey implements KmsPublicKey, RSAPublicKey {
 
-    @NonNull
+    @NotNull
     private final String id;
     private final RSAPublicKey publicKey;
+
+    public KmsRSAPublicKey(String id, RSAPublicKey publicKey) {
+        Objects.requireNonNull(id);
+        this.id = id;
+        this.publicKey = publicKey;
+    }
 
     public String getId() {
         return id;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSignature.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSignature.java
@@ -1,0 +1,108 @@
+package software.amazon.awssdk.services.kms.jce.provider.signature;
+
+import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
+import lombok.NonNull;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.MessageType;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import software.amazon.awssdk.services.kms.model.VerifyRequest;
+
+import java.security.*;
+
+public class KmsSignature extends SignatureSpi {
+
+    private final KmsClient kmsClient;
+
+    private SigningAlgorithmSpec signingAlgorithmSpec;
+    private MessageDigest messageDigest;
+    private boolean digestReset;
+
+    private KmsKey key;
+
+    public KmsSignature(@NonNull KmsClient kmsClient, @NonNull KmsSigningAlgorithm kmsSigningAlgorithm) {
+        this.kmsClient = kmsClient;
+        this.signingAlgorithmSpec = kmsSigningAlgorithm.getSigningAlgorithmSpec();
+        initMessageDigest(kmsSigningAlgorithm.getDigestAlgorithm());
+    }
+
+    @Override
+    protected void engineInitVerify(PublicKey publicKey) {
+        this.key = (KmsKey) publicKey;
+        this.resetDigest();
+    }
+
+    @Override
+    protected void engineInitSign(PrivateKey privateKey) {
+        this.key = (KmsKey) privateKey;
+        this.resetDigest();
+    }
+
+    @Override
+    protected void engineUpdate(byte bytes) {
+        this.messageDigest.update(bytes);
+        this.digestReset = false;
+    }
+
+    @Override
+    protected void engineUpdate(byte[] bytes, int off, int len) {
+        this.messageDigest.update(bytes, off, len);
+        this.digestReset = false;
+    }
+
+    @Override
+    protected byte[] engineSign() {
+        SignRequest signRequest = SignRequest.builder()
+                .keyId(key.getId())
+                .messageType(MessageType.DIGEST)
+                .signingAlgorithm(signingAlgorithmSpec)
+                .message(SdkBytes.fromByteArray(this.getDigestValue()))
+                .build();
+        return kmsClient.sign(signRequest).signature().asByteArray();
+    }
+
+    @Override
+    protected boolean engineVerify(byte[] signature) throws SignatureException {
+        VerifyRequest verifyRequest = VerifyRequest.builder()
+                .keyId(key.getId())
+                .messageType(MessageType.DIGEST)
+                .signingAlgorithm(signingAlgorithmSpec)
+                .message(SdkBytes.fromByteArray(this.getDigestValue()))
+                .signature(SdkBytes.fromByteArray(signature))
+                .build();
+        return kmsClient.verify(verifyRequest).signatureValid();
+    }
+
+    @Override
+    protected void engineSetParameter(String s, Object o) throws InvalidParameterException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Object engineGetParameter(String param) throws InvalidParameterException {
+        throw new UnsupportedOperationException();
+    }
+
+    private void initMessageDigest(String digestAlgorithm) {
+        try {
+            this.messageDigest = MessageDigest.getInstance(digestAlgorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new ProviderException(e);
+        }
+        this.digestReset = true;
+    }
+
+    private void resetDigest() {
+        if (!this.digestReset) {
+            this.messageDigest.reset();
+            this.digestReset = true;
+        }
+    }
+
+    private byte[] getDigestValue() {
+        this.digestReset = true;
+        return this.messageDigest.digest();
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSignature.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSignature.java
@@ -1,15 +1,22 @@
-package software.amazon.awssdk.services.kms.jce.provider.signature;
+package net.corda.cli.plugins.packaging.aws.kms.signature;
 
-import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
 import lombok.NonNull;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
 import software.amazon.awssdk.services.kms.model.MessageType;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import software.amazon.awssdk.services.kms.model.VerifyRequest;
 
-import java.security.*;
+import java.security.InvalidParameterException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.ProviderException;
+import java.security.PublicKey;
+import java.security.SignatureException;
+import java.security.SignatureSpi;
 
 public class KmsSignature extends SignatureSpi {
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSignature.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSignature.java
@@ -1,9 +1,9 @@
 package net.corda.cli.plugins.packaging.aws.kms.signature;
 
 import lombok.NonNull;
+import net.corda.cli.plugins.packaging.aws.kms.KmsKey;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
-import software.amazon.awssdk.services.kms.jce.provider.KmsKey;
 import software.amazon.awssdk.services.kms.model.MessageType;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSignature.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSignature.java
@@ -1,7 +1,7 @@
 package net.corda.cli.plugins.packaging.aws.kms.signature;
 
-import lombok.NonNull;
 import net.corda.cli.plugins.packaging.aws.kms.KmsKey;
+import org.jetbrains.annotations.NotNull;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.MessageType;
@@ -17,6 +17,7 @@ import java.security.ProviderException;
 import java.security.PublicKey;
 import java.security.SignatureException;
 import java.security.SignatureSpi;
+import java.util.Objects;
 
 public class KmsSignature extends SignatureSpi {
 
@@ -28,7 +29,9 @@ public class KmsSignature extends SignatureSpi {
 
     private KmsKey key;
 
-    public KmsSignature(@NonNull KmsClient kmsClient, @NonNull KmsSigningAlgorithm kmsSigningAlgorithm) {
+    public KmsSignature(@NotNull KmsClient kmsClient, @NotNull KmsSigningAlgorithm kmsSigningAlgorithm) {
+        Objects.requireNonNull(kmsClient);
+        Objects.requireNonNull(kmsSigningAlgorithm);
         this.kmsClient = kmsClient;
         this.signingAlgorithmSpec = kmsSigningAlgorithm.getSigningAlgorithmSpec();
         initMessageDigest(kmsSigningAlgorithm.getDigestAlgorithm());

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSigningAlgorithm.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSigningAlgorithm.java
@@ -1,0 +1,27 @@
+package software.amazon.awssdk.services.kms.jce.provider.signature;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+
+@Getter
+@AllArgsConstructor
+public enum KmsSigningAlgorithm {
+
+    RSASSA_PSS_SHA_256("RSASSA-PSS/SHA256", "SHA-256", SigningAlgorithmSpec.RSASSA_PSS_SHA_256),
+    RSASSA_PSS_SHA_384("RSASSA-PSS/SHA384", "SHA-384", SigningAlgorithmSpec.RSASSA_PSS_SHA_384),
+    RSASSA_PSS_SHA_512("RSASSA-PSS/SHA512", "SHA-512", SigningAlgorithmSpec.RSASSA_PSS_SHA_512),
+
+    RSASSA_PKCS1_V1_5_SHA_256("SHA256withRSA", "SHA-256", SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_256),
+    RSASSA_PKCS1_V1_5_SHA_384("SHA384withRSA", "SHA-384", SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_384),
+    RSASSA_PKCS1_V1_5_SHA_512("SHA512withRSA", "SHA-512", SigningAlgorithmSpec.RSASSA_PKCS1_V1_5_SHA_512),
+
+    ECDSA_SHA_256("SHA256withECDSA", "SHA-256", SigningAlgorithmSpec.ECDSA_SHA_256),
+    ECDSA_SHA_384("SHA384withECDSA", "SHA-384", SigningAlgorithmSpec.ECDSA_SHA_384),
+    ECDSA_SHA_512("SHA512withECDSA", "SHA-512", SigningAlgorithmSpec.ECDSA_SHA_512);
+
+    private final String algorithm;
+    private final String digestAlgorithm;
+    private final SigningAlgorithmSpec signingAlgorithmSpec;
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSigningAlgorithm.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSigningAlgorithm.java
@@ -1,9 +1,7 @@
 package net.corda.cli.plugins.packaging.aws.kms.signature;
 
-import lombok.AllArgsConstructor;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 
-@AllArgsConstructor
 public enum KmsSigningAlgorithm {
 
     RSASSA_PSS_SHA_256("RSASSA-PSS/SHA256", "SHA-256", SigningAlgorithmSpec.RSASSA_PSS_SHA_256),
@@ -21,6 +19,12 @@ public enum KmsSigningAlgorithm {
     private final String algorithm;
     private final String digestAlgorithm;
     private final SigningAlgorithmSpec signingAlgorithmSpec;
+
+    KmsSigningAlgorithm(String algorithm, String digestAlgorithm, SigningAlgorithmSpec signingAlgorithmSpec) {
+        this.algorithm = algorithm;
+        this.digestAlgorithm = digestAlgorithm;
+        this.signingAlgorithmSpec = signingAlgorithmSpec;
+    }
 
     public String getAlgorithm() {
         return algorithm;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSigningAlgorithm.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSigningAlgorithm.java
@@ -1,4 +1,4 @@
-package software.amazon.awssdk.services.kms.jce.provider.signature;
+package net.corda.cli.plugins.packaging.aws.kms.signature;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSigningAlgorithm.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/signature/KmsSigningAlgorithm.java
@@ -1,10 +1,8 @@
 package net.corda.cli.plugins.packaging.aws.kms.signature;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 
-@Getter
 @AllArgsConstructor
 public enum KmsSigningAlgorithm {
 
@@ -24,4 +22,15 @@ public enum KmsSigningAlgorithm {
     private final String digestAlgorithm;
     private final SigningAlgorithmSpec signingAlgorithmSpec;
 
+    public String getAlgorithm() {
+        return algorithm;
+    }
+
+    public String getDigestAlgorithm() {
+        return digestAlgorithm;
+    }
+
+    public SigningAlgorithmSpec getSigningAlgorithmSpec() {
+        return signingAlgorithmSpec;
+    }
 }

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/crt/SelfSignedCrtGenerator.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/crt/SelfSignedCrtGenerator.java
@@ -1,0 +1,71 @@
+package software.amazon.awssdk.services.kms.jce.util.crt;
+
+import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.util.io.pem.PemObject;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+public abstract class SelfSignedCrtGenerator {
+
+    /**
+     * Generate Self Signed Certificate for the CSR that was previously generated.
+     * @see software.amazon.awssdk.services.kms.jce.util.csr.CsrGenerator
+     *
+     * @param keyPair
+     * @param csr
+     * @param kmsSigningAlgorithm
+     * @param validity in days
+     * @return
+     */
+    public static String generate(KeyPair keyPair, String csr, KmsSigningAlgorithm kmsSigningAlgorithm, int validity) {
+
+        try {
+            PEMParser pemParser = new PEMParser(new InputStreamReader(new ByteArrayInputStream(csr.getBytes(StandardCharsets.UTF_8))));
+            PKCS10CertificationRequest csrRequest = (PKCS10CertificationRequest) pemParser.readObject();
+
+            X509v3CertificateBuilder certificateGenerator = new X509v3CertificateBuilder(
+                    csrRequest.getSubject(),
+                    new BigInteger("1"),
+                    Date.from(LocalDateTime.now().toInstant(ZoneOffset.UTC)),
+                    Date.from(LocalDateTime.now().plusDays(validity).toInstant(ZoneOffset.UTC)),
+                    csrRequest.getSubject(),
+                    csrRequest.getSubjectPublicKeyInfo()
+            );
+
+            ContentSigner signGen = new JcaContentSignerBuilder(kmsSigningAlgorithm.getAlgorithm()).setProvider("KMS").build(keyPair.getPrivate());
+
+            X509CertificateHolder holder = certificateGenerator.build(signGen);
+            CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+            X509Certificate certificate = (X509Certificate) certificateFactory.generateCertificate(new ByteArrayInputStream(holder.toASN1Structure().getEncoded()));
+
+            ByteArrayOutputStream certOutputStream = new ByteArrayOutputStream();
+            JcaPEMWriter pemWriter = new JcaPEMWriter(new OutputStreamWriter(certOutputStream));
+            pemWriter.writeObject(new PemObject("CERTIFICATE", certificate.getEncoded()));
+            pemWriter.close();
+
+            return certOutputStream.toString(StandardCharsets.UTF_8);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/crt/SelfSignedCrtGenerator.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/crt/SelfSignedCrtGenerator.java
@@ -1,5 +1,6 @@
 package net.corda.cli.plugins.packaging.aws.kms.utils.crt;
 
+import net.corda.cli.plugins.packaging.aws.kms.signature.KmsSigningAlgorithm;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.openssl.PEMParser;
@@ -8,7 +9,6 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.util.io.pem.PemObject;
-import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -27,7 +27,7 @@ public abstract class SelfSignedCrtGenerator {
 
     /**
      * Generate Self Signed Certificate for the CSR that was previously generated.
-     * @see software.amazon.awssdk.services.kms.jce.util.csr.CsrGenerator
+     * @see net.corda.cli.plugins.packaging.aws.kms.utils.csr.CsrGenerator
      *
      * @param keyPair
      * @param csr

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/crt/SelfSignedCrtGenerator.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/crt/SelfSignedCrtGenerator.java
@@ -1,6 +1,5 @@
-package software.amazon.awssdk.services.kms.jce.util.crt;
+package net.corda.cli.plugins.packaging.aws.kms.utils.crt;
 
-import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.openssl.PEMParser;
@@ -9,6 +8,7 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.util.io.pem.PemObject;
+import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrGenerator.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrGenerator.java
@@ -1,0 +1,48 @@
+package software.amazon.awssdk.services.kms.jce.util.csr;
+
+import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+
+import javax.security.auth.x500.X500Principal;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+
+public abstract class CsrGenerator {
+
+    /**
+     * Generate CSR.
+     *
+     * @param keyPair
+     * @param csrInfo
+     * @param kmsSigningAlgorithm
+     * @return
+     */
+    public static String generate(KeyPair keyPair, CsrInfo csrInfo, KmsSigningAlgorithm kmsSigningAlgorithm) {
+        try {
+            X500Principal subject = new X500Principal(csrInfo.toString());
+
+            ContentSigner signGen = new JcaContentSignerBuilder(kmsSigningAlgorithm.getAlgorithm()).setProvider("KMS").build(keyPair.getPrivate());
+
+            PKCS10CertificationRequestBuilder builder = new JcaPKCS10CertificationRequestBuilder(subject, keyPair.getPublic());
+            PKCS10CertificationRequest csr = builder.build(signGen);
+
+            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            JcaPEMWriter pemWriter = new JcaPEMWriter(new OutputStreamWriter(byteArrayOutputStream));
+            pemWriter.writeObject(csr);
+            pemWriter.close();
+
+            return byteArrayOutputStream.toString(StandardCharsets.UTF_8);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrGenerator.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrGenerator.java
@@ -1,12 +1,12 @@
 package net.corda.cli.plugins.packaging.aws.kms.utils.csr;
 
+import net.corda.cli.plugins.packaging.aws.kms.signature.KmsSigningAlgorithm;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
-import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
 
 import javax.security.auth.x500.X500Principal;
 import java.io.ByteArrayOutputStream;
@@ -24,7 +24,7 @@ public abstract class CsrGenerator {
      * @param kmsSigningAlgorithm
      * @return
      */
-    public static String generate(KeyPair keyPair, software.amazon.awssdk.services.kms.jce.util.csr.CsrInfo csrInfo, KmsSigningAlgorithm kmsSigningAlgorithm) {
+    public static String generate(KeyPair keyPair, CsrInfo csrInfo, KmsSigningAlgorithm kmsSigningAlgorithm) {
         try {
             X500Principal subject = new X500Principal(csrInfo.toString());
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrGenerator.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrGenerator.java
@@ -1,12 +1,12 @@
-package software.amazon.awssdk.services.kms.jce.util.csr;
+package net.corda.cli.plugins.packaging.aws.kms.utils.csr;
 
-import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.bouncycastle.pkcs.PKCS10CertificationRequestBuilder;
 import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder;
+import software.amazon.awssdk.services.kms.jce.provider.signature.KmsSigningAlgorithm;
 
 import javax.security.auth.x500.X500Principal;
 import java.io.ByteArrayOutputStream;
@@ -24,7 +24,7 @@ public abstract class CsrGenerator {
      * @param kmsSigningAlgorithm
      * @return
      */
-    public static String generate(KeyPair keyPair, CsrInfo csrInfo, KmsSigningAlgorithm kmsSigningAlgorithm) {
+    public static String generate(KeyPair keyPair, software.amazon.awssdk.services.kms.jce.util.csr.CsrInfo csrInfo, KmsSigningAlgorithm kmsSigningAlgorithm) {
         try {
             X500Principal subject = new X500Principal(csrInfo.toString());
 

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
@@ -1,0 +1,39 @@
+package software.amazon.awssdk.services.kms.jce.util.csr;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CsrInfo {
+
+    private final String cn;
+    private final String ou;
+    private final String o;
+    private final String l;
+    private final String st;
+    private final String c;
+    private final String mail;
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+
+        append(builder, "CN", cn);
+        append(builder, "OU", ou);
+        append(builder, "O", o);
+        append(builder, "L", l);
+        append(builder, "ST", st);
+        append(builder, "C", c);
+        append(builder, "emailAddress", mail);
+
+        return builder.toString();
+    }
+
+    private void append(StringBuilder builder, String attribute, String value) {
+        if (value != null) {
+            if (builder.length() > 0) builder.append(", ");
+            builder.append(attribute).append("=").append(value);
+        }
+    }
+}

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
@@ -72,24 +72,50 @@ public class CsrInfo {
 
     // Builder class
     public static class CsrInfoBuilder {
+        private String cn;
+        private String ou;
+        private String o;
+        private String l;
+        private String st;
+        private String c;
+        private String mail;
 
-        private final String cn;
-        private final String ou;
-        private final String o;
-        private final String l;
-        private final String st;
-        private final String c;
-        private final String mail;
+        public CsrInfoBuilder() {
+        }
 
-
-        public CsrInfoBuilder(String cn, String ou, String o, String l, String st, String c, String mail) {
+        public CsrInfoBuilder cn(String cn) {
             this.cn = cn;
+            return this;
+        }
+
+        public CsrInfoBuilder ou(String ou) {
             this.ou = ou;
+            return this;
+        }
+
+        public CsrInfoBuilder o(String o) {
             this.o = o;
+            return this;
+        }
+
+        public CsrInfoBuilder l(String l) {
             this.l = l;
+            return this;
+        }
+
+        public CsrInfoBuilder st(String st) {
             this.st = st;
+            return this;
+        }
+
+        public CsrInfoBuilder c(String c) {
             this.c = c;
+            return this;
+        }
+
+        public CsrInfoBuilder mail(String mail) {
             this.mail = mail;
+            return this;
         }
 
         public CsrInfo build() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
@@ -1,8 +1,5 @@
 package net.corda.cli.plugins.packaging.aws.kms.utils.csr;
 
-import lombok.Builder;
-
-@Builder
 public class CsrInfo {
 
     private final String cn;
@@ -60,6 +57,43 @@ public class CsrInfo {
         if (value != null) {
             if (builder.length() > 0) builder.append(", ");
             builder.append(attribute).append("=").append(value);
+        }
+    }
+
+    private CsrInfo(CsrInfoBuilder builder) {
+        this.cn = builder.cn;
+        this.ou = builder.ou;
+        this.o = builder.o;
+        this.l = builder.l;
+        this.st = builder.st;
+        this.c = builder.c;
+        this.mail = builder.mail;
+    }
+
+    // Builder class
+    public static class CsrInfoBuilder {
+
+        private final String cn;
+        private final String ou;
+        private final String o;
+        private final String l;
+        private final String st;
+        private final String c;
+        private final String mail;
+
+
+        public CsrInfoBuilder(String cn, String ou, String o, String l, String st, String c, String mail) {
+            this.cn = cn;
+            this.ou = ou;
+            this.o = o;
+            this.l = l;
+            this.st = st;
+            this.c = c;
+            this.mail = mail;
+        }
+
+        public CsrInfo build() {
+            return new CsrInfo(this);
         }
     }
 }

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
@@ -1,9 +1,7 @@
 package net.corda.cli.plugins.packaging.aws.kms.utils.csr;
 
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
 public class CsrInfo {
 
@@ -14,6 +12,34 @@ public class CsrInfo {
     private final String st;
     private final String c;
     private final String mail;
+
+    public String getCn() {
+        return cn;
+    }
+
+    public String getOu() {
+        return ou;
+    }
+
+    public String getO() {
+        return o;
+    }
+
+    public String getL() {
+        return l;
+    }
+
+    public String getSt() {
+        return st;
+    }
+
+    public String getC() {
+        return c;
+    }
+
+    public String getMail() {
+        return mail;
+    }
 
     @Override
     public String toString() {

--- a/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
+++ b/tools/plugins/package/src/main/java/net/corda/cli/plugins/packaging/aws/kms/utils/csr/CsrInfo.java
@@ -1,4 +1,4 @@
-package software.amazon.awssdk.services.kms.jce.util.csr;
+package net.corda.cli.plugins.packaging.aws.kms.utils.csr;
 
 import lombok.Builder;
 import lombok.Getter;


### PR DESCRIPTION
This is the first step of creating an internal tool (modified `corda-cli`) to allow signing CPx with the AWS KMS key.
JCE Provider (https://github.com/aws-samples/aws-kms-jce) contains helpful classes needed to interact with AWS KMS.

Changes:
* JCE Java classes are copied to runtime-os repo
* Lombok dependencies are removed from JCE Java classes