### PR TITLE
CORE-14246: Ensure CPK chunks are created and assembled atomically.

### DIFF
--- a/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
+++ b/components/chunking/chunk-db-write-impl/src/main/kotlin/net/corda/chunking/db/impl/validation/ValidationFunctions.kt
@@ -69,21 +69,13 @@ fun assembleFileFromChunks(
  * @throws ValidationException
  */
 fun FileInfo.validateAndGetCpi(cpiPartsDir: Path, requestId: String): Cpi {
-    val cpi: Cpi =
-        try {
-            Files.newInputStream(this.path).use { CpiReader.readCpi(it, cpiPartsDir) }
-        } catch (ex: Exception) {
-            when (ex) {
-                is PackagingException -> {
-                    throw ValidationException("Invalid CPI.  ${ex.message}", requestId, ex)
-                }
-
-                else -> {
-                    throw ValidationException("Unexpected exception when unpacking CPI.  ${ex.message}", requestId, ex)
-                }
-            }
-        }
-    return cpi
+    return try {
+        Files.newInputStream(path).use { CpiReader.readCpi(it, cpiPartsDir) }
+    } catch (ex: PackagingException) {
+        throw ValidationException("Invalid CPI: ${ex.message}", requestId, ex)
+    } catch (ex: Exception) {
+        throw ValidationException("Unexpected exception when unpacking CPI: ${ex.message}", requestId, ex)
+    }
 }
 
 /**

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
@@ -168,8 +168,9 @@ class CpkReadServiceImpl (
     }
 
     private fun onCpkAssembled(cpkFileChecksum: SecureHash, cpk: Cpk) {
-        logger.info("${this::class.java.simpleName} storing:  $cpkFileChecksum")
-        cpksByChecksum[cpkFileChecksum] = cpk
+        if (cpksByChecksum.putIfAbsent(cpkFileChecksum, cpk) == null) {
+            logger.info("Storing: {}", cpkFileChecksum)
+        }
     }
 
     override val isRunning: Boolean

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
@@ -9,20 +9,24 @@ import net.corda.utilities.posixOptional
 import net.corda.v5.crypto.SecureHash
 import org.slf4j.LoggerFactory
 import java.nio.channels.FileChannel
+import java.nio.channels.SeekableByteChannel
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
 import java.nio.file.StandardOpenOption.READ
-import java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
 import java.nio.file.StandardOpenOption.WRITE
+import java.nio.file.attribute.DosFileAttributeView
+import java.nio.file.attribute.PosixFileAttributeView
 import java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
 import java.nio.file.attribute.PosixFilePermission.OWNER_READ
 import java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
 import java.nio.file.attribute.PosixFilePermissions.asFileAttribute
+import java.util.Collections.singleton
 import java.util.SortedSet
+import java.util.function.Consumer
 
 /**
- * Creates resources on disk, that something needs to clear them on shutdown.
+ * Creates resources on disk, that something needs to remove on shutdown.
  */
 class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileManager {
     companion object {
@@ -32,7 +36,7 @@ class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileMan
 
         private val CPK_DIRECTORY_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE))
         private val CPK_FILE_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE))
-        private val CREATE_OR_REPLACE = setOf(CREATE, WRITE, TRUNCATE_EXISTING)
+        private val READ_ONLY = singleton(OWNER_READ)
 
         internal fun SecureHash.toCpkDirName() = toHexString()
 
@@ -61,10 +65,15 @@ class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileMan
             @Suppress("SpreadOperator")
             Files.createDirectory(cpkXDir, *cpkXDir.posixOptional(CPK_DIRECTORY_PERMISSIONS))
         }
-        val filePath = cpkXDir.resolve(chunkId.toFileName())
-        @Suppress("SpreadOperator")
-        Files.newByteChannel(filePath, CREATE_OR_REPLACE, *filePath.posixOptional(CPK_FILE_PERMISSIONS)).use { channel ->
-            channel.write(chunk.data)
+
+        cpkXDir.resolve(chunkId.toFileName()).also { chunkFile ->
+            if (!Files.isRegularFile(chunkFile)) {
+                // Write the chunk's contents to an invisible temporary file, and only
+                // move this file to its proper name once writing is complete.
+                writeAtomically(chunkFile, ".chunk-") { output ->
+                    output.write(chunk.data)
+                }
+            }
         }
     }
 
@@ -77,13 +86,43 @@ class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileMan
             return null
         }
 
