### PR TITLE
CORE-13974: Optimise CordaClassResolver for Kryo 5.5.

### DIFF
--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/resolver/CordaClassResolver.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/resolver/CordaClassResolver.kt
@@ -55,7 +55,11 @@ class CordaClassResolver(
         nameId = nextNameId++
         classToNameId.put(type, nameId)
         output.writeVarInt(nameId, true)
-        output.writeString(type.name)
+        if (registration.isTypeNameAscii) {
+            output.writeAscii(type.name)
+        } else {
+            output.writeString(type.name)
+        }
         output.writeString(sandboxGroup.getStaticTag(type))
     }
 


### PR DESCRIPTION
Update `CordaClassResolver` to write class names as ASCII unless they actually _need_ UTF-8.

This optimisation was introduced in Kryo 5.x, although our `CordaClassResolver` was still based on the Kryo 4.x version of `DefaultClassResolver`.