### PR TITLE
CORE-14127: Set explicit file permissions for CPK disk cache.

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/RecreateBinaryTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/RecreateBinaryTest.kt
@@ -1,5 +1,6 @@
 package net.corda.chunking.db.impl.tests
 
+import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import java.nio.file.FileSystem
 import java.nio.file.Files
@@ -98,7 +99,10 @@ class RecreateBinaryTest {
 
     @BeforeEach
     fun beforeEach() {
-        fs = Jimfs.newFileSystem()
+        val posix = Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "posix")
+            .build()
+        fs = Jimfs.newFileSystem(posix)
     }
 
     @AfterEach

--- a/components/virtual-node/cpk-read-service-impl/build.gradle
+++ b/components/virtual-node/cpk-read-service-impl/build.gradle
@@ -31,4 +31,5 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
@@ -22,7 +22,6 @@ import net.corda.lifecycle.createCoordinator
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas
-import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.PathProvider
@@ -65,7 +64,7 @@ class CpkReadServiceImpl (
     )
 
     companion object {
-        val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val CPK_CACHE_DIR = "cpk-cache"
         const val CPK_PARTS_DIR = "cpk-parts"
@@ -106,10 +105,7 @@ class CpkReadServiceImpl (
             configSubscription?.close()
             configSubscription = configReadService.registerComponentForUpdates(
                 coordinator,
-                setOf(
-                    ConfigKeys.BOOT_CONFIG,
-                    ConfigKeys.MESSAGING_CONFIG
-                )
+                setOf(BOOT_CONFIG, MESSAGING_CONFIG)
             )
         } else {
             logger.warn(

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
@@ -22,8 +22,8 @@ class CpkChunksKafkaReader(
     private val cpkChunksFileManager: CpkChunksFileManager,
     private val onCpkAssembled: (SecureHash, Cpk) -> Unit
 ) : CompactedProcessor<CpkChunkId, Chunk> {
-    companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    private companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     // Assuming [CompactedProcessor.onSnapshot] and [CompactedProcessor.onNext] are not called concurrently.

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
@@ -3,14 +3,21 @@ package net.corda.cpk.read.impl.services.persistence
 import net.corda.crypto.core.toCorda
 import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.CpkChunkId
+import net.corda.libs.packaging.writeFile
 import net.corda.utilities.debug
-import net.corda.utilities.inputStream
-import net.corda.utilities.outputStream
 import net.corda.v5.crypto.SecureHash
 import org.slf4j.LoggerFactory
+import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption
+import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.READ
+import java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
+import java.nio.file.StandardOpenOption.WRITE
+import java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.OWNER_READ
+import java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
+import java.nio.file.attribute.PosixFilePermissions.asFileAttribute
 import java.util.SortedSet
 
 /**
@@ -18,9 +25,13 @@ import java.util.SortedSet
  */
 class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileManager {
     companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private const val DELIMITER = ".cpk.part."
+
+        private val CPK_DIRECTORY_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE))
+        private val CPK_FILE_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE))
+        private val CREATE_OR_REPLACE = setOf(CREATE, WRITE, TRUNCATE_EXISTING)
 
         internal fun SecureHash.toCpkDirName() = toHexString()
 
@@ -36,41 +47,40 @@ class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileMan
     override fun chunkFileExists(chunkId: CpkChunkId): CpkChunkFileLookUp {
         val cpkXDir = cpkCacheDir.resolve(chunkId.cpkChecksum.toCorda().toCpkDirName())
         val filePath = cpkXDir.resolve(chunkId.toFileName())
-        return CpkChunkFileLookUp(Files.exists(filePath), filePath)
+        return CpkChunkFileLookUp(Files.isRegularFile(filePath), filePath)
     }
 
     override fun writeChunkFile(chunkId: CpkChunkId, chunk: Chunk) {
         logger.debug { "Writing CPK chunk file ${chunkId.toFileName()}" }
         val cpkXDir = cpkCacheDir.resolve(chunkId.cpkChecksum.toCorda().toCpkDirName())
-        if (!Files.exists(cpkXDir)) {
+        if (!Files.isDirectory(cpkXDir)) {
+            // Try to create the directory. Will fail if this path
+            // already exists as something other than a directory.
             logger.debug { "Creating CPK directory: $cpkXDir" }
-            Files.createDirectory(cpkXDir)
+            Files.createDirectory(cpkXDir, CPK_DIRECTORY_PERMISSIONS)
         }
         val filePath = cpkXDir.resolve(chunkId.toFileName())
-        Files.newByteChannel(filePath, StandardOpenOption.WRITE, StandardOpenOption.CREATE).use {
-            it.position(0)
-            it.write(chunk.data)
+        Files.newByteChannel(filePath, CREATE_OR_REPLACE, CPK_FILE_PERMISSIONS).use { channel ->
+            channel.write(chunk.data)
         }
     }
 
     // TODO need to take care of incomplete CPK assemble as per https://r3-cev.atlassian.net/browse/CORE-4155
     override fun assembleCpk(cpkChecksum: SecureHash, chunkParts: SortedSet<CpkChunkId>): Path? {
         val cpkXDir = cpkCacheDir.resolve(cpkChecksum.toCpkDirName())
-        logger.info("Assembling CPK on disk: $cpkXDir")
-        if (!Files.exists(cpkXDir)) {
-            logger.warn("CPK directory should exist but it does not: $cpkXDir")
+        logger.info("Assembling CPK on disk: {}", cpkXDir)
+        if (!Files.isDirectory(cpkXDir)) {
+            logger.warn("CPK directory should exist but it does not: {}", cpkXDir)
             return null
         }
 
-        val cpkFilePath = cpkXDir.resolve(cpkChecksum.toCpkFileName())
-        cpkFilePath.outputStream(StandardOpenOption.WRITE, StandardOpenOption.CREATE).use { outStream ->
-            chunkParts.forEach {
-                val cpkChunkPath = cpkXDir.resolve(it.toFileName())
-                cpkChunkPath.inputStream(StandardOpenOption.READ).use { inStream ->
-                    inStream.copyTo(outStream)
+        return cpkXDir.resolve(cpkChecksum.toCpkFileName()).also { cpkFilePath ->
+            Files.newByteChannel(cpkFilePath, CREATE_OR_REPLACE, CPK_FILE_PERMISSIONS).use { output ->
+                chunkParts.forEach { chunkId ->
+                    val cpkChunkPath = cpkXDir.resolve(chunkId.toFileName())
+                    FileChannel.open(cpkChunkPath, READ).use(output::writeFile)
                 }
             }
         }
-        return cpkFilePath
     }
 }

--- a/libs/chunking/chunking-core/build.gradle
+++ b/libs/chunking/chunking-core/build.gradle
@@ -24,4 +24,5 @@ dependencies {
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkWriterImpl.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkWriterImpl.kt
@@ -32,7 +32,7 @@ internal class ChunkWriterImpl(
         }
     }
 
-    var chunkWriteCallback: ChunkWriteCallback? = null
+    private var chunkWriteCallback: ChunkWriteCallback? = null
 
     // chunk size must be smaller than the max allowed message size to allow a buffer for the rest of the message.
     //add extra overhead to avoid message bus level chunking

--- a/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkWritingTest.kt
+++ b/libs/chunking/chunking-core/src/test/kotlin/net/corda/chunking/ChunkWritingTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class ChunkWritingTest {
-    lateinit var fs: FileSystem
+    private lateinit var fs: FileSystem
 
     private val chunkBuilderService: ChunkBuilderService = ChunkBuilderServiceImpl()
 
@@ -36,9 +36,9 @@ class ChunkWritingTest {
 
     private fun createFile(fileSize: Long): Path {
         val path = fs.getPath(randomFileName())
-        Files.newByteChannel(path, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW).apply {
-            position(fileSize)
-            write(ByteBuffer.wrap(ByteArray(0)))
+        Files.newByteChannel(path, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW).use { channel ->
+            channel.position(fileSize)
+            channel.write(ByteBuffer.wrap(ByteArray(0)))
         }
 
         assertThat(fileSize).isEqualTo(Files.size(path))

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpiReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpiReader.kt
@@ -5,45 +5,40 @@ import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.UnknownFormatVersionException
 import net.corda.libs.packaging.internal.FormatVersionReader
 import net.corda.libs.packaging.internal.v2.CpiLoaderV2
-import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.file.Path
 import java.util.jar.JarInputStream
 
-class CpiReader {
-    companion object {
-        private val version2 = CpkFormatVersion(2, 0)
+object CpiReader {
+    private val version2 = CpkFormatVersion(2, 0)
 
-        /**
-         * Parses a CPI file and stores its information in a [Cpi] instance
-         * @param inputStream a stream with the CPI file content
-         * @param expansionLocation a filesystem directory where the CPK files
-         * contained in the provided CPI will be extracted
-         * @param cpiLocation an optional string containing information about the cpi location that will be used
-         * in exception messages to ease troubleshooting
-         * @param verifySignature whether to verify CPI and CPK files signatures
-         * @return a new [Cpi] instance containing information about the provided CPI
-         */
-        fun readCpi(
-            inputStream: InputStream,
-            expansionLocation: Path,
-            cpiLocation: String? = null,
-            verifySignature: Boolean = jarSignatureVerificationEnabledByDefault()
-        ): Cpi {
-            // Read input stream, so we can process it through different classes that will consume the stream
-            val buffer = inputStream.readAllBytes()
+    /**
+     * Parses a CPI file and stores its information in a [Cpi] instance
+     * @param inputStream a stream with the CPI file content
+     * @param expansionLocation a filesystem directory where the CPK files
+     * contained in the provided CPI will be extracted
+     * @param cpiLocation an optional string containing information about the cpi location that will be used
+     * in exception messages to ease troubleshooting
+     * @param verifySignature whether to verify CPI and CPK files signatures
+     * @return a new [Cpi] instance containing information about the provided CPI
+     */
+    fun readCpi(
+        inputStream: InputStream,
+        expansionLocation: Path,
+        cpiLocation: String? = null,
+        verifySignature: Boolean = jarSignatureVerificationEnabledByDefault()
+    ): Cpi {
+        // Read input stream, so we can process it through different classes that will consume the stream
+        val buffer = inputStream.readAllBytes()
 
-            // Read format version
-            val manifest = ByteArrayInputStream(buffer).use {
-                JarInputStream(it).use { it.manifest }
-            } ?: throw CordappManifestException("No manifest in Jar file")
-            val formatVersion = FormatVersionReader.readCpiFormatVersion(manifest)
+        // Read format version
+        val manifest = JarInputStream(buffer.inputStream()).use(JarInputStream::getManifest)
+            ?: throw CordappManifestException("No manifest in Jar file")
 
-            // Choose correct implementation to read this version
-            return when (formatVersion) {
-                version2 -> CpiLoaderV2().loadCpi(buffer, expansionLocation, cpiLocation, verifySignature)
-                else -> throw UnknownFormatVersionException("Unknown Corda-CPI-Format - \"$formatVersion\"")
-            }
+        // Choose correct implementation to read this version
+        return when (val formatVersion = FormatVersionReader.readCpiFormatVersion(manifest)) {
+            version2 -> CpiLoaderV2().loadCpi(buffer, expansionLocation, cpiLocation, verifySignature)
+            else -> throw UnknownFormatVersionException("Unknown Corda-CPI-Format - \"$formatVersion\"")
         }
     }
 }

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkDocumentReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkDocumentReader.kt
@@ -27,242 +27,240 @@ import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
 import javax.xml.validation.SchemaFactory
 
-class CpkDocumentReader {
-    companion object {
-        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
-        val SAME_SIGNER_PLACEHOLDER = SecureHashImpl("NONE", byteArrayOf(0))
+object CpkDocumentReader {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    val SAME_SIGNER_PLACEHOLDER = SecureHashImpl("NONE", byteArrayOf(0))
 
-        private const val CORDA_CPK_V1 = "corda-cpk-1.0.xsd"
+    private const val CORDA_CPK_V1 = "corda-cpk-1.0.xsd"
 
-        // The tags used in the XML of the file specifying a CPK's dependencies.
-        private const val DEPENDENCY_TAG = "cpkDependency"
-        private const val DEPENDENCY_NAME_TAG = "name"
-        private const val DEPENDENCY_VERSION_TAG = "version"
-        private const val DEPENDENCY_SIGNERS_TAG = "signers"
-        private const val DEPENDENCY_TYPE_TAG = "type"
-        private const val DEPENDENCY_SIGNER_TAG = "signer"
-        private const val DEPENDENCY_SAME_SIGNER_TAG = "sameAsMe"
+    // The tags used in the XML of the file specifying a CPK's dependencies.
+    private const val DEPENDENCY_TAG = "cpkDependency"
+    private const val DEPENDENCY_NAME_TAG = "name"
+    private const val DEPENDENCY_VERSION_TAG = "version"
+    private const val DEPENDENCY_SIGNERS_TAG = "signers"
+    private const val DEPENDENCY_TYPE_TAG = "type"
+    private const val DEPENDENCY_SIGNER_TAG = "signer"
+    private const val DEPENDENCY_SAME_SIGNER_TAG = "sameAsMe"
 
-        // The tags used in the XML of the file specifying library constraints.
-        private const val LIBRARY_CONSTRAINT_TAG = "dependencyConstraint"
-        private const val LIBRARY_FILENAME_TAG = "fileName"
-        private const val LIBRARY_HASH_TAG = "hash"
-        private const val LIBRARY_HASH_ALGORITHM_ATTRIBUTE = "algorithm"
+    // The tags used in the XML of the file specifying library constraints.
+    private const val LIBRARY_CONSTRAINT_TAG = "dependencyConstraint"
+    private const val LIBRARY_FILENAME_TAG = "fileName"
+    private const val LIBRARY_HASH_TAG = "hash"
+    private const val LIBRARY_HASH_ALGORITHM_ATTRIBUTE = "algorithm"
 
-        /** Returns the [CpkIdentifier]s for the provided [dependenciesFileContent]. */
-        @Suppress("ThrowsCount", "TooGenericExceptionCaught", "ComplexMethod")
-        fun readDependencies(
-            jarName: String,
-            dependenciesFileContent: InputStream,
-            fileLocationAppender: (String) -> String
-        ): NavigableSet<CpkIdentifier> {
-            val cpkDependencyDocument: Document = try {
-                // The CPK dependencies are specified as an XML file.
-                val documentBuilder = cpkV1DocumentBuilderFactory.newDocumentBuilder()
-                documentBuilder.setErrorHandler(XmlErrorHandler(jarName))
-                documentBuilder.parse(dependenciesFileContent)
-            } catch (e: DependencyMetadataException) {
-                throw e
-            } catch (e: SecurityException) {
-                throw e
-            } catch (e: Exception) {
-                throw DependencyMetadataException(fileLocationAppender("Error parsing CPK dependencies file"), e)
-            }
-            val cpkDependencyNodes = cpkDependencyDocument.getElementsByTagName(DEPENDENCY_TAG)
-
-            return ElementIterator(cpkDependencyNodes).asSequence().withIndex().mapNotNull { el ->
-                val dependencyNameElements = el.value.getElementsByTagName(DEPENDENCY_NAME_TAG)
-                val dependencyVersionElements = el.value.getElementsByTagName(DEPENDENCY_VERSION_TAG)
-                val dependencyTypeElements = el.value.getElementsByTagName(DEPENDENCY_TYPE_TAG)
-                val dependencySignersElements = el.value.getElementsByTagName(DEPENDENCY_SIGNERS_TAG)
-
-                if (dependencyNameElements.length != 1) {
-                    // Should already have been validated by schema.
-                    val msg = fileLocationAppender(
-                        "The entry at index ${el.index} of the CPK dependencies did not specify its name correctly.")
-                    throw DependencyMetadataException(msg)
-                }
-                if (dependencyVersionElements.length != 1) {
-                    // Should already have been validated by schema.
-                    val msg = fileLocationAppender(
-                        "The entry at index ${el.index} of the CPK dependencies file did not specify its version correctly.")
-                    throw DependencyMetadataException(msg)
-                }
-                if (dependencySignersElements.length != 1) {
-                    // Should already have been validated by schema.
-                    val msg = fileLocationAppender(
-                        "The entry at index ${el.index} of the CPK dependencies file did not specify its signers correctly.")
-                    throw DependencyMetadataException(msg)
-                }
-
-                val signers = dependencySignersElements.item(0) as Element
-
-                val publicKeySummaryHash: SecureHash =
-                    ElementIterator(signers.getElementsByTagName(DEPENDENCY_SIGNER_TAG)).asSequence().map { signer ->
-                        val algorithm = signer.getAttribute("algorithm").trim()
-                        if (algorithm.isNullOrEmpty()) {
-                            // Should already have been validated by schema.
-                            val msg = fileLocationAppender(
-                                "The entry at index ${el.index} of the CPK dependencies file" +
-                                        " did not specify an algorithm for its signer's public key hash."
-                            )
-                            throw DependencyMetadataException(msg)
-                        }
-                        val hashData = Base64.getDecoder().decode(signer.textContent)
-                        SecureHashImpl(algorithm, hashData)
-                    }.summaryHash() ?:
-                    if (signers.getElementsByTagName(DEPENDENCY_SAME_SIGNER_TAG).length == 1) {
-                        // Use this until we can determine this CPK's own certificates.
-                        SAME_SIGNER_PLACEHOLDER
-                    } else {
-                        throw IllegalStateException("No \"$DEPENDENCY_SIGNER_TAG\" or \"$DEPENDENCY_SAME_SIGNER_TAG\" elements found")
-                    }
-                CpkIdentifier(
-                    dependencyNameElements.item(0).textContent,
-                    dependencyVersionElements.item(0).textContent,
-                    publicKeySummaryHash
-                ).takeIf {
-                    when (dependencyTypeElements.length) {
-                        0 -> true
-                        1 -> CpkType.parse(dependencyTypeElements.item(0).textContent) != CpkType.CORDA_API
-                        else -> {
-                            val msg = fileLocationAppender(
-                                "The entry at index ${el.index} of the CPK dependencies file has multiple types")
-                            throw DependencyMetadataException(msg)
-                        }
-                    }
-                }
-            }.toCollection(TreeSet())
+    /** Returns the [CpkIdentifier]s for the provided [dependenciesFileContent]. */
+    @Suppress("ThrowsCount", "TooGenericExceptionCaught", "ComplexMethod")
+    fun readDependencies(
+        jarName: String,
+        dependenciesFileContent: InputStream,
+        fileLocationAppender: (String) -> String
+    ): NavigableSet<CpkIdentifier> {
+        val cpkDependencyDocument: Document = try {
+            // The CPK dependencies are specified as an XML file.
+            val documentBuilder = cpkV1DocumentBuilderFactory.newDocumentBuilder()
+            documentBuilder.setErrorHandler(XmlErrorHandler(jarName))
+            documentBuilder.parse(dependenciesFileContent)
+        } catch (e: DependencyMetadataException) {
+            throw e
+        } catch (e: SecurityException) {
+            throw e
+        } catch (e: Exception) {
+            throw DependencyMetadataException(fileLocationAppender("Error parsing CPK dependencies file"), e)
         }
+        val cpkDependencyNodes = cpkDependencyDocument.getElementsByTagName(DEPENDENCY_TAG)
 
-        @Suppress("ThrowsCount", "TooGenericExceptionCaught", "ComplexMethod")
-        fun readLibraryConstraints(
-            jarName: String,
-            inputStream: InputStream,
-            fileLocationAppender: (String) -> String
-        ): NavigableMap<String, SecureHash> {
-            val doc: Document = try {
-                // The CPK library constraints are specified as an XML file.
-                val documentBuilder = cpkV1DocumentBuilderFactory.newDocumentBuilder()
-                documentBuilder.setErrorHandler(XmlErrorHandler(jarName))
-                documentBuilder.parse(inputStream)
-            } catch (e: DependencyMetadataException) {
-                throw e
-            } catch (e: SecurityException) {
-                throw e
-            } catch (e: Exception) {
-                throw LibraryMetadataException(
-                    fileLocationAppender("Error parsing $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY file"),
-                    e
-                )
+        return ElementIterator(cpkDependencyNodes).asSequence().withIndex().mapNotNull { el ->
+            val dependencyNameElements = el.value.getElementsByTagName(DEPENDENCY_NAME_TAG)
+            val dependencyVersionElements = el.value.getElementsByTagName(DEPENDENCY_VERSION_TAG)
+            val dependencyTypeElements = el.value.getElementsByTagName(DEPENDENCY_TYPE_TAG)
+            val dependencySignersElements = el.value.getElementsByTagName(DEPENDENCY_SIGNERS_TAG)
+
+            if (dependencyNameElements.length != 1) {
+                // Should already have been validated by schema.
+                val msg = fileLocationAppender(
+                    "The entry at index ${el.index} of the CPK dependencies did not specify its name correctly.")
+                throw DependencyMetadataException(msg)
+            }
+            if (dependencyVersionElements.length != 1) {
+                // Should already have been validated by schema.
+                val msg = fileLocationAppender(
+                    "The entry at index ${el.index} of the CPK dependencies file did not specify its version correctly.")
+                throw DependencyMetadataException(msg)
+            }
+            if (dependencySignersElements.length != 1) {
+                // Should already have been validated by schema.
+                val msg = fileLocationAppender(
+                    "The entry at index ${el.index} of the CPK dependencies file did not specify its signers correctly.")
+                throw DependencyMetadataException(msg)
             }
 
-            val result = TreeMap<String, SecureHash>()
-            ElementIterator(doc.getElementsByTagName(LIBRARY_CONSTRAINT_TAG)).asSequence().withIndex().map { el ->
-                val libraryFilenameElements = el.value.getElementsByTagName(LIBRARY_FILENAME_TAG)
-                val libraryHashElements = el.value.getElementsByTagName(LIBRARY_HASH_TAG)
+            val signers = dependencySignersElements.item(0) as Element
 
-                if (libraryFilenameElements.length != 1) {
-                    val msg = fileLocationAppender(
-                        "The entry at index ${el.index} of the $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY requires " +
-                        "a single $LIBRARY_FILENAME_TAG")
-                    throw LibraryMetadataException(msg)
-                }
-                if (libraryHashElements.length != 1) {
-                    val msg = fileLocationAppender(
-                        "The entry at index ${el.index} of the $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY requires a single $LIBRARY_HASH_TAG")
-                    throw LibraryMetadataException(msg)
-                }
-                libraryFilenameElements.item(0).textContent to libraryHashElements.item(0).let {
-                    val algorithmName = it.attributes.getNamedItem(LIBRARY_HASH_ALGORITHM_ATTRIBUTE).textContent
-                    if (algorithmName != DigestAlgorithmName.SHA2_256.name) {
-                        throw LibraryMetadataException(
-                            fileLocationAppender(
-                                "Expected ${DigestAlgorithmName.SHA2_256.name} in $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY," +
-                                        " got '$algorithmName' instead"
-                            )
+            val publicKeySummaryHash: SecureHash =
+                ElementIterator(signers.getElementsByTagName(DEPENDENCY_SIGNER_TAG)).asSequence().map { signer ->
+                    val algorithm = signer.getAttribute("algorithm").trim()
+                    if (algorithm.isNullOrEmpty()) {
+                        // Should already have been validated by schema.
+                        val msg = fileLocationAppender(
+                            "The entry at index ${el.index} of the CPK dependencies file" +
+                                    " did not specify an algorithm for its signer's public key hash."
                         )
+                        throw DependencyMetadataException(msg)
                     }
-                    SecureHashImpl(algorithmName, Base64.getDecoder().decode(it.textContent))
+                    val hashData = Base64.getDecoder().decode(signer.textContent)
+                    SecureHashImpl(algorithm, hashData)
+                }.summaryHash() ?:
+                if (signers.getElementsByTagName(DEPENDENCY_SAME_SIGNER_TAG).length == 1) {
+                    // Use this until we can determine this CPK's own certificates.
+                    SAME_SIGNER_PLACEHOLDER
+                } else {
+                    throw IllegalStateException("No \"$DEPENDENCY_SIGNER_TAG\" or \"$DEPENDENCY_SAME_SIGNER_TAG\" elements found")
                 }
-            }.forEach { pair ->
-                result.put("$CPK_LIB_FOLDER/${pair.first}", pair.second)?.let {
-                    throw LibraryMetadataException(
-                        fileLocationAppender(
-                            "Found duplicate entry for library ${pair.first} of the $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY")
-                    )
+            CpkIdentifier(
+                dependencyNameElements.item(0).textContent,
+                dependencyVersionElements.item(0).textContent,
+                publicKeySummaryHash
+            ).takeIf {
+                when (dependencyTypeElements.length) {
+                    0 -> true
+                    1 -> CpkType.parse(dependencyTypeElements.item(0).textContent) != CpkType.CORDA_API
+                    else -> {
+                        val msg = fileLocationAppender(
+                            "The entry at index ${el.index} of the CPK dependencies file has multiple types")
+                        throw DependencyMetadataException(msg)
+                    }
                 }
             }
-            return Collections.unmodifiableNavigableMap(result)
-        }
+        }.toCollection(TreeSet())
+    }
 
-        /**
-         * [Iterator] for traversing every [Element] within a [NodeList].
-         * Skips any [org.w3c.dom.Node] that is not also an [Element].
-         */
-        private class ElementIterator(private val nodes: NodeList) : Iterator<Element> {
-            private var index = 0
-            override fun hasNext() = index < nodes.length
-            override fun next() = if (hasNext()) nodes.item(index++) as Element else throw NoSuchElementException()
-        }
-
-        private class XmlErrorHandler(private val jarName: String) : ErrorHandler {
-            override fun warning(ex: SAXParseException) {
-                logger.warn(
-                    "Problem at (line {}, column {}) parsing CPK dependencies for {}: {}",
-                    ex.lineNumber, ex.columnNumber, jarName, ex.message
-                )
-            }
-
-            override fun error(ex: SAXParseException) {
-                logger.error(
-                    "Error at (line {}, column {}) parsing CPK dependencies for {}: {}",
-                    ex.lineNumber, ex.columnNumber, jarName, ex.message
-                )
-                throw DependencyMetadataException(ex.message ?: "", ex)
-            }
-
-            override fun fatalError(ex: SAXParseException) {
-                logger.error(
-                    "Fatal error at (line {}, column {}) parsing CPK dependencies for {}: {}",
-                    ex.lineNumber, ex.columnNumber, jarName, ex.message
-                )
-                throw ex
-            }
-        }
-
-        private val cpkV1DocumentBuilderFactory = DocumentBuilderFactory.newInstance().also { dbf ->
-            dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
-            dbf.disableProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA)
-            dbf.disableProperty(XMLConstants.ACCESS_EXTERNAL_DTD)
-            dbf.isExpandEntityReferences = false
-            dbf.isIgnoringComments = true
-            dbf.isNamespaceAware = true
-
-            dbf.schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).also { sf ->
-                sf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
-                sf.disableProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA)
-                sf.disableProperty(XMLConstants.ACCESS_EXTERNAL_DTD)
-            }.newSchema(
-                this::class.java.classLoader.getResource(CORDA_CPK_V1)
-                    ?: throw IllegalStateException("Corda CPK v1 schema missing")
+    @Suppress("ThrowsCount", "TooGenericExceptionCaught", "ComplexMethod")
+    fun readLibraryConstraints(
+        jarName: String,
+        inputStream: InputStream,
+        fileLocationAppender: (String) -> String
+    ): NavigableMap<String, SecureHash> {
+        val doc: Document = try {
+            // The CPK library constraints are specified as an XML file.
+            val documentBuilder = cpkV1DocumentBuilderFactory.newDocumentBuilder()
+            documentBuilder.setErrorHandler(XmlErrorHandler(jarName))
+            documentBuilder.parse(inputStream)
+        } catch (e: DependencyMetadataException) {
+            throw e
+        } catch (e: SecurityException) {
+            throw e
+        } catch (e: Exception) {
+            throw LibraryMetadataException(
+                fileLocationAppender("Error parsing $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY file"),
+                e
             )
         }
 
-        private fun DocumentBuilderFactory.disableProperty(propertyName: String) {
-            try {
-                setAttribute(propertyName, "")
-            } catch (_: IllegalArgumentException) {
-                // Property not supported.
+        val result = TreeMap<String, SecureHash>()
+        ElementIterator(doc.getElementsByTagName(LIBRARY_CONSTRAINT_TAG)).asSequence().withIndex().map { el ->
+            val libraryFilenameElements = el.value.getElementsByTagName(LIBRARY_FILENAME_TAG)
+            val libraryHashElements = el.value.getElementsByTagName(LIBRARY_HASH_TAG)
+
+            if (libraryFilenameElements.length != 1) {
+                val msg = fileLocationAppender(
+                    "The entry at index ${el.index} of the $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY requires " +
+                    "a single $LIBRARY_FILENAME_TAG")
+                throw LibraryMetadataException(msg)
+            }
+            if (libraryHashElements.length != 1) {
+                val msg = fileLocationAppender(
+                    "The entry at index ${el.index} of the $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY requires a single $LIBRARY_HASH_TAG")
+                throw LibraryMetadataException(msg)
+            }
+            libraryFilenameElements.item(0).textContent to libraryHashElements.item(0).let {
+                val algorithmName = it.attributes.getNamedItem(LIBRARY_HASH_ALGORITHM_ATTRIBUTE).textContent
+                if (algorithmName != DigestAlgorithmName.SHA2_256.name) {
+                    throw LibraryMetadataException(
+                        fileLocationAppender(
+                            "Expected ${DigestAlgorithmName.SHA2_256.name} in $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY," +
+                                    " got '$algorithmName' instead"
+                        )
+                    )
+                }
+                SecureHashImpl(algorithmName, Base64.getDecoder().decode(it.textContent))
+            }
+        }.forEach { pair ->
+            result.put("$CPK_LIB_FOLDER/${pair.first}", pair.second)?.let {
+                throw LibraryMetadataException(
+                    fileLocationAppender(
+                        "Found duplicate entry for library ${pair.first} of the $CPK_DEPENDENCY_CONSTRAINTS_FILE_ENTRY")
+                )
             }
         }
+        return Collections.unmodifiableNavigableMap(result)
+    }
 
-        private fun SchemaFactory.disableProperty(propertyName: String) {
-            try {
-                setProperty(propertyName, "")
-            } catch (_: SAXNotRecognizedException) {
-                // Property not supported.
-            }
+    /**
+     * [Iterator] for traversing every [Element] within a [NodeList].
+     * Skips any [org.w3c.dom.Node] that is not also an [Element].
+     */
+    private class ElementIterator(private val nodes: NodeList) : Iterator<Element> {
+        private var index = 0
+        override fun hasNext() = index < nodes.length
+        override fun next() = if (hasNext()) nodes.item(index++) as Element else throw NoSuchElementException()
+    }
+
+    private class XmlErrorHandler(private val jarName: String) : ErrorHandler {
+        override fun warning(ex: SAXParseException) {
+            logger.warn(
+                "Problem at (line {}, column {}) parsing CPK dependencies for {}: {}",
+                ex.lineNumber, ex.columnNumber, jarName, ex.message
+            )
+        }
+
+        override fun error(ex: SAXParseException) {
+            logger.error(
+                "Error at (line {}, column {}) parsing CPK dependencies for {}: {}",
+                ex.lineNumber, ex.columnNumber, jarName, ex.message
+            )
+            throw DependencyMetadataException(ex.message ?: "", ex)
+        }
+
+        override fun fatalError(ex: SAXParseException) {
+            logger.error(
+                "Fatal error at (line {}, column {}) parsing CPK dependencies for {}: {}",
+                ex.lineNumber, ex.columnNumber, jarName, ex.message
+            )
+            throw ex
+        }
+    }
+
+    private val cpkV1DocumentBuilderFactory = DocumentBuilderFactory.newInstance().also { dbf ->
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+        dbf.disableProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA)
+        dbf.disableProperty(XMLConstants.ACCESS_EXTERNAL_DTD)
+        dbf.isExpandEntityReferences = false
+        dbf.isIgnoringComments = true
+        dbf.isNamespaceAware = true
+
+        dbf.schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI).also { sf ->
+            sf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+            sf.disableProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA)
+            sf.disableProperty(XMLConstants.ACCESS_EXTERNAL_DTD)
+        }.newSchema(
+            this::class.java.classLoader.getResource(CORDA_CPK_V1)
+                ?: throw IllegalStateException("Corda CPK v1 schema missing")
+        )
+    }
+
+    private fun DocumentBuilderFactory.disableProperty(propertyName: String) {
+        try {
+            setAttribute(propertyName, "")
+        } catch (_: IllegalArgumentException) {
+            // Property not supported.
+        }
+    }
+
+    private fun SchemaFactory.disableProperty(propertyName: String) {
+        try {
+            setProperty(propertyName, "")
+        } catch (_: SAXNotRecognizedException) {
+            // Property not supported.
         }
     }
 }

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/CpkReader.kt
@@ -5,37 +5,32 @@ import net.corda.libs.packaging.core.exception.CordappManifestException
 import net.corda.libs.packaging.core.exception.UnknownFormatVersionException
 import net.corda.libs.packaging.internal.FormatVersionReader
 import net.corda.libs.packaging.internal.v2.CpkLoaderV2
-import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.file.Path
 import java.util.jar.JarInputStream
 
-class CpkReader {
-    companion object {
-        private val version2 = CpkFormatVersion(2, 0)
+object CpkReader {
+    private val version2 = CpkFormatVersion(2, 0)
 
-        fun readCpk(
-            inputStream: InputStream,
-            cacheDir: Path,
-            cpkLocation: String? = null,
-            verifySignature: Boolean = jarSignatureVerificationEnabledByDefault(),
-            cpkFileName: String? = null
-        ): Cpk {
+    fun readCpk(
+        inputStream: InputStream,
+        cacheDir: Path,
+        cpkLocation: String? = null,
+        verifySignature: Boolean = jarSignatureVerificationEnabledByDefault(),
+        cpkFileName: String? = null
+    ): Cpk {
 
-            // Read input stream, so we can process it through different classes that will consume the stream
-            val buffer = inputStream.readAllBytes()
+        // Read input stream, so we can process it through different classes that will consume the stream
+        val buffer = inputStream.readAllBytes()
 
-            // Read format version
-            val manifest = ByteArrayInputStream(buffer).use {
-                JarInputStream(it).use { it.manifest }
-            } ?: throw CordappManifestException("No manifest in Jar file")
-            val formatVersion = FormatVersionReader.readCpkFormatVersion(manifest)
+        // Read format version
+        val manifest = JarInputStream(buffer.inputStream()).use(JarInputStream::getManifest)
+            ?: throw CordappManifestException("No manifest in Jar file")
 
-            // Choose correct implementation to read this version
-            return when (formatVersion) {
-                version2 -> CpkLoaderV2().loadCPK(buffer, cacheDir, cpkLocation, verifySignature, cpkFileName)
-                else -> throw UnknownFormatVersionException("Unknown Corda-CPK-Format - \"$formatVersion\"")
-            }
+        // Choose correct implementation to read this version
+        return when (val formatVersion = FormatVersionReader.readCpkFormatVersion(manifest)) {
+            version2 -> CpkLoaderV2().loadCPK(buffer, cacheDir, cpkLocation, verifySignature, cpkFileName)
+            else -> throw UnknownFormatVersionException("Unknown Corda-CPK-Format - \"$formatVersion\"")
         }
     }
 }

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/FormatVersionReader.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/FormatVersionReader.kt
@@ -4,44 +4,42 @@ import net.corda.libs.packaging.core.CpkFormatVersion
 import net.corda.libs.packaging.core.exception.PackagingException
 import java.util.jar.Manifest
 
-internal class FormatVersionReader {
-    companion object {
-        private const val CPK_FORMAT = "Corda-CPK-Format"
-        private const val CPB_FORMAT = "Corda-CPB-Format"
-        private const val CPI_FORMAT = "Corda-CPI-Format"
+internal object FormatVersionReader {
+    private const val CPK_FORMAT = "Corda-CPK-Format"
+    private const val CPB_FORMAT = "Corda-CPB-Format"
+    private const val CPI_FORMAT = "Corda-CPI-Format"
 
-        // A regex matching CPK format strings.
-        private val VERSION_PATTERN = "(\\d++)\\.(\\d++)".toRegex()
+    // A regex matching CPK format strings.
+    private val VERSION_PATTERN = "(\\d++)\\.(\\d++)".toRegex()
 
-        private val version1 = CpkFormatVersion(1, 0)
+    private val version1 = CpkFormatVersion(1, 0)
 
-        fun readCpkFormatVersion(manifest: Manifest): CpkFormatVersion {
-            val formatAttribute = manifest.mainAttributes.getValue(CPK_FORMAT)
-                ?: return version1 // Version 1 files sometimes lacked the FormatVersion
-            return parse(formatAttribute)
-        }
+    fun readCpkFormatVersion(manifest: Manifest): CpkFormatVersion {
+        val formatAttribute = manifest.mainAttributes.getValue(CPK_FORMAT)
+            ?: return version1 // Version 1 files sometimes lacked the FormatVersion
+        return parse(formatAttribute)
+    }
 
-        fun readCpbFormatVersion(manifest: Manifest): CpkFormatVersion {
-            val formatAttribute = manifest.mainAttributes.getValue(CPB_FORMAT)
-                ?: return version1 // Version 1 files sometimes lacked the FormatVersion
-            return parse(formatAttribute)
-        }
+    fun readCpbFormatVersion(manifest: Manifest): CpkFormatVersion {
+        val formatAttribute = manifest.mainAttributes.getValue(CPB_FORMAT)
+            ?: return version1 // Version 1 files sometimes lacked the FormatVersion
+        return parse(formatAttribute)
+    }
 
-        fun readCpiFormatVersion(manifest: Manifest): CpkFormatVersion {
-            val formatAttribute = manifest.mainAttributes.getValue(CPI_FORMAT)
-                ?: return version1 // Version 1 files sometimes lacked the FormatVersion
-            return parse(formatAttribute)
-        }
+    fun readCpiFormatVersion(manifest: Manifest): CpkFormatVersion {
+        val formatAttribute = manifest.mainAttributes.getValue(CPI_FORMAT)
+            ?: return version1 // Version 1 files sometimes lacked the FormatVersion
+        return parse(formatAttribute)
+    }
 
-        /**
-         * Parses the [formatAttribute] into a [CpkFormatVersion].
-         *
-         * Throws [PackagingException] if the CPK format is missing or incorrectly specified.
-         */
-        private fun parse(formatAttribute: String): CpkFormatVersion {
-            val matches = VERSION_PATTERN.matchEntire(formatAttribute)
-                ?: throw PackagingException("Does not match 'majorVersion.minorVersion': '$formatAttribute'")
-            return CpkFormatVersion(matches.groupValues[1].toInt(), matches.groupValues[2].toInt())
-        }
+    /**
+     * Parses the [formatAttribute] into a [CpkFormatVersion].
+     *
+     * Throws [PackagingException] if the CPK format is missing or incorrectly specified.
+     */
+    private fun parse(formatAttribute: String): CpkFormatVersion {
+        val matches = VERSION_PATTERN.matchEntire(formatAttribute)
+            ?: throw PackagingException("Does not match 'majorVersion.minorVersion': '$formatAttribute'")
+        return CpkFormatVersion(matches.groupValues[1].toInt(), matches.groupValues[2].toInt())
     }
 }

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/SignatureCollector.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/SignatureCollector.kt
@@ -2,20 +2,16 @@ package net.corda.libs.packaging.internal.v2
 
 import java.util.jar.JarEntry
 
-internal class SignatureCollector {
+internal object SignatureCollector {
+    /**
+     * @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File>
+     * Additionally accepting *.EC as its valid for [java.util.jar.JarVerifier] and jarsigner @see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html,
+     * temporally treating META-INF/INDEX.LIST as unsignable entry because [java.util.jar.JarVerifier] doesn't load its signers.
+     */
+    private val unsignableEntryName = "META-INF/(?:(?:.*[.](?:SF|DSA|RSA|EC)|SIG-.*)|INDEX\\.LIST)".toRegex()
 
-    companion object {
-        /**
-         * @see <https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Signed_JAR_File>
-         * Additionally accepting *.EC as its valid for [java.util.jar.JarVerifier] and jarsigner @see https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html,
-         * temporally treating META-INF/INDEX.LIST as unsignable entry because [java.util.jar.JarVerifier] doesn't load its signers.
-         */
-        private val unsignableEntryName = "META-INF/(?:(?:.*[.](?:SF|DSA|RSA|EC)|SIG-.*)|INDEX\\.LIST)".toRegex()
-
-        /**
-         * @return if the [entry] [JarEntry] can be signed.
-         */
-        @JvmStatic
-        fun isSignable(entry: JarEntry): Boolean = !entry.isDirectory && !unsignableEntryName.matches(entry.name)
-    }
+    /**
+     * @return if the [entry] [JarEntry] can be signed.
+     */
+    fun isSignable(entry: JarEntry): Boolean = !entry.isDirectory && !unsignableEntryName.matches(entry.name)
 }

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/PathProvider.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/PathProvider.kt
@@ -5,6 +5,14 @@ import net.corda.schema.configuration.ConfigKeys
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.GROUP_READ
+import java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.OTHERS_READ
+import java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.OWNER_READ
+import java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
+import java.nio.file.attribute.PosixFilePermissions.asFileAttribute
 
 interface PathProvider {
     /**
@@ -17,13 +25,21 @@ interface PathProvider {
 class WorkspacePathProvider(
     private val dirResolver: (String, Array<out String>) -> Path = { first, more -> Paths.get(first, *more) }
 ) : PathProvider {
+    private companion object {
+        private val WORKSPACE_DIR_PERMISSIONS = asFileAttribute(setOf(
+            OWNER_READ, OWNER_WRITE, OWNER_EXECUTE,
+            GROUP_READ, GROUP_EXECUTE,
+            OTHERS_READ, OTHERS_EXECUTE
+        ))
+    }
+
     override fun getOrCreate(config: SmartConfig, vararg dirPath: String): Path {
         require(config.hasPath(ConfigKeys.WORKSPACE_DIR)) {
             "Configuration should not be null for ${ConfigKeys.WORKSPACE_DIR}"
         }
 
         return dirResolver(config.getString(ConfigKeys.WORKSPACE_DIR)!!, dirPath).also {
-            Files.createDirectories(it)
+            Files.createDirectories(it, WORKSPACE_DIR_PERMISSIONS)
         }
     }
 }
@@ -32,13 +48,17 @@ class WorkspacePathProvider(
 class TempPathProvider(
     private val dirResolver: (String, Array<out String>) -> Path = { first, more -> Paths.get(first, *more) }
 ) : PathProvider {
+    private companion object {
+        private val TEMP_DIR_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE))
+    }
+
     override fun getOrCreate(config: SmartConfig, vararg dirPath: String): Path {
         require(config.hasPath(ConfigKeys.TEMP_DIR)) {
             "Configuration should not be null for ${ConfigKeys.TEMP_DIR}"
         }
 
         return dirResolver(config.getString(ConfigKeys.TEMP_DIR)!!, dirPath).also {
-            Files.createDirectories(it)
+            Files.createDirectories(it, TEMP_DIR_PERMISSIONS)
         }
     }
 }

--- a/libs/utilities/src/test/kotlin/net/corda/utilities/PathProviderTest.kt
+++ b/libs/utilities/src/test/kotlin/net/corda/utilities/PathProviderTest.kt
@@ -4,22 +4,34 @@ import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import net.corda.libs.configuration.SmartConfig
 import net.corda.schema.configuration.ConfigKeys
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.file.FileSystem
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.GROUP_READ
+import java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.OTHERS_READ
+import java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
+import java.nio.file.attribute.PosixFilePermission.OWNER_READ
+import java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
 
 @Suppress("SpreadOperator")
 class PathProviderTest {
-    lateinit var fs: FileSystem
-    lateinit var config: SmartConfig
+    private lateinit var fs: FileSystem
+    private lateinit var config: SmartConfig
 
     @BeforeEach
     fun setUp() {
-        fs = Jimfs.newFileSystem(Configuration.unix())
+        val posix = Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "posix")
+            .build()
+        fs = Jimfs.newFileSystem(posix)
 
         config = mock()
     }
@@ -30,14 +42,42 @@ class PathProviderTest {
     }
 
     @Test
-    fun `on get or create creates dir if not existing`() {
+    fun `getOrCreate creates workspace dir if not existing`() {
         whenever(config.hasPath(ConfigKeys.WORKSPACE_DIR)).thenReturn(true)
         whenever(config.getString(ConfigKeys.WORKSPACE_DIR)).thenReturn("/workspace")
         val workspacePathProvider = WorkspacePathProvider { first, more ->
             fs.getPath(first, *more)
         }
 
-        val dir = workspacePathProvider.getOrCreate(config)
-        assertTrue(dir.exists())
+        val dir = workspacePathProvider.getOrCreate(config, "subdir")
+        assertThat(dir).hasToString("/workspace/subdir")
+            .isDirectory
+            .isReadable
+            .isWritable
+            .isExecutable
+        assertThat(Files.getPosixFilePermissions(dir))
+            .containsExactlyInAnyOrder(OWNER_WRITE, OWNER_READ, OWNER_EXECUTE, GROUP_READ, GROUP_EXECUTE, OTHERS_EXECUTE, OTHERS_READ)
+        verify(config).hasPath(ConfigKeys.WORKSPACE_DIR)
+        verify(config).getString(ConfigKeys.WORKSPACE_DIR)
+    }
+
+    @Test
+    fun `getOrCreate creates temporary dir if not existing`() {
+        whenever(config.hasPath(ConfigKeys.TEMP_DIR)).thenReturn(true)
+        whenever(config.getString(ConfigKeys.TEMP_DIR)).thenReturn("/tmp")
+        val temporaryPathProvider = TempPathProvider { first, more ->
+            fs.getPath(first, *more)
+        }
+
+        val dir = temporaryPathProvider.getOrCreate(config, "subdir")
+        assertThat(dir).hasToString("/tmp/subdir")
+            .isDirectory
+            .isReadable
+            .isWritable
+            .isExecutable
+        assertThat(Files.getPosixFilePermissions(dir))
+            .containsExactlyInAnyOrder(OWNER_WRITE, OWNER_READ, OWNER_EXECUTE)
+        verify(config).hasPath(ConfigKeys.TEMP_DIR)
+        verify(config).getString(ConfigKeys.TEMP_DIR)
     }
 }


### PR DESCRIPTION
Set file permissions for the CPKs that we cache on disk to be `rw-------`.
Also set the permissions for this cache directory to be `rwx------`.
Set workspace directory permissions to `rwxr-xr-x`.
Set temporary directory permissions to `rwx------`.

It is also probably a Very Good Idea :tm: to close a `ByteChannel` once we've finished writing to it.
And convert some Kotlin classes which only contain `companion object` into a Kotlin `object`.