### PR TITLE
CORE-14387 Added zipkin and io.micrometer to the quasar exclude list.

### DIFF
--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -23,7 +23,9 @@ quasar {
         'org.apache.**',
         'org.objectweb.asm',
         'org.objenesis**',
-        'org.osgi.**'
+        'org.osgi.**',
+        'io.zipkin.**',
+        'io.micrometer.**',
     ]
 }
 


### PR DESCRIPTION
Excludes io.zipkin and io.micrometer to the quasar exclude list to ensure they are not instrumented by quasar