### PR TITLE
CORE-14504: Upgrade to Bndlib 6.4.1.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,7 @@ plugins {
 def constants = new Properties()
 file("$rootDir/../gradle.properties").withInputStream { InputStream input -> constants.load(input) }
 def bndVersion = constants.getProperty('bndVersion')
+def bndlibVersion = constants.getProperty('bndlibVersion')
 def artifactoryContextUrl = constants.getProperty('artifactoryContextUrl')
 def jibCoreVersion = constants.getProperty('jibCoreVersion')
 def internalPublishVersion = constants.getProperty('internalPublishVersion')
@@ -14,8 +15,20 @@ def gradleEnterpriseVersion = constants.getProperty('gradleEnterpriseVersion')
 def log4jVersion = constants.getProperty('log4jVersion')
 
 dependencies {
+    constraints {
+        implementation('biz.aQute.bnd:biz.aQute.bnd.embedded-repo') {
+            version {
+                require bndlibVersion
+            }
+        }
+        implementation('biz.aQute.bnd:biz.aQute.resolve') {
+            version {
+                require bndlibVersion
+            }
+        }
+    }
     implementation "biz.aQute.bnd:biz.aQute.bnd.gradle:$bndVersion"
-    implementation "biz.aQute.bnd:biz.aQute.bndlib:$bndVersion"
+    implementation "biz.aQute.bnd:biz.aQute.bndlib:$bndlibVersion"
 
     implementation "com.google.cloud.tools:jib-core:$jibCoreVersion"
     implementation "com.gradle:gradle-enterprise-gradle-plugin:$gradleEnterpriseVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,7 @@ cordaRuntimeRevision=0
 
 # Plugin dependency versions
 bndVersion=6.4.0
+bndlibVersion=6.4.1
 cordaGradlePluginsVersion=7.0.3
 detektPluginVersion=1.22.+
 internalPublishVersion=1.+

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
+    compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndlibVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-application"

--- a/libs/serialization/serialization-encoding/build.gradle
+++ b/libs/serialization/serialization-encoding/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations'
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
+    compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndlibVersion"
     compileOnly "org.iq80.snappy:snappy:$snappyVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")

--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndVersion"
+    compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndlibVersion"
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")


### PR DESCRIPTION
Bndlib 6.4.1 has been released, although the latest version of the Bnd Gradle plugin is still 6.4.0.