### PR TITLE
CORE-13740: Remove unstable tag

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
@@ -18,7 +18,6 @@ import net.corda.applications.workers.rest.utils.setSslConfiguration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -61,7 +60,6 @@ class MultiClusterDynamicNetworkTest {
         assertThat(clusterC.members).hasSize(1)
     }
 
-    @Tag("Unstable")
     @Test
     fun `Create mgm and allow members to join the group - one way TLS`() {
         onboardMultiClusterGroup(false)

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
@@ -16,7 +16,6 @@ import net.corda.applications.workers.rest.utils.onboardMgm
 import net.corda.applications.workers.rest.utils.setSslConfiguration
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -55,7 +54,6 @@ class SessionCertificateTest {
     }
 
     @Test
-    @Tag("Unstable")
     fun `Create mgm and allow members to join the group`() {
         onboardMultiClusterGroup()
     }

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SingleClusterDynamicNetworkTest.kt
@@ -14,7 +14,6 @@ import net.corda.applications.workers.rest.utils.onboardMembers
 import net.corda.applications.workers.rest.utils.onboardMgm
 import net.corda.data.identity.HoldingIdentity
 import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -31,7 +30,6 @@ class SingleClusterDynamicNetworkTest {
 
     private val mgm = cordaCluster.createTestMember("Mgm")
 
-    @Tag("Unstable")
     @Test
     fun `Create mgm and allow members to join the group`() {
         onboardSingleClusterGroup()

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/StaticNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/StaticNetworkTest.kt
@@ -13,7 +13,6 @@ import net.corda.applications.workers.rest.utils.getMemberName
 import net.corda.applications.workers.rest.utils.onboardStaticMembers
 import net.corda.data.identity.HoldingIdentity
 import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.io.TempDir
@@ -31,7 +30,6 @@ class StaticNetworkTest {
         addMembers((3..4).map { createTestMember("Member$it") })
     }
 
-    @Tag("Unstable")
     @Test
     fun `register members`() {
         onboardStaticGroup(tempDir)


### PR DESCRIPTION
Following https://github.com/corda/corda-runtime-os/pull/3916 and after a few successful unstable overnight runs, this change will re-enable the previous unstable tests.