### PR TITLE
CORE-13987: Make more Timer metrics use System.nanoTime().

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -74,7 +74,7 @@ class CryptoFlowOpsBusProcessor(
 
         return withMDC(mdc) {
             val requestPayload = request.request
-            val startTime = Instant.now()
+            val startTime = System.nanoTime()
             logger.info("Handling ${requestPayload::class.java.name} for tenant ${request.context.tenantId}")
 
             try {
@@ -118,7 +118,7 @@ class CryptoFlowOpsBusProcessor(
                 CordaMetrics.Metric.Crypto.FlowOpsProcessorExecutionTime.builder()
                     .withTag(CordaMetrics.Tag.OperationName, requestPayload::class.java.simpleName)
                     .build()
-                    .record(Duration.between(startTime, Instant.now()))
+                    .record(Duration.ofNanos(System.nanoTime() - startTime))
             }
         }
     }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -35,7 +35,6 @@ import java.security.PrivateKey
 import java.security.Provider
 import java.security.PublicKey
 import java.time.Duration
-import java.time.Instant
 import javax.crypto.Cipher
 
 const val WRAPPING_KEY_ENCODING_VERSION: Int = 1
@@ -200,7 +199,7 @@ class SoftCryptoService(
     }
 
     private fun sign(spec: SigningSpec, privateKey: PrivateKey, data: ByteArray): ByteArray {
-        val startTime = Instant.now()
+        val startTime = System.nanoTime()
         val signingData = spec.signatureSpec.getSigningData(digestService, data)
         val signatureBytes = if (spec.signatureSpec is CustomSignatureSpec && spec.keyScheme.algorithmName == "RSA") {
             // when the hash is precalculated and the key is RSA the actual sign operation is encryption
@@ -219,7 +218,7 @@ class SoftCryptoService(
             .builder()
             .withTag(CordaMetrics.Tag.SignatureSpec, spec.signatureSpec.signatureName)
             .build()
-            .record(Duration.between(startTime, Instant.now()))
+            .record(Duration.ofNanos(System.nanoTime() - startTime))
         return signatureBytes
     }
 

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
@@ -28,6 +28,7 @@ import net.corda.v5.base.types.MemberX500Name
 import org.bouncycastle.asn1.x500.X500Name
 import org.slf4j.LoggerFactory
 import java.net.URI
+import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
@@ -172,12 +173,12 @@ internal class OutboundMessageHandler(
             trustStore,
             clientCertificateKeyStore,
         )
-        val startTime = System.currentTimeMillis()
+        val startTime = System.nanoTime()
         val responseFuture = sendMessage(destinationInfo, gatewayMessage)
             .orTimeout(connectionConfig().responseTimeout.toMillis(), TimeUnit.MILLISECONDS)
         return responseFuture.whenCompleteAsync({ response, error ->
-            val requestLatency = System.currentTimeMillis() - startTime
-            getRequestTimer(peerMessage, response).record(requestLatency, TimeUnit.MILLISECONDS)
+            val requestLatency = Duration.ofNanos(System.nanoTime() - startTime)
+            getRequestTimer(peerMessage, response).record(requestLatency)
             handleResponse(PendingRequest(gatewayMessage, destinationInfo, responseFuture), response, error, MAX_RETRIES)
         }, retryThreadPool).thenApply {  }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/PersistenceRequestProcessor.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/PersistenceRequestProcessor.kt
@@ -20,7 +20,6 @@ import net.corda.v5.application.flows.FlowContextPropertyKeys.CPK_FILE_CHECKSUM
 import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.time.Instant
 
 /**
  * Handles incoming requests, typically from the flow worker, and sends responses.
@@ -47,7 +46,7 @@ class PersistenceRequestProcessor(
         return events
             .mapNotNull { it.value }
             .flatMap { request ->
-                val startTime = Instant.now()
+                val startTime = System.nanoTime()
                 val clientRequestId = request.flowExternalEventContext.contextProperties.toMap()[MDC_CLIENT_ID] ?: ""
                 val holdingIdentity = request.holdingIdentity.toCorda()
 
@@ -90,7 +89,7 @@ class PersistenceRequestProcessor(
                             .withTag(CordaMetrics.Tag.LedgerType, request.ledgerType.toString())
                             .withTag(CordaMetrics.Tag.OperationName, request.request.javaClass.simpleName)
                             .build()
-                            .record(Duration.between(startTime, Instant.now()))
+                            .record(Duration.ofNanos(System.nanoTime() - startTime))
                     }
                 }
             }

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessor.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessor.kt
@@ -20,7 +20,6 @@ import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 import java.time.Duration
-import java.time.Instant
 
 /**
  * Handles incoming requests, typically from the flow worker, and sends responses.
@@ -47,7 +46,7 @@ class VerificationRequestProcessor(
         return events
             .mapNotNull { it.value }
             .map { request ->
-                val startTime = Instant.now()
+                val startTime = System.nanoTime()
                 val clientRequestId = request.flowExternalEventContext.contextProperties.toMap()[MDC_CLIENT_ID] ?: ""
                 val holdingIdentity = request.holdingIdentity.toCorda()
 
@@ -72,7 +71,7 @@ class VerificationRequestProcessor(
                             .builder()
                             .forVirtualNode(holdingIdentity.shortHash.toString())
                             .build()
-                            .record(Duration.between(startTime, Instant.now()))
+                            .record(Duration.ofNanos(System.nanoTime() - startTime))
                     }
                 }
             }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessor.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessor.kt
@@ -17,7 +17,7 @@ internal class MembershipPersistenceRPCProcessor(
 ) : RPCResponderProcessor<MembershipPersistenceRequest, MembershipPersistenceResponse> {
 
     private companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun onNext(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
@@ -74,7 +74,7 @@ class MembershipPersistenceServiceImpl @Activate constructor(
 ) : MembershipPersistenceService {
 
     private companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val GROUP_NAME = "membership.db.persistence"
         const val CLIENT_NAME = "membership.db.persistence"

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandler.kt
@@ -1,9 +1,9 @@
 package net.corda.membership.impl.persistence.service.handler
 
-import net.corda.avro.serialization.CordaAvroDeserializer
-import net.corda.avro.serialization.CordaAvroSerializer
 import javax.persistence.EntityManager
 import javax.persistence.PessimisticLockException
+import net.corda.avro.serialization.CordaAvroDeserializer
+import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.SignedGroupParameters

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -35,7 +35,7 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
 ) : PersistenceHandler<REQUEST, RESPONSE> {
 
     companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        internal val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val dbConnectionManager get() = persistenceHandlerServices.dbConnectionManager

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -44,7 +44,6 @@ import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.time.Instant
 import javax.persistence.EntityExistsException
 import javax.persistence.EntityManager
 import javax.persistence.OptimisticLockException
@@ -85,7 +84,7 @@ open class JPABackingStoreImpl @Activate constructor(
 
     override fun session(holdingIdentity: HoldingIdentity, block: (BackingStore.Session) -> Unit) {
 
-        val sessionStartTime = Instant.now().toEpochMilli()
+        val sessionStartTime = System.nanoTime()
 
         val entityManagerFactory = dbConnectionManager.getOrCreateEntityManagerFactory(
             VirtualNodeDbType.UNIQUENESS.getSchemaName(holdingIdentity.shortHash),
@@ -115,7 +114,7 @@ open class JPABackingStoreImpl @Activate constructor(
                 .builder()
                 .withTag(CordaMetrics.Tag.SourceVirtualNode, holdingIdentity.shortHash.toString())
                 .build()
-                .record(Duration.ofMillis(Instant.now().toEpochMilli() - sessionStartTime))
+                .record(Duration.ofNanos(System.nanoTime() - sessionStartTime))
         }
     }
 
@@ -141,7 +140,7 @@ open class JPABackingStoreImpl @Activate constructor(
         override fun executeTransaction(
             block: (BackingStore.Session, BackingStore.Session.TransactionOps) -> Unit
         ) {
-            val transactionStartTime = Instant.now().toEpochMilli()
+            val transactionStartTime = System.nanoTime()
 
             try {
                 for (attemptNumber in 1..MAX_ATTEMPTS) {
@@ -227,7 +226,7 @@ open class JPABackingStoreImpl @Activate constructor(
                     .builder()
                     .withTag(CordaMetrics.Tag.SourceVirtualNode, holdingIdentity.shortHash.toString())
                     .build()
-                    .record(Duration.ofMillis(Instant.now().toEpochMilli() - transactionStartTime))
+                    .record(Duration.ofNanos(System.nanoTime() - transactionStartTime))
             }
         }
 
@@ -235,7 +234,7 @@ open class JPABackingStoreImpl @Activate constructor(
             states: Collection<UniquenessCheckStateRef>
         ): Map<UniquenessCheckStateRef, UniquenessCheckStateDetails> {
 
-            val queryStartTime = Instant.now().toEpochMilli()
+            val queryStartTime = System.nanoTime()
 
             val results = HashMap<
                     UniquenessCheckStateRef, UniquenessCheckStateDetails>()
@@ -268,7 +267,7 @@ open class JPABackingStoreImpl @Activate constructor(
                 .withTag(CordaMetrics.Tag.SourceVirtualNode, holdingIdentity.shortHash.toString())
                 .withTag(CordaMetrics.Tag.OperationName, "getStateDetails")
                 .build()
-                .record(Duration.ofMillis(Instant.now().toEpochMilli() - queryStartTime))
+                .record(Duration.ofNanos(System.nanoTime() - queryStartTime))
 
             return results
         }
@@ -277,7 +276,7 @@ open class JPABackingStoreImpl @Activate constructor(
             txIds: Collection<SecureHash>
         ): Map<out SecureHash, UniquenessCheckTransactionDetailsInternal> {
 
-            val queryStartTime = Instant.now().toEpochMilli()
+            val queryStartTime = System.nanoTime()
 
             val txPks = txIds.map {
                 UniquenessTxAlgoIdKey(it.algorithm, it.bytes)
@@ -321,7 +320,7 @@ open class JPABackingStoreImpl @Activate constructor(
                 .withTag(CordaMetrics.Tag.SourceVirtualNode, holdingIdentity.shortHash.toString())
                 .withTag(CordaMetrics.Tag.OperationName, "getTransactionDetails")
                 .build()
-                .record(Duration.ofMillis(Instant.now().toEpochMilli() - queryStartTime))
+                .record(Duration.ofNanos(System.nanoTime() - queryStartTime))
 
             return results
         }
@@ -330,7 +329,7 @@ open class JPABackingStoreImpl @Activate constructor(
             txEntity: UniquenessTransactionDetailEntity
         ): UniquenessCheckError? {
 
-            val queryStartTime = Instant.now().toEpochMilli()
+            val queryStartTime = System.nanoTime()
 
             val existing = entityManager.createNamedQuery(
                 "UniquenessRejectedTransactionEntity.select",
@@ -350,7 +349,7 @@ open class JPABackingStoreImpl @Activate constructor(
                     .withTag(CordaMetrics.Tag.SourceVirtualNode, holdingIdentity.shortHash.toString())
                     .withTag(CordaMetrics.Tag.OperationName, "getTransactionError")
                     .build()
-                    .record(Duration.ofMillis(Instant.now().toEpochMilli() - queryStartTime))
+                    .record(Duration.ofNanos(System.nanoTime() - queryStartTime))
             }
         }
 
@@ -401,7 +400,7 @@ open class JPABackingStoreImpl @Activate constructor(
                 transactionDetails: Collection<Pair<
                         UniquenessCheckRequestInternal, UniquenessCheckResult>>
             ) {
-                val commitStartTime = Instant.now().toEpochMilli()
+                val commitStartTime = System.nanoTime()
 
                 transactionDetails.forEach { (request, result) ->
                     entityManager.persist(
@@ -430,7 +429,7 @@ open class JPABackingStoreImpl @Activate constructor(
                     .builder()
                     .withTag(CordaMetrics.Tag.SourceVirtualNode, holdingIdentity.shortHash.toString())
                     .build()
-                    .record(Duration.ofMillis(Instant.now().toEpochMilli() - commitStartTime))
+                    .record(Duration.ofNanos(System.nanoTime() - commitStartTime))
             }
         }
     }

--- a/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImpl.kt
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/LedgerUniquenessCheckerClientServiceImpl.kt
@@ -29,7 +29,7 @@ class LedgerUniquenessCheckerClientServiceImpl @Activate constructor(
 ): LedgerUniquenessCheckerClientService, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     @Suspendable
@@ -44,7 +44,7 @@ class LedgerUniquenessCheckerClientServiceImpl @Activate constructor(
     ): UniquenessCheckResult {
         log.debug { "Received request with id: $txId, sending it to Uniqueness Checker" }
 
-        val startTime = Instant.now().toEpochMilli()
+        val startTime = System.nanoTime()
 
         return externalEventExecutor.execute(
             UniquenessCheckExternalEventFactory::class.java,
@@ -68,7 +68,7 @@ class LedgerUniquenessCheckerClientServiceImpl @Activate constructor(
                         it.javaClass.simpleName
                     })
                 .build()
-                .record(Duration.ofMillis(Instant.now().toEpochMilli() - startTime))
+                .record(Duration.ofNanos(System.nanoTime() - startTime))
         }
     }
 }

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
@@ -156,7 +156,7 @@ class BatchedUniquenessCheckerImpl(
         requests: List<UniquenessCheckRequestAvro>
     ): Map<UniquenessCheckRequestAvro, UniquenessCheckResponseAvro> {
 
-        val batchStartTime = Instant.now().toEpochMilli()
+        val batchStartTime = System.nanoTime()
         val results = HashMap<UniquenessCheckRequestAvro, UniquenessCheckResponseAvro>()
         val requestsToProcess = ArrayList<
                 Pair<UniquenessCheckRequestInternal, UniquenessCheckRequestAvro>>(requests.size)
@@ -203,7 +203,7 @@ class BatchedUniquenessCheckerImpl(
             .toList()
             .shuffled()
             .forEach { (holdingIdentity, partitionedRequests) ->
-                val subBatchStartTime = Instant.now().toEpochMilli()
+                val subBatchStartTime = System.nanoTime()
                 val cordaHoldingIdentity = holdingIdentity.toCorda()
 
                 try {
@@ -260,7 +260,7 @@ class BatchedUniquenessCheckerImpl(
                     .builder()
                     .withTag(CordaMetrics.Tag.SourceVirtualNode, cordaHoldingIdentity.shortHash.toString())
                     .build()
-                    .record(Duration.ofMillis(Instant.now().toEpochMilli() - subBatchStartTime))
+                    .record(Duration.ofNanos(System.nanoTime() - subBatchStartTime))
 
                 CordaMetrics.Metric.UniquenessCheckerSubBatchSize
                     .builder()
@@ -272,7 +272,7 @@ class BatchedUniquenessCheckerImpl(
         CordaMetrics.Metric.UniquenessCheckerBatchExecutionTime
             .builder()
             .build()
-            .record(Duration.ofMillis(Instant.now().toEpochMilli() - batchStartTime))
+            .record(Duration.ofNanos(System.nanoTime() - batchStartTime))
 
         CordaMetrics.Metric.UniquenessCheckerBatchSize
             .builder()

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/WireUtils.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/WireUtils.kt
@@ -66,7 +66,7 @@ private const val TO_SIGNATURE_SPEC_OPERATION_NAME = "toSignatureSpec"
 private const val TO_WIRE_OPERATION_NAME = "toWire"
 
 fun CryptoSignatureSpec.toSignatureSpec(serializer: AlgorithmParameterSpecEncodingService): SignatureSpec {
-    val startTime = Instant.now()
+    val startTime = System.nanoTime()
     val algorithmParams = if (params != null) {
         serializer.deserialize(
             SerializedAlgorithmParameterSpec(
@@ -87,13 +87,13 @@ fun CryptoSignatureSpec.toSignatureSpec(serializer: AlgorithmParameterSpecEncodi
         CordaMetrics.Metric.Crypto.SignatureSpecTimer.builder()
             .withTag(CordaMetrics.Tag.OperationName, TO_SIGNATURE_SPEC_OPERATION_NAME)
             .build()
-            .record(Duration.between(startTime, Instant.now()))
+            .record(Duration.ofNanos(System.nanoTime() - startTime))
     }
 }
 
 
 fun SignatureSpec.toWire(serializer: AlgorithmParameterSpecEncodingService): CryptoSignatureSpec {
-    val startTime = Instant.now()
+    val startTime = System.nanoTime()
     return when (this) {
         is CustomSignatureSpec -> CryptoSignatureSpec(
             signatureName,
@@ -112,7 +112,7 @@ fun SignatureSpec.toWire(serializer: AlgorithmParameterSpecEncodingService): Cry
         CordaMetrics.Metric.Crypto.SignatureSpecTimer.builder()
             .withTag(CordaMetrics.Tag.OperationName, TO_WIRE_OPERATION_NAME)
             .build()
-            .record(Duration.between(startTime, Instant.now()))
+            .record(Duration.ofNanos(System.nanoTime() - startTime))
     }
 }
 

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/fiber/metrics/Timer.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/fiber/metrics/Timer.kt
@@ -3,14 +3,13 @@ package net.corda.flow.fiber.metrics
 import io.micrometer.core.instrument.Timer
 import net.corda.v5.base.annotations.Suspendable
 import java.time.Duration
-import java.time.Instant
 
 @Suspendable
 fun <T> recordSuspendable(timer: () -> Timer, operation: () -> T): T {
-    val startTime = Instant.now()
+    val startTime = System.nanoTime()
     return try {
         operation()
     } finally {
-        timer().record(Duration.between(startTime, Instant.now()))
+        timer().record(Duration.ofNanos(System.nanoTime() - startTime))
     }
 }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -5,7 +5,6 @@ import io.javalin.http.Context
 import io.javalin.http.ForbiddenResponse
 import io.javalin.http.UnauthorizedResponse
 import java.time.Duration
-import java.time.Instant
 import javax.security.auth.login.FailedLoginException
 import net.corda.metrics.CordaMetrics
 import net.corda.rest.exception.HttpApiException
@@ -107,7 +106,7 @@ internal object ContextUtils {
                 methodLogger.debug { "Invoke method \"${method.method.name}\" for route info." }
                 methodLogger.trace { "Get parameter values." }
 
-                val startTime = Instant.now()
+                val startTime = System.nanoTime()
                 try {
                     validateRequestContentType(this, ctx)
 
@@ -137,13 +136,11 @@ internal object ContextUtils {
                         cleanUpMultipartRequest(ctx)
                     }
 
-                    val endTime = Instant.now()
-
                     CordaMetrics.Metric.HttpRequestTime.builder()
-                        .withTag(CordaMetrics.Tag.UriPath, "${ctx.matchedPath()}")
-                        .withTag(CordaMetrics.Tag.HttpMethod, "$ctxMethod")
+                        .withTag(CordaMetrics.Tag.UriPath, ctx.matchedPath())
+                        .withTag(CordaMetrics.Tag.HttpMethod, ctxMethod)
                         .withTag(CordaMetrics.Tag.OperationStatus, "${ctx.status()}")
-                        .build().record(Duration.between(startTime, endTime))
+                        .build().record(Duration.ofNanos(System.nanoTime() - startTime))
                 }
             }
         }


### PR DESCRIPTION
We should be using `System.nanoTime()` to compute durations of elapsed time. The `Timer.recordCallable` API already uses `System.nanoTime()` internally, and this PR fixes low-hanging fruit where we were using the "wall time" clock.