### PR TITLE
CORE-14350 refactor kafka clients ids

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
@@ -12,7 +12,7 @@ consumer = ${common} {
     group.id = ${group}
     # Consumer client ID. This requires the topic name, group name and client ID to be set at the top level
     # before attempting to resolve this file. Primarily used for logging.
-    client.id = consumer-${clientId}
+    client.id = consumer--${clientId}
     # This ensures a default where connection with no offset for a consumer group does not result in an exception.
     auto.offset.reset = earliest
     # Ensures that messages from uncommitted transactions are not visible. This is required to meet transactionality
@@ -28,7 +28,7 @@ consumer = ${common} {
 producer = ${common} {
     # Producer client ID. This requires the clientId to be set at the top level before attempting to resolve this file.
     # Primarily used for logging.
-    client.id = producer-${clientId}
+    client.id = producer--${clientId}
     # Ensures that messages are sent to the broker exactly once. Note that some configuration settings must be set to
     # compatible values as a result of this. A ConfigException will be raised if these are set to incompatible values.
     enable.idempotence = true
@@ -64,11 +64,11 @@ roles {
     stateAndEvent {
         stateConsumer = ${consumer} {
             # Need to be able to distinguish between the state and event consumers for this pattern.
-            client.id = stateConsumer-${clientId}
+            client.id = stateConsumer--${clientId}
         }
         eventConsumer = ${consumer} {
             # Need to be able to distinguish between the state and event consumers for this pattern.
-            client.id = eventConsumer-${clientId}
+            client.id = eventConsumer--${clientId}
         }
         producer = ${producer}
     }

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
@@ -66,14 +66,14 @@ class MessageBusConfigResolverTest {
                     mapOf(
                         BOOTSTRAP_SERVERS_PROP to "kafka:1001",
                         SSL_KEYSTORE_PROP to "foo/bar",
-                        CLIENT_ID_PROP to "stateConsumer-$CLIENT_ID"
+                        CLIENT_ID_PROP to "stateConsumer--$CLIENT_ID"
                     )
                 ),
                 ConsumerRoles.SAE_EVENT to getExpectedConsumerProperties(
                     mapOf(
                         BOOTSTRAP_SERVERS_PROP to "kafka:1001",
                         SSL_KEYSTORE_PROP to "foo/bar",
-                        CLIENT_ID_PROP to "eventConsumer-$CLIENT_ID"
+                        CLIENT_ID_PROP to "eventConsumer--$CLIENT_ID"
                     )
                 ),
                 ConsumerRoles.EVENT_LOG to getExpectedConsumerProperties(
@@ -149,7 +149,7 @@ class MessageBusConfigResolverTest {
         private fun getExpectedConsumerProperties(overrides: Map<String, String?>): Properties {
             val defaults = mapOf(
                 GROUP_ID_PROP to GROUP_NAME,
-                CLIENT_ID_PROP to "consumer-$CLIENT_ID",
+                CLIENT_ID_PROP to "consumer--$CLIENT_ID",
                 ISOLATION_LEVEL_PROP to "read_committed",
                 BOOTSTRAP_SERVERS_PROP to "localhost:9092",
                 SESSION_TIMEOUT_PROP to "60000",
@@ -168,7 +168,7 @@ class MessageBusConfigResolverTest {
         private fun getExpectedProducerProperties(overrides: Map<String, String?>): Properties {
             val defaults = mapOf(
                 GROUP_ID_PROP to GROUP_NAME,
-                CLIENT_ID_PROP to "producer-$CLIENT_ID",
+                CLIENT_ID_PROP to "producer--$CLIENT_ID",
                 TRANSACTIONAL_ID_PROP to "$CLIENT_ID-$INSTANCE_ID",
                 BOOTSTRAP_SERVERS_PROP to "localhost:9092",
                 ACKS_PROP to "all"

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedSubscriptionConfig.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedSubscriptionConfig.kt
@@ -64,6 +64,6 @@ data class ResolvedSubscriptionConfig(
         }
     }
 
-    val clientId = "$subscriptionType-$group-$topic-$uniqueId"
-    val lifecycleCoordinatorName = LifecycleCoordinatorName("$subscriptionType-$group-$topic", uniqueId)
+    val clientId = "$subscriptionType--$group--$topic--$uniqueId"
+    val lifecycleCoordinatorName = LifecycleCoordinatorName("$subscriptionType--$group--$topic", uniqueId)
 }


### PR DESCRIPTION
Adding distinct separators in the Kafka client Id to identify the Id segments easier.