### PR TITLE
CORE-14538: Remove full stack trace logging

### DIFF
--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -129,7 +129,10 @@ internal object ContextUtils {
                     ctx.header(Header.CACHE_CONTROL, "no-cache")
                     methodLogger.debug { "Invoke method \"${this.method.method.name}\" for route info completed." }
                 } catch (e: Exception) {
-                    methodLogger.info("Error invoking path '${this.fullPath}' - ${e.message}", e)
+                    "Error invoking path '${this.fullPath}' - ${e.message}".let {
+                        methodLogger.info(it)
+                        methodLogger.debug(it, e)
+                    }
                     throw HttpExceptionMapper.mapToResponse(e)
                 } finally {
                     if (ctx.isMultipartFormData()) {


### PR DESCRIPTION
Exception like `ResourceNotFoundException` can be quite "normal" and there is no point logging them at INFO level. Should anyone will be willing to know more, it is possible to see the full stacktrace at DEBUG level if it is enabled.