### PR TITLE
CORE-14350: Standardise publisher clientIds for metrics traceability

### DIFF
--- a/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
+++ b/components/configuration/configuration-read-service-impl/src/main/kotlin/net/corda/configuration/read/impl/ConfigReadServiceEventHandler.kt
@@ -59,7 +59,7 @@ internal class ConfigReadServiceEventHandler(
     val publisher by lazy {
         publisherFactory.createPublisher(
             PublisherConfig(
-                "ConfigReadServiceEventHandler Avro Schema publisher", false
+                "ConfigReadServiceEventHandler_Avro_Schema_publisher", false
             ), configuration.getConfig(ConfigKeys.MESSAGING_CONFIG)
         )
     }

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/FlowMapperService.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/FlowMapperService.kt
@@ -1,5 +1,6 @@
 package net.corda.session.mapper.service
 
+import java.util.concurrent.Executors
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.flow.mapper.factory.FlowMapperEventExecutorFactory
@@ -30,7 +31,6 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
-import java.util.concurrent.Executors
 
 @Component(service = [FlowMapperService::class])
 class FlowMapperService @Activate constructor(
@@ -103,7 +103,7 @@ class FlowMapperService @Activate constructor(
                 ScheduledTaskState(
                     Executors.newSingleThreadScheduledExecutor(),
                     publisherFactory.createPublisher(
-                        PublisherConfig("$CONSUMER_GROUP-cleanup-publisher"),
+                        PublisherConfig("$CONSUMER_GROUP-cleanup-publisher", topic = FLOW_MAPPER_EVENT_TOPIC),
                         messagingConfig
                     ),
                     mutableMapOf()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/scheduler/impl/FlowWakeUpSchedulerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/scheduler/impl/FlowWakeUpSchedulerImpl.kt
@@ -1,5 +1,10 @@
 package net.corda.flow.scheduler.impl
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
 import net.corda.data.flow.event.Wakeup
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.flow.pipeline.factory.FlowRecordFactory
@@ -10,16 +15,12 @@ import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.metrics.CordaMetrics
+import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
 
 @Component(service = [FlowWakeUpScheduler::class])
 class FlowWakeUpSchedulerImpl constructor(
@@ -41,7 +42,7 @@ class FlowWakeUpSchedulerImpl constructor(
 
     override fun onConfigChange(config: Map<String, SmartConfig>) {
         publisher?.close()
-        publisher = publisherFactory.createPublisher(PublisherConfig("FlowWakeUpRestResource"), config.getConfig(MESSAGING_CONFIG))
+        publisher = publisherFactory.createPublisher(PublisherConfig("FlowWakeUpRestResource", topic = FLOW_EVENT_TOPIC), config.getConfig(MESSAGING_CONFIG))
     }
 
     override fun onPartitionSynced(states: Map<String, Checkpoint>) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/scheduler/impl/FlowWakeUpSchedulerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/scheduler/impl/FlowWakeUpSchedulerImpl.kt
@@ -42,7 +42,10 @@ class FlowWakeUpSchedulerImpl constructor(
 
     override fun onConfigChange(config: Map<String, SmartConfig>) {
         publisher?.close()
-        publisher = publisherFactory.createPublisher(PublisherConfig("FlowWakeUpRestResource", topic = FLOW_EVENT_TOPIC), config.getConfig(MESSAGING_CONFIG))
+        publisher = publisherFactory.createPublisher(
+            PublisherConfig("FlowWakeUpRestResource", topic = FLOW_EVENT_TOPIC),
+            config.getConfig(MESSAGING_CONFIG)
+        )
     }
 
     override fun onPartitionSynced(states: Map<String, Checkpoint>) {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedPublisherConfig.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedPublisherConfig.kt
@@ -1,6 +1,7 @@
 package net.corda.messaging.config
 
 import java.time.Duration
+import java.util.UUID
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
@@ -25,14 +26,17 @@ internal data class ResolvedPublisherConfig(
          * @return Concrete class containing all config values used by a publisher.
          */
         fun merge(publisherConfig: PublisherConfig, messagingConfig: SmartConfig): ResolvedPublisherConfig {
+            val transactionalFlag = if (publisherConfig.transactional) "TRANSACTIONAL" else "ASYNCHRONOUS"
+            val clientId = "$transactionalFlag--${publisherConfig.clientId}--${publisherConfig.topic}--${UUID.randomUUID()}"
             return ResolvedPublisherConfig(
-                publisherConfig.clientId,
+                clientId,
                 messagingConfig.getInt(INSTANCE_ID),
                 publisherConfig.transactional,
                 Duration.ofMillis(messagingConfig.getLong(CLOSE_TIMEOUT)),
                 messagingConfig
             )
         }
+
     }
 
     val loggerName = "PUBLISHER-$clientId"

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedPublisherConfig.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedPublisherConfig.kt
@@ -27,7 +27,12 @@ internal data class ResolvedPublisherConfig(
          */
         fun merge(publisherConfig: PublisherConfig, messagingConfig: SmartConfig): ResolvedPublisherConfig {
             val transactionalFlag = if (publisherConfig.transactional) "TRANSACTIONAL" else "ASYNCHRONOUS"
-            val clientId = "$transactionalFlag--${publisherConfig.clientId}--${publisherConfig.topic}--${UUID.randomUUID()}"
+            val origClientIdWithoutSpaces = publisherConfig.clientId.replace(
+                " ",
+                "_"
+            )
+            val clientId =
+                "$transactionalFlag--$origClientIdWithoutSpaces--${publisherConfig.topic}--${UUID.randomUUID()}"
             return ResolvedPublisherConfig(
                 clientId,
                 messagingConfig.getInt(INSTANCE_ID),

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/publisher/config/PublisherConfig.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/publisher/config/PublisherConfig.kt
@@ -4,8 +4,10 @@ package net.corda.messaging.api.publisher.config
  * Class to store the required params to create a Publisher.
  * @property clientId Is an identifier of the source of a record.
  * @property transactional True to publish records as a transaction, false to send asynchronously.
+ * @property topic If there will only be one topic that this publisher sends to then it can put in the clientId for metrics
  */
 data class PublisherConfig (
     val clientId: String,
     val transactional: Boolean = true,
+    val topic: String = "general",
 )


### PR DESCRIPTION
By having a standard we should be able to better track Kafka metrics in the cluster