### PR TITLE
CORE-14335: make SigningKeyInfo.keyMaterial non-nullable

### DIFF
--- a/components/crypto/crypto-persistence/src/main/kotlin/net/corda/crypto/persistence/SigningKeyInfo.kt
+++ b/components/crypto/crypto-persistence/src/main/kotlin/net/corda/crypto/persistence/SigningKeyInfo.kt
@@ -17,7 +17,7 @@ data class SigningKeyInfo(
     val alias: String?,
     val hsmAlias: String?,
     val publicKey: ByteArray,
-    val keyMaterial: ByteArray?,
+    val keyMaterial: ByteArray,
     val schemeCodeName: String,
     val masterKeyAlias: String?,
     val externalId: String?,
@@ -39,10 +39,7 @@ data class SigningKeyInfo(
         if (alias != other.alias) return false
         if (hsmAlias != other.hsmAlias) return false
         if (!publicKey.contentEquals(other.publicKey)) return false
-        if (keyMaterial != null) {
-            if (other.keyMaterial == null) return false
-            if (!keyMaterial.contentEquals(other.keyMaterial)) return false
-        } else if (other.keyMaterial != null) return false
+        if (!keyMaterial.contentEquals(other.keyMaterial)) return false
         if (schemeCodeName != other.schemeCodeName) return false
         if (masterKeyAlias != other.masterKeyAlias) return false
         if (externalId != other.externalId) return false
@@ -62,7 +59,7 @@ data class SigningKeyInfo(
         result = 31 * result + (alias?.hashCode() ?: 0)
         result = 31 * result + (hsmAlias?.hashCode() ?: 0)
         result = 31 * result + publicKey.contentHashCode()
-        result = 31 * result + (keyMaterial?.contentHashCode() ?: 0)
+        result = 31 * result + (keyMaterial.contentHashCode())
         result = 31 * result + schemeCodeName.hashCode()
         result = 31 * result + (masterKeyAlias?.hashCode() ?: 0)
         result = 31 * result + (externalId?.hashCode() ?: 0)

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
@@ -38,7 +38,7 @@ class TestSigningRepository: SigningRepository {
             alias = context.alias,
             hsmAlias = context.key.hsmAlias,
             publicKey = encodedKey,
-            keyMaterial = null,
+            keyMaterial = byteArrayOf(),
             schemeCodeName = context.keyScheme.codeName,
             masterKeyAlias = null,
             externalId = null,

--- a/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/SigningRepositoryTest.kt
+++ b/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/SigningRepositoryTest.kt
@@ -53,7 +53,7 @@ class SigningRepositoryTest : CryptoRepositoryTest() {
     private val defaultTenantId = "Memento Mori"
     private val defaultMasterKeyName = "Domination's the name of the game"
 
-    private fun createPrivateKeyInfo(): SigningKeyInfo {
+    private fun createSigningKeyInfo(): SigningKeyInfo {
         val privKey = SecureHashUtils.randomBytes()
         val unique = UUID.randomUUID().toString()
         val key = SecureHashUtils.randomBytes()
@@ -149,7 +149,7 @@ class SigningRepositoryTest : CryptoRepositoryTest() {
 
         saveWrappingKey(emf, defaultMasterKeyName)
         val privateKeys = (0..2).map { _ ->
-            val info = createPrivateKeyInfo()
+            val info = createSigningKeyInfo()
             val ctx = createSigningWrappedKeySaveContext(info)
             repo.savePrivateKey(ctx)
         }
@@ -175,7 +175,7 @@ class SigningRepositoryTest : CryptoRepositoryTest() {
     @ParameterizedTest
     @MethodSource("emfs")
     fun `savePrivateKey and find by alias`(emf: EntityManagerFactory) {
-        val info = createPrivateKeyInfo()
+        val info = createSigningKeyInfo()
         saveWrappingKey(emf, info.masterKeyAlias!!)
 
         val ctx = createSigningWrappedKeySaveContext(info)
@@ -200,7 +200,7 @@ class SigningRepositoryTest : CryptoRepositoryTest() {
     @ParameterizedTest
     @MethodSource("emfs")
     fun `savePrivateKey twice fails`(emf: EntityManagerFactory) {
-        val info = createPrivateKeyInfo()
+        val info = createSigningKeyInfo()
         saveWrappingKey(emf, info.masterKeyAlias!!)
 
         val ctx = createSigningWrappedKeySaveContext(info)
@@ -222,7 +222,7 @@ class SigningRepositoryTest : CryptoRepositoryTest() {
     @ParameterizedTest
     @MethodSource("emfs")
     fun `save same key for 2 tenants should work`(emf: EntityManagerFactory) {
-        val info = createPrivateKeyInfo()
+        val info = createSigningKeyInfo()
         saveWrappingKey(emf, info.masterKeyAlias!!)
 
         val ctx = createSigningWrappedKeySaveContext(info)

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
@@ -268,12 +268,11 @@ fun SigningKeyEntity.joinSigningKeyInfo(em: EntityManager): SigningKeyInfo {
         "FROM ${SigningKeyMaterialEntity::class.java.simpleName} WHERE signingKeyId=:signingKeyId",
         SigningKeyMaterialEntity::class.java
     ).setParameter("signingKeyId", id)
-        .resultList.singleOrNull()
-    val wrappingKey = if (signingKeyMaterialEntity != null) {
-        em.createQuery(
-            "FROM WrappingKeyEntity WHERE id=:wrappingKeyId", WrappingKeyEntity::class.java,
-        ).setParameter("wrappingKeyId", signingKeyMaterialEntity.wrappingKeyId).resultList.singleOrNull()
-    } else null
+        .resultList.singleOrNull() ?: throw InvalidObjectException("private key material for $id not found")
+    val wrappingKey = em.createQuery(
+        "FROM WrappingKeyEntity WHERE id=:wrappingKeyId", WrappingKeyEntity::class.java
+    ).setParameter("wrappingKeyId", signingKeyMaterialEntity.wrappingKeyId).resultList.singleOrNull()
+
     return SigningKeyInfo(
         id = ShortHash.parse(keyId),
         fullId = parseSecureHash(fullKeyId),
@@ -282,7 +281,7 @@ fun SigningKeyEntity.joinSigningKeyInfo(em: EntityManager): SigningKeyInfo {
         alias = alias,
         hsmAlias = hsmAlias,
         publicKey = publicKey,
-        keyMaterial = signingKeyMaterialEntity?.keyMaterial,
+        keyMaterial = signingKeyMaterialEntity.keyMaterial,
         schemeCodeName = schemeCodeName,
         masterKeyAlias = wrappingKey?.alias,
         externalId = externalId,

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
@@ -264,11 +264,11 @@ class SigningRepositoryImpl(
 
 
 fun SigningKeyEntity.joinSigningKeyInfo(em: EntityManager): SigningKeyInfo {
-    val signingKeyMaterialEntity = em.createQuery(
+    val signingKeyMaterialEntity = requireNotNull(em.createQuery(
         "FROM ${SigningKeyMaterialEntity::class.java.simpleName} WHERE signingKeyId=:signingKeyId",
         SigningKeyMaterialEntity::class.java
     ).setParameter("signingKeyId", id)
-        .resultList.singleOrNull() ?: throw InvalidObjectException("private key material for $id not found")
+        .resultList.singleOrNull(), { "private key material for $id not found"})
     val wrappingKey = em.createQuery(
         "FROM WrappingKeyEntity WHERE id=:wrappingKeyId", WrappingKeyEntity::class.java
     ).setParameter("wrappingKeyId", signingKeyMaterialEntity.wrappingKeyId).resultList.singleOrNull()

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SharedSecretAliasSpec.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SharedSecretAliasSpec.kt
@@ -3,6 +3,7 @@ package net.corda.crypto.cipher.suite
 import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import java.security.PublicKey
 
+// TODO remove
 /**
  * Parameters for the Diffie–Hellman key agreement shared secret derivation when using the private key stored in the HSM.
  *

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SharedSecretAliasSpec.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SharedSecretAliasSpec.kt
@@ -3,7 +3,7 @@ package net.corda.crypto.cipher.suite
 import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import java.security.PublicKey
 
-// TODO remove
+// TODO this is dead code - remove it
 /**
  * Parameters for the Diffie–Hellman key agreement shared secret derivation when using the private key stored in the HSM.
  *

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SigningAliasSpec.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SigningAliasSpec.kt
@@ -21,7 +21,7 @@ class SigningAliasSpec(
     val hsmAlias: String,
     override val publicKey: PublicKey,
     override val keyScheme: KeyScheme,
-    override val signatureSpec: SignatureSpec,
+    override val signatureSpec: SignatureSpec
 ) : SigningSpec {
 
     /**

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SigningAliasSpec.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SigningAliasSpec.kt
@@ -4,7 +4,7 @@ import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import net.corda.v5.crypto.SignatureSpec
 import java.security.PublicKey
 
-// TODO remove
+// TODO this is dead code - remove it
 
 /**
  * Parameters for signing operation when using the key stored in the HSM.

--- a/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SigningAliasSpec.kt
+++ b/libs/crypto/cipher-suite/src/main/kotlin/net/corda/crypto/cipher/suite/SigningAliasSpec.kt
@@ -4,6 +4,8 @@ import net.corda.crypto.cipher.suite.schemes.KeyScheme
 import net.corda.v5.crypto.SignatureSpec
 import java.security.PublicKey
 
+// TODO remove
+
 /**
  * Parameters for signing operation when using the key stored in the HSM.
  *
@@ -19,7 +21,7 @@ class SigningAliasSpec(
     val hsmAlias: String,
     override val publicKey: PublicKey,
     override val keyScheme: KeyScheme,
-    override val signatureSpec: SignatureSpec
+    override val signatureSpec: SignatureSpec,
 ) : SigningSpec {
 
     /**


### PR DESCRIPTION
SiginingKeyInfo.keyMaterial used to be nullable, in order to support HSMs where we do not have the key material (i.e. we do not have access to an encrypted private key). Tlet's remove support for missing key material in signing key records since it can never happen in production right now with our current feature set. This is a step towards removing the HSM layers in order to squash together code in order to improve performance, 