### PR TITLE
CORE-13660: Improve synchronisation stability 

### DIFF
--- a/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
+++ b/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
@@ -78,6 +78,8 @@ interface MembershipPersistenceClient : Lifecycle {
      * The epoch of the new [groupParameters] to be persisted must be higher than that of previous group parameter
      * versions.
      *
+     * If successful, the operation will put the latest group parameters on to the bus.
+     *
      * This operation is idempotent.
      *
      * @param viewOwningIdentity The holding identity owning this view of the group parameters.

--- a/components/membership/membership-persistence-service-impl/build.gradle
+++ b/components/membership/membership-persistence-service-impl/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation project(':components:db:db-connection-manager')
     implementation project(':components:membership:membership-persistence-service')
     implementation project(':components:membership:mtls-mgm-allowed-list-reader-writer')
+    implementation project(':components:membership:group-params-writer-service')
 
     implementation project(':libs:crypto:cipher-suite')
     implementation project(':libs:lifecycle:lifecycle')

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/dummy/GroupParametersWriterServiceDummy.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/dummy/GroupParametersWriterServiceDummy.kt
@@ -1,0 +1,47 @@
+package net.corda.membership.impl.persistence.service.dummy
+
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
+import net.corda.membership.lib.InternalGroupParameters
+import net.corda.virtualnode.HoldingIdentity
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [GroupParametersWriterService::class])
+class GroupParametersWriterServiceDummy @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+): GroupParametersWriterService {
+    private val coordinator = coordinatorFactory.createCoordinator(lifecycleCoordinatorName) { event, coordinator ->
+        if (event is StartEvent) {
+            coordinator.updateStatus(LifecycleStatus.UP)
+        }
+    }
+    override fun put(recordKey: HoldingIdentity, recordValue: InternalGroupParameters) {
+        // Do nothing
+    }
+
+    override fun remove(recordKey: HoldingIdentity) {
+        // Do nothing
+    }
+
+    override val lifecycleCoordinatorName
+        get() = LifecycleCoordinatorName.forComponent<GroupParametersWriterServiceDummy>()
+
+    override val isRunning: Boolean
+        get() = coordinator.isRunning
+
+    override fun start() {
+        coordinator.start()
+    }
+
+    override fun stop() {
+        coordinator.stop()
+    }
+}

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
@@ -21,7 +21,9 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.impl.persistence.service.handler.HandlerFactories
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderWriterService
 import net.corda.membership.persistence.service.MembershipPersistenceService
