### PR TITLE
CORE-10051: Remove assign hardware HSM path in crypto worker

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/HSMService.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/HSMService.kt
@@ -8,11 +8,6 @@ import net.corda.lifecycle.Lifecycle
  */
 interface HSMService : Lifecycle {
     /**
-     * Assigns an HSM out of existing pull of configured HSMs (except Soft HSM)
-     */
-    fun assignHSM(tenantId: String, category: String, context: Map<String, String>): HSMAssociationInfo
-
-    /**
      * Assigns a Soft HSM, note that a new HSMConfig record will be created for each tenant.
      */
     fun assignSoftHSM(tenantId: String, category: String): HSMAssociationInfo

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/HSMStats.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/HSMStats.kt
@@ -2,6 +2,7 @@ package net.corda.crypto.service.impl
 
 import net.corda.crypto.config.impl.PrivateKeyPolicy
 
+// TODO this is currently not being used anywhere
 data class HSMStats(
     val allUsages: Int,
     val hsmId: String,

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessor.kt
@@ -3,14 +3,12 @@ package net.corda.crypto.service.impl.bus
 import net.corda.crypto.config.impl.RetryingConfig
 import net.corda.crypto.impl.retrying.BackoffStrategy
 import net.corda.crypto.impl.retrying.CryptoRetryingExecutor
-import net.corda.crypto.impl.toMap
 import net.corda.crypto.service.HSMService
 import net.corda.data.crypto.wire.CryptoNoContentValue
 import net.corda.data.crypto.wire.CryptoRequestContext
 import net.corda.data.crypto.wire.CryptoResponseContext
 import net.corda.data.crypto.wire.hsm.registration.HSMRegistrationRequest
 import net.corda.data.crypto.wire.hsm.registration.HSMRegistrationResponse
-import net.corda.data.crypto.wire.hsm.registration.commands.AssignHSMCommand
 import net.corda.data.crypto.wire.hsm.registration.commands.AssignSoftHSMCommand
 import net.corda.data.crypto.wire.hsm.registration.queries.AssignedHSMQuery
 import net.corda.messaging.api.processor.RPCResponderProcessor
@@ -53,7 +51,6 @@ class HSMRegistrationBusProcessor(
 
     private fun handleRequest(request: Any, context: CryptoRequestContext): Any {
         return when (request) {
-            is AssignHSMCommand -> hsmService.assignHSM(context.tenantId, request.category, request.context.toMap())
             is AssignSoftHSMCommand -> hsmService.assignSoftHSM(context.tenantId, request.category)
             is AssignedHSMQuery -> hsmService.findAssignedHSM(context.tenantId, request.category) ?: CryptoNoContentValue()
             else -> throw IllegalArgumentException("Unknown request type ${request::class.java.name}")

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/HSMServiceTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/HSMServiceTests.kt
@@ -1,23 +1,17 @@
 package net.corda.crypto.service.impl
 
 import net.corda.crypto.core.CryptoConsts
-import net.corda.crypto.core.CryptoConsts.HSMContext.PREFERRED_PRIVATE_KEY_POLICY_ALIASED
-import net.corda.crypto.core.CryptoConsts.HSMContext.PREFERRED_PRIVATE_KEY_POLICY_KEY
 import net.corda.crypto.core.CryptoConsts.SOFT_HSM_ID
 import net.corda.crypto.service.impl.infra.TestServicesFactory
-import net.corda.crypto.service.impl.infra.TestServicesFactory.Companion.CUSTOM1_HSM_ID
-import net.corda.crypto.service.impl.infra.TestServicesFactory.Companion.CUSTOM2_HSM_ID
 import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 class HSMServiceTests {
     companion object {
@@ -85,105 +79,5 @@ class HSMServiceTests {
         assertHSMAssociation(association1, tenantId, CryptoConsts.Categories.LEDGER)
         val association2 = factory.hsmService.assignSoftHSM(tenantId, CryptoConsts.Categories.LEDGER)
         assertHSMAssociation(association2, tenantId, CryptoConsts.Categories.LEDGER)
-    }
-
-    @Disabled
-    @Test
-    fun `Should assign HSM and retrieve assignment`() {
-        val tenantId1 = UUID.randomUUID().toString()
-        val tenantId2 = UUID.randomUUID().toString()
-
-        factory.hsmService.assignHSM(tenantId1, CryptoConsts.Categories.LEDGER, emptyMap())
-        val usage1 = factory.hsmStore.getHSMUsage()
-        assertThat(usage1).hasSize(1)
-        assertThat(usage1.first().usages).isEqualTo(1)
-        assertThat(usage1.first().hsmId).isIn(CUSTOM1_HSM_ID, CUSTOM2_HSM_ID)
-
-        factory.hsmService.assignHSM(tenantId1, CryptoConsts.Categories.TLS, emptyMap())
-        val usage2 = factory.hsmStore.getHSMUsage()
-        assertThat(usage2).hasSize(2)
-        assertThat(usage2).anyMatch { it.hsmId == CUSTOM1_HSM_ID && it.usages == 1 }
-        assertThat(usage2).anyMatch { it.hsmId == CUSTOM2_HSM_ID && it.usages == 1 }
-
-        factory.hsmService.assignHSM(tenantId2, CryptoConsts.Categories.LEDGER, emptyMap())
-        val usage3 = factory.hsmStore.getHSMUsage()
-        assertThat(usage3).hasSize(2)
-        assertThat(usage3).anyMatch { it.hsmId == CUSTOM1_HSM_ID }
-        assertThat(usage3).anyMatch { it.hsmId == CUSTOM2_HSM_ID }
-        assertTrue(
-            (usage3[0].usages == 2 && usage3[1].usages == 1) ||
-                    (usage3[0].usages == 1 && usage3[1].usages == 2)
-        )
-    }
-
-    @Disabled
-    @Test
-    fun `Should assign HSM with preference to use ALIASED and retrieve assignment`() {
-        val tenantId1 = UUID.randomUUID().toString()
-        val tenantId2 = UUID.randomUUID().toString()
-
-        factory.hsmService.assignHSM(
-            tenantId1, CryptoConsts.Categories.LEDGER, mapOf(
-                PREFERRED_PRIVATE_KEY_POLICY_KEY to PREFERRED_PRIVATE_KEY_POLICY_ALIASED
-            )
-        )
-        val usage1 = factory.hsmStore.getHSMUsage()
-        assertThat(usage1).hasSize(1)
-        assertThat(usage1.first().usages).isEqualTo(1)
-        assertThat(usage1.first().hsmId).isEqualTo(CUSTOM1_HSM_ID)
-
-        factory.hsmService.assignHSM(
-            tenantId1, CryptoConsts.Categories.TLS, mapOf(
-                PREFERRED_PRIVATE_KEY_POLICY_KEY to PREFERRED_PRIVATE_KEY_POLICY_ALIASED
-            )
-        )
-        val usage2 = factory.hsmStore.getHSMUsage()
-        assertThat(usage2).hasSize(1)
-        assertThat(usage2).anyMatch { it.hsmId == CUSTOM1_HSM_ID && it.usages == 2 }
-
-        // should fall back to use another one as the exact match already full
-        factory.hsmService.assignHSM(
-            tenantId2, CryptoConsts.Categories.LEDGER, mapOf(
-                PREFERRED_PRIVATE_KEY_POLICY_KEY to PREFERRED_PRIVATE_KEY_POLICY_ALIASED
-            )
-        )
-        val usage3 = factory.hsmStore.getHSMUsage()
-        assertThat(usage3).hasSize(2)
-        assertThat(usage3).anyMatch { it.hsmId == CUSTOM1_HSM_ID && it.usages == 2 }
-        assertThat(usage3).anyMatch { it.hsmId == CUSTOM2_HSM_ID && it.usages == 1 }
-    }
-
-    @Disabled
-    @Test
-    @Suppress("ComplexMethod")
-    fun `Should assign HSM ignoring SOFT HSM stats and retrieve assignment`() {
-        factory.hsmService.assignSoftHSM(UUID.randomUUID().toString(), CryptoConsts.Categories.LEDGER)
-
-        val tenantId1 = UUID.randomUUID().toString()
-        val tenantId2 = UUID.randomUUID().toString()
-
-        factory.hsmService.assignHSM(tenantId1, CryptoConsts.Categories.LEDGER, emptyMap())
-        val usage1 = factory.hsmStore.getHSMUsage()
-        assertThat(usage1).hasSize(2)
-        assertThat(usage1).anyMatch { it.hsmId == SOFT_HSM_ID && it.usages == 1 }
-        assertThat(usage1).anyMatch { (it.hsmId == CUSTOM1_HSM_ID || it.hsmId == CUSTOM2_HSM_ID) && it.usages == 1 }
-
-        factory.hsmService.assignHSM(tenantId1, CryptoConsts.Categories.TLS, emptyMap())
-        val usage2 = factory.hsmStore.getHSMUsage()
-        assertThat(usage2).hasSize(3)
-        assertThat(usage1).anyMatch { it.hsmId == SOFT_HSM_ID && it.usages == 1 }
-        assertThat(usage2).anyMatch { it.hsmId == CUSTOM1_HSM_ID && it.usages == 1 }
-        assertThat(usage2).anyMatch { it.hsmId == CUSTOM2_HSM_ID && it.usages == 1 }
-
-        factory.hsmService.assignHSM(tenantId2, CryptoConsts.Categories.LEDGER, emptyMap())
-        val usage3 = factory.hsmStore.getHSMUsage()
-        assertThat(usage3).hasSize(3)
-        assertThat(usage1).anyMatch { it.hsmId == SOFT_HSM_ID && it.usages == 1 }
-        assertThat(usage3).anyMatch { it.hsmId == CUSTOM1_HSM_ID }
-        assertThat(usage3).anyMatch { it.hsmId == CUSTOM2_HSM_ID }
-        assertTrue(
-            (usage3[0].usages == 2 && usage3[1].usages == 1) ||
-                    (usage3[0].usages == 1 && usage3[1].usages == 2)
-        )
     }
 }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
@@ -6,8 +6,6 @@ import net.corda.crypto.config.impl.createDefaultCryptoConfig
 import net.corda.crypto.config.impl.retrying
 import net.corda.crypto.config.impl.toCryptoConfig
 import net.corda.crypto.core.CryptoConsts
-import net.corda.crypto.core.CryptoConsts.HSMContext.PREFERRED_PRIVATE_KEY_POLICY_KEY
-import net.corda.crypto.core.CryptoConsts.HSMContext.PREFERRED_PRIVATE_KEY_POLICY_NONE
 import net.corda.crypto.service.HSMService
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
@@ -17,7 +15,6 @@ import net.corda.data.crypto.wire.CryptoResponseContext
 import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import net.corda.data.crypto.wire.hsm.registration.HSMRegistrationRequest
 import net.corda.data.crypto.wire.hsm.registration.HSMRegistrationResponse
-import net.corda.data.crypto.wire.hsm.registration.commands.AssignHSMCommand
 import net.corda.data.crypto.wire.hsm.registration.commands.AssignSoftHSMCommand
 import net.corda.data.crypto.wire.hsm.registration.queries.AssignedHSMQuery
 import net.corda.data.crypto.wire.ops.rpc.commands.GenerateWrappingKeyRpcCommand
@@ -29,7 +26,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
@@ -84,42 +80,6 @@ class HSMRegistrationBusProcessorTests {
                         expected.other.items.containsAll(actual.other.items)
             )
         }
-    }
-
-    @Test
-    fun `Should handle AssignHSMCommand`() {
-        val info = HSMAssociationInfo()
-        val hsmService = mock<HSMService> {
-            on { assignHSM(any(), any(), any()) } doReturn info
-        }
-        val processor = HSMRegistrationBusProcessor(hsmService, configEvent.config.toCryptoConfig().retrying())
-        val context = createRequestContext()
-        val future = CompletableFuture<HSMRegistrationResponse>()
-        processor.onNext(
-            HSMRegistrationRequest(
-                context,
-                AssignHSMCommand(
-                    CryptoConsts.Categories.LEDGER,
-                    KeyValuePairList(
-                        listOf(
-                            KeyValuePair(PREFERRED_PRIVATE_KEY_POLICY_KEY, PREFERRED_PRIVATE_KEY_POLICY_NONE)
-                        )
-                    )
-                )
-            ),
-            future
-        )
-        val result = future.get()
-        assertResponseContext(context, result.context)
-        assertThat(result.response).isInstanceOf(HSMAssociationInfo::class.java)
-        assertSame(info, result.response)
-        Mockito.verify(hsmService, times(1)).assignHSM(
-            eq(tenantId),
-            eq(CryptoConsts.Categories.LEDGER),
-            argThat {
-                this[PREFERRED_PRIVATE_KEY_POLICY_KEY] == PREFERRED_PRIVATE_KEY_POLICY_NONE
-            }
-        )
     }
 
     @Test
@@ -223,7 +183,7 @@ class HSMRegistrationBusProcessorTests {
     fun `Should complete future exceptionally in case of service failure`() {
         val originalException = RuntimeException()
         val hsmService = mock<HSMService> {
-            on { assignHSM(any(), any(), any()) } doThrow originalException
+            on { assignSoftHSM(any(), any()) } doThrow originalException
         }
         val processor = HSMRegistrationBusProcessor(hsmService, configEvent.config.toCryptoConfig().retrying())
         val context = createRequestContext()
@@ -231,13 +191,8 @@ class HSMRegistrationBusProcessorTests {
         processor.onNext(
             HSMRegistrationRequest(
                 context,
-                AssignHSMCommand(
-                    CryptoConsts.Categories.LEDGER,
-                    KeyValuePairList(
-                        listOf(
-                            KeyValuePair(PREFERRED_PRIVATE_KEY_POLICY_KEY, PREFERRED_PRIVATE_KEY_POLICY_NONE)
-                        )
-                    )
+                AssignSoftHSMCommand(
+                    CryptoConsts.Categories.LEDGER
                 )
             ),
             future
@@ -247,12 +202,9 @@ class HSMRegistrationBusProcessorTests {
         }
         assertNotNull(exception.cause)
         assertSame(originalException, exception.cause)
-        Mockito.verify(hsmService, times(1)).assignHSM(
+        Mockito.verify(hsmService, times(1)).assignSoftHSM(
             eq(tenantId),
-            eq(CryptoConsts.Categories.LEDGER),
-            argThat {
-                this[PREFERRED_PRIVATE_KEY_POLICY_KEY] == PREFERRED_PRIVATE_KEY_POLICY_NONE
-            }
+            eq(CryptoConsts.Categories.LEDGER)
         )
     }
 }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoConsts.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoConsts.kt
@@ -82,6 +82,7 @@ object CryptoConsts {
         const val SERVICE_NAME_FILTER = "serviceName"
     }
 
+    // TODO The below seems to only be relevant to hardware HSMs
     /**
      * Constants defining keys for the context in the HSM services functions.
      */


### PR DESCRIPTION
(cherry-picked from  425c7926c89e87e9b5508564437fc023c2487588 and which is  in 5.1 so that the 5.0 and 5.1 crypto workers will be in sync once all the merging is done.

We want the changes here to simplify the upcoming caching change)