-        return cpkXDir.resolve(cpkChecksum.toCpkFileName()).also { cpkFilePath ->
-            @Suppress("SpreadOperator")
-            Files.newByteChannel(cpkFilePath, CREATE_OR_REPLACE, *cpkFilePath.posixOptional(CPK_FILE_PERMISSIONS)).use { output ->
-                chunkParts.forEach { chunkId ->
-                    val cpkChunkPath = cpkXDir.resolve(chunkId.toFileName())
-                    FileChannel.open(cpkChunkPath, READ).use(output::writeFile)
+        return cpkXDir.resolve(cpkChecksum.toCpkFileName()).also { cpkFile ->
+            if (!Files.isRegularFile(cpkFile)) {
+                // Assemble the chunks into an invisible temporary file, and only
+                // move this file to its proper name once writing is complete.
+                writeAtomically(cpkFile, ".cpk-") { output ->
+                    chunkParts.forEach { chunkId ->
+                        val cpkChunkPath = cpkXDir.resolve(chunkId.toFileName())
+                        FileChannel.open(cpkChunkPath, READ).use(output::writeFile)
+                    }
                 }
+            }
+        }
+    }
+
+    private fun writeAtomically(target: Path, tempPrefix: String, writer: Consumer<SeekableByteChannel>) {
+        val directory = target.parent
+        @Suppress("SpreadOperator")
+        Files.createTempFile(directory, tempPrefix, "", *directory.posixOptional(CPK_FILE_PERMISSIONS)).also { tempFile ->
+            try {
+                Files.newByteChannel(tempFile, WRITE).use(writer::accept)
+                setReadOnly(tempFile)
+
+                // Rename our temporary file as the final step.
+                Files.move(tempFile, target, ATOMIC_MOVE)
+            } catch (e: Exception) {
+                Files.delete(tempFile)
+                throw e
+            }
+        }
+    }
+
+    private fun setReadOnly(file: Path) {
+        Files.getFileAttributeView(file, PosixFileAttributeView::class.java)?.also { view ->
+            view.setPermissions(READ_ONLY)
+        } ?: run {
+            Files.getFileAttributeView(file, DosFileAttributeView::class.java)?.also { view ->
+                view.setReadOnly(true)
             }
         }
     }

--- a/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkReaderImpl.kt
+++ b/libs/chunking/chunking-core/src/main/kotlin/net/corda/chunking/impl/ChunkReaderImpl.kt
@@ -26,7 +26,7 @@ import java.nio.file.attribute.PosixFilePermissions.asFileAttribute
  */
 internal class ChunkReaderImpl(private val destDir: Path) : ChunkReader {
     companion object {
-        private val CHUNK_FILE_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE))
+        private val CPI_FILE_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE))
         private val CREATE_OR_UPDATE = setOf(CREATE, WRITE)
 
         private fun KeyValuePairList.fromAvro(): Map<String, String?> {
@@ -68,7 +68,7 @@ internal class ChunkReaderImpl(private val destDir: Path) : ChunkReader {
             // We expect the data to be correctly sized. There is a unit test to
             // ensure the writer does this.
             @Suppress("SpreadOperator")
-            Files.newByteChannel(path, CREATE_OR_UPDATE, *path.posixOptional(CHUNK_FILE_PERMISSIONS)).use { channel ->
+            Files.newByteChannel(path, CREATE_OR_UPDATE, *path.posixOptional(CPI_FILE_PERMISSIONS)).use { channel ->
                 channel.position(chunk.offset)
                 channel.write(chunk.data)
             }


### PR DESCRIPTION
This issue concerns `CpkReadServiceImpl` and consequently all services which use it, such as the sandboxes and flow processing etc. `CpkReadServiceImpl` receives CPK chunks for assembly directly from Kafka.

Prevent CPKs and CPK chunks from being read until they have been written _entirely_ to disk. We achieve this by writing the contents to an invisible temporary file in the target directory, and only moving this _atomically_ to its expected name once writing is complete. Also make the final file "read only" to protect against accidental subsequent writes.

I have confirmed that `ATOMIC_MOVE` works on Windows.

The `assembleFileFromChunks()` function is used by `ChunkDbWriterFactoryImpl` to verify that a set of chunks fetched from the database defines a valid CPI. It apparently achieves concurrency by constantly overwriting the disk with the same information, which sounds I/O intensive to me. However, I don't think that counts as a "bug". (And if it does then it's likely too difficult to fix for Corda 5.0.)