### PR TITLE
CORE-14543 Remove unused client side percentile metrics

### DIFF
--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -828,7 +828,6 @@ object CordaMetrics {
 
     private fun timer(name: String, tags: Iterable<micrometerTag>): Timer {
         return Timer.builder(name)
-            .publishPercentiles(0.50, 0.95, 0.99)
             .publishPercentileHistogram()
             .tags(tags)
             .register(registry)


### PR DESCRIPTION
Remove usage of `publishPercentiles` in favor of the recently added call to `publishPercentileHistogram`. 

For reference: https://github.com/corda/corda-runtime-os/commit/3824622b8ffd75095cbb60528e79b37b7a52980e