### PR TITLE
CORE-14242: Upgrade Kotlin Metadata 0.6.0 -> 0.6.1.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ artifactoryContextUrl=https://software.r3.com/artifactory
 kotlin.code.style=official
 kotlinVersion=1.8.21
 kotlin.stdlib.default.dependency=false
-kotlinMetadataVersion = 0.6.0
+kotlinMetadataVersion=0.6.1
 
 org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8


### PR DESCRIPTION
Upgrade to [kotlinx-metadata-jvm 0.6.1](https://github.com/JetBrains/kotlin/blob/master/libraries/kotlinx-metadata/jvm/ChangeLog.md), which is able to parse Kotlin 2.0 metdata.

> This release uses Kotlin 1.8.20 with metadata version 1.8, and as a special case, is able to read metadata of version 2.0. This is done as an incentive to test K2 compiler and 2.0 language version. No other changes were made and no migration is needed.