@@ -68,6 +70,10 @@ class MembershipPersistenceServiceImpl @Activate constructor(
     platformInfoProvider: PlatformInfoProvider,
     @Reference(service = AllowedCertificatesReaderWriterService::class)
     allowedCertificatesReaderWriterService: AllowedCertificatesReaderWriterService,
+    @Reference(service = GroupParametersWriterService::class)
+    groupParametersWriterService: GroupParametersWriterService,
+    @Reference(service = GroupParametersFactory::class)
+    groupParametersFactory: GroupParametersFactory,
 ) : MembershipPersistenceService {
 
     private companion object {
@@ -177,6 +183,8 @@ class MembershipPersistenceServiceImpl @Activate constructor(
             cordaAvroSerializationFactory,
             keyEncodingService,
             platformInfoProvider,
+            groupParametersWriterService,
+            groupParametersFactory,
             allowedCertificatesReaderWriterService,
         )
     }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/RecoverableException.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/RecoverableException.kt
@@ -5,4 +5,4 @@ import net.corda.membership.lib.exceptions.MembershipPersistenceException
 /**
  * An exception that indicate that the request can be retried if it was sent via the MEMBERSHIP_DB_ASYNC_TOPIC topic.
  */
-internal class RecoverableException(message: String) : MembershipPersistenceException(message)
+internal class RecoverableException(message: String, cause: Exception? = null) : MembershipPersistenceException(message, cause)

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/HandlerFactories.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/HandlerFactories.kt
@@ -32,6 +32,8 @@ import net.corda.data.membership.db.request.query.QueryRegistrationRequests
 import net.corda.data.membership.db.request.query.QueryStaticNetworkInfo
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.membership.lib.metrics.TimerMetricTypes
@@ -49,6 +51,8 @@ internal class HandlerFactories(
     cordaAvroSerializationFactory: CordaAvroSerializationFactory,
     keyEncodingService: KeyEncodingService,
     platformInfoProvider: PlatformInfoProvider,
+    groupParametersWriterService: GroupParametersWriterService,
+    groupParametersFactory: GroupParametersFactory,
     allowedCertificatesReaderWriterService: AllowedCertificatesReaderWriterService,
 ) {
     val persistenceHandlerServices = PersistenceHandlerServices(
@@ -60,6 +64,8 @@ internal class HandlerFactories(
         keyEncodingService,
         platformInfoProvider,
         allowedCertificatesReaderWriterService,
+        groupParametersWriterService,
+        groupParametersFactory,
         ::getTransactionTimer
     )
     private val handlerFactories: Map<Class<*>, () -> PersistenceHandler<out Any, out Any>> = mapOf(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -11,6 +11,8 @@ import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
+import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderWriterService
 import net.corda.orm.JpaEntitiesRegistry
@@ -46,6 +48,9 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
     val keyEncodingService get() = persistenceHandlerServices.keyEncodingService
     val platformInfoProvider get() = persistenceHandlerServices.platformInfoProvider
     val allowedCertificatesReaderWriterService get() = persistenceHandlerServices.allowedCertificatesReaderWriterService
+
+    val groupParametersWriterService get() = persistenceHandlerServices.groupParametersWriterService
+    val groupParametersFactory get() = persistenceHandlerServices.groupParametersFactory
 
     fun <R> transaction(holdingIdentityShortHash: ShortHash, block: (EntityManager) -> R): R {
         val factory = getEntityManagerFactory(holdingIdentityShortHash)
@@ -86,5 +91,7 @@ internal data class PersistenceHandlerServices(
     val keyEncodingService: KeyEncodingService,
     val platformInfoProvider: PlatformInfoProvider,
     val allowedCertificatesReaderWriterService: AllowedCertificatesReaderWriterService,
+    val groupParametersWriterService: GroupParametersWriterService,
+    val groupParametersFactory: GroupParametersFactory,
     val transactionTimerFactory: (String) -> Timer
 )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -291,6 +291,8 @@ class MembershipPersistenceRPCProcessorTest {
                 keyEncodingService,
                 platformInfoProvider,
                 mock(),
+                mock(),
+                mock(),
             )
         )
         responseFuture = CompletableFuture()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImplTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImplTest.kt
@@ -138,7 +138,9 @@ class MembershipPersistenceServiceImplTest {
             cordaAvroSerializationFactory,
             keyEncodingService,
             platformInfoProvider,
-            mock()
+            mock(),
+            mock(),
+            mock(),
         )
         verify(coordinatorFactory).createCoordinator(any(), any())
     }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -121,6 +121,8 @@ class PersistMemberInfoHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        mock(),
+        mock(),
         transactionTimerFactory
     )
     private lateinit var persistMemberInfoHandler: PersistMemberInfoHandler

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
@@ -98,7 +98,9 @@ class PersistRegistrationRequestHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
-        transactionTimerFactory
+        mock(),
+        mock(),
+        transactionTimerFactory,
     )
     private lateinit var persistRegistrationRequestHandler: PersistRegistrationRequestHandler
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
@@ -86,6 +86,8 @@ class QueryGroupPolicyHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        mock(),
+        mock(),
         transactionTimerFactory
     )
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
@@ -105,6 +105,8 @@ class QueryMemberInfoHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        mock(),
+        mock(),
         transactionTimerFactory
     )
     private lateinit var queryMemberInfoHandler: QueryMemberInfoHandler

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
@@ -78,6 +78,8 @@ class QueryMemberSignatureHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        mock(),
+        mock(),
         transactionTimerFactory
     )
     private val handler = QueryMemberSignatureHandler(service)

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
@@ -93,6 +93,8 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        mock(),
+        mock(),
         transactionTimeFactory
     )
     private val handler = UpdateMemberAndRegistrationRequestToApprovedHandler(service)

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
@@ -89,6 +89,8 @@ class UpdateRegistrationRequestStatusHandlerTest {
         keyEncodingService,
         platformInfoProvider,
         mock(),
+        mock(),
+        mock(),
         transactionTimerFactory
     )
     private lateinit var updateRegistrationRequestStatusHandler: UpdateRegistrationRequestStatusHandler

