### PR TITLE
CORE-13858 Keep session manager metrics as a member variables

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -167,6 +167,9 @@ internal class SessionManagerImpl(
         it.scheduleAtFixedRate({ recordTotalSessionMetrics() }, 5, 5, TimeUnit.SECONDS)
     }
 
+    private val outboundSessionCountMetric = CordaMetrics.Metric.OutboundSessionCount.builder().build()
+    private val inboundSessionCountMetric = CordaMetrics.Metric.InboundSessionCount.builder().build()
+
     override val dominoTile = ComplexDominoTile(
         this::class.java.simpleName,
         coordinatorFactory,
@@ -901,12 +904,9 @@ internal class SessionManagerImpl(
         return false
     }
 
-    private val outboundSessionCountMetric = CordaMetrics.Metric.OutboundSessionCount.builder().build()
-    private val inboundSessionContMetric = CordaMetrics.Metric.InboundSessionCount.builder().build()
-
     private fun recordTotalSessionMetrics() {
         outboundSessionCountMetric.set(outboundSessionPool.getAllSessionIds().size)
-        inboundSessionContMetric.set(activeInboundSessions.size + pendingInboundSessions.size)
+        inboundSessionCountMetric.set(activeInboundSessions.size + pendingInboundSessions.size)
     }
 
     class HeartbeatManager(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -901,11 +901,12 @@ internal class SessionManagerImpl(
         return false
     }
 
+    private val outboundSessionCountMetric = CordaMetrics.Metric.OutboundSessionCount.builder().build()
+    private val inboundSessionContMetric = CordaMetrics.Metric.InboundSessionCount.builder().build()
+
     private fun recordTotalSessionMetrics() {
-        CordaMetrics.Metric.OutboundSessionCount.builder()
-            .build().set(outboundSessionPool.getAllSessionIds().size)
-        CordaMetrics.Metric.InboundSessionCount.builder()
-            .build().set(activeInboundSessions.size + pendingInboundSessions.size)
+        outboundSessionCountMetric.set(outboundSessionPool.getAllSessionIds().size)
+        inboundSessionContMetric.set(activeInboundSessions.size + pendingInboundSessions.size)
     }
 
     class HeartbeatManager(


### PR DESCRIPTION
This prevents them being garbage collected. If they are garbage collected it means micrometer can't read them.