### PR TITLE
CORE-11657 SubFlow metric fix

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowEngineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowEngineImpl.kt
@@ -64,7 +64,7 @@ class FlowEngineImpl @Activate constructor(
              */
 
             closeSessionsOnSubFlowFinish()
-            getFiberExecutionContext().flowMetrics.subFlowFinished(FlowStates.FAILED)
+            getFiberExecutionContext().flowMetrics.subFlowFinished(FlowStates.COMPLETED)
 
             return result
         } catch (t: Throwable) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/metrics/impl/FlowMetricsImpl.kt
@@ -120,7 +120,7 @@ class FlowMetricsImpl(
         val flowStackItemMetricState = FlowStackItemMetricState().apply {
             name = requireNotNull(flowCheckpoint.flowStack.peek()?.flowName) { "Flow stack is empty" }
         }
-        if (currentState.flowStackItemMetricStates.isEmpty()) {
+        if (currentState.flowStackItemMetricStates.isNotEmpty()) {
             flowStackItemMetricState.isSubFlow = true
         }
         currentState.flowStackItemMetricStates.add(flowStackItemMetricState)


### PR DESCRIPTION
The `isSubFlow` flag was incorrectly set as `true` for only the top-level flow.

When a SubFlow was completed correctly it was recorded as FAILED instead of COMPLETED.