### PR TITLE
CORE-13756: Ensure AMQP deserialises a naked Char object correctly.

### DIFF
--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/CastingSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/CastingSerializer.kt
@@ -1,0 +1,5 @@
+package net.corda.internal.serialization.amqp
+
+interface CastingSerializer<out T, out R> : AMQPSerializer<T> {
+    val actualType: Class<out R>
+}

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializerFactoryBuilder.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializerFactoryBuilder.kt
@@ -2,6 +2,7 @@ package net.corda.internal.serialization.amqp
 
 import com.google.common.primitives.Primitives
 import net.corda.internal.serialization.amqp.standard.AMQPPrimitiveSerializer
+import net.corda.internal.serialization.amqp.standard.CharacterAsIntegerSerializer
 import net.corda.internal.serialization.model.ClassTypeLoader
 import net.corda.internal.serialization.model.ConfigurableLocalTypeModel
 import net.corda.internal.serialization.model.FingerPrinter
@@ -143,7 +144,9 @@ object SerializerFactoryBuilder {
             { clazz -> clazz.isPrimitive || Primitives.unwrap(clazz).isPrimitive },
             customSerializerRegistry,
             onlyCustomSerializers
-        )
+        ).apply {
+            registerForCasting(CharacterAsIntegerSerializer())
+        }
 
         val typeLoader: TypeLoader = ClassTypeLoader()
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/ArraySerializer.kt
@@ -122,13 +122,14 @@ open class ArraySerializer(override val type: Type, factory: LocalSerializerFact
 }
 
 // Boxed Character arrays required a specialisation to handle the type conversion properly when populating
-// the array since Kotlin won't allow an implicit cast from Int (as they're stored as 16bit ints) to Char
+// the array since Kotlin won't allow an implicit cast from Int (as they're stored as 16bit ints) to Char.
+// This type conversion is handled by [CharacterAsIntegerSerializer].
 class CharArraySerializer(factory: LocalSerializerFactory) : ArraySerializer(Array<Char>::class.java, factory) {
     override fun <T> List<T>.toArrayOfType(type: Type): Any {
         val elementType = type.asClass()
         val list = this
         return java.lang.reflect.Array.newInstance(elementType, this.size).apply {
-            (0..lastIndex).forEach { java.lang.reflect.Array.set(this, it, (list[it] as Int).toChar()) }
+            (0..lastIndex).forEach { java.lang.reflect.Array.set(this, it, list[it]) }
         }
     }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CharacterAsIntegerSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/standard/CharacterAsIntegerSerializer.kt
@@ -1,0 +1,50 @@
+package net.corda.internal.serialization.amqp.standard
+
+import net.corda.internal.serialization.amqp.AMQPTypeIdentifiers.primitiveTypeName
+import net.corda.internal.serialization.amqp.CastingSerializer
+import net.corda.internal.serialization.amqp.DeserializationInput
+import net.corda.internal.serialization.amqp.Metadata
+import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.SerializationSchemas
+import net.corda.serialization.SerializationContext
+import org.apache.qpid.proton.amqp.Symbol
+import org.apache.qpid.proton.codec.Data
+import java.lang.reflect.Type
+
+/**
+ * Serializer for a field which is declared as [Char] but where the
+ * actual type is [Int]. Most probably just used for deserializing.
+ */
+class CharacterAsIntegerSerializer : CastingSerializer<Char, Int> {
+    override val type: Class<Char>
+        get() = Char::class.javaObjectType
+
+    override val actualType: Class<Int>
+        get() = Int::class.javaObjectType
+
+    override val typeDescriptor: Symbol = Symbol.valueOf(primitiveTypeName(type))
+
+    override fun writeClassInfo(output: SerializationOutput, context: SerializationContext) {
+    }
+
+    override fun writeObject(
+        obj: Any,
+        data: Data,
+        type: Type,
+        output: SerializationOutput,
+        context: SerializationContext,
+        debugIndent: Int
+    ) {
+        data.putChar(obj as Int)
+    }
+
+    override fun readObject(
+        obj: Any,
+        serializationSchemas: SerializationSchemas,
+        metadata: Metadata,
+        input: DeserializationInput,
+        context: SerializationContext
+    ): Char {
+        return (obj as Int).toChar()
+    }
+}

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -95,7 +95,19 @@ class SerializationOutputTests {
     data class TestDouble(val d: Double)
 
     @CordaSerializable
+    data class TestLong(val l: Long)
+
+    @CordaSerializable
+    data class TestInt(val i: Int)
+
+    @CordaSerializable
     data class TestShort(val s: Short)
+
+    @CordaSerializable
+    data class TestByte(val b: Byte)
+
+    @CordaSerializable
+    data class TestChar(val c: Char)
 
     @CordaSerializable
     data class TestBoolean(val b: Boolean)
@@ -321,8 +333,32 @@ class SerializationOutputTests {
     }
 
     @Test
+    fun `test long`() {
+        val obj = TestLong(23923)
+        serdes(obj)
+    }
+
+    @Test
+    fun `test int`() {
+        val obj = TestInt(1)
+        serdes(obj)
+    }
+
+    @Test
     fun `test short`() {
         val obj = TestShort(1)
+        serdes(obj)
+    }
+
+    @Test
+    fun `test byte`() {
+        val obj = TestByte(1)
+        serdes(obj)
+    }
+
+    @Test
+    fun `test char`() {
+        val obj = TestChar('?')
         serdes(obj)
     }
 
@@ -330,6 +366,54 @@ class SerializationOutputTests {
     fun `test bool`() {
         val obj = TestBoolean(true)
         serdes(obj)
+    }
+
+    @Test
+    fun `test naked double`() {
+        val primitiveObj = 101.234
+        serdes(primitiveObj)
+    }
+
+    @Test
+    fun `test naked float`() {
+        val primitiveObj = 101.0f
+        serdes(primitiveObj)
+    }
+
+    @Test
+    fun `test naked long`() {
+        val primitiveObj = 9347347L
+        serdes(primitiveObj)
+    }
+
+    @Test
+    fun `test naked int`() {
+        val primitiveObj = 101
+        serdes(primitiveObj)
+    }
+
+    @Test
+    fun `test naked short`() {
+        val primitiveObj = 101.toShort()
+        serdes(primitiveObj)
+    }
+
+    @Test
+    fun `test naked byte`() {
+        val primitiveObj = 101.toByte()
+        serdes(primitiveObj)
+    }
+
+    @Test
+    fun `test naked char`() {
+        val primitiveObj = '?'
+        serdes(primitiveObj)
+    }
+
+    @Test
+    fun `test naked boolean`() {
+        val primitiveObj = true
+        serdes(primitiveObj)
     }
 
     @Test


### PR DESCRIPTION
Using AMQP to serialise and deserialise naked Java primitives is _hideously_ inefficient. Anyone using this functionality will therefore be suitably rewarded by its _miserable_ performance :no_mouth:.

The "trick" here is to register an AMQP serializer _specifically_ for the case where the declared type is `java.lang.Character` but the actual type is `java.lang.Integer`, rather than using `AMQPPrimitiveSerializer`.