### PR TITLE
CORE-13593: Restore default registration of SerializedLambda serializer.

### DIFF
--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
@@ -104,6 +104,7 @@ class DefaultKryoCustomizer {
 
                 addDefaultSerializer(LinkedEntrySetSerializer.serializedType, LinkedEntrySetSerializer)
 
+                register(java.lang.invoke.SerializedLambda::class.java)
                 register(ClosureSerializer.Closure::class.java, CordaClosureSerializer)
 
                 addDefaultSerializer(Throwable::class.java, object: BaseSerializerFactory<ThrowableSerializer<*>>() {


### PR DESCRIPTION
Ensure that Kryo never needs to create a serializer for `SerializedLambda` "on the fly".