### PR TITLE
CORE-14540: Explicitly exclude Snappy library dependency

### DIFF
--- a/libs/tracing/build.gradle
+++ b/libs/tracing/build.gradle
@@ -27,8 +27,11 @@ dependencies {
     implementation("io.zipkin.brave:brave-context-slf4j:$braveVersion")
     implementation("io.zipkin.brave:brave-instrumentation-kafka-clients:$braveVersion")
     implementation("io.zipkin.brave:brave-instrumentation-servlet:$braveVersion")
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
-
+    implementation ("org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion") {
+        // Need to explicitly exclude this dependency (which seems non-essential), however it will prevent running
+        // Combined Worker on Mac M1. Please see README of Combined worker for more details.
+        exclude group: 'org.xerial.snappy'
+    }
 
     implementation "io.javalin:javalin-osgi:$javalinVersion"
     constraints {

--- a/libs/tracing/build.gradle
+++ b/libs/tracing/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation ("org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion") {
         // Need to explicitly exclude this dependency (which seems non-essential), however it will prevent running
         // Combined Worker on Mac M1. Please see README of Combined worker for more details.
+        // We should not need this dependency as long as we are not using `snappy` compression type in Kafka
+        // topics configuration.
         exclude group: 'org.xerial.snappy'
     }
 


### PR DESCRIPTION
We should not need this dependency as long as we are not using `snappy` compression type in Kafka topics configuration.