### PR TITLE
CORE-14204 Use cashed EntityManagerFactory for virtual node reconciliation

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/TestSigningRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/TestSigningRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.crypto.softhsm.impl
 
-import javax.persistence.EntityManagerFactory
 import net.corda.crypto.core.CryptoTenants
 import net.corda.crypto.persistence.getEntityManagerFactory
 import net.corda.db.connection.manager.DbConnectionManager
@@ -17,6 +16,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
+import javax.persistence.EntityManagerFactory
 
 class TestSigningRepositoryImpl {
 
@@ -26,7 +26,7 @@ class TestSigningRepositoryImpl {
         // Arguably this is really tessting getEntityManagerFactory so should be moved to a new test class
         val entityManagerFactory = mock<EntityManagerFactory>()
         val dbConnectionManager = mock<DbConnectionManager> {
-            on { getOrCreateEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+            on { getOrCreateEntityManagerFactory(any<CordaDb>(), any()) } doReturn entityManagerFactory
         }
         val tenant = CryptoTenants.CRYPTO
         makeMockSigningRepository(tenant, dbConnectionManager).use { repo ->
@@ -62,7 +62,7 @@ class TestSigningRepositoryImpl {
             on { cryptoDmlConnectionId } doReturn mock()
         }
         val dbConnectionManager = mock<DbConnectionManager> {
-            on { getOrCreateEntityManagerFactory(any(), any()) } doReturn mock()
+            on { getOrCreateEntityManagerFactory(any<CordaDb>(), any()) } doReturn mock()
             on { createEntityManagerFactory(any(), any()) } doReturn ownedEntityManagerFactory
         }
         val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsCachedImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsCachedImpl.kt
@@ -7,7 +7,7 @@ import net.corda.db.schema.CordaDb
 import net.corda.libs.configuration.SmartConfig
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
@@ -55,6 +55,15 @@ class DbConnectionOpsCachedImpl(
     ): EntityManagerFactory {
         return cache.computeIfAbsent(Pair(name,privilege)) {
             delegate.getOrCreateEntityManagerFactory(name, privilege, entitiesSet)
+        }
+    }
+
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory {
+        return cache.computeIfAbsent(Pair(connectionId.toString(), DbPrivilege.DML)) {
+            delegate.getOrCreateEntityManagerFactory(connectionId, entitiesSet)
         }
     }
 }

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsImpl.kt
@@ -80,6 +80,13 @@ class DbConnectionOpsImpl(
         )
     }
 
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory {
+        return createEntityManagerFactory(connectionId, entitiesSet)
+    }
+
     override fun createEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet):
             EntityManagerFactory {
         logger.info("Loading DB connection details for $connectionId")

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/LateInitDbConnectionOps.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/LateInitDbConnectionOps.kt
@@ -6,7 +6,7 @@ import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.libs.configuration.SmartConfig
 import net.corda.orm.JpaEntitiesSet
-import java.util.*
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.sql.DataSource
@@ -61,6 +61,12 @@ class LateInitDbConnectionOps: DbConnectionOps {
         entitiesSet: JpaEntitiesSet
     ): EntityManagerFactory =
         delegate.getOrCreateEntityManagerFactory(name, privilege, entitiesSet)
+
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory =
+        delegate.getOrCreateEntityManagerFactory(connectionId, entitiesSet)
 
     override fun createEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet):
             EntityManagerFactory = delegate.createEntityManagerFactory(connectionId, entitiesSet)

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionOps.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionOps.kt
@@ -5,7 +5,7 @@ import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.libs.configuration.SmartConfig
 import net.corda.orm.JpaEntitiesSet
-import java.util.*
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.sql.DataSource
@@ -130,14 +130,24 @@ interface DbConnectionOps {
             EntityManagerFactory
 
     /**
+     * Get an instance of [EntityManagerFactory] for the for a given connection ID. Use cache or create one if necessary.
+     *
+     * @param connectionId Connection UUID
+     * @param entitiesSet Set of all entities managed by [javax.persistence.EntityManager]s created by the
+     *                  [EntityManagerFactory] returned
+     * @return [EntityManagerFactory] from cache, or created on demand.
+     */
+    fun getOrCreateEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet): EntityManagerFactory
+
+    /**
      * Create an [EntityManagerFactory] for a given connection ID.
      *
      * A new EMF should be created and implementations of this class should not cache it.
      *
-     * @param connectionId
+     * @param connectionId Connection UUID
      * @param entitiesSet Set of all entities managed by [javax.persistence.EntityManager]s created by the
      *                  [EntityManagerFactory] returned
-     * @return
+     * @return Created [EntityManagerFactory].
      */
     fun createEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet): EntityManagerFactory
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
@@ -49,7 +49,7 @@ class VirtualNodeReconciliationContext(
     private var entityManager: EntityManager? = null
 
     private fun getOrCreateEntityManagerFactory() = entityManagerFactory
-        ?: dbConnectionManager.createEntityManagerFactory(virtualNodeInfo.vaultDmlConnectionId, jpaEntitiesSet)
+        ?: dbConnectionManager.getOrCreateEntityManagerFactory(virtualNodeInfo.vaultDmlConnectionId, jpaEntitiesSet)
             .also { entityManagerFactory = it }
 
     override fun getOrCreateEntityManager(): EntityManager = entityManager

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
@@ -105,9 +105,9 @@ class GroupParametersReconcilerTest {
         on { createCoordinator(any(), any()) } doReturn coordinator
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(eq(vnode1.vaultDmlConnectionId), any()) } doReturn emf1
-        on { createEntityManagerFactory(eq(vnode2.vaultDmlConnectionId), any()) } doReturn emf2
-        on { createEntityManagerFactory(eq(vnode3.vaultDmlConnectionId), any()) } doReturn emf3
+        on { getOrCreateEntityManagerFactory(eq(vnode1.vaultDmlConnectionId), any()) } doReturn emf1
+        on { getOrCreateEntityManagerFactory(eq(vnode2.vaultDmlConnectionId), any()) } doReturn emf2
+        on { getOrCreateEntityManagerFactory(eq(vnode3.vaultDmlConnectionId), any()) } doReturn emf3
     }
 
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
@@ -226,7 +226,7 @@ class GroupParametersReconcilerTest {
             // call terminal operation to process stream
             groupParametersReconciler.dbReconcilerReader?.getAllVersionedRecords()?.count()
 
-            verify(dbConnectionManager, times(2)).createEntityManagerFactory(any(), any())
+            verify(dbConnectionManager, times(2)).getOrCreateEntityManagerFactory(any<UUID>(), any())
             verify(em1).criteriaBuilder
             verify(em1).createQuery(any<CriteriaQuery<GroupParametersEntity>>())
             verify(em2).criteriaBuilder

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
@@ -70,7 +70,7 @@ class MgmAllowedCertificateSubjectsReconcilerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(connectionId, entitySet) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(connectionId, entitySet) } doReturn entityManagerFactory
     }
     private val reconcilerFactory = mock<ReconcilerFactory> {
         on {

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContextTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContextTest.kt
@@ -46,7 +46,7 @@ class ReconciliationContextTest {
     private val dbConnectionManager: DbConnectionManager = mock {
         on { getClusterEntityManagerFactory() } doReturn clusterEmf
         on {
-            createEntityManagerFactory(eq(virtualNodeInfo.vaultDmlConnectionId), eq(jpaEntitiesSet))
+            getOrCreateEntityManagerFactory(eq(virtualNodeInfo.vaultDmlConnectionId), eq(jpaEntitiesSet))
         } doReturn vnodeEmf
     }
 
@@ -115,7 +115,7 @@ class ReconciliationContextTest {
 
         @Test
         fun `Context initialisation does not create the entity manager factory and the entity manager`() {
-            verify(dbConnectionManager, never()).createEntityManagerFactory(
+            verify(dbConnectionManager, never()).getOrCreateEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -125,7 +125,7 @@ class ReconciliationContextTest {
         @Test
         fun `Context entity manager factory and entity manager are created when called`() {
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager).createEntityManagerFactory(
+            verify(dbConnectionManager).getOrCreateEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -136,7 +136,7 @@ class ReconciliationContextTest {
         fun `Context entity manager factory and entity manager are not recreated if they haven't been closed`() {
             context.getOrCreateEntityManager()
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager).createEntityManagerFactory(
+            verify(dbConnectionManager).getOrCreateEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -148,7 +148,7 @@ class ReconciliationContextTest {
             context.getOrCreateEntityManager()
             context.close()
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager, times(2)).createEntityManagerFactory(
+            verify(dbConnectionManager, times(2)).getOrCreateEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
@@ -138,6 +138,13 @@ class DbConnectionManagerImpl @Activate constructor(
         TODO("Not yet implemented")
     }
 
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory {
+        TODO("Not yet implemented")
+    }
+
     override fun createEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet): EntityManagerFactory {
         val source = dataSources[connectionId]
             ?: throw NoSuchElementException("No DataSource for connectionId=$connectionId")

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -141,6 +141,13 @@ class FakeDbConnectionManager(
         TODO("Not yet implemented")
     }
 
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory {
+        TODO("Not yet implemented")
+    }
+
     override fun create(
         driverClass: String,
         jdbcUrl: String,


### PR DESCRIPTION
- Using cached `EntityManagerFactory` in `VirtualNodeReconciliationContext`

Note: This cannot be merged until proper cache is used: https://github.com/corda/corda-runtime-os/pull/3979#discussion_r1209974585