### PR TITLE
CORE-14425: Create JUnit extensions for testing with CordaMetrics.

### DIFF
--- a/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCacheImplTest.kt
+++ b/components/membership/membership-group-read-impl/src/test/kotlin/net/corda/membership/impl/read/cache/MemberListCacheImplTest.kt
@@ -3,7 +3,6 @@ package net.corda.membership.impl.read.cache
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.Meter
 import io.micrometer.core.instrument.Tag as micrometerTag
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import net.corda.membership.impl.read.TestProperties.Companion.GROUP_ID_1
 import net.corda.membership.impl.read.TestProperties.Companion.GROUP_ID_2
 import net.corda.membership.impl.read.TestProperties.Companion.aliceName
@@ -14,6 +13,8 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PEND
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.metrics.CordaMetrics
+import net.corda.test.util.metrics.CORDA_METRICS_LOCK
+import net.corda.test.util.metrics.EachTestCordaMetrics
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
@@ -22,12 +23,19 @@ import org.assertj.core.api.Condition
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.parallel.ResourceLock
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import kotlin.math.roundToLong
 
+@ResourceLock(CORDA_METRICS_LOCK)
 class MemberListCacheImplTest {
     private lateinit var memberListCache: MemberListCache
+
+    @Suppress("unused")
+    @RegisterExtension
+    private val metrics = EachTestCordaMetrics("MemberList Testing")
 
     private val alice = aliceName
     private val bob = bobName
@@ -72,8 +80,6 @@ class MemberListCacheImplTest {
 
     @BeforeEach
     fun setUp() {
-        CordaMetrics.registry.clear()
-        CordaMetrics.configure("MemberList Testing", SimpleMeterRegistry())
         memberListCache = MemberListCache.Impl()
     }
 

--- a/libs/cache/cache-caffeine/src/main/kotlin/net/corda/cache/caffeine/CacheFactoryImpl.kt
+++ b/libs/cache/cache-caffeine/src/main/kotlin/net/corda/cache/caffeine/CacheFactoryImpl.kt
@@ -17,8 +17,7 @@ class CacheFactoryImpl: CacheFactory {
             .executor(SecManagerForkJoinPool.pool)
             .recordStats()
             .build()
-        CaffeineCacheMetrics.monitor(CordaMetrics.registry, cache, name)
-        return cache
+        return CaffeineCacheMetrics.monitor(CordaMetrics.registry, cache, name)
     }
 
     override fun <K, V> build(name: String, caffeine: Caffeine<in K, in V>, loader: CacheLoader<K, V>): LoadingCache<K, V> {
@@ -26,7 +25,6 @@ class CacheFactoryImpl: CacheFactory {
             .executor(SecManagerForkJoinPool.pool)
             .recordStats()
             .build(loader)
-        CaffeineCacheMetrics.monitor(CordaMetrics.registry, cache, name)
-        return cache
+        return CaffeineCacheMetrics.monitor(CordaMetrics.registry, cache, name)
     }
 }

--- a/libs/metrics/src/test/kotlin/net/corda/metrics/CordaMetricsTest.kt
+++ b/libs/metrics/src/test/kotlin/net/corda/metrics/CordaMetricsTest.kt
@@ -5,10 +5,13 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import net.corda.metrics.CordaMetrics.Tag.ContentsType
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Condition
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.ResourceLock
 import kotlin.math.roundToLong
 
+@ResourceLock("corda-metrics")
 class CordaMetricsTest {
     private val meterSourceName = "Testing"
     private val registry = SimpleMeterRegistry()
@@ -20,10 +23,15 @@ class CordaMetricsTest {
     }
 
     @BeforeEach
-    @Test
     fun setup() {
-        CordaMetrics.registry.clear()
         CordaMetrics.configure(meterSourceName, registry)
+        assertThat(CordaMetrics.registry.registries).hasSize(1)
+    }
+
+    @AfterEach
+    fun done() {
+        CordaMetrics.registry.clear()
+        CordaMetrics.registry.remove(registry)
     }
 
     @Test

--- a/testing/test-utilities/build.gradle
+++ b/testing/test-utilities/build.gradle
@@ -9,8 +9,10 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    api project(":libs:utilities")
+    api project(':libs:metrics')
+    api project(':libs:utilities')
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
+    implementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     implementation "org.mockito:mockito-core:$mockitoVersion"
     implementation project(":components:virtual-node:cpi-info-read-service")
     implementation project(":libs:virtual-node:virtual-node-info")
@@ -22,7 +24,9 @@ tasks.named('jar', Jar) {
     bundle {
         bnd '''\
 Import-Package: \
+    io.micrometer.*;resolution:=optional,\
     net.corda.*;resolution:=optional,\
+    org.junit.jupiter.*;resolution:=optional,\
     org.mockito.*;resolution:=optional,\
     *
 '''

--- a/testing/test-utilities/src/main/java/net/corda/test/util/metrics/package-info.java
+++ b/testing/test-utilities/src/main/java/net/corda/test/util/metrics/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.test.util.metrics;
+
+import org.osgi.annotation.bundle.Export;

--- a/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/AllTestsCordaMetrics.kt
+++ b/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/AllTestsCordaMetrics.kt
@@ -1,0 +1,33 @@
+package net.corda.test.util.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import net.corda.metrics.CordaMetrics
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * A JUnit extension that configures [CordaMetrics] for all tests in a given class.
+ */
+class AllTestsCordaMetrics(
+    private val workerType: String,
+    private val registry: MeterRegistry
+) : BeforeAllCallback, AfterEachCallback, AfterAllCallback {
+    constructor(workerType: String) : this(workerType, SimpleMeterRegistry())
+
+    override fun beforeAll(ctx: ExtensionContext) {
+        CordaMetrics.configure(workerType, registry)
+        assertEquals(1, CordaMetrics.registry.registries.size)
+    }
+
+    override fun afterEach(ctx: ExtensionContext) {
+        CordaMetrics.registry.clear()
+    }
+
+    override fun afterAll(ctx: ExtensionContext) {
+        CordaMetrics.registry.remove(registry)
+    }
+}

--- a/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/CordaMetrics.kt
+++ b/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/CordaMetrics.kt
@@ -1,0 +1,10 @@
+@file:JvmName("CordaMetrics")
+package net.corda.test.util.metrics
+
+/**
+ * Key value for a JUnit [ResourceLock][org.junit.jupiter.api.parallel.ResourceLock].
+ * Required by JUnit's parallel execution when running in concurrent mode:
+ * - `junit.jupiter.execution.parallel.enabled=true`
+ * - `junit.jupiter.execution.parallel.mode.default=concurrent`
+ */
+const val CORDA_METRICS_LOCK = "corda-metrics"

--- a/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/EachTestCordaMetrics.kt
+++ b/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/EachTestCordaMetrics.kt
@@ -1,0 +1,29 @@
+package net.corda.test.util.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import net.corda.metrics.CordaMetrics
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * A JUnit extension that configures [CordaMetrics] for each test in a given class.
+ */
+class EachTestCordaMetrics(
+    private val workerType: String,
+    private val registry: MeterRegistry
+) : BeforeEachCallback, AfterEachCallback {
+    constructor(workerType: String) : this(workerType, SimpleMeterRegistry())
+
+    override fun beforeEach(ctx: ExtensionContext) {
+        CordaMetrics.configure(workerType, registry)
+        assertEquals(1, CordaMetrics.registry.registries.size)
+    }
+
+    override fun afterEach(ctx: ExtensionContext) {
+        CordaMetrics.registry.clear()
+        CordaMetrics.registry.remove(registry)
+    }
+}


### PR DESCRIPTION
- Create JUnit extensions to integrate managing `CordaMetrics`  with the JUnit lifecycle.
- Use JUnit `@ResourceLock` to ensure each test has exclusive access to the global `MeterRegistry`. (`CordaMetrics` _own_ tests cannot use this extension themselves without creating a circular dependency.)
- Also tweak `SandboxGroupContextCacheTest` in attempt to resolve flaky behaviour.

---
`@ResourceLock` is only effective when used with JUnit's built-in parallel execution mode. Gradle's `--parallel` option appears to work by dividing the work-load up among separate "worker" JVMs.