### PR TITLE
CORE-13455 Set limits on deployments from p2p scripts to match CI deployments

### DIFF
--- a/applications/tools/p2p-test/app-simulator/README.md
+++ b/applications/tools/p2p-test/app-simulator/README.md
@@ -298,3 +298,7 @@ Then using [helm-docs](https://github.com/norwoodj/helm-docs), generate the READ
 ```shell
 helm-docs
 ```
+
+# Deploying Corda
+
+This directory also contains a script (`deploy.sh`) which can be used to deploy Corda to a k8s cluster. The environment deployed by the deploy script is configurable through yaml files. The base configuration for Corda comes from the `values.yaml` file at the top level directory of this repo. Resource limits are then set to align with the resource limits used in the e2e testing environment in the `corda-eks.yaml` file. The `debug.yaml` file, also in the top level directory, is used to override this with debug properties. For the prereqs, `prereqs-eks.yaml` is used to set the resource limits. Again, these limits are set to align with the e2e testing environment. 

--- a/applications/tools/p2p-test/app-simulator/scripts/corda-eks.yaml
+++ b/applications/tools/p2p-test/app-simulator/scripts/corda-eks.yaml
@@ -1,0 +1,7 @@
+resources:
+  requests:
+    memory: "620Mi"
+    cpu: "500m"
+  limits:
+    memory: "1250Mi"
+    cpu: "1000m"

--- a/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
@@ -16,6 +16,7 @@ deploy() {
      oci://corda-os-docker.software.r3.com/helm-charts/corda-dev \
      --set image.registry="corda-os-docker.software.r3.com" \
      --set kafka.replicaCount=$KAFKA_REPLICAS,kafka.zookeeper.replicaCount=$KAFKA_ZOOKEEPER_REPLICAS \
+     -f prereqs-eks.yaml \
      --render-subchart-notes \
      --timeout 10m \
      --wait
@@ -24,6 +25,7 @@ deploy() {
    helm upgrade --install corda -n $namespace oci://corda-os-docker.software.r3.com/helm-charts/release/os/5.0/corda \
      --set "imagePullSecrets={docker-registry-cred}" --set image.tag=$DOCKER_IMAGE_VERSION \
      --set image.registry="corda-os-docker.software.r3.com" --values $REPO_TOP_LEVEL_DIR/values.yaml \
+     -f corda-eks.yaml \
      --values $REPO_TOP_LEVEL_DIR/debug.yaml --wait --version $CORDA_CHART_VERSION
 }
 

--- a/applications/tools/p2p-test/app-simulator/scripts/prereqs-eks.yaml
+++ b/applications/tools/p2p-test/app-simulator/scripts/prereqs-eks.yaml
@@ -1,0 +1,18 @@
+kafka:
+  resources:
+    requests:
+      memory: 390Mi
+      cpu: 1000m
+    limits:
+      memory: 800Mi
+      cpu: 1000m
+
+postgresql:
+  primary:
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 300m
+      limits:  
+        memory: 512Mi
+        cpu: 600m


### PR DESCRIPTION
This adds the same CPU and memory limits as done for the CI deployments so that pods aren't running without an uper limit and so that we can more easily reproduce issues often seen in the e2e tests.