### PR TITLE
CORE-11037 Read extra properties from DbConfig

### DIFF
--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -86,6 +86,10 @@ fun createDbConfig(
     jdbcUrl: String? = null,
     maxPoolSize: Int? = null,
     minPoolSize: Int? = null,
+    idleTimeout: Int,
+    maxLifetime: Int,
+    keepaliveTime: Int,
+    validationTimeout: Int,
     key: String = "database-password"
 ): SmartConfig {
     var config =
@@ -99,6 +103,11 @@ fun createDbConfig(
         config = config.withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(maxPoolSize))
     if(null != minPoolSize)
         config = config.withValue(DatabaseConfig.DB_POOL_MIN_SIZE, ConfigValueFactory.fromAnyRef(minPoolSize))
+
+    config = config.withValue(DatabaseConfig.DB_POOL_IDLE_TIMEOUT, ConfigValueFactory.fromAnyRef(idleTimeout))
+    config = config.withValue(DatabaseConfig.DB_POOL_MAX_LIFETIME, ConfigValueFactory.fromAnyRef(maxLifetime))
+    config = config.withValue(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME, ConfigValueFactory.fromAnyRef(keepaliveTime))
+    config = config.withValue(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT, ConfigValueFactory.fromAnyRef(validationTimeout))
     return config
 
 }

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -11,6 +11,7 @@ import net.corda.libs.configuration.validation.getConfigurationDefaults
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.DatabaseConfig
 import org.slf4j.LoggerFactory
+import java.time.Duration
 import javax.sql.DataSource
 
 internal object DbConfig {
@@ -39,6 +40,11 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
     } else {
         null
     }
+    val idleTimeout = configWithFallback.getInt(DatabaseConfig.DB_POOL_IDLE_TIMEOUT).toLong().run(Duration::ofSeconds)
+    val maxLifetime = configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_LIFETIME).toLong().run(Duration::ofSeconds)
+    val keepaliveTime = configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME).toLong().run(Duration::ofSeconds)
+    val validationTimeout =
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT).toLong().run(Duration::ofSeconds)
 
     val username = if (configWithFallback.hasPath(DatabaseConfig.DB_USER)) configWithFallback.getString(DatabaseConfig.DB_USER) else
         throw DBConfigurationException(
@@ -59,6 +65,10 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
         password = password,
         maximumPoolSize = maxPoolSize,
         minimumPoolSize = minPoolSize,
+        idleTimeout = idleTimeout,
+        maxLifetime = maxLifetime,
+        keepaliveTime = keepaliveTime,
+        validationTimeout = validationTimeout
     )
 }
 

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -83,24 +83,22 @@ fun createDbConfig(
     username: String,
     password: String,
     jdbcDriver: String? = null,
-    jdbcUrl: String? = null,
-    maxPoolSize: Int? = null,
-    minPoolSize: Int? = null,
+    jdbcUrl: String,
+    maxPoolSize: Int,
+    minPoolSize: Int?,
     idleTimeout: Int,
     maxLifetime: Int,
     keepaliveTime: Int,
     validationTimeout: Int,
-    key: String = "database-password"
+    key: String
 ): SmartConfig {
     var config =
         smartConfigFactory.makeSecret(password, key).atPath(DatabaseConfig.DB_PASS)
             .withValue(DatabaseConfig.DB_USER, ConfigValueFactory.fromAnyRef(username))
     if(null != jdbcDriver)
         config = config.withValue(DatabaseConfig.JDBC_DRIVER, ConfigValueFactory.fromAnyRef(jdbcDriver))
-    if(null != jdbcUrl)
-        config = config.withValue(DatabaseConfig.JDBC_URL, ConfigValueFactory.fromAnyRef(jdbcUrl))
-    if(null != maxPoolSize)
-        config = config.withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(maxPoolSize))
+    config = config.withValue(DatabaseConfig.JDBC_URL, ConfigValueFactory.fromAnyRef(jdbcUrl))
+    config = config.withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(maxPoolSize))
     if(null != minPoolSize)
         config = config.withValue(DatabaseConfig.DB_POOL_MIN_SIZE, ConfigValueFactory.fromAnyRef(minPoolSize))
 

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -35,7 +35,7 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
     val driver = configWithFallback.getString(DatabaseConfig.JDBC_DRIVER)
     val jdbcUrl = configWithFallback.getString(DatabaseConfig.JDBC_URL)
     val maxPoolSize = configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_SIZE)
