### PR TITLE
NOTICK: Add worker extraArgs

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -134,7 +134,9 @@ spec:
             {{- end }}
             '-r', '{{ .Values.bootstrap.kafka.replicas }}',
             '-p', '{{ .Values.bootstrap.kafka.partitions }}',
-            'connect'{{- if .Values.bootstrap.kafka.cleanup }},
+            'connect',
+            '-w',
+            '300'{{- if .Values.bootstrap.kafka.cleanup }},
             '-d'
             {{- end }}
           ]

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -272,6 +272,9 @@ spec:
           - "-ddatabase.jdbc.directory=/opt/jdbc-driver"
           - "-ddatabase.pool.max_size={{ .clusterDbConnectionPool.maxSize }}"
           {{- end }}
+          {{- range $i, $arg := .extraArgs }}
+          - {{ $arg | quote }}
+          {{- end }}
           {{- range $i, $arg := $optionalArgs.additionalWorkerArgs }}
           - {{ $arg | quote }}
           {{- end }}

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1111,6 +1111,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "extraArgs": {},
                                 "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
@@ -1150,6 +1151,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "extraArgs": {},
                                 "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
@@ -1219,6 +1221,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "extraArgs": {},
                                 "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
@@ -1277,6 +1280,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "extraArgs": {},
                                 "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
@@ -1301,6 +1305,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "extraArgs": {},
                                 "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
@@ -1545,6 +1550,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "extraArgs": {},
                                 "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
@@ -1596,6 +1602,7 @@
                             "properties": {
                                 "image": {},
                                 "javaOptions": {},
+                                "extraArgs": {},
                                 "annotations": {},
                                 "replicaCount": {},
                                 "debug": {},
@@ -1948,6 +1955,20 @@
                 },
                 "javaOptions": {
                     "type": "string"
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "default": [],
+                    "title": "extra arguments",
+                    "items": {
+                        "type":"string"
+                    },
+                    "examples": [
+                        [
+                            "-mheartbeat.interval.ms=3000",
+                            "-msession.timeout.ms=45000"
+                        ]
+                    ]
                 },
                 "annotations": {
                     "type": "object",

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -413,6 +413,8 @@ workers:
     annotations: {}
     # -- additional Java options for the crypto worker
     javaOptions: "-XX:MaxRAMPercentage=75"
+    # -- list of extra arguments for the crypto worker
+    extraArgs: []
     # crypto worker debug configuration
     debug:
       # -- run crypto worker with debug enabled
@@ -483,6 +485,8 @@ workers:
     annotations: {}
     # -- additional Java options for the DB worker
     javaOptions: "-XX:MaxRAMPercentage=75"
+    # -- list of extra arguments for the DB worker
+    extraArgs: []
     # DB worker debug configuration
     debug:
       # -- run DB worker with debug enabled
@@ -554,6 +558,8 @@ workers:
     annotations: {}
     # -- additional Java options for the flow worker
     javaOptions: "-XX:MaxRAMPercentage=75"
+    # -- list of extra arguments for the flow worker
+    extraArgs: []
     # flow worker debug configuration
     debug:
       # -- run flow worker with debug enabled
@@ -622,6 +628,8 @@ workers:
     annotations: {}
     # -- additional Java options for the membership worker
     javaOptions: "-XX:MaxRAMPercentage=75"
+    # -- list of extra arguments for the membership worker
+    extraArgs: []
     # membership worker debug configuration
     debug:
       # -- run membership worker with debug enabled
@@ -688,6 +696,8 @@ workers:
     annotations: {}
     # -- additional Java options for the rest worker
     javaOptions: "-XX:MaxRAMPercentage=75"
+    # -- list of extra arguments for the REST worker
+    extraArgs: []
     # REST worker debug configuration
     debug:
       # -- run REST worker with debug enabled
@@ -794,6 +804,8 @@ workers:
     annotations: {}
     # -- additional Java options for the P2P link manager worker
     javaOptions: "-XX:MaxRAMPercentage=75"
+    # -- list of extra arguments for the P2P link manager worker
+    extraArgs: []
     # p2p-link-manager worker debug configuration
     debug:
       # -- run P2P link manager worker with debug enabled
@@ -860,6 +872,8 @@ workers:
     annotations: {}
     # -- additional Java options for the P2P gateway worker
     javaOptions: "-XX:MaxRAMPercentage=75"
+    # -- list of extra arguments for the P2P gateway worker
+    extraArgs: []
     # p2p-gateway worker debug configuration
     debug:
       # -- run P2P gateway worker with debug enabled


### PR DESCRIPTION
Enables the addition of extra arguments to a worker. For example:

```
workers:
  crypto:
    extraArgs:
      - "-mheartbeat.interval.ms=3000"
```