### PR TITLE
CORE-14072: Logging - Change date in filename to sortable Y-M-D

### DIFF
--- a/osgi-framework-bootstrap/src/main/resources/log4j2.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2.xml
@@ -7,7 +7,7 @@
 
         <RollingFile name="App"
                      fileName="logs/corda.log"
-                     filePattern="logs/corda.%d{MM-dd-yyyy}.%i.log"
+                     filePattern="logs/corda.%d{yyyy-MM-dd}.%i.log"
                      ignoreExceptions="false">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} %X - %msg%n"/>
             <Policies>


### PR DESCRIPTION
Change date format from `MM-dd-yyyy` to `yyyy-MM-dd` so filenames sort correctly.