### PR TITLE
CORE-7243: add new ClusterBuilder methods

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -159,8 +159,8 @@ class ClusterBuilder {
             |   } 
             | }""".trimMargin()
 
-    private fun createRbacUserBody(fullName: String, loginName: String) =
-        """{ "fullName" : "$fullName", "loginName" : "$loginName" }"""
+    private fun createRbacUserBody(fullName: String, loginName: String, password: String) =
+        """{ "fullName" : "$fullName", "loginName" : "$loginName", "initialPassword" : "$password }"""
 
     /** Create a virtual node */
     fun vNodeCreate(cpiHash: String, x500Name: String) =
@@ -254,7 +254,7 @@ class ClusterBuilder {
     fun getRbacRoles() = get("/api/v1/role")
 
     /** Create new RBAC user */
-    fun createRbacUser(fullName: String, loginName: String) = post("/api/v1/user", createRbacUserBody(fullName, loginName))
+    fun createRbacUser(fullName: String, loginName: String, password: String) = post("/api/v1/user", createRbacUserBody(fullName, loginName, password))
 
     /** Assign a specified role to a specified user */
     fun assignRoleToUser(loginName: String, roleId: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -159,6 +159,9 @@ class ClusterBuilder {
             |   } 
             | }""".trimMargin()
 
+    private fun createRbacUserBody(fullName: String, loginName: String) =
+        """{ "fullName" : "$fullName", "loginName" : "$loginName" }"""
+
     /** Create a virtual node */
     fun vNodeCreate(cpiHash: String, x500Name: String) =
         post("/api/v1/virtualnode", vNodeBody(cpiHash, x500Name))
@@ -249,6 +252,13 @@ class ClusterBuilder {
 
     /** Get all RBAC roles */
     fun getRbacRoles() = get("/api/v1/role")
+
+    /** Create new RBAC user */
+    fun createRbacUser(fullName: String, loginName: String) = post("/api/v1/user", createRbacUserBody(fullName, loginName))
+
+    /** Assign a specified role to a specified user */
+    fun assignRoleToUser(loginName: String, roleId: String) =
+        put("/api/v1/user/$loginName/role/$roleId", "")
 
     /** Start a flow */
     fun flowStart(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -159,8 +159,8 @@ class ClusterBuilder {
             |   } 
             | }""".trimMargin()
 
-    private fun createRbacUserBody(fullName: String, loginName: String, password: String) =
-        """{ "fullName" : "$fullName", "loginName" : "$loginName", "initialPassword" : "$password" }"""
+    private fun createRbacUserBody(fullName: String, password: String, loginName: String) =
+        """{ "fullName" : "$fullName", "initialPassword" : "$password", "loginName" : "$loginName" }"""
 
     /** Create a virtual node */
     fun vNodeCreate(cpiHash: String, x500Name: String) =
@@ -254,8 +254,8 @@ class ClusterBuilder {
     fun getRbacRoles() = get("/api/v1/role")
 
     /** Create new RBAC user */
-    fun createRbacUser(fullName: String, loginName: String, password: String) =
-        post("/api/v1/user", createRbacUserBody(fullName, loginName, password))
+    fun createRbacUser(fullName: String, password: String, loginName: String) =
+        post("/api/v1/user", createRbacUserBody(fullName, password, loginName))
 
     /** Assign a specified role to a specified user */
     fun assignRoleToUser(loginName: String, roleId: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -160,7 +160,7 @@ class ClusterBuilder {
             | }""".trimMargin()
 
     private fun createRbacUserBody(fullName: String, loginName: String, password: String) =
-        """{ "fullName" : "$fullName", "loginName" : "$loginName", "initialPassword" : "$password }"""
+        """{ "fullName" : "$fullName", "loginName" : "$loginName", "initialPassword" : "$password" }"""
 
     /** Create a virtual node */
     fun vNodeCreate(cpiHash: String, x500Name: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -254,7 +254,8 @@ class ClusterBuilder {
     fun getRbacRoles() = get("/api/v1/role")
 
     /** Create new RBAC user */
-    fun createRbacUser(fullName: String, loginName: String, password: String) = post("/api/v1/user", createRbacUserBody(fullName, loginName, password))
+    fun createRbacUser(fullName: String, loginName: String, password: String) =
+        post("/api/v1/user", createRbacUserBody(fullName, loginName, password))
 
     /** Assign a specified role to a specified user */
     fun assignRoleToUser(loginName: String, roleId: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -159,8 +159,11 @@ class ClusterBuilder {
             |   } 
             | }""".trimMargin()
 
-    private fun createRbacUserBody(fullName: String, password: String, loginName: String) =
-        """{ "fullName" : "$fullName", "initialPassword" : "$password", "loginName" : "$loginName" }"""
+    private fun createRbacUserBody(enabled: Boolean, fullName: String, password: String, loginName: String) =
+        """{ "enabled" : "$enabled", 
+            |"fullName" : "$fullName", 
+            |"initialPassword" : "$password", 
+            |"loginName" : "$loginName" }""".trimMargin()
 
     /** Create a virtual node */
     fun vNodeCreate(cpiHash: String, x500Name: String) =
@@ -254,8 +257,8 @@ class ClusterBuilder {
     fun getRbacRoles() = get("/api/v1/role")
 
     /** Create new RBAC user */
-    fun createRbacUser(fullName: String, password: String, loginName: String) =
-        post("/api/v1/user", createRbacUserBody(fullName, password, loginName))
+    fun createRbacUser(enabled: Boolean, fullName: String, password: String, loginName: String) =
+        post("/api/v1/user", createRbacUserBody(enabled, fullName, password, loginName))
 
     /** Assign a specified role to a specified user */
     fun assignRoleToUser(loginName: String, roleId: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -165,6 +165,7 @@ fun awaitMultipleRpcFlowFinished(holdingId: String, expectedFlowCount: Int) {
 fun getFlowClasses(
     holdingId: String
 ) = DEFAULT_CLUSTER.getFlowClasses(holdingId)
+
 fun ClusterInfo.getFlowClasses(holdingId: String): List<String> {
     return cluster {
         val vNodeJson = assertWithRetry {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -162,8 +162,11 @@ fun awaitMultipleRpcFlowFinished(holdingId: String, expectedFlowCount: Int) {
     }
 }
 
-fun getFlowClasses(holdingId: String): List<String> {
-    return DEFAULT_CLUSTER.cluster {
+fun getFlowClasses(
+    holdingId: String
+) = DEFAULT_CLUSTER.getFlowClasses(holdingId)
+fun ClusterInfo.getFlowClasses(holdingId: String): List<String> {
+    return cluster {
         val vNodeJson = assertWithRetry {
             command { runnableFlowClasses(holdingId) }
             condition { it.code == 200 }


### PR DESCRIPTION
- Added `createRbacUser`, `createRbacUserBody` and `assignRoleToUser` methods to make API calls in `ClusterBuilder.kt`
- Extended `getFlowClasses` in `FlowTestUtils.kt`, so we can use it on different cluster info

Relating to: [CORE-7243: Add new test to FlowExecutorE2eTest #128](https://github.com/corda/corda-e2e-tests/pull/128)