### PR TITLE
CORE-13934 bypass backchain resolution if there are no dependencies

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -83,7 +83,7 @@ class UtxoFinalityFlowV1(
                 flowEngine.subFlow(TransactionBackchainSenderFlow(initialTransaction.id, it))
             } else {
                 log.trace {
-                    "Transaction with id ${initialTransaction.id} has no dependencies so no backchain resolution will be performed."
+                    "Transaction with id ${initialTransaction.id} has no dependencies so backchain resolution will not be performed."
                 }
             }
         }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -5,6 +5,7 @@ import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
 import net.corda.ledger.notary.worker.selection.NotaryVirtualNodeSelectorService
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
+import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.sandbox.CordaSystemFlow
@@ -78,7 +79,13 @@ class UtxoFinalityFlowV1(
     private fun sendTransactionAndBackchainToCounterparties() {
         sessions.forEach {
             it.send(initialTransaction)
-            flowEngine.subFlow(TransactionBackchainSenderFlow(initialTransaction.id, it))
+            if (initialTransaction.dependencies.isNotEmpty()) {
+                flowEngine.subFlow(TransactionBackchainSenderFlow(initialTransaction.id, it))
+            } else {
+                log.trace {
+                    "Transaction with id ${initialTransaction.id} has no dependencies so no backchain resolution will be performed."
+                }
+            }
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -8,6 +8,7 @@ import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
 import net.corda.ledger.utxo.flow.impl.flows.finality.v1.FinalityNotarizationFailureType.Companion.toFinalityNotarizationFailureType
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.sandbox.CordaSystemFlow
+import net.corda.utilities.trace
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
@@ -69,7 +70,14 @@ class UtxoReceiveFinalityFlowV1(
         if (log.isDebugEnabled) {
             log.debug( "Beginning receive finality for transaction: ${initialTransaction.id}")
         }
-        flowEngine.subFlow(TransactionBackchainResolutionFlow(initialTransaction.dependencies, session))
+        val transactionDependencies = initialTransaction.dependencies
+        if (transactionDependencies.isNotEmpty()) {
+            flowEngine.subFlow(TransactionBackchainResolutionFlow(transactionDependencies, session))
+        } else {
+            log.trace {
+                "Transaction with id ${initialTransaction.id} has no dependencies so no backchain resolution will be performed."
+            }
+        }
         return initialTransaction
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -75,7 +75,7 @@ class UtxoReceiveFinalityFlowV1(
             flowEngine.subFlow(TransactionBackchainResolutionFlow(transactionDependencies, session))
         } else {
             log.trace {
-                "Transaction with id ${initialTransaction.id} has no dependencies so no backchain resolution will be performed."
+                "Transaction with id ${initialTransaction.id} has no dependencies so backchain resolution will not be performed."
             }
         }
         return initialTransaction

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -910,6 +910,7 @@ class UtxoFinalityFlowV1Test {
     @Test
     fun `each passed in session is sent the transaction backchain`() {
         whenever(initialTx.getMissingSignatories()).thenReturn(setOf(publicKeyAlice1, publicKeyAlice2, publicKeyBob))
+        whenever(initialTx.inputStateRefs).thenReturn(listOf(mock()))
         whenever(flowEngine.subFlow(pluggableNotaryClientFlow)).thenReturn(listOf(signatureNotary))
 
         whenever(sessionAlice.receive(Payload::class.java)).thenReturn(

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -928,6 +928,30 @@ class UtxoFinalityFlowV1Test {
         verify(flowEngine).subFlow(TransactionBackchainSenderFlow(TX_ID, sessionBob))
     }
 
+    @Test
+    fun `called with a transaction that has no dependencies should not invoke backchain resolution`() {
+        whenever(initialTx.getMissingSignatories()).thenReturn(setOf(publicKeyAlice1, publicKeyAlice2, publicKeyBob))
+        whenever(initialTx.inputStateRefs).thenReturn(emptyList())
+        whenever(initialTx.referenceStateRefs).thenReturn(emptyList())
+
+        whenever(flowEngine.subFlow(pluggableNotaryClientFlow)).thenReturn(listOf(signatureNotary))
+
+        whenever(sessionAlice.receive(Payload::class.java)).thenReturn(
+            Payload.Success(
+                listOf(
+                    signatureAlice1,
+                    signatureAlice2
+                )
+            )
+        )
+        whenever(sessionBob.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureBob)))
+
+        callFinalityFlow(initialTx, listOf(sessionAlice, sessionBob))
+
+        verify(flowEngine, never()).subFlow(TransactionBackchainSenderFlow(TX_ID, sessionAlice))
+        verify(flowEngine, never()).subFlow(TransactionBackchainSenderFlow(TX_ID, sessionBob))
+    }
+
     private fun callFinalityFlow(signedTransaction: UtxoSignedTransactionInternal, sessions: List<FlowSession>) {
         val flow = spy(UtxoFinalityFlowV1(
             signedTransaction,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -402,6 +402,8 @@ class UtxoReceiveFinalityFlowV1Test {
     @Test
     fun `receiving a transaction resolves the transaction's backchain`() {
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
+        whenever(signedTransaction.inputStateRefs).thenReturn(listOf(mock()))
+        whenever(signedTransaction.referenceStateRefs).thenReturn(listOf(mock()))
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
@@ -413,6 +415,8 @@ class UtxoReceiveFinalityFlowV1Test {
     @Test
     fun `receiving a transaction resolves the transaction's backchain even when it fails verification`() {
         whenever(ledgerTransaction.outputStateAndRefs).thenReturn(listOf(getExampleInvalidStateAndRefImpl()))
+        whenever(signedTransaction.inputStateRefs).thenReturn(listOf(mock()))
+        whenever(signedTransaction.referenceStateRefs).thenReturn(listOf(mock()))
         whenever(transactionVerificationService.verify(any())).thenThrow(
             TransactionVerificationException(
                 ID,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -428,6 +428,19 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(flowEngine).subFlow(TransactionBackchainResolutionFlow(signedTransaction.dependencies, session))
     }
 
+    @Test
+    fun `if receiving a transaction with no dependencies then the backchain resolution flow will not be called`() {
+        whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
+        whenever(signedTransaction.inputStateRefs).thenReturn(emptyList())
+        whenever(signedTransaction.referenceStateRefs).thenReturn(emptyList())
+        whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
+        whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
+
+        callReceiveFinalityFlow()
+
+        verify(flowEngine, never()).subFlow(TransactionBackchainResolutionFlow(signedTransaction.dependencies, session))
+    }
+
     private fun callReceiveFinalityFlow(validator: UtxoTransactionValidator = UtxoTransactionValidator { }) {
         val flow = UtxoReceiveFinalityFlowV1(session, validator)
         flow.memberLookup = memberLookup


### PR DESCRIPTION
### Overview

The backchain resolution flow was initiated even if the given transaction had no dependencies. 
We now added a check and a trace log to not call it in certain situations. 
This will also improve performance in issuance situations where other parties are involved.

Perf testing: https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4496752831/Test+5+Bypassing+back-chain+resolution+if+transaction+has+no+dependencies

Please note that this document contains important information about performance impact of exceeding sandbox cache size too. 
