### PR TITLE
CORE-13862 Add metrics in DB worker

### DIFF
--- a/components/persistence/entity-processor-service-impl/build.gradle
+++ b/components/persistence/entity-processor-service-impl/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation project(':libs:flows:external-event-responses')
     implementation project(':libs:flows:flow-utils')
     implementation project(":libs:messaging:messaging")
+    implementation project(':libs:metrics')
     implementation project(":libs:utilities")
     implementation project(':libs:virtual-node:sandbox-group-context')
     implementation project(":libs:serialization:serialization-avro")

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
@@ -70,6 +70,13 @@ class EntityMessageProcessor(
                 // We received a [null] external event therefore we do not know the flow id to respond to.
                 return@mapNotNull null
             } else {
+                CordaMetrics.Metric.Db.EntityPersistenceRequestLag.builder()
+                    .withTag(CordaMetrics.Tag.OperationName, request.request::class.java.name)
+                    .build()
+                    .record(
+                        Duration.ofMillis(Instant.now().toEpochMilli() - event.timestamp)
+                    )
+
                 val clientRequestId =
                     request.flowExternalEventContext.contextProperties.toMap()[MDC_CLIENT_ID] ?: ""
 
@@ -103,7 +110,7 @@ class EntityMessageProcessor(
                             .withTag(CordaMetrics.Tag.OperationStatus, requestOutcome)
                             .build()
                             .record(Duration.between(startTime, Instant.now()))
-                        
+
                         currentSandboxGroupContext.remove()
                     }
                 }

--- a/components/reconciliation/reconciliation-impl/build.gradle
+++ b/components/reconciliation/reconciliation-impl/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(":libs:lifecycle:lifecycle-impl")
     implementation project(':libs:lifecycle:registry')
+    implementation project(':libs:metrics')
     implementation project(':libs:utilities')
     implementation project(':components:reconciliation:reconciliation')
 

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -82,13 +82,13 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
             reconciliationOutcome = "SUCCEEDED"
             reconciliationRunTime = System.currentTimeMillis() - startTime
             logger.info("Reconciliation completed in $reconciliationRunTime ms")
+            scheduleNextReconciliation(coordinator)
         } catch (e: Throwable) {
             // An error here could be a transient or not exception. We should transition to `DOWN` and wait
             // on subsequent `RegistrationStatusChangeEvent` to see if it is going to be a `DOWN` or an `ERROR`.
             reconciliationRunTime = System.currentTimeMillis() - startTime
             logger.warn("Reconciliation failed. Terminating reconciliations", e)
             coordinator.updateStatus(LifecycleStatus.DOWN)
-            return
         } finally {
             CordaMetrics.Metric.Db.ReconciliationRunTime.builder()
                 .withTag(CordaMetrics.Tag.OperationName, name)
@@ -102,8 +102,6 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                 .build()
                 .record(reconciledCount.toDouble())
         }
-
-        scheduleNextReconciliation(coordinator)
     }
 
     // TODO following method should be extracted to dedicated file, to be tested separately

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -503,6 +503,14 @@ object CordaMetrics {
             }
             VoidMeter
         })
+
+        object Db {
+            /**
+             * The time taken to process a flow persistence request, from the moment the request is received from Kafka.
+             */
+            object EntityPersistenceRequestTime : Metric<Timer>("db.flow.persistence.request.time", CordaMetrics::timer)
+
+        }
     }
 
     /**

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -505,11 +505,16 @@ object CordaMetrics {
         })
 
         object Db {
+
             /**
-             * The time taken to process an entity persistence request, from the moment the request is received from Kafka.
+             * Metric for the time taken to process an entity persistence request, from the moment the request is received from Kafka.
              */
             object EntityPersistenceRequestTime : Metric<Timer>("db.entity.persistence.request.time", CordaMetrics::timer)
 
+            /**
+             * Metric for the lag between the flow putting the entity persistence request to Kafka and the EntityMessageProcessor.
+             */
+            object EntityPersistenceRequestLag : Metric<Timer>("db.entity.persistence.request.lag", CordaMetrics::timer)
         }
     }
 

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -515,6 +515,11 @@ object CordaMetrics {
              * Metric for the lag between the flow putting the entity persistence request to Kafka and the EntityMessageProcessor.
              */
             object EntityPersistenceRequestLag : Metric<Timer>("db.entity.persistence.request.lag", CordaMetrics::timer)
+
+            /**
+             * Metric for the time taken for a full reconciliation run.
+             */
+            object ReconciliationRunTime : Metric<Timer>("db.reconciliation.run.time", CordaMetrics::timer)
         }
     }
 

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -506,9 +506,9 @@ object CordaMetrics {
 
         object Db {
             /**
-             * The time taken to process a flow persistence request, from the moment the request is received from Kafka.
+             * The time taken to process an entity persistence request, from the moment the request is received from Kafka.
              */
-            object EntityPersistenceRequestTime : Metric<Timer>("db.flow.persistence.request.time", CordaMetrics::timer)
+            object EntityPersistenceRequestTime : Metric<Timer>("db.entity.persistence.request.time", CordaMetrics::timer)
 
         }
     }

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -520,6 +520,11 @@ object CordaMetrics {
              * Metric for the time taken for a full reconciliation run.
              */
             object ReconciliationRunTime : Metric<Timer>("db.reconciliation.run.time", CordaMetrics::timer)
+
+            /**
+             * Metric for the number of reconciled records for a reconciliation run.
+             */
+            object ReconciliationRecordsCount : Metric<DistributionSummary>("db.reconciliation.records.count", Metrics::summary)
         }
     }
 


### PR DESCRIPTION
- adds metrics for: 
  - DB entity persistence request processing time
  - DB entity persistence request Kafka lag (i.e. how long the stayed on Kafka)
  - Reconciliation run time
  - Number of Reconciled records 