### PR TITLE
ES-89: removed obsolete parameter of shared pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@
 
 cordaPipeline(
     dailyBuildCron: 'H H/6 * * *',
-    nexusAppId: 'flow-worker-5.0',
     runIntegrationTests: true,
     createPostgresDb: true,
     publishOSGiImage: true,


### PR DESCRIPTION
* removed obsolete `nexusAppId` parameter
* we no longer run checks with Nexus and the functionality is gone from shared pipelines

This is just a cosmetic change and it does not modify any behaviour.