### PR TITLE
CORE-13920 message pattern lib metrics

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
@@ -62,7 +62,7 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
     private var responsePartition: CordaTopicPartition? = null
     private val responseTopic = getRPCResponseTopic(config.topic)
 
-    private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
+    private val processorMeter = CordaMetrics.Metric.Messaging.MessageProcessorTime.builder()
         .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.RPC_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
         .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.RPC_SENDER_OPERATION)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
@@ -67,7 +67,7 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
     private val errorMsg = "Failed to read and process records from topic ${config.topic}, group ${config.group}, producerClientId " +
             "${config.clientId}."
 
-    private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
+    private val processorMeter = CordaMetrics.Metric.Messaging.MessageProcessorTime.builder()
         .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.DURABLE_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
         .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.ON_NEXT_OPERATION)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/PubSubSubscriptionImpl.kt
@@ -49,7 +49,7 @@ internal class PubSubSubscriptionImpl<K : Any, V : Any>(
     private val errorMsg = "PubSubConsumer failed to create and subscribe consumer for group ${config.group}, " +
             "topic ${config.topic}."
 
-    private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
+    private val processorMeter = CordaMetrics.Metric.Messaging.MessageProcessorTime.builder()
         .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.PUB_SUB_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
         .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.ON_NEXT_OPERATION)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
@@ -50,7 +50,7 @@ internal class RPCSubscriptionImpl<REQUEST : Any, RESPONSE : Any>(
 
     private val errorMsg = "Failed to read records from group ${config.group}, topic ${config.topic}"
 
-    private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
+    private val processorMeter = CordaMetrics.Metric.Messaging.MessageProcessorTime.builder()
         .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.RPC_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
         .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.RPC_RESPONDER_OPERATION)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -77,18 +77,13 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
     private val errorMsg = "Failed to read and process records from topic $eventTopic, group ${config.group}, " +
             "producerClientId ${config.clientId}."
 
-    private val processorMeter = CordaMetrics.Metric.MessageProcessorTime.builder()
+    private val processorMeter = CordaMetrics.Metric.Messaging.MessageProcessorTime.builder()
         .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
         .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.BATCH_PROCESS_OPERATION)
         .build()
 
-    private val batchSizeHistogram = CordaMetrics.Metric.MessageBatchSize.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
-        .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .build()
-
-    private val commitTimer = CordaMetrics.Metric.MessageCommitTime.builder()
+    private val commitTimer = CordaMetrics.Metric.Messaging.MessageCommitTime.builder()
         .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
         .build()
@@ -193,7 +188,6 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
                 log.debug { "Polling and processing events" }
                 var rebalanceOccurred = false
                 val records = stateAndEventConsumer.pollEvents()
-                batchSizeHistogram.record(records.size.toDouble())
                 val batches = getEventsByBatch(records).iterator()
                 while (!rebalanceOccurred && batches.hasNext()) {
                     val batch = batches.next()

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.subscription.consumer
 
+import io.micrometer.core.instrument.Gauge
 import net.corda.lifecycle.Resource
 import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.consumer.CordaConsumer
@@ -60,18 +61,20 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
     private val partitionsToSync = ConcurrentHashMap.newKeySet<CordaTopicPartition>()
     private val inSyncPartitions = ConcurrentHashMap.newKeySet<CordaTopicPartition>()
 
-    private val statePollTimer = CordaMetrics.Metric.MessagePollTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
-        .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.STATE_POLL_OPERATION)
-        .build()
-
-    private val eventPollTimer = CordaMetrics.Metric.MessagePollTime.builder()
-        .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
-        .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
-        .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.EVENT_POLL_OPERATION)
-        .build()
-
+    // a map of gauges, each one recording the number of states currently in memory for each partition
+    private val inMemoryStatesPerPartitionGaugeCache = ConcurrentHashMap<Int, Gauge>()
+    private fun createGaugesForInMemoryStates(partitions: List<Int>) {
+        partitions.forEach { partition ->
+            inMemoryStatesPerPartitionGaugeCache.computeIfAbsent(partition) {
+                CordaMetrics.Metric.Messaging.PartitionedConsumerInMemoryStore { currentStates[partition]?.size ?: 0 }
+                    .builder()
+                    .withTag(CordaMetrics.Tag.MessagePatternType, MetricsConstants.STATE_AND_EVENT_PATTERN_TYPE)
+                    .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
+                    .withTag(CordaMetrics.Tag.Partition, "$partition")
+                    .build()
+            }
+        }
+    }
 
     private var pollIntervalCutoff = 0L
 
@@ -104,6 +107,7 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
                 listener.onPartitionSynced(getStatesForPartition(partition.partition))
             }
         }
+        createGaugesForInMemoryStates(partitions.map { it.partition })
     }
 
     private fun onPartitionsSynchronized(partitions: Set<CordaTopicPartition>) {
@@ -175,10 +179,8 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
             return
         }
 
-        val states = statePollTimer.recordCallable {
-            stateConsumer.poll(STATE_POLL_TIMEOUT)
-        }
-        states?.forEach { state ->
+        val states = stateConsumer.poll(STATE_POLL_TIMEOUT)
+        states.forEach { state ->
             log.trace { "Processing state: $state" }
             // This condition should always be true. This can however guard against a potential race where the partition
             // is revoked while states are being processed, resulting in the partition no longer being required to sync.
@@ -201,6 +203,7 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
         eventConsumer.close()
         stateConsumer.close()
         executor.shutdown()
+        inMemoryStatesPerPartitionGaugeCache.values.forEach { CordaMetrics.registry.remove(it) }
     }
 
     private fun removeAndReturnSyncedPartitions(): Set<CordaTopicPartition> {
@@ -217,11 +220,9 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
     override fun pollEvents(): List<CordaConsumerRecord<K, E>> {
         return when {
             inSyncPartitions.isNotEmpty() -> {
-                eventPollTimer.recordCallable {
-                    eventConsumer.poll(EVENT_POLL_TIMEOUT).also {
-                        log.debug { "Received ${it.size} events on keys ${it.joinToString { it.key.toString() }}" }
-                    }
-                }!!
+                eventConsumer.poll(EVENT_POLL_TIMEOUT).also {
+                    log.debug { "Received ${it.size} events on keys ${it.joinToString { it.key.toString() }}" }
+                }
             }
             partitionsToSync.isEmpty() -> {
                 // Call poll more frequently to trigger a rebalance of the event consumer.

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -44,26 +44,6 @@ object CordaMetrics {
         object SandboxCreateTime : Metric<Timer>("sandbox.create.time", CordaMetrics::timer)
 
         /**
-         * Time it took to execute a message pattern processor
-         */
-        object MessageProcessorTime : Metric<Timer>("messaging.processor.time", CordaMetrics::timer)
-
-        /**
-         * The size of batches of messages received in a poll from the message bus.
-         */
-        object MessageBatchSize : Metric<DistributionSummary>("messaging.batch.size", Metrics::summary)
-
-        /**
-         * The time taken to commit a processed batch of messages back to the bus.
-         */
-        object MessageCommitTime : Metric<Timer>("messaging.commit.time", CordaMetrics::timer)
-
-        /**
-         * The time blocking inside a poll call waiting for messages from the bus.
-         */
-        object MessagePollTime : Metric<Timer>("messaging.poll.time", CordaMetrics::timer)
-
-        /**
          * FLOW METRICS
          *
          * Time it took for a flow or subFlow to complete successfully or to error.
@@ -621,6 +601,50 @@ object CordaMetrics {
              */
             object ReconciliationRecordsCount : Metric<DistributionSummary>("db.reconciliation.records.count", Metrics::summary)
         }
+
+        object Messaging {
+
+            /**
+             * Time it took to execute a message pattern processor
+             */
+            object MessageProcessorTime : Metric<Timer>("messaging.processor.time", CordaMetrics::timer)
+
+            /**
+             * The size of batches of messages received in polls from the message bus by consumers.
+             */
+            object ConsumerBatchSize : Metric<DistributionSummary>("consumer.batch.size", Metrics::summary)
+
+            /**
+             * The time taken to commit a processed batch of messages back to the bus.
+             */
+            object MessageCommitTime : Metric<Timer>("messaging.commit.time", CordaMetrics::timer)
+
+            /**
+             * Generic consumer poll time, time taken by kafka to respond to consumer polls for each client ID.
+             */
+            object ConsumerPollTime : Metric<Timer>("consumer.poll.time", CordaMetrics::timer)
+
+            /**
+             * Measure for the number of chunks generated when writing records.
+             */
+            object ProducerChunksGenerated : Metric<DistributionSummary>("producer.chunks.generated", Metrics::summary)
+
+            /**
+             * Measure for the number of in-memory states held in compacted consumers.
+             */
+            class CompactedConsumerInMemoryStore(computation: Supplier<Number>) : ComputedValue<Nothing>(
+                "consumer.compacted.inmemory.store",
+                computation
+            )
+
+            /**
+             * Measure for the number of in-memory states held in consumers with partitions.
+             */
+            class PartitionedConsumerInMemoryStore(computation: Supplier<Number>) : ComputedValue<Nothing>(
+                "consumer.partitioned.inmemory.store",
+                computation
+            )
+        }
     }
 
     /**
@@ -792,7 +816,17 @@ object CordaMetrics {
         /**
          * Result of a TLS connection (i.e. success or failure).
          */
-        ConnectionResult("connection.result")
+        ConnectionResult("connection.result"),
+
+        /**
+         * Name of a message bus topic published to or consumed from.
+         */
+        Topic("topic"),
+
+        /**
+         * Partition of a message bus topic published to or consumed from.
+         */
+        Partition("partition")
     }
 
     /**


### PR DESCRIPTION
I've now updated [flow dashboard](https://github.com/corda/engineering-helm/pull/50/files#diff-f4bd8bfd6097f7b6628b3835244f804d8173df626065098302e11e3ff6ebc576) following renaming of some "messaging" metrics to "consumer" (as they cover all consumers).

See grafana dashboard of flow worker with these updates [here](https://grafana.non-functional-tests.corda.cloud/d/Conal-FlowWorker/conal-flow-worker?orgId=1&from=1687544802980&to=1687545779676).

See the message pattern dashboard [here](https://grafana.non-functional-tests.corda.cloud/d/Conal-Messaging/conal-messaging-patterns?orgId=1&from=1687544779198&to=1687545767527)

See engineering-helm changes [here](https://github.com/corda/engineering-helm/pull/50).