### PR TITLE
CORE-13755 Add persistence metrics for membership

### DIFF
--- a/.ci/e2eTests/corda-eks.yaml
+++ b/.ci/e2eTests/corda-eks.yaml
@@ -13,9 +13,3 @@ resources:
   limits:
     memory: "1250Mi"
     cpu: "1000m"
-
-metrics:
-  podMonitor:
-    enabled: true
-    labels:
-      release: kube-prometheus-stack

--- a/.ci/e2eTests/corda-eks.yaml
+++ b/.ci/e2eTests/corda-eks.yaml
@@ -13,3 +13,9 @@ resources:
   limits:
     memory: "1250Mi"
     cpu: "1000m"
+
+metrics:
+  podMonitor:
+    enabled: true
+    labels:
+      release: kube-prometheus-stack

--- a/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
@@ -21,7 +21,7 @@ deploy() {
      --wait
 
    echo Installing corda image $DOCKER_IMAGE_VERSION into $namespace
-   helm upgrade --install corda -n $namespace oci://corda-os-docker.software.r3.com/helm-charts/release/os/5.0/corda \
+   helm upgrade --install corda -n $namespace oci://corda-os-docker-dev.software.r3.com/helm-charts/pr-3906/corda \
      --set "imagePullSecrets={docker-registry-cred}" --set image.tag=$DOCKER_IMAGE_VERSION \
      --set image.registry="corda-os-docker.software.r3.com" --values $REPO_TOP_LEVEL_DIR/values.yaml \
      --values $REPO_TOP_LEVEL_DIR/debug.yaml --wait --version $CORDA_CHART_VERSION
@@ -36,6 +36,7 @@ fi
 
 helm registry login corda-os-docker.software.r3.com -u $CORDA_ARTIFACTORY_USERNAME -p $CORDA_ARTIFACTORY_PASSWORD
 helm registry login corda-os-docker-unstable.software.r3.com -u $CORDA_ARTIFACTORY_USERNAME -p $CORDA_ARTIFACTORY_PASSWORD
+helm registry login corda-os-docker-dev.software.r3.com -u $CORDA_ARTIFACTORY_USERNAME -p $CORDA_ARTIFACTORY_PASSWORD
 
 for namespace in ${namespaces[@]}; do
     deploy $namespace &

--- a/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
@@ -21,7 +21,7 @@ deploy() {
      --wait
 
    echo Installing corda image $DOCKER_IMAGE_VERSION into $namespace
-   helm upgrade --install corda -n $namespace oci://corda-os-docker-dev.software.r3.com/helm-charts/pr-3906/corda \
+   helm upgrade --install corda -n $namespace oci://corda-os-docker.software.r3.com/helm-charts/release/os/5.0/corda \
      --set "imagePullSecrets={docker-registry-cred}" --set image.tag=$DOCKER_IMAGE_VERSION \
      --set image.registry="corda-os-docker.software.r3.com" --values $REPO_TOP_LEVEL_DIR/values.yaml \
      --values $REPO_TOP_LEVEL_DIR/debug.yaml --wait --version $CORDA_CHART_VERSION

--- a/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
@@ -36,7 +36,6 @@ fi
 
 helm registry login corda-os-docker.software.r3.com -u $CORDA_ARTIFACTORY_USERNAME -p $CORDA_ARTIFACTORY_PASSWORD
 helm registry login corda-os-docker-unstable.software.r3.com -u $CORDA_ARTIFACTORY_USERNAME -p $CORDA_ARTIFACTORY_PASSWORD
-helm registry login corda-os-docker-dev.software.r3.com -u $CORDA_ARTIFACTORY_USERNAME -p $CORDA_ARTIFACTORY_PASSWORD
 
 for namespace in ${namespaces[@]}; do
     deploy $namespace &

--- a/applications/tools/p2p-test/app-simulator/scripts/settings.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/settings.sh
@@ -5,11 +5,11 @@
 NAMESPACE_PREFIX="${USER//./}"
 
 # Chart and Docker Image versions to deploy
-CORDA_CHART_VERSION="5.1.0-alpha.1684426510056"
-#if [ -z $DOCKER_IMAGE_VERSION ]; then
-#  DOCKER_IMAGE_VERSION=$(curl -u $CORDA_ARTIFACTORY_USERNAME:$CORDA_ARTIFACTORY_PASSWORD  https://corda-os-docker-unstable.software.r3.com:/v2/corda-os-p2p-link-manager-worker/tags/list | jq -r -M '.["tags"] | map(select(contains("5.0.0.0-beta"))) | sort | reverse | .[0]')
-#fi
-DOCKER_IMAGE_VERSION=5.1.0.0-alpha-1684426510056
+CORDA_CHART_VERSION="^5.0.0-beta"
+if [ -z $DOCKER_IMAGE_VERSION ]; then
+  DOCKER_IMAGE_VERSION=$(curl -u $CORDA_ARTIFACTORY_USERNAME:$CORDA_ARTIFACTORY_PASSWORD  https://corda-os-docker-unstable.software.r3.com:/v2/corda-os-p2p-link-manager-worker/tags/list | jq -r -M '.["tags"] | map(select(contains("5.0.0.0-beta"))) | sort | reverse | .[0]')
+fi
+#DOCKER_IMAGE_VERSION=5.0.0.0-beta-167361472154
 
 # Uncomment to enable mutual TLS
 # MTLS="Y"

--- a/applications/tools/p2p-test/app-simulator/scripts/settings.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/settings.sh
@@ -5,11 +5,11 @@
 NAMESPACE_PREFIX="${USER//./}"
 
 # Chart and Docker Image versions to deploy
-CORDA_CHART_VERSION="^5.0.0-beta"
-if [ -z $DOCKER_IMAGE_VERSION ]; then
-  DOCKER_IMAGE_VERSION=$(curl -u $CORDA_ARTIFACTORY_USERNAME:$CORDA_ARTIFACTORY_PASSWORD  https://corda-os-docker-unstable.software.r3.com:/v2/corda-os-p2p-link-manager-worker/tags/list | jq -r -M '.["tags"] | map(select(contains("5.0.0.0-beta"))) | sort | reverse | .[0]')
-fi
-#DOCKER_IMAGE_VERSION=5.0.0.0-beta-167361472154
+CORDA_CHART_VERSION="5.1.0-alpha.1684426510056"
+#if [ -z $DOCKER_IMAGE_VERSION ]; then
+#  DOCKER_IMAGE_VERSION=$(curl -u $CORDA_ARTIFACTORY_USERNAME:$CORDA_ARTIFACTORY_PASSWORD  https://corda-os-docker-unstable.software.r3.com:/v2/corda-os-p2p-link-manager-worker/tags/list | jq -r -M '.["tags"] | map(select(contains("5.0.0.0-beta"))) | sort | reverse | .[0]')
+#fi
+DOCKER_IMAGE_VERSION=5.1.0.0-alpha-1684426510056
 
 # Uncomment to enable mutual TLS
 # MTLS="Y"

--- a/components/membership/membership-persistence-service-impl/build.gradle
+++ b/components/membership/membership-persistence-service-impl/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation project(':libs:membership:membership-common')
     implementation project(':libs:membership:network-info')
     implementation project(':libs:messaging:messaging')
+    implementation project(':libs:metrics')
     implementation project(":libs:platform-info")
     implementation project(':libs:virtual-node:virtual-node-info')
     implementation project(':libs:utilities')

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandler.kt
@@ -28,6 +28,7 @@ internal class ActivateMemberHandler(
         = {clock: Clock, serializer: CordaAvroDeserializer<KeyValuePairList>, deserializer: CordaAvroSerializer<KeyValuePairList>
         -> SuspensionActivationEntityOperations(clock, serializer, deserializer)}
 ) : BasePersistenceHandler<ActivateMember, ActivateMemberResponse>(persistenceHandlerServices) {
+    override val operation: String = ActivateMember::class.java.simpleName
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
         cordaAvroSerializationFactory.createAvroDeserializer(
             {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandler.kt
@@ -28,7 +28,7 @@ internal class ActivateMemberHandler(
         = {clock: Clock, serializer: CordaAvroDeserializer<KeyValuePairList>, deserializer: CordaAvroSerializer<KeyValuePairList>
         -> SuspensionActivationEntityOperations(clock, serializer, deserializer)}
 ) : BasePersistenceHandler<ActivateMember, ActivateMemberResponse>(persistenceHandlerServices) {
-    override val operation: String = ActivateMember::class.java.simpleName
+    override val operation = ActivateMember::class.java
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
         cordaAvroSerializationFactory.createAvroDeserializer(
             {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandler.kt
@@ -26,6 +26,7 @@ import kotlin.streams.asSequence
 internal class AddNotaryToGroupParametersHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<AddNotaryToGroupParameters, PersistGroupParametersResponse>(persistenceHandlerServices) {
+    override val operation: String = AddNotaryToGroupParameters::class.java.simpleName
     private companion object {
         val notaryServiceRegex = NOTARY_SERVICE_NAME_KEY.format("([0-9]+)").toRegex()
     }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandler.kt
@@ -26,11 +26,11 @@ import kotlin.streams.asSequence
 internal class AddNotaryToGroupParametersHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<AddNotaryToGroupParameters, PersistGroupParametersResponse>(persistenceHandlerServices) {
-    override val operation: String = AddNotaryToGroupParameters::class.java.simpleName
     private companion object {
         val notaryServiceRegex = NOTARY_SERVICE_NAME_KEY.format("([0-9]+)").toRegex()
     }
 
+    override val operation = AddNotaryToGroupParameters::class.java
     private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandler.kt
@@ -8,7 +8,7 @@ import net.corda.virtualnode.toCorda
 
 internal class AddPreAuthTokenHandler(persistenceHandlerServices: PersistenceHandlerServices) :
     BasePersistenceHandler<AddPreAuthToken, Unit>(persistenceHandlerServices) {
-
+    override val operation: String = AddPreAuthToken::class.java.simpleName
     override fun invoke(context: MembershipRequestContext, request: AddPreAuthToken) {
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             em.persist(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandler.kt
@@ -8,7 +8,7 @@ import net.corda.virtualnode.toCorda
 
 internal class AddPreAuthTokenHandler(persistenceHandlerServices: PersistenceHandlerServices) :
     BasePersistenceHandler<AddPreAuthToken, Unit>(persistenceHandlerServices) {
-    override val operation: String = AddPreAuthToken::class.java.simpleName
+    override val operation = AddPreAuthToken::class.java
     override fun invoke(context: MembershipRequestContext, request: AddPreAuthToken) {
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             em.persist(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandler.kt
@@ -11,7 +11,7 @@ import javax.persistence.LockModeType
 
 internal class ConsumePreAuthTokenHandler(persistenceHandlerServices: PersistenceHandlerServices) :
     BasePersistenceHandler<ConsumePreAuthToken, Unit>(persistenceHandlerServices) {
-
+    override val operation: String = ConsumePreAuthToken::class.java.simpleName
     override fun invoke(context: MembershipRequestContext, request: ConsumePreAuthToken) {
         val requestReceived = clock.instant()
         logger.info("Consuming pre-auth token with ID ${request.tokenId}")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandler.kt
@@ -11,7 +11,7 @@ import javax.persistence.LockModeType
 
 internal class ConsumePreAuthTokenHandler(persistenceHandlerServices: PersistenceHandlerServices) :
     BasePersistenceHandler<ConsumePreAuthToken, Unit>(persistenceHandlerServices) {
-    override val operation: String = ConsumePreAuthToken::class.java.simpleName
+    override val operation = ConsumePreAuthToken::class.java
     override fun invoke(context: MembershipRequestContext, request: ConsumePreAuthToken) {
         val requestReceived = clock.instant()
         logger.info("Consuming pre-auth token with ID ${request.tokenId}")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/DeleteApprovalRuleHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/DeleteApprovalRuleHandler.kt
@@ -11,6 +11,7 @@ import net.corda.virtualnode.toCorda
 internal class DeleteApprovalRuleHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<DeleteApprovalRule, DeleteApprovalRuleResponse>(persistenceHandlerServices) {
+    override val operation: String = DeleteApprovalRule::class.java.simpleName
     override fun invoke(context: MembershipRequestContext, request: DeleteApprovalRule): DeleteApprovalRuleResponse {
         logger.info("Deleting approval rule.")
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/DeleteApprovalRuleHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/DeleteApprovalRuleHandler.kt
@@ -11,7 +11,7 @@ import net.corda.virtualnode.toCorda
 internal class DeleteApprovalRuleHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<DeleteApprovalRule, DeleteApprovalRuleResponse>(persistenceHandlerServices) {
-    override val operation: String = DeleteApprovalRule::class.java.simpleName
+    override val operation = DeleteApprovalRule::class.java
     override fun invoke(context: MembershipRequestContext, request: DeleteApprovalRule): DeleteApprovalRuleResponse {
         logger.info("Deleting approval rule.")
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandler.kt
@@ -9,7 +9,7 @@ import net.corda.virtualnode.toCorda
 internal class MutualTlsAddToAllowedCertificatesHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<MutualTlsAddToAllowedCertificates, Unit>(persistenceHandlerServices) {
-    override val operation: String = MutualTlsAddToAllowedCertificates::class.java.simpleName
+    override val operation = MutualTlsAddToAllowedCertificates::class.java
     override fun invoke(
         context: MembershipRequestContext,
         request: MutualTlsAddToAllowedCertificates

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandler.kt
@@ -9,6 +9,7 @@ import net.corda.virtualnode.toCorda
 internal class MutualTlsAddToAllowedCertificatesHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<MutualTlsAddToAllowedCertificates, Unit>(persistenceHandlerServices) {
+    override val operation: String = MutualTlsAddToAllowedCertificates::class.java.simpleName
     override fun invoke(
         context: MembershipRequestContext,
         request: MutualTlsAddToAllowedCertificates

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandler.kt
@@ -9,7 +9,7 @@ import net.corda.virtualnode.toCorda
 internal class MutualTlsListAllowedCertificatesHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<MutualTlsListAllowedCertificates, MutualTlsListAllowedCertificatesResponse>(persistenceHandlerServices) {
-    override val operation: String = MutualTlsListAllowedCertificates::class.java.simpleName
+    override val operation = MutualTlsListAllowedCertificates::class.java
     override fun invoke(
         context: MembershipRequestContext,
         request: MutualTlsListAllowedCertificates

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandler.kt
@@ -9,6 +9,7 @@ import net.corda.virtualnode.toCorda
 internal class MutualTlsListAllowedCertificatesHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<MutualTlsListAllowedCertificates, MutualTlsListAllowedCertificatesResponse>(persistenceHandlerServices) {
+    override val operation: String = MutualTlsListAllowedCertificates::class.java.simpleName
     override fun invoke(
         context: MembershipRequestContext,
         request: MutualTlsListAllowedCertificates

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandler.kt
@@ -9,6 +9,7 @@ import net.corda.virtualnode.toCorda
 internal class MutualTlsRemoveFromAllowedCertificatesHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<MutualTlsRemoveFromAllowedCertificates, Unit>(persistenceHandlerServices) {
+    override val operation: String = MutualTlsRemoveFromAllowedCertificates::class.java.simpleName
     override fun invoke(
         context: MembershipRequestContext,
         request: MutualTlsRemoveFromAllowedCertificates

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandler.kt
@@ -9,7 +9,7 @@ import net.corda.virtualnode.toCorda
 internal class MutualTlsRemoveFromAllowedCertificatesHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<MutualTlsRemoveFromAllowedCertificates, Unit>(persistenceHandlerServices) {
-    override val operation: String = MutualTlsRemoveFromAllowedCertificates::class.java.simpleName
+    override val operation = MutualTlsRemoveFromAllowedCertificates::class.java
     override fun invoke(
         context: MembershipRequestContext,
         request: MutualTlsRemoveFromAllowedCertificates

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandler.kt
@@ -11,6 +11,7 @@ import net.corda.virtualnode.toCorda
 internal class PersistApprovalRuleHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistApprovalRule, PersistApprovalRuleResponse>(persistenceHandlerServices) {
+    override val operation: String = PersistApprovalRule::class.java.simpleName
     override fun invoke(context: MembershipRequestContext, request: PersistApprovalRule): PersistApprovalRuleResponse {
         logger.info("Persisting approval rule.")
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandler.kt
@@ -11,7 +11,7 @@ import net.corda.virtualnode.toCorda
 internal class PersistApprovalRuleHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistApprovalRule, PersistApprovalRuleResponse>(persistenceHandlerServices) {
-    override val operation: String = PersistApprovalRule::class.java.simpleName
+    override val operation = PersistApprovalRule::class.java
     override fun invoke(context: MembershipRequestContext, request: PersistApprovalRule): PersistApprovalRuleResponse {
         logger.info("Persisting approval rule.")
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandler.kt
@@ -15,7 +15,7 @@ import javax.persistence.LockModeType
 internal class PersistGroupParametersHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistGroupParameters, PersistGroupParametersResponse>(persistenceHandlerServices) {
-    override val operation: String = PersistGroupParameters::class.java.simpleName
+    override val operation = PersistGroupParameters::class.java
     private val deserializer: CordaAvroDeserializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroDeserializer(
             {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandler.kt
@@ -15,7 +15,7 @@ import javax.persistence.LockModeType
 internal class PersistGroupParametersHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistGroupParameters, PersistGroupParametersResponse>(persistenceHandlerServices) {
-
+    override val operation: String = PersistGroupParameters::class.java.simpleName
     private val deserializer: CordaAvroDeserializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroDeserializer(
             {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
@@ -21,6 +21,7 @@ internal class PersistGroupParametersInitialSnapshotHandler(
 ) : BasePersistenceHandler<PersistGroupParametersInitialSnapshot, PersistGroupParametersResponse>(
     persistenceHandlerServices
 ) {
+    override val operation: String = PersistGroupParametersInitialSnapshot::class.java.simpleName
     private val serializer: CordaAvroSerializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandler.kt
@@ -21,7 +21,7 @@ internal class PersistGroupParametersInitialSnapshotHandler(
 ) : BasePersistenceHandler<PersistGroupParametersInitialSnapshot, PersistGroupParametersResponse>(
     persistenceHandlerServices
 ) {
-    override val operation: String = PersistGroupParametersInitialSnapshot::class.java.simpleName
+    override val operation = PersistGroupParametersInitialSnapshot::class.java
     private val serializer: CordaAvroSerializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
@@ -14,6 +14,7 @@ import net.corda.virtualnode.toCorda
 internal class PersistGroupPolicyHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistGroupPolicy, Unit>(persistenceHandlerServices) {
+    override val operation: String = PersistGroupPolicy::class.java.simpleName
     private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandler.kt
@@ -14,7 +14,7 @@ import net.corda.virtualnode.toCorda
 internal class PersistGroupPolicyHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistGroupPolicy, Unit>(persistenceHandlerServices) {
-    override val operation: String = PersistGroupPolicy::class.java.simpleName
+    override val operation = PersistGroupPolicy::class.java
     private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
@@ -20,7 +20,7 @@ import net.corda.virtualnode.toCorda
 internal class PersistMemberInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistMemberInfo, Unit>(persistenceHandlerServices) {
-    override val operation: String = PersistMemberInfo::class.java.simpleName
+    override val operation = PersistMemberInfo::class.java
     private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
@@ -20,7 +20,7 @@ import net.corda.virtualnode.toCorda
 internal class PersistMemberInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistMemberInfo, Unit>(persistenceHandlerServices) {
-
+    override val operation: String = PersistMemberInfo::class.java.simpleName
     private val keyValuePairListSerializer: CordaAvroSerializer<KeyValuePairList> =
         cordaAvroSerializationFactory.createAvroSerializer {
             logger.error("Failed to serialize key value pair list.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
@@ -11,7 +11,7 @@ import javax.persistence.LockModeType
 internal class PersistRegistrationRequestHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistRegistrationRequest, Unit>(persistenceHandlerServices) {
-    override val operation: String = PersistRegistrationRequest::class.java.simpleName
+    override val operation = PersistRegistrationRequest::class.java
     override fun invoke(context: MembershipRequestContext, request: PersistRegistrationRequest) {
         val registrationId = request.registrationRequest.registrationId
         logger.info("Persisting registration request with ID [$registrationId] to status ${request.status}.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandler.kt
@@ -11,7 +11,7 @@ import javax.persistence.LockModeType
 internal class PersistRegistrationRequestHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<PersistRegistrationRequest, Unit>(persistenceHandlerServices) {
-
+    override val operation: String = PersistRegistrationRequest::class.java.simpleName
     override fun invoke(context: MembershipRequestContext, request: PersistRegistrationRequest) {
         val registrationId = request.registrationRequest.registrationId
         logger.info("Persisting registration request with ID [$registrationId] to status ${request.status}.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -53,17 +53,17 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
     }
 
     fun <R> transaction(holdingIdentityShortHash: ShortHash, block: (EntityManager) -> R): R {
-            val virtualNodeInfo = virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
-                ?: throw MembershipPersistenceException(
-                    "Virtual node info can't be retrieved for " +
-                            "holding identity ID $holdingIdentityShortHash"
-                )
-            val factory = getEntityManagerFactory(virtualNodeInfo)
-            return try {
-                transactionTimer.recordCallable { factory.transaction(block) }!!
-            } finally {
-                factory.close()
-            }
+        val virtualNodeInfo = virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
+            ?: throw MembershipPersistenceException(
+                "Virtual node info can't be retrieved for " +
+                        "holding identity ID $holdingIdentityShortHash"
+            )
+        val factory = getEntityManagerFactory(virtualNodeInfo)
+        return try {
+            transactionTimer.recordCallable { factory.transaction(block) }!!
+        } finally {
+            factory.close()
+        }
     }
 
     fun <R> transaction(block: (EntityManager) -> R): R {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -60,7 +60,7 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
                 )
             val factory = getEntityManagerFactory(virtualNodeInfo)
             return try {
-                transactionTimer.recordCallable { factory.transaction(block).also{println(it != null)}}!!
+                transactionTimer.recordCallable { factory.transaction(block) }!!
             } finally {
                 factory.close()
             }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -25,7 +25,7 @@ internal interface PersistenceHandler<REQUEST, RESPONSE> {
     /**
      * Persistence operation identifier for logging and metrics purposes.
      */
-    val operation: String
+    val operation: Class<REQUEST>
 
     fun invoke(context: MembershipRequestContext, request: REQUEST): RESPONSE?
 }
@@ -49,7 +49,7 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
     val allowedCertificatesReaderWriterService get() = persistenceHandlerServices.allowedCertificatesReaderWriterService
 
     private val transactionTimer by lazy {
-        persistenceHandlerServices.transactionTimerFactory(operation)
+        persistenceHandlerServices.transactionTimerFactory(operation.simpleName)
     }
 
     fun <R> transaction(holdingIdentityShortHash: ShortHash, block: (EntityManager) -> R): R {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -41,16 +41,13 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
     private val dbConnectionManager get() = persistenceHandlerServices.dbConnectionManager
     private val jpaEntitiesRegistry get() = persistenceHandlerServices.jpaEntitiesRegistry
     private val virtualNodeInfoReadService get() = persistenceHandlerServices.virtualNodeInfoReadService
+    private val transactionTimer get() = persistenceHandlerServices.transactionTimerFactory(operation.simpleName)
     val clock get() = persistenceHandlerServices.clock
     val cordaAvroSerializationFactory get() = persistenceHandlerServices.cordaAvroSerializationFactory
     val memberInfoFactory get() = persistenceHandlerServices.memberInfoFactory
     val keyEncodingService get() = persistenceHandlerServices.keyEncodingService
     val platformInfoProvider get() = persistenceHandlerServices.platformInfoProvider
     val allowedCertificatesReaderWriterService get() = persistenceHandlerServices.allowedCertificatesReaderWriterService
-
-    private val transactionTimer by lazy {
-        persistenceHandlerServices.transactionTimerFactory(operation.simpleName)
-    }
 
     fun <R> transaction(holdingIdentityShortHash: ShortHash, block: (EntityManager) -> R): R {
         val virtualNodeInfo = virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandler.kt
@@ -10,6 +10,7 @@ import net.corda.virtualnode.toCorda
 internal class QueryApprovalRulesHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryApprovalRules, ApprovalRulesQueryResponse>(persistenceHandlerServices) {
+    override val operation: String = QueryApprovalRules::class.java.simpleName
     override fun invoke(context: MembershipRequestContext, request: QueryApprovalRules): ApprovalRulesQueryResponse {
         logger.info("Retrieving approval rules.")
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandler.kt
@@ -10,7 +10,7 @@ import net.corda.virtualnode.toCorda
 internal class QueryApprovalRulesHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryApprovalRules, ApprovalRulesQueryResponse>(persistenceHandlerServices) {
-    override val operation: String = QueryApprovalRules::class.java.simpleName
+    override val operation = QueryApprovalRules::class.java
     override fun invoke(context: MembershipRequestContext, request: QueryApprovalRules): ApprovalRulesQueryResponse {
         logger.info("Retrieving approval rules.")
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandler.kt
@@ -12,7 +12,7 @@ import net.corda.virtualnode.toCorda
 internal class QueryGroupPolicyHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryGroupPolicy, GroupPolicyQueryResponse>(persistenceHandlerServices) {
-    override val operation: String = QueryGroupPolicy::class.java.simpleName
+    override val operation = QueryGroupPolicy::class.java
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
         cordaAvroSerializationFactory.createAvroDeserializer(
             {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandler.kt
@@ -12,6 +12,7 @@ import net.corda.virtualnode.toCorda
 internal class QueryGroupPolicyHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryGroupPolicy, GroupPolicyQueryResponse>(persistenceHandlerServices) {
+    override val operation: String = QueryGroupPolicy::class.java.simpleName
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
         cordaAvroSerializationFactory.createAvroDeserializer(
             {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandler.kt
@@ -12,7 +12,7 @@ import net.corda.virtualnode.toCorda
 internal class QueryMemberInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryMemberInfo, MemberInfoQueryResponse>(persistenceHandlerServices) {
-    override val operation: String = QueryMemberInfo::class.java.simpleName
+    override val operation = QueryMemberInfo::class.java
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
         cordaAvroSerializationFactory.createAvroDeserializer(
             {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandler.kt
@@ -12,7 +12,7 @@ import net.corda.virtualnode.toCorda
 internal class QueryMemberInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryMemberInfo, MemberInfoQueryResponse>(persistenceHandlerServices) {
-
+    override val operation: String = QueryMemberInfo::class.java.simpleName
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
         cordaAvroSerializationFactory.createAvroDeserializer(
             {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandler.kt
@@ -14,7 +14,7 @@ import java.nio.ByteBuffer
 internal class QueryMemberSignatureHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryMemberSignature, MemberSignatureQueryResponse>(persistenceHandlerServices) {
-    override val operation: String = QueryMemberSignature::class.java.simpleName
+    override val operation = QueryMemberSignature::class.java
     override fun invoke(
         context: MembershipRequestContext,
         request: QueryMemberSignature,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandler.kt
@@ -14,7 +14,7 @@ import java.nio.ByteBuffer
 internal class QueryMemberSignatureHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryMemberSignature, MemberSignatureQueryResponse>(persistenceHandlerServices) {
-
+    override val operation: String = QueryMemberSignature::class.java.simpleName
     override fun invoke(
         context: MembershipRequestContext,
         request: QueryMemberSignature,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryPreAuthTokenHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryPreAuthTokenHandler.kt
@@ -10,7 +10,7 @@ import javax.persistence.criteria.Predicate
 
 internal class QueryPreAuthTokenHandler(persistenceHandlerServices: PersistenceHandlerServices) :
     BasePersistenceHandler<QueryPreAuthToken, PreAuthTokenQueryResponse>(persistenceHandlerServices) {
-
+    override val operation: String = QueryPreAuthToken::class.java.simpleName
     override fun invoke(context: MembershipRequestContext, request: QueryPreAuthToken): PreAuthTokenQueryResponse {
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             val criteriaBuilder = em.criteriaBuilder

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryPreAuthTokenHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryPreAuthTokenHandler.kt
@@ -10,7 +10,7 @@ import javax.persistence.criteria.Predicate
 
 internal class QueryPreAuthTokenHandler(persistenceHandlerServices: PersistenceHandlerServices) :
     BasePersistenceHandler<QueryPreAuthToken, PreAuthTokenQueryResponse>(persistenceHandlerServices) {
-    override val operation: String = QueryPreAuthToken::class.java.simpleName
+    override val operation = QueryPreAuthToken::class.java
     override fun invoke(context: MembershipRequestContext, request: QueryPreAuthToken): PreAuthTokenQueryResponse {
         return transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             val criteriaBuilder = em.criteriaBuilder

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
@@ -9,6 +9,7 @@ import net.corda.virtualnode.toCorda
 internal class QueryRegistrationRequestHandler(persistenceHandlerServices: PersistenceHandlerServices)
     :BaseRequestStatusHandler<QueryRegistrationRequest, RegistrationRequestQueryResponse>(persistenceHandlerServices)
 {
+    override val operation: String = QueryRegistrationRequest::class.java.simpleName
     override fun invoke(
         context: MembershipRequestContext,
         request: QueryRegistrationRequest,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandler.kt
@@ -9,7 +9,7 @@ import net.corda.virtualnode.toCorda
 internal class QueryRegistrationRequestHandler(persistenceHandlerServices: PersistenceHandlerServices)
     :BaseRequestStatusHandler<QueryRegistrationRequest, RegistrationRequestQueryResponse>(persistenceHandlerServices)
 {
-    override val operation: String = QueryRegistrationRequest::class.java.simpleName
+    override val operation = QueryRegistrationRequest::class.java
     override fun invoke(
         context: MembershipRequestContext,
         request: QueryRegistrationRequest,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandler.kt
@@ -13,6 +13,7 @@ import javax.persistence.criteria.Predicate
 internal class QueryRegistrationRequestsHandler(persistenceHandlerServices: PersistenceHandlerServices)
     :BaseRequestStatusHandler<QueryRegistrationRequests, RegistrationRequestsQueryResponse>(persistenceHandlerServices)
 {
+    override val operation: String = QueryRegistrationRequests::class.java.simpleName
     override fun invoke(
         context: MembershipRequestContext,
         request: QueryRegistrationRequests,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandler.kt
@@ -13,7 +13,7 @@ import javax.persistence.criteria.Predicate
 internal class QueryRegistrationRequestsHandler(persistenceHandlerServices: PersistenceHandlerServices)
     :BaseRequestStatusHandler<QueryRegistrationRequests, RegistrationRequestsQueryResponse>(persistenceHandlerServices)
 {
-    override val operation: String = QueryRegistrationRequests::class.java.simpleName
+    override val operation = QueryRegistrationRequests::class.java
     override fun invoke(
         context: MembershipRequestContext,
         request: QueryRegistrationRequests,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryStaticNetworkInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryStaticNetworkInfoHandler.kt
@@ -10,7 +10,7 @@ import net.corda.membership.network.writer.staticnetwork.StaticNetworkInfoMappin
 internal class QueryStaticNetworkInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryStaticNetworkInfo, StaticNetworkInfoQueryResponse>(persistenceHandlerServices) {
-
+    override val operation: String = QueryStaticNetworkInfo::class.java.simpleName
     private val deserializer = cordaAvroSerializationFactory.createAvroDeserializer({
         logger.error("Failed to deserialize KeyValuePairList.")
     }, KeyValuePairList::class.java)

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryStaticNetworkInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/QueryStaticNetworkInfoHandler.kt
@@ -10,7 +10,7 @@ import net.corda.membership.network.writer.staticnetwork.StaticNetworkInfoMappin
 internal class QueryStaticNetworkInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<QueryStaticNetworkInfo, StaticNetworkInfoQueryResponse>(persistenceHandlerServices) {
-    override val operation: String = QueryStaticNetworkInfo::class.java.simpleName
+    override val operation = QueryStaticNetworkInfo::class.java
     private val deserializer = cordaAvroSerializationFactory.createAvroDeserializer({
         logger.error("Failed to deserialize KeyValuePairList.")
     }, KeyValuePairList::class.java)

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandler.kt
@@ -12,7 +12,7 @@ import javax.persistence.LockModeType
 
 internal class RevokePreAuthTokenHandler(persistenceHandlerServices: PersistenceHandlerServices)
     : BasePersistenceHandler<RevokePreAuthToken, RevokePreAuthTokenResponse>(persistenceHandlerServices) {
-    override val operation: String = RevokePreAuthToken::class.java.simpleName
+    override val operation = RevokePreAuthToken::class.java
     companion object {
         fun PreAuthTokenEntity.toAvro(): PreAuthToken {
             return PreAuthToken(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandler.kt
@@ -12,7 +12,7 @@ import javax.persistence.LockModeType
 
 internal class RevokePreAuthTokenHandler(persistenceHandlerServices: PersistenceHandlerServices)
     : BasePersistenceHandler<RevokePreAuthToken, RevokePreAuthTokenResponse>(persistenceHandlerServices) {
-
+    override val operation: String = RevokePreAuthToken::class.java.simpleName
     companion object {
         fun PreAuthTokenEntity.toAvro(): PreAuthToken {
             return PreAuthToken(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandler.kt
@@ -42,7 +42,7 @@ internal class SuspendMemberHandler(
         SuspensionActivationEntityOperations(clock, serializer, deserializer)
     }
 ) : BasePersistenceHandler<SuspendMember, SuspendMemberResponse>(persistenceHandlerServices) {
-    override val operation: String = SuspendMember::class.java.simpleName
+    override val operation = SuspendMember::class.java
     private companion object {
         val notaryServiceRegex = NOTARY_SERVICE_NAME_KEY.format("([0-9]+)").toRegex()
     }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandler.kt
@@ -42,6 +42,7 @@ internal class SuspendMemberHandler(
         SuspensionActivationEntityOperations(clock, serializer, deserializer)
     }
 ) : BasePersistenceHandler<SuspendMember, SuspendMemberResponse>(persistenceHandlerServices) {
+    override val operation: String = SuspendMember::class.java.simpleName
     private companion object {
         val notaryServiceRegex = NOTARY_SERVICE_NAME_KEY.format("([0-9]+)").toRegex()
     }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
@@ -27,6 +27,7 @@ internal class UpdateMemberAndRegistrationRequestToApprovedHandler(
         UpdateMemberAndRegistrationRequestToApproved,
         UpdateMemberAndRegistrationRequestResponse
         >(persistenceHandlerServices) {
+    override val operation: String = UpdateMemberAndRegistrationRequestToApproved::class.java.simpleName
 
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
         cordaAvroSerializationFactory.createAvroDeserializer(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
@@ -27,7 +27,7 @@ internal class UpdateMemberAndRegistrationRequestToApprovedHandler(
         UpdateMemberAndRegistrationRequestToApproved,
         UpdateMemberAndRegistrationRequestResponse
         >(persistenceHandlerServices) {
-    override val operation: String = UpdateMemberAndRegistrationRequestToApproved::class.java.simpleName
+    override val operation = UpdateMemberAndRegistrationRequestToApproved::class.java
 
     private val keyValuePairListDeserializer: CordaAvroDeserializer<KeyValuePairList> by lazy {
         cordaAvroSerializationFactory.createAvroDeserializer(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandler.kt
@@ -12,6 +12,7 @@ import javax.persistence.LockModeType
 internal class UpdateRegistrationRequestStatusHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<UpdateRegistrationRequestStatus, Unit>(persistenceHandlerServices) {
+    override val operation: String = UpdateRegistrationRequestStatus::class.java.simpleName
     override fun invoke(context: MembershipRequestContext, request: UpdateRegistrationRequestStatus) {
         transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             val registrationRequest = em.find(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandler.kt
@@ -12,7 +12,7 @@ import javax.persistence.LockModeType
 internal class UpdateRegistrationRequestStatusHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<UpdateRegistrationRequestStatus, Unit>(persistenceHandlerServices) {
-    override val operation: String = UpdateRegistrationRequestStatus::class.java.simpleName
+    override val operation = UpdateRegistrationRequestStatus::class.java
     override fun invoke(context: MembershipRequestContext, request: UpdateRegistrationRequestStatus) {
         transaction(context.holdingIdentity.toCorda().shortHash) { em ->
             val registrationRequest = em.find(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateStaticNetworkInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateStaticNetworkInfoHandler.kt
@@ -14,7 +14,7 @@ import net.corda.utilities.serialization.wrapWithNullErrorHandling
 internal class UpdateStaticNetworkInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<UpdateStaticNetworkInfo, StaticNetworkInfoQueryResponse>(persistenceHandlerServices) {
-    override val operation: String = UpdateStaticNetworkInfo::class.java.simpleName
+    override val operation = UpdateStaticNetworkInfo::class.java
 
     private val deserializer = cordaAvroSerializationFactory.createAvroDeserializer({
         logger.error("Failed to deserialize KeyValuePairList.")

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateStaticNetworkInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateStaticNetworkInfoHandler.kt
@@ -14,6 +14,7 @@ import net.corda.utilities.serialization.wrapWithNullErrorHandling
 internal class UpdateStaticNetworkInfoHandler(
     persistenceHandlerServices: PersistenceHandlerServices
 ) : BasePersistenceHandler<UpdateStaticNetworkInfo, StaticNetworkInfoQueryResponse>(persistenceHandlerServices) {
+    override val operation: String = UpdateStaticNetworkInfo::class.java.simpleName
 
     private val deserializer = cordaAvroSerializationFactory.createAvroDeserializer({
         logger.error("Failed to deserialize KeyValuePairList.")

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -81,6 +81,7 @@ import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
@@ -256,6 +257,7 @@ class MembershipPersistenceRPCProcessorTest {
         on { merge(preAuthTokenEntity) } doReturn preAuthTokenEntity
         on { createQuery(registrationRequestsQuery) } doReturn registrationRequestQuery
         on { find(eq(MemberInfoEntity::class.java), any(), eq(LockModeType.PESSIMISTIC_WRITE)) } doReturn memberEntity
+        on { merge(any<Any>()) } doAnswer { it.arguments[0] }
     }
     private val entityManagerFactory: EntityManagerFactory = mock {
         on { createEntityManager() } doReturn entityManager

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandlerTest.kt
@@ -137,6 +137,7 @@ class ActivateMemberHandlerTest {
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { cordaAvroSerializationFactory } doReturn cordaAvroSerializationFactory
         on { memberInfoFactory } doReturn memberInfoFactory
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
 
     private val addNotaryToGroupParametersHandler = mock<AddNotaryToGroupParametersHandler>()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
@@ -224,6 +224,7 @@ class AddNotaryToGroupParametersHandlerTest {
         on { clock } doReturn clock
         on { keyEncodingService } doReturn keyEncodingService
         on { memberInfoFactory } doReturn memberInfoFactory
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = AddNotaryToGroupParametersHandler(persistenceHandlerServices)
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandlerTest.kt
@@ -58,6 +58,7 @@ class AddPreAuthTokenHandlerTest {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = AddPreAuthTokenHandler(persistenceHandlerServices)
     private val context = mock<MembershipRequestContext> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/BaseRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/BaseRequestStatusHandlerTest.kt
@@ -83,6 +83,7 @@ class BaseRequestStatusHandlerTest {
         on { cordaAvroSerializationFactory } doReturn serializationFactory
     }
     private val handler = object: BaseRequestStatusHandler<String, String>(persistenceHandlerServices) {
+        override val operation: String = "TestOperation"
         override fun invoke(context: MembershipRequestContext, request: String): String {
             // Do nothing...
             return ""

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/BaseRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/BaseRequestStatusHandlerTest.kt
@@ -83,7 +83,7 @@ class BaseRequestStatusHandlerTest {
         on { cordaAvroSerializationFactory } doReturn serializationFactory
     }
     private val handler = object: BaseRequestStatusHandler<String, String>(persistenceHandlerServices) {
-        override val operation: String = "TestOperation"
+        override val operation = String::class.java
         override fun invoke(context: MembershipRequestContext, request: String): String {
             // Do nothing...
             return ""

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandlerTest.kt
@@ -74,6 +74,7 @@ class ConsumePreAuthTokenHandlerTest {
         on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
 
     private val handler: ConsumePreAuthTokenHandler = ConsumePreAuthTokenHandler(persistenceHandlerServices)

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/DeleteApprovalRuleHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/DeleteApprovalRuleHandlerTest.kt
@@ -75,6 +75,7 @@ class DeleteApprovalRuleHandlerTest {
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val context = mock<MembershipRequestContext> {
         on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/HandlerTestHelpers.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/HandlerTestHelpers.kt
@@ -1,0 +1,14 @@
+package net.corda.membership.impl.persistence.service.handler
+
+import io.micrometer.core.instrument.Timer
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import java.util.concurrent.Callable
+
+val transactionTimer: Timer = mock {
+    on { recordCallable(any<Callable<*>>()) } doAnswer {
+        @Suppress("unchecked_cast")
+        (it.arguments[0] as Callable<Any>).call()
+    }
+}

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandlerTest.kt
@@ -15,6 +15,7 @@ import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -37,6 +38,7 @@ class MutualTlsAddToAllowedCertificatesHandlerTest {
     private val entityTransaction = mock<EntityTransaction>()
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn entityTransaction
+        on { merge<Any>(any()) } doAnswer { it.arguments[0] }
     }
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
@@ -54,6 +56,7 @@ class MutualTlsAddToAllowedCertificatesHandlerTest {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = MutualTlsAddToAllowedCertificatesHandler(persistenceHandlerServices)
     private val context = mock<MembershipRequestContext> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandlerTest.kt
@@ -58,6 +58,7 @@ class MutualTlsListAllowedCertificatesHandlerTest {
         on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = MutualTlsListAllowedCertificatesHandler(persistenceHandlerServices)
     private val context = mock<MembershipRequestContext> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandlerTest.kt
@@ -15,6 +15,7 @@ import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -37,6 +38,7 @@ class MutualTlsRemoveFromAllowedCertificatesHandlerTest {
     private val entityTransaction = mock<EntityTransaction>()
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn entityTransaction
+        on { merge<Any>(any()) } doAnswer { it.arguments[0] }
     }
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
@@ -54,6 +56,7 @@ class MutualTlsRemoveFromAllowedCertificatesHandlerTest {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = MutualTlsRemoveFromAllowedCertificatesHandler(persistenceHandlerServices)
     private val context = mock<MembershipRequestContext> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandlerTest.kt
@@ -100,6 +100,7 @@ class PersistApprovalRuleHandlerTest {
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private lateinit var handler: PersistApprovalRuleHandler
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandlerTest.kt
@@ -163,6 +163,7 @@ class PersistGroupParametersHandlerTest {
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
         on { clock } doReturn clock
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = PersistGroupParametersHandler(persistenceHandlerServices)
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
@@ -96,6 +96,7 @@ class PersistGroupParametersInitialSnapshotHandlerTest {
         on { dbConnectionManager } doReturn connectionManager
         on { clock } doReturn clock
         on { keyEncodingService } doReturn keyEncodingService
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = PersistGroupParametersInitialSnapshotHandler(persistenceHandlerServices)
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -87,6 +87,7 @@ class PersistGroupPolicyHandlerTest {
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
         on { clock } doReturn clock
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = PersistGroupPolicyHandler(persistenceHandlerServices)
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -127,7 +127,7 @@ class PersistMemberInfoHandlerTest {
     }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
-
+    private val transactionTimerFactory = { _: String -> transactionTimer }
     private val services = PersistenceHandlerServices(
         clock,
         dbConnectionManager,
@@ -138,6 +138,7 @@ class PersistMemberInfoHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        transactionTimerFactory
     )
     private lateinit var persistMemberInfoHandler: PersistMemberInfoHandler
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
@@ -105,7 +105,7 @@ class PersistRegistrationRequestHandlerTest {
     }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
-
+    private val transactionTimerFactory = { _: String -> transactionTimer }
     private val services = PersistenceHandlerServices(
         clock,
         dbConnectionManager,
@@ -116,6 +116,7 @@ class PersistRegistrationRequestHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        transactionTimerFactory
     )
     private lateinit var persistRegistrationRequestHandler: PersistRegistrationRequestHandler
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandlerTest.kt
@@ -94,6 +94,7 @@ class QueryApprovalRulesHandlerTest {
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val context = mock<MembershipRequestContext> {
         on { holdingIdentity } doReturn HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group")

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
@@ -91,6 +91,7 @@ class QueryGroupPolicyHandlerTest {
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
 
+    private val transactionTimerFactory = { _: String -> transactionTimer }
     private val services = PersistenceHandlerServices(
         clock,
         dbConnectionManager,
@@ -101,6 +102,7 @@ class QueryGroupPolicyHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        transactionTimerFactory
     )
 
     private lateinit var queryGroupPolicyHandler: QueryGroupPolicyHandler

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
@@ -112,7 +112,7 @@ class QueryMemberInfoHandlerTest {
     }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
-
+    private val transactionTimerFactory = { _: String -> transactionTimer }
     private val services = PersistenceHandlerServices(
         clock,
         dbConnectionManager,
@@ -123,6 +123,7 @@ class QueryMemberInfoHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        transactionTimerFactory
     )
     private lateinit var queryMemberInfoHandler: QueryMemberInfoHandler
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
@@ -87,6 +87,7 @@ class QueryMemberSignatureHandlerTest {
     }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
+    private val transactionTimerFactory = { _: String -> transactionTimer }
     private val service = PersistenceHandlerServices(
         clock,
         dbConnectionManager,
@@ -97,6 +98,7 @@ class QueryMemberSignatureHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        transactionTimerFactory
     )
     private val handler = QueryMemberSignatureHandler(service)
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryPreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryPreAuthTokenHandlerTest.kt
@@ -100,6 +100,7 @@ class QueryPreAuthTokenHandlerTest {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = QueryPreAuthTokenHandler(persistenceHandlerServices)
     private val context = mock<MembershipRequestContext> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandlerTest.kt
@@ -100,6 +100,7 @@ class QueryRegistrationRequestHandlerTest {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { cordaAvroSerializationFactory } doReturn serializationFactory
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val context = mock<MembershipRequestContext> {
         on { holdingIdentity } doReturn holdingIdentity

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
@@ -103,6 +103,7 @@ class QueryRegistrationRequestsHandlerTest {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { cordaAvroSerializationFactory } doReturn serializationFactory
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val context = MembershipRequestContext(Instant.ofEpochSecond(0), null, holdingIdentity)
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryStaticNetworkInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryStaticNetworkInfoHandlerTest.kt
@@ -46,6 +46,7 @@ class QueryStaticNetworkInfoHandlerTest {
     private val services = mock<PersistenceHandlerServices> {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { cordaAvroSerializationFactory } doReturn serializationFactory
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = QueryStaticNetworkInfoHandler(services)
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandlerTest.kt
@@ -67,6 +67,7 @@ class RevokePreAuthTokenHandlerTest  {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = RevokePreAuthTokenHandler(persistenceHandlerServices)
     private val context = mock<MembershipRequestContext> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandlerTest.kt
@@ -212,6 +212,7 @@ class SuspendMemberHandlerTest {
         on { cordaAvroSerializationFactory } doReturn cordaAvroSerializationFactory
         on { memberInfoFactory } doReturn memberInfoFactory
         on { keyEncodingService } doReturn mock()
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val notaryUpdater = mock<GroupParametersNotaryUpdater>()
     private val handler: SuspendMemberHandler = SuspendMemberHandler(persistenceHandlerServices, notaryUpdater) { _, _, _, ->

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
@@ -102,6 +102,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
     }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
+    private val transactionTimeFactory = { _: String -> transactionTimer }
     private val service = PersistenceHandlerServices(
         clock,
         dbConnectionManager,
@@ -112,6 +113,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        transactionTimeFactory
     )
     private val handler = UpdateMemberAndRegistrationRequestToApprovedHandler(service)
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -66,6 +67,7 @@ class UpdateRegistrationRequestStatusHandlerTest {
     private val entityTransaction: EntityTransaction = mock()
     private val entityManager: EntityManager = mock {
         on { transaction } doReturn entityTransaction
+        on { merge(any<Any>()) } doAnswer { it.arguments[0] }
     }
     private val entityManagerFactory: EntityManagerFactory = mock {
         on { createEntityManager() } doReturn entityManager
@@ -94,7 +96,7 @@ class UpdateRegistrationRequestStatusHandlerTest {
     }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
-
+    private val transactionTimerFactory = { _: String -> transactionTimer }
     private val services = PersistenceHandlerServices(
         clock,
         dbConnectionManager,
@@ -105,6 +107,7 @@ class UpdateRegistrationRequestStatusHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        transactionTimerFactory
     )
     private lateinit var updateRegistrationRequestStatusHandler: UpdateRegistrationRequestStatusHandler
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateStaticNetworkInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateStaticNetworkInfoHandlerTest.kt
@@ -101,6 +101,7 @@ class UpdateStaticNetworkInfoHandlerTest {
     private val services = mock<PersistenceHandlerServices> {
         on { dbConnectionManager } doReturn dbConnectionManager
         on { cordaAvroSerializationFactory } doReturn serializationFactory
+        on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val handler = UpdateStaticNetworkInfoHandler(services)
 

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -186,6 +186,22 @@ object CordaMetrics {
          * The time taken by the backing store to perform a single read operation from the database.
          */
         object UniquenessBackingStoreDbReadTime: Metric<Timer>("uniqueness.backingstore.db.read.time", CordaMetrics::timer)
+
+        /**
+         * Time taken for a membership persistence transaction to complete.
+         */
+        object MembershipPersistenceTransaction: Metric<Timer>(
+            "membership.persistence.transaction.time",
+            CordaMetrics::timer
+        )
+
+        /**
+         * Total time taken for a membership persistence handler to execute.
+         */
+        object MembershipPersistenceHandler: Metric<Timer>(
+            "membership.persistence.handler.time",
+            CordaMetrics::timer
+        )
     }
 
     /**


### PR DESCRIPTION
Added metrics to capture both the overall membership persistence handler execution time and the membership persistence transaction times. This is because the recent performance issues we saw in the e2e test environment was caused by the time spent getting the database connection which only became clear after comparing the transaction times to the handler execution times. 

The Corda metrics library for timers give a breakdown of the 50th, 95th, and 99th percentile times, as well as count, sum and max metrics. 

Added dashboard "Membership" to "eks-e2e-dev". This will likely need to be moved to a base image.

On Grafana we can see an overview of all persistence operations for transaction time and handler times
<img width="819" alt="Screenshot 2023-05-19 at 12 10 53" src="https://github.com/corda/corda-runtime-os/assets/69511999/a892cc83-e670-4b22-af81-32a40b0f70de">

Here is a closer look at the handler execution times
<img width="1554" alt="Screenshot 2023-05-19 at 12 11 43" src="https://github.com/corda/corda-runtime-os/assets/69511999/67264903-3cac-4ed5-8b90-6007111ce74d">

A more useful view is to click in to a specific persistence operation and percentile. This is showing the 50th percentile times for `QueryRegistrationRequest`
<img width="1554" alt="Screenshot 2023-05-19 at 12 12 45" src="https://github.com/corda/corda-runtime-os/assets/69511999/64d85139-af6a-4fa2-aa73-46f446aaffb5">

And here is the transaction times breakdown
<img width="1554" alt="Screenshot 2023-05-19 at 12 13 23" src="https://github.com/corda/corda-runtime-os/assets/69511999/db6096b5-8834-401d-bf40-36815921541b">

And again, the 50th percentile view for QueryRegistrationRequest
<img width="1554" alt="Screenshot 2023-05-19 at 12 13 51" src="https://github.com/corda/corda-runtime-os/assets/69511999/e432eaae-b63a-4b6a-a579-f8fdf1f07a0e">
