### PR TITLE
CORE-14076 Return 409 error code when trying to suspend an already suspended member

### DIFF
--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/SuspensionActivationEntityOperations.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/SuspensionActivationEntityOperations.kt
@@ -43,14 +43,16 @@ internal class SuspensionActivationEntityOperations(
             )
         }
         expectedSerial?.let {
-            require(member.serialNumber == it) {
+            if(member.serialNumber != it) {
                 throw InvalidEntityUpdateException(
-                    "The provided serial number '$expectedSerial' does not match the current version '${member.serialNumber}' of " +
-                        "MemberInfo for member '$memberName'.")
+                    "The provided serial number '$expectedSerial' does not match the current version " +
+                            "'${member.serialNumber}' of MemberInfo for member '$memberName'.")
             }
         }
-        require(member.status == expectedStatus) {
-            "This action cannot be performed on member '$memberName' because it has status '${member.status}'."
+        if(member.status != expectedStatus) {
+            throw InvalidEntityUpdateException(
+                "This action cannot be performed on member '$memberName' because it has status '${member.status}'."
+            )
         }
         return member
     }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/SuspensionActivationEntityOperationsTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/SuspensionActivationEntityOperationsTest.kt
@@ -136,7 +136,7 @@ class SuspensionActivationEntityOperationsTest {
     }
 
     @Test
-    fun `findMember throws an IllegalArgumentException if status is different from expected`() {
+    fun `findMember throws an InvalidEntityUpdateException if status is different from expected`() {
         val currentStatus = "Status"
         val expectedStatus = "expected"
         val mockEntity = mock<MemberInfoEntity> {
@@ -147,7 +147,7 @@ class SuspensionActivationEntityOperationsTest {
             em.find(eq(MemberInfoEntity::class.java), eq(primaryKey), eq(LockModeType.PESSIMISTIC_WRITE))
         ).doReturn(mockEntity)
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<InvalidEntityUpdateException> {
             handler.findMember(em, knownX500Name.toString(), knownGroupId, null, expectedStatus)
         }.apply {
             assertThat(this.message).contains("cannot be performed")


### PR DESCRIPTION
This PR corrects the exception thrown when trying to update the status of a member who is already in that status. 