### PR TITLE
CORE-14203: Fix Session Event Wrapping

### DIFF
--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionInitExecutor.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionInitExecutor.kt
@@ -41,9 +41,18 @@ class SessionInitExecutor(
         } else {
             //duplicate
             log.debug { "Duplicate SessionInit event received. Key: $eventKey, Event: $sessionEvent" }
-            if(messageDirection == MessageDirection.OUTBOUND){
+            if (messageDirection == MessageDirection.OUTBOUND) {
                 sessionInit.flowId = null
-                FlowMapperResult(flowMapperState, listOf(Record(outputTopic, eventKey, sessionEvent)))
+                FlowMapperResult(
+                    flowMapperState,
+                    listOf(
+                        Record(
+                            outputTopic,
+                            eventKey,
+                            generateAppMessage(sessionEvent, sessionEventSerializer, flowConfig)
+                        )
+                    )
+                )
             } else {
                 CordaMetrics.Metric.FlowMapperDeduplicationCount.builder()
                     .withTag(CordaMetrics.Tag.FlowEvent, sessionInit::class.java.name)

--- a/libs/flows/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/executor/SessionInitExecutorTest.kt
+++ b/libs/flows/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/executor/SessionInitExecutorTest.kt
@@ -103,12 +103,12 @@ class SessionInitExecutorTest {
 
     @Test
     fun `Subsequent OUTBOUND SessionInit messages get passed through if no ACK received from first message`(){
+        whenever(sessionEventSerializer.serialize(any())).thenReturn("bytes".toByteArray())
         val retrySessionInit = SessionInit("info", "1", emptyKeyValuePairList(), emptyKeyValuePairList(), emptyKeyValuePairList(), null)
-
         val payload = buildSessionEvent(MessageDirection.OUTBOUND, "sessionId", 1, retrySessionInit)
 
         val flowMapperState = FlowMapperState()
-        flowMapperState.setStatus(FlowMapperStateType.OPEN)
+        flowMapperState.status = FlowMapperStateType.OPEN
 
         val resultOutbound = SessionInitExecutor(
             "sessionId",
@@ -129,7 +129,7 @@ class SessionInitExecutorTest {
         val payload = buildSessionEvent(MessageDirection. INBOUND, "sessionId", 1, retrySessionInit)
 
         val flowMapperState = FlowMapperState()
-        flowMapperState.setStatus(FlowMapperStateType.OPEN)
+        flowMapperState.status = FlowMapperStateType.OPEN
 
         val resultOutbound = SessionInitExecutor(
             "sessionId",

--- a/libs/flows/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/executor/SessionInitExecutorTest.kt
+++ b/libs/flows/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/executor/SessionInitExecutorTest.kt
@@ -120,6 +120,10 @@ class SessionInitExecutorTest {
         ).execute()
 
         assertThat(resultOutbound.outputEvents).isNotEmpty
+        resultOutbound.outputEvents.forEach {
+            assertThat(it.topic).isEqualTo(P2P_OUT_TOPIC)
+            assertThat(it.value!!::class).isEqualTo(AppMessage::class)
+        }
     }
 
     @Test


### PR DESCRIPTION
Ensure that all messages sent to 'p2p.out' topic are wrapped as
instaces of 'AppMessage' to prevent deserialization issues.
