### PR TITLE
CORE-check reconciliation for performance

### DIFF
--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -1,6 +1,5 @@
 package net.corda.reconciliation.impl
 
-import kotlin.streams.asSequence
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleEvent
 import net.corda.lifecycle.LifecycleEventHandler
@@ -15,6 +14,7 @@ import net.corda.reconciliation.ReconcilerWriter
 import net.corda.utilities.debug
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.LoggerFactory
+import kotlin.streams.asSequence
 
 @Suppress("LongParameterList")
 internal class ReconcilerEventHandler<K : Any, V : Any>(
@@ -107,7 +107,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                 }
 
                 if (toBeReconciled) {
-                    logger.debug { "DbRecord[k=${dbRecord.key},v=${dbRecord.version}] marked for reconciliation" }
+                    logger.info ("DbRecord[k=${dbRecord.key},v=${dbRecord.version}] marked for reconciliation")
                 }
 
                 toBeReconciled


### PR DESCRIPTION
Reconciliation in the logs varies from 0-3 ms to 1500+ in HoldingIdentity, Internal Group Parameters and MGMAllowedCertificateSubject. Check if we are overly-reconciling in the DB Worker and if it could impact performance.