### PR TITLE
CORE-14321: Reduce logging at debug level in state and event pattern

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -14,6 +14,7 @@ import net.corda.metrics.CordaMetrics
 import net.corda.schema.Schemas.getStateAndEventStateTopic
 import net.corda.tracing.wrapWithTracingExecutor
 import net.corda.utilities.debug
+import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
@@ -171,7 +172,6 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
 
     override fun pollAndUpdateStates(syncPartitions: Boolean) {
         if (stateConsumer.assignment().isEmpty()) {
-            log.debug { "State consumer has no partitions assigned." }
             return
         }
 
@@ -179,7 +179,7 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
             stateConsumer.poll(STATE_POLL_TIMEOUT)
         }
         states?.forEach { state ->
-            log.debug { "Processing state: $state" }
+            log.trace { "Processing state: $state" }
             // This condition should always be true. This can however guard against a potential race where the partition
             // is revoked while states are being processed, resulting in the partition no longer being required to sync.
             val partition = CordaTopicPartition(state.topic.removeSuffix(STATE_TOPIC_SUFFIX), state.partition)


### PR DESCRIPTION
At debug level the logs become swamped by a few state and event pattern logs in a tight loop. This PR removes one of these and reduces the levels for another to try and improve debuggability.