### PR TITLE
CORE-8808 Fix error code in Certificates API

### DIFF
--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificatesRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificatesRestResource.kt
@@ -154,14 +154,14 @@ interface CertificatesRestResource : RestResource {
     )
 
     /**
-     * The [getCertificateAliases] method enables you to get the virtual node certificate aliases..
+     * The [getCertificateAliases] method enables you to get the virtual node certificate aliases.
      *
      * @param usage The certificate usage. Can be:
      *     * 'p2p-tls' for a TLS certificate to be used in P2P communication.
      *     * 'p2p-session' for a session certificate to be used in P2P communication.
      *     * 'rest-tls' for a TLS certificate to be used in REST communication.
      *     * 'code-signer' for a certificate of the code signing service
-     * @param holdingIdentityId The holding identity of the virtual node that own the certificate.
+     * @param holdingIdentityId The holding identity of the virtual node that owns the certificate.
      * @return A list of the virtual node certificates aliases in the usage.
      */
     @HttpGET(
@@ -178,7 +178,7 @@ interface CertificatesRestResource : RestResource {
         )
         usage: String,
         @RestPathParameter(
-            description = "The certificate holding identity ID",
+            description = "Holding identity ID of the virtual node that owns the certificate.",
         )
         holdingIdentityId: String?,
     ): List<String>

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline.json
@@ -263,11 +263,11 @@
         }, {
           "name" : "holdingidentityid",
           "in" : "path",
-          "description" : "The certificate holding identity ID",
+          "description" : "Holding identity ID of the virtual node that owns the certificate.",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "The certificate holding identity ID",
+            "description" : "Holding identity ID of the virtual node that owns the certificate.",
             "nullable" : true,
             "example" : "string"
           }


### PR DESCRIPTION
Endpoints on Certificates API now throw 404 Resource Not found in case of non-existent holding identity ID, instead of 500 Internal Server Error.

Valid hex identifier, non-existent vnode:

<img width="1417" alt="Screenshot 2023-06-12 at 12 29 44" src="https://github.com/corda/corda-runtime-os/assets/17948697/10dee3ea-25d3-44fe-b723-be06eee732e8">

Invalid hex identifier:

<img width="1410" alt="Screenshot 2023-06-12 at 13 12 40" src="https://github.com/corda/corda-runtime-os/assets/17948697/16a8edd1-103c-472c-891d-c46b1abde29b">
