### PR TITLE
CORE-14290 Publish percentile histogram for timer metrics to allow calculation of percentiles on aggregation of metrics

### DIFF
--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -707,6 +707,7 @@ object CordaMetrics {
     fun timer(name: String, tags: Iterable<micrometerTag>): Timer {
         return Timer.builder(name)
             .publishPercentiles(0.50, 0.95, 0.99)
+            .publishPercentileHistogram()
             .tags(tags)
             .register(registry)
     }


### PR DESCRIPTION
Publish percentile histogram for timer metrics to allow calculation of percentiles on aggregation of metrics. 
Client side publication of metrics does not allow for aggregation of metrics on the server side. Publishing the percentile histogram allows us to group by operation type and namespace and get the percentile values.

It should be possible to remove the usage of `publishPercentiles` for timer metrics, but to allow others time to switch to the histogram for rendering percentile graphs, this will be removed in a follow-on PR.