### PR TITLE
CORE-13870: Unique Kafka ClientId

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
@@ -12,7 +12,7 @@ consumer = ${common} {
     group.id = ${group}
     # Consumer client ID. This requires the topic name, group name and client ID to be set at the top level
     # before attempting to resolve this file. Primarily used for logging.
-    client.id = ${group}-consumer-${clientId}
+    client.id = consumer-${clientId}
     # This ensures a default where connection with no offset for a consumer group does not result in an exception.
     auto.offset.reset = earliest
     # Ensures that messages from uncommitted transactions are not visible. This is required to meet transactionality
@@ -28,7 +28,7 @@ consumer = ${common} {
 producer = ${common} {
     # Producer client ID. This requires the clientId to be set at the top level before attempting to resolve this file.
     # Primarily used for logging.
-    client.id = ${clientId}-producer
+    client.id = producer-${clientId}
     # Ensures that messages are sent to the broker exactly once. Note that some configuration settings must be set to
     # compatible values as a result of this. A ConfigException will be raised if these are set to incompatible values.
     enable.idempotence = true
@@ -64,11 +64,11 @@ roles {
     stateAndEvent {
         stateConsumer = ${consumer} {
             # Need to be able to distinguish between the state and event consumers for this pattern.
-            client.id = ${group}-stateConsumer-${clientId}
+            client.id = stateConsumer-${clientId}
         }
         eventConsumer = ${consumer} {
             # Need to be able to distinguish between the state and event consumers for this pattern.
-            client.id = ${group}-eventConsumer-${clientId}
+            client.id = eventConsumer-${clientId}
         }
         producer = ${producer}
     }

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
@@ -66,14 +66,14 @@ class MessageBusConfigResolverTest {
                     mapOf(
                         BOOTSTRAP_SERVERS_PROP to "kafka:1001",
                         SSL_KEYSTORE_PROP to "foo/bar",
-                        CLIENT_ID_PROP to "$GROUP_NAME-stateConsumer-$CLIENT_ID"
+                        CLIENT_ID_PROP to "stateConsumer-$CLIENT_ID"
                     )
                 ),
                 ConsumerRoles.SAE_EVENT to getExpectedConsumerProperties(
                     mapOf(
                         BOOTSTRAP_SERVERS_PROP to "kafka:1001",
                         SSL_KEYSTORE_PROP to "foo/bar",
-                        CLIENT_ID_PROP to "$GROUP_NAME-eventConsumer-$CLIENT_ID"
+                        CLIENT_ID_PROP to "eventConsumer-$CLIENT_ID"
                     )
                 ),
                 ConsumerRoles.EVENT_LOG to getExpectedConsumerProperties(
@@ -149,7 +149,7 @@ class MessageBusConfigResolverTest {
         private fun getExpectedConsumerProperties(overrides: Map<String, String?>): Properties {
             val defaults = mapOf(
                 GROUP_ID_PROP to GROUP_NAME,
-                CLIENT_ID_PROP to "$GROUP_NAME-consumer-$CLIENT_ID",
+                CLIENT_ID_PROP to "consumer-$CLIENT_ID",
                 ISOLATION_LEVEL_PROP to "read_committed",
                 BOOTSTRAP_SERVERS_PROP to "localhost:9092",
                 SESSION_TIMEOUT_PROP to "6000",
@@ -168,7 +168,7 @@ class MessageBusConfigResolverTest {
         private fun getExpectedProducerProperties(overrides: Map<String, String?>): Properties {
             val defaults = mapOf(
                 GROUP_ID_PROP to GROUP_NAME,
-                CLIENT_ID_PROP to "$CLIENT_ID-producer",
+                CLIENT_ID_PROP to "producer-$CLIENT_ID",
                 TRANSACTIONAL_ID_PROP to "$CLIENT_ID-$INSTANCE_ID",
                 BOOTSTRAP_SERVERS_PROP to "localhost:9092",
                 ACKS_PROP to "all"

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/MessagingConfigResolver.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/MessagingConfigResolver.kt
@@ -32,18 +32,18 @@ internal class MessagingConfigResolver(private val smartConfigFactory: SmartConf
      * @param subscriptionType Type of subscription.
      * @param subscriptionConfig User configurable values for a subscription.
      * @param messagingConfig Messaging smart config.
-     * @param counter Client counter.
+     * @param uniqueId Unique id, used to uniquely identify the subscription.
      * @return concrete class containing all config values used by a subscription.
      */
     fun buildSubscriptionConfig(
         subscriptionType: SubscriptionType,
         subscriptionConfig: SubscriptionConfig,
         messagingConfig: SmartConfig,
-        counter: Long
+        uniqueId: String
     ): ResolvedSubscriptionConfig {
         val config = messagingConfig.withFallback(defaults)
         return try {
-            ResolvedSubscriptionConfig.merge(subscriptionType, subscriptionConfig, config, counter)
+            ResolvedSubscriptionConfig.merge(subscriptionType, subscriptionConfig, config, uniqueId)
         } catch (e: ConfigException) {
             logger.error("Failed to resolve subscription config $subscriptionConfig: ${e.message}")
             throw CordaMessageAPIConfigException(

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedSubscriptionConfig.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedSubscriptionConfig.kt
@@ -20,7 +20,7 @@ data class ResolvedSubscriptionConfig(
     val subscriptionType: SubscriptionType,
     val topic: String,
     val group: String,
-    val idCounter: Long,
+    val uniqueId: String,
     val instanceId: Int,
     val pollTimeout: Duration,
     val threadStopTimeout: Duration,
@@ -38,20 +38,20 @@ data class ResolvedSubscriptionConfig(
          * @param subscriptionType Type of subscription.
          * @param subscriptionConfig User configurable values for a subscription.
          * @param messagingConfig Messaging smart config.
-         * @param counter Client counter.
+         * @param uniqueId Unique id, used to uniquely identify the subscription.
          * @return concrete class containing all config values used by a subscription.
          */
         fun merge(
             subscriptionType: SubscriptionType,
             subscriptionConfig: SubscriptionConfig,
             messagingConfig: SmartConfig,
-            idCounter: Long
+            uniqueId: String
         ): ResolvedSubscriptionConfig {
             return ResolvedSubscriptionConfig(
                 subscriptionType,
                 subscriptionConfig.eventTopic,
                 subscriptionConfig.groupName,
-                idCounter,
+                uniqueId,
                 messagingConfig.getInt(INSTANCE_ID),
                 Duration.ofMillis(messagingConfig.getLong(POLL_TIMEOUT)),
                 Duration.ofMillis(messagingConfig.getLong(THREAD_STOP_TIMEOUT)),
@@ -64,7 +64,6 @@ data class ResolvedSubscriptionConfig(
         }
     }
 
-    val clientId = "$subscriptionType-$group-$topic-$idCounter"
-    val loggerName = clientId
+    val clientId = "$subscriptionType-$group-$topic-$uniqueId"
     val lifecycleCoordinatorName = LifecycleCoordinatorName("$topic-$subscriptionType-$group", clientId)
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedSubscriptionConfig.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedSubscriptionConfig.kt
@@ -65,5 +65,5 @@ data class ResolvedSubscriptionConfig(
     }
 
     val clientId = "$subscriptionType-$group-$topic-$uniqueId"
-    val lifecycleCoordinatorName = LifecycleCoordinatorName("$topic-$subscriptionType-$group", clientId)
+    val lifecycleCoordinatorName = LifecycleCoordinatorName("$subscriptionType-$group-$topic", uniqueId)
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
@@ -64,8 +64,7 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
     private var producer: CordaProducer? = null
 
     private val partitionListener = RPCConsumerRebalanceListener(
-        getRPCResponseTopic(config.topic),
-        "RPC Response listener",
+        config.clientId,
         futureTracker,
         threadLooper
     )

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/factory/CordaPublisherFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/factory/CordaPublisherFactory.kt
@@ -20,7 +20,7 @@ import net.corda.messaging.publisher.CordaRPCSenderImpl
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.concurrent.atomic.AtomicLong
+import java.util.UUID
 
 /**
  * Patterns implementation for Publisher Factory.
@@ -36,9 +36,6 @@ class CordaPublisherFactory @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : PublisherFactory {
-
-    // Used to ensure that each subscription has a unique client.id
-    private val clientIdCounter = AtomicLong()
 
     override fun createPublisher(
         publisherConfig: PublisherConfig,
@@ -62,7 +59,7 @@ class CordaPublisherFactory @Activate constructor(
             SubscriptionType.RPC_SENDER,
             subscriptionConfig,
             messagingConfig,
-            clientIdCounter.getAndIncrement()
+            UUID.randomUUID().toString()
         )
         val serializer = avroSerializationFactory.createAvroSerializer<REQUEST> { }
         val deserializer = avroSerializationFactory.createAvroDeserializer({}, rpcConfig.responseType)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImpl.kt
@@ -28,7 +28,7 @@ internal class CompactedSubscriptionImpl<K : Any, V : Any>(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : CompactedSubscription<K, V> {
 
-    private val log = LoggerFactory.getLogger(config.loggerName)
+    private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.clientId}")
 
     private val errorMsg = "Failed to read records from group ${config.group}, topic ${config.topic}"
 

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
@@ -57,7 +57,7 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : Subscription<K, V> {
 
-    private val log = LoggerFactory.getLogger(config.loggerName)
+    private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.clientId}")
 
     private var threadLooper =
         ThreadLooper(log, config, lifecycleCoordinatorFactory, "durable processing thread", ::runConsumeLoop)
@@ -102,9 +102,9 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
                 log.debug { "Attempt: $attempts" }
                 deadLetterRecords = mutableListOf()
                 val rebalanceListener = if (partitionAssignmentListener == null) {
-                    LoggingConsumerRebalanceListener(config.topic, config.group, config.clientId)
+                    LoggingConsumerRebalanceListener(config.clientId)
                 } else {
-                    ForwardingRebalanceListener(config.topic, config.group, config.clientId, partitionAssignmentListener)
+                    ForwardingRebalanceListener(config.topic, config.clientId, partitionAssignmentListener)
                 }
                 val consumerConfig = ConsumerConfig(config.group, config.clientId, ConsumerRoles.EVENT_LOG)
                 consumer = cordaConsumerBuilder.createConsumer(

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
@@ -41,7 +41,7 @@ internal class PubSubSubscriptionImpl<K : Any, V : Any>(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : Subscription<K, V> {
 
-    private val log = LoggerFactory.getLogger(config.loggerName)
+    private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.clientId}")
 
     private var threadLooper =
         ThreadLooper(log, config, lifecycleCoordinatorFactory, "pubsub processing thread", ::runConsumeLoop)
@@ -90,9 +90,7 @@ internal class PubSubSubscriptionImpl<K : Any, V : Any>(
                     processor.valueClass,
                     ::logFailedDeserialize
                 ).use {
-                    val listener = PubSubConsumerRebalanceListener(
-                        config.topic, config.group, it
-                    )
+                    val listener = PubSubConsumerRebalanceListener(config.clientId, it)
                     it.setDefaultRebalanceListener(listener)
                     it.subscribe(config.topic)
                     threadLooper.updateLifecycleStatus(LifecycleStatus.UP)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
@@ -43,7 +43,7 @@ internal class RPCSubscriptionImpl<REQUEST : Any, RESPONSE : Any>(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : RPCSubscription<REQUEST, RESPONSE> {
 
-    private val log = LoggerFactory.getLogger(config.loggerName)
+    private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.clientId}")
 
     private var threadLooper =
         ThreadLooper(log, config, lifecycleCoordinatorFactory, "rpc subscription thread", ::runConsumeLoop)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -46,7 +46,7 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
     private val clock: Clock = Clock.systemUTC(),
 ) : StateAndEventSubscription<K, S, E> {
 
-    private val log = LoggerFactory.getLogger(config.loggerName)
+    private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.clientId}")
 
     private var nullableProducer: CordaProducer? = null
     private var nullableStateAndEventConsumer: StateAndEventConsumer<K, S, E>? = null

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -49,7 +49,7 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
         thread
     }
 
-    private val log = LoggerFactory.getLogger(config.loggerName)
+    private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.clientId}")
 
     private val maxPollInterval = config.processorTimeout.toMillis()
     private val initialProcessorTimeout = maxPollInterval / 4

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/ForwardingRebalanceListener.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/ForwardingRebalanceListener.kt
@@ -9,14 +9,13 @@ import org.slf4j.LoggerFactory
 /**
  * A [CordaConsumerRebalanceListener] that logs any assignment events and forwards them to the underlying [partitionAssignmentListener].
  */
-class ForwardingRebalanceListener(private val topic: String,
-                                  groupName: String,
-                                  clientId: String,
-                                  private val partitionAssignmentListener: PartitionAssignmentListener
-):
-    LoggingConsumerRebalanceListener(topic, groupName, clientId) {
+class ForwardingRebalanceListener(
+    private val topic: String,
+    clientId: String,
+    private val partitionAssignmentListener: PartitionAssignmentListener
+) : LoggingConsumerRebalanceListener(clientId) {
 
-    override val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-$topic-$groupName")
+    override val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-${clientId}")
 
     override fun onPartitionsRevoked(partitions: Collection<CordaTopicPartition>) {
         super.onPartitionsRevoked(partitions)
@@ -27,5 +26,4 @@ class ForwardingRebalanceListener(private val topic: String,
         super.onPartitionsAssigned(partitions)
         partitionAssignmentListener.onPartitionsAssigned(partitions.map { topic to it.partition })
     }
-
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/LoggingConsumerRebalanceListener.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/LoggingConsumerRebalanceListener.kt
@@ -5,30 +5,26 @@ import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-open class LoggingConsumerRebalanceListener(
-    private val topic: String,
-    private val groupName: String,
-    private val clientId: String = "",
-) : CordaConsumerRebalanceListener {
+open class LoggingConsumerRebalanceListener(clientId: String) : CordaConsumerRebalanceListener {
 
     /**
      * In derived classes, override the [log] with the more specific log name for that class.
      */
-    open val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-$topic-$groupName")
+    open val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-${clientId}")
 
     /**
      * When a [partitions] are revoked write to the log.
      */
     override fun onPartitionsRevoked(partitions: Collection<CordaTopicPartition>) {
-        val partitionIds = partitions.map{ it.partition }.joinToString(",")
-        log.info("Consumer ($clientId) group name $groupName for topic $topic partition revoked: $partitionIds.")
+        val partitionIds = partitions.map { it.partition }.joinToString(",")
+        log.info("Partitions revoked: $partitionIds.")
     }
 
     /**
      * When a [partitions] are assigned write to the log.
      */
     override fun onPartitionsAssigned(partitions: Collection<CordaTopicPartition>) {
-        val partitionIds = partitions.map{ it.partition }.joinToString(",")
-        log.info("Consumer ($clientId) group name $groupName for topic $topic partition assigned: $partitionIds.")
+        val partitionIds = partitions.map { it.partition }.joinToString(",")
+        log.info("Partitions assigned: $partitionIds.")
     }
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/PubSubConsumerRebalanceListener.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/PubSubConsumerRebalanceListener.kt
@@ -6,12 +6,11 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class PubSubConsumerRebalanceListener<K : Any, V : Any>(
-    topic: String,
-    groupName: String,
+    clientId: String,
     val consumer: CordaConsumer<K, V>
-) : LoggingConsumerRebalanceListener(topic, groupName) {
+) : LoggingConsumerRebalanceListener(clientId) {
 
-    override val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-$topic-$groupName")
+    override val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-${clientId}")
 
     /**
      * When assigned [partitions] set the consumer offset to the end of the partition.

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/RPCConsumerRebalanceListener.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/RPCConsumerRebalanceListener.kt
@@ -6,16 +6,15 @@ import net.corda.messaging.subscription.LifecycleStatusUpdater
 import net.corda.messaging.utils.FutureTracker
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.*
+import java.util.Collections
 
 class RPCConsumerRebalanceListener<RESPONSE>(
-    topic: String,
-    groupName: String,
+    clientId: String,
     private var tracker: FutureTracker<RESPONSE>,
     private val lifecycleStatusUpdater: LifecycleStatusUpdater
-) : LoggingConsumerRebalanceListener(topic, groupName) {
+) : LoggingConsumerRebalanceListener(clientId) {
 
-    override val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-$topic-$groupName")
+    override val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-${clientId}")
 
     private val partitions = mutableListOf<CordaTopicPartition>()
 

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/StateAndEventConsumerRebalanceListenerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/StateAndEventConsumerRebalanceListenerImpl.kt
@@ -19,8 +19,7 @@ internal class StateAndEventConsumerRebalanceListenerImpl<K : Any, S : Any, E : 
     private val stateAndEventListener: StateAndEventListener<K, S>? = null
 ) : StateAndEventConsumerRebalanceListener {
 
-    private val log = LoggerFactory.getLogger(config.loggerName)
-
+    private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.clientId}")
     private val currentStates = partitionState.currentStates
     private val stateConsumer = stateAndEventConsumer.stateConsumer
 
@@ -30,7 +29,7 @@ internal class StateAndEventConsumerRebalanceListenerImpl<K : Any, S : Any, E : 
      */
     override fun onPartitionsAssigned(partitions: Collection<CordaTopicPartition>) {
         val partitionIds = partitions.map{ it.partition }.joinToString(",")
-        log.info("Consumer (${config.clientId}) group name ${config.group} for topic ${config.topic} partition assigned: $partitionIds.")
+        log.info("Partitions assigned: $partitionIds.")
         stateAndEventConsumer.onPartitionsAssigned(partitions.toSet())
 
         val newStatePartitions = partitions.toStateTopics()
@@ -55,8 +54,8 @@ internal class StateAndEventConsumerRebalanceListenerImpl<K : Any, S : Any, E : 
      *  keeps up
      */
     override fun onPartitionsRevoked(partitions: Collection<CordaTopicPartition>) {
-        val partitionIds = partitions.map{ it.partition }.joinToString(",")
-        log.info("Consumer (${config.clientId}) group name ${config.group} for topic ${config.topic} partition revoked: $partitionIds.")
+        val partitionIds = partitions.map { it.partition }.joinToString(",")
+        log.info("Partition revoked: $partitionIds.")
         stateAndEventConsumer.onPartitionsRevoked(partitions.toSet())
         val removedPartitionIds = partitions.map { it.partition }
         for (partitionId in removedPartitionIds) {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/factory/CordaSubscriptionFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/factory/CordaSubscriptionFactory.kt
@@ -1,7 +1,6 @@
 package net.corda.messaging.subscription.factory
 
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -39,6 +38,7 @@ import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.util.UUID
 
 /**
  * Kafka implementation of the Subscription Factory.
@@ -60,9 +60,6 @@ class CordaSubscriptionFactory @Activate constructor(
     @Reference(service = MessagingChunkFactory::class)
     private val messagingChunkFactory: MessagingChunkFactory,
 ) : SubscriptionFactory {
-
-    // Used to ensure that each subscription has a unique client.id
-    private val clientIdCounter = AtomicLong()
 
     override fun <K : Any, V : Any> createPubSubSubscription(
         subscriptionConfig: SubscriptionConfig,
@@ -193,7 +190,7 @@ class CordaSubscriptionFactory @Activate constructor(
             subscriptionType,
             subscriptionConfig,
             messagingConfig,
-            clientIdCounter.getAndIncrement()
+            UUID.randomUUID().toString()
         )
     }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/TestUtils.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/TestUtils.kt
@@ -20,7 +20,7 @@ internal fun createResolvedSubscriptionConfig(type: SubscriptionType): ResolvedS
         type,
         TOPIC,
         GROUP,
-        1L,
+        "1L",
         1,
         Duration.ofMillis(100L),
         Duration.ofMillis(100L),

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/listener/PubSubConsumerRebalanceListenerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/listener/PubSubConsumerRebalanceListenerTest.kt
@@ -16,7 +16,7 @@ class PubSubConsumerRebalanceListenerTest {
 
     @BeforeEach
     fun beforeEach() {
-        listener = PubSubConsumerRebalanceListener("", "", consumer)
+        listener = PubSubConsumerRebalanceListener("", consumer)
     }
 
     @Test

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/listener/RPCConsumerRebalanceListenerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/listener/RPCConsumerRebalanceListenerTest.kt
@@ -20,13 +20,13 @@ class RPCConsumerRebalanceListenerTest {
     @BeforeEach
     fun setup() {
         lifecycleStatusUpdater = mock()
-        listener = RPCConsumerRebalanceListener<String>("", "", FutureTracker(), lifecycleStatusUpdater)
+        listener = RPCConsumerRebalanceListener("", FutureTracker(), lifecycleStatusUpdater)
     }
 
     @Test
     fun `Test up and down status changes are triggered correctly`() {
         val lifecycleStatusUpdater: LifecycleStatusUpdater = mock()
-        val listener = RPCConsumerRebalanceListener<String>("test", "test", FutureTracker(), lifecycleStatusUpdater)
+        val listener = RPCConsumerRebalanceListener<String>("test", FutureTracker(), lifecycleStatusUpdater)
 
         listener.onPartitionsAssigned(mutableListOf(CordaTopicPartition("test", 0)))
         verify(lifecycleStatusUpdater, times(1)).updateLifecycleStatus(LifecycleStatus.UP)

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/factory/CordaPublisherFactory.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/factory/CordaPublisherFactory.kt
@@ -14,7 +14,7 @@ import net.corda.messaging.emulation.topic.service.TopicService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.UUID
 
 /**
  * In-memory implementation for Publisher Factory.
@@ -29,13 +29,6 @@ class CordaPublisherFactory @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : PublisherFactory {
-
-    // Used to ensure that each rpc sender has a unique client.id
-    private val clientIdCounter = AtomicInteger()
-
-    companion object {
-        const val PUBLISHER_CLIENT_ID = "clientId"
-    }
 
     override fun createPublisher(
         publisherConfig: PublisherConfig,
@@ -52,7 +45,7 @@ class CordaPublisherFactory @Activate constructor(
             rpcConfig,
             rpcTopicService,
             lifecycleCoordinatorFactory,
-            clientIdCounter.getAndIncrement().toString()
+            UUID.randomUUID().toString()
         )
     }
 }

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/factory/InMemSubscriptionFactory.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/factory/InMemSubscriptionFactory.kt
@@ -29,7 +29,7 @@ import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.UUID
 
 /**
  * In memory implementation of the Subscription Factory.
@@ -44,9 +44,6 @@ class InMemSubscriptionFactory @Activate constructor(
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : SubscriptionFactory {
 
-    // Used to ensure that each subscription has a unique client.id
-    private val clientIdCounter = AtomicInteger()
-
     override fun <K : Any, V : Any> createPubSubSubscription(
         subscriptionConfig: SubscriptionConfig,
         processor: PubSubProcessor<K, V>,
@@ -57,7 +54,7 @@ class InMemSubscriptionFactory @Activate constructor(
             processor,
             topicService,
             lifecycleCoordinatorFactory,
-            clientIdCounter.getAndIncrement().toString()
+            UUID.randomUUID().toString()
         )
     }
 
@@ -87,7 +84,7 @@ class InMemSubscriptionFactory @Activate constructor(
             processor,
             topicService,
             lifecycleCoordinatorFactory,
-            clientIdCounter.getAndIncrement().toString()
+            UUID.randomUUID().toString()
         )
     }
 
@@ -133,7 +130,7 @@ class InMemSubscriptionFactory @Activate constructor(
             rpcTopicService,
             responderProcessor,
             lifecycleCoordinatorFactory,
-            clientIdCounter.getAndIncrement().toString()
+            UUID.randomUUID().toString()
         )
     }
 }


### PR DESCRIPTION
The 'client.id' property is built aggregating multiple ids,
'$subscriptionType-$group-$topic-$idCounter'. All components are static
except for 'idCounter' (instance of 'AtomicLong'), which is supposed to
be unique within a single JVM. When multiple instances of the same
worker are started, however, there's a chance of ending up having the
same 'client.id' for different consumers within the same consumer
group, which makes troubleshooting difficult.

- Improve uniqueness guarantee for the 'clientId' by using 'UUID'
  instead of 'AtomicLong'.
- Remove redundant information ('group.id') from logger names, logging
  messages and Kafka 'client.id' configuration.
- Standardise logger name (class name + clientId) across subscriptions.