### PR TITLE
CORE-14544: Upgrade Kotlin Metadata 0.6.1 -> 0.6.2.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ artifactoryContextUrl=https://software.r3.com/artifactory
 kotlin.code.style=official
 kotlinVersion=1.8.21
 kotlin.stdlib.default.dependency=false
-kotlinMetadataVersion=0.6.1
+kotlinMetadataVersion=0.6.2
 
 org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8


### PR DESCRIPTION
JetBrains has released [Kotlin Metdata 0.6.2](https://github.com/JetBrains/kotlin/blob/master/libraries/kotlinx-metadata/jvm/ChangeLog.md) with the following note:

> 0.6.1 was released with incorrect fix for this problem. Do not use 0.6.1.
