### PR TITLE
CORE-13492 Add option to Corda helm charts for preinstall checks

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -85,8 +85,7 @@ spec:
             - -c
           args:
             - |
-                touch /tmp/values.yaml
-                echo -e {{ toYaml .Values | quote }} >> /tmp/values.yaml
+                echo -e {{ toYaml .Values | quote }} > /tmp/values.yaml
           volumeMounts:
             - mountPath: /tmp
               name: temp

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -2,6 +2,7 @@
 Preinstall Checks
 */}}
 {{- define "corda.bootstrapPreinstallJob" -}}
+{{- if .Values.bootstrap.preinstallCheck.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -73,7 +74,6 @@ spec:
             {{ include "corda.log4jVolumeMount" . | nindent 12 }}
           env:
             {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
-
       initContainers:
         - name: create-preinstall-values
           image: {{ include "corda.bootstrapCliImage" . }}
@@ -96,6 +96,7 @@ spec:
       restartPolicy: Never
       {{- include "corda.bootstrapNodeSelector" . | nindent 6 }}
   backoffLimit: 0
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -1,4 +1,105 @@
 {{/*
+Preinstall Checks
+*/}}
+{{- define "corda.bootstrapPreinstallJob" -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-3"
+  name: {{ include "corda.fullname" . }}-preinstall-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-2"
+  name: {{ include "corda.fullname" . }}-preinstall-role-binding
+subjects:
+- kind: ServiceAccount
+  name: {{ include "corda.fullname" . }}-preinstall-service-account
+roleRef:
+  kind: Role
+  name: {{ include "corda.fullname" . }}-preinstall-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-4"
+  name: {{ include "corda.fullname" . }}-preinstall-service-account
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "corda.fullname" . }}-preinstall-checks
+  labels:
+    {{- include "corda.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+spec:
+  template:
+    metadata:
+      labels:
+        {{- include "corda.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.tolerations" . | nindent 6 }}
+      serviceAccountName: {{ include "corda.fullname" . }}-preinstall-service-account
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 10002
+        fsGroup: 1000
+      containers:
+        - name: preinstall-checks
+          image: {{ include "corda.bootstrapCliImage" . }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
+          {{- include "corda.bootstrapResources" . | nindent 10 }}
+          args: ['preinstall', 'run-all', '/tmp/values.yaml']
+          volumeMounts:
+            - mountPath: /tmp
+              name: temp
+            {{ include "corda.log4jVolumeMount" . | nindent 12 }}
+          env:
+            {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
+
+      initContainers:
+        - name: create-preinstall-values
+          image: {{ include "corda.bootstrapCliImage" . }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
+          command:
+            - /bin/bash
+            - -c
+          args:
+            - |
+                touch /tmp/values.yaml
+                echo -e {{ toYaml .Values | quote }} >> /tmp/values.yaml
+          volumeMounts:
+            - mountPath: /tmp
+              name: temp
+      volumes:
+        - name: temp
+          emptyDir: {}
+        {{ include "corda.log4jVolume" . | nindent 8 }}
+      restartPolicy: Never
+      {{- include "corda.bootstrapNodeSelector" . | nindent 6 }}
+  backoffLimit: 0
+{{- end }}
+
+{{/*
 DB bootstrap job
 */}}
 {{- define "corda.bootstrapDbJob" -}}
@@ -183,7 +284,6 @@ spec:
             - -c
           args:
             - |
-                mkdir /tmp
                 touch /tmp/config.properties
                 {{- if .Values.kafka.tls.enabled }}
                 {{- if .Values.kafka.sasl.enabled }}

--- a/charts/corda/templates/bootstrap.yaml
+++ b/charts/corda/templates/bootstrap.yaml
@@ -1,3 +1,4 @@
+{{- include "corda.bootstrapPreinstallJob" . }}
 {{- include "corda.bootstrapDbJob" . }}
 {{- include "corda.bootstrapKafkaJob" . }}
 {{- include "corda.bootstrapRbacJob" . }}

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -583,6 +583,7 @@
             "default": {},
             "title": "configuration for cluster bootstrap",
             "required": [
+                "preinstallCheck",
                 "restApiAdmin",
                 "db",
                 "kafka",
@@ -592,6 +593,26 @@
             ],
             "additionalProperties": false,
             "properties": {
+                "preinstallCheck": {
+                    "type": "object",
+                    "default": {},
+                    "title": "configuration for the preinstall check",
+                    "required": [
+                        "enabled"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true,
+                            "title": "indicates whether the preinstall check is enabled",
+                            "examples": [
+                                true,
+                                false
+                            ]
+                        }
+                    }
+                },
                 "restApiAdmin": {
                     "type": "object",
                     "default": {},

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -171,6 +171,10 @@ kafka:
 
 # Configuration for cluster bootstrap
 bootstrap:
+  # Configuration for the preinstall check
+  preinstallCheck:
+    # -- indicates whether the preinstall check is enabled
+    enabled: true
   # Configuration for the REST API admin to be created during cluster bootstrap
   restApiAdmin:
     # the username configuration for the REST API admin to be created during cluster bootstrap

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
@@ -139,7 +139,8 @@ class CheckKafka : Callable<Int>, PluginContext() {
         }
     }
 
-    private fun checkKafka(kafkaProperties : KafkaProperties, defaultSasl: PreInstallPlugin.SASL?, clientSasl: PreInstallPlugin.ClientSASL?, replicas: Int) {
+    private fun checkKafka(kafkaProperties : KafkaProperties, defaultSasl: PreInstallPlugin.SASL?,
+                           clientSasl: PreInstallPlugin.ClientSASL?, replicas: Int) {
 
         val kafkaPropertiesWithCredentials = kafkaProperties.copy()
         if (kafkaProperties.saslEnabled) {

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
@@ -3,6 +3,8 @@ package net.corda.cli.plugins.preinstall
 import net.corda.cli.plugins.preinstall.PreInstallPlugin.PluginContext
 import net.corda.cli.plugins.preinstall.PreInstallPlugin.Kafka
 import net.corda.cli.plugins.preinstall.PreInstallPlugin.ReportEntry
+import net.corda.cli.plugins.preinstall.PreInstallPlugin.KafkaConfiguration
+import net.corda.cli.plugins.preinstall.PreInstallPlugin.KafkaBootstrap
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.Node
@@ -37,11 +39,12 @@ class CheckKafka : Callable<Int>, PluginContext() {
     class SASLCredentialException(message: String) : Exception(message)
     private val logger = getLogger()
 
-    open class KafkaAdmin(props: Properties) {
+    open class KafkaAdmin(props: Properties, report: PreInstallPlugin.Report) {
         private val admin: AdminClient?
 
         init {
             admin = AdminClient.create(props)
+            report.addEntry(ReportEntry("Created admin client successfully", true))
         }
 
         open fun getNodes(): Collection<Node> {
@@ -147,15 +150,17 @@ class CheckKafka : Callable<Int>, PluginContext() {
         }
     }
 
-    override fun call(): Int {
-        val yaml: Kafka
-        try {
-            yaml = parseYaml<Kafka>(path)
-            report.addEntry(ReportEntry("Parse Kafka properties from YAML", true))
-        } catch (e: Exception) {
-            report.addEntry(ReportEntry("Parse Kafka properties from YAML", false, e))
-            logger.error(report.failingTests())
-            return 1
+    private fun checkKafka(workerKafka: KafkaConfiguration?, rootKafka: KafkaConfiguration, bootstrap: KafkaBootstrap?) {
+        val kafka = workerKafka ?: rootKafka
+
+        if (rootKafka.tls == null) {
+            report.addEntry(ReportEntry("TLS has not been defined under Kafka", false))
+            return
+        }
+
+        if (rootKafka.bootstrapServers == null) {
+            report.addEntry(ReportEntry("Bootstrap servers have not been defined under Kafka", false))
+            return
         }
 
         var saslUsername: String? = null
@@ -166,55 +171,55 @@ class CheckKafka : Callable<Int>, PluginContext() {
         var truststoreFile: String? = null
         var truststoreType: String? = null
 
-        if (yaml.kafka.sasl.enabled) {
-            checkCredential(yaml.kafka.sasl.username, SASLCredentialException("If SASL is enabled, you must provide a username."))
-            checkCredential(yaml.kafka.sasl.password, SASLCredentialException("If SASL is enabled, you must provide a password."))
-            checkCredential(yaml.kafka.sasl.mechanism, SASLCredentialException("If SASL is enabled, you must provide a mechanism."))
+        if (rootKafka.sasl.enabled) {
+            checkCredential(kafka.sasl.username, SASLCredentialException("If SASL is enabled, you must provide a username."))
+            checkCredential(kafka.sasl.password, SASLCredentialException("If SASL is enabled, you must provide a password."))
+            checkCredential(rootKafka.sasl.mechanism, SASLCredentialException("If SASL is enabled, you must provide a mechanism."))
 
-            saslMechanism = yaml.kafka.sasl.mechanism
+            saslMechanism = rootKafka.sasl.mechanism
 
             try {
-                saslUsername = getCredential(yaml.kafka.sasl.username!!, namespace)
-                saslPassword = getCredential(yaml.kafka.sasl.password!!, namespace)
+                saslUsername = getCredential(kafka.sasl.username!!, namespace)
+                saslPassword = getCredential(kafka.sasl.password!!, namespace)
                 report.addEntry(ReportEntry("Get SASL credentials", true))
             } catch (e: Exception) {
                 report.addEntry(ReportEntry("Get SASL credentials", false, e))
                 logger.error(report.failingTests())
-                return 1
+                return
             }
         }
 
-        if (yaml.kafka.tls.enabled) {
-            truststoreType = yaml.kafka.tls.truststore?.type
+        if (rootKafka.tls.enabled) {
+            truststoreType = rootKafka.tls.truststore?.type
 
-            if (truststoreType != "PEM" && yaml.kafka.tls.truststore?.password != null) {
+            if (truststoreType != "PEM" && rootKafka.tls.truststore?.password != null) {
                 try {
-                    truststorePassword = getCredential(yaml.kafka.tls.truststore.password, namespace)
+                    truststorePassword = getCredential(rootKafka.tls.truststore.password, namespace)
                     report.addEntry(ReportEntry("Get TLS truststore password", true))
                 } catch (e: Exception) {
                     report.addEntry(ReportEntry("Get TLS truststore password", false, e))
                     logger.error(report.failingTests())
-                    return 1
+                    return
                 }
-            } else if (yaml.kafka.tls.truststore?.valueFrom?.secretKeyRef?.name != null ) {
-                val secret = PreInstallPlugin.SecretValues(yaml.kafka.tls.truststore.valueFrom, null, null, null, null)
+            } else if (rootKafka.tls.truststore?.valueFrom?.secretKeyRef?.name != null ) {
+                val secret = PreInstallPlugin.SecretValues(rootKafka.tls.truststore.valueFrom, null, null, null, null)
                 try {
                     truststoreFile = getCredential(secret, namespace)
                     report.addEntry(ReportEntry("Get TLS truststore certificate", true))
                 } catch (e: Exception) {
                     report.addEntry(ReportEntry("Get TLS truststore certificate", false, e))
                     logger.error(report.failingTests())
-                    return 1
+                    return
                 }
             }
         }
 
-        val creds = KafkaProperties(yaml.kafka.bootstrapServers)
-        creds.saslEnabled = yaml.kafka.sasl.enabled
+        val creds = KafkaProperties(rootKafka.bootstrapServers)
+        creds.saslEnabled = rootKafka.sasl.enabled
         creds.saslUsername = saslUsername
         creds.saslPassword = saslPassword
         creds.saslMechanism = saslMechanism
-        creds.tlsEnabled = yaml.kafka.tls.enabled
+        creds.tlsEnabled = rootKafka.tls.enabled
         creds.truststorePassword = truststorePassword
         creds.truststoreFile = truststoreFile
         creds.truststoreType = truststoreType
@@ -227,16 +232,38 @@ class CheckKafka : Callable<Int>, PluginContext() {
         } catch (e: Exception) {
             report.addEntry(ReportEntry("Create Kafka client properties", false, e))
             logger.error(report.failingTests())
-            return 1
+            return
         }
 
+        logger.info(props.entries.joinToString(separator = ",\n"))
+
         try {
-            checkConnectionAndBrokers(KafkaAdmin(props), yaml.bootstrap?.kafka?.replicas)
+            checkConnectionAndBrokers(KafkaAdmin(props, report), bootstrap?.kafka?.replicas)
         } catch (e: KafkaException) {
             report.addEntry(ReportEntry("Connect to Kafka cluster using client", false, e))
         } catch (e: ExecutionException) {
             report.addEntry(ReportEntry("Connect to Kafka cluster using client", false, e))
         }
+    }
+
+    override fun call(): Int {
+        val yaml: Kafka
+        try {
+            yaml = parseYaml<Kafka>(path)
+            report.addEntry(ReportEntry("Parse Kafka properties from YAML", true))
+        } catch (e: Exception) {
+            report.addEntry(ReportEntry("Parse Kafka properties from YAML", false, e))
+            logger.error(report.failingTests())
+            return 1
+        }
+
+        checkKafka(yaml.workers?.crypto?.kafka, yaml.kafka, yaml.bootstrap)
+        checkKafka(yaml.workers?.db?.kafka, yaml.kafka, yaml.bootstrap)
+        checkKafka(yaml.workers?.flow?.kafka, yaml.kafka, yaml.bootstrap)
+        checkKafka(yaml.workers?.membership?.kafka, yaml.kafka, yaml.bootstrap)
+        checkKafka(yaml.workers?.rest?.kafka, yaml.kafka, yaml.bootstrap)
+        checkKafka(yaml.workers?.p2pGateway?.kafka, yaml.kafka, yaml.bootstrap)
+        checkKafka(yaml.workers?.p2pLinkManager?.kafka, yaml.kafka, yaml.bootstrap)
 
         return if (report.testsPassed()) {
             logger.info(report.toString())

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
@@ -3,8 +3,6 @@ package net.corda.cli.plugins.preinstall
 import net.corda.cli.plugins.preinstall.PreInstallPlugin.PluginContext
 import net.corda.cli.plugins.preinstall.PreInstallPlugin.Kafka
 import net.corda.cli.plugins.preinstall.PreInstallPlugin.ReportEntry
-import net.corda.cli.plugins.preinstall.PreInstallPlugin.KafkaConfiguration
-import net.corda.cli.plugins.preinstall.PreInstallPlugin.KafkaBootstrap
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.Node
@@ -35,8 +33,6 @@ class CheckKafka : Callable<Int>, PluginContext() {
         description = ["The timeout in milliseconds for testing the Kafka connection - defaults to 3000"]
     )
     var timeout: Int = 3000
-
-    class SASLCredentialException(message: String) : Exception(message)
 
     open class KafkaAdmin(props: Properties, report: PreInstallPlugin.Report) {
         private val admin: AdminClient?
@@ -143,43 +139,13 @@ class CheckKafka : Callable<Int>, PluginContext() {
         }
     }
 
-    private fun checkCredential(value: Any?, e: Exception) {
-        if (value == null) {
-            report.addEntry(ReportEntry("Create Kafka client properties", false, e))
-        }
-    }
+    private fun checkKafka(kafkaProperties : KafkaProperties, defaultSasl: PreInstallPlugin.SASL?, clientSasl: PreInstallPlugin.ClientSASL?, replicas: Int) {
 
-    private fun checkKafka(workerKafka: KafkaConfiguration?, rootKafka: KafkaConfiguration, bootstrap: KafkaBootstrap?) {
-        val kafka = workerKafka ?: rootKafka
-
-        if (rootKafka.tls == null) {
-            report.addEntry(ReportEntry("TLS has not been defined under Kafka", false))
-            return
-        }
-
-        if (rootKafka.bootstrapServers == null) {
-            report.addEntry(ReportEntry("Bootstrap servers have not been defined under Kafka", false))
-            return
-        }
-
-        var saslUsername: String? = null
-        var saslPassword: String? = null
-        var saslMechanism: String? = null
-
-        var truststorePassword: String? = null
-        var truststoreFile: String? = null
-        var truststoreType: String? = null
-
-        if (rootKafka.sasl.enabled) {
-            checkCredential(kafka.sasl.username, SASLCredentialException("If SASL is enabled, you must provide a username."))
-            checkCredential(kafka.sasl.password, SASLCredentialException("If SASL is enabled, you must provide a password."))
-            checkCredential(rootKafka.sasl.mechanism, SASLCredentialException("If SASL is enabled, you must provide a mechanism."))
-
-            saslMechanism = rootKafka.sasl.mechanism
-
+        val kafkaPropertiesWithCredentials = kafkaProperties.copy()
+        if (kafkaProperties.saslEnabled) {
             try {
-                saslUsername = getCredential(kafka.sasl.username!!, namespace)
-                saslPassword = getCredential(kafka.sasl.password!!, namespace)
+                kafkaPropertiesWithCredentials.saslUsername = getCredential(defaultSasl?.username, clientSasl?.username, namespace)
+                kafkaPropertiesWithCredentials.saslPassword = getCredential(defaultSasl?.password, clientSasl?.password, namespace)
                 report.addEntry(ReportEntry("Get SASL credentials", true))
             } catch (e: Exception) {
                 report.addEntry(ReportEntry("Get SASL credentials", false, e))
@@ -188,45 +154,9 @@ class CheckKafka : Callable<Int>, PluginContext() {
             }
         }
 
-        if (rootKafka.tls.enabled) {
-            truststoreType = rootKafka.tls.truststore?.type
-
-            if (truststoreType != "PEM" && rootKafka.tls.truststore?.password != null) {
-                try {
-                    truststorePassword = getCredential(rootKafka.tls.truststore.password, namespace)
-                    report.addEntry(ReportEntry("Get TLS truststore password", true))
-                } catch (e: Exception) {
-                    report.addEntry(ReportEntry("Get TLS truststore password", false, e))
-                    logger.error(report.failingTests())
-                    return
-                }
-            } else if (rootKafka.tls.truststore?.valueFrom?.secretKeyRef?.name != null ) {
-                val secret = PreInstallPlugin.SecretValues(rootKafka.tls.truststore.valueFrom, null, null, null, null)
-                try {
-                    truststoreFile = getCredential(secret, namespace)
-                    report.addEntry(ReportEntry("Get TLS truststore certificate", true))
-                } catch (e: Exception) {
-                    report.addEntry(ReportEntry("Get TLS truststore certificate", false, e))
-                    logger.error(report.failingTests())
-                    return
-                }
-            }
-        }
-
-        val creds = KafkaProperties(rootKafka.bootstrapServers)
-        creds.saslEnabled = rootKafka.sasl.enabled
-        creds.saslUsername = saslUsername
-        creds.saslPassword = saslPassword
-        creds.saslMechanism = saslMechanism
-        creds.tlsEnabled = rootKafka.tls.enabled
-        creds.truststorePassword = truststorePassword
-        creds.truststoreFile = truststoreFile
-        creds.truststoreType = truststoreType
-        creds.timeout = timeout
-
         val props: Properties
         try {
-            props = creds.getKafkaProperties()
+            props = kafkaPropertiesWithCredentials.getKafkaProperties()
             report.addEntry(ReportEntry("Create Kafka client properties", true))
         } catch (e: Exception) {
             report.addEntry(ReportEntry("Create Kafka client properties", false, e))
@@ -237,7 +167,7 @@ class CheckKafka : Callable<Int>, PluginContext() {
         logger.info(props.entries.joinToString(separator = ",\n"))
 
         try {
-            checkConnectionAndBrokers(KafkaAdmin(props, report), bootstrap?.kafka?.replicas)
+            checkConnectionAndBrokers(KafkaAdmin(props, report), replicas)
         } catch (e: KafkaException) {
             report.addEntry(ReportEntry("Connect to Kafka cluster using client", false, e))
         } catch (e: ExecutionException) {
@@ -248,7 +178,7 @@ class CheckKafka : Callable<Int>, PluginContext() {
     override fun call(): Int {
         val yaml: Kafka
         try {
-            yaml = parseYaml<Kafka>(path)
+            yaml = parseYaml(path)
             report.addEntry(ReportEntry("Parse Kafka properties from YAML", true))
         } catch (e: Exception) {
             report.addEntry(ReportEntry("Parse Kafka properties from YAML", false, e))
@@ -256,13 +186,59 @@ class CheckKafka : Callable<Int>, PluginContext() {
             return 1
         }
 
-        checkKafka(yaml.workers?.crypto?.kafka, yaml.kafka, yaml.bootstrap)
-        checkKafka(yaml.workers?.db?.kafka, yaml.kafka, yaml.bootstrap)
-        checkKafka(yaml.workers?.flow?.kafka, yaml.kafka, yaml.bootstrap)
-        checkKafka(yaml.workers?.membership?.kafka, yaml.kafka, yaml.bootstrap)
-        checkKafka(yaml.workers?.rest?.kafka, yaml.kafka, yaml.bootstrap)
-        checkKafka(yaml.workers?.p2pGateway?.kafka, yaml.kafka, yaml.bootstrap)
-        checkKafka(yaml.workers?.p2pLinkManager?.kafka, yaml.kafka, yaml.bootstrap)
+        if (yaml.kafka.bootstrapServers == null) {
+            report.addEntry(ReportEntry("Bootstrap servers have not been defined under Kafka", false))
+            return 1
+        }
+        val kafkaProperties = KafkaProperties(yaml.kafka.bootstrapServers)
+        kafkaProperties.timeout = timeout
+
+        if (yaml.kafka.tls?.enabled == true) {
+            kafkaProperties.tlsEnabled = true
+            kafkaProperties.truststoreType = yaml.kafka.tls.truststore?.type
+
+            if (kafkaProperties.truststoreType == "JKS" && yaml.kafka.tls.truststore?.password != null) {
+                try {
+                    kafkaProperties.truststorePassword = getCredential(yaml.kafka.tls.truststore.password, namespace)
+                    report.addEntry(ReportEntry("Get TLS truststore password", true))
+                } catch (e: Exception) {
+                    report.addEntry(ReportEntry("Get TLS truststore password", false, e))
+                    logger.error(report.failingTests())
+                    return 1
+                }
+            }
+            if (yaml.kafka.tls.truststore?.valueFrom?.secretKeyRef?.name != null ) {
+                val secret = PreInstallPlugin.SecretValues(yaml.kafka.tls.truststore.valueFrom, null)
+                try {
+                    kafkaProperties.truststoreFile = getCredential(secret, namespace)
+                    report.addEntry(ReportEntry("Get TLS truststore certificate", true))
+                } catch (e: Exception) {
+                    report.addEntry(ReportEntry("Get TLS truststore certificate", false, e))
+                    logger.error(report.failingTests())
+                    return 1
+                }
+            }
+        }
+
+        if (yaml.kafka.sasl?.enabled == true) {
+            if (yaml.kafka.sasl.mechanism == null) {
+                report.addEntry(ReportEntry("SASL mechanism provided", false))
+            }
+            kafkaProperties.saslEnabled = true
+            kafkaProperties.saslMechanism = yaml.kafka.sasl.mechanism
+        }
+
+        val replicas = yaml.bootstrap?.kafka?.replicas ?: 3
+        if (yaml.bootstrap?.kafka?.enabled == true) {
+            checkKafka(kafkaProperties, yaml.kafka.sasl, yaml.bootstrap.kafka.sasl, replicas)
+        }
+        checkKafka(kafkaProperties, yaml.kafka.sasl, yaml.workers?.crypto?.kafka?.sasl, replicas)
+        checkKafka(kafkaProperties, yaml.kafka.sasl, yaml.workers?.db?.kafka?.sasl, replicas)
+        checkKafka(kafkaProperties, yaml.kafka.sasl, yaml.workers?.flow?.kafka?.sasl, replicas)
+        checkKafka(kafkaProperties, yaml.kafka.sasl, yaml.workers?.membership?.kafka?.sasl, replicas)
+        checkKafka(kafkaProperties, yaml.kafka.sasl, yaml.workers?.rest?.kafka?.sasl, replicas)
+        checkKafka(kafkaProperties, yaml.kafka.sasl, yaml.workers?.p2pGateway?.kafka?.sasl, replicas)
+        checkKafka(kafkaProperties, yaml.kafka.sasl, yaml.workers?.p2pLinkManager?.kafka?.sasl, replicas)
 
         return if (report.testsPassed()) {
             logger.info(report.toString())

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
@@ -37,7 +37,6 @@ class CheckKafka : Callable<Int>, PluginContext() {
     var timeout: Int = 3000
 
     class SASLCredentialException(message: String) : Exception(message)
-    private val logger = getLogger()
 
     open class KafkaAdmin(props: Properties, report: PreInstallPlugin.Report) {
         private val admin: AdminClient?

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckLimits.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckLimits.kt
@@ -25,39 +25,59 @@ class CheckLimits : Callable<Int>, PluginContext() {
     private val logger = getLogger()
 
     // split resource into a digit portion and a unit portion
-    private fun parseResourceString(resourceString: String): Long {
-        val regex = Regex("(\\d+)([EPTGMK]?i?[Bb]?)?")
-
-        val (value, unit) = regex.matchEntire(resourceString)?.destructured
-            ?: throw IllegalArgumentException("Invalid memory string format: $resourceString")
-
-        // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage
-        val multiplier = when (unit.uppercase()) {
-            "E", "EB" -> 1024L * 1024L * 1024L * 1024L * 1024L * 1024L
-            "P", "PB" -> 1024L * 1024L * 1024L * 1024L * 1024L
-            "T", "TB" -> 1024L * 1024L * 1024L * 1024L
-            "G", "GB" -> 1024L * 1024L * 1024L
-            "M", "MB" -> 1024L * 1024L
-            "K", "KB" -> 1024L
-            "EI", "EIB" -> 1000L * 1000L * 1000L * 1000L * 1000L * 1000L
-            "PI", "PIB" -> 1000L * 1000L * 1000L * 1000L * 1000L
-            "TI", "TIB" -> 1000L * 1000L * 1000L * 1000L
-            "GI", "GIB" -> 1000L * 1000L * 1000L
-            "MI", "MIB" -> 1000L * 1000L
-            "KI", "KIB" -> 1000L
-            "B" -> 1L
-            else -> if (unit.isEmpty()) 1L else throw IllegalArgumentException("Invalid memory unit: $unit")
+    @SuppressWarnings("ThrowsCount")
+    private fun parseResourceString(resourceString: String, type: String): Double {
+        val regex: Regex = if (type == "memory") {
+            Regex("(\\d+)([EPTGMKk]?i?[Bb]?)?")
+        } else {
+            Regex("(\\d*\\.?\\d+)([EPTGMkm])?")
         }
 
-        logger.debug("$resourceString -> $value x $multiplier = ${value.toLong() * multiplier} bytes")
+        val (value, unit) = regex.matchEntire(resourceString)?.destructured
+            ?: throw IllegalArgumentException("Invalid $type string format: $resourceString")
 
-        return (value.toLong() * multiplier)
+        // https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage
+        val multiplier: Double = if (type == "memory") {
+            when (unit.uppercase()) {
+                "E", "EB" -> 1000.0 * 1000 * 1000 * 1000 * 1000 * 1000
+                "P", "PB" -> 1000.0 * 1000 * 1000 * 1000 * 1000
+                "T", "TB" -> 1000.0 * 1000 * 1000 * 1000
+                "G", "GB" -> 1000.0 * 1000 * 1000
+                "M", "MB" -> 1000.0 * 1000
+                "K", "KB" -> 1000.0
+                "EI", "EIB" -> 1024.0 * 1024 * 1024 * 1024 * 1024 * 1024
+                "PI", "PIB" -> 1024.0 * 1024 * 1024 * 1024 * 1024
+                "TI", "TIB" -> 1024.0 * 1024 * 1024 * 1024
+                "GI", "GIB" -> 1024.0 * 1024 * 1024
+                "MI", "MIB" -> 1024.0 * 1024
+                "KI", "KIB" -> 1024.0
+                "", "B" -> 1.0
+                else -> throw IllegalArgumentException("Invalid $type unit: $unit")
+            }
+        } else {
+            when (unit) {
+                "E" -> 1000.0 * 1000 * 1000 * 1000 * 1000 * 1000
+                "P" -> 1000.0 * 1000 * 1000 * 1000 * 1000
+                "T" -> 1000.0 * 1000 * 1000 * 1000
+                "G" -> 1000.0 * 1000 * 1000
+                "M" -> 1000.0 * 1000
+                "k" -> 1000.0
+                "" -> 1.0
+                "m" -> 0.001
+                else -> throw IllegalArgumentException("Invalid $type unit: $unit")
+            }
+        }
+
+        val result: Double = value.toDouble() * multiplier
+
+        logger.debug("{} -> {} x {} = {} bytes", resourceString, value, multiplier, result)
+        return result
     }
 
     // check the individual resource limits supplied
-    private fun checkResource(requestString: String, limitString: String) {
-        val limit: Long = parseResourceString(limitString)
-        val request: Long = parseResourceString(requestString)
+    private fun checkResource(requestString: String, limitString: String, type: String) {
+        val limit: Double = parseResourceString(limitString, type)
+        val request: Double = parseResourceString(requestString, type)
 
         if (limit < request) {
             throw ResourceLimitsExceededException("Request ($requestString) is greater than it's limit ($limitString)")
@@ -88,7 +108,7 @@ class CheckLimits : Callable<Int>, PluginContext() {
                 }
                 report.addEntry(ReportEntry("${name.uppercase()} memory resources contains both a request and a limit", true))
                 logger.info("Memory: \n\t request - ${requests.memory}\n\t limit - ${limits.memory}")
-                checkResource(requests.memory!!, limits.memory!!)
+                checkResource(requests.memory!!, limits.memory!!, "memory")
             }
 
             if (requests?.cpu == null) {
@@ -105,7 +125,7 @@ class CheckLimits : Callable<Int>, PluginContext() {
                 }
                 report.addEntry(ReportEntry("${name.uppercase()} cpu resources contains both a request and a limit", true))
                 logger.info("CPU: \n\t request - ${requests.cpu}\n\t limit - ${limits.cpu}")
-                checkResource(requests.cpu!!, limits.cpu!!)
+                checkResource(requests.cpu!!, limits.cpu!!, "cpu")
             }
 
             report.addEntry(ReportEntry("Parse \"$name\" resource strings", true))
@@ -135,6 +155,7 @@ class CheckLimits : Callable<Int>, PluginContext() {
             defaultRequests = it.requests
         }
 
+        checkResources(yaml.workers?.crypto?.resources, "crypto")
         checkResources(yaml.bootstrap?.resources, "bootstrap")
         checkResources(yaml.workers?.db?.resources, "DB")
         checkResources(yaml.workers?.flow?.resources, "flow")

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckPostgres.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckPostgres.kt
@@ -24,7 +24,6 @@ class CheckPostgres : Callable<Int>, PluginContext() {
         description = ["The namespace in which to look for the secrets if there are any"]
     )
     var namespace: String? = null
-    private val logger = getLogger()
 
     private fun connect(postgresUrl: String, username: String, password: String, credentialType: String) {
         try {

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
@@ -41,14 +41,11 @@ class PreInstallPlugin : Plugin() {
     open class PluginContext {
         var report = Report()
         private var client = KubernetesClientBuilder().build()
+        var logger = PreInstallPlugin.logger
 
         class SecretException: Exception {
             constructor (message: String?) : super(message)
             constructor (message: String?, cause: Throwable?) : super(message, cause)
-        }
-
-        fun getLogger(): Logger {
-            return logger
         }
 
         // parse a yaml file, and return an object of type T or null if there was an error

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
@@ -287,6 +287,8 @@ class PreInstallPlugin : Plugin() {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class Workers(
+        @JsonProperty("crypto")
+        val crypto: Resources?,
         @JsonProperty("db")
         val db: Resources?,
         @JsonProperty("flow")

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
@@ -64,20 +64,22 @@ class PreInstallPlugin : Plugin() {
         // object, and a namespace (if the credential is in a secret)
         @Suppress("ThrowsCount")
         fun getCredential(defaultValues: SecretValues?, values: SecretValues?, namespace: String?): String {
-            val secretName = values?.valueFrom?.secretKeyRef?.name ?: defaultValues?.valueFrom?.secretKeyRef?.name
+            val secretName = valueOrDefault(defaultValues?.valueFrom?.secretKeyRef?.name, values?.valueFrom?.secretKeyRef?.name)
             if (secretName.isNullOrEmpty())  {
-                val credential = values?.value ?: defaultValues?.value
+                val credential = valueOrDefault(defaultValues?.value, values?.value)
                 if (credential.isNullOrEmpty()) {
                     throw SecretException("No secretKeyRef name or value provided.")
                 }
                 return credential
             }
 
-            val secretKey = values?.valueFrom?.secretKeyRef?.key ?: defaultValues?.valueFrom?.secretKeyRef?.key
+            val secretKey = valueOrDefault(defaultValues?.valueFrom?.secretKeyRef?.key, values?.valueFrom?.secretKeyRef?.key)
             val encoded = getSecret(secretName, secretKey, namespace) ?:
             throw SecretException("Secret $secretName has no key $secretKey.")
             return String(Base64.getDecoder().decode(encoded))
         }
+
+        private fun valueOrDefault(default: String?, value: String?) = if (value.isNullOrEmpty()) default else value
 
         // get the credentials (.value) or credentials from a secret (.valueFrom.secretKeyRef...) from a SecretValues
         // object, and a namespace (if the credential is in a secret)

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
@@ -157,15 +157,17 @@ class PreInstallPlugin : Plugin() {
         @JsonProperty("kafka")
         val kafka: KafkaConfiguration,
         @JsonProperty("bootstrap")
-        val bootstrap: KafkaBootstrap?
+        val bootstrap: KafkaBootstrap?,
+        @JsonProperty("workers")
+        val workers: KafkaWorkers?
     )
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class KafkaConfiguration(
         @JsonProperty("bootstrapServers")
-        val bootstrapServers: String,
+        val bootstrapServers: String?,
         @JsonProperty("tls")
-        val tls: TLS,
+        val tls: TLS?,
         @JsonProperty("sasl")
         val sasl: SASL
     )
@@ -198,6 +200,24 @@ class PreInstallPlugin : Plugin() {
         val username: SecretValues?,
         @JsonProperty("password")
         val password: SecretValues?
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class KafkaWorkers(
+        @JsonProperty("crypto")
+        val crypto: Kafka?,
+        @JsonProperty("db")
+        val db: Kafka?,
+        @JsonProperty("flow")
+        val flow: Kafka?,
+        @JsonProperty("membership")
+        val membership: Kafka?,
+        @JsonProperty("rest")
+        val rest: Kafka?,
+        @JsonProperty("p2pLinkManager")
+        val p2pLinkManager: Kafka?,
+        @JsonProperty("p2pGateway")
+        val p2pGateway: Kafka?
     )
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/tools/plugins/preinstall/src/test/kotlin/net/corda/cli/plugins/preinstall/TestSubCommands.kt
+++ b/tools/plugins/preinstall/src/test/kotlin/net/corda/cli/plugins/preinstall/TestSubCommands.kt
@@ -90,7 +90,7 @@ class TestSubCommands {
         fun testKafkaSaslSslNonPemTruststore() {
             // Test SASL_SSL with non-PEM format truststore
             val path = "./src/test/resources/KafkaTestSaslTls.yaml"
-            val yaml: PreInstallPlugin.Kafka = parseYaml<PreInstallPlugin.Kafka>(path)
+            val yaml: PreInstallPlugin.Kafka = parseYaml(path)
             val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
             props.saslEnabled = yaml.kafka.sasl?.enabled ?: false
             props.saslUsername = "sasl-user"
@@ -202,22 +202,9 @@ class TestSubCommands {
             whenever(mockAdmin.getNodes()).thenReturn(nodes)
 
             val ck = CheckKafka()
-            ck.checkConnectionAndBrokers(mockAdmin, 2)
+            ck.checkConnectionAndBrokers("foo", mockAdmin, 2)
 
-            assertTrue( ck.report.toString().contains("Connect to Kafka cluster using client: PASSED") )
-        }
-
-        @Test
-        fun testKafkaConnectNoBrokers() {
-            val mockAdmin = mock<CheckKafka.KafkaAdmin>()
-            val nodes: Collection<Node> = listOf()
-            whenever(mockAdmin.getDescriptionID()).thenReturn("ClusterID")
-            whenever(mockAdmin.getNodes()).thenReturn(nodes)
-
-            val ck = CheckKafka()
-            ck.checkConnectionAndBrokers(mockAdmin, 2)
-
-            assertTrue( ck.report.toString().contains("Kafka cluster has brokers: FAILED") )
+            assertTrue( ck.report.toString().contains("Connect to Kafka cluster using foo client: PASSED") )
         }
 
         @Test
@@ -228,9 +215,9 @@ class TestSubCommands {
             whenever(mockAdmin.getNodes()).thenReturn(nodes)
 
             val ck = CheckKafka()
-            ck.checkConnectionAndBrokers(mockAdmin, 2)
+            ck.checkConnectionAndBrokers("foo", mockAdmin, 2)
 
-            assertTrue( ck.report.toString().contains("Kafka replica count is less than the broker count: FAILED") )
+            assertTrue( ck.report.toString().contains("Kafka replica count is less than or equal to the broker count: FAILED") )
         }
 
         @Test

--- a/tools/plugins/preinstall/src/test/kotlin/net/corda/cli/plugins/preinstall/TestSubCommands.kt
+++ b/tools/plugins/preinstall/src/test/kotlin/net/corda/cli/plugins/preinstall/TestSubCommands.kt
@@ -92,10 +92,10 @@ class TestSubCommands {
             val path = "./src/test/resources/KafkaTestSaslTls.yaml"
             val yaml: PreInstallPlugin.Kafka = parseYaml<PreInstallPlugin.Kafka>(path)
             val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
-            props.saslEnabled = yaml.kafka.sasl.enabled
+            props.saslEnabled = yaml.kafka.sasl?.enabled ?: false
             props.saslUsername = "sasl-user"
             props.saslPassword = "sasl-pass"
-            props.saslMechanism = yaml.kafka.sasl.mechanism
+            props.saslMechanism = yaml.kafka.sasl?.mechanism
             props.tlsEnabled = yaml.kafka.tls!!.enabled
             props.truststoreFile = "-----BEGIN CERTIFICATE-----"
             props.truststorePassword = "truststore-pass"
@@ -119,10 +119,10 @@ class TestSubCommands {
             val path = "./src/test/resources/KafkaTestSaslTlsPEM.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
             val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
-            props.saslEnabled = yaml.kafka.sasl.enabled
+            props.saslEnabled = yaml.kafka.sasl?.enabled ?: false
             props.saslUsername = "sasl-user1"
             props.saslPassword = "sasl-pass2"
-            props.saslMechanism = yaml.kafka.sasl.mechanism
+            props.saslMechanism = yaml.kafka.sasl?.mechanism
             props.tlsEnabled = yaml.kafka.tls!!.enabled
             props.truststoreFile = "-----BEGIN CERTIFICATE-----"
             props.truststoreType = yaml.kafka.tls!!.truststore!!.type
@@ -144,10 +144,10 @@ class TestSubCommands {
             val path = "./src/test/resources/KafkaTestSaslPlain.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
             val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
-            props.saslEnabled = yaml.kafka.sasl.enabled
+            props.saslEnabled = yaml.kafka.sasl?.enabled ?: false
             props.saslUsername = "sasl-user"
             props.saslPassword = "sasl-pass"
-            props.saslMechanism = yaml.kafka.sasl.mechanism
+            props.saslMechanism = yaml.kafka.sasl?.mechanism
 
             assertThrows<CheckKafka.KafkaProperties.SaslPlainWithoutTlsException> {
                 props.getKafkaProperties()
@@ -160,10 +160,10 @@ class TestSubCommands {
             val path = "./src/test/resources/KafkaTestSaslScram.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
             val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
-            props.saslEnabled = yaml.kafka.sasl.enabled
+            props.saslEnabled = yaml.kafka.sasl?.enabled ?: false
             props.saslUsername = "sasl-user"
             props.saslPassword = "sasl-pass"
-            props.saslMechanism = yaml.kafka.sasl.mechanism
+            props.saslMechanism = yaml.kafka.sasl?.mechanism
 
             val check = props.getKafkaProperties()
 
@@ -238,10 +238,10 @@ class TestSubCommands {
             val path = "./src/test/resources/KafkaTestBadConnection.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
             val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
-            props.saslEnabled = yaml.kafka.sasl.enabled
+            props.saslEnabled = yaml.kafka.sasl?.enabled ?: false
             props.saslUsername = "sasl-user"
             props.saslPassword = "sasl-pass"
-            props.saslMechanism = yaml.kafka.sasl.mechanism
+            props.saslMechanism = yaml.kafka.sasl?.mechanism
             props.tlsEnabled = yaml.kafka.tls!!.enabled
             props.truststoreFile = "-----BEGIN CERTIFICATE-----"
             props.truststorePassword = "truststore-pass"

--- a/tools/plugins/preinstall/src/test/kotlin/net/corda/cli/plugins/preinstall/TestSubCommands.kt
+++ b/tools/plugins/preinstall/src/test/kotlin/net/corda/cli/plugins/preinstall/TestSubCommands.kt
@@ -91,15 +91,15 @@ class TestSubCommands {
             // Test SASL_SSL with non-PEM format truststore
             val path = "./src/test/resources/KafkaTestSaslTls.yaml"
             val yaml: PreInstallPlugin.Kafka = parseYaml<PreInstallPlugin.Kafka>(path)
-            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers)
+            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
             props.saslEnabled = yaml.kafka.sasl.enabled
             props.saslUsername = "sasl-user"
             props.saslPassword = "sasl-pass"
             props.saslMechanism = yaml.kafka.sasl.mechanism
-            props.tlsEnabled = yaml.kafka.tls.enabled
+            props.tlsEnabled = yaml.kafka.tls!!.enabled
             props.truststoreFile = "-----BEGIN CERTIFICATE-----"
             props.truststorePassword = "truststore-pass"
-            props.truststoreType = yaml.kafka.tls.truststore!!.type
+            props.truststoreType = yaml.kafka.tls!!.truststore!!.type
 
             val check = props.getKafkaProperties()
 
@@ -118,14 +118,14 @@ class TestSubCommands {
             // Test SASL_SSL with PEM format truststore (i.e. no password required)
             val path = "./src/test/resources/KafkaTestSaslTlsPEM.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
-            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers)
+            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
             props.saslEnabled = yaml.kafka.sasl.enabled
             props.saslUsername = "sasl-user1"
             props.saslPassword = "sasl-pass2"
             props.saslMechanism = yaml.kafka.sasl.mechanism
-            props.tlsEnabled = yaml.kafka.tls.enabled
+            props.tlsEnabled = yaml.kafka.tls!!.enabled
             props.truststoreFile = "-----BEGIN CERTIFICATE-----"
-            props.truststoreType = yaml.kafka.tls.truststore!!.type
+            props.truststoreType = yaml.kafka.tls!!.truststore!!.type
 
             val check = props.getKafkaProperties()
 
@@ -143,7 +143,7 @@ class TestSubCommands {
             // Test SASL_PLAINTEXT
             val path = "./src/test/resources/KafkaTestSaslPlain.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
-            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers)
+            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
             props.saslEnabled = yaml.kafka.sasl.enabled
             props.saslUsername = "sasl-user"
             props.saslPassword = "sasl-pass"
@@ -159,7 +159,7 @@ class TestSubCommands {
             // Test SASL_PLAINTEXT
             val path = "./src/test/resources/KafkaTestSaslScram.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
-            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers)
+            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
             props.saslEnabled = yaml.kafka.sasl.enabled
             props.saslUsername = "sasl-user"
             props.saslPassword = "sasl-pass"
@@ -179,11 +179,11 @@ class TestSubCommands {
             // Test SSL
             val path = "./src/test/resources/KafkaTestTls.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
-            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers)
-            props.tlsEnabled = yaml.kafka.tls.enabled
+            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
+            props.tlsEnabled = yaml.kafka.tls!!.enabled
             props.truststoreFile = "-----BEGIN CERTIFICATE-----"
             props.truststorePassword = "truststore-pass"
-            props.truststoreType = yaml.kafka.tls.truststore!!.type
+            props.truststoreType = yaml.kafka.tls!!.truststore!!.type
 
             val check = props.getKafkaProperties()
 
@@ -237,15 +237,15 @@ class TestSubCommands {
         fun testKafkaConnectFails() {
             val path = "./src/test/resources/KafkaTestBadConnection.yaml"
             val yaml = parseYaml<PreInstallPlugin.Kafka>(path)
-            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers)
+            val props = CheckKafka.KafkaProperties(yaml.kafka.bootstrapServers!!)
             props.saslEnabled = yaml.kafka.sasl.enabled
             props.saslUsername = "sasl-user"
             props.saslPassword = "sasl-pass"
             props.saslMechanism = yaml.kafka.sasl.mechanism
-            props.tlsEnabled = yaml.kafka.tls.enabled
+            props.tlsEnabled = yaml.kafka.tls!!.enabled
             props.truststoreFile = "-----BEGIN CERTIFICATE-----"
             props.truststorePassword = "truststore-pass"
-            props.truststoreType = yaml.kafka.tls.truststore!!.type
+            props.truststoreType = yaml.kafka.tls!!.truststore!!.type
 
 
             val config = props.getKafkaProperties()

--- a/tools/plugins/preinstall/src/test/resources/KafkaTestSaslScram.yaml
+++ b/tools/plugins/preinstall/src/test/resources/KafkaTestSaslScram.yaml
@@ -7,9 +7,86 @@ kafka:
     mechanism: "SCRAM"
     enabled: true
     username:
-      value: "alice"
+      value: ""
     password:
       valueFrom:
         secretKeyRef:
-          name: "kafka-sasl"
-          key: "kafka-sasl-password"
+          name: ""
+          key: ""
+
+workers:
+  crypto:
+    kafka:
+      sasl:
+        username:
+          value: "alice"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "kafka-sasl"
+              key: "kafka-sasl-password"
+
+  db:
+    kafka:
+      sasl:
+        username:
+          value: "alice"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "kafka-sasl"
+              key: "kafka-sasl-password"
+
+  flow:
+    kafka:
+      sasl:
+        username:
+          value: "alice"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "kafka-sasl"
+              key: "kafka-sasl-password"
+
+  membership:
+    kafka:
+      sasl:
+        username:
+          value: "alice"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "kafka-sasl"
+              key: "kafka-sasl-password"
+  rest:
+    kafka:
+      sasl:
+        username:
+          value: "alice"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "kafka-sasl"
+              key: "kafka-sasl-password"
+
+  p2pGateway:
+    kafka:
+      sasl:
+        username:
+          value: "alice"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "kafka-sasl"
+              key: "kafka-sasl-password"
+
+  p2pLinkManager:
+    kafka:
+      sasl:
+        username:
+          value: "alice"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "kafka-sasl"
+              key: "kafka-sasl-password"

--- a/tools/plugins/preinstall/src/test/resources/KafkaTestSaslScram.yaml
+++ b/tools/plugins/preinstall/src/test/resources/KafkaTestSaslScram.yaml
@@ -7,12 +7,12 @@ kafka:
     mechanism: "SCRAM"
     enabled: true
     username:
-      value: ""
+      value: "bob"
     password:
       valueFrom:
         secretKeyRef:
-          name: ""
-          key: ""
+          name: "kafka-sasl"
+          key: "kafka-sasl-password"
 
 workers:
   crypto:
@@ -29,8 +29,6 @@ workers:
   db:
     kafka:
       sasl:
-        username:
-          value: "alice"
         password:
           valueFrom:
             secretKeyRef:
@@ -42,27 +40,19 @@ workers:
       sasl:
         username:
           value: "alice"
-        password:
-          valueFrom:
-            secretKeyRef:
-              name: "kafka-sasl"
-              key: "kafka-sasl-password"
 
   membership:
     kafka:
       sasl:
-        username:
-          value: "alice"
-        password:
-          valueFrom:
-            secretKeyRef:
-              name: "kafka-sasl"
-              key: "kafka-sasl-password"
+
   rest:
     kafka:
       sasl:
         username:
-          value: "alice"
+          valueFrom:
+            secretKeyRef:
+              name: "kafka-sasl"
+              key: "kafka-sasl-username"
         password:
           valueFrom:
             secretKeyRef:
@@ -75,10 +65,7 @@ workers:
         username:
           value: "alice"
         password:
-          valueFrom:
-            secretKeyRef:
-              name: "kafka-sasl"
-              key: "kafka-sasl-password"
+          value: "password"
 
   p2pLinkManager:
     kafka:
@@ -88,5 +75,4 @@ workers:
         password:
           valueFrom:
             secretKeyRef:
-              name: "kafka-sasl"
               key: "kafka-sasl-password"

--- a/values-prereqs.yaml
+++ b/values-prereqs.yaml
@@ -8,7 +8,7 @@
 imagePullPolicy: "IfNotPresent"
 image:
   registry: "corda-os-docker-dev.software.r3.com"
-  tag: "latest-local"
+  tag: "latest-local-5.1.0"
 
 logging:
   format: "text"

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@
 imagePullPolicy: "IfNotPresent"
 image:
   registry: "corda-os-docker-dev.software.r3.com"
-  tag: "latest-local"
+  tag: "latest-local-5.1.0"
 
 logging:
   format: "text"


### PR DESCRIPTION
Preinstall Job
 - runs before bootstrap jobs
 - init container creates `/tmp/values.yaml` from helm `.Values` in a temp volume
 - calls `preinstall run-all /tmp/values.yaml`, under the service account `preinstall-service-account`

Service account, role, and role binding
 - necessary for the plugin to get the values of secrets within the namespace

Preinstall Plugin Changes
- add CPU units parsing to check-limits
- change parsing of `kafka.sasl` (and `workers.<worker>.kafka.sasl`) to allow for credentials to be overriden by workers