### PR TITLE
CORE-14583: change logging level to info for updateVirtualNodeState endpoint

### DIFF
--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -400,7 +400,7 @@ internal class VirtualNodeRestResourceImpl(
         val instant = clock.instant()
         // Lookup actor to keep track of which REST user triggered an update
         val actor = restContextProvider.principal
-        logger.debug { "Received request to update state for $virtualNodeShortId to $newState by $actor at $instant" }
+        logger.info("Received request to update state for $virtualNodeShortId to $newState by $actor at $instant")
 
         val virtualNodeState = when (validateStateChange(virtualNodeShortId, newState)
         ) {
@@ -420,10 +420,14 @@ internal class VirtualNodeRestResourceImpl(
         val resp = tryWithExceptionHandling(logger, "Update vNode state") {
             sendAndReceive(rpcRequest)
         }
-        logger.debug { "Received response to update for $virtualNodeShortId to $newState by $actor" }
+        logger.info("Received response to update for $virtualNodeShortId to $newState by $actor")
 
         return when (val resolvedResponse = resp.responseType) {
             is VirtualNodeStateChangeResponse -> {
+                logger.info("Updated states in response for $virtualNodeShortId: ${resolvedResponse.flowOperationalStatus}, " +
+                        "${resolvedResponse.flowP2pOperationalStatus}, ${resolvedResponse.flowStartOperationalStatus}, " +
+                        "${resolvedResponse.vaultDbOperationalStatus}")
+
                 resolvedResponse.run {
                     ChangeVirtualNodeStateResponse(holdingIdentityShortHash, newState)
                 }


### PR DESCRIPTION
The updateVirtualNodeState endpoint has been failing occasionally in various e2e tests. This PR changes the logging level in this endpoint to be info, so that we can hopefully get a better idea of where it is going wrong. 