### PR TITLE
NOTICK: Restrict flow messaging to AMQP serializable types.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/utils/SessionUtils.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/utils/SessionUtils.kt
@@ -1,17 +1,31 @@
+@file:JvmName("SessionUtils")
 package net.corda.flow.application.sessions.utils
 
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.flow.fiber.FlowFiberService
+import net.corda.internal.serialization.amqp.AMQPNotSerializableException
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
-internal object SessionUtils {
-    fun verifySessionStatusNotErrorOrClose(sessionId: String, flowFiberService: FlowFiberService) {
-        val status = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.getSessionState(
-            sessionId
-        )?.status
+fun verifySessionStatusNotErrorOrClose(sessionId: String, flowFiberService: FlowFiberService) {
+    val status = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.getSessionState(
+        sessionId
+    )?.status
 
-        if (setOf(SessionStateType.CLOSED, SessionStateType.ERROR).contains(status)) {
-            throw CordaRuntimeException("Session: $sessionId Status is ${status?.name ?: "NULL"}")
-        }
+    if (setOf(SessionStateType.CLOSED, SessionStateType.ERROR).contains(status)) {
+        throw CordaRuntimeException("Session: $sessionId Status is ${status?.name ?: "NULL"}")
+    }
+}
+
+@Suppress("ComplexCondition")
+fun requireAMQPSerializable(clazz: Class<*>) {
+    if (!clazz.isAnnotationPresent(CordaSerializable::class.java)
+            && !clazz.isInterface
+            && !clazz.isEnum
+            && !Collection::class.java.isAssignableFrom(clazz)
+            && !Map::class.java.isAssignableFrom(clazz)) {
+        throw AMQPNotSerializableException(
+            clazz,
+            "Class \"${clazz.name}\" is not annotated with @CordaSerializable.")
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/versioning/impl/sessions/VersionReceivingFlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/versioning/impl/sessions/VersionReceivingFlowSessionImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.application.versioning.impl.sessions
 
 import net.corda.flow.application.sessions.FlowSessionInternal
+import net.corda.flow.application.sessions.utils.requireAMQPSerializable
 import net.corda.utilities.reflection.castIfPossible
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
@@ -45,6 +46,7 @@ class VersionReceivingFlowSessionImpl(
     }
 
     private fun <R: Any> getInitialPayload(receiveType: Class<R>): R {
+        requireAMQPSerializable(receiveType)
         val payload = serializationService.deserialize(initialSerializedPayload, receiveType)
         return receiveType.castIfPossible(payload) ?: throw CordaRuntimeException(
             "Expecting to receive a $receiveType but received a ${initialSerializedPayload::class.java.name} instead, payload: " +

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/versioning/impl/sessions/VersionSendingFlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/versioning/impl/sessions/VersionSendingFlowSessionImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.application.versioning.impl.sessions
 
 import net.corda.flow.application.sessions.FlowSessionInternal
+import net.corda.flow.application.sessions.utils.requireAMQPSerializable
 import net.corda.flow.application.versioning.impl.AgreedVersion
 import net.corda.flow.application.versioning.impl.AgreedVersionAndPayload
 import net.corda.v5.application.serialization.SerializationService
@@ -110,6 +111,7 @@ class VersionSendingFlowSessionImpl(
     }
 
     private fun getPayloadToSend(payload: Any): Any {
+        requireAMQPSerializable(payload::class.java)
         return if (hasSentInitialPayload) {
             payload
         } else {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/PersistenceServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/PersistenceServiceImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.application.persistence
 
 import java.nio.ByteBuffer
+import javax.persistence.Entity
 import net.corda.flow.application.persistence.external.events.AbstractPersistenceExternalEventFactory
 import net.corda.flow.application.persistence.external.events.FindExternalEventFactory
 import net.corda.flow.application.persistence.external.events.MergeExternalEventFactory
@@ -213,5 +214,6 @@ class PersistenceServiceImplTest {
         verify(pagedQueryFactory).createNamedParameterizedQuery<TestObject>(any(), any())
     }
 
+    @Entity
     class TestObject
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionFactoryImplTest.kt
@@ -8,6 +8,7 @@ import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.state.asFlowContext
 import net.corda.internal.serialization.SerializedBytesImpl
 import net.corda.v5.application.messaging.FlowContextPropertiesBuilder
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -22,9 +23,12 @@ import org.mockito.kotlin.whenever
 
 class FlowSessionFactoryImplTest {
 
+    @CordaSerializable
+    data class Payload(val message: String)
+
     private companion object {
         const val SESSION_ID = "session id"
-        const val HI = "hi"
+        val HI = Payload("hi")
     }
 
     private val contextMap = mapOf("key" to "value")
@@ -38,7 +42,7 @@ class FlowSessionFactoryImplTest {
     @BeforeEach
     fun setup() {
         serializationService.apply {
-            whenever(serialize(HI)).thenReturn(SerializedBytesImpl(HI.toByteArray()))
+            whenever(serialize(HI)).thenReturn(SerializedBytesImpl(HI.message.toByteArray()))
         }
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/utils/SessionUtilsTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/utils/SessionUtilsTest.kt
@@ -37,7 +37,7 @@ class SessionUtilsTest {
 
         whenever(sessionState.status).thenReturn(sessionStateType)
         assertThrows<CordaRuntimeException> {
-            SessionUtils.verifySessionStatusNotErrorOrClose(SESSION_ID, flowFiberService)
+            verifySessionStatusNotErrorOrClose(SESSION_ID, flowFiberService)
         }
     }
 
@@ -46,7 +46,7 @@ class SessionUtilsTest {
     fun `verifySessionStatusNotErrorOrClose doesnt throw on all types`(sessionStateType: SessionStateType) {
         whenever(sessionState.status).thenReturn(sessionStateType)
         assertDoesNotThrow {
-            SessionUtils.verifySessionStatusNotErrorOrClose(SESSION_ID, flowFiberService)
+            verifySessionStatusNotErrorOrClose(SESSION_ID, flowFiberService)
         }
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/versioning/impl/sessions/VersionReceivingFlowSessionImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/versioning/impl/sessions/VersionReceivingFlowSessionImplTest.kt
@@ -2,6 +2,7 @@ package net.corda.flow.application.versioning.impl.sessions
 
 import net.corda.flow.application.sessions.FlowSessionInternal
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.CordaSerializable
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -14,9 +15,12 @@ import org.mockito.kotlin.whenever
 
 class VersionReceivingFlowSessionImplTest {
 
+    @CordaSerializable
+    data class Payload(val message: String)
+
     private companion object {
-        const val PAYLOAD = "payload"
-        const val INITIAL_PAYLOAD = "initial payload"
+        val PAYLOAD = Payload("payload")
+        val INITIAL_PAYLOAD = Payload("initial payload")
         val SERIALIZED_INITIAL_PAYLOAD = byteArrayOf(1, 1, 1, 1)
     }
 
@@ -27,95 +31,95 @@ class VersionReceivingFlowSessionImplTest {
 
     @BeforeEach
     fun beforeEach() {
-        whenever(serializationService.deserialize(SERIALIZED_INITIAL_PAYLOAD, Any::class.java)).thenReturn(INITIAL_PAYLOAD)
-        whenever(delegate.receive(Any::class.java)).thenReturn(PAYLOAD)
-        whenever(delegate.sendAndReceive(eq(Any::class.java), any())).thenReturn(PAYLOAD)
+        whenever(serializationService.deserialize(SERIALIZED_INITIAL_PAYLOAD, Payload::class.java)).thenReturn(INITIAL_PAYLOAD)
+        whenever(delegate.receive(Payload::class.java)).thenReturn(PAYLOAD)
+        whenever(delegate.sendAndReceive(eq(Payload::class.java), any())).thenReturn(PAYLOAD)
     }
 
     @Test
     fun `extracts the received payload from the initial payload the first time receive is called`() {
-        assertThat(session.receive(Any::class.java)).isEqualTo(INITIAL_PAYLOAD)
-        verify(delegate, never()).receive(Any::class.java)
-        verify(serializationService).deserialize(SERIALIZED_INITIAL_PAYLOAD, Any::class.java)
+        assertThat(session.receive(Payload::class.java)).isEqualTo(INITIAL_PAYLOAD)
+        verify(delegate, never()).receive(Payload::class.java)
+        verify(serializationService).deserialize(SERIALIZED_INITIAL_PAYLOAD, Payload::class.java)
     }
 
     @Test
     fun `extracts the received payload from the initial payload and does a separate send the first time sendAndReceive is called`() {
-        assertThat(session.sendAndReceive(Any::class.java, PAYLOAD)).isEqualTo(INITIAL_PAYLOAD)
-        verify(delegate, never()).sendAndReceive(eq(Any::class.java), any())
+        assertThat(session.sendAndReceive(Payload::class.java, PAYLOAD)).isEqualTo(INITIAL_PAYLOAD)
+        verify(delegate, never()).sendAndReceive(eq(Payload::class.java), any())
         verify(delegate).send(PAYLOAD)
-        verify(serializationService).deserialize(SERIALIZED_INITIAL_PAYLOAD, Any::class.java)
+        verify(serializationService).deserialize(SERIALIZED_INITIAL_PAYLOAD, Payload::class.java)
     }
 
     @Test
     fun `extracts the received payload from the initial payload the first time getInitialPayloadIfNotAlreadyReceived is called`() {
-        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Any::class.java)).isEqualTo(INITIAL_PAYLOAD)
-        verify(serializationService).deserialize(SERIALIZED_INITIAL_PAYLOAD, Any::class.java)
+        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Payload::class.java)).isEqualTo(INITIAL_PAYLOAD)
+        verify(serializationService).deserialize(SERIALIZED_INITIAL_PAYLOAD, Payload::class.java)
     }
 
     @Test
     fun `does a normal receive after the session has done a receive`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
-        assertThat(session.receive(Any::class.java)).isEqualTo(PAYLOAD)
-        verify(delegate).receive(Any::class.java)
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
+        assertThat(session.receive(Payload::class.java)).isEqualTo(PAYLOAD)
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
     fun `does a normal receive after the session has done a sendAndReceive`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(eq(Any::class.java), any())
-        assertThat(session.receive(Any::class.java)).isEqualTo(PAYLOAD)
-        verify(delegate).receive(Any::class.java)
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(eq(Payload::class.java), any())
+        assertThat(session.receive(Payload::class.java)).isEqualTo(PAYLOAD)
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
     fun `does a normal receive after getInitialPayloadIfNotAlreadyReceived is called`() {
-        session.getInitialPayloadIfNotAlreadyReceived(Any::class.java)
-        assertThat(session.receive(Any::class.java)).isEqualTo(PAYLOAD)
-        verify(delegate).receive(Any::class.java)
+        session.getInitialPayloadIfNotAlreadyReceived(Payload::class.java)
+        assertThat(session.receive(Payload::class.java)).isEqualTo(PAYLOAD)
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
     fun `does a normal sendAndReceive after the session has done a receive`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
-        assertThat(session.sendAndReceive(Any::class.java, PAYLOAD)).isEqualTo(PAYLOAD)
-        verify(delegate).sendAndReceive(Any::class.java, PAYLOAD)
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
+        assertThat(session.sendAndReceive(Payload::class.java, PAYLOAD)).isEqualTo(PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, PAYLOAD)
     }
 
     @Test
     fun `does a normal sendAndReceive after the session has done a sendAndReceive`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(eq(Any::class.java), any())
-        assertThat(session.sendAndReceive(Any::class.java, PAYLOAD)).isEqualTo(PAYLOAD)
-        verify(delegate).sendAndReceive(Any::class.java, PAYLOAD)
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(eq(Payload::class.java), any())
+        assertThat(session.sendAndReceive(Payload::class.java, PAYLOAD)).isEqualTo(PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, PAYLOAD)
     }
 
     @Test
     fun `does a normal sendAndReceive after getInitialPayloadIfNotAlreadyReceived is called`() {
-        session.getInitialPayloadIfNotAlreadyReceived(Any::class.java)
-        assertThat(session.sendAndReceive(Any::class.java, PAYLOAD)).isEqualTo(PAYLOAD)
-        verify(delegate).sendAndReceive(Any::class.java, PAYLOAD)
+        session.getInitialPayloadIfNotAlreadyReceived(Payload::class.java)
+        assertThat(session.sendAndReceive(Payload::class.java, PAYLOAD)).isEqualTo(PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, PAYLOAD)
     }
 
     @Test
     fun `returns null when calling getInitialPayloadIfNotAlreadyReceived after receive is called`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
-        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Any::class.java)).isNull()
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
+        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Payload::class.java)).isNull()
     }
 
     @Test
     fun `returns null when calling getInitialPayloadIfNotAlreadyReceived after sendAndReceive is called`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(eq(Any::class.java), any())
-        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Any::class.java)).isNull()
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(eq(Payload::class.java), any())
+        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Payload::class.java)).isNull()
     }
 
     @Test
     fun `returns null when calling getInitialPayloadIfNotAlreadyReceived after getInitialPayloadIfNotAlreadyReceived is called`() {
-        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Any::class.java)).isEqualTo(INITIAL_PAYLOAD)
-        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Any::class.java)).isNull()
+        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Payload::class.java)).isEqualTo(INITIAL_PAYLOAD)
+        assertThat(session.getInitialPayloadIfNotAlreadyReceived(Payload::class.java)).isNull()
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/versioning/impl/sessions/VersionSendingFlowSessionImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/versioning/impl/sessions/VersionSendingFlowSessionImplTest.kt
@@ -5,6 +5,7 @@ import net.corda.flow.application.versioning.impl.AgreedVersion
 import net.corda.flow.application.versioning.impl.AgreedVersionAndPayload
 import net.corda.internal.serialization.SerializedBytesImpl
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.CordaSerializable
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,10 +20,13 @@ import org.mockito.kotlin.whenever
 
 class VersionSendingFlowSessionImplTest {
 
+    @CordaSerializable
+    data class Payload(val message: String)
+
     private companion object {
-        const val PAYLOAD = "payload"
-        const val ANOTHER_PAYLOAD = "another payload"
         const val VERSION = 1
+        val PAYLOAD = Payload("payload")
+        val ANOTHER_PAYLOAD = Payload("another payload")
         val ADDITIONAL_CONTEXT = linkedMapOf<String, Any>("key" to "value")
         val SERIALIZED_PAYLOAD = byteArrayOf(1, 1, 1, 1)
         val SERIALIZED_ANOTHER_PAYLOAD = byteArrayOf(2, 2, 2, 2)
@@ -40,8 +44,8 @@ class VersionSendingFlowSessionImplTest {
         whenever(serializationService.serialize(ANOTHER_PAYLOAD)).thenReturn(SerializedBytesImpl(SERIALIZED_ANOTHER_PAYLOAD))
         whenever(serializationService.serialize(any<AgreedVersionAndPayload>()))
             .thenReturn(SerializedBytesImpl(SERIALIZED_VERSION_AND_PAYLOAD))
-        whenever(delegate.sendAndReceive(eq(Any::class.java), any())).thenReturn(PAYLOAD)
-        whenever(delegate.receive(Any::class.java)).thenReturn(PAYLOAD)
+        whenever(delegate.sendAndReceive(eq(Payload::class.java), any())).thenReturn(PAYLOAD)
+        whenever(delegate.receive(Payload::class.java)).thenReturn(PAYLOAD)
     }
 
     @Test
@@ -53,22 +57,22 @@ class VersionSendingFlowSessionImplTest {
 
     @Test
     fun `sends versioning information along with the payload the first time a sendAndReceive is called`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
         verify(delegate).sendAndReceive(
-            Any::class.java,
+            Payload::class.java,
             AgreedVersionAndPayload(AgreedVersion(VERSION, ADDITIONAL_CONTEXT), SERIALIZED_PAYLOAD)
         )
-        verify(delegate, never()).sendAndReceive(Any::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(Payload::class.java, PAYLOAD)
     }
 
     @Test
     fun `sends versioning information separately the first time a receive is called`() {
-        session.receive(Any::class.java)
+        session.receive(Payload::class.java)
         verify(delegate).sendAndReceive(
-            Any::class.java,
+            Payload::class.java,
             AgreedVersionAndPayload(AgreedVersion(VERSION, ADDITIONAL_CONTEXT), serializedPayload = null)
         )
-        verify(delegate, never()).receive(Any::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
     }
 
     @Test
@@ -108,8 +112,8 @@ class VersionSendingFlowSessionImplTest {
 
     @Test
     fun `does not send versioning information when calling send after the session has done a sendAndReceive`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(Any::class.java, PAYLOAD)
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(Payload::class.java, PAYLOAD)
         session.send(ANOTHER_PAYLOAD)
         verify(delegate, never()).send(AgreedVersionAndPayload(AgreedVersion(VERSION, ADDITIONAL_CONTEXT), SERIALIZED_ANOTHER_PAYLOAD))
         verify(delegate).send(ANOTHER_PAYLOAD)
@@ -117,8 +121,8 @@ class VersionSendingFlowSessionImplTest {
 
     @Test
     fun `does not send versioning information when calling send after the session has done a receive`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
         session.send(ANOTHER_PAYLOAD)
         verify(delegate, never()).send(AgreedVersionAndPayload(AgreedVersion(VERSION, ADDITIONAL_CONTEXT), SERIALIZED_ANOTHER_PAYLOAD))
         verify(delegate).send(ANOTHER_PAYLOAD)
@@ -154,89 +158,89 @@ class VersionSendingFlowSessionImplTest {
     fun `does not send versioning information when calling sendAndReceive after the session has done a send`() {
         session.send(PAYLOAD)
         verify(delegate, never()).send(PAYLOAD)
-        session.sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        session.sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
         verify(delegate, never()).sendAndReceive(
-            Any::class.java,
+            Payload::class.java,
             AgreedVersionAndPayload(
                 AgreedVersion(VERSION, ADDITIONAL_CONTEXT),
                 SERIALIZED_ANOTHER_PAYLOAD
             )
         )
-        verify(delegate).sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
     }
 
     @Test
     fun `does not send versioning information when calling sendAndReceive after the session has done a sendAndReceive`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(Any::class.java, PAYLOAD)
-        session.sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(Payload::class.java, PAYLOAD)
+        session.sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
         verify(delegate, never()).sendAndReceive(
-            Any::class.java,
+            Payload::class.java,
             AgreedVersionAndPayload(
                 AgreedVersion(VERSION, ADDITIONAL_CONTEXT),
                 SERIALIZED_ANOTHER_PAYLOAD
             )
         )
-        verify(delegate).sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
     }
 
     @Test
     fun `does not send versioning information when calling sendAndReceive after the session has done a receive`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
-        session.sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
+        session.sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
         verify(delegate, never()).sendAndReceive(
-            Any::class.java,
+            Payload::class.java,
             AgreedVersionAndPayload(
                 AgreedVersion(VERSION, ADDITIONAL_CONTEXT),
                 SERIALIZED_ANOTHER_PAYLOAD
             )
         )
-        verify(delegate).sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
     }
 
     @Test
     fun `does not send versioning information when calling sendAndReceive after close is called`() {
         session.close()
-        session.sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        session.sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
         verify(delegate, never()).sendAndReceive(
-            Any::class.java,
+            Payload::class.java,
             AgreedVersionAndPayload(
                 AgreedVersion(VERSION, ADDITIONAL_CONTEXT),
                 SERIALIZED_ANOTHER_PAYLOAD
             )
         )
-        verify(delegate).sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
     }
 
     @Test
     fun `does not send versioning information when calling sendAndReceive after getPayloadToSend is called`() {
         session.getPayloadToSend(SERIALIZED_PAYLOAD)
         verify(serializationService).serialize(any<AgreedVersionAndPayload>())
-        session.sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        session.sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
         verify(delegate, never()).sendAndReceive(
-            Any::class.java,
+            Payload::class.java,
             AgreedVersionAndPayload(
                 AgreedVersion(VERSION, ADDITIONAL_CONTEXT),
                 SERIALIZED_ANOTHER_PAYLOAD
             )
         )
-        verify(delegate).sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
     }
 
     @Test
     fun `does not send versioning information when calling sendAndReceive after getVersioningPayloadToSend is called`() {
         session.getVersioningPayloadToSend()
         verify(serializationService).serialize(any<AgreedVersionAndPayload>())
-        session.sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        session.sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
         verify(delegate, never()).sendAndReceive(
-            Any::class.java,
+            Payload::class.java,
             AgreedVersionAndPayload(
                 AgreedVersion(VERSION, ADDITIONAL_CONTEXT),
                 SERIALIZED_ANOTHER_PAYLOAD
             )
         )
-        verify(delegate).sendAndReceive(Any::class.java, ANOTHER_PAYLOAD)
+        verify(delegate).sendAndReceive(Payload::class.java, ANOTHER_PAYLOAD)
     }
 
     @Test
@@ -244,56 +248,56 @@ class VersionSendingFlowSessionImplTest {
         session.send(PAYLOAD)
         verify(delegate, never()).send(PAYLOAD)
         verify(delegate).send(any<AgreedVersionAndPayload>())
-        session.receive(Any::class.java)
+        session.receive(Payload::class.java)
         verify(delegate).send(any<AgreedVersionAndPayload>())
-        verify(delegate).receive(Any::class.java)
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
     fun `does not send versioning information when calling receive after the session has done a sendAndReceive`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate).sendAndReceive(eq(Any::class.java), any<AgreedVersionAndPayload>())
-        session.receive(Any::class.java)
-        verify(delegate).sendAndReceive(eq(Any::class.java), any<AgreedVersionAndPayload>())
-        verify(delegate).receive(Any::class.java)
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate).sendAndReceive(eq(Payload::class.java), any<AgreedVersionAndPayload>())
+        session.receive(Payload::class.java)
+        verify(delegate).sendAndReceive(eq(Payload::class.java), any<AgreedVersionAndPayload>())
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
     fun `does not send versioning information when calling receive after the session has done a receive`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
-        verify(delegate).sendAndReceive(eq(Any::class.java), any<AgreedVersionAndPayload>())
-        session.receive(Any::class.java)
-        verify(delegate).sendAndReceive(eq(Any::class.java), any<AgreedVersionAndPayload>())
-        verify(delegate).receive(Any::class.java)
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
+        verify(delegate).sendAndReceive(eq(Payload::class.java), any<AgreedVersionAndPayload>())
+        session.receive(Payload::class.java)
+        verify(delegate).sendAndReceive(eq(Payload::class.java), any<AgreedVersionAndPayload>())
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
     fun `does not send versioning information when calling receive after close is called`() {
         session.close()
         verify(delegate).send(any<AgreedVersionAndPayload>())
-        session.receive(Any::class.java)
+        session.receive(Payload::class.java)
         verify(delegate).send(any<AgreedVersionAndPayload>())
-        verify(delegate).receive(Any::class.java)
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
     fun `does not send versioning information when calling receive after getPayloadToSend is called`() {
         session.getPayloadToSend(SERIALIZED_PAYLOAD)
         verify(serializationService).serialize(any<AgreedVersionAndPayload>())
-        session.receive(Any::class.java)
+        session.receive(Payload::class.java)
         verify(serializationService).serialize(any<AgreedVersionAndPayload>())
-        verify(delegate).receive(Any::class.java)
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
     fun `does not send versioning information when calling receive after getVersioningPayloadToSend is called`() {
         session.getVersioningPayloadToSend()
         verify(serializationService).serialize(any<AgreedVersionAndPayload>())
-        session.receive(Any::class.java)
+        session.receive(Payload::class.java)
         verify(serializationService).serialize(any<AgreedVersionAndPayload>())
-        verify(delegate).receive(Any::class.java)
+        verify(delegate).receive(Payload::class.java)
     }
 
     @Test
@@ -308,9 +312,9 @@ class VersionSendingFlowSessionImplTest {
 
     @Test
     fun `does not send versioning information when calling close after the session has done a sendAndReceive`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate).sendAndReceive(eq(Any::class.java), any<AgreedVersionAndPayload>())
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate).sendAndReceive(eq(Payload::class.java), any<AgreedVersionAndPayload>())
         session.close()
         verify(delegate, never()).send(any<AgreedVersionAndPayload>())
         verify(delegate).close()
@@ -318,9 +322,9 @@ class VersionSendingFlowSessionImplTest {
 
     @Test
     fun `does not send versioning information when calling close after the session has done a receive`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
-        verify(delegate).sendAndReceive(eq(Any::class.java), any<AgreedVersionAndPayload>())
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
+        verify(delegate).sendAndReceive(eq(Payload::class.java), any<AgreedVersionAndPayload>())
         session.close()
         verify(delegate, never()).send(any<AgreedVersionAndPayload>())
         verify(delegate).close()
@@ -364,16 +368,16 @@ class VersionSendingFlowSessionImplTest {
 
     @Test
     fun `returns the passed in payload when calling getPayloadToSend after the session has done a sendAndReceive`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(Any::class.java, PAYLOAD)
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(Payload::class.java, PAYLOAD)
         assertThat(session.getPayloadToSend(SERIALIZED_PAYLOAD)).isEqualTo(SERIALIZED_PAYLOAD)
         verify(serializationService, never()).serialize(any<AgreedVersionAndPayload>())
     }
 
     @Test
     fun `returns the passed in payload when calling getPayloadToSend after the session has done a receive`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
         assertThat(session.getPayloadToSend(SERIALIZED_PAYLOAD)).isEqualTo(SERIALIZED_PAYLOAD)
         verify(serializationService, never()).serialize(any<AgreedVersionAndPayload>())
     }
@@ -421,16 +425,16 @@ class VersionSendingFlowSessionImplTest {
 
     @Test
     fun `returns null when calling getVersioningPayloadToSend after the session has done a sendAndReceive`() {
-        session.sendAndReceive(Any::class.java, PAYLOAD)
-        verify(delegate, never()).sendAndReceive(Any::class.java, PAYLOAD)
+        session.sendAndReceive(Payload::class.java, PAYLOAD)
+        verify(delegate, never()).sendAndReceive(Payload::class.java, PAYLOAD)
         assertThat(session.getVersioningPayloadToSend()).isNull()
         verify(serializationService, never()).serialize(any<AgreedVersionAndPayload>())
     }
 
     @Test
     fun `returns null when calling getVersioningPayloadToSend after the session has done a receive`() {
-        session.receive(Any::class.java)
-        verify(delegate, never()).receive(Any::class.java)
+        session.receive(Payload::class.java)
+        verify(delegate, never()).receive(Payload::class.java)
         assertThat(session.getVersioningPayloadToSend()).isNull()
         verify(serializationService, never()).serialize(any<AgreedVersionAndPayload>())
     }

--- a/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/flows/Payload.kt
+++ b/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/flows/Payload.kt
@@ -7,11 +7,11 @@ import java.util.function.Function
 /**
  * [Payload] represents a response sent to and received by a session that is either successful or unsuccessful.
  *
- * Using this interface allows flows to branch their logic if expected errors occur in the counterparty flow while restricting the use of
+ * Using this class allows flows to branch their logic if expected errors occur in the counterparty flow while restricting the use of
  * exceptions from the platform to represent exceptional behaviour.
  */
 @CordaSerializable
-sealed interface Payload<T> {
+sealed class Payload<T> {
 
     /**
      * Gets the [Payload]'s underlying value if it represents a successful response, or throw an exception if it represents an error.
@@ -22,7 +22,7 @@ sealed interface Payload<T> {
      *
      * @throws CordaRuntimeException If the [Payload] is a [Failure].
      */
-    fun getOrThrow(): T
+    abstract fun getOrThrow(): T
 
     /**
      * Gets the [Payload]'s underlying value if it represents a successful response, or throw an exception if it represents an error.
@@ -38,14 +38,14 @@ sealed interface Payload<T> {
      *
      * @throws CordaRuntimeException If the [Payload] is a [Failure].
      */
-    fun getOrThrow(throwOnFailure: Function<Failure<*>, Throwable>): T
+    abstract fun getOrThrow(throwOnFailure: Function<Failure<*>, Throwable>): T
 
     /**
      * [Success] represents a successful response.
      *
      * @property value The underlying payload.
      */
-    data class Success<T>(val value: T) : Payload<T> {
+    data class Success<T>(val value: T) : Payload<T>() {
 
         override fun getOrThrow(): T {
             return value
@@ -63,7 +63,7 @@ sealed interface Payload<T> {
      * @property reason The reason for the error. [reason] should refer to a statically defined string that can also be accessed by the
      * flow that received this [Failure].
      */
-    data class Failure<T>(val message: String, val reason: String?): Payload<T> {
+    data class Failure<T>(val message: String, val reason: String?): Payload<T>() {
 
         constructor(message: String) : this(message, reason = null)
 

--- a/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
+++ b/components/ledger/ledger-consensual-flow/src/main/kotlin/net/corda/ledger/consensual/flow/impl/transaction/ConsensualSignedTransactionImpl.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionI
 import net.corda.ledger.consensual.data.transaction.verifier.verifyMetadata
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.KeyUtils
@@ -19,6 +20,7 @@ import java.security.PublicKey
 import java.util.Objects
 
 @Suppress("TooManyFunctions")
+@CordaSerializable
 class ConsensualSignedTransactionImpl(
     private val serializationService: SerializationService,
     private val transactionSignatureService: TransactionSignatureServiceInternal,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainRequestV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainRequestV1.kt
@@ -4,7 +4,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.SecureHash
 
 @CordaSerializable
-sealed interface TransactionBackchainRequestV1 {
-    data class Get(val transactionIds: Set<SecureHash>): TransactionBackchainRequestV1
-    object Stop: TransactionBackchainRequestV1
+sealed class TransactionBackchainRequestV1 {
+    data class Get(val transactionIds: Set<SecureHash>): TransactionBackchainRequestV1()
+    object Stop: TransactionBackchainRequestV1()
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -8,6 +8,7 @@ import net.corda.ledger.utxo.data.transaction.verifier.verifyMetadata
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
@@ -25,6 +26,7 @@ import java.security.PublicKey
 import java.util.Objects
 
 @Suppress("TooManyFunctions")
+@CordaSerializable
 data class UtxoSignedTransactionImpl(
     private val serializationService: SerializationService,
     private val transactionSignatureServiceInternal: TransactionSignatureServiceInternal,

--- a/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/RollCallFlowTest.kt
+++ b/simulator/example-app/src/test/kotlin/net/cordacon/example/rollcall/RollCallFlowTest.kt
@@ -22,7 +22,7 @@ class RollCallFlowTest {
 
     companion object {
         private fun receiveAndSendResponse(session: FlowSession, response: String) {
-            session.receive(Any::class.java)
+            session.receive(RollCallRequest::class.java)
             session.send(RollCallResponse(response))
         }
     }

--- a/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SessionManagementTest.kt
+++ b/simulator/runtime/src/integrationTest/kotlin/net/corda/simulator/SessionManagementTest.kt
@@ -12,14 +12,17 @@ import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class SessionManagementTest {
+
+    @CordaSerializable
+    data class Payload(val message: String)
 
     companion object {
 
@@ -35,7 +38,7 @@ class SessionManagementTest {
             @Suspendable
             override fun call(requestBody: ClientRequestBody): String {
                 val session = flowMessaging.initiateFlow(bob)
-                session.send(Unit)
+                session.send(Payload("hello"))
                 return ""
             }
         }
@@ -47,7 +50,7 @@ class SessionManagementTest {
 
             @Suspendable
             override fun call(session: FlowSession) {
-                session.receive(Any::class.java)
+                session.receive(Payload::class.java)
                 flowEngine.subFlow(SendingOnSubFlow())
 
             }
@@ -61,7 +64,7 @@ class SessionManagementTest {
             @Suspendable
             override fun call(): String {
                 val session = flowMessaging.initiateFlow(charlie)
-                session.receive(Any::class.java)
+                session.receive(Payload::class.java)
                 return ""
             }
         }
@@ -71,7 +74,7 @@ class SessionManagementTest {
 
             override fun call(session: FlowSession) {
                 Thread.sleep(200)
-                session.send(Any::class.java)
+                session.send(Payload("hello"))
                 finished = true
             }
         }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualSignedTransactionBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/consensual/ConsensualSignedTransactionBase.kt
@@ -12,6 +12,7 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.consensual.ConsensualState
@@ -22,6 +23,7 @@ import java.security.PublicKey
 import java.time.Instant
 import java.util.Objects
 
+@CordaSerializable
 class ConsensualSignedTransactionBase(
     private val signatures: List<DigitalSignatureAndMetadata>,
     private val ledgerTransactionInfo: ConsensualStateLedgerInfo,

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/TransactionBackchainHandler.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/TransactionBackchainHandler.kt
@@ -121,9 +121,8 @@ class TransactionBackchainHandlerBase(
     }
 }
 
-
 @CordaSerializable
-sealed interface TransactionBackchainRequest {
-    data class Get(val transactionIds: Set<SecureHash>): TransactionBackchainRequest
-    object Stop: TransactionBackchainRequest
+sealed class TransactionBackchainRequest {
+    data class Get(val transactionIds: Set<SecureHash>): TransactionBackchainRequest()
+    object Stop: TransactionBackchainRequest()
 }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoSignedTransactionBase.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/UtxoSignedTransactionBase.kt
@@ -14,6 +14,7 @@ import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.crypto.SigningService
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.SecureHash
@@ -35,6 +36,7 @@ import java.util.Objects
  * Simulator implementation of [UtxoSignedTransaction]
  */
 @Suppress("LongParameterList", "TooManyFunctions")
+@CordaSerializable
 class UtxoSignedTransactionBase(
     private val signatures: List<DigitalSignatureAndMetadata>,
     private val ledgerInfo: UtxoStateLedgerInfo,

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
@@ -2,6 +2,7 @@ package net.corda.simulator.runtime.messaging
 
 import net.corda.simulator.exceptions.ResponderFlowException
 import net.corda.simulator.exceptions.SessionAlreadyClosedException
+import net.corda.simulator.runtime.utils.requireAMQPSerializable
 import net.corda.v5.application.flows.FlowContextProperties
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
@@ -65,7 +66,7 @@ abstract class BlockingQueueFlowSession(
      */
     override fun <R : Any> receive(receiveType: Class<R>): R {
         state.closedCheck()
-        requireBoxedType(receiveType)
+        requireAMQPSerializable(receiveType)
         val start = configuration.clock.instant()
         while (true) {
             checkTimeout(start)
@@ -91,10 +92,6 @@ abstract class BlockingQueueFlowSession(
         }
     }
 
-    private fun requireBoxedType(type: Class<*>) {
-        require(!type.isPrimitive) { "Cannot receive primitive type $type" }
-    }
-
     /**
      * @param receiveType The class of the received payload.
      * @param payload The payload to send.
@@ -103,7 +100,7 @@ abstract class BlockingQueueFlowSession(
      * @see [BlockingQueueFlowSession.receive] for details of thrown exceptions.
      */
     override fun <R : Any> sendAndReceive(receiveType: Class<R>, payload: Any): R {
-        requireBoxedType(receiveType)
+        requireAMQPSerializable(receiveType)
         send(payload)
         return receive(receiveType)
     }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/InitiatorFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/InitiatorFlowSession.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 import net.corda.simulator.exceptions.ResponderFlowException
+import net.corda.simulator.runtime.utils.requireAMQPSerializable
 import net.corda.v5.application.messaging.FlowInfo
 import net.corda.v5.application.messaging.FlowSession
 import org.slf4j.LoggerFactory
@@ -27,8 +28,8 @@ class BaseInitiatorFlowSession(
     flowContextProperties: SimFlowContextProperties
 ) : BlockingQueueFlowSession(flowDetails, from, to, flowContextProperties), InitiatorFlowSession {
 
-    companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    private companion object {
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private var responderSessionClosed: Boolean = false
@@ -39,6 +40,7 @@ class BaseInitiatorFlowSession(
      * @param payload The payload to send to the counterparty.
      */
     override fun send(payload: Any) {
+        requireAMQPSerializable(payload::class.java)
         rethrowAnyResponderError()
         state.closedCheck()
         to.put(payload)

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/utils/Utilities.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/utils/Utilities.kt
@@ -1,5 +1,6 @@
 package net.corda.simulator.runtime.utils
 
+import net.corda.internal.serialization.amqp.AMQPNotSerializableException
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
@@ -15,6 +16,7 @@ import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.consensual.ConsensualLedgerService
@@ -113,3 +115,19 @@ val availableAPIs = setOf(
     NotaryLookup::class.java,
     DigestService::class.java
 )
+
+/**
+ * @param clazz This class must be AMQP serializable.
+ */
+@Suppress("ComplexCondition")
+fun requireAMQPSerializable(clazz: Class<*>) {
+    if (!clazz.isAnnotationPresent(CordaSerializable::class.java)
+            && !clazz.isInterface
+            && !clazz.isEnum
+            && !Collection::class.java.isAssignableFrom(clazz)
+            && !Map::class.java.isAssignableFrom(clazz)) {
+        throw AMQPNotSerializableException(
+            clazz,
+            "Class \"${clazz.name}\" is not annotated with @CordaSerializable.")
+    }
+}

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InitiatorFlowSessionTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/flows/InitiatorFlowSessionTest.kt
@@ -5,6 +5,7 @@ import net.corda.simulator.factories.SimulatorConfigurationBuilder
 import net.corda.simulator.runtime.messaging.BaseInitiatorFlowSession
 import net.corda.simulator.runtime.messaging.FlowContext
 import net.corda.simulator.runtime.messaging.SimFlowContextProperties
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.types.MemberX500Name
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -15,6 +16,9 @@ class InitiatorFlowSessionTest {
 
     private val sender = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")
     private val flowCallConfiguration = SimulatorConfigurationBuilder.create().build()
+
+    @CordaSerializable
+    data class Payload(val message: String)
 
     @Test
     fun `initiators should throw an exception if receivedException is set`() {
@@ -38,17 +42,17 @@ class InitiatorFlowSessionTest {
 
         // Then it should throw in that receive
         assertThrows<ResponderFlowException> {
-            sendingSession.receive(Any::class.java)
+            sendingSession.receive(Payload::class.java)
         }
 
         // Or in any subsequent send
         assertThrows<ResponderFlowException> {
-            sendingSession.send(Unit)
+            sendingSession.send(Payload("hello"))
         }
 
         // Or any subsequent receive
         assertThrows<ResponderFlowException> {
-            sendingSession.receive(Any::class.java)
+            sendingSession.receive(Payload::class.java)
         }
 
         // Or when we try to close the session

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSessionTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSessionTest.kt
@@ -3,6 +3,7 @@ package net.corda.simulator.runtime.messaging
 import net.corda.simulator.SimulatorConfiguration
 import net.corda.simulator.exceptions.SessionAlreadyClosedException
 import net.corda.simulator.runtime.testflows.PingAckMessage
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
@@ -26,6 +27,9 @@ import kotlin.concurrent.thread
 
 @Timeout(value = 5, unit = TimeUnit.SECONDS)
 class BlockingQueueFlowSessionTest {
+
+    @CordaSerializable
+    data class Payload(val message: String)
 
     private val sender = MemberX500Name.parse("CN=IRunCorDapps, OU=Application, O=R3, L=London, C=GB")
     private val receiver = MemberX500Name.parse("CN=IRunCorDappsToo, OU=Application, O=R3, L=London, C=GB")
@@ -101,11 +105,11 @@ class BlockingQueueFlowSessionTest {
         initiatorSession.close()
 
         // Then subsequent calls should error
-        assertThrows<SessionAlreadyClosedException> { initiatorSession.send("ping-ack") }
-        assertThrows<SessionAlreadyClosedException> { initiatorSession.receive(Any::class.java) }
+        assertThrows<SessionAlreadyClosedException> { initiatorSession.send(Payload("ping-ack")) }
+        assertThrows<SessionAlreadyClosedException> { initiatorSession.receive(Payload::class.java) }
 
-        assertThrows<SessionAlreadyClosedException> { responderSession.send("ping-ack") }
-        assertThrows<SessionAlreadyClosedException> { responderSession.receive(Any::class.java) }
+        assertThrows<SessionAlreadyClosedException> { responderSession.send(Payload("ping-ack")) }
+        assertThrows<SessionAlreadyClosedException> { responderSession.receive(Payload::class.java) }
 
         // Except for closing again
         assertDoesNotThrow { initiatorSession.close() }
@@ -137,7 +141,7 @@ class BlockingQueueFlowSessionTest {
 
         // Then the session should time out from any receive
         assertThrows<TimeoutException> {
-            sendingSession.receive(Any::class.java)
+            sendingSession.receive(Payload::class.java)
         }
     }
 

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessagingTest.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessagingTest.kt
@@ -10,6 +10,7 @@ import net.corda.simulator.runtime.testflows.PingAckMessage
 import net.corda.simulator.runtime.testflows.PingAckResponderFlow
 import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.types.MemberX500Name
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
@@ -175,7 +176,7 @@ class ConcurrentFlowMessagingTest {
         // When we receive on the sending flow
         // Then it should rethrow the error (note Real Corda will not contain the original error)
         assertThrows<ResponderFlowException> {
-            sendingSession.sendAndReceive(Any::class.java, PingAckMessage("Ping"))
+            sendingSession.sendAndReceive(Message::class.java, PingAckMessage("Ping"))
         }
     }
 
@@ -242,7 +243,7 @@ class ConcurrentFlowMessagingTest {
 
         // When we call the responder session and wait for it to close (closing our initiator session will wait)
         val session = flowMessaging.initiateFlow(receiverX500)
-        session.receive(Any::class.java)
+        session.receive(Message::class.java)
         session.close()
 
         // Then the responder session should have been closed without timeout
@@ -434,5 +435,7 @@ class ConcurrentFlowMessagingTest {
             session.send(Unit)
         }
     }
+
+    @CordaSerializable
     data class Message(val message: String)
 }

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/PingAckFlow.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/testflows/PingAckFlow.kt
@@ -9,6 +9,7 @@ import net.corda.v5.application.flows.ResponderFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 
@@ -38,4 +39,5 @@ class PingAckResponderFlow : ResponderFlow {
     }
 }
 
+@CordaSerializable
 data class PingAckMessage(val message: String)


### PR DESCRIPTION
Require that messages exchanged by flows can be AMQP serialized. This is mostly ensuring that the message class has been annotated as `@CordaSerializable`, although there are a few caveats:
- `@CordaSerializable` is an [`@Inherited`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/annotation/Inherited.html) annotation, but this inheritance _does not work for interfaces!_ Specifically:
    > Note that this meta-annotation type has no effect if the annotated type is used to annotate anything other than a class. Note also that this meta-annotation only causes annotations to be inherited from superclasses; annotations on implemented interfaces have no effect.

    This affects sealed interfaces such as `Payload`, which must become sealed classes instead so that their sub-classes are all `@CordaSerializable`.
- If the `receiveType` is an interface then checking whether it has been annotated as `@CordaSerializable` is insufficient. However, we can still exclude concrete classes such as primitive types and their boxed equivalents.

Unfortunately, lots of tests incorrectly assume that _anything_ can be AMQP serialised, e.g. `kotlin.Unit`.