--- a/components/membership/registration-impl/build.gradle
+++ b/components/membership/registration-impl/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     integrationTestRuntimeOnly project(':components:crypto:crypto-client-hsm-impl')
     integrationTestRuntimeOnly project(':components:db:db-connection-manager-impl')
     integrationTestRuntimeOnly project(':components:membership:membership-group-read-impl')
-    integrationTestRuntimeOnly project(':components:membership:membership-persistence-client-impl')
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestMembershipQueryClient.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestMembershipQueryClient.kt
@@ -1,0 +1,110 @@
+package net.corda.membership.impl.registration.dummy
+
+import net.corda.data.crypto.wire.CryptoSignatureSpec
+import net.corda.data.crypto.wire.CryptoSignatureWithKey
+import net.corda.data.membership.StaticNetworkInfo
+import net.corda.data.membership.common.ApprovalRuleDetails
+import net.corda.data.membership.common.ApprovalRuleType
+import net.corda.data.membership.common.RegistrationRequestDetails
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.preauth.PreAuthToken
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import net.corda.membership.persistence.client.MembershipQueryClient
+import net.corda.membership.persistence.client.MembershipQueryResult
+import net.corda.v5.base.types.LayeredPropertyMap
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.HoldingIdentity
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
+import java.util.UUID
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [MembershipQueryClient::class])
+class TestMembershipQueryClient @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+) : MembershipQueryClient {
+    private val coordinator =
+        coordinatorFactory.createCoordinator(
+            LifecycleCoordinatorName.forComponent<MembershipQueryClient>()
+        ) { event, coordinator ->
+            if (event is StartEvent) {
+                coordinator.updateStatus(LifecycleStatus.UP)
+            }
+        }
+    override fun queryMemberInfo(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<Collection<MemberInfo>> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun queryMemberInfo(
+        viewOwningIdentity: HoldingIdentity,
+        queryFilter: Collection<HoldingIdentity>,
+    ): MembershipQueryResult<Collection<MemberInfo>> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun queryRegistrationRequest(
+        viewOwningIdentity: HoldingIdentity,
+        registrationId: String,
+    ): MembershipQueryResult<RegistrationRequestDetails?> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun queryRegistrationRequests(
+        viewOwningIdentity: HoldingIdentity,
+        requestSubjectX500Name: MemberX500Name?,
+        statuses: List<RegistrationStatus>,
+        limit: Int?,
+    ): MembershipQueryResult<List<RegistrationRequestDetails>> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun queryMembersSignatures(
+        viewOwningIdentity: HoldingIdentity,
+        holdingsIdentities: Collection<HoldingIdentity>,
+    ): MembershipQueryResult<Map<HoldingIdentity, Pair<CryptoSignatureWithKey, CryptoSignatureSpec>>> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun queryGroupPolicy(viewOwningIdentity: HoldingIdentity): MembershipQueryResult<Pair<LayeredPropertyMap, Long>> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun mutualTlsListAllowedCertificates(mgmHoldingIdentity: HoldingIdentity): MembershipQueryResult<Collection<String>> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun queryPreAuthTokens(
+        mgmHoldingIdentity: HoldingIdentity,
+        ownerX500Name: MemberX500Name?,
+        preAuthTokenId: UUID?,
+        viewInactive: Boolean,
+    ): MembershipQueryResult<List<PreAuthToken>> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun getApprovalRules(
+        viewOwningIdentity: HoldingIdentity,
+        ruleType: ApprovalRuleType,
+    ): MembershipQueryResult<Collection<ApprovalRuleDetails>> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override fun queryStaticNetworkInfo(groupId: String): MembershipQueryResult<StaticNetworkInfo> {
+        return MembershipQueryResult.Failure("oops")
+    }
+
+    override val isRunning = true
+
+    override fun start() {
+        coordinator.start()
+    }
+
+    override fun stop() = Unit
+}

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/RegistrationServiceLifecycleHandlerTest.kt
@@ -85,7 +85,6 @@ class RegistrationServiceLifecycleHandlerTest {
         platformInfoProvider,
         mock(),
         virtualNodeInfoReadService,
-        mock(),
         membershipGroupReaderProvider,
         membershipQueryClient,
     )
@@ -240,7 +239,6 @@ class RegistrationServiceLifecycleHandlerTest {
                 platformInfoProvider,
                 mock(),
                 virtualNodeInfoReadService,
-                mock(),
                 membershipGroupReaderProvider,
                 membershipQueryClient,
             )

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
@@ -96,7 +96,7 @@ class TestMembershipPersistenceClientImpl @Activate constructor(
             override fun execute() = MembershipPersistenceResult.Success(groupParameters)
 
             override fun createAsyncCommands(): Collection<Record<*, *>> {
-                throw UnsupportedOperationException(UNIMPLEMENTED_FUNCTION)
+                return emptyList()
             }
         }
     }

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -32,7 +32,6 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.TimerEvent
-import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.lib.MemberInfoExtension.Companion.id
@@ -92,7 +91,6 @@ class MemberSynchronisationServiceImpl internal constructor(
     private val clock: Clock,
     private val membershipPersistenceClient: MembershipPersistenceClient,
     private val groupParametersFactory: GroupParametersFactory,
-    private val groupParametersWriterService: GroupParametersWriterService,
 ) : MemberSynchronisationService {
     @Suppress("LongParameterList")
     @Activate
@@ -121,8 +119,6 @@ class MemberSynchronisationServiceImpl internal constructor(
         membershipPersistenceClient: MembershipPersistenceClient,
         @Reference(service = GroupParametersFactory::class)
         groupParametersFactory: GroupParametersFactory,
-        @Reference(service = GroupParametersWriterService::class)
-        groupParametersWriterService: GroupParametersWriterService,
     ) : this(
         publisherFactory,
         configurationReadService,
@@ -149,14 +145,13 @@ class MemberSynchronisationServiceImpl internal constructor(
         UTCClock(),
         membershipPersistenceClient,
         groupParametersFactory,
-        groupParametersWriterService,
     )
 
     /**
      * Private interface used for implementation swapping in response to lifecycle events.
      */
     private interface InnerSynchronisationService : AutoCloseable {
-        fun processMembershipUpdates(updates: ProcessMembershipUpdates)
+        fun processMembershipUpdates(updates: ProcessMembershipUpdates): List<Record<*, *>>
 
         fun cancelCurrentRequestAndScheduleNewOne(
             memberIdentity: HoldingIdentity,
@@ -168,6 +163,7 @@ class MemberSynchronisationServiceImpl internal constructor(
         val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         const val PUBLICATION_TIMEOUT_SECONDS = 30L
+        const val RESEND_NOW_MAX_IN_MINUTES = 5L
         const val SERVICE = "MemberSynchronisationService"
 
         private val random by lazy {
@@ -285,12 +281,12 @@ class MemberSynchronisationServiceImpl internal constructor(
             return true
         }
 
-        override fun processMembershipUpdates(updates: ProcessMembershipUpdates) {
+        override fun processMembershipUpdates(updates: ProcessMembershipUpdates): List<Record<*, *>> {
             val viewOwningMember = updates.synchronisationMetaData.member.toCorda()
             val mgm = updates.synchronisationMetaData.mgm.toCorda()
             logger.debug { "Member $viewOwningMember received membership updates from $mgm." }
 
-            try {
+            return try {
                 cancelCurrentRequestAndScheduleNewOne(viewOwningMember, mgm)
                 val updateMembersInfo = updates.membershipPackage.memberships.memberships.map { update ->
                     verifier.verify(
@@ -358,26 +354,27 @@ class MemberSynchronisationServiceImpl internal constructor(
                 }
 
 
-                groupReader.lookup().firstOrNull { it.isMgm }?.let {
+                val persistRecords = groupReader.lookup().firstOrNull { it.isMgm }?.let {
                     val groupParameters = parseGroupParameters(
                         it,
                         updates.membershipPackage
                     )
-                    val latestGroupParameters =
                         membershipPersistenceClient
                             .persistGroupParameters(viewOwningMember, groupParameters)
-                            .getOrThrow()
-                    groupParametersWriterService.put(viewOwningMember, latestGroupParameters)
+                            .createAsyncCommands()
                 } ?: throw CordaRuntimeException(
                     "Could not find MGM info in the member list for member ${viewOwningMember.x500Name}"
                 )
-                publisher.publish(allRecords).first().get(PUBLICATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                allRecords + persistRecords
             } catch (e: Exception) {
                 logger.warn("Failed to process membership updates received by ${viewOwningMember.x500Name}.", e)
-                // TODO - CORE-5813 - trigger sync protocol.
                 logger.warn(
                     "Cannot recover from failure to process membership updates. ${viewOwningMember.x500Name}" +
                             " cannot initiate sync protocol with MGM as this is not implemented."
+                )
+                createSynchroniseNowRequest(
+                    viewOwningMember,
+                    mgm,
                 )
             }
         }
@@ -426,6 +423,31 @@ class MemberSynchronisationServiceImpl internal constructor(
                 memberHash,
             )
         )
+    }
+
+    private fun createSynchroniseNowRequest(
+        viewOwningMember: HoldingIdentity,
+        mgm: HoldingIdentity
+    ): List<Record<*, *>> {
+        return try {
+            listOf(
+                createSynchronisationRequestMessage(
+                    groupReader = membershipGroupReaderProvider.getGroupReader(viewOwningMember),
+                    memberIdentity = viewOwningMember,
+                    mgm = mgm,
+                ),
+            )
+        } catch (e: Exception) {
+            logger.warn("Could not create a synchronisation request. Will retry soon.", e)
+            // Could not create a synchronisation, schedual to create one soon
+            coordinator.setTimer(
+                key = "SendSyncRequest-${viewOwningMember.fullHash}",
+                delay = (random.nextDouble() * TimeUnit.MINUTES.toMillis(RESEND_NOW_MAX_IN_MINUTES)).toLong()
+            ) {
+                SendSyncRequest(viewOwningMember, mgm, it)
+            }
+            emptyList()
+        }
     }
 
     private fun handleEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -368,7 +368,8 @@ class MemberSynchronisationServiceImpl internal constructor(
                 allRecords + persistRecords
             } catch (e: Exception) {
                 logger.warn(
-                    "Failed to process membership updates received by ${viewOwningMember.x500Name}. Will retry again soon.",
+                    "Failed to process membership updates received by ${viewOwningMember.x500Name}. " +
+                        "Will trigger a fresh sync with MGM.",
                     e,
                 )
                 createSynchroniseNowRequest(
@@ -437,7 +438,7 @@ class MemberSynchronisationServiceImpl internal constructor(
                 ),
             )
         } catch (e: Exception) {
-            logger.warn("Failed to trigger an immediate sync, will schedule on to be triggered later.", e)
+            logger.warn("Failed to trigger an immediate sync, will schedule one to be triggered later.", e)
             coordinator.setTimer(
                 key = "SendSyncRequest-${viewOwningMember.fullHash}",
                 delay = TimeUnit.MINUTES.toMillis(RESEND_NOW_MAX_IN_MINUTES),

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -367,10 +367,9 @@ class MemberSynchronisationServiceImpl internal constructor(
                 )
                 allRecords + persistRecords
             } catch (e: Exception) {
-                logger.warn("Failed to process membership updates received by ${viewOwningMember.x500Name}.", e)
                 logger.warn(
-                    "Cannot recover from failure to process membership updates. ${viewOwningMember.x500Name}" +
-                            " cannot initiate sync protocol with MGM as this is not implemented."
+                    "Failed to process membership updates received by ${viewOwningMember.x500Name}. Will retry again soon.",
+                    e,
                 )
                 createSynchroniseNowRequest(
                     viewOwningMember,
@@ -438,11 +437,10 @@ class MemberSynchronisationServiceImpl internal constructor(
                 ),
             )
         } catch (e: Exception) {
-            logger.warn("Could not create a synchronisation request. Will retry soon.", e)
-            // Could not create a synchronisation, schedual to create one soon
+            logger.warn("Failed to trigger an immediate sync, will schedule on to be triggered later.", e)
             coordinator.setTimer(
                 key = "SendSyncRequest-${viewOwningMember.fullHash}",
-                delay = (random.nextDouble() * TimeUnit.MINUTES.toMillis(RESEND_NOW_MAX_IN_MINUTES)).toLong()
+                delay = TimeUnit.MINUTES.toMillis(RESEND_NOW_MAX_IN_MINUTES),
             ) {
                 SendSyncRequest(viewOwningMember, mgm, it)
             }

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImplTest.kt
@@ -364,12 +364,12 @@ class MemberSynchronisationServiceImplTest {
         postConfigChangedEvent()
         synchronisationService.start()
 
-        val publishedMemberList = synchronisationService.processMembershipUpdates(updates)
+        val producedRecords = synchronisationService.processMembershipUpdates(updates)
 
         assertSoftly {
-            it.assertThat(publishedMemberList).hasSize(2)
+            it.assertThat(producedRecords).hasSize(2)
 
-            val publishedMember = publishedMemberList.first()
+            val publishedMember = producedRecords.first()
             it.assertThat(publishedMember.topic).isEqualTo(MEMBER_LIST_TOPIC)
             it.assertThat(publishedMember.key).isEqualTo("${member.shortHash}-${participant.id}")
             it.assertThat(publishedMember.value).isInstanceOf(PersistentMemberInfo::class.java)
@@ -435,7 +435,7 @@ class MemberSynchronisationServiceImplTest {
 
         synchronisationService.processMembershipUpdates(updates)
 
-        assertThat(captureDelay.lastValue).isLessThanOrEqualTo(5 * 1000 * 60)
+        assertThat(captureDelay.lastValue).isEqualTo(5 * 1000 * 60)
     }
 
     @Test
@@ -473,10 +473,10 @@ class MemberSynchronisationServiceImplTest {
         synchronisationService.start()
         whenever(signedMemberships.hashCheck) doReturn null
 
-        val publishedMemberList = synchronisationService.processMembershipUpdates(updates)
+        val producedRecords = synchronisationService.processMembershipUpdates(updates)
 
         assertSoftly {
-            it.assertThat(publishedMemberList)
+            it.assertThat(producedRecords)
                 .hasSize(3)
                 .anySatisfy {
                     assertThat(it.topic).isEqualTo(MEMBER_LIST_TOPIC)

--- a/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImplTest.kt
+++ b/components/membership/synchronisation-impl/src/test/kotlin/net/corda/membership/impl/synchronisation/SynchronisationProxyImplTest.kt
@@ -497,22 +497,25 @@ class SynchronisationProxyImplTest {
     }
 
     class MemberSyncProtocol1 : AbstractMemberSyncProtocol() {
-        override fun processMembershipUpdates(updates: ProcessMembershipUpdates) {
+        override fun processMembershipUpdates(updates: ProcessMembershipUpdates): List<Record<*, *>> {
             classes.add(MemberSyncProtocol1::class.java)
+            return emptyList()
         }
     }
 
     class MemberSyncProtocol2 : AbstractMemberSyncProtocol() {
-        override fun processMembershipUpdates(updates: ProcessMembershipUpdates) {
+        override fun processMembershipUpdates(updates: ProcessMembershipUpdates): List<Record<*, *>> {
             classes.add(MemberSyncProtocol2::class.java)
+            return emptyList()
         }
     }
 
     abstract class AbstractMemberSyncProtocol : MemberSynchronisationService {
         var started = 0
 
-        override fun processMembershipUpdates(updates: ProcessMembershipUpdates) {
+        override fun processMembershipUpdates(updates: ProcessMembershipUpdates): List<Record<*, *>> {
             classes.add(AbstractMemberSyncProtocol::class.java)
+            return emptyList()
         }
 
         override val isRunning = true
@@ -521,16 +524,18 @@ class SynchronisationProxyImplTest {
     }
 
     class MgmSyncProtocol1 : AbstractMgmSyncProtocol() {
-        override fun processSyncRequest(request: ProcessSyncRequest) {
+        override fun processSyncRequest(request: ProcessSyncRequest): List<Record<*, *>> {
             classes.add(MgmSyncProtocol1::class.java)
+            return emptyList()
         }
     }
 
     abstract class AbstractMgmSyncProtocol : MgmSynchronisationService {
         var started = 0
 
-        override fun processSyncRequest(request: ProcessSyncRequest) {
+        override fun processSyncRequest(request: ProcessSyncRequest) : List<Record<*, *>> {
             classes.add(AbstractMgmSyncProtocol::class.java)
+            return emptyList()
         }
 
         override val isRunning = true

--- a/components/membership/synchronisation/build.gradle
+++ b/components/membership/synchronisation/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":libs:lifecycle:lifecycle")
+    implementation project(':libs:messaging:messaging')
 
     api project(":libs:membership:membership-common")
     api project(":libs:virtual-node:virtual-node-info")

--- a/components/membership/synchronisation/src/main/kotlin/net/corda/membership/synchronisation/MemberSynchronisationService.kt
+++ b/components/membership/synchronisation/src/main/kotlin/net/corda/membership/synchronisation/MemberSynchronisationService.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.synchronisation
 
 import net.corda.data.membership.command.synchronisation.member.ProcessMembershipUpdates
+import net.corda.messaging.api.records.Record
 
 /**
  * Handles the membership data synchronisation process on the member side.
@@ -10,6 +11,7 @@ interface MemberSynchronisationService : SynchronisationService {
      * Publishes the member list updates contained in the [updates] sent by the MGM to the receiving member.
      *
      * @param updates Data package distributed by the MGM containing membership updates.
+     * @return list of records to post to the message bus
      */
-    fun processMembershipUpdates(updates: ProcessMembershipUpdates)
+    fun processMembershipUpdates(updates: ProcessMembershipUpdates): List<Record<*, *>>
 }

--- a/components/membership/synchronisation/src/main/kotlin/net/corda/membership/synchronisation/MgmSynchronisationService.kt
+++ b/components/membership/synchronisation/src/main/kotlin/net/corda/membership/synchronisation/MgmSynchronisationService.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.synchronisation
 
 import net.corda.data.membership.command.synchronisation.mgm.ProcessSyncRequest
+import net.corda.messaging.api.records.Record
 
 /**
  * Handles the membership data synchronisation process on the mgm side.
@@ -11,6 +12,7 @@ interface MgmSynchronisationService : SynchronisationService {
      * and sends it back to the given member.
      *
      * @param request The sync request which needs to be processed.
+     * @return list of records to post to the message bus
      */
-    fun processSyncRequest(request: ProcessSyncRequest)
+    fun processSyncRequest(request: ProcessSyncRequest): List<Record<*, *>>
 }


### PR DESCRIPTION
This pull request is making some changes to the synchronization to make it more stable:
1. Instead of persisting the group parameters in the member worker and waiting for a reply, it will send an asynchronous request to the DB worker to do that. For that, the group parameter persistent code was changed to publish the latest group parameter into the bus as part of the handler in the persistence service.
2. If the synchronization handling fails, we will try to ask for another synchronization from the MGM.