-    // The below `hashPath` takes care the case where DB_POOL_MIN_SIZE is null (and not if present, it will always be present)
+    // The below `hashPath` takes care the case where DB_POOL_MIN_SIZE is null (DB_POOL_MIN_SIZE will always be present)
     val minPoolSize = if(configWithFallback.hasPath(DatabaseConfig.DB_POOL_MIN_SIZE)) {
         configWithFallback.getInt(DatabaseConfig.DB_POOL_MIN_SIZE)
     } else {

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -36,7 +36,7 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
     val driver = configWithFallback.getString(DatabaseConfig.JDBC_DRIVER)
     val jdbcUrl = configWithFallback.getString(DatabaseConfig.JDBC_URL)
     val maxPoolSize = configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_SIZE)
-    // The below `hashPath` takes care the case where DB_POOL_MIN_SIZE is null (DB_POOL_MIN_SIZE will always be present)
+    // The below "has path" takes care the case where DB_POOL_MIN_SIZE is null (DB_POOL_MIN_SIZE will always be present)
     val minPoolSize = if(configWithFallback.hasPath(DatabaseConfig.DB_POOL_MIN_SIZE)) {
         configWithFallback.getInt(DatabaseConfig.DB_POOL_MIN_SIZE)
     } else {

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -48,7 +48,7 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
     val maxLifetime =
         configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_LIFETIME).toLong().run(Duration::ofSeconds)
     val keepaliveTime =
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME).toLong().run(Duration::ofSeconds)
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEPALIVE_TIME).toLong().run(Duration::ofSeconds)
     val validationTimeout =
         configWithFallback.getInt(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT).toLong().run(Duration::ofSeconds)
 
@@ -105,7 +105,7 @@ fun createDbConfig(
 
     config = config.withValue(DatabaseConfig.DB_POOL_IDLE_TIMEOUT, ConfigValueFactory.fromAnyRef(idleTimeout))
     config = config.withValue(DatabaseConfig.DB_POOL_MAX_LIFETIME, ConfigValueFactory.fromAnyRef(maxLifetime))
-    config = config.withValue(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME, ConfigValueFactory.fromAnyRef(keepaliveTime))
+    config = config.withValue(DatabaseConfig.DB_POOL_KEEPALIVE_TIME, ConfigValueFactory.fromAnyRef(keepaliveTime))
     config = config.withValue(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT, ConfigValueFactory.fromAnyRef(validationTimeout))
     return config
 

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -32,40 +32,24 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
     DbConfig.log.debug("Given configuration: ${config.toSafeConfig().root().render(ConfigRenderOptions.concise())}")
     DbConfig.log.debug("Fallback configuration: ${dbFallbackConfig.root().render(ConfigRenderOptions.concise())}")
 
-    // TODO all the following configuration reading should probably be changed to mandatory (i.e. throw if not found),
-    //  since, with the config defaulting process it should all be there.
     val driver = configWithFallback.getString(DatabaseConfig.JDBC_DRIVER)
     val jdbcUrl = configWithFallback.getString(DatabaseConfig.JDBC_URL)
     val maxPoolSize = configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_SIZE)
+    // The below `hashPath` takes care the case where DB_POOL_MIN_SIZE is null (and not if present, it will always be present)
     val minPoolSize = if(configWithFallback.hasPath(DatabaseConfig.DB_POOL_MIN_SIZE)) {
         configWithFallback.getInt(DatabaseConfig.DB_POOL_MIN_SIZE)
     } else {
         null
     }
 
