### PR TITLE
CORE-7074 - move to official micrometer release

### DIFF
--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -38,12 +38,12 @@ dependencies {
         }
     }
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation ("net.corda.micrometer:micrometer-core:$micrometerVersion") {
+    implementation ("io.micrometer:micrometer-core:$micrometerVersion") {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
         exclude group: 'org.latencyutils', module: 'LatencyUtils'
     }
-    implementation "net.corda.micrometer:micrometer-registry-prometheus:$micrometerVersion"
+    implementation "io.micrometer:micrometer-registry-prometheus:$micrometerVersion"
 
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly "org.apache.commons:commons-lang3:$commonsLangVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -197,19 +197,6 @@ allprojects {
                     includeGroup 'antlr'
                 }
             }
-
-            // NOTE: this block needs to be removed once Micrometer release 1.11.0 
-            // and code in this project is updated to use this version rather than the forked version.
-            exclusiveContent {
-                forRepository {
-                    maven {
-                        url "$artifactoryContextUrl/corda-dependencies"
-                    }
-                }
-                filter {
-                    includeGroup 'net.corda.micrometer'
-                }
-            }
         }
     }
 

--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -17,7 +17,7 @@ quasar {
         'com.networknt.schema**',
         'com.typesafe.**',
         'de.javakaffee.kryoserializers**',
-        'net.corda.micrometer.**',
+        'io.micrometer:micrometer.**',
         'javax.**',
         'kotlin**',
         'org.apache.**',

--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -17,7 +17,7 @@ quasar {
         'com.networknt.schema**',
         'com.typesafe.**',
         'de.javakaffee.kryoserializers**',
-        'io.micrometer:micrometer.**',
+        'io.micrometer.**',
         'javax.**',
         'kotlin**',
         'org.apache.**',

--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
-    api ("net.corda.micrometer:micrometer-core:$micrometerVersion") {
+    api ("io.micrometer:micrometer-core:$micrometerVersion") {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.latencyutils', module: 'LatencyUtils'
     }


### PR DESCRIPTION
Remove dependency on R3 compiled version of Micrometer, since our patch was merged in the official version.