### PR TITLE
CORE-13865 - REST worker metrics

### DIFF
--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -353,7 +353,7 @@ object CordaMetrics {
         /**
          * Method name for which the metric is applicable.
          */
-        Method("method"),
+        Http_Method("http.method"),
 
         /**
          * Type of the SandboxGroup to which the metric applies.

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -341,12 +341,12 @@ object CordaMetrics {
      */
     enum class Tag(val value: String) {
         /**
-         * Uri for which the metric is applicable.
+         * URI's path for which the metric is applicable.
          */
         UriPath("uri.path"),
 
         /**
-         * Method name for which the metric is applicable.
+         * Http method for which the metric is applicable.
          */
         HttpMethod("http.method"),
 

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -343,12 +343,12 @@ object CordaMetrics {
         /**
          * Uri for which the metric is applicable.
          */
-        Uri_path("uri.path"),
+        UriPath("uri.path"),
 
         /**
          * Method name for which the metric is applicable.
          */
-        Http_Method("http.method"),
+        HttpMethod("http.method"),
 
         /**
          * Type of the SandboxGroup to which the metric applies.

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -26,11 +26,6 @@ object CordaMetrics {
         // NOTE: please ensure the metric names adhere to the conventions described on https://micrometer.io/docs/concepts#_naming_meters
 
         /**
-         * Number of HTTP Requests.
-         */
-        object HttpRequestCount : Metric<Counter>("http.server.request", Metrics::counter)
-
-        /**
          * HTTP Requests time.
          */
         object HttpRequestTime : Metric<Timer>("http.server.request.time", CordaMetrics::timer)

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -346,9 +346,14 @@ object CordaMetrics {
      */
     enum class Tag(val value: String) {
         /**
-         * Address for which the metric is applicable.
+         * Uri for which the metric is applicable.
          */
-        Address("address"),
+        Uri("uri"),
+
+        /**
+         * Method name for which the metric is applicable.
+         */
+        Method("method"),
 
         /**
          * Type of the SandboxGroup to which the metric applies.

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -348,7 +348,7 @@ object CordaMetrics {
         /**
          * Uri for which the metric is applicable.
          */
-        Uri("uri"),
+        Uri_path("uri.path"),
 
         /**
          * Method name for which the metric is applicable.

--- a/libs/metrics/src/test/kotlin/net/corda/metrics/CordaMetricsTest.kt
+++ b/libs/metrics/src/test/kotlin/net/corda/metrics/CordaMetricsTest.kt
@@ -23,7 +23,7 @@ class CordaMetricsTest {
 
     @Test
     fun `create meter supports tags name`() {
-        val meter = CordaMetrics.Metric.HttpRequestCount
+        val meter = CordaMetrics.Metric.HttpRequestTime
             .builder()
             .withTag(CordaMetrics.Tag.Uri_path, "/hello")
             .withTag(CordaMetrics.Tag.Http_Method, "GET")
@@ -37,7 +37,7 @@ class CordaMetricsTest {
 
     @Test
     fun `create meter supports vnode tag`() {
-        val meter = CordaMetrics.Metric.HttpRequestCount
+        val meter = CordaMetrics.Metric.HttpRequestTime
             .builder()
             .forVirtualNode("ABC")
             .build()
@@ -47,8 +47,8 @@ class CordaMetricsTest {
 
     @Test
     fun `create http counter sets name`() {
-        val meter = CordaMetrics.Metric.HttpRequestCount.builder().build()
-        assertThat(meter.id.name).isEqualTo("corda.${CordaMetrics.Metric.HttpRequestCount.metricsName}")
+        val meter = CordaMetrics.Metric.HttpRequestTime.builder().build()
+        assertThat(meter.id.name).isEqualTo("corda.${CordaMetrics.Metric.HttpRequestTime.metricsName}")
         assertThat(meter.id.tags.map { Pair(it.key, it.value) })
             .contains(Pair(CordaMetrics.Tag.WorkerType.value, meterSourceName))
     }

--- a/libs/metrics/src/test/kotlin/net/corda/metrics/CordaMetricsTest.kt
+++ b/libs/metrics/src/test/kotlin/net/corda/metrics/CordaMetricsTest.kt
@@ -25,10 +25,14 @@ class CordaMetricsTest {
     fun `create meter supports tags name`() {
         val meter = CordaMetrics.Metric.HttpRequestCount
             .builder()
-            .withTag(CordaMetrics.Tag.Address, "blah")
+            .withTag(CordaMetrics.Tag.Uri_path, "/hello")
+            .withTag(CordaMetrics.Tag.Http_Method, "GET")
+            .withTag(CordaMetrics.Tag.OperationStatus, "200")
             .build()
         assertThat(meter.id.tags.map { Pair(it.key, it.value) })
-            .contains(Pair(CordaMetrics.Tag.Address.value, "blah"))
+            .contains(Pair(CordaMetrics.Tag.Uri_path.value, "/hello"))
+            .contains(Pair(CordaMetrics.Tag.Http_Method.value, "GET"))
+            .contains(Pair(CordaMetrics.Tag.OperationStatus.value, "200"))
     }
 
     @Test

--- a/libs/metrics/src/test/kotlin/net/corda/metrics/CordaMetricsTest.kt
+++ b/libs/metrics/src/test/kotlin/net/corda/metrics/CordaMetricsTest.kt
@@ -25,13 +25,13 @@ class CordaMetricsTest {
     fun `create meter supports tags name`() {
         val meter = CordaMetrics.Metric.HttpRequestTime
             .builder()
-            .withTag(CordaMetrics.Tag.Uri_path, "/hello")
-            .withTag(CordaMetrics.Tag.Http_Method, "GET")
+            .withTag(CordaMetrics.Tag.UriPath, "/hello")
+            .withTag(CordaMetrics.Tag.HttpMethod, "GET")
             .withTag(CordaMetrics.Tag.OperationStatus, "200")
             .build()
         assertThat(meter.id.tags.map { Pair(it.key, it.value) })
-            .contains(Pair(CordaMetrics.Tag.Uri_path.value, "/hello"))
-            .contains(Pair(CordaMetrics.Tag.Http_Method.value, "GET"))
+            .contains(Pair(CordaMetrics.Tag.UriPath.value, "/hello"))
+            .contains(Pair(CordaMetrics.Tag.HttpMethod.value, "GET"))
             .contains(Pair(CordaMetrics.Tag.OperationStatus.value, "200"))
     }
 

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -140,11 +140,15 @@ internal object ContextUtils {
                     val endTime = Instant.now()
 
                     CordaMetrics.Metric.HttpRequestCount.builder()
-                        .withTag(CordaMetrics.Tag.Address, "$ctxMethod ${ctx.matchedPath()} ${ctx.status()}")
+                        .withTag(CordaMetrics.Tag.Uri, "${ctx.matchedPath()}")
+                        .withTag(CordaMetrics.Tag.Method, "$ctxMethod")
+                        .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
                         .build().increment()
 
                     CordaMetrics.Metric.HttpRequestTime.builder()
-                        .withTag(CordaMetrics.Tag.Address, "$ctxMethod ${ctx.matchedPath()} ${ctx.status()}")
+                        .withTag(CordaMetrics.Tag.Uri, "${ctx.matchedPath()}")
+                        .withTag(CordaMetrics.Tag.Method, "$ctxMethod")
+                        .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
                         .build().record(Duration.between(startTime, endTime))
                 }
             }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -140,13 +140,13 @@ internal object ContextUtils {
                     val endTime = Instant.now()
 
                     CordaMetrics.Metric.HttpRequestCount.builder()
-                        .withTag(CordaMetrics.Tag.Uri, "${ctx.matchedPath()}")
+                        .withTag(CordaMetrics.Tag.Uri_path, "${ctx.matchedPath()}")
                         .withTag(CordaMetrics.Tag.Http_Method, "$ctxMethod")
                         .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
                         .build().increment()
 
                     CordaMetrics.Metric.HttpRequestTime.builder()
-                        .withTag(CordaMetrics.Tag.Uri, "${ctx.matchedPath()}")
+                        .withTag(CordaMetrics.Tag.Uri_path, "${ctx.matchedPath()}")
                         .withTag(CordaMetrics.Tag.Http_Method, "$ctxMethod")
                         .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
                         .build().record(Duration.between(startTime, endTime))

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -4,6 +4,10 @@ import io.javalin.core.util.Header
 import io.javalin.http.Context
 import io.javalin.http.ForbiddenResponse
 import io.javalin.http.UnauthorizedResponse
+import java.time.Duration
+import java.time.Instant
+import javax.security.auth.login.FailedLoginException
+import net.corda.metrics.CordaMetrics
 import net.corda.rest.exception.HttpApiException
 import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.security.Actor
@@ -19,15 +23,12 @@ import net.corda.rest.server.impl.internal.ParameterRetrieverFactory
 import net.corda.rest.server.impl.internal.ParametersRetrieverContext
 import net.corda.rest.server.impl.security.RestAuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.CredentialResolver
-import net.corda.metrics.CordaMetrics
 import net.corda.utilities.debug
 import net.corda.utilities.trace
 import net.corda.utilities.withMDC
 import net.corda.v5.base.types.MemberX500Name
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.lang.IllegalArgumentException
-import javax.security.auth.login.FailedLoginException
 
 internal object ContextUtils {
 
@@ -106,42 +107,45 @@ internal object ContextUtils {
                 methodLogger.debug { "Invoke method \"${method.method.name}\" for route info." }
                 methodLogger.trace { "Get parameter values." }
 
-                CordaMetrics.Metric.HttpRequestCount.builder()
-                    .withTag(CordaMetrics.Tag.Address, "$ctxMethod ${ctx.matchedPath()}")
-                    .build().increment()
-                val requestTimer = CordaMetrics.Metric.HttpRequestTime.builder()
-                    .withTag(CordaMetrics.Tag.Address, "$ctxMethod ${ctx.matchedPath()}")
-                    .build()
-                requestTimer.recordCallable {
-                    try {
-                        validateRequestContentType(this, ctx)
+                val startTime = Instant.now()
+                try {
+                    validateRequestContentType(this, ctx)
 
-                        val clientHttpRequestContext = ClientHttpRequestContext(ctx)
-                        val paramValues = retrieveParameters(clientHttpRequestContext)
+                    val clientHttpRequestContext = ClientHttpRequestContext(ctx)
+                    val paramValues = retrieveParameters(clientHttpRequestContext)
 
-                        methodLogger.debug {
-                            "Invoke method \"${method.method.name}\" with paramValues \"${
-                                paramValues.joinToString(
-                                    ","
-                                )
-                            }\"."
-                        }
-
-                        @Suppress("SpreadOperator")
-                        val result = invokeDelegatedMethod(*paramValues.toTypedArray())
-
-                        ctx.buildJsonResult(result, this.method.method.returnType)
-
-                        ctx.header(Header.CACHE_CONTROL, "no-cache")
-                        methodLogger.debug { "Invoke method \"${this.method.method.name}\" for route info completed." }
-                    } catch (e: Exception) {
-                        methodLogger.info("Error invoking path '${this.fullPath}' - ${e.message}")
-                        throw HttpExceptionMapper.mapToResponse(e)
-                    } finally {
-                        if (ctx.isMultipartFormData()) {
-                            cleanUpMultipartRequest(ctx)
-                        }
+                    methodLogger.debug {
+                        "Invoke method \"${method.method.name}\" with paramValues \"${
+                            paramValues.joinToString(
+                                ","
+                            )
+                        }\"."
                     }
+
+                    @Suppress("SpreadOperator")
+                    val result = invokeDelegatedMethod(*paramValues.toTypedArray())
+
+                    ctx.buildJsonResult(result, this.method.method.returnType)
+
+                    ctx.header(Header.CACHE_CONTROL, "no-cache")
+                    methodLogger.debug { "Invoke method \"${this.method.method.name}\" for route info completed." }
+                } catch (e: Exception) {
+                    methodLogger.info("Error invoking path '${this.fullPath}' - ${e.message}")
+                    throw HttpExceptionMapper.mapToResponse(e)
+                } finally {
+                    if (ctx.isMultipartFormData()) {
+                        cleanUpMultipartRequest(ctx)
+                    }
+
+                    val endTime = Instant.now()
+
+                    CordaMetrics.Metric.HttpRequestCount.builder()
+                        .withTag(CordaMetrics.Tag.Address, "$ctxMethod ${ctx.matchedPath()} ${ctx.status()}")
+                        .build().increment()
+
+                    CordaMetrics.Metric.HttpRequestTime.builder()
+                        .withTag(CordaMetrics.Tag.Address, "$ctxMethod ${ctx.matchedPath()} ${ctx.status()}")
+                        .build().record(Duration.between(startTime, endTime))
                 }
             }
         }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -141,13 +141,13 @@ internal object ContextUtils {
 
                     CordaMetrics.Metric.HttpRequestCount.builder()
                         .withTag(CordaMetrics.Tag.Uri, "${ctx.matchedPath()}")
-                        .withTag(CordaMetrics.Tag.Method, "$ctxMethod")
+                        .withTag(CordaMetrics.Tag.Http_Method, "$ctxMethod")
                         .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
                         .build().increment()
 
                     CordaMetrics.Metric.HttpRequestTime.builder()
                         .withTag(CordaMetrics.Tag.Uri, "${ctx.matchedPath()}")
-                        .withTag(CordaMetrics.Tag.Method, "$ctxMethod")
+                        .withTag(CordaMetrics.Tag.Http_Method, "$ctxMethod")
                         .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
                         .build().record(Duration.between(startTime, endTime))
                 }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -139,12 +139,6 @@ internal object ContextUtils {
 
                     val endTime = Instant.now()
 
-                    CordaMetrics.Metric.HttpRequestCount.builder()
-                        .withTag(CordaMetrics.Tag.Uri_path, "${ctx.matchedPath()}")
-                        .withTag(CordaMetrics.Tag.Http_Method, "$ctxMethod")
-                        .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
-                        .build().increment()
-
                     CordaMetrics.Metric.HttpRequestTime.builder()
                         .withTag(CordaMetrics.Tag.Uri_path, "${ctx.matchedPath()}")
                         .withTag(CordaMetrics.Tag.Http_Method, "$ctxMethod")

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -140,8 +140,8 @@ internal object ContextUtils {
                     val endTime = Instant.now()
 
                     CordaMetrics.Metric.HttpRequestTime.builder()
-                        .withTag(CordaMetrics.Tag.Uri_path, "${ctx.matchedPath()}")
-                        .withTag(CordaMetrics.Tag.Http_Method, "$ctxMethod")
+                        .withTag(CordaMetrics.Tag.UriPath, "${ctx.matchedPath()}")
+                        .withTag(CordaMetrics.Tag.HttpMethod, "$ctxMethod")
                         .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
                         .build().record(Duration.between(startTime, endTime))
                 }


### PR DESCRIPTION
The label `address` has been removed.
The labels `UriPath`, and `HttpMethod` have been added.
The metric `HttpRequestTime` used by the REST is now labelled with the `UriPath`, `HttpMethod`, and `OperationalStatus`.
Removed the metric `HttpRequestCount` because `HttpRequestTime` also provides a counter.