-    val idleTimeout = if (configWithFallback.hasPath(DatabaseConfig.DB_POOL_IDLE_TIMEOUT)) {
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_IDLE_TIMEOUT)
-    } else {
-        120
-    }.toLong().run(Duration::ofSeconds)
-
-    val maxLifetime = if (configWithFallback.hasPath(DatabaseConfig.DB_POOL_MAX_LIFETIME)) {
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_LIFETIME)
-    } else {
-        1800
-    }.toLong().run(Duration::ofSeconds)
-
-    val keepaliveTime = if (configWithFallback.hasPath(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME)) {
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME)
-    } else {
-        0
-    }.toLong().run(Duration::ofSeconds)
-
-    val validationTimeout = if (configWithFallback.hasPath(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT)) {
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT)
-    } else {
-        5
-    }.toLong().run(Duration::ofSeconds)
+    val idleTimeout =
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_IDLE_TIMEOUT).toLong().run(Duration::ofSeconds)
+    val maxLifetime =
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_LIFETIME).toLong().run(Duration::ofSeconds)
+    val keepaliveTime =
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME).toLong().run(Duration::ofSeconds)
+    val validationTimeout =
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT).toLong().run(Duration::ofSeconds)
 
     val username = if (configWithFallback.hasPath(DatabaseConfig.DB_USER)) configWithFallback.getString(DatabaseConfig.DB_USER) else
         throw DBConfigurationException(

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -27,6 +27,7 @@ val dbFallbackConfig = getConfigurationDefaults(ConfigKeys.DB_CONFIG, DB_SCHEMA_
  * @throws DBConfigurationException If required configuration attributes are missing.
  */
 fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource {
+    // We are falling back to the (same) defaults from the schema for both cluster and VNode datasource configurations
     val configWithFallback = config.withFallback(dbFallbackConfig)
 
     DbConfig.log.debug("Given configuration: ${config.toSafeConfig().root().render(ConfigRenderOptions.concise())}")

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -32,6 +32,8 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
     DbConfig.log.debug("Given configuration: ${config.toSafeConfig().root().render(ConfigRenderOptions.concise())}")
     DbConfig.log.debug("Fallback configuration: ${dbFallbackConfig.root().render(ConfigRenderOptions.concise())}")
 
+    // TODO all the following configuration reading should probably be changed to mandatory (i.e. throw if not found),
+    //  since, with the config defaulting process it should all be there.
     val driver = configWithFallback.getString(DatabaseConfig.JDBC_DRIVER)
     val jdbcUrl = configWithFallback.getString(DatabaseConfig.JDBC_URL)
     val maxPoolSize = configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_SIZE)
@@ -40,11 +42,30 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
     } else {
         null
     }
-    val idleTimeout = configWithFallback.getInt(DatabaseConfig.DB_POOL_IDLE_TIMEOUT).toLong().run(Duration::ofSeconds)
-    val maxLifetime = configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_LIFETIME).toLong().run(Duration::ofSeconds)
-    val keepaliveTime = configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME).toLong().run(Duration::ofSeconds)
-    val validationTimeout =
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT).toLong().run(Duration::ofSeconds)
+
+    val idleTimeout = if (configWithFallback.hasPath(DatabaseConfig.DB_POOL_IDLE_TIMEOUT)) {
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_IDLE_TIMEOUT)
+    } else {
+        120
+    }.toLong().run(Duration::ofSeconds)
+
+    val maxLifetime = if (configWithFallback.hasPath(DatabaseConfig.DB_POOL_MAX_LIFETIME)) {
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_LIFETIME)
+    } else {
+        1800
+    }.toLong().run(Duration::ofSeconds)
+
+    val keepaliveTime = if (configWithFallback.hasPath(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME)) {
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME)
+    } else {
+        0
+    }.toLong().run(Duration::ofSeconds)
+
+    val validationTimeout = if (configWithFallback.hasPath(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT)) {
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT)
+    } else {
+        5
+    }.toLong().run(Duration::ofSeconds)
 
     val username = if (configWithFallback.hasPath(DatabaseConfig.DB_USER)) configWithFallback.getString(DatabaseConfig.DB_USER) else
         throw DBConfigurationException(

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConfig.kt
@@ -44,13 +44,13 @@ fun DataSourceFactory.createFromConfig(config: SmartConfig): CloseableDataSource
     }
 
     val idleTimeout =
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_IDLE_TIMEOUT).toLong().run(Duration::ofSeconds)
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_IDLE_TIMEOUT_SECONDS).toLong().run(Duration::ofSeconds)
     val maxLifetime =
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_LIFETIME).toLong().run(Duration::ofSeconds)
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_MAX_LIFETIME_SECONDS).toLong().run(Duration::ofSeconds)
     val keepaliveTime =
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEPALIVE_TIME).toLong().run(Duration::ofSeconds)
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_KEEPALIVE_TIME_SECONDS).toLong().run(Duration::ofSeconds)
     val validationTimeout =
