### PR TITLE
CORE-14127: Fix CPK file attributes for CpkLoaderV2.

### DIFF
--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/CpkReadServiceImpl.kt
@@ -159,7 +159,7 @@ class CpkReadServiceImpl (
         removeMetrics()
 
         // Monitor the amount of available disk space in these two directories.
-        arrayOf(DiskSpace.Cpks(cpkCacheDir), DiskSpace.CpkChunks(cpkPartsDir))
+        arrayOf(DiskSpace.Cpks(cpkCacheDir), DiskSpace.UnpackedCpks(cpkPartsDir))
             .flatMap(DiskSpace::metrics)
             .map { metric ->
                 metric.builder().build()

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/CpkChunksKafkaReader.kt
@@ -80,9 +80,8 @@ class CpkChunksKafkaReader(
     }
 
     private fun onAllChunksReceived(cpkChecksum: SecureHash, chunks: SortedSet<CpkChunkId>) {
-        val cpkPath = cpkChunksFileManager.assembleCpk(cpkChecksum, chunks)
-        cpkPath?.let {
-            val cpk = Files.newInputStream(it).use { inStream ->
+        cpkChunksFileManager.assembleCpk(cpkChecksum, chunks)?.let { cpkPath ->
+            val cpk = Files.newInputStream(cpkPath).use { inStream ->
                 CpkReader.readCpk(inStream, cpkPartsDir)
             }
             onCpkAssembled(cpk.metadata.fileChecksum, cpk)

--- a/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
+++ b/components/virtual-node/cpk-read-service-impl/src/main/kotlin/net/corda/cpk/read/impl/services/persistence/CpkChunksFileManagerImpl.kt
@@ -3,6 +3,7 @@ package net.corda.cpk.read.impl.services.persistence
 import net.corda.crypto.core.toCorda
 import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.CpkChunkId
+import net.corda.libs.packaging.setReadOnly
 import net.corda.libs.packaging.writeFile
 import net.corda.utilities.debug
 import net.corda.utilities.posixOptional
@@ -15,13 +16,10 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption.ATOMIC_MOVE
 import java.nio.file.StandardOpenOption.READ
 import java.nio.file.StandardOpenOption.WRITE
-import java.nio.file.attribute.DosFileAttributeView
-import java.nio.file.attribute.PosixFileAttributeView
 import java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE
 import java.nio.file.attribute.PosixFilePermission.OWNER_READ
 import java.nio.file.attribute.PosixFilePermission.OWNER_WRITE
 import java.nio.file.attribute.PosixFilePermissions.asFileAttribute
-import java.util.Collections.singleton
 import java.util.SortedSet
 import java.util.function.Consumer
 
@@ -36,7 +34,6 @@ class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileMan
 
         private val CPK_DIRECTORY_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE))
         private val CPK_FILE_PERMISSIONS = asFileAttribute(setOf(OWNER_READ, OWNER_WRITE))
-        private val READ_ONLY = singleton(OWNER_READ)
 
         internal fun SecureHash.toCpkDirName() = toHexString()
 
@@ -113,16 +110,6 @@ class CpkChunksFileManagerImpl(private val cpkCacheDir: Path) : CpkChunksFileMan
             } catch (e: Exception) {
                 Files.delete(tempFile)
                 throw e
-            }
-        }
-    }
-
-    private fun setReadOnly(file: Path) {
-        Files.getFileAttributeView(file, PosixFileAttributeView::class.java)?.also { view ->
-            view.setPermissions(READ_ONLY)
-        } ?: run {
-            Files.getFileAttributeView(file, DosFileAttributeView::class.java)?.also { view ->
-                view.setReadOnly(true)
             }
         }
     }

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -588,8 +588,15 @@ object CordaMetrics {
                 return listOf(TotalSpace(), UsableSpace())
             }
 
+            /**
+             * Disk space used to store CPKs and their chunks.
+             */
             class Cpks(path: Path): DiskSpace("cpks", path)
-            class CpkChunks(path: Path): DiskSpace("cpk.chunks", path)
+
+            /**
+             * Disk space used to unpack CPKs.
+             */
+            class UnpackedCpks(path: Path): DiskSpace("cpks.unpacked", path)
         }
 
         object Db {

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2Test.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2Test.kt
@@ -1,4 +1,5 @@
-import net.corda.libs.packaging.internal.v2.CpiLoaderV2
+package net.corda.libs.packaging.internal.v2
+
 import net.corda.libs.packaging.testutils.TestUtils.ALICE
 import net.corda.libs.packaging.testutils.cpi.TestCpiV2Builder
 import org.junit.jupiter.api.Assertions.assertAll

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2Test.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpkLoaderV2Test.kt
@@ -1,5 +1,6 @@
+package net.corda.libs.packaging.internal.v2
+
 import net.corda.libs.packaging.PackagingConstants.CPK_FORMAT_VERSION2_MAINBUNDLE_PLACEHOLDER
-import net.corda.libs.packaging.internal.v2.CpkLoaderV2
 import net.corda.libs.packaging.testutils.TestUtils
 import net.corda.libs.packaging.testutils.cpk.TestCpkV2Builder
 import org.junit.jupiter.api.Assertions.assertAll


### PR DESCRIPTION
Update `CpkLoaderV2` to write CPK files atomically, with safe file attributes.

It also now appears that `cpkPartsDir` actually contains expanded CPI and CPK files rather than chunks from Kafka, so update its `DiskSpace` metric description accordingly.

---
As an aside, we appear to have _two_ caches of CPK files - one "working" cache for combining Kafka chunks, and another "temporary" cache for extracting CPI and CPK contents. I suspect that some of this disk I/O is unnecessary, but I cannot change that now.

I also notice that this _now removed_ code created a CPK file _outside_ the cache directory `cacheDir` as a sibling of its parent:
```diff
- val finalCpkFile = cacheDir.parent.resolve(hash.toHexString()).toFile()
+ val cpkFile = cacheDir.resolve(hash.toHexString())
```
That cannot possibly have been the original intention.