### PR TITLE
CORE-13987: Add AMQP serialization metrics to all sandboxes, and simplify CurrentSandboxGroupContext.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/factory/SandboxDependencyInjectorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sandbox/factory/SandboxDependencyInjectorFactoryImpl.kt
@@ -47,7 +47,7 @@ class SandboxDependencyInjectorFactoryImpl : SandboxDependencyInjectorFactory {
                             return@mapNotNull null
                         }
 
-                        @Suppress("unchecked_cast", "RemoveExplicitTypeArguments")
+                        @Suppress("unchecked_cast")
                         (ref.getProperty(OBJECTCLASS) as? Array<String> ?: emptyArray<String>())
                             .filterNot(FORBIDDEN_INTERFACES::contains)
                             .takeIf(List<*>::isNotEmpty)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/SerializationServiceImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/SerializationServiceImplTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -52,8 +51,8 @@ class SerializationServiceImplTest {
         val deserialized = flowFiberSerializationService.deserialize(byteArray, TestObject::class.java)
 
         assertThat(deserialized).isEqualTo(tesObj)
-        verify(serializationService, times(1)).deserialize(byteArray,  TestObject::class.java)
-        verify(currentSandboxGroupContext, times(2)).get()
+        verify(serializationService).deserialize(byteArray,  TestObject::class.java)
+        verify(currentSandboxGroupContext).get()
     }
 
     @Test
@@ -64,8 +63,8 @@ class SerializationServiceImplTest {
         val deserialized = flowFiberSerializationService.deserializeAndCheckType(byteArray, TestObject::class.java)
 
         assertThat(deserialized).isEqualTo(tesObj)
-        verify(serializationService, times(1)).deserialize(byteArray,  TestObject::class.java)
-        verify(currentSandboxGroupContext, times(2)).get()
+        verify(serializationService).deserialize(byteArray,  TestObject::class.java)
+        verify(currentSandboxGroupContext).get()
     }
 
     @Test
@@ -74,8 +73,8 @@ class SerializationServiceImplTest {
 
         assertThrows<CordaRuntimeException> { flowFiberSerializationService.deserializeAndCheckType(byteArray, TestObject::class.java) }
 
-        verify(serializationService, times(1)).deserialize(byteArray,  TestObject::class.java)
-        verify(currentSandboxGroupContext, times(2)).get()
+        verify(serializationService).deserialize(byteArray,  TestObject::class.java)
+        verify(currentSandboxGroupContext).get()
     }
 
     @Test
@@ -84,7 +83,7 @@ class SerializationServiceImplTest {
         val deserialized = flowFiberSerializationService.serialize(testObj)
 
         assertThat(deserialized).isEqualTo(serializedBytes)
-        verify(serializationService, times(1)).serialize(testObj)
-        verify(currentSandboxGroupContext, times(2)).get()
+        verify(serializationService).serialize(testObj)
+        verify(currentSandboxGroupContext).get()
     }
 }

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
@@ -74,10 +74,13 @@ class AMQPSerializationProvider @Activate constructor(
         val serializationOutput = SerializationOutput(factory)
         val deserializationInput = DeserializationInput(factory)
 
-        val serializationService = SerializationServiceImpl(
-            serializationOutput,
-            deserializationInput,
-            AMQP_STORAGE_CONTEXT.withSandboxGroup(context.sandboxGroup) //todo double check in CORE-12472
+        val serializationService = SerializationMetricsWrapper(
+            serializationService = SerializationServiceImpl(
+                serializationOutput,
+                deserializationInput,
+                AMQP_STORAGE_CONTEXT.withSandboxGroup(context.sandboxGroup) //todo double check in CORE-12472
+            ),
+            context
         )
 
         context.putObjectByKey(AMQP_SERIALIZATION_SERVICE, serializationService)

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/SerializationMetricsWrapper.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/SerializationMetricsWrapper.kt
@@ -1,0 +1,44 @@
+package net.corda.sandbox.serialization.amqp
+
+import io.micrometer.core.instrument.Timer
+import net.corda.metrics.CordaMetrics
+import net.corda.metrics.recordOptionally
+import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.serialization.SerializedBytes
+
+class SerializationMetricsWrapper(
+    private val serializationService: SerializationService,
+    sandboxGroupContext: SandboxGroupContext
+) : SerializationService {
+    private val holdingId = sandboxGroupContext.virtualNodeContext.holdingIdentity.shortHash.toString()
+
+    override fun <T : Any> serialize(obj: T): SerializedBytes<T> {
+        return CordaMetrics.Metric.Serialization.SerializationTime
+            .builder()
+            .forVirtualNode(holdingId)
+            .withTag(CordaMetrics.Tag.SerializedClass, obj::class.java.name)
+            .build()
+            .recordOptionally(greaterThanMillis = 1) { serializationService.serialize(obj) }
+    }
+
+    override fun <T : Any> deserialize(serializedBytes: SerializedBytes<T>, clazz: Class<T>): T {
+        return deserializationTime(clazz).recordOptionally(greaterThanMillis = 1) {
+            serializationService.deserialize(serializedBytes, clazz)
+        }
+    }
+
+    override fun <T : Any> deserialize(bytes: ByteArray, clazz: Class<T>): T {
+        return deserializationTime(clazz).recordOptionally(greaterThanMillis = 1) {
+            serializationService.deserialize(bytes, clazz)
+        }
+    }
+
+    private fun deserializationTime(clazz: Class<*>): Timer {
+        return CordaMetrics.Metric.Serialization.DeserializationTime
+            .builder()
+            .forVirtualNode(holdingId)
+            .withTag(CordaMetrics.Tag.SerializedClass, clazz.name)
+            .build()
+    }
+}

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/SerializationServiceProxy.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/SerializationServiceProxy.kt
@@ -1,16 +1,10 @@
 package net.corda.sandbox.serialization.amqp
 
-import io.micrometer.core.instrument.Timer
-import net.corda.metrics.CordaMetrics
-import net.corda.metrics.recordOptionally
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
-import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.serialization.SerializedBytes
-import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 /**
@@ -26,10 +20,7 @@ import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
     ],
     scope = PROTOTYPE
 )
-class SerializationServiceProxy @Activate constructor(
-    @Reference(service = CurrentSandboxGroupContext::class)
-    private val currentSandboxGroupContext: CurrentSandboxGroupContext
-) : SerializationService, UsedByPersistence, UsedByVerification {
+class SerializationServiceProxy : SerializationService, UsedByPersistence, UsedByVerification {
     private var serializationService: SerializationService? = null
 
     fun wrap(serializer: SerializationService) {
@@ -38,39 +29,16 @@ class SerializationServiceProxy @Activate constructor(
 
     override fun <T : Any> deserialize(bytes: ByteArray, clazz: Class<T>): T {
         return checkNotNull(serializationService) { "deserialize(byte[], Class): Not initialised" }
-            .run {
-                deserializationTime(clazz).recordOptionally(greaterThanMillis = 1) {
-                    deserialize(bytes, clazz)
-                }
-            }
+            .deserialize(bytes, clazz)
     }
 
     override fun <T : Any> deserialize(serializedBytes: SerializedBytes<T>, clazz: Class<T>): T {
         return checkNotNull(serializationService) { "deserialize(SerializedBytes, Class): Not initialized" }
-            .run {
-                deserializationTime(clazz).recordOptionally(greaterThanMillis = 1) {
-                    deserialize(serializedBytes, clazz)
-                }
-            }
+            .deserialize(serializedBytes, clazz)
     }
 
     override fun <T : Any> serialize(obj: T): SerializedBytes<T> {
         return checkNotNull(serializationService) { "serialize(Object): Not initialized" }
-            .run {
-                CordaMetrics.Metric.Serialization.SerializationTime
-                    .builder()
-                    .forVirtualNode(currentSandboxGroupContext.get().virtualNodeContext.holdingIdentity.shortHash.toString())
-                    .withTag(CordaMetrics.Tag.SerializedClass, obj::class.java.name)
-                    .build()
-                    .recordOptionally(greaterThanMillis = 1) { serialize(obj) }
-            }
-    }
-
-    private fun deserializationTime(clazz: Class<*>): Timer {
-        return CordaMetrics.Metric.Serialization.DeserializationTime
-            .builder()
-            .forVirtualNode(currentSandboxGroupContext.get().virtualNodeContext.holdingIdentity.shortHash.toString())
-            .withTag(CordaMetrics.Tag.SerializedClass, clazz.name)
-            .build()
+            .serialize(obj)
     }
 }

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/CurrentSandboxGroupContextImpl.kt
@@ -1,35 +1,25 @@
 package net.corda.sandboxgroupcontext.service.impl
 
-import net.corda.sandbox.type.UsedByFlow
-import net.corda.sandbox.type.UsedByPersistence
-import net.corda.sandbox.type.UsedByVerification
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.utilities.trace
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Component
-import org.slf4j.Logger
+import org.osgi.service.component.annotations.ServiceScope.SINGLETON
 import org.slf4j.LoggerFactory
 
-@Component(
-    service = [
-        CurrentSandboxGroupContext::class,
-        SingletonSerializeAsToken::class,
-        UsedByFlow::class,
-        UsedByPersistence::class,
-        UsedByVerification::class
-    ]
-)
-class CurrentSandboxGroupContextImpl
-    : CurrentSandboxGroupContext, SingletonSerializeAsToken, UsedByFlow, UsedByPersistence, UsedByVerification {
+/**
+ * A singleton service wrapping a [ThreadLocal] that contains the current [SandboxGroupContext].
+ * Declare this service _explicitly_ as a [SINGLETON], just to make the point.
+ *
+ * FLOW sandboxes need this component to declare [SingletonSerializeAsToken] as one of its OSGi
+ * services so that it can be registered with the Checkpoint serializer.
+ */
+@Component(service = [ CurrentSandboxGroupContext::class, SingletonSerializeAsToken::class ], scope = SINGLETON)
+class CurrentSandboxGroupContextImpl : CurrentSandboxGroupContext, SingletonSerializeAsToken {
+    private val log = LoggerFactory.getLogger(CurrentSandboxGroupContextImpl::class.java)
 
-    private companion object {
-        @JvmField
-        val log: Logger = LoggerFactory.getLogger(CurrentSandboxGroupContextImpl::class.java)
-
-        @JvmField
-        val currentSandboxGroupContext = ThreadLocal<SandboxGroupContext?>()
-    }
+    private val currentSandboxGroupContext = ThreadLocal<SandboxGroupContext?>()
 
     override fun set(sandboxGroupContext: SandboxGroupContext) {
         log.trace {


### PR DESCRIPTION
`CurrentSandboxGroupContext` is a singleton platform component, and so does not need to declare any of the sandbox marker interfaces.

`FlowSandboxServiceImpl` needs this component to advertise `SingletonSerializeAsToken` so that it can be registered with the Checkpoint serializer as a "non-injectable service".

Wrap `SerializationService` inside `SerializationMetricsWrapper` to ensure that serialization metrics are available in all cases.