### PR TITLE
CORE-13987: Make Timer.recordOptionally() more accurate.

### DIFF
--- a/libs/metrics/src/main/kotlin/net/corda/metrics/Timer.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/Timer.kt
@@ -2,7 +2,6 @@ package net.corda.metrics
 
 import io.micrometer.core.instrument.Timer
 import java.time.Duration
-import java.time.Instant
 
 /**
  * Updates the statistics kept by the timer with the specified amount if the time to complete the operation is greater than
@@ -12,13 +11,13 @@ import java.time.Instant
  * @param operation The operation to execute.
  */
 inline fun <T> Timer.recordOptionally(greaterThanMillis: Int, operation: () -> T): T {
-    val startTime = Instant.now()
+    val startTime = System.nanoTime()
     return try {
         operation()
     } finally {
-        val duration = Duration.between(startTime, Instant.now())
+        val duration = Duration.ofNanos(System.nanoTime() - startTime)
         if (duration.toMillis() > greaterThanMillis) {
-            record(Duration.between(startTime, Instant.now()))
+            record(duration)
         }
     }
 }


### PR DESCRIPTION
`System.nanoTime()` is the preferred way of timing durations. We also don't need to compute the duration more than once.