### PR TITLE
CORE-13806: Handle loading Java primitives from sandboxes.

### DIFF
--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.osgi.framework.BundleContext
 import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
 import org.osgi.framework.FrameworkUtil
@@ -116,5 +118,18 @@ class SandboxClassTagTests {
 
         assertEquals(systemBundleClass, sandboxFactory.group1.getClass(systemBundleClass.name, staticTag))
         assertEquals(systemBundleClass, sandboxFactory.group1.getClass(systemBundleClass.name, evolvableTag))
+    }
+
+    @ParameterizedTest
+    @ValueSource(classes = [ Long::class, Int::class, Short::class, Byte::class, Char::class, Boolean::class, Double::class, Float::class ])
+    fun `can handle primitive types`(primitiveType: Class<*>) {
+        val sandboxGroup = sandboxFactory.group1
+
+        val primitiveTag = sandboxGroup.getStaticTag(primitiveType)
+        assertEquals(primitiveType, sandboxGroup.getClass(primitiveType.name, primitiveTag))
+
+        val boxedType = primitiveType.kotlin.javaObjectType
+        val boxedTag = sandboxGroup.getStaticTag(boxedType)
+        assertEquals(boxedType, sandboxGroup.getClass(boxedType.name, boxedTag))
     }
 }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -12,6 +12,7 @@ import net.corda.sandbox.internal.sandbox.Sandbox
 import net.corda.sandbox.internal.utilities.BundleUtils
 import org.osgi.framework.Bundle
 import org.slf4j.LoggerFactory
+import java.util.Collections.unmodifiableMap
 import java.util.Collections.unmodifiableSortedMap
 import java.util.SortedMap
 import java.util.TreeMap
@@ -36,6 +37,17 @@ internal class SandboxGroupImpl(
 
     private companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+
+        private val primitiveTypes = unmodifiableMap(setOf(
+            Long::class.java,
+            Int::class.java,
+            Short::class.java,
+            Byte::class.java,
+            Char::class.java,
+            Boolean::class.java,
+            Double::class.java,
+            Float::class.java
+        ).associateBy(Class<*>::getName))
 
         private fun Throwable.withSuppressed(exceptions: Iterable<Throwable>): Throwable {
             exceptions.forEach(::addSuppressed)
@@ -101,7 +113,7 @@ internal class SandboxGroupImpl(
         return when (classTag.classType) {
             ClassType.NonBundleClass -> {
                 try {
-                    bundleUtils.loadClassFromSystemBundle(className)
+                    primitiveTypes[className] ?: bundleUtils.loadClassFromSystemBundle(className)
                 } catch (e: ClassNotFoundException) {
                     throw SandboxException(
                         "Class $className was not from a bundle, and could not be found in the system classloader."

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImpl.kt
@@ -11,6 +11,8 @@ import net.corda.sandbox.internal.classtag.v1.EvolvableTagImplV1
 import net.corda.sandbox.internal.classtag.v1.StaticTagImplV1
 import net.corda.sandbox.internal.sandbox.CpkSandbox
 import org.osgi.framework.Bundle
+import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
+import org.osgi.framework.Constants.SYSTEM_BUNDLE_SYMBOLICNAME
 
 /** An implementation of [ClassTagFactory]. */
 internal class ClassTagFactoryImpl : ClassTagFactory {
@@ -23,9 +25,12 @@ internal class ClassTagFactoryImpl : ClassTagFactory {
             }.serialise()
         }
 
-        val bundleName = bundle.symbolicName ?: throw SandboxException(
-            "Bundle at ${bundle.location} does not have a symbolic name, preventing serialisation."
-        )
+        val bundleName = when (bundle.bundleId) {
+            SYSTEM_BUNDLE_ID -> SYSTEM_BUNDLE_SYMBOLICNAME
+            else -> bundle.symbolicName ?: throw SandboxException(
+                "Bundle at ${bundle.location} does not have a symbolic name, preventing serialisation."
+            )
+        }
 
         return if (cpkSandbox == null) {
             if (isStaticTag) {

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/sandbox/SandboxImpl.kt
@@ -2,6 +2,8 @@ package net.corda.sandbox.internal.sandbox
 
 import net.corda.sandbox.SandboxException
 import org.osgi.framework.Bundle
+import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
+import org.osgi.framework.Constants.SYSTEM_BUNDLE_SYMBOLICNAME
 import org.slf4j.LoggerFactory
 import java.util.Collections.unmodifiableSet
 import java.util.UUID
@@ -38,8 +40,14 @@ internal open class SandboxImpl(
     }
 
     override fun loadClass(className: String, bundleName: String): Class<*>? {
-        val bundle = allBundles.find { bundle ->
-            bundle.symbolicName == bundleName
+        val bundle = if (bundleName == SYSTEM_BUNDLE_SYMBOLICNAME) {
+            allBundles.find { bundle ->
+                bundle.bundleId == SYSTEM_BUNDLE_ID
+            }
+        } else {
+            allBundles.find { bundle ->
+                bundle.symbolicName == bundleName
+            }
         } ?: return null
 
         return try {

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
@@ -23,7 +23,11 @@ internal class BundleUtils @Activate constructor(
     /** Returns the bundle from which [klass] is loaded, or null if there is no such bundle. */
     fun getBundle(klass: Class<*>): Bundle? = FrameworkUtil.getBundle(klass) ?: try {
         // The lookup approach above does not work for the system bundle.
-        if (loadClassFromSystemBundle(klass.name) === klass) systemBundle else null
+        if (!klass.isPrimitive && loadClassFromSystemBundle(klass.name) === klass) {
+            systemBundle
+        } else {
+            null
+        }
     } catch (e: ClassNotFoundException) {
         null
     }

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/TestUtils.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.osgi.framework.Bundle
 import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
+import org.osgi.framework.Constants.SYSTEM_BUNDLE_SYMBOLICNAME
 import org.osgi.framework.Version
 import kotlin.math.abs
 import kotlin.random.Random
@@ -29,7 +30,7 @@ fun mockBundle(
     bundleLocation: String = random.nextInt().toString()
 ) = mock<Bundle>().apply {
     val bundleVersion = Version.parseVersion("${abs(random.nextInt())}.${abs(random.nextInt())}")
-    val id = if ("org.apache.felix.framework" == bundleSymbolicName) {
+    val id = if ("org.apache.felix.framework" == bundleSymbolicName || SYSTEM_BUNDLE_SYMBOLICNAME == bundleSymbolicName) {
         SYSTEM_BUNDLE_ID
     } else {
         nextLong()

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/classtag/ClassTagFactoryImplTests.kt
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.kotlin.mock
 import java.util.UUID.randomUUID
 
 const val MOCK_BUNDLE_NAME = "mock_bundle_symbolic_name"
@@ -135,7 +134,7 @@ class ClassTagFactoryImplTests {
     @Test
     fun `throws if asked to create a class tag for a bundle with no symbolic name`() {
         assertThrows<SandboxException> {
-            classTagFactory.createSerialisedTag(false, mock(), null)
+            classTagFactory.createSerialisedTag(false, mockBundle(bundleSymbolicName = null), null)
         }
     }
 


### PR DESCRIPTION
Allow serialization "class tags" to use Java primitive types. Also use the standard OSGi constant `system.bundle` for the symbolic name of the system bundle rather than `org.apache.felix.framework`.