### PR TITLE
CORE-14055: Reduce Producer Request Rate

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -56,32 +56,38 @@ roles {
     }
     durable {
         consumer = ${consumer}
-        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached.
+        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached. The producer used
+        # within this pattern is transactional by default, and the transaction commit also causes a flush.
         producer = ${producer} {
             # Maximum time to wait for additional messages before sending the current batch.
             linger.ms = 1000
-            # Maximum amount of memory in bytes (not messages) that will be used for each batch.
+            # Maximum amount of memory in bytes (not messages) that will be used for each batch. Can not be higher than
+            # the value configured for "message.max.bytes" on the broker side (1mb by default).
             batch.size = 750000
         }
     }
     stateAndEvent {
         stateConsumer = ${consumer}
         eventConsumer = ${consumer}
-        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached.
+        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached. The producer used
+        # within this pattern is transactional by default, and the transaction commit also causes a flush.
         producer = ${producer} {
             # Maximum time to wait for additional messages before sending the current batch.
             linger.ms = 1000
-            # Maximum amount of memory in bytes (not messages) that will be used for each batch.
+            # Maximum amount of memory in bytes (not messages) that will be used for each batch. Can not be higher than
+            # the value configured for "message.max.bytes" on the broker side (1mb by default).
             batch.size = 750000
         }
     }
     eventLog {
         consumer = ${consumer}
-        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached.
+        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached. The producer used
+        # within this pattern is transactional by default, and the transaction commit also causes a flush.
         producer = ${producer} {
             # Maximum time to wait for additional messages before sending the current batch.
             linger.ms = 1000
-            # Maximum amount of memory in bytes (not messages) that will be used for each batch.
+            # Maximum amount of memory in bytes (not messages) that will be used for each batch. Can not be higher than
+            # the value configured for "message.max.bytes" on the broker side (1mb by default).
             batch.size = 750000
         }
     }

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -56,16 +56,34 @@ roles {
     }
     durable {
         consumer = ${consumer}
-        producer = ${producer}
+        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached.
+        producer = ${producer} {
+            # Maximum time to wait for additional messages before sending the current batch.
+            linger.ms = 1000
+            # Maximum amount of memory in bytes (not messages) that will be used for each batch.
+            batch.size = 750000
+        }
     }
     stateAndEvent {
         stateConsumer = ${consumer}
         eventConsumer = ${consumer}
-        producer = ${producer}
+        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached.
+        producer = ${producer} {
+            # Maximum time to wait for additional messages before sending the current batch.
+            linger.ms = 1000
+            # Maximum amount of memory in bytes (not messages) that will be used for each batch.
+            batch.size = 750000
+        }
     }
     eventLog {
         consumer = ${consumer}
-        producer = ${producer}
+        # Producer sends a batch either when the batch is full or when the linger.ms limit is reached.
+        producer = ${producer} {
+            # Maximum time to wait for additional messages before sending the current batch.
+            linger.ms = 1000
+            # Maximum amount of memory in bytes (not messages) that will be used for each batch.
+            batch.size = 750000
+        }
     }
     rpcSender {
         consumer = ${consumer} {


### PR DESCRIPTION
Update default KafkaProducer configuration used within the State and
Event, Durable and Event Log Message Patterns so more events are sent
per message batch. Change has proven to reduce the amount of producer
requests roughly by half when running a simple settlement Corda
application and keeping a steady inflow rate of 1 start flow request
per second.

Deployment configuration (non default values, AWS cluster):
 . Zookeper Instances: 3.
 . Kafka Brokers (cpu:4000m, memory:8192Mi, persistence:100Gi): 3.
 . Corda Workers (cpu:4000m, memory:8192Mi, partitions:10): 2 per type.

- Set the "batch.size" property (maximum size per batch) as 0.75Mb. The
  producer sends all messages once the batch is full but this is not a
  hard rule, half full batches can still be sent, so increasing this
  value does not cause delays when sending messages (leaving it too low
  adds overhead, though, as the producer needs to make more requests to
  the brokers). The value itself must be lower than the property
  "message.max.bytes" configured on the broker side, which is 1Mb by
  default (bibliography recommends against increasing the 1Mb default,
  as it negatively impacts the overall cluster performance).
- Set the "linger.ms" property (maximum time to wait for events to fill
  a batch) as 1 second. By default the producer sends messages as soon
  as they are available, increasing this value adds a small delay so
  multiple messages can be sent within a single batch, thus reducing
  the overhead per message and increasing the throughput (small latency
  increase is also expected).
