### PR TITLE
CORE-13908: signing cache fixes

### DIFF
--- a/components/crypto/crypto-persistence/src/main/kotlin/net/corda/crypto/persistence/SigningKeyInfo.kt
+++ b/components/crypto/crypto-persistence/src/main/kotlin/net/corda/crypto/persistence/SigningKeyInfo.kt
@@ -6,7 +6,7 @@ import java.time.Instant
 
 /**
  * The main data transfer object type
- * to and from the [WrappingRepository].
+ * to and from the [SigningRepository].
  */
 @Suppress("LongParameterList")
 data class SigningKeyInfo(

--- a/components/crypto/crypto-service-impl/build.gradle
+++ b/components/crypto/crypto-service-impl/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     testImplementation project(":libs:lifecycle:lifecycle-test-impl")
     testImplementation project(":libs:lifecycle:registry")
     testImplementation project(":testing:test-utilities")
+    testImplementation project(":testing:crypto-testkit")
 
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
@@ -363,15 +363,17 @@ class SigningServiceImpl(
             val requestedFullKeyId = publicKey.fullIdHash(schemeMetadata, digestService)
             val keyId = ShortHash.of(requestedFullKeyId)
             val cacheKey = CacheKey(tenantId, keyId)
-            val signingKeyInfo =  cache.get(cacheKey) {
+            val signingKeyInfo = cache.get(cacheKey) {
                 val repo = signingRepositoryFactory.getInstance(tenantId)
                 val result = repo.findKey(publicKey)
                 if (result == null) throw IllegalArgumentException("The public key '${publicKey.publicKeyId()}' was not found")
-                if (result.fullId != requestedFullKeyId) throw IllegalArgumentException(
-                        "The tenant $tenantId doesn't own public key '${publicKey.publicKeyId()}'.")
                 cache.put(cacheKey, result)
                 result
             }
+            if (signingKeyInfo.fullId != requestedFullKeyId) throw IllegalArgumentException(
+                "The tenant $tenantId doesn't own public key '${publicKey.publicKeyId()}'."
+            )
+
             return OwnedKeyRecord(publicKey, signingKeyInfo)
         }
     }

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
@@ -129,8 +129,8 @@ class SigningServiceImpl(
             cache.getAllPresent(keyIds.mapTo(mutableSetOf()) {
                 CacheKey(tenantId, it)
             }).mapTo(mutableSetOf()) { it.value }
-        if (cachedKeys.size == keyIds.size) return cachedKeys
         val notFound: List<ShortHash> = keyIds - cachedKeys.map { it.id }.toSet()
+        if (notFound.isEmpty()) return cachedKeys
         val fetchedKeys = signingRepositoryFactory.getInstance(tenantId).use {
             it.lookupByPublicKeyShortHashes(notFound.toMutableSet())
         }

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
@@ -126,6 +126,7 @@ class SigningServiceImpl(
             cache.getAllPresent(keyIds.mapTo(mutableSetOf()) {
                 CacheKey(tenantId, it)
             }).mapTo(mutableSetOf()) { it.value }
+        // TODO handle short ID clashes
         if (cachedKeys.size == keyIds.size) return cachedKeys
         val notFound: List<ShortHash> = keyIds - cachedKeys.map { it.id }.toSet()
 
@@ -143,6 +144,7 @@ class SigningServiceImpl(
         fullKeyIds: List<SecureHash>,
     ): Collection<SigningKeyInfo> {
         val keyIds = fullKeyIds.map { ShortHash.of(it) }
+        // TODO handle short ID clashes
         val cachedMap = cache.getAllPresent(keyIds.mapTo(mutableSetOf()) { CacheKey(tenantId, it) })
         val cachedList = cachedMap.map { it.value }
         if (cachedMap.size == fullKeyIds.size) return cachedList

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt
@@ -41,7 +41,7 @@ import java.security.PublicKey
 data class CacheKey(val tenantId: String, val publicKeyId: ShortHash)
 
 /**
- * 1. Provide a (mostly) cached versions of the signing key operations, unlike the signing key operations
+ * 1. Provide (mostly) cached versions of the signing key operations, unlike the signing key operations
  * in [SigningRepositoryImpl] which are uncached.
  *
  * 2. Provide wrapping key operations, routing to the appropriate crypto service implementation. The crypto

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -313,16 +313,13 @@ class SigningServiceGeneralTests {
     private fun makeSigningServiceImpl(
         repo: SigningRepository,
         cache: Cache<CacheKey, SigningKeyInfo>,
-    ): SigningServiceImpl {
-        val signingService = SigningServiceImpl(
-            cryptoServiceFactory = mock(),
-            signingRepositoryFactory = { repo },
-            schemeMetadata = schemeMetadata,
-            digestService = mockDigestService(),
-            cache = cache
-        )
-        return signingService
-    }
+    ): SigningServiceImpl = SigningServiceImpl(
+        cryptoServiceFactory = mock(),
+        signingRepositoryFactory = { repo },
+        schemeMetadata = schemeMetadata,
+        digestService = mockDigestService(),
+        cache = cache
+    )
 
     @Test
     @Suppress("ComplexMethod")

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
@@ -82,9 +83,6 @@ class SigningServiceGeneralTests {
             on { fullId }.thenReturn(fullKeyId1)
             on { id }.thenReturn(shortKeyId1)
         }
-
-        @JvmStatic
-        fun numCached(): Collection<Int> = setOf(0, 1, 2)
     }
 
 
@@ -468,7 +466,7 @@ class SigningServiceGeneralTests {
     }
 
     @ParameterizedTest
-    @MethodSource("numCached")
+    @CsvSource("0", "1", "2")
     fun `lookupSigningKeysByPublicKeyShortHash returns requested keys from cache and db`(
         keysInCache: Int,
     ) {

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -76,7 +76,7 @@ class SigningServiceGeneralTests {
         val repo = mock<SigningRepository> {
             on { findKey(any<PublicKey>()) } doThrow exception
         }
-        val signingService = makeSigningServiceImpl(repo, makeCache())
+        val signingService = makeSigningServiceImpl(repo)
         val thrown = assertThrows(exception::class.java) {
             signingService.sign(
                 tenantId = tenantId,
@@ -97,8 +97,7 @@ class SigningServiceGeneralTests {
         val repo = mock<SigningRepository> {
             on { findKey(any<PublicKey>()) } doReturn null
         }
-        val cache = makeCache()
-        val signingService = makeSigningServiceImpl(repo, cache)
+        val signingService = makeSigningServiceImpl(repo)
         val publicKey = mock<PublicKey> {
             on { encoded } doReturn UUID.randomUUID().toString().toByteArray()
         }
@@ -128,7 +127,7 @@ class SigningServiceGeneralTests {
         val repo = mock<SigningRepository> {
             on { findKey(any<PublicKey>()) } doThrow exception
         }
-        val signingService = makeSigningServiceImpl(repo, makeCache())
+        val signingService = makeSigningServiceImpl(repo)
         val thrown = assertThrows(exception::class.java) {
             signingService.deriveSharedSecret(
                 tenantId = UUID.randomUUID().toString(),
@@ -150,7 +149,7 @@ class SigningServiceGeneralTests {
         val repo = mock<SigningRepository> {
             on { findKey(any<PublicKey>()) } doReturn null
         }
-        val signingService = makeSigningServiceImpl(repo, makeCache())
+        val signingService = makeSigningServiceImpl(repo)
         assertThrows(IllegalArgumentException::class.java) {
             signingService.deriveSharedSecret(
                 tenantId = UUID.randomUUID().toString(),
@@ -187,7 +186,7 @@ class SigningServiceGeneralTests {
         val repo = mock<SigningRepository> {
             on { findKey(anyString()) } doReturn existingKey
         }
-        val signingService = makeSigningServiceImpl(repo, makeCache())
+        val signingService = makeSigningServiceImpl(repo)
         assertThrows(KeyAlreadyExistsException::class.java) {
             signingService.generateKeyPair(
                 tenantId = UUID.randomUUID().toString(),
@@ -254,7 +253,7 @@ class SigningServiceGeneralTests {
         val store = mock<SigningRepository> {
             on { query(any(), any(), any(), any()) } doReturn emptyList()
         }
-        val signingService = makeSigningServiceImpl(store, mock())
+        val signingService = makeSigningServiceImpl(store)
         val filter = mapOf(
             CATEGORY_FILTER to category,
             SCHEME_CODE_NAME_FILTER to schemeCodeName,
@@ -290,7 +289,7 @@ class SigningServiceGeneralTests {
         val repo = mock<SigningRepository> {
             on { query(any(), any(), any(), any()) } doReturn emptyList()
         }
-        val signingService = makeSigningServiceImpl(repo, mock())
+        val signingService = makeSigningServiceImpl(repo)
         val filter = emptyMap<String, String>()
         val result = signingService.querySigningKeys(
             tenantId,
@@ -311,14 +310,14 @@ class SigningServiceGeneralTests {
 
     private fun makeSigningServiceImpl(
         repo: SigningRepository,
-        cache: Cache<CacheKey, SigningKeyInfo>,
-        cryptoServiceFactory: CryptoServiceFactory = mock()
+        cache: Cache<CacheKey, SigningKeyInfo>? = null,
+        cryptoServiceFactory: CryptoServiceFactory = mock(),
     ): SigningServiceImpl = SigningServiceImpl(
         cryptoServiceFactory = cryptoServiceFactory,
         signingRepositoryFactory = { repo },
         schemeMetadata = schemeMetadata,
         digestService = mockDigestService(),
-        cache = cache
+        cache = cache ?: makeCache()
     )
 
     @Test

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -534,7 +534,13 @@ class SigningServiceGeneralTests {
             digestService = mockDigestService(),
             cache = cache
         )
-        signingService.lookupSigningKeysByPublicKeyHashes(tenantId, listOf(requestedFullKeyId))
+        val lookedUpByFullKeyIdsKeys =
+            signingService.lookupSigningKeysByPublicKeyHashes(tenantId, listOf(requestedFullKeyId))
+        assertEquals(0, lookedUpByFullKeyIdsKeys.size)
+
+        // since we could not find anything in the cache which is 
+        // suitable we should have gone to the repository
+        assertEquals(1, repoCount)
     }
 
 

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -55,6 +55,7 @@ import java.time.Instant
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
+// TODO - move content into SigningServiceImplTest
 class SigningServiceGeneralTests {
     companion object {
         private lateinit var schemeMetadata: CipherSchemeMetadata

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -104,7 +104,7 @@ class SigningServiceGeneralTests {
         }
         assertThrows(IllegalArgumentException::class.java) {
             signingService.sign(
-                tenantId = UUID.randomUUID().toString(),
+                tenantId = tenantId,
                 publicKey = publicKey,
                 signatureSpec = SignatureSpecImpl("NONE"),
                 data = ByteArray(2),
@@ -245,7 +245,6 @@ class SigningServiceGeneralTests {
         val skip = 17
         val take = 21
         val orderBy: KeyOrderBy = KeyOrderBy.ALIAS
-        val tenantId: String = UUID.randomUUID().toString()
         val category: String = CryptoConsts.Categories.TLS
         val schemeCodeName: String = UUID.randomUUID().toString()
         val alias: String = UUID.randomUUID().toString()
@@ -313,8 +312,9 @@ class SigningServiceGeneralTests {
     private fun makeSigningServiceImpl(
         repo: SigningRepository,
         cache: Cache<CacheKey, SigningKeyInfo>,
+        cryptoServiceFactory: CryptoServiceFactory = mock()
     ): SigningServiceImpl = SigningServiceImpl(
-        cryptoServiceFactory = mock(),
+        cryptoServiceFactory = cryptoServiceFactory,
         signingRepositoryFactory = { repo },
         schemeMetadata = schemeMetadata,
         digestService = mockDigestService(),
@@ -410,14 +410,7 @@ class SigningServiceGeneralTests {
             on { lookupByPublicKeyShortHashes(keyIdsCap.capture()) } doReturn setOf(signingKeyInfo)
         }
 
-        val signingService = SigningServiceImpl(
-            signingRepositoryFactory = { repo },
-            cryptoServiceFactory = cryptoServiceFactory,
-            schemeMetadata = schemeMetadata,
-            digestService = mockDigestService(),
-            cache = cache,
-        )
-
+        val signingService = makeSigningServiceImpl(repo, cache, cryptoServiceFactory)
         signingService.lookupSigningKeysByPublicKeyShortHash("tenant", keys)
 
         val cacheKeys = setOf(CacheKey("tenant", hashA), CacheKey("tenant", hashB))
@@ -448,14 +441,7 @@ class SigningServiceGeneralTests {
             on { lookupByPublicKeyHashes(fullIdsCap.capture()) } doReturn setOf(signingKeyInfo)
         }
 
-        val signingService = SigningServiceImpl(
-            signingRepositoryFactory = { repo },
-            cryptoServiceFactory = cryptoServiceFactory,
-            schemeMetadata = schemeMetadata,
-            digestService = mockDigestService(),
-            cache = cache,
-        )
-
+        val signingService = makeSigningServiceImpl(repo, cache, cryptoServiceFactory)
         signingService.lookupSigningKeysByPublicKeyHashes("tenant", keys)
 
         val cacheKeys = setOf(CacheKey("tenant", shortA), CacheKey("tenant", shortB))

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/SigningServiceGeneralTests.kt
@@ -72,9 +72,21 @@ class SigningServiceGeneralTests {
         // Remember key ids cannot clash for same tenant so short keys of testing keys need to be different
         val fullKeyId0 = parseSecureHash("SHA-256:ABC12345678911111111111111")
         val shortKeyId0 = ShortHash.of(fullKeyId0)
+        val signingKeyInfo0 = mock<SigningKeyInfo> {
+            on { fullId }.thenReturn(fullKeyId0)
+            on { id }.thenReturn(shortKeyId0)
+        }
         val fullKeyId1 = parseSecureHash("SHA-256:BBC12345678911111111111111")
         val shortKeyId1 = ShortHash.of(fullKeyId1)
+        val signingKeyInfo1 = mock<SigningKeyInfo> {
+            on { fullId }.thenReturn(fullKeyId1)
+            on { id }.thenReturn(shortKeyId1)
+        }
+
+        @JvmStatic
+        fun numCached(): Collection<Int> = setOf(0, 1, 2)
     }
+
 
     @Test
     fun `Should throw original exception failing signing`() {
@@ -455,52 +467,18 @@ class SigningServiceGeneralTests {
         assertThat(fullIdsCap.allValues.single()).isEqualTo(setOf(hashB))
     }
 
-    @Test
-    fun `lookupSigningKeysByPublicKeyShortHash returns requested keys from cache if all requested keys are in cache`() {
-        // Remember key ids cannot clash for same tenant so short keys of testing keys need to be different
-        val fullKeyId0 = parseSecureHash("SHA-256:ABC12345678911111111111111")
-        val shortKeyId0 = ShortHash.of(fullKeyId0)
-        val fullKeyId1 = parseSecureHash("SHA-256:BBC12345678911111111111111")
-        val shortKeyId1 = ShortHash.of(fullKeyId1)
-        val repo = mock<SigningRepository> {
-            on { findKey(any<PublicKey>()) } doReturn null
-        }
-        val cache = makeCache()
-        var repoCount = 0
-        val signingService = SigningServiceImpl(
-            signingRepositoryFactory = {
-                repoCount++
-                repo
-            },
-            cryptoServiceFactory = mock(),
-            schemeMetadata = schemeMetadata,
-            digestService = mockDigestService(),
-            cache = cache,
-        )
-        populateCache(cache, shortKeyId0, fullKeyId0)
-        populateCache(cache, shortKeyId1, fullKeyId1)
-        val r = signingService.lookupSigningKeysByPublicKeyShortHash(tenantId, listOf(shortKeyId0, shortKeyId1))
-        assertEquals(
-            setOf(fullKeyId0, fullKeyId1).map { it.toString() }.toSet(),
-            r.map { it.fullId.toString() }.toSet()
-        )
-        // verify it didn't go to the database
-        assertThat(repoCount).isEqualTo(0)
-    }
-
-    @Test
-    fun `lookupSigningKeysByPublicKeyShortHash requested keys from cache and from database if they are not cached`() {
-        var repoCount = 0
+    @ParameterizedTest
+    @MethodSource("numCached")
+    fun `lookupSigningKeysByPublicKeyShortHash returns requested keys from cache and db`(
+        keysInCache: Int,
+    ) {
         val keysCaptor = argumentCaptor<Set<ShortHash>>()
-        val mockDbResults = setOf(mock<SigningKeyInfo> {
-            on { fullId }.thenReturn(fullKeyId1)
-            on { id }.thenReturn(shortKeyId1)
-        })
+        val mockDbResults = if (keysInCache == 0) setOf(signingKeyInfo0, signingKeyInfo1) else setOf(signingKeyInfo1)
         val repo = mock<SigningRepository> {
             on { lookupByPublicKeyShortHashes(keysCaptor.capture()) }.thenReturn(mockDbResults)
         }
         val cache = makeCache()
-        populateCache(cache, shortKeyId0, fullKeyId0)
+        var repoCount = 0
         val signingService = SigningServiceImpl(
             signingRepositoryFactory = {
                 repoCount++
@@ -511,18 +489,18 @@ class SigningServiceGeneralTests {
             digestService = mockDigestService(),
             cache = cache,
         )
+        if (keysInCache >= 1) populateCache(cache, shortKeyId0, fullKeyId0)
+        if (keysInCache >= 2) populateCache(cache, shortKeyId1, fullKeyId1)
         val r = signingService.lookupSigningKeysByPublicKeyShortHash(tenantId, listOf(shortKeyId0, shortKeyId1))
         assertEquals(
             setOf(fullKeyId0, fullKeyId1).map { it.toString() }.toSet(),
             r.map { it.fullId.toString() }.toSet()
         )
-        assertEquals(setOf(shortKeyId1), keysCaptor.firstValue)
-        assertThat(repoCount).isEqualTo(1) // we should have opened the repository layer once
-        assertEquals(
-            setOf(shortKeyId0.value, shortKeyId1.value).map { it.toString() }.toSet(),
-            r.map { it.id.toString() }.toSet()
-        )
+        assertThat(repoCount).isEqualTo(if (keysInCache == 2) 0 else 1)
+        if (keysInCache == 0) assertEquals(setOf(shortKeyId0, shortKeyId1), keysCaptor.firstValue)
+        if (keysInCache == 1) assertEquals(setOf(shortKeyId1), keysCaptor.firstValue)
     }
+
 
     private fun populateCache(
         cache: Cache<CacheKey, SigningKeyInfo>,


### PR DESCRIPTION
Extend signing key metadata cache implementation in SigningServiceImpl to be used properly when signing from flows. Improve and extend test coverage while reducing duplication.