### PR TITLE
CORE-12172 Fix error handling for static network notary updates

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -58,6 +58,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.membership.lib.MemberInfoExtension.Companion.isNotary
 import net.corda.membership.lib.MemberInfoExtension.Companion.notaryDetails
 import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.lib.exceptions.InvalidGroupParametersUpdateException
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.ProtocolParameters.SessionKeyPolicy
 import net.corda.membership.lib.registration.RegistrationRequest
@@ -284,6 +285,9 @@ class StaticMemberRegistrationService(
         } catch (e: MembershipPersistenceResult.PersistenceRequestException) {
             logger.warn("Registration failed. Reason:", e)
             throw NotReadyMembershipRegistrationException("Registration failed. Reason: ${e.message}", e)
+        } catch(e: InvalidGroupParametersUpdateException) {
+            logger.warn("Registration failed. Reason:", e)
+            throw InvalidMembershipRegistrationException("Registration failed. Reason: ${e.message}", e)
         } catch (e: Exception) {
             logger.warn("Registration failed. Reason:", e)
             throw NotReadyMembershipRegistrationException("Registration failed. Reason: ${e.message}", e)

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
@@ -3,7 +3,7 @@ package net.corda.membership.lib
 import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
-import net.corda.membership.lib.exceptions.MembershipPersistenceException
+import net.corda.membership.lib.exceptions.InvalidGroupParametersUpdateException
 import net.corda.membership.lib.notary.MemberNotaryDetails
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
@@ -35,12 +35,12 @@ class GroupParametersNotaryUpdater(
         val notaryServiceName = notaryDetails.serviceName.toString()
         logger.info("Adding notary to group parameters under new notary service '$notaryServiceName'.")
         requireNotNull(notaryDetails.serviceProtocol) {
-            throw MembershipPersistenceException("Cannot add notary to group parameters - notary protocol must be" +
+            throw InvalidGroupParametersUpdateException("Cannot add notary to group parameters - notary protocol must be" +
                     " specified to create new notary service '$notaryServiceName'."
             )
         }
         require(notaryDetails.serviceProtocolVersions.isNotEmpty()) {
-            throw MembershipPersistenceException(
+            throw InvalidGroupParametersUpdateException(
                 "Cannot add notary to notary service '$notaryServiceName' - protocol versions are missing."
             )
         }
@@ -80,11 +80,11 @@ class GroupParametersNotaryUpdater(
         logger.info("Adding notary to group parameters under existing notary service '$notaryServiceName'.")
         notaryDetails.serviceProtocol?.let {
             require(currentParameters[String.format(NOTARY_SERVICE_PROTOCOL_KEY, notaryServiceNumber)].toString() == it) {
-                throw MembershipPersistenceException("Cannot add notary to notary service " +
+                throw InvalidGroupParametersUpdateException("Cannot add notary to notary service " +
                         "'$notaryServiceName' - protocols do not match.")
             }
             require(notaryDetails.serviceProtocolVersions.isNotEmpty()) {
-                throw MembershipPersistenceException("Cannot add notary to notary service '$notaryServiceName' - protocol" +
+                throw InvalidGroupParametersUpdateException("Cannot add notary to notary service '$notaryServiceName' - protocol" +
                         "  versions are missing.")
             }
         }
@@ -142,11 +142,11 @@ class GroupParametersNotaryUpdater(
         logger.info("Removing notary from group parameters under notary service '$notaryServiceName'.")
         notaryDetails.serviceProtocol?.let {
             require(currentParameters[String.format(NOTARY_SERVICE_PROTOCOL_KEY, notaryServiceNumber)].toString() == it) {
-                throw MembershipPersistenceException("Cannot remove notary from notary service " +
+                throw InvalidGroupParametersUpdateException("Cannot remove notary from notary service " +
                         "'$notaryServiceName' - protocols do not match.")
             }
             require(notaryDetails.serviceProtocolVersions.isNotEmpty()) {
-                throw MembershipPersistenceException("Cannot remove notary from notary service '$notaryServiceName' - protocol" +
+                throw InvalidGroupParametersUpdateException("Cannot remove notary from notary service '$notaryServiceName' - protocol" +
                         "  versions are missing.")
             }
         }

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/exceptions/InvalidGroupParametersUpdateException.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/exceptions/InvalidGroupParametersUpdateException.kt
@@ -1,0 +1,8 @@
+package net.corda.membership.lib.exceptions
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+/**
+ * Thrown to indicate that there was an exception while updating the group parameters.
+ */
+class InvalidGroupParametersUpdateException(message: String, cause: Throwable? = null) : CordaRuntimeException(message, cause)

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdaterTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdaterTest.kt
@@ -8,6 +8,7 @@ import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SE
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_NAME_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_PROTOCOL_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY
+import net.corda.membership.lib.exceptions.InvalidGroupParametersUpdateException
 import net.corda.membership.lib.notary.MemberNotaryDetails
 import net.corda.membership.lib.notary.MemberNotaryKey
 import net.corda.test.util.time.TestClock
@@ -22,7 +23,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import java.security.PublicKey
 import java.time.Instant
-import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import org.junit.jupiter.api.assertThrows
 
 class GroupParametersNotaryUpdaterTest {
@@ -80,7 +80,9 @@ class GroupParametersNotaryUpdaterTest {
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
         val notaryToAdd = MemberNotaryDetails(notaryAx500Name, null, setOf(1, 3), listOf(notaryKey))
 
-        val ex = assertThrows<MembershipPersistenceException> { notaryUpdater.addNewNotaryService(originalGroupParameters, notaryToAdd) }
+        val ex = assertThrows<InvalidGroupParametersUpdateException> {
+            notaryUpdater.addNewNotaryService(originalGroupParameters, notaryToAdd)
+        }
         assertThat(ex).hasMessageContaining("protocol must be specified")
     }
 
@@ -90,7 +92,9 @@ class GroupParametersNotaryUpdaterTest {
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
         val notaryToAdd = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, emptySet(), listOf(notaryKey))
 
-        val ex = assertThrows<MembershipPersistenceException> { notaryUpdater.addNewNotaryService(originalGroupParameters, notaryToAdd) }
+        val ex = assertThrows<InvalidGroupParametersUpdateException> {
+            notaryUpdater.addNewNotaryService(originalGroupParameters, notaryToAdd)
+        }
         assertThat(ex).hasMessageContaining("protocol versions are missing")
     }
 
@@ -175,7 +179,7 @@ class GroupParametersNotaryUpdaterTest {
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
         val notaryDetails = MemberNotaryDetails(notaryAx500Name, "incorrect.plugin.type", emptySet(), listOf(notaryKey))
 
-        val ex = assertThrows<MembershipPersistenceException> { notaryUpdater.updateExistingNotaryService(
+        val ex = assertThrows<InvalidGroupParametersUpdateException> { notaryUpdater.updateExistingNotaryService(
             currentGroupParameters,
             notaryDetails,
             5,
@@ -197,7 +201,7 @@ class GroupParametersNotaryUpdaterTest {
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
         val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, emptySet(), listOf(notaryKey))
 
-        val ex = assertThrows<MembershipPersistenceException> { notaryUpdater.updateExistingNotaryService(
+        val ex = assertThrows<InvalidGroupParametersUpdateException> { notaryUpdater.updateExistingNotaryService(
             currentGroupParameters,
             notaryDetails,
             5,
@@ -352,7 +356,7 @@ class GroupParametersNotaryUpdaterTest {
         val otherNotary1 = MemberNotaryDetails(notaryBx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey))
         val otherNotary2 = MemberNotaryDetails(notaryCx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey))
 
-        val ex = assertThrows<MembershipPersistenceException> { notaryUpdater.removeNotaryFromExistingNotaryService(
+        val ex = assertThrows<InvalidGroupParametersUpdateException> { notaryUpdater.removeNotaryFromExistingNotaryService(
             currentGroupParameters,
             notaryToRemove,
             5,
@@ -376,7 +380,7 @@ class GroupParametersNotaryUpdaterTest {
         val otherNotary1 = MemberNotaryDetails(notaryBx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey))
         val otherNotary2 = MemberNotaryDetails(notaryCx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey))
 
-        val ex = assertThrows<MembershipPersistenceException> { notaryUpdater.removeNotaryFromExistingNotaryService(
+        val ex = assertThrows<InvalidGroupParametersUpdateException> { notaryUpdater.removeNotaryFromExistingNotaryService(
             currentGroupParameters,
             notaryToRemove,
             5,


### PR DESCRIPTION
Fixes an issue where a static network registration request with an invalid notary context fails with the wrong error reason. This was because a `MembershipPersistenceException` was thrown in case of invalid registration context, which would then be caught in `MemberOpsAsyncProcessor`, and replayed. Now an `InvalidGroupParametersUpdateException` is thrown, which leads to the request being converted to "INVALID" with the right error message.

**Static Network**
1. Missing notary protocol versions
![Screenshot 2023-06-12 at 17 03 07](https://github.com/corda/corda-runtime-os/assets/17948697/d2119f8a-63ac-4997-85e5-2d100d3edab1)

2. Missing notary protocol name
![Screenshot 2023-06-12 at 17 12 26](https://github.com/corda/corda-runtime-os/assets/17948697/11ff5b59-99d8-453a-bcb4-97b5735c23fc)

**Dynamic Network**
1. Missing notary protocol versions
```
membership.db.rpc.ops] WARN  net.corda.membership.impl.persistence.service.MembershipPersistenceRPCProcessor {} - Exception thrown while processing membership persistence request: Cannot add notary to notary service 'O=NotaryServiceA, L=London, C=GB' - protocol versions are missing.
```
2. Missing notary protocol name
```
membership.db.rpc.ops] WARN  net.corda.membership.impl.persistence.service.MembershipPersistenceRPCProcessor {} - Exception thrown while processing membership persistence request: Cannot add notary to group parameters - notary protocol must be specified to create new notary service 'O=NotaryServiceB, L=London, C=GB'.
```