### PR TITLE
CORE-13952: Remove tracking of RPC subscription

### DIFF
--- a/components/membership/certificates-service-impl/src/main/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImpl.kt
+++ b/components/membership/certificates-service-impl/src/main/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImpl.kt
@@ -115,8 +115,8 @@ class CertificatesServiceImpl internal constructor(
                     configHandle = null
                     rpcSubscription?.close()
                     rpcSubscription = null
+                    coordinator.updateStatus(event.status)
                 }
-                coordinator.updateStatus(event.status)
             }
 
             is ConfigChangedEvent -> {
@@ -134,6 +134,7 @@ class CertificatesServiceImpl internal constructor(
                 ).also {
                     it.start()
                 }
+                coordinator.updateStatus(LifecycleStatus.UP)
             }
 
             else -> {

--- a/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImplTest.kt
+++ b/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImplTest.kt
@@ -118,7 +118,7 @@ class CertificatesServiceImplTest {
 
             handler.firstValue.processEvent(StopEvent(), coordinator)
 
-            verify(registrationHandle, times(2)).close()
+            verify(registrationHandle, times(1)).close()
             verify(configHandle).close()
             verify(subscription).close()
         }
@@ -248,7 +248,7 @@ class CertificatesServiceImplTest {
         }
 
         @Test
-        fun `ConfigChangedEvent will start and follow the subscription`() {
+        fun `ConfigChangedEvent will start`() {
             whenever(subscription.subscriptionName).doReturn(mock())
             val event = ConfigChangedEvent(
                 emptySet(),
@@ -258,14 +258,11 @@ class CertificatesServiceImplTest {
             handler.firstValue.processEvent(event, coordinator)
 
             verify(subscription).start()
-            verify(coordinator).followStatusChangesByName(setOf(subscription.subscriptionName))
         }
 
         @Test
         fun `second ConfigChangedEvent will stop the subscription`() {
-            val registration = mock<RegistrationHandle>()
             whenever(subscription.subscriptionName).doReturn(mock())
-            whenever(coordinator.followStatusChangesByName(setOf(subscription.subscriptionName))).doReturn(registration)
             val event = ConfigChangedEvent(
                 emptySet(),
                 mapOf(ConfigKeys.MESSAGING_CONFIG to mock())
@@ -275,7 +272,6 @@ class CertificatesServiceImplTest {
             handler.firstValue.processEvent(event, coordinator)
 
             verify(subscription).close()
-            verify(registration).close()
         }
     }
 }


### PR DESCRIPTION
We shouldn't need to track the subscription as part of the lifecycle.  This can lead to spurious ERROR messages when we don't correctly manage the tracking of the subscription and our handling of the subscription itself.  (e.g. we bring the subscription down but we haven't stopped tracking it)

Removing the subscription tracking clears that up and ensures we're consistent with the rest of Corda as well.