### PR TITLE
CORE-14127: Detect whether filesystem supports POSIX.

### DIFF
--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
@@ -5,6 +5,7 @@ import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.CpkChunkId
 import net.corda.libs.packaging.writeFile
 import net.corda.utilities.debug
+import net.corda.utilities.posixOptional
 import net.corda.v5.crypto.SecureHash
 import org.slf4j.LoggerFactory
 import java.nio.channels.FileChannel
@@ -57,10 +58,12 @@ class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileMan
             // Try to create the directory. Will fail if this path
             // already exists as something other than a directory.
             logger.debug { "Creating CPK directory: $cpkXDir" }
-            Files.createDirectory(cpkXDir, CPK_DIRECTORY_PERMISSIONS)
+            @Suppress("SpreadOperator")
+            Files.createDirectory(cpkXDir, *cpkXDir.posixOptional(CPK_DIRECTORY_PERMISSIONS))
         }
         val filePath = cpkXDir.resolve(chunkId.toFileName())
-        Files.newByteChannel(filePath, CREATE_OR_REPLACE, CPK_FILE_PERMISSIONS).use { channel ->
+        @Suppress("SpreadOperator")
+        Files.newByteChannel(filePath, CREATE_OR_REPLACE, *filePath.posixOptional(CPK_FILE_PERMISSIONS)).use { channel ->
             channel.write(chunk.data)
         }
     }
@@ -75,7 +78,8 @@ class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileMan
         }
 
         return cpkXDir.resolve(cpkChecksum.toCpkFileName()).also { cpkFilePath ->
-            Files.newByteChannel(cpkFilePath, CREATE_OR_REPLACE, CPK_FILE_PERMISSIONS).use { output ->
+            @Suppress("SpreadOperator")
+            Files.newByteChannel(cpkFilePath, CREATE_OR_REPLACE, *cpkFilePath.posixOptional(CPK_FILE_PERMISSIONS)).use { output ->
                 chunkParts.forEach { chunkId ->
                     val cpkChunkPath = cpkXDir.resolve(chunkId.toFileName())
                     FileChannel.open(cpkChunkPath, READ).use(output::writeFile)

--- a/libs/chunking/chunking-core/build.gradle
+++ b/libs/chunking/chunking-core/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 
     implementation project(":libs:configuration:configuration-core")
     implementation project(':libs:crypto:crypto-core')
+    implementation project(':libs:utilities')
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkReaderImpl.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkReaderImpl.kt
@@ -9,6 +9,7 @@ import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.toCorda
 import net.corda.data.KeyValuePairList
 import net.corda.data.chunking.Chunk
+import net.corda.utilities.posixOptional
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash
 import java.nio.file.Files
@@ -64,9 +65,10 @@ internal class ChunkReaderImpl(private val destDir: Path) : ChunkReader {
             chunksReceived.expectedChecksum = chunk.checksum.toCorda()
         } else {
             // We have a chunk, move to the correct offset, and write the data.
-            // We expect the data to be correct sized.  There is a unit test to
+            // We expect the data to be correctly sized. There is a unit test to
             // ensure the writer does this.
-            Files.newByteChannel(path, CREATE_OR_UPDATE, CHUNK_FILE_PERMISSIONS).use { channel ->
+            @Suppress("SpreadOperator")
+            Files.newByteChannel(path, CREATE_OR_UPDATE, *path.posixOptional(CHUNK_FILE_PERMISSIONS)).use { channel ->
                 channel.position(chunk.offset)
                 channel.write(chunk.data)
             }

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/PathProvider.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/PathProvider.kt
@@ -38,8 +38,8 @@ class WorkspacePathProvider(
             "Configuration should not be null for ${ConfigKeys.WORKSPACE_DIR}"
         }
 
-        return dirResolver(config.getString(ConfigKeys.WORKSPACE_DIR)!!, dirPath).also {
-            Files.createDirectories(it, WORKSPACE_DIR_PERMISSIONS)
+        return dirResolver(config.getString(ConfigKeys.WORKSPACE_DIR)!!, dirPath).also { dir ->
+            Files.createDirectories(dir, *dir.posixOptional(WORKSPACE_DIR_PERMISSIONS))
         }
     }
 }
@@ -57,8 +57,8 @@ class TempPathProvider(
             "Configuration should not be null for ${ConfigKeys.TEMP_DIR}"
         }
 
-        return dirResolver(config.getString(ConfigKeys.TEMP_DIR)!!, dirPath).also {
-            Files.createDirectories(it, TEMP_DIR_PERMISSIONS)
+        return dirResolver(config.getString(ConfigKeys.TEMP_DIR)!!, dirPath).also { dir ->
+            Files.createDirectories(dir, *dir.posixOptional(TEMP_DIR_PERMISSIONS))
         }
     }
 }

--- a/libs/utilities/src/test/kotlin/net/corda/utilities/PathProviderTest.kt
+++ b/libs/utilities/src/test/kotlin/net/corda/utilities/PathProviderTest.kt
@@ -7,6 +7,8 @@ import net.corda.schema.configuration.ConfigKeys
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -26,58 +28,116 @@ class PathProviderTest {
     private lateinit var fs: FileSystem
     private lateinit var config: SmartConfig
 
-    @BeforeEach
-    fun setUp() {
-        val posix = Configuration.unix().toBuilder()
-            .setAttributeViews("basic", "posix")
-            .build()
-        fs = Jimfs.newFileSystem(posix)
-
-        config = mock()
-    }
-
     @AfterEach
     fun clear() {
         fs.close()
     }
 
-    @Test
-    fun `getOrCreate creates workspace dir if not existing`() {
-        whenever(config.hasPath(ConfigKeys.WORKSPACE_DIR)).thenReturn(true)
-        whenever(config.getString(ConfigKeys.WORKSPACE_DIR)).thenReturn("/workspace")
-        val workspacePathProvider = WorkspacePathProvider { first, more ->
-            fs.getPath(first, *more)
+    @Nested
+    @DisplayName("PathProvider with UNIX filesystem")
+    inner class Unix {
+        @BeforeEach
+        fun setUp() {
+            val posix = Configuration.unix().toBuilder()
+                .setAttributeViews("basic", "posix")
+                .build()
+            fs = Jimfs.newFileSystem(posix)
+
+            config = mock()
         }
 
-        val dir = workspacePathProvider.getOrCreate(config, "subdir")
-        assertThat(dir).hasToString("/workspace/subdir")
-            .isDirectory
-            .isReadable
-            .isWritable
-            .isExecutable
-        assertThat(Files.getPosixFilePermissions(dir))
-            .containsExactlyInAnyOrder(OWNER_WRITE, OWNER_READ, OWNER_EXECUTE, GROUP_READ, GROUP_EXECUTE, OTHERS_EXECUTE, OTHERS_READ)
-        verify(config).hasPath(ConfigKeys.WORKSPACE_DIR)
-        verify(config).getString(ConfigKeys.WORKSPACE_DIR)
+        @Test
+        fun `getOrCreate creates workspace dir if not existing`() {
+            whenever(config.hasPath(ConfigKeys.WORKSPACE_DIR)).thenReturn(true)
+            whenever(config.getString(ConfigKeys.WORKSPACE_DIR)).thenReturn("/workspace")
+            val workspacePathProvider = WorkspacePathProvider { first, more ->
+                fs.getPath(first, *more)
+            }
+
+            val dir = workspacePathProvider.getOrCreate(config, "subdir")
+            assertThat(dir).hasToString("/workspace/subdir")
+                .isDirectory
+                .isReadable
+                .isWritable
+                .isExecutable
+            assertThat(Files.getPosixFilePermissions(dir))
+                .containsExactlyInAnyOrder(
+                    OWNER_WRITE,
+                    OWNER_READ,
+                    OWNER_EXECUTE,
+                    GROUP_READ,
+                    GROUP_EXECUTE,
+                    OTHERS_EXECUTE,
+                    OTHERS_READ
+                )
+            verify(config).hasPath(ConfigKeys.WORKSPACE_DIR)
+            verify(config).getString(ConfigKeys.WORKSPACE_DIR)
+        }
+
+        @Test
+        fun `getOrCreate creates temporary dir if not existing`() {
+            whenever(config.hasPath(ConfigKeys.TEMP_DIR)).thenReturn(true)
+            whenever(config.getString(ConfigKeys.TEMP_DIR)).thenReturn("/tmp")
+            val temporaryPathProvider = TempPathProvider { first, more ->
+                fs.getPath(first, *more)
+            }
+
+            val dir = temporaryPathProvider.getOrCreate(config, "subdir")
+            assertThat(dir).hasToString("/tmp/subdir")
+                .isDirectory
+                .isReadable
+                .isWritable
+                .isExecutable
+            assertThat(Files.getPosixFilePermissions(dir))
+                .containsExactlyInAnyOrder(OWNER_WRITE, OWNER_READ, OWNER_EXECUTE)
+            verify(config).hasPath(ConfigKeys.TEMP_DIR)
+            verify(config).getString(ConfigKeys.TEMP_DIR)
+        }
     }
 
-    @Test
-    fun `getOrCreate creates temporary dir if not existing`() {
-        whenever(config.hasPath(ConfigKeys.TEMP_DIR)).thenReturn(true)
-        whenever(config.getString(ConfigKeys.TEMP_DIR)).thenReturn("/tmp")
-        val temporaryPathProvider = TempPathProvider { first, more ->
-            fs.getPath(first, *more)
+    @Nested
+    @DisplayName("PathProvider with Windows filesystem")
+    inner class Windows {
+        @BeforeEach
+        fun setUp() {
+            fs = Jimfs.newFileSystem(Configuration.windows())
+            config = mock()
         }
 
-        val dir = temporaryPathProvider.getOrCreate(config, "subdir")
-        assertThat(dir).hasToString("/tmp/subdir")
-            .isDirectory
-            .isReadable
-            .isWritable
-            .isExecutable
-        assertThat(Files.getPosixFilePermissions(dir))
-            .containsExactlyInAnyOrder(OWNER_WRITE, OWNER_READ, OWNER_EXECUTE)
-        verify(config).hasPath(ConfigKeys.TEMP_DIR)
-        verify(config).getString(ConfigKeys.TEMP_DIR)
+        @Test
+        fun `getOrCreate creates workspace dir if not existing`() {
+            whenever(config.hasPath(ConfigKeys.WORKSPACE_DIR)).thenReturn(true)
+            whenever(config.getString(ConfigKeys.WORKSPACE_DIR)).thenReturn("c:\\workspace")
+            val workspacePathProvider = WorkspacePathProvider { first, more ->
+                fs.getPath(first, *more)
+            }
+
+            val dir = workspacePathProvider.getOrCreate(config, "subdir")
+            assertThat(dir).hasToString("c:\\workspace\\subdir")
+                .isDirectory
+                .isReadable
+                .isWritable
+                .isExecutable
+            verify(config).hasPath(ConfigKeys.WORKSPACE_DIR)
+            verify(config).getString(ConfigKeys.WORKSPACE_DIR)
+        }
+
+        @Test
+        fun `getOrCreate creates temporary dir if not existing`() {
+            whenever(config.hasPath(ConfigKeys.TEMP_DIR)).thenReturn(true)
+            whenever(config.getString(ConfigKeys.TEMP_DIR)).thenReturn("c:\\tmp")
+            val temporaryPathProvider = TempPathProvider { first, more ->
+                fs.getPath(first, *more)
+            }
+
+            val dir = temporaryPathProvider.getOrCreate(config, "subdir")
+            assertThat(dir).hasToString("c:\\tmp\\subdir")
+                .isDirectory
+                .isReadable
+                .isWritable
+                .isExecutable
+            verify(config).hasPath(ConfigKeys.TEMP_DIR)
+            verify(config).getString(ConfigKeys.TEMP_DIR)
+        }
     }
 }


### PR DESCRIPTION
Windows _still_ doesn't support POSIX file attributes _after over 40 years!_ Detect whether the filesystem has a `PosixFileAttributeView` before passing any POSIX file attributes.