### PR TITLE
CORE-13725: Ensure Payload and TransactionBackchainRequest are @CordaSerializable.

### DIFF
--- a/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/flows/Payload.kt
+++ b/components/ledger/ledger-common-flow-api/src/main/kotlin/net/corda/ledger/common/flow/flows/Payload.kt
@@ -11,7 +11,7 @@ import java.util.function.Function
  * exceptions from the platform to represent exceptional behaviour.
  */
 @CordaSerializable
-sealed interface Payload<T> {
+sealed class Payload<T> {
 
     /**
      * Gets the [Payload]'s underlying value if it represents a successful response, or throw an exception if it represents an error.
@@ -22,7 +22,7 @@ sealed interface Payload<T> {
      *
      * @throws CordaRuntimeException If the [Payload] is a [Failure].
      */
-    fun getOrThrow(): T
+    abstract fun getOrThrow(): T
 
     /**
      * Gets the [Payload]'s underlying value if it represents a successful response, or throw an exception if it represents an error.
@@ -38,14 +38,14 @@ sealed interface Payload<T> {
      *
      * @throws CordaRuntimeException If the [Payload] is a [Failure].
      */
-    fun getOrThrow(throwOnFailure: Function<Failure<*>, Throwable>): T
+    abstract fun getOrThrow(throwOnFailure: Function<Failure<*>, Throwable>): T
 
     /**
      * [Success] represents a successful response.
      *
      * @property value The underlying payload.
      */
-    data class Success<T>(val value: T) : Payload<T> {
+    data class Success<T>(val value: T) : Payload<T>() {
 
         override fun getOrThrow(): T {
             return value
@@ -63,7 +63,7 @@ sealed interface Payload<T> {
      * @property reason The reason for the error. [reason] should refer to a statically defined string that can also be accessed by the
      * flow that received this [Failure].
      */
-    data class Failure<T>(val message: String, val reason: String?): Payload<T> {
+    data class Failure<T>(val message: String, val reason: String?): Payload<T>() {
 
         constructor(message: String) : this(message, reason = null)
 

--- a/components/ledger/ledger-common-flow-api/src/test/kotlin/net/corda/ledger/common/flow/flows/PayloadTest.kt
+++ b/components/ledger/ledger-common-flow-api/src/test/kotlin/net/corda/ledger/common/flow/flows/PayloadTest.kt
@@ -1,0 +1,14 @@
+package net.corda.ledger.common.flow.flows
+
+import net.corda.v5.base.annotations.CordaSerializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class PayloadTest {
+    @Test
+    fun testSerializable() {
+        assertThat(Payload::class.java).hasAnnotation(CordaSerializable::class.java)
+        assertThat(Payload.Success::class.java).hasAnnotation(CordaSerializable::class.java)
+        assertThat(Payload.Failure::class.java).hasAnnotation(CordaSerializable::class.java)
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainRequestV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainRequestV1.kt
@@ -4,7 +4,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.SecureHash
 
 @CordaSerializable
-sealed interface TransactionBackchainRequestV1 {
-    data class Get(val transactionIds: Set<SecureHash>): TransactionBackchainRequestV1
-    object Stop: TransactionBackchainRequestV1
+sealed class TransactionBackchainRequestV1 {
+    data class Get(val transactionIds: Set<SecureHash>): TransactionBackchainRequestV1()
+    object Stop: TransactionBackchainRequestV1()
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainRequestV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainRequestV1Test.kt
@@ -1,0 +1,14 @@
+package net.corda.ledger.utxo.flow.impl.flows.backchain.v1
+
+import net.corda.v5.base.annotations.CordaSerializable
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class TransactionBackchainRequestV1Test {
+    @Test
+    fun testSerializable() {
+        assertThat(TransactionBackchainRequestV1::class.java).hasAnnotation(CordaSerializable::class.java)
+        assertThat(TransactionBackchainRequestV1.Get::class.java).hasAnnotation(CordaSerializable::class.java)
+        assertThat(TransactionBackchainRequestV1.Stop::class.java).hasAnnotation(CordaSerializable::class.java)
+    }
+}

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/TransactionBackchainHandler.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/TransactionBackchainHandler.kt
@@ -123,7 +123,7 @@ class TransactionBackchainHandlerBase(
 
 
 @CordaSerializable
-sealed interface TransactionBackchainRequest {
-    data class Get(val transactionIds: Set<SecureHash>): TransactionBackchainRequest
-    object Stop: TransactionBackchainRequest
+sealed class TransactionBackchainRequest {
+    data class Get(val transactionIds: Set<SecureHash>): TransactionBackchainRequest()
+    object Stop: TransactionBackchainRequest()
 }


### PR DESCRIPTION
Java only allows `@Inherited` annotations to be inherited from classes, not from interfaces. Change the `Payload` and `TransactionBackchainRequest` interfaces to be abstract classes so that all their sub-classes become `@CordaSerializable` as they are supposed to be.