### PR TITLE
CORE-14040: Add metrics for events processed per flow and suspension count

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/FlowMetricsRecorder.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/FlowMetricsRecorder.kt
@@ -11,5 +11,5 @@ interface FlowMetricsRecorder {
     fun recordTotalSuspensionTime(executionTimeMillis: Long)
     fun recordFlowCompletion(executionTimeMillis: Long, completionStatus:String)
     fun recordTotalEventsProcessed(eventsProcessed: Long)
-    fun recordTotalFiberResumes(fiberResumes: Long)
+    fun recordTotalFiberSuspensions(fiberSuspensions: Long)
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/FlowMetricsRecorder.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/FlowMetricsRecorder.kt
@@ -10,4 +10,6 @@ interface FlowMetricsRecorder {
     fun recordTotalFiberExecutionTime(executionTimeMillis: Long)
     fun recordTotalSuspensionTime(executionTimeMillis: Long)
     fun recordFlowCompletion(executionTimeMillis: Long, completionStatus:String)
+    fun recordTotalEventsProcessed(eventsProcessed: Long)
+    fun recordTotalFiberResumes(fiberResumes: Long)
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsImpl.kt
@@ -47,7 +47,7 @@ class FlowMetricsImpl(
 
     override fun flowFiberEntered() {
         fiberStartTime = clock.nowInMillis()
-        currentState.totalEventResumptionCount++
+        currentState.totalFiberSuspensionCount++
 
         // If we were waiting on a suspension then record the wait time.
         if (currentState.suspensionAction != null && currentState.suspensionTimestampMillis != null) {
@@ -97,7 +97,7 @@ class FlowMetricsImpl(
         flowMetricsRecorder.recordTotalFiberExecutionTime(currentState.totalFiberExecutionTime)
         flowMetricsRecorder.recordTotalPipelineExecutionTime(currentState.totalPipelineExecutionTime)
         flowMetricsRecorder.recordTotalEventsProcessed(currentState.totalEventProcessedCount)
-        flowMetricsRecorder.recordTotalFiberResumes(currentState.totalEventResumptionCount)
+        flowMetricsRecorder.recordTotalFiberSuspensions(currentState.totalFiberSuspensionCount)
     }
 
     private fun Clock.nowInMillis(): Long {
@@ -113,6 +113,6 @@ class FlowMetricsImpl(
         var totalFiberExecutionTime: Long = 0
         var totalPipelineExecutionTime: Long = 0
         var totalEventProcessedCount: Long = 0
-        var totalEventResumptionCount: Long = 0
+        var totalFiberSuspensionCount: Long = 0
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsImpl.kt
@@ -47,6 +47,7 @@ class FlowMetricsImpl(
 
     override fun flowFiberEntered() {
         fiberStartTime = clock.nowInMillis()
+        currentState.totalEventResumptionCount++
 
         // If we were waiting on a suspension then record the wait time.
         if (currentState.suspensionAction != null && currentState.suspensionTimestampMillis != null) {
@@ -77,6 +78,7 @@ class FlowMetricsImpl(
         val pipelineExecutionTime = clock.instant().toEpochMilli() - eventReceivedTimestampMillis
         flowMetricsRecorder.recordPipelineExecution(pipelineExecutionTime, flowEventType)
         currentState.totalPipelineExecutionTime += pipelineExecutionTime
+        currentState.totalEventProcessedCount++
         flowCheckpoint.setMetricsState(objectMapper.writeValueAsString(currentState))
     }
 
@@ -94,6 +96,8 @@ class FlowMetricsImpl(
         flowMetricsRecorder.recordTotalSuspensionTime(currentState.totalSuspensionTime)
         flowMetricsRecorder.recordTotalFiberExecutionTime(currentState.totalFiberExecutionTime)
         flowMetricsRecorder.recordTotalPipelineExecutionTime(currentState.totalPipelineExecutionTime)
+        flowMetricsRecorder.recordTotalEventsProcessed(currentState.totalEventProcessedCount)
+        flowMetricsRecorder.recordTotalFiberResumes(currentState.totalEventResumptionCount)
     }
 
     private fun Clock.nowInMillis(): Long {
@@ -108,5 +112,7 @@ class FlowMetricsImpl(
         var totalSuspensionTime: Long = 0
         var totalFiberExecutionTime: Long = 0
         var totalPipelineExecutionTime: Long = 0
+        var totalEventProcessedCount: Long = 0
+        var totalEventResumptionCount: Long = 0
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsRecorderImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsRecorderImpl.kt
@@ -76,4 +76,18 @@ class FlowMetricsRecorderImpl(
             .withTag(CordaMetrics.Tag.OperationStatus, completionStatus)
             .build().record(Duration.ofMillis(executionTimeMillis))
     }
+
+    override fun recordTotalEventsProcessed(eventsProcessed: Long) {
+        CordaMetrics.Metric.FlowEventProcessedCount.builder()
+            .forVirtualNode(flowCheckpoint.holdingIdentity.shortHash.toString())
+            .withTag(CordaMetrics.Tag.FlowClass, flowCheckpoint.flowStartContext.flowClassName)
+            .build().record(eventsProcessed.toDouble())
+    }
+
+    override fun recordTotalFiberResumes(fiberResumes: Long) {
+        CordaMetrics.Metric.FlowEventResumeCount.builder()
+            .forVirtualNode(flowCheckpoint.holdingIdentity.shortHash.toString())
+            .withTag(CordaMetrics.Tag.FlowClass, flowCheckpoint.flowStartContext.flowClassName)
+            .build().record(fiberResumes.toDouble())
+    }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsRecorderImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsRecorderImpl.kt
@@ -84,10 +84,10 @@ class FlowMetricsRecorderImpl(
             .build().record(eventsProcessed.toDouble())
     }
 
-    override fun recordTotalFiberResumes(fiberResumes: Long) {
-        CordaMetrics.Metric.FlowEventResumeCount.builder()
+    override fun recordTotalFiberSuspensions(fiberSuspensions: Long) {
+        CordaMetrics.Metric.FlowFiberSuspensionCount.builder()
             .forVirtualNode(flowCheckpoint.holdingIdentity.shortHash.toString())
             .withTag(CordaMetrics.Tag.FlowClass, flowCheckpoint.flowStartContext.flowClassName)
-            .build().record(fiberResumes.toDouble())
+            .build().record(fiberSuspensions.toDouble())
     }
 }

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -146,7 +146,7 @@ object CordaMetrics {
         /**
          * Number of flow events that lead to a fiber resume for a single flow.
          */
-        object FlowEventResumeCount : Metric<DistributionSummary>("flow.event.resume.count", Metrics::summary)
+        object FlowFiberSuspensionCount : Metric<DistributionSummary>("flow.fiber.suspension.total.count", Metrics::summary)
 
         /**
          * FLOW MAPPER METRICS

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -139,6 +139,16 @@ object CordaMetrics {
         object FlowScheduledWakeupCount : Metric<Counter>("flow.scheduled.wakeup.count", Metrics::counter)
 
         /**
+         * Number of events a flow received in order for it to complete.
+         */
+        object FlowEventProcessedCount : Metric<DistributionSummary>("flow.event.processed.count", Metrics::summary)
+
+        /**
+         * Number of flow events that lead to a fiber resume for a single flow.
+         */
+        object FlowEventResumeCount : Metric<DistributionSummary>("flow.event.resume.count", Metrics::summary)
+
+        /**
          * FLOW MAPPER METRICS
          *
          * Time to process a single message in the flow mapper


### PR DESCRIPTION
Adds two new metrics to the flow pipeline:

- Total count of events processed for a single flow
- Total suspension count in a flow.

In the steady state these should be constant provided the platform is running flows, so a change in the counts here could indicate some issue with the platform (e.g. higher than normal session replay counts).

Some sample graphs using these metrics below:

<img width="1870" alt="event-suspension-count" src="https://github.com/corda/corda-runtime-os/assets/45565019/6dfa1323-3821-4d6e-90b5-27fc9b2d45ae">

This shows a sample flow using sessions. The first graph shows the total event count for the flow and its responder. The second shows the percentage of events that led to a fiber suspension - i.e. the percentage that resulted in user code being executed.