-        configWithFallback.getInt(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT).toLong().run(Duration::ofSeconds)
+        configWithFallback.getInt(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT_SECONDS).toLong().run(Duration::ofSeconds)
 
     val username = if (configWithFallback.hasPath(DatabaseConfig.DB_USER)) configWithFallback.getString(DatabaseConfig.DB_USER) else
         throw DBConfigurationException(
@@ -103,10 +103,10 @@ fun createDbConfig(
     if(null != minPoolSize)
         config = config.withValue(DatabaseConfig.DB_POOL_MIN_SIZE, ConfigValueFactory.fromAnyRef(minPoolSize))
 
-    config = config.withValue(DatabaseConfig.DB_POOL_IDLE_TIMEOUT, ConfigValueFactory.fromAnyRef(idleTimeout))
-    config = config.withValue(DatabaseConfig.DB_POOL_MAX_LIFETIME, ConfigValueFactory.fromAnyRef(maxLifetime))
-    config = config.withValue(DatabaseConfig.DB_POOL_KEEPALIVE_TIME, ConfigValueFactory.fromAnyRef(keepaliveTime))
-    config = config.withValue(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT, ConfigValueFactory.fromAnyRef(validationTimeout))
+    config = config.withValue(DatabaseConfig.DB_POOL_IDLE_TIMEOUT_SECONDS, ConfigValueFactory.fromAnyRef(idleTimeout))
+    config = config.withValue(DatabaseConfig.DB_POOL_MAX_LIFETIME_SECONDS, ConfigValueFactory.fromAnyRef(maxLifetime))
+    config = config.withValue(DatabaseConfig.DB_POOL_KEEPALIVE_TIME_SECONDS, ConfigValueFactory.fromAnyRef(keepaliveTime))
+    config = config.withValue(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT_SECONDS, ConfigValueFactory.fromAnyRef(validationTimeout))
     return config
 
 }

--- a/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
+++ b/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
@@ -52,7 +52,7 @@ class DbConfigTest {
         ${DatabaseConfig.DB_POOL_MIN_SIZE}=null
         ${DatabaseConfig.DB_POOL_IDLE_TIMEOUT}=$idleTimeout
         ${DatabaseConfig.DB_POOL_MAX_LIFETIME}=$maxLifetime
-        ${DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME}=$keepaliveTime
+        ${DatabaseConfig.DB_POOL_KEEPALIVE_TIME}=$keepaliveTime
         ${DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT}=$validationTimeout
     """.trimIndent()
     private val fullSmartConfig = SmartConfigImpl(

--- a/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
+++ b/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
@@ -8,7 +8,6 @@ import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.libs.configuration.secret.SecretsLookupService
 import net.corda.schema.configuration.DatabaseConfig
-import net.corda.schema.configuration.DatabaseConfig.DB_POOL_MIN_SIZE
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -16,6 +15,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import java.time.Duration
 
 class DbConfigTest {
     companion object {
@@ -38,6 +38,11 @@ class DbConfigTest {
     private val url = "url"
     private val poolsize = 987
     private val minPoolSize = 5
+    private val idleTimeout = 120
+    private val maxLifetime = 1800
+    private val keepaliveTime = 0
+    private val validationTimeout = 5
+
     private val fullConfig = """
         ${DatabaseConfig.JDBC_DRIVER}=$driver
         ${DatabaseConfig.JDBC_URL}=$url
@@ -45,6 +50,10 @@ class DbConfigTest {
         ${DatabaseConfig.DB_USER}=$user
         ${DatabaseConfig.DB_PASS}=$pass
         ${DatabaseConfig.DB_POOL_MIN_SIZE}=null
+        ${DatabaseConfig.DB_POOL_IDLE_TIMEOUT}=$idleTimeout
+        ${DatabaseConfig.DB_POOL_MAX_LIFETIME}=$maxLifetime
+        ${DatabaseConfig.DB_POOL_KEEP_ALIVE_TIME}=$keepaliveTime
+        ${DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT}=$validationTimeout
     """.trimIndent()
     private val fullSmartConfig = SmartConfigImpl(
         ConfigFactory.parseString(fullConfig),
@@ -73,8 +82,15 @@ class DbConfigTest {
             password = pass,
             maximumPoolSize = poolsize,
             minimumPoolSize = null,
+            idleTimeout = durationOfSeconds(idleTimeout),
+            maxLifetime = durationOfSeconds(maxLifetime),
+            keepaliveTime = durationOfSeconds(keepaliveTime),
+            validationTimeout = durationOfSeconds(validationTimeout)
         )
     }
+
+    private fun durationOfSeconds(duration: Int) =
+        Duration.ofSeconds(duration.toLong())
 
     @Test
     fun `when default config return datasource`() {
@@ -93,7 +109,7 @@ class DbConfigTest {
     @Test
     fun `when minimum pull size exists, the createFromConfig will read it`() {
         val configWithMin = minimalSmartConfig.withValue(
-            DB_POOL_MIN_SIZE,
+            DatabaseConfig.DB_POOL_MIN_SIZE,
             ConfigValueFactory.fromAnyRef(minPoolSize),
         )
 

--- a/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
+++ b/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
@@ -91,7 +91,7 @@ class DbConfigTest {
     }
 
     @Test
-    fun `when minimum pull size exsits, the createFromConfig will read it`() {
+    fun `when minimum pull size exists, the createFromConfig will read it`() {
         val configWithMin = minimalSmartConfig.withValue(
             DB_POOL_MIN_SIZE,
             ConfigValueFactory.fromAnyRef(minPoolSize),

--- a/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
+++ b/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
@@ -103,6 +103,10 @@ class DbConfigTest {
             pass,
             maximumPoolSize = DB_POOL_MAX_SIZE,
             minimumPoolSize = null,
+            idleTimeout = durationOfSeconds(idleTimeout),
+            maxLifetime = durationOfSeconds(maxLifetime),
+            keepaliveTime = durationOfSeconds(keepaliveTime),
+            validationTimeout = durationOfSeconds(validationTimeout)
         )
     }
 
@@ -122,6 +126,10 @@ class DbConfigTest {
             pass,
             maximumPoolSize = DB_POOL_MAX_SIZE,
             minimumPoolSize = minPoolSize,
+            idleTimeout = durationOfSeconds(idleTimeout),
+            maxLifetime = durationOfSeconds(maxLifetime),
+            keepaliveTime = durationOfSeconds(keepaliveTime),
+            validationTimeout = durationOfSeconds(validationTimeout)
         )
     }
 

--- a/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
+++ b/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
@@ -166,7 +166,8 @@ class DbConfigTest {
             idleTimeout = 0,
             maxLifetime = 0,
             keepaliveTime = 0,
-            validationTimeout = 0)
+            validationTimeout = 0,
+            key = "database-password")
 
         assertThat(createdConfig.getString(DatabaseConfig.DB_USER)).isEqualTo(user)
         assertThat(createdConfig.getConfig(DatabaseConfig.DB_PASS)).isEqualTo(secretConfig)
@@ -185,45 +186,15 @@ class DbConfigTest {
             pass,
             jdbcUrl = url,
             maxPoolSize = poolsize,
+            minPoolSize = null,
             idleTimeout = 0,
             maxLifetime = 0,
             keepaliveTime = 0,
-            validationTimeout = 0
+            validationTimeout = 0,
+            key = "database-password"
         )
 
         assertThat(createdConfig.hasPath(DatabaseConfig.JDBC_DRIVER)).isFalse
-    }
-
-    @Test
-    fun `when createDbConfig leave default url empty`() {
-        val createdConfig = createDbConfig(
-            smartConfigFactory,
-            user,
-            pass,
-            jdbcDriver = driver,
-            maxPoolSize = poolsize,
-            idleTimeout = 0,
-            maxLifetime = 0,
-            keepaliveTime = 0,
-            validationTimeout = 0)
-
-        assertThat(createdConfig.hasPath(DatabaseConfig.JDBC_URL)).isFalse
-    }
-
-    @Test
-    fun `when createDbConfig leave default poolsize empty`() {
-        val createdConfig = createDbConfig(
-            smartConfigFactory,
-            user,
-            pass,
-            jdbcUrl = url,
-            jdbcDriver = driver,
-            idleTimeout = 0,
-            maxLifetime = 0,
-            keepaliveTime = 0,
-            validationTimeout = 0)
-
-        assertThat(createdConfig.hasPath(DatabaseConfig.DB_POOL_MAX_SIZE)).isFalse
     }
 
     @Test
@@ -233,11 +204,14 @@ class DbConfigTest {
             user,
             pass,
             jdbcUrl = url,
+            maxPoolSize = poolsize,
+            minPoolSize = null,
             jdbcDriver = driver,
             idleTimeout = 0,
             maxLifetime = 0,
             keepaliveTime = 0,
-            validationTimeout = 0)
+            validationTimeout = 0,
+            key = "database-password")
 
         assertThat(createdConfig.hasPath(DatabaseConfig.DB_POOL_MIN_SIZE)).isFalse
     }

--- a/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
+++ b/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
@@ -50,10 +50,10 @@ class DbConfigTest {
         ${DatabaseConfig.DB_USER}=$user
         ${DatabaseConfig.DB_PASS}=$pass
         ${DatabaseConfig.DB_POOL_MIN_SIZE}=null
-        ${DatabaseConfig.DB_POOL_IDLE_TIMEOUT}=$idleTimeout
-        ${DatabaseConfig.DB_POOL_MAX_LIFETIME}=$maxLifetime
-        ${DatabaseConfig.DB_POOL_KEEPALIVE_TIME}=$keepaliveTime
-        ${DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT}=$validationTimeout
+        ${DatabaseConfig.DB_POOL_IDLE_TIMEOUT_SECONDS}=$idleTimeout
+        ${DatabaseConfig.DB_POOL_MAX_LIFETIME_SECONDS}=$maxLifetime
+        ${DatabaseConfig.DB_POOL_KEEPALIVE_TIME_SECONDS}=$keepaliveTime
+        ${DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT_SECONDS}=$validationTimeout
     """.trimIndent()
     private val fullSmartConfig = SmartConfigImpl(
         ConfigFactory.parseString(fullConfig),

--- a/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
+++ b/components/db/db-connection-manager/src/test/kotlin/DbConfigTest.kt
@@ -155,7 +155,18 @@ class DbConfigTest {
 
     @Test
     fun `when createDbConfig can be read`() {
-        val createdConfig = createDbConfig(smartConfigFactory, user, pass, driver, url, poolsize, minPoolSize)
+        val createdConfig = createDbConfig(
+            smartConfigFactory,
+            user,
+            pass,
+            driver,
+            url,
+            poolsize,
+            minPoolSize,
+            idleTimeout = 0,
+            maxLifetime = 0,
+            keepaliveTime = 0,
+            validationTimeout = 0)
 
         assertThat(createdConfig.getString(DatabaseConfig.DB_USER)).isEqualTo(user)
         assertThat(createdConfig.getConfig(DatabaseConfig.DB_PASS)).isEqualTo(secretConfig)
@@ -168,28 +179,65 @@ class DbConfigTest {
 
     @Test
     fun `when createDbConfig leave default driver empty`() {
-        val createdConfig = createDbConfig(smartConfigFactory, user, pass, jdbcUrl = url, maxPoolSize = poolsize)
+        val createdConfig = createDbConfig(
+            smartConfigFactory,
+            user,
+            pass,
+            jdbcUrl = url,
+            maxPoolSize = poolsize,
+            idleTimeout = 0,
+            maxLifetime = 0,
+            keepaliveTime = 0,
+            validationTimeout = 0
+        )
 
         assertThat(createdConfig.hasPath(DatabaseConfig.JDBC_DRIVER)).isFalse
     }
 
     @Test
     fun `when createDbConfig leave default url empty`() {
-        val createdConfig = createDbConfig(smartConfigFactory, user, pass, jdbcDriver = driver, maxPoolSize = poolsize)
+        val createdConfig = createDbConfig(
+            smartConfigFactory,
+            user,
+            pass,
+            jdbcDriver = driver,
+            maxPoolSize = poolsize,
+            idleTimeout = 0,
+            maxLifetime = 0,
+            keepaliveTime = 0,
+            validationTimeout = 0)
 
         assertThat(createdConfig.hasPath(DatabaseConfig.JDBC_URL)).isFalse
     }
 
     @Test
     fun `when createDbConfig leave default poolsize empty`() {
-        val createdConfig = createDbConfig(smartConfigFactory, user, pass, jdbcUrl = url, jdbcDriver = driver, )
+        val createdConfig = createDbConfig(
+            smartConfigFactory,
+            user,
+            pass,
+            jdbcUrl = url,
+            jdbcDriver = driver,
+            idleTimeout = 0,
+            maxLifetime = 0,
+            keepaliveTime = 0,
+            validationTimeout = 0)
 
         assertThat(createdConfig.hasPath(DatabaseConfig.DB_POOL_MAX_SIZE)).isFalse
     }
 
     @Test
     fun `when createDbConfig leave default min pool size empty`() {
-        val createdConfig = createDbConfig(smartConfigFactory, user, pass, jdbcUrl = url, jdbcDriver = driver, )
+        val createdConfig = createDbConfig(
+            smartConfigFactory,
+            user,
+            pass,
+            jdbcUrl = url,
+            jdbcDriver = driver,
+            idleTimeout = 0,
+            maxLifetime = 0,
+            keepaliveTime = 0,
+            validationTimeout = 0)
 
         assertThat(createdConfig.hasPath(DatabaseConfig.DB_POOL_MIN_SIZE)).isFalse
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -169,7 +169,9 @@ internal class VirtualNodeDbFactoryImpl(
 
             // TODO support for CharArray passwords in SmartConfig
             val config = createDbConfig(
-                smartConfigFactory, user, password.concatToString(),
+                smartConfigFactory,
+                user,
+                password.concatToString(),
                 jdbcUrl = jdbcUrl,
                 maxPoolSize = maxPoolSize,
                 minPoolSize = minPoolSize,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -30,6 +30,10 @@ internal class VirtualNodeDbFactoryImpl(
         private const val ddlMaxPoolSize = 1
         private const val dmlMaxPoolSize = 10
         private const val dmlMinPoolSize = 0
+        private const val idleTimeout = 120
+        private const val maxLifetime = 1800 // 30 mins
+        private const val keepaliveTime = 0
+        private const val validationTimeout = 5
         private const val passwordLength = 64
         private val passwordSource = (('0'..'9') + ('A'..'Z') + ('a'..'z')).toCharArray()
         private val random = SecureRandom()
@@ -175,6 +179,10 @@ internal class VirtualNodeDbFactoryImpl(
                 jdbcUrl = jdbcUrl,
                 maxPoolSize = maxPoolSize,
                 minPoolSize = minPoolSize,
+                idleTimeout = idleTimeout,
+                maxLifetime = maxLifetime,
+                keepaliveTime = keepaliveTime,
+                validationTimeout = validationTimeout,
                 key = "corda-vault-$holdingIdentityShortHash-database-password"
             )
             return DbConnectionImpl(

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.5-beta+
+cordaApiVersion=5.1.0.5-alpha-1686303757878
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,7 +43,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-#cordaApiVersion=5.0.0.xxx-SNAPSHOT
+#cordaApiVersion=5.1.0.xxx-SNAPSHOT
 cordaApiVersion=5.1.0.5-beta+
 
 disruptorVersion=3.4.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.5-alpha-1686303757878
+cordaApiVersion=5.1.0.5-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/db/db-core/src/integrationTest/kotlin/net/corda/db/core/HikariDataSourceFactoryTest.kt
+++ b/libs/db/db-core/src/integrationTest/kotlin/net/corda/db/core/HikariDataSourceFactoryTest.kt
@@ -28,6 +28,11 @@ class HikariDataSourceFactoryTest {
             username = "postgres",
             password = "password",
             maximumPoolSize = 1,
+            minimumPoolSize = null,
+            idleTimeout = Duration.ofMinutes(2),
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         )
     }
     private val monitorPool by monitorPoolDelegate
@@ -52,7 +57,10 @@ class HikariDataSourceFactoryTest {
             password = "password",
             maximumPoolSize = maxConnections,
             minimumPoolSize = minConnections,
-            idleTimeout = idleTimeout
+            idleTimeout = idleTimeout,
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         ).use { hf ->
             val connections1 = checkConnections()
             println("Pool has $connections1 connections.")

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
@@ -30,7 +30,6 @@ interface DataSourceFactory {
      * @param validationTimeout maximum amount of time that a connection will be tested for aliveness. Default - 5 seconds.
      */
     @Suppress("LongParameterList")
-    // TODO I understand the default config now always comes from `SmartConfig` so perhaps all the below defaults should be removed now
     fun create(
         driverClass: String,
         jdbcUrl: String,

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
@@ -30,6 +30,7 @@ interface DataSourceFactory {
      * @param validationTimeout maximum amount of time that a connection will be tested for aliveness. Default - 5 seconds.
      */
     @Suppress("LongParameterList")
+    // TODO I understand the default config now always comes from `SmartConfig` so perhaps all the below defaults should be removed now
     fun create(
         driverClass: String,
         jdbcUrl: String,

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/DataSourceFactory.kt
@@ -37,11 +37,11 @@ interface DataSourceFactory {
         password: String,
         isAutoCommit: Boolean = false,
         isReadOnly: Boolean = false,
-        maximumPoolSize: Int = 10,
-        minimumPoolSize: Int? = null,
-        idleTimeout: Duration = Duration.ofMinutes(2),
-        maxLifetime: Duration = Duration.ofMinutes(30),
-        keepaliveTime: Duration = Duration.ZERO,
-        validationTimeout: Duration = Duration.ofSeconds(5),
+        maximumPoolSize: Int,
+        minimumPoolSize: Int?,
+        idleTimeout: Duration,
+        maxLifetime: Duration,
+        keepaliveTime: Duration,
+        validationTimeout: Duration,
     ): CloseableDataSource
 }

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/InMemoryDataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/InMemoryDataSourceFactory.kt
@@ -1,5 +1,7 @@
 package net.corda.db.core
 
+import java.time.Duration
+
 class InMemoryDataSourceFactory(
     private val datasourceFactory: DataSourceFactory = HikariDataSourceFactory()
 ) {
@@ -8,7 +10,13 @@ class InMemoryDataSourceFactory(
             "org.hsqldb.jdbc.JDBCDriver",
             "jdbc:hsqldb:mem:$dbName",
             "sa",
-            ""
+            "",
+            maximumPoolSize = 10,
+            minimumPoolSize = null,
+            idleTimeout = Duration.ofMinutes(2),
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         )
     }
 }

--- a/libs/db/db-core/src/main/kotlin/net/corda/db/core/PostgresDataSourceFactory.kt
+++ b/libs/db/db-core/src/main/kotlin/net/corda/db/core/PostgresDataSourceFactory.kt
@@ -1,5 +1,7 @@
 package net.corda.db.core
 
+import java.time.Duration
+
 class PostgresDataSourceFactory(
     private val datasourceFactory: DataSourceFactory = HikariDataSourceFactory()
 ) {
@@ -14,8 +16,12 @@ class PostgresDataSourceFactory(
             jdbcUrl = jdbcUrl,
             username = username,
             password = password,
-            minimumPoolSize = 1,
             maximumPoolSize = maximumPoolSize,
+            minimumPoolSize = 1,
+            idleTimeout = Duration.ofMinutes(2),
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         )
     }
 }

--- a/libs/db/db-core/src/test/kotlin/net/corda/db/core/HikariDataSourceFactoryTest.kt
+++ b/libs/db/db-core/src/test/kotlin/net/corda/db/core/HikariDataSourceFactoryTest.kt
@@ -15,33 +15,43 @@ class HikariDataSourceFactoryTest {
     }
 
     @Test
-    fun `create will not set the minimumIdle if not set`() {
+    fun `create will set minimumIdle to maximumPoolSize if minimumPoolSize is set to null`() {
         factory.create(
             driverClass = HikariDataSourceFactoryTest::class.java.name,
             jdbcUrl = "url",
             username = "user",
             password = "password",
             maximumPoolSize = 44,
+            minimumPoolSize = null,
+            idleTimeout = Duration.ofMinutes(2),
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         )
 
         assertThat(hikariConfig?.minimumIdle).isEqualTo(44)
     }
 
     @Test
-    fun `create will set the minimumIdle if set`() {
+    fun `create will set the minimumIdle if minimumPoolSize is set`() {
         factory.create(
             driverClass = HikariDataSourceFactoryTest::class.java.name,
             jdbcUrl = "url",
             username = "user",
             password = "password",
             minimumPoolSize = 3,
+            maximumPoolSize = 10,
+            idleTimeout = Duration.ofMinutes(2),
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         )
 
         assertThat(hikariConfig?.minimumIdle).isEqualTo(3)
     }
 
     @Test
-    fun `create will not set the idleTimeout if minimumPoolSize is not defined`() {
+    fun `create will not set the idleTimeout if minimumPoolSize is not set`() {
         factory.create(
             driverClass = HikariDataSourceFactoryTest::class.java.name,
             jdbcUrl = "url",
@@ -49,13 +59,17 @@ class HikariDataSourceFactoryTest {
             password = "password",
             maximumPoolSize = 21,
             idleTimeout = Duration.ofDays(2),
+            minimumPoolSize = null,
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         )
 
         assertThat(hikariConfig?.idleTimeout).isEqualTo(0)
     }
 
     @Test
-    fun `create will not set the idleTimeout if minimumPoolSize the same as maximumPoolSize`() {
+    fun `create will not set the idleTimeout if minimumPoolSize is set to be the same as maximumPoolSize`() {
         factory.create(
             driverClass = HikariDataSourceFactoryTest::class.java.name,
             jdbcUrl = "url",
@@ -64,6 +78,9 @@ class HikariDataSourceFactoryTest {
             maximumPoolSize = 21,
             minimumPoolSize = 21,
             idleTimeout = Duration.ofDays(2),
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         )
 
         assertThat(hikariConfig?.idleTimeout).isEqualTo(0)
@@ -79,6 +96,9 @@ class HikariDataSourceFactoryTest {
             maximumPoolSize = 21,
             minimumPoolSize = 1,
             idleTimeout = Duration.ofDays(2),
+            maxLifetime = Duration.ofMinutes(30),
+            keepaliveTime = Duration.ZERO,
+            validationTimeout = Duration.ofSeconds(5),
         )
 
         assertThat(hikariConfig?.idleTimeout).isEqualTo(Duration.ofDays(2).toMillis())


### PR DESCRIPTION
* Reads the following datasource properties from configuration on datasources creation:

  *  idle timeout
  *  max lifetime
  *  keepalive time
  *  validation timeout

* Adds the above datasource properties to VNode datasource configuration with hardcoded values

* Makes datasource parameters not optional now that they are always passed in, in prod path(s)