### PR TITLE
CORE-13837: Add disk-usage metrics for CPK caches.

### DIFF
--- a/components/virtual-node/cpk-read-service-impl/build.gradle
+++ b/components/virtual-node/cpk-read-service-impl/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation project(":libs:crypto:crypto-core")
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:messaging:messaging")
+    implementation project(':libs:metrics')
     implementation project(":libs:utilities")
     implementation project(":components:configuration:configuration-read-service")
 

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
@@ -21,6 +21,8 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.metrics.CordaMetrics
+import net.corda.metrics.CordaMetrics.Tag.ContentsType
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
@@ -147,12 +149,20 @@ class CpkReadServiceImpl (
             return
         }
 
+        // Monitor the amount of available disk space in these two directories.
+        CordaMetrics.Metric.DiskSpace(cpkCacheDir).builder()
+            .withTag(ContentsType, "CPKs")
+            .build()
+        CordaMetrics.Metric.DiskSpace(cpkPartsDir).builder()
+            .withTag(ContentsType, "CPK chunks")
+            .build()
+
         val cpkChunksFileManager = CpkChunksFileManagerImpl(cpkCacheDir)
         cpkChunksKafkaReaderSubscription?.close()
         cpkChunksKafkaReaderSubscription =
             subscriptionFactory.createCompactedSubscription(
                 SubscriptionConfig(CPK_READ_GROUP, Schemas.VirtualNode.CPK_FILE_TOPIC),
-                CpkChunksKafkaReader(cpkPartsDir, cpkChunksFileManager, this::onCpkAssembled),
+                CpkChunksKafkaReader(cpkPartsDir, cpkChunksFileManager, ::onCpkAssembled),
                 messagingConfig
             ).also { it.start() }
     }

--- a/components/virtual-node/cpk-read-service-impl/src/test/kotlin/net/corda/cpk/read/impl/CpkReadServiceImplTest.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/test/kotlin/net/corda/cpk/read/impl/CpkReadServiceImplTest.kt
@@ -27,12 +27,12 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class CpkReadServiceImplTest {
-    lateinit var cpkReadService: CpkReadServiceImpl
-    lateinit var coordinatorFactory: LifecycleCoordinatorFactory
-    lateinit var configReadService: ConfigurationReadService
-    lateinit var subscriptionFactory: SubscriptionFactory
+    private lateinit var cpkReadService: CpkReadServiceImpl
+    private lateinit var coordinatorFactory: LifecycleCoordinatorFactory
+    private lateinit var configReadService: ConfigurationReadService
+    private lateinit var subscriptionFactory: SubscriptionFactory
 
-    lateinit var coordinator: LifecycleCoordinator
+    private lateinit var coordinator: LifecycleCoordinator
 
     @BeforeEach
     fun setUp() {
@@ -64,7 +64,10 @@ class CpkReadServiceImplTest {
 
     @Test
     fun `on onConfigChangedEvent fully sets the component`() {
-        val fs = Jimfs.newFileSystem(Configuration.unix())
+        val posix = Configuration.unix().toBuilder()
+            .setAttributeViews("basic", "posix")
+            .build()
+        val fs = Jimfs.newFileSystem(posix)
         val workspacePathProvider = mock<PathProvider>()
         whenever(workspacePathProvider.getOrCreate(any(), anyVararg())).thenReturn(fs.getPath("/workspace/$CPK_CACHE_DIR"))
         val tempPathProvider = mock<PathProvider>()

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -7,8 +7,12 @@ import io.micrometer.core.instrument.Meter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Timer
+import io.micrometer.core.instrument.binder.system.DiskSpaceMetrics
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry
 import io.micrometer.core.instrument.config.MeterFilter
+import io.micrometer.core.instrument.noop.NoopMeter
+import java.nio.file.FileSystems
+import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicInteger
 import io.micrometer.core.instrument.Tag as micrometerTag
 
@@ -456,6 +460,13 @@ object CordaMetrics {
              */
             object DeserializationTime : Metric<Timer>("serialization.amqp.deserialization.time", CordaMetrics::timer)
         }
+
+        class DiskSpace(path: Path) : Metric<NoopMeter>("", meter = { _, tags ->
+            if (path.fileSystem == FileSystems.getDefault()) {
+                DiskSpaceMetrics(path.toFile(), tags).bindTo(registry)
+            }
+            VoidMeter
+        })
     }
 
     /**
@@ -519,6 +530,11 @@ object CordaMetrics {
          * The flow event type this metric was recorded for.
          */
         FlowEvent("flow.event"),
+
+        /**
+         * Label for a type of content.
+         */
+        ContentsType("contents.type"),
 
         /**
          * The status of the operation. Can be used to indicate whether an operation was successful or failed.
@@ -624,24 +640,24 @@ object CordaMetrics {
      * @param registry Registry instance
      */
     fun configure(workerType: String, registry: MeterRegistry) {
-        this.registry.add(registry)
-        this.registry.config()
+        this.registry.add(registry).config()
+            .commonTags(Tag.WorkerType.value, workerType)
             .meterFilter(object : MeterFilter {
                 override fun map(id: Meter.Id): Meter.Id {
                     // prefix all metrics with `corda`, except standard JVM and Process metrics
                     @Suppress("ComplexCondition")
-                    if (
+                    return if (
                         id.name.startsWith("corda") ||
                         id.name.startsWith("jvm") ||
                         id.name.startsWith("system") ||
                         id.name.startsWith("process")
                     ) {
-                        return id
+                        id
+                    } else {
+                        id.withName("corda." + id.name)
                     }
-                    return id.withName("corda." + id.name)
                 }
             })
-            .commonTags(Tag.WorkerType.value, workerType)
     }
 
     fun settableGauge(name: String, tags: Iterable<micrometerTag>): SettableGauge {
@@ -682,3 +698,9 @@ object CordaMetrics {
         }
     }
 }
+
+/**
+ * This is a dummy "placeholder" meter.
+ */
+@Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+private object VoidMeter : NoopMeter(null)


### PR DESCRIPTION
Create a `DiskSpace` metric, and use it to monitor the available disk space in the CPK and chunk cache directories.

Note that `DiskSpace` is determined via `File::getUsableSpace` and `File::getTotalSpace`, which operate on the disk partition that `File` object refers to. This means that:
- We need an actual `File` instance to create one of these metrics.
- A server may be created to have _many_ disk partitions, and there is no reason to assume that two different paths share the same partition.
- Conversely, a single disk partition may contain several directories that we may wish to monitor, and so it wouldn't make sense to have metrics for each of them. Most likely, we'd only need to monitor their common parent directory.

We should therefore _carefully_ consider which directories we need to monitor. We certainly don't need to monitor _every_ directory.