### PR TITLE
CORE-14178 - Adjust gateway metrics to populate same set of tags for a specific metric name

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
@@ -232,9 +232,8 @@ internal class OutboundMessageHandler(
     ): Timer {
         val builder = CordaMetrics.Metric.OutboundGatewayRequestLatency.builder()
         builder.withTag(CordaMetrics.Tag.DestinationEndpoint, peerMessage.header.address)
-        if (response != null) {
-            builder.withTag(CordaMetrics.Tag.HttpResponseType, response.statusCode.code().toString())
-        }
+        val responseType = response?.statusCode?.code()?.toString() ?: "none"
+        builder.withTag(CordaMetrics.Tag.HttpResponseType, responseType)
         return builder.build()
     }
 

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -606,6 +606,15 @@ object CordaMetrics {
         ConnectionResult("connection.result")
     }
 
+    /**
+     * Prometheus requires the same set of tags to be populated for a specific metric name.
+     * Otherwise, metrics will be (silently) not exported.
+     *
+     * This value can be used to comply with this rule in scenarios where a tag is not relevant in some conditions,
+     * but it still needs to be populated in order to avoid lost data points.
+     */
+    const val NOT_APPLICABLE_TAG_VALUE = "not_applicable"
+
     val registry: CompositeMeterRegistry = Metrics.globalRegistry
 
     /**


### PR DESCRIPTION
Adjust gateway metrics to populate same set of tags for a specific metric name.

I also adjusted the code around metrics for inbound/outbound connections to make it less error-prone to not specifying the same set of tags always and make it a bit easier to read.