### PR TITLE
CORE-13750: return 404 rather than null for missing HSM association

### DIFF
--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImpl.kt
@@ -58,7 +58,9 @@ class HsmRestResourceImpl @Activate constructor(
             "Find HSM",
             untranslatedExceptions = setOf(ResourceNotFoundException::class.java)
         ) {
-            hsmRegistrationClient.findHSM(tenantId, category.toCategory())?.expose()
+            hsmRegistrationClient.findHSM(tenantId, category.toCategory())?.expose() ?: throw ResourceNotFoundException(
+                "No association found for tenant ${tenantId} category ${category}"
+            )
         }
     }
 

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImpl.kt
@@ -51,7 +51,7 @@ class HsmRestResourceImpl @Activate constructor(
         }
     }
 
-    override fun assignedHsm(tenantId: String, category: String): HsmAssociationInfo? {
+    override fun assignedHsm(tenantId: String, category: String): HsmAssociationInfo {
         verifyTenantId(tenantId)
         return tryWithExceptionHandling(
             logger,

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImplTest.kt
@@ -50,7 +50,7 @@ class HsmRestResourceImplTest {
             whenever(hsmRegistrationClient.findHSM(tenantId, TLS)).doReturn(null)
 
             val e = assertThrows<ResourceNotFoundException> { ops.assignedHsm(tenantId, "tls") }
-            assertThat(e.message).contains("No association found for tenant ${tenantId} category tls")
+            assertThat(e).hasMessageContaining("No association found for tenant ${tenantId} category tls")
         }
 
         @Test

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImplTest.kt
@@ -46,11 +46,21 @@ class HsmRestResourceImplTest {
     @Nested
     inner class ApiTests {
         @Test
-        fun `assignedHsm returns null if no HSM found`() {
+        fun `assignedHsm returns 404 if no HSM found`() {
             whenever(hsmRegistrationClient.findHSM(tenantId, TLS)).doReturn(null)
 
-            assertThrows<ResourceNotFoundException> { ops.assignedHsm(tenantId, "tls") }
+            val e = assertThrows<ResourceNotFoundException> { ops.assignedHsm(tenantId, "tls") }
+            assertThat(e.message).contains("No association found for tenant ${tenantId} category tls")
         }
+
+        @Test
+        fun `assignedHsm returns 404 if category is not known`() {
+            whenever(hsmRegistrationClient.findHSM(tenantId, "Bob")).doReturn(null)
+
+            val e = assertThrows<ResourceNotFoundException> { ops.assignedHsm(tenantId, "Bob") }
+            assertThat(e.message).contains("Invalid category: BOB")
+        }
+
 
         @Test
         fun `assignedHsm calls the client with upper case`() {

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/HsmRestResourceImplTest.kt
@@ -49,13 +49,14 @@ class HsmRestResourceImplTest {
         fun `assignedHsm returns null if no HSM found`() {
             whenever(hsmRegistrationClient.findHSM(tenantId, TLS)).doReturn(null)
 
-            val hsm = ops.assignedHsm(tenantId, "tls")
-
-            assertThat(hsm).isNull()
+            assertThrows<ResourceNotFoundException> { ops.assignedHsm(tenantId, "tls") }
         }
 
         @Test
         fun `assignedHsm calls the client with upper case`() {
+            val association = HSMAssociationInfo("a", "b", "SOFT", NOTARY, "foo", 0L)
+            whenever(hsmRegistrationClient.findHSM(tenantId, NOTARY)).doReturn(association)
+
             ops.assignedHsm(tenantId, "Notary")
 
             verify(hsmRegistrationClient).findHSM(tenantId, NOTARY)
@@ -63,7 +64,9 @@ class HsmRestResourceImplTest {
 
         @Test
         fun `assignedHsm verify the tenantId`() {
-            ops.assignedHsm(tenantId, "Notary")
+            val association = HSMAssociationInfo("a", "b", "SOFT", CI, "foo", 0L)
+            whenever(hsmRegistrationClient.findHSM(tenantId, CI)).doReturn(association)
+            ops.assignedHsm(tenantId, CI)
 
             verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(tenantIdShortHash)
         }
@@ -140,7 +143,7 @@ class HsmRestResourceImplTest {
                 ),
             )
 
-            ops.assignSoftHsm(tenantId, "ci")
+            ops.assignSoftHsm(tenantId, CI)
 
             verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(tenantIdShortHash)
         }

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
@@ -35,7 +35,7 @@ interface HsmRestResource : RestResource {
      * @param category The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT',
      * 'TLS', or 'JWT_KEY'.
      *
-     * @return Information on the assigned HSM, or null if no HSM is assigned.
+     * @return Information on the assigned HSM, or 404 if no HSM is assigned.
      */
     @HttpGET(
         path = "{tenantId}/{category}",

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
@@ -57,7 +57,7 @@ interface HsmRestResource : RestResource {
         @RestPathParameter(description = "The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER'," +
                 " 'NOTARY', 'SESSION_INIT', 'TLS', or 'JWT_KEY'")
         category: String
-    ): HsmAssociationInfo?
+    ): HsmAssociationInfo
 
     /**
      * The [assignSoftHsm] method enables you to assign a soft HSM to the tenant for the specified category. Unlike a

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
@@ -35,7 +35,7 @@ interface HsmRestResource : RestResource {
      * @param category The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT',
      * 'TLS', or 'JWT_KEY'.
      *
-     * @return Information on the assigned HSM, or 404 if no HSM is assigned.
+     * @return Information on the assigned HSM, or throws `ResourceNotFoundException` if no HSM is assigned.
      */
     @HttpGET(
         path = "{tenantId}/{category}",

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -1181,10 +1181,7 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "nullable" : true,
-                  "allOf" : [ {
-                    "$ref" : "#/components/schemas/HsmAssociationInfo"
-                  } ]
+                  "$ref" : "#/components/schemas/HsmAssociationInfo"
                 }
               }
             }


### PR DESCRIPTION
This aligns better with other REST endpoints, and may be less surprising.

Before we would return 404 for a missing tenant or category, and a JSON body containing null if the tenant and category were correct. Now we return 404 in all cases, with different message bodies identifying the problem.