### PR TITLE
CORE-14320: Create a ComputedValue gauge metric.

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -119,10 +119,10 @@ internal class SessionManagerImpl(
         messagingConfiguration,
         groupPolicyProvider,
         membershipGroupReaderProvider,
-        clock,
+        clock
     ),
 
-    executorServiceFactory: () -> ScheduledExecutorService = { Executors.newSingleThreadScheduledExecutor() },
+    executorServiceFactory: () -> ScheduledExecutorService = Executors::newSingleThreadScheduledExecutor
 ) : SessionManager {
 
     companion object {
@@ -132,9 +132,14 @@ internal class SessionManagerImpl(
     private val pendingInboundSessions = ConcurrentHashMap<String, AuthenticationProtocolResponder>()
     private val activeInboundSessions = ConcurrentHashMap<String, Pair<SessionManager.Counterparties, Session>>()
 
-    private val logger = LoggerFactory.getLogger(this::class.java.name)
+    private val logger = LoggerFactory.getLogger(this::class.java)
 
     private val sessionNegotiationLock = ReentrantReadWriteLock()
+
+    init {
+        CordaMetrics.Metric.OutboundSessionCount { outboundSessionPool.getAllSessionIds().size }.builder().build()
+        CordaMetrics.Metric.InboundSessionCount { activeInboundSessions.size + pendingInboundSessions.size }.builder().build()
+    }
 
     // This default needs to be removed and the lifecycle dependency graph adjusted to ensure the inbound subscription starts only after
     // the configuration has been received and the session manager has started (see CORE-6730).
@@ -163,18 +168,13 @@ internal class SessionManagerImpl(
     )
 
     private val revocationCheckerClient = RevocationCheckerClient(publisherFactory, coordinatorFactory, messagingConfiguration)
-    private val executorService = executorServiceFactory().also {
-        it.scheduleAtFixedRate({ recordTotalSessionMetrics() }, 5, 5, TimeUnit.SECONDS)
-    }
-
-    private val outboundSessionCountMetric = CordaMetrics.Metric.OutboundSessionCount.builder().build()
-    private val inboundSessionCountMetric = CordaMetrics.Metric.InboundSessionCount.builder().build()
+    private val executorService = executorServiceFactory()
 
     override val dominoTile = ComplexDominoTile(
         this::class.java.simpleName,
         coordinatorFactory,
         ::onTileStart,
-        onClose = { executorService.shutdownNow() },
+        onClose = executorService::shutdownNow,
         dependentChildren = setOf(
             heartbeatManager.dominoTile.coordinatorName, sessionReplayer.dominoTile.coordinatorName,
             LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
@@ -796,7 +796,7 @@ internal class SessionManagerImpl(
         }
 
         session.generateHandshakeSecrets()
-        val ourIdentityData = session.validatePeerHandshakeMessageHandleError(message, peer,) ?: return null
+        val ourIdentityData = session.validatePeerHandshakeMessageHandleError(message, peer) ?: return null
         // Find the correct Holding Identity to use (using the public key hash).
         val ourIdentityInfo = linkManagerHostingMap.getInfo(ourIdentityData.responderPublicKeyHash, ourIdentityData.groupId)
         if (ourIdentityInfo == null) {
@@ -904,11 +904,6 @@ internal class SessionManagerImpl(
         return false
     }
 
-    private fun recordTotalSessionMetrics() {
-        outboundSessionCountMetric.set(outboundSessionPool.getAllSessionIds().size)
-        inboundSessionCountMetric.set(activeInboundSessions.size + pendingInboundSessions.size)
-    }
-
     class HeartbeatManager(
         publisherFactory: PublisherFactory,
         private val configurationReaderService: ConfigurationReadService,
@@ -973,7 +968,7 @@ internal class SessionManagerImpl(
         override val dominoTile = ComplexDominoTile(
             this::class.java.simpleName,
             coordinatorFactory,
-            onClose = { executorService.shutdownNow() },
+            onClose = executorService::shutdownNow,
             dependentChildren = setOf(
                 LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
                 LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),

--- a/libs/crypto/merkle-impl/test.bndrun
+++ b/libs/crypto/merkle-impl/test.bndrun
@@ -12,7 +12,6 @@
     javax.annotation.meta;version=3.0.0
 
 -runrequires: \
-    bnd.identity;id='net.corda.metrics',\
     bnd.identity;id='net.corda.merkle-impl',\
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='junit-jupiter-engine',\

--- a/libs/flows/flow-mapper-impl/test.bndrun
+++ b/libs/flows/flow-mapper-impl/test.bndrun
@@ -26,7 +26,6 @@
     org.slf4j.simpleLogger.dateTimeFormat='yyyy-MM-dd HH:mm:ss:SSS Z'
 
 -runrequires: \
-    bnd.identity;id='net.corda.metrics',\
     bnd.identity;id='net.corda.flow-mapper-impl',\
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='net.corda.flow-utilities',\

--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -21,6 +21,5 @@ dependencies {
     }
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
-    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 }

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/SettableGauge.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/SettableGauge.kt
@@ -3,6 +3,24 @@ package net.corda.metrics
 import io.micrometer.core.instrument.Gauge
 import java.util.concurrent.atomic.AtomicInteger
 
+/**
+ * A [Gauge] metric is for measuring the current value of some property, but it doesn't necessarily need
+ * to wrap an object. You can also build a [Gauge] around a [Supplier&lt;Number&gt;][java.util.function.Supplier]
+ * lambda. For example, to gauge the size of some [Collection] you really only need something like:
+ *
+ * ```kotlin
+ * object CordaMetrics {
+ *     sealed class Metric<T : Meter> {
+ *
+ *         class MyCollectionSize(computation: Supplier<Number>) : ComputedValue("my.collection.size", computation)
+ *     }
+ * }
+ *
+ * CordaMetrics.Metric.MyCollectionSize { myCollection.size }.builder().build()
+ * ```
+ * A [ComputedValue][CordaMetrics.Metric.ComputedValue] gauge is simpler because we will automatically
+ * collect the latest value without needing to update an [AtomicInteger] manually.
+ */
 class SettableGauge(private val gauge: Gauge, private val gaugeValue: AtomicInteger): Gauge by gauge {
 
     fun set(value: Int) {


### PR DESCRIPTION
Create a `Gauge` metric that wraps `Supplier<Number>` instead of `AtomicInteger`. The advantage of `Supplier<Number>` is that the gauge will automatically compute a new value each time without constantly needing for one to be "set" manually.