### PR TITLE
CORE-13866: Increase Kakfa timeouts

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -21,12 +21,14 @@ consumer = ${common} {
     # batch may contain fewer than 500 records.
     max.poll.records = 500
     # Time to allow between polls on a consumer before a rebalance occurs that removes this consumer's partitions.
-    max.poll.interval.ms = 100000
+    max.poll.interval.ms = 300000
     # Timeout of heartbeats between the consumer and the broker. If no heartbeat is received in this timeframe, a
     # rebalance will occur.
-    session.timeout.ms = 6000
+    session.timeout.ms = 60000
     # Frequency of heartbeats between the consumer and the broker. Should be no higher than 1/3 of the session timeout.
-    heartbeat.interval.ms = 2000
+    heartbeat.interval.ms = 20000
+    # How long to wait to allow consumers to join the group before performing a rebalance
+    group.initial.rebalance.delay.ms = 60000
 }
 
 # Defaults for all producers.

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -27,8 +27,6 @@ consumer = ${common} {
     session.timeout.ms = 60000
     # Frequency of heartbeats between the consumer and the broker. Should be no higher than 1/3 of the session timeout.
     heartbeat.interval.ms = 20000
-    # How long to wait to allow consumers to join the group before performing a rebalance
-    group.initial.rebalance.delay.ms = 60000
 }
 
 # Defaults for all producers.

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
@@ -152,7 +152,7 @@ class MessageBusConfigResolverTest {
                 CLIENT_ID_PROP to "consumer-$CLIENT_ID",
                 ISOLATION_LEVEL_PROP to "read_committed",
                 BOOTSTRAP_SERVERS_PROP to "localhost:9092",
-                SESSION_TIMEOUT_PROP to "6000",
+                SESSION_TIMEOUT_PROP to "60000",
                 AUTO_OFFSET_RESET_PROP to "earliest"
             )
             val properties = Properties()


### PR DESCRIPTION
The assumption is that the current timeouts are too slow and are leading to increased rebalancing.  This has been through limited testing using the performance tests.

More testing should help stabilise these numbers and it's likely that as other areas improve we'll be able to refine them further.