### PR TITLE
CORE-14349 SubFlow finished optimisation

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowEngineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowEngineImpl.kt
@@ -62,7 +62,7 @@ class FlowEngineImpl @Activate constructor(
              * suspend for flows that require session cleanup
              */
 
-            finishSubFlow()
+            closeSessionsOnSubFlowFinish()
 
             return result
         } catch (t: Throwable) {
@@ -72,7 +72,7 @@ class FlowEngineImpl @Activate constructor(
             // We cannot conclude that throwing an exception out of a sub-flow is an error. User code is free to do this
             // as long as it catches it in the flow which initiated it. The only thing Corda needs to do here is mark
             // the sub-flow as failed and rethrow.
-            failSubFlow(t)
+            errorSessionsOnSubFlowFinish(t)
             throw t
         } finally {
             popCurrentFlowStackItem()
@@ -94,15 +94,21 @@ class FlowEngineImpl @Activate constructor(
             .map(FlowStackItemSession::getSessionId)
 
     @Suspendable
-    private fun finishSubFlow() {
-        flowFiberService.getExecutingFiber()
-            .suspend(FlowIORequest.SubFlowFinished(currentSessionIds))
+    private fun closeSessionsOnSubFlowFinish() {
+        val currentSessionIds = this.currentSessionIds
+        if (currentSessionIds.isNotEmpty()) {
+            flowFiberService.getExecutingFiber()
+                .suspend(FlowIORequest.SubFlowFinished(currentSessionIds))
+        }
     }
 
     @Suspendable
-    private fun failSubFlow(t: Throwable) {
-        flowFiberService.getExecutingFiber()
-            .suspend(FlowIORequest.SubFlowFailed(t, currentSessionIds))
+    private fun errorSessionsOnSubFlowFinish(t: Throwable) {
+        val currentSessionIds = this.currentSessionIds
+        if (currentSessionIds.isNotEmpty()) {
+            flowFiberService.getExecutingFiber()
+                .suspend(FlowIORequest.SubFlowFailed(t, currentSessionIds))
+        }
     }
 
     private fun peekCurrentFlowStackItem(): FlowStackItem {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/FlowEngineImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/FlowEngineImplTest.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.application.services
 
 import net.corda.data.flow.state.checkpoint.FlowStackItem
+import net.corda.data.flow.state.checkpoint.FlowStackItemSession
 import net.corda.flow.application.services.impl.FlowEngineImpl
 import net.corda.flow.application.versioning.impl.RESET_VERSIONING_MARKER
 import net.corda.flow.application.versioning.impl.VERSIONING_PROPERTY_NAME
@@ -12,6 +13,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.inOrder
@@ -52,7 +54,7 @@ class FlowEngineImplTest {
     }
 
     @Test
-    fun `sub flow completes successfully`() {
+    fun `sub flow with no sessions tied to it completes successfully and does not suspend`() {
         assertThat(flowEngine.subFlow(subFlow)).isEqualTo(result)
 
         // verify unordered calls.
@@ -63,19 +65,54 @@ class FlowEngineImplTest {
         inOrder(sandboxDependencyInjector, flowFiber, flowStack, subFlow) {
             verify(sandboxDependencyInjector).injectServices(subFlow)
             verify(subFlow).call()
+            verify(flowFiber, never()).suspend(any())
+        }
+    }
 
+    @Test
+    fun `sub flow with uninitiated sessions tied to it completes successfully and does not suspend`() {
+        val flowStackItemSession = FlowStackItemSession("s", false)
+        flowStackItem.sessions = listOf(flowStackItemSession)
+        assertThat(flowEngine.subFlow(subFlow)).isEqualTo(result)
+
+        // verify unordered calls.
+        verify(sandboxDependencyInjector).injectServices(subFlow)
+        verify(flowStack).push(subFlow)
+
+        // verify ordered calls
+        inOrder(sandboxDependencyInjector, flowFiber, flowStack, subFlow) {
+            verify(sandboxDependencyInjector).injectServices(subFlow)
+            verify(subFlow).call()
+            verify(flowFiber, never()).suspend(any())
+        }
+    }
+
+    @Test
+    fun `sub flow with initiated sessions tied to it completes successfully and suspends`() {
+        val flowStackItemSession = FlowStackItemSession("s", true)
+        flowStackItem.sessions = listOf(flowStackItemSession)
+        assertThat(flowEngine.subFlow(subFlow)).isEqualTo(result)
+
+        // verify unordered calls.
+        verify(sandboxDependencyInjector).injectServices(subFlow)
+        verify(flowStack).push(subFlow)
+
+        // verify ordered calls
+        inOrder(sandboxDependencyInjector, flowFiber, flowStack, subFlow) {
+            verify(sandboxDependencyInjector).injectServices(subFlow)
+            verify(subFlow).call()
             // Assert the flow stack item is popped of the stack
             // and passed to the sub flow finished IO request
             argumentCaptor<FlowIORequest.SubFlowFinished>().apply {
                 verify(flowFiber).suspend(capture())
 
-                assertThat(firstValue.sessionIds).isEqualTo(flowStackItem.sessions.map { it.sessionId })
+                assertThat(firstValue.sessionIds).containsOnly(flowStackItemSession.sessionId)
             }
         }
     }
 
     @Test
-    fun `sub flow completes with error`() {
+    fun `sub flow with no sessions tied to it completes with error and does not suspend`() {
         val error = Exception()
 
         whenever(subFlow.call()).doAnswer { throw error }
@@ -84,7 +121,55 @@ class FlowEngineImplTest {
 
         assertThat(thrownError).isEqualTo(error)
 
-        // verify unordered calls
+        // verify unordered calls.
+        verify(sandboxDependencyInjector).injectServices(subFlow)
+        verify(flowStack).push(subFlow)
+
+        // verify ordered calls
+        inOrder(sandboxDependencyInjector, flowFiber, flowStack, subFlow) {
+            verify(sandboxDependencyInjector).injectServices(subFlow)
+            verify(subFlow).call()
+            verify(flowFiber, never()).suspend(any())
+        }
+    }
+
+    @Test
+    fun `sub flow with uninitiated sessions tied to it completes with error and does not suspend`() {
+        val flowStackItemSession = FlowStackItemSession("s", false)
+        flowStackItem.sessions = listOf(flowStackItemSession)
+        val error = Exception()
+
+        whenever(subFlow.call()).doAnswer { throw error }
+
+        val thrownError = assertThrows<Exception> { flowEngine.subFlow(subFlow) }
+
+        assertThat(thrownError).isEqualTo(error)
+
+        // verify unordered calls.
+        verify(sandboxDependencyInjector).injectServices(subFlow)
+        verify(flowStack).push(subFlow)
+
+        // verify ordered calls
+        inOrder(sandboxDependencyInjector, flowFiber, flowStack, subFlow) {
+            verify(sandboxDependencyInjector).injectServices(subFlow)
+            verify(subFlow).call()
+            verify(flowFiber, never()).suspend(any())
+        }
+    }
+
+    @Test
+    fun `sub flow with initiated sessions tied to it completes with error and suspends`() {
+        val flowStackItemSession = FlowStackItemSession("s", true)
+        flowStackItem.sessions = listOf(flowStackItemSession)
+        val error = Exception()
+
+        whenever(subFlow.call()).doAnswer { throw error }
+
+        val thrownError = assertThrows<Exception> { flowEngine.subFlow(subFlow) }
+
+        assertThat(thrownError).isEqualTo(error)
+
+        // verify unordered calls.
         verify(sandboxDependencyInjector).injectServices(subFlow)
         verify(flowStack).push(subFlow)
 


### PR DESCRIPTION
Do not call the SubFlow finished or failed handlers for inline SubFlows. This saves us suspending for no reason. Normally we suspend here to ensure sessions tied to the SubFlow are closed before moving on.

Writeup for this PR - https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4508745729/Test+14+-+Skip+checkpoint+when+finishing+SubFlow+if+no+sessions+are+tied+to+the+SubFlow