### PR TITLE
CORE-14564 - Review backward compatibility for RegistrationStatus

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -109,7 +109,7 @@ pipeline {
         }
         stage('smoketests') {
                 options {
-                    timeout(time: 45, unit: 'MINUTES')
+                    timeout(time: 30, unit: 'MINUTES')
                 }
                 steps {
                    gradlew('smoketest -PisCombinedWorker=true')

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -109,7 +109,7 @@ pipeline {
         }
         stage('smoketests') {
                 options {
-                    timeout(time: 30, unit: 'MINUTES')
+                    timeout(time: 45, unit: 'MINUTES')
                 }
                 steps {
                    gradlew('smoketest -PisCombinedWorker=true')

--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/stub/MembershipQueryClientStub.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/stub/MembershipQueryClientStub.kt
@@ -1,7 +1,7 @@
 package net.corda.p2p.linkmanager.integration.stub
 
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
@@ -13,7 +13,7 @@ import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.data.membership.preauth.PreAuthTokenStatus
 import net.corda.data.membership.rpc.request.MGMGroupPolicyRequest

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
@@ -12,7 +12,7 @@ import net.corda.data.membership.SignedData
 import net.corda.data.membership.async.request.MembershipAsyncRequest
 import net.corda.data.membership.async.request.RegistrationAsyncRequest
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
@@ -18,7 +18,7 @@ import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.data.membership.preauth.PreAuthTokenStatus
 import net.corda.data.membership.rpc.request.MGMGroupPolicyRequest

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MemberResourceClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MemberResourceClientTest.kt
@@ -12,7 +12,7 @@ import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.async.request.MembershipAsyncRequest
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessor.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessor.kt
@@ -4,7 +4,7 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.hes.StableKeyPairDecryptor
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.MembershipSyncRequest
-import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
+import net.corda.data.membership.p2p.SetOwnRegistrationStatus
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.p2p.VerificationResponse
@@ -18,6 +18,7 @@ import net.corda.membership.impl.p2p.handler.RegistrationRequestHandler
 import net.corda.membership.impl.p2p.handler.SetOwnRegistrationStatusHandler
 import net.corda.membership.impl.p2p.handler.VerificationRequestHandler
 import net.corda.membership.impl.p2p.handler.VerificationResponseHandler
+import net.corda.membership.lib.SetOwnRegistrationStatusV2
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
@@ -54,7 +55,8 @@ class MembershipP2PProcessor(
         VerificationResponse::class.java to { VerificationResponseHandler(avroSchemaRegistry) },
         MembershipPackage::class.java to { MembershipPackageHandler(avroSchemaRegistry) },
         MembershipSyncRequest::class.java to { MembershipSyncRequestHandler(avroSchemaRegistry) },
-        SetOwnRegistrationStatus::class.java to { SetOwnRegistrationStatusHandler(avroSchemaRegistry) }
+        SetOwnRegistrationStatus::class.java to { SetOwnRegistrationStatusHandler(avroSchemaRegistry) },
+        SetOwnRegistrationStatusV2::class.java to { SetOwnRegistrationStatusHandler(avroSchemaRegistry) }
     )
 
     override fun onNext(events: List<Record<String, AppMessage>>): List<Record<*, *>> {

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessor.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/MembershipP2PProcessor.kt
@@ -4,7 +4,7 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.crypto.hes.StableKeyPairDecryptor
 import net.corda.data.membership.p2p.MembershipPackage
 import net.corda.data.membership.p2p.MembershipSyncRequest
-import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.p2p.VerificationResponse

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandler.kt
@@ -11,7 +11,6 @@ import net.corda.membership.lib.SetOwnRegistrationStatusV2
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.toCorda
 import java.nio.ByteBuffer
 
@@ -22,10 +21,10 @@ internal class SetOwnRegistrationStatusHandler(
         header: AuthenticatedMessageHeader,
         payload: ByteBuffer
     ): Record<String, RegistrationCommand> {
-        val response = try {
-            avroSchemaRegistry.deserialize(payload)
-        } catch (e: CordaRuntimeException) {
+        val response = if (avroSchemaRegistry.getClassType(payload) == SetOwnRegistrationStatus::class.java) {
             avroSchemaRegistry.deserialize<SetOwnRegistrationStatus>(payload).convertToNewVersion()
+        } else {
+            avroSchemaRegistry.deserialize(payload)
         }
         return Record(
             REGISTRATION_COMMAND_TOPIC,
@@ -41,11 +40,16 @@ internal class SetOwnRegistrationStatusHandler(
 
     private fun SetOwnRegistrationStatus.convertToNewVersion() : SetOwnRegistrationStatusV2 {
         val status = when(newStatus) {
+            RegistrationStatus.NEW -> RegistrationStatusV2.NEW
+            RegistrationStatus.SENT_TO_MGM -> RegistrationStatusV2.SENT_TO_MGM
             RegistrationStatus.RECEIVED_BY_MGM -> RegistrationStatusV2.RECEIVED_BY_MGM
+            RegistrationStatus.PENDING_MEMBER_VERIFICATION -> RegistrationStatusV2.PENDING_MEMBER_VERIFICATION
             RegistrationStatus.PENDING_MANUAL_APPROVAL -> RegistrationStatusV2.PENDING_MANUAL_APPROVAL
             RegistrationStatus.PENDING_AUTO_APPROVAL -> RegistrationStatusV2.PENDING_AUTO_APPROVAL
             RegistrationStatus.APPROVED -> RegistrationStatusV2.APPROVED
             RegistrationStatus.DECLINED -> RegistrationStatusV2.DECLINED
+            RegistrationStatus.INVALID -> RegistrationStatusV2.INVALID
+            RegistrationStatus.FAILED -> RegistrationStatusV2.FAILED
             else -> throw IllegalArgumentException("Unknown status '${newStatus.name}' received.")
         }
         return SetOwnRegistrationStatusV2(registrationId, status)

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandler.kt
@@ -2,12 +2,16 @@ package net.corda.membership.impl.p2p.handler
 
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.member.PersistMemberRegistrationState
-import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.p2p.SetOwnRegistrationStatus
 import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.membership.lib.RegistrationStatusV2
+import net.corda.membership.lib.SetOwnRegistrationStatusV2
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.toCorda
 import java.nio.ByteBuffer
 
@@ -18,7 +22,11 @@ internal class SetOwnRegistrationStatusHandler(
         header: AuthenticatedMessageHeader,
         payload: ByteBuffer
     ): Record<String, RegistrationCommand> {
-        val response = avroSchemaRegistry.deserialize<SetOwnRegistrationStatus>(payload)
+        val response = try {
+            avroSchemaRegistry.deserialize(payload)
+        } catch (e: CordaRuntimeException) {
+            avroSchemaRegistry.deserialize<SetOwnRegistrationStatus>(payload).convertToNewVersion()
+        }
         return Record(
             REGISTRATION_COMMAND_TOPIC,
             "${response.registrationId}-${response.newStatus}-${header.destination.toCorda().shortHash}",
@@ -29,5 +37,17 @@ internal class SetOwnRegistrationStatusHandler(
                 )
             )
         )
+    }
+
+    private fun SetOwnRegistrationStatus.convertToNewVersion() : SetOwnRegistrationStatusV2 {
+        val status = when(newStatus) {
+            RegistrationStatus.RECEIVED_BY_MGM -> RegistrationStatusV2.RECEIVED_BY_MGM
+            RegistrationStatus.PENDING_MANUAL_APPROVAL -> RegistrationStatusV2.PENDING_MANUAL_APPROVAL
+            RegistrationStatus.PENDING_AUTO_APPROVAL -> RegistrationStatusV2.PENDING_AUTO_APPROVAL
+            RegistrationStatus.APPROVED -> RegistrationStatusV2.APPROVED
+            RegistrationStatus.DECLINED -> RegistrationStatusV2.DECLINED
+            else -> throw IllegalArgumentException("Unknown status '${newStatus.name}' received.")
+        }
+        return SetOwnRegistrationStatusV2(registrationId, status)
     }
 }

--- a/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandler.kt
+++ b/components/membership/membership-p2p-impl/src/main/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandler.kt
@@ -2,7 +2,7 @@ package net.corda.membership.impl.p2p.handler
 
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.member.PersistMemberRegistrationState
-import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC

--- a/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandlerTest.kt
+++ b/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandlerTest.kt
@@ -3,27 +3,38 @@ package net.corda.membership.impl.p2p.handler
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.member.PersistMemberRegistrationState
-import net.corda.data.membership.common.v2.RegistrationStatus
-import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.p2p.SetOwnRegistrationStatus
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
+import net.corda.membership.lib.RegistrationStatusV2
+import net.corda.membership.lib.SetOwnRegistrationStatusV2
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import java.nio.ByteBuffer
 
 class SetOwnRegistrationStatusHandlerTest {
-    private val payload = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
-    private val status = SetOwnRegistrationStatus(
+    private val payloadV1 = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
+    private val statusV1 = SetOwnRegistrationStatus(
         "id",
         RegistrationStatus.DECLINED
     )
+    private val payloadV2 = ByteBuffer.wrap(byteArrayOf(4, 5, 6))
+    private val statusV2 = SetOwnRegistrationStatusV2(
+        "id",
+        RegistrationStatusV2.DECLINED
+    )
     private val avroSchemaRegistry: AvroSchemaRegistry = mock {
-        on { deserialize<SetOwnRegistrationStatus>(payload) } doReturn status
+        on { deserialize<SetOwnRegistrationStatus>(payloadV1) } doReturn statusV1
+        on { deserialize<SetOwnRegistrationStatusV2>(payloadV1) } doThrow  CordaRuntimeException("")
+        on { deserialize<SetOwnRegistrationStatusV2>(payloadV2) } doReturn statusV2
     }
     private val identity = HoldingIdentity("O=Alice, L=London, C=GB", "GroupId")
     private val header = mock<AuthenticatedMessageHeader> {
@@ -32,8 +43,8 @@ class SetOwnRegistrationStatusHandlerTest {
     private val handler = SetOwnRegistrationStatusHandler(avroSchemaRegistry)
 
     @Test
-    fun `invokeAuthenticatedMessage returns PersistMemberRegistrationState command`() {
-        val record = handler.invokeAuthenticatedMessage(header, payload)
+    fun `invokeAuthenticatedMessage returns PersistMemberRegistrationState command - V1 version converted to V2 successfully`() {
+        val record = handler.invokeAuthenticatedMessage(header, payloadV1)
 
         assertSoftly { softly ->
             softly.assertThat(record.topic).isEqualTo(REGISTRATION_COMMAND_TOPIC)
@@ -42,7 +53,25 @@ class SetOwnRegistrationStatusHandlerTest {
                 RegistrationCommand(
                     PersistMemberRegistrationState(
                         identity,
-                        status
+                        statusV2
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `invokeAuthenticatedMessage returns PersistMemberRegistrationState command - V2 version`() {
+        val record = handler.invokeAuthenticatedMessage(header, payloadV2)
+
+        assertSoftly { softly ->
+            softly.assertThat(record.topic).isEqualTo(REGISTRATION_COMMAND_TOPIC)
+            softly.assertThat(record.key).isEqualTo("id-DECLINED-${identity.toCorda().shortHash}")
+            softly.assertThat(record.value).isEqualTo(
+                RegistrationCommand(
+                    PersistMemberRegistrationState(
+                        identity,
+                        statusV2
                     )
                 )
             )

--- a/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandlerTest.kt
+++ b/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandlerTest.kt
@@ -11,12 +11,10 @@ import net.corda.membership.lib.SetOwnRegistrationStatusV2
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import java.nio.ByteBuffer
 
@@ -32,8 +30,9 @@ class SetOwnRegistrationStatusHandlerTest {
         RegistrationStatusV2.DECLINED
     )
     private val avroSchemaRegistry: AvroSchemaRegistry = mock {
+        on { getClassType(payloadV1) } doReturn SetOwnRegistrationStatus::class.java
+        on { getClassType(payloadV2) } doReturn SetOwnRegistrationStatusV2::class.java
         on { deserialize<SetOwnRegistrationStatus>(payloadV1) } doReturn statusV1
-        on { deserialize<SetOwnRegistrationStatusV2>(payloadV1) } doThrow  CordaRuntimeException("")
         on { deserialize<SetOwnRegistrationStatusV2>(payloadV2) } doReturn statusV2
     }
     private val identity = HoldingIdentity("O=Alice, L=London, C=GB", "GroupId")

--- a/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandlerTest.kt
+++ b/components/membership/membership-p2p-impl/src/test/kotlin/net/corda/membership/impl/p2p/handler/SetOwnRegistrationStatusHandlerTest.kt
@@ -3,8 +3,8 @@ package net.corda.membership.impl.p2p.handler
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.member.PersistMemberRegistrationState
-import net.corda.data.membership.common.RegistrationStatus
-import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
+import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
 import net.corda.schema.Schemas.Membership.REGISTRATION_COMMAND_TOPIC
 import net.corda.schema.registry.AvroSchemaRegistry

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImpl.kt
@@ -10,7 +10,7 @@ import net.corda.data.membership.PersistentSignedMemberInfo
 import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipPersistenceRequest
 import net.corda.data.membership.db.request.command.ActivateMember
 import net.corda.data.membership.db.request.command.AddNotaryToGroupParameters

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImpl.kt
@@ -7,7 +7,7 @@ import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipPersistenceRequest
 import net.corda.data.membership.db.request.query.MutualTlsListAllowedCertificates
 import net.corda.data.membership.db.request.query.QueryApprovalRules

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -17,7 +17,7 @@ import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
 import net.corda.data.membership.common.ApprovalRuleType.PREAUTH
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipPersistenceRequest
 import net.corda.data.membership.db.request.command.ActivateMember
 import net.corda.data.membership.db.request.command.AddNotaryToGroupParameters

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -11,7 +11,7 @@ import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipPersistenceRequest
 import net.corda.data.membership.db.request.query.MutualTlsListAllowedCertificates
 import net.corda.data.membership.db.request.query.QueryMemberInfo

--- a/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
+++ b/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipPersistenceClient.kt
@@ -4,7 +4,7 @@ import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.lifecycle.Lifecycle
 import net.corda.membership.lib.InternalGroupParameters

--- a/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipQueryClient.kt
+++ b/components/membership/membership-persistence-client/src/main/kotlin/net/corda/membership/persistence/client/MembershipQueryClient.kt
@@ -8,7 +8,7 @@ import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.lifecycle.Lifecycle
 import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -19,7 +19,7 @@ import net.corda.data.membership.SignedData
 import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.db.admin.LiquibaseSchemaMigrator
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.connection.manager.VirtualNodeDbType

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/RegistrationStatusHelper.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/RegistrationStatusHelper.kt
@@ -1,6 +1,6 @@
 package net.corda.membership.impl.persistence.service.handler
 
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 
 internal object RegistrationStatusHelper {

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandler.kt
@@ -6,7 +6,7 @@ import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.membership.PersistentMemberInfo
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToApproved
 import net.corda.data.membership.db.response.query.UpdateMemberAndRegistrationRequestResponse

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -11,7 +11,7 @@ import net.corda.data.membership.SignedData
 import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipPersistenceRequest
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.ActivateMember

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/BaseRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/BaseRequestStatusHandlerTest.kt
@@ -6,7 +6,7 @@ import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.membership.datamodel.RegistrationRequestEntity
 import net.corda.membership.lib.exceptions.MembershipPersistenceException

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
@@ -8,7 +8,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.SignedData
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.PersistRegistrationRequest
 import net.corda.data.membership.p2p.MembershipRegistrationRequest

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
@@ -4,7 +4,7 @@ import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePairList
 import net.corda.data.identity.HoldingIdentity
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.query.QueryRegistrationRequests
 import net.corda.db.connection.manager.DbConnectionManager

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/RegistrationStatusHelperTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/RegistrationStatusHelperTest.kt
@@ -1,6 +1,6 @@
 package net.corda.membership.impl.persistence.service.handler
 
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.membership.impl.persistence.service.handler.RegistrationStatusHelper.toStatus
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import org.assertj.core.api.Assertions.assertThat

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
@@ -8,7 +8,7 @@ import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.PersistentMemberInfo
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToApproved
 import net.corda.db.connection.manager.DbConnectionManager

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
@@ -4,7 +4,7 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.UpdateRegistrationRequestStatus
 import net.corda.db.connection.manager.DbConnectionManager

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -613,20 +613,20 @@ class MGMRestResourceImpl internal constructor(
                 serial,
             )
 
-        private fun net.corda.data.membership.common.RegistrationStatus.fromAvro() = when (this) {
-            net.corda.data.membership.common.RegistrationStatus.NEW -> RegistrationStatus.NEW
-            net.corda.data.membership.common.RegistrationStatus.SENT_TO_MGM -> RegistrationStatus.SENT_TO_MGM
-            net.corda.data.membership.common.RegistrationStatus.RECEIVED_BY_MGM -> RegistrationStatus.RECEIVED_BY_MGM
-            net.corda.data.membership.common.RegistrationStatus.STARTED_PROCESSING_BY_MGM ->
+        private fun net.corda.data.membership.common.v2.RegistrationStatus.fromAvro() = when (this) {
+            net.corda.data.membership.common.v2.RegistrationStatus.NEW -> RegistrationStatus.NEW
+            net.corda.data.membership.common.v2.RegistrationStatus.SENT_TO_MGM -> RegistrationStatus.SENT_TO_MGM
+            net.corda.data.membership.common.v2.RegistrationStatus.RECEIVED_BY_MGM -> RegistrationStatus.RECEIVED_BY_MGM
+            net.corda.data.membership.common.v2.RegistrationStatus.STARTED_PROCESSING_BY_MGM ->
                 RegistrationStatus.STARTED_PROCESSING_BY_MGM
-            net.corda.data.membership.common.RegistrationStatus.PENDING_MEMBER_VERIFICATION ->
+            net.corda.data.membership.common.v2.RegistrationStatus.PENDING_MEMBER_VERIFICATION ->
                 RegistrationStatus.PENDING_MEMBER_VERIFICATION
-            net.corda.data.membership.common.RegistrationStatus.PENDING_MANUAL_APPROVAL -> RegistrationStatus.PENDING_MANUAL_APPROVAL
-            net.corda.data.membership.common.RegistrationStatus.PENDING_AUTO_APPROVAL -> RegistrationStatus.PENDING_AUTO_APPROVAL
-            net.corda.data.membership.common.RegistrationStatus.DECLINED -> RegistrationStatus.DECLINED
-            net.corda.data.membership.common.RegistrationStatus.INVALID -> RegistrationStatus.INVALID
-            net.corda.data.membership.common.RegistrationStatus.FAILED -> RegistrationStatus.FAILED
-            net.corda.data.membership.common.RegistrationStatus.APPROVED -> RegistrationStatus.APPROVED
+            net.corda.data.membership.common.v2.RegistrationStatus.PENDING_MANUAL_APPROVAL -> RegistrationStatus.PENDING_MANUAL_APPROVAL
+            net.corda.data.membership.common.v2.RegistrationStatus.PENDING_AUTO_APPROVAL -> RegistrationStatus.PENDING_AUTO_APPROVAL
+            net.corda.data.membership.common.v2.RegistrationStatus.DECLINED -> RegistrationStatus.DECLINED
+            net.corda.data.membership.common.v2.RegistrationStatus.INVALID -> RegistrationStatus.INVALID
+            net.corda.data.membership.common.v2.RegistrationStatus.FAILED -> RegistrationStatus.FAILED
+            net.corda.data.membership.common.v2.RegistrationStatus.APPROVED -> RegistrationStatus.APPROVED
         }
 
         private fun deleteGroupApprovalRule(

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsAsyncProcessor.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsAsyncProcessor.kt
@@ -5,7 +5,7 @@ import net.corda.data.membership.async.request.MembershipAsyncRequest
 import net.corda.data.membership.async.request.MembershipAsyncRequestState
 import net.corda.data.membership.async.request.RetriableFailure
 import net.corda.data.membership.async.request.SentToMgmWaitingForNetwork
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.libs.configuration.SmartConfig
 import net.corda.membership.lib.registration.RegistrationStatusExt.order
 import net.corda.membership.lib.toMap

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsAsyncProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsAsyncProcessorTest.kt
@@ -9,7 +9,7 @@ import net.corda.data.membership.async.request.RegistrationAsyncRequest
 import net.corda.data.membership.async.request.RetriableFailure
 import net.corda.data.membership.async.request.SentToMgmWaitingForNetwork
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.libs.configuration.SmartConfig
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceOperation

--- a/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestMembershipPersistenceClientImpl.kt
+++ b/components/membership/registration-impl/src/integrationTest/kotlin/net/corda/membership/impl/registration/dummy/TestMembershipPersistenceClientImpl.kt
@@ -4,7 +4,7 @@ import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.membership.lib.InternalGroupParameters
 import net.corda.membership.lib.SignedMemberInfo

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
@@ -88,6 +88,7 @@ class RegistrationProcessor(
             cordaAvroSerializationFactory,
             memberTypeChecker,
             membershipConfig,
+            membershipGroupReaderProvider,
         ),
 
         ProcessMemberVerificationRequest::class.java to ProcessMemberVerificationRequestHandler(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/ProcessMemberVerificationRequestHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/ProcessMemberVerificationRequestHandler.kt
@@ -4,7 +4,7 @@ import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.membership.command.registration.member.ProcessMemberVerificationRequest
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.p2p.VerificationResponse
 import net.corda.data.membership.state.RegistrationState
 import net.corda.membership.impl.registration.VerificationResponseKeys.FAILURE_REASONS

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
@@ -21,6 +21,7 @@ import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandle
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.membership.lib.MemberInfoExtension.Companion.notaryDetails
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
+import net.corda.membership.lib.retrieveRegistrationStatusMessage
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult
@@ -128,9 +129,10 @@ internal class ApproveRegistrationHandler(
             val persistApproveMessage = p2pRecordsFactory.createAuthenticatedMessageRecord(
                 source = approvedBy,
                 destination = approvedMember,
-                content = SetOwnRegistrationStatus(
+                content = retrieveRegistrationStatusMessage(
+                    memberInfo.platformVersion,
                     registrationId,
-                    RegistrationStatus.APPROVED
+                    RegistrationStatus.APPROVED.name
                 ),
                 filter = MembershipStatusFilter.ACTIVE_OR_SUSPENDED
             )

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
@@ -8,8 +8,7 @@ import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.ApproveRegistration
 import net.corda.data.membership.command.registration.mgm.CheckForPendingRegistration
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
-import net.corda.data.membership.common.RegistrationStatus
-import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.layeredpropertymap.toAvro

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
@@ -20,7 +20,7 @@ import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandle
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
 import net.corda.membership.lib.MemberInfoExtension.Companion.notaryDetails
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
-import net.corda.membership.lib.retrieveRegistrationStatusMessage
+import net.corda.membership.lib.VersionedMessageBuilder.retrieveRegistrationStatusMessage
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceResult

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/CheckForPendingRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/CheckForPendingRegistrationHandler.kt
@@ -3,7 +3,7 @@ package net.corda.membership.impl.registration.dynamic.handler.mgm
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.CheckForPendingRegistration
 import net.corda.data.membership.command.registration.mgm.StartRegistration
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DeclineRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DeclineRegistrationHandler.kt
@@ -12,7 +12,7 @@ import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
-import net.corda.membership.lib.retrieveRegistrationStatusMessage
+import net.corda.membership.lib.VersionedMessageBuilder.retrieveRegistrationStatusMessage
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.p2p.helpers.P2pRecordsFactory.Companion.getTtlMinutes
 import net.corda.membership.persistence.client.MembershipPersistenceClient

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
@@ -6,8 +6,7 @@ import net.corda.data.membership.command.registration.mgm.ApproveRegistration
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.command.registration.mgm.ProcessMemberVerificationResponse
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
-import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.libs.configuration.SmartConfig
@@ -22,6 +21,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.approval.RegistrationRule
 import net.corda.membership.lib.approval.RegistrationRulesEngine
 import net.corda.membership.lib.registration.PRE_AUTH_TOKEN
+import net.corda.membership.lib.retrieveRegistrationStatusMessage
 import net.corda.membership.lib.toMap
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.p2p.helpers.P2pRecordsFactory.Companion.getTtlMinutes
@@ -89,7 +89,11 @@ internal class ProcessMemberVerificationResponseHandler(
                 )
             }
 
+            val groupReader = membershipGroupReaderProvider.getGroupReader(mgm.toCorda())
             val status = getNextRegistrationStatus(mgm.toCorda(), member.toCorda(), registrationId)
+            val pendingInfo = groupReader.lookup(member.toCorda().x500Name, MembershipStatusFilter.PENDING)
+                ?: throw CordaRuntimeException("Could not find pending information " +
+                        "for member with holding ID '${member.toCorda().shortHash}'.")
             val setRegistrationRequestStatusCommands = membershipPersistenceClient.setRegistrationRequestStatus(
                 mgm.toCorda(),
                 registrationId,
@@ -98,10 +102,7 @@ internal class ProcessMemberVerificationResponseHandler(
             val persistStatusMessage = p2pRecordsFactory.createAuthenticatedMessageRecord(
                 source = mgm,
                 destination = member,
-                content = SetOwnRegistrationStatus(
-                    registrationId,
-                    status
-                ),
+                content = retrieveRegistrationStatusMessage(pendingInfo.platformVersion, registrationId, status.name),
                 minutesToWait = membershipConfig.getTtlMinutes(UPDATE_TO_PENDING_AUTO_APPROVAL),
                 filter = MembershipStatusFilter.PENDING,
             )

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
@@ -100,13 +100,18 @@ internal class ProcessMemberVerificationResponseHandler(
                 registrationId,
                 status
             ).createAsyncCommands()
-            val persistStatusMessage = p2pRecordsFactory.createAuthenticatedMessageRecord(
-                source = mgm,
-                destination = member,
-                content = retrieveRegistrationStatusMessage(pendingInfo.platformVersion, registrationId, status.name),
-                minutesToWait = membershipConfig.getTtlMinutes(UPDATE_TO_PENDING_AUTO_APPROVAL),
-                filter = MembershipStatusFilter.PENDING,
+            val statusUpdateMessage = retrieveRegistrationStatusMessage(
+                pendingInfo.platformVersion, registrationId, status.name
             )
+            val persistStatusMessage = if (statusUpdateMessage != null) {
+                p2pRecordsFactory.createAuthenticatedMessageRecord(
+                    source = mgm,
+                    destination = member,
+                    content = statusUpdateMessage,
+                    minutesToWait = membershipConfig.getTtlMinutes(UPDATE_TO_PENDING_AUTO_APPROVAL),
+                    filter = MembershipStatusFilter.PENDING,
+                )
+            } else { null }
             val approveRecord = if (status == RegistrationStatus.PENDING_AUTO_APPROVAL) {
                 Record(
                     REGISTRATION_COMMAND_TOPIC,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
@@ -21,7 +21,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.approval.RegistrationRule
 import net.corda.membership.lib.approval.RegistrationRulesEngine
 import net.corda.membership.lib.registration.PRE_AUTH_TOKEN
-import net.corda.membership.lib.retrieveRegistrationStatusMessage
+import net.corda.membership.lib.VersionedMessageBuilder.retrieveRegistrationStatusMessage
 import net.corda.membership.lib.toMap
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.p2p.helpers.P2pRecordsFactory.Companion.getTtlMinutes

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/QueueRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/QueueRegistrationHandler.kt
@@ -3,7 +3,7 @@ package net.corda.membership.impl.registration.dynamic.handler.mgm
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.CheckForPendingRegistration
 import net.corda.data.membership.command.registration.mgm.QueueRegistration
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -33,7 +33,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.SignedMemberInfo
 import net.corda.membership.lib.registration.RegistrationRequestHelpers.getPreAuthToken
-import net.corda.membership.lib.retrieveRegistrationStatusMessage
+import net.corda.membership.lib.VersionedMessageBuilder.retrieveRegistrationStatusMessage
 import net.corda.membership.lib.toMap
 import net.corda.membership.p2p.helpers.P2pRecordsFactory
 import net.corda.membership.persistence.client.MembershipPersistenceClient
@@ -199,14 +199,15 @@ internal class StartRegistrationHandler(
                 RegistrationStatus.RECEIVED_BY_MGM.name,
             )
             if (statusUpdateMessage != null) {
-                p2pRecordsFactory.createAuthenticatedMessageRecord(
+                val record = p2pRecordsFactory.createAuthenticatedMessageRecord(
                     source = mgmHoldingId.toAvro(),
                     destination = pendingMemberHoldingId.toAvro(),
                     content = statusUpdateMessage,
                     minutesToWait = 5,
                     filter = PENDING
                 )
-            } else { null }?.let { outputRecords.add(it) }
+                outputRecords.add(record)
+            }
 
             logger.info("Successful initial validation of registration request with ID ${registrationRequest.registrationId}")
             VerifyMember()

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
@@ -6,7 +6,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.command.registration.mgm.VerifyMember
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.state.RegistrationState
 import net.corda.data.p2p.app.MembershipStatusFilter

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -26,7 +26,7 @@ import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.membership.SignedData
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequest
 import net.corda.data.membership.p2p.UnauthenticatedRegistrationRequestHeader

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/ExpirationProcessorImpl.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/ExpirationProcessorImpl.kt
@@ -5,7 +5,7 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.core.ShortHash
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
-import net.corda.data.membership.common.RegistrationStatus.PENDING_MEMBER_VERIFICATION
+import net.corda.data.membership.common.v2.RegistrationStatus.PENDING_MEMBER_VERIFICATION
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinator

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationRequestHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationRequestHandler.kt
@@ -7,7 +7,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.SignedData
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.membership.lib.SignedMemberInfo
 import net.corda.membership.lib.registration.RegistrationRequest
 import net.corda.membership.lib.toWire

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -17,7 +17,7 @@ import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.SignedData
 import net.corda.data.membership.StaticNetworkInfo
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.p2p.HostedIdentityEntry
 import net.corda.data.p2p.HostedIdentitySessionKeyAndCert
 import net.corda.layeredpropertymap.toAvro

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
@@ -16,9 +16,9 @@ import net.corda.data.membership.command.registration.mgm.QueueRegistration
 import net.corda.data.membership.command.registration.mgm.StartRegistration
 import net.corda.data.membership.command.registration.mgm.VerifyMember
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
-import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.p2p.VerificationResponse
 import net.corda.data.membership.state.RegistrationState
@@ -177,6 +177,7 @@ class  RegistrationProcessorTest {
         on { name } doReturn x500Name
         on { memberProvidedContext } doReturn memberMemberContext
         on { mgmProvidedContext } doReturn memberMgmContext
+        on { platformVersion } doReturn 50100
     }
 
     private val mgmMemberContext: MemberContext = mock {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/TestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/TestUtils.kt
@@ -52,6 +52,7 @@ object TestUtils {
             on { memberProvidedContext } doReturn memberContext
             on { name } doReturn holdingIdentity.x500Name
             on { groupId } doReturn holdingIdentity.groupId
+            on { platformVersion } doReturn 50100
         }
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/PersistMemberRegistrationStateHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/PersistMemberRegistrationStateHandlerTest.kt
@@ -2,8 +2,8 @@ package net.corda.membership.impl.registration.dynamic.handler.member
 
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.command.registration.member.PersistMemberRegistrationState
-import net.corda.data.membership.common.RegistrationStatus
-import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
+import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipPersistenceOperation
 import net.corda.messaging.api.records.Record

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/ProcessMemberVerificationRequestHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/ProcessMemberVerificationRequestHandlerTest.kt
@@ -5,7 +5,7 @@ import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.member.ProcessMemberVerificationRequest
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.p2p.VerificationResponse
 import net.corda.membership.impl.registration.VerificationResponseKeys

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
@@ -9,8 +9,8 @@ import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.ApproveRegistration
 import net.corda.data.membership.command.registration.mgm.CheckForPendingRegistration
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
-import net.corda.data.membership.common.RegistrationStatus
-import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
+import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.MembershipStatusFilter

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandlerTest.kt
@@ -263,6 +263,17 @@ class ApproveRegistrationHandlerTest {
     }
 
     @Test
+    fun `invoke does not send registration status update message when status cannot be retrieved`() {
+        whenever(p2pRecordsFactory.createAuthenticatedMessageRecord(any(), any(), any(), anyOrNull(), any(), any()))
+            .thenReturn(null)
+
+        val results = handler.invoke(state, key, command)
+        assertThat(results.outputStates)
+            .hasSize(3)
+        results.outputStates.forEach { assertThat(it.value).isNotInstanceOf(AppMessage::class.java) }
+    }
+
+    @Test
     fun `Error is thrown when there is no MGM`() {
         whenever(
             memberTypeChecker.getMgmMemberInfo(owner)

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/CheckForPendingRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/CheckForPendingRegistrationHandlerTest.kt
@@ -5,7 +5,7 @@ import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.CheckForPendingRegistration
 import net.corda.data.membership.command.registration.mgm.StartRegistration
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.persistence.client.MembershipQueryResult

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DeclineRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DeclineRegistrationHandlerTest.kt
@@ -1,4 +1,5 @@
-package net.corda.membership.impl.registration.dynamic.handler.mgm
+// need to adjust it after approach is working
+/*package net.corda.membership.impl.registration.dynamic.handler.mgm
 
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.CheckForPendingRegistration
@@ -132,3 +133,4 @@ class DeclineRegistrationHandlerTest {
         }
     }
 }
+*/

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DeclineRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/DeclineRegistrationHandlerTest.kt
@@ -27,6 +27,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -135,6 +136,17 @@ class DeclineRegistrationHandlerTest {
         handler.invoke(state, Record(TOPIC, member.toString(), RegistrationCommand(command)))
 
         verify(config).getIsNull("$TTLS.$DECLINE_REGISTRATION")
+    }
+
+    @Test
+    fun `handler does not send registration status update message when status cannot be retrieved`() {
+        whenever(p2pRecordsFactory.createAuthenticatedMessageRecord(any(), any(), any(), anyOrNull(), any(), any()))
+            .thenReturn(null)
+
+        val results = handler.invoke(state, Record(TOPIC, member.toString(), RegistrationCommand(command)))
+        assertThat(results.outputStates)
+            .hasSize(2)
+        results.outputStates.forEach { assertThat(it.value).isNotInstanceOf(AppMessage::class.java) }
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/QueueRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/QueueRegistrationHandlerTest.kt
@@ -5,7 +5,7 @@ import net.corda.data.membership.SignedData
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.CheckForPendingRegistration
 import net.corda.data.membership.command.registration.mgm.QueueRegistration
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.membership.lib.registration.RegistrationRequest
 import net.corda.membership.persistence.client.MembershipPersistenceClient

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -13,7 +13,7 @@ import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.command.registration.mgm.StartRegistration
 import net.corda.data.membership.command.registration.mgm.VerifyMember
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.data.membership.state.RegistrationState
 import net.corda.data.p2p.app.AppMessage
@@ -142,6 +142,7 @@ class StartRegistrationHandlerTest {
         on { mgmProvidedContext } doReturn memberMgmContext
         on { status } doReturn MEMBER_STATUS_PENDING
         on { serial } doReturn 1L
+        on { platformVersion } doReturn 50100
     }
     private val activeMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceX500Name

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -292,6 +292,17 @@ class StartRegistrationHandlerTest {
     }
 
     @Test
+    fun `invoke does not send registration status update message when status cannot be retrieved`() {
+        whenever(p2pRecordsFactory.createAuthenticatedMessageRecord(any(), any(), any(), anyOrNull(), any(), any()))
+            .thenReturn(null)
+
+        val results = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
+        assertThat(results.outputStates)
+            .hasSize(2)
+        results.outputStates.forEach { assertThat(it.value).isNotInstanceOf(AppMessage::class.java) }
+    }
+
+    @Test
     fun `serial is increased when building pending member info`() {
         whenever(membershipQueryClient.queryRegistrationRequest(eq(mgmHoldingIdentity.toCorda()), eq(registrationId)))
             .thenReturn(MembershipQueryResult.Success(createRegistrationRequest(serial = 10L)))

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -36,6 +36,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.lib.VersionedMessageBuilder
 import net.corda.membership.lib.notary.MemberNotaryDetails
 import net.corda.membership.lib.registration.PRE_AUTH_TOKEN
 import net.corda.membership.lib.toMap
@@ -62,6 +63,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
@@ -293,13 +295,19 @@ class StartRegistrationHandlerTest {
 
     @Test
     fun `invoke does not send registration status update message when status cannot be retrieved`() {
-        whenever(p2pRecordsFactory.createAuthenticatedMessageRecord(any(), any(), any(), anyOrNull(), any(), any()))
-            .thenReturn(null)
+        val mockedBuilder = Mockito.mockStatic(VersionedMessageBuilder::class.java).also {
+            it.`when`<VersionedMessageBuilder> {
+                VersionedMessageBuilder.retrieveRegistrationStatusMessage(any(), any(), any())
+            } doReturn null
+        }
 
         val results = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
+        verify(p2pRecordsFactory, never()).createAuthenticatedMessageRecord(any(), any(), any(), anyOrNull(), any(), any())
         assertThat(results.outputStates)
             .hasSize(2)
         results.outputStates.forEach { assertThat(it.value).isNotInstanceOf(AppMessage::class.java) }
+
+        mockedBuilder.close()
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandlerTest.kt
@@ -5,7 +5,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.command.registration.mgm.VerifyMember
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.state.RegistrationState
 import net.corda.libs.configuration.SmartConfig

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -22,7 +22,7 @@ import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.crypto.wire.CryptoSigningKey
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.OutboundUnauthenticatedMessage

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/ExpirationProcessorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/ExpirationProcessorTest.kt
@@ -5,7 +5,7 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.membership.command.registration.RegistrationCommand
 import net.corda.data.membership.command.registration.mgm.DeclineRegistration
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus.PENDING_MEMBER_VERIFICATION
+import net.corda.data.membership.common.v2.RegistrationStatus.PENDING_MEMBER_VERIFICATION
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -16,7 +16,7 @@ import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.membership.PersistentMemberInfo
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.event.MembershipEvent
 import net.corda.data.membership.event.registration.MgmOnboarded
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MgmRegistrationRequestHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MgmRegistrationRequestHandlerTest.kt
@@ -7,7 +7,7 @@ import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.membership.lib.SignedMemberInfo
 import net.corda.membership.lib.registration.RegistrationRequest
 import net.corda.membership.lib.toWire

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -21,7 +21,7 @@ import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.p2p.HostedIdentityEntry
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.lifecycle.LifecycleCoordinator

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipPersistenceClient.kt
@@ -4,7 +4,7 @@ import net.corda.data.membership.PersistentMemberInfo
 import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus

--- a/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
+++ b/components/membership/synchronisation-impl/src/integrationTest/kotlin/net/corda/membership/impl/synchronisation/dummy/TestMembershipQueryClient.kt
@@ -6,7 +6,7 @@ import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.746-MGM-alpha+
+cordaApiVersion=5.1.0.746-MGM-alpha-1686821550909
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.747-MGM-alpha-1687166321100
+cordaApiVersion=5.1.0.747-MGM-alpha-1687185551196
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.746-MGM-alpha-1686821550909
+cordaApiVersion=5.1.0.747-MGM-alpha-1687166321100
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.747-MGM-alpha-1687185551196
+cordaApiVersion=5.1.0.747-MGM-alpha+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
@@ -2,12 +2,20 @@ package net.corda.membership.lib
 
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger("net.corda.membership.lib.VersionedMessageBuilder.kt")
 
 fun retrieveRegistrationStatusMessage(platformVersion: Int, registrationId: String, status: String) =
-    if (platformVersion < 50100) {
-        SetOwnRegistrationStatus(registrationId, RegistrationStatus.valueOf(status))
-    } else {
-        SetOwnRegistrationStatusV2(registrationId, RegistrationStatusV2.valueOf(status))
+    try {
+        if (platformVersion < 50100) {
+            SetOwnRegistrationStatus(registrationId, RegistrationStatus.valueOf(status))
+        } else {
+            SetOwnRegistrationStatusV2(registrationId, RegistrationStatusV2.valueOf(status))
+        }
+    } catch (e: IllegalArgumentException) {
+        logger.warn("Could not retrieve status '$status', returning null.")
+        null
     }
 
 typealias SetOwnRegistrationStatusV2 = net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
@@ -2,18 +2,17 @@ package net.corda.membership.lib
 
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.p2p.SetOwnRegistrationStatus
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.apache.avro.specific.SpecificRecordBase
 
-private val regexForV50000 = "5+0*".toRegex()
-private val regexForV50100 = "5+1*".toRegex()
+private val regexForV50000 = "500[0-9][0-9]$".toRegex()
+private val regexForV50100 = "501[0-9][0-9]$".toRegex()
 
 fun retrieveRegistrationStatusMessage(platformVersion: Int, registrationId: String, status: String): SpecificRecordBase {
     val platformVersionString = platformVersion.toString()
     return when {
         regexForV50000.matches(platformVersionString) -> SetOwnRegistrationStatus(registrationId, retrieveV1Status(status))
         regexForV50100.matches(platformVersionString) -> SetOwnRegistrationStatusV2(registrationId, retrieveV2Status(status))
-        else -> throw CordaRuntimeException("Unknown platform version: $platformVersion")
+        else -> throw IllegalArgumentException("Unknown platform version: $platformVersion")
     }
 }
 

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
@@ -2,51 +2,13 @@ package net.corda.membership.lib
 
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.p2p.SetOwnRegistrationStatus
-import org.apache.avro.specific.SpecificRecordBase
 
-private val regexForV50000 = "500[0-9][0-9]$".toRegex()
-private val regexForV50100 = "501[0-9][0-9]$".toRegex()
-
-fun retrieveRegistrationStatusMessage(platformVersion: Int, registrationId: String, status: String): SpecificRecordBase {
-    val platformVersionString = platformVersion.toString()
-    return when {
-        regexForV50000.matches(platformVersionString) -> SetOwnRegistrationStatus(registrationId, retrieveV1Status(status))
-        regexForV50100.matches(platformVersionString) -> SetOwnRegistrationStatusV2(registrationId, retrieveV2Status(status))
-        else -> throw IllegalArgumentException("Unknown platform version: $platformVersion")
+fun retrieveRegistrationStatusMessage(platformVersion: Int, registrationId: String, status: String) =
+    if (platformVersion < 50100) {
+        SetOwnRegistrationStatus(registrationId, RegistrationStatus.valueOf(status))
+    } else {
+        SetOwnRegistrationStatusV2(registrationId, RegistrationStatusV2.valueOf(status))
     }
-}
-
-private fun retrieveV1Status(status: String): RegistrationStatus {
-    return when (status) {
-        StatusesBeingSent.RECEIVED_BY_MGM.name -> RegistrationStatus.RECEIVED_BY_MGM
-        StatusesBeingSent.PENDING_MANUAL_APPROVAL.name -> RegistrationStatus.PENDING_MANUAL_APPROVAL
-        StatusesBeingSent.PENDING_AUTO_APPROVAL.name -> RegistrationStatus.PENDING_AUTO_APPROVAL
-        StatusesBeingSent.APPROVED.name -> RegistrationStatus.APPROVED
-        StatusesBeingSent.DECLINED.name -> RegistrationStatus.DECLINED
-        else -> throw IllegalArgumentException(exceptionMessageForInvalidStatus(status))
-    }
-}
-
-private fun retrieveV2Status(status: String): RegistrationStatusV2 {
-    return when (status) {
-        StatusesBeingSent.RECEIVED_BY_MGM.name -> RegistrationStatusV2.RECEIVED_BY_MGM
-        StatusesBeingSent.PENDING_MANUAL_APPROVAL.name -> RegistrationStatusV2.PENDING_MANUAL_APPROVAL
-        StatusesBeingSent.PENDING_AUTO_APPROVAL.name -> RegistrationStatusV2.PENDING_AUTO_APPROVAL
-        StatusesBeingSent.APPROVED.name -> RegistrationStatusV2.APPROVED
-        StatusesBeingSent.DECLINED.name -> RegistrationStatusV2.DECLINED
-        else -> throw IllegalArgumentException(exceptionMessageForInvalidStatus(status))
-    }
-}
-
-private fun exceptionMessageForInvalidStatus(status: String) = "This status '$status' should not be distributed."
 
 typealias SetOwnRegistrationStatusV2 = net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 typealias RegistrationStatusV2 = net.corda.data.membership.common.v2.RegistrationStatus
-
-enum class StatusesBeingSent {
-    RECEIVED_BY_MGM,
-    PENDING_MANUAL_APPROVAL,
-    PENDING_AUTO_APPROVAL,
-    APPROVED,
-    DECLINED
-}

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
@@ -1,0 +1,51 @@
+package net.corda.membership.lib
+
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.apache.avro.specific.SpecificRecordBase
+
+private val regexForV50000 = "5+0*".toRegex()
+private val regexForV50100 = "5+1*".toRegex()
+
+fun retrieveRegistrationStatusMessage(platformVersion: Int, registrationId: String, status: String): SpecificRecordBase {
+    val platformVersionString = platformVersion.toString()
+    return when {
+        regexForV50000.matches(platformVersionString) -> SetOwnRegistrationStatus(registrationId, retrieveV1Status(status))
+        regexForV50100.matches(platformVersionString) -> SetOwnRegistrationStatusV2(registrationId, retrieveV2Status(status))
+        else -> throw CordaRuntimeException("Unknown platform version: $platformVersion")
+    }
+}
+
+private fun retrieveV1Status(status: String): RegistrationStatus {
+    return when (status) {
+        StatusesBeingSent.RECEIVED_BY_MGM.name -> RegistrationStatus.RECEIVED_BY_MGM
+        StatusesBeingSent.PENDING_MANUAL_APPROVAL.name -> RegistrationStatus.PENDING_MANUAL_APPROVAL
+        StatusesBeingSent.PENDING_AUTO_APPROVAL.name -> RegistrationStatus.PENDING_AUTO_APPROVAL
+        StatusesBeingSent.APPROVED.name -> RegistrationStatus.APPROVED
+        StatusesBeingSent.DECLINED.name -> RegistrationStatus.DECLINED
+        else -> { throw IllegalArgumentException("This status '$status' should not be distributed.") }
+    }
+}
+
+private fun retrieveV2Status(status: String): RegistrationStatusV2 {
+    return when (status) {
+        StatusesBeingSent.RECEIVED_BY_MGM.name -> RegistrationStatusV2.RECEIVED_BY_MGM
+        StatusesBeingSent.PENDING_MANUAL_APPROVAL.name -> RegistrationStatusV2.PENDING_MANUAL_APPROVAL
+        StatusesBeingSent.PENDING_AUTO_APPROVAL.name -> RegistrationStatusV2.PENDING_AUTO_APPROVAL
+        StatusesBeingSent.APPROVED.name -> RegistrationStatusV2.APPROVED
+        StatusesBeingSent.DECLINED.name -> RegistrationStatusV2.DECLINED
+        else -> { throw IllegalArgumentException("This status '$status' should not be distributed.") }
+    }
+}
+
+typealias SetOwnRegistrationStatusV2 = net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
+typealias RegistrationStatusV2 = net.corda.data.membership.common.v2.RegistrationStatus
+
+enum class StatusesBeingSent {
+    RECEIVED_BY_MGM,
+    PENDING_MANUAL_APPROVAL,
+    PENDING_AUTO_APPROVAL,
+    APPROVED,
+    DECLINED
+}

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
@@ -4,19 +4,22 @@ import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.p2p.SetOwnRegistrationStatus
 import org.slf4j.LoggerFactory
 
-private val logger = LoggerFactory.getLogger("net.corda.membership.lib.VersionedMessageBuilder.kt")
+object VersionedMessageBuilder {
+    private val logger = LoggerFactory.getLogger("net.corda.membership.lib.VersionedMessageBuilder.kt")
 
-fun retrieveRegistrationStatusMessage(platformVersion: Int, registrationId: String, status: String) =
-    try {
-        if (platformVersion < 50100) {
-            SetOwnRegistrationStatus(registrationId, RegistrationStatus.valueOf(status))
-        } else {
-            SetOwnRegistrationStatusV2(registrationId, RegistrationStatusV2.valueOf(status))
+    @JvmStatic
+    fun retrieveRegistrationStatusMessage(platformVersion: Int, registrationId: String, status: String) =
+        try {
+            if (platformVersion < 50100) {
+                SetOwnRegistrationStatus(registrationId, RegistrationStatus.valueOf(status))
+            } else {
+                SetOwnRegistrationStatusV2(registrationId, RegistrationStatusV2.valueOf(status))
+            }
+        } catch (e: IllegalArgumentException) {
+            logger.warn("Could not retrieve status '$status', returning null.")
+            null
         }
-    } catch (e: IllegalArgumentException) {
-        logger.warn("Could not retrieve status '$status', returning null.")
-        null
-    }
+}
 
 typealias SetOwnRegistrationStatusV2 = net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 typealias RegistrationStatusV2 = net.corda.data.membership.common.v2.RegistrationStatus

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/VersionedMessageBuilder.kt
@@ -23,7 +23,7 @@ private fun retrieveV1Status(status: String): RegistrationStatus {
         StatusesBeingSent.PENDING_AUTO_APPROVAL.name -> RegistrationStatus.PENDING_AUTO_APPROVAL
         StatusesBeingSent.APPROVED.name -> RegistrationStatus.APPROVED
         StatusesBeingSent.DECLINED.name -> RegistrationStatus.DECLINED
-        else -> { throw IllegalArgumentException("This status '$status' should not be distributed.") }
+        else -> throw IllegalArgumentException(exceptionMessageForInvalidStatus(status))
     }
 }
 
@@ -34,9 +34,11 @@ private fun retrieveV2Status(status: String): RegistrationStatusV2 {
         StatusesBeingSent.PENDING_AUTO_APPROVAL.name -> RegistrationStatusV2.PENDING_AUTO_APPROVAL
         StatusesBeingSent.APPROVED.name -> RegistrationStatusV2.APPROVED
         StatusesBeingSent.DECLINED.name -> RegistrationStatusV2.DECLINED
-        else -> { throw IllegalArgumentException("This status '$status' should not be distributed.") }
+        else -> throw IllegalArgumentException(exceptionMessageForInvalidStatus(status))
     }
 }
+
+private fun exceptionMessageForInvalidStatus(status: String) = "This status '$status' should not be distributed."
 
 typealias SetOwnRegistrationStatusV2 = net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus
 typealias RegistrationStatusV2 = net.corda.data.membership.common.v2.RegistrationStatus

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationRequest.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationRequest.kt
@@ -1,7 +1,7 @@
 package net.corda.membership.lib.registration
 
 import net.corda.data.membership.SignedData
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.virtualnode.HoldingIdentity
 
 /**

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationStatusExt.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationStatusExt.kt
@@ -1,6 +1,6 @@
 package net.corda.membership.lib.registration
 
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 
 object RegistrationStatusExt {
 

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/VersionedMessageBuilderTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/VersionedMessageBuilderTest.kt
@@ -14,35 +14,32 @@ class VersionedMessageBuilderTest {
 
     @Test
     fun `SetOwnRegistrationStatus version 1 messages are built as expected`() {
-        with(retrieveRegistrationStatusMessage(50001, registrationId, RegistrationStatus.APPROVED.name)) {
-            assertThat(this).isInstanceOf(SetOwnRegistrationStatus::class.java)
-            val message = this as SetOwnRegistrationStatus
-            assertThat(message.newStatus).isInstanceOf(RegistrationStatus::class.java)
-            assertThat(message.newStatus.name).isEqualTo(RegistrationStatus.APPROVED.name)
+        RegistrationStatus.values().forEach { status ->
+            with(retrieveRegistrationStatusMessage(50001, registrationId, status.name)) {
+                assertThat(this).isInstanceOf(SetOwnRegistrationStatus::class.java)
+                val message = this as SetOwnRegistrationStatus
+                assertThat(message.newStatus).isInstanceOf(RegistrationStatus::class.java)
+                assertThat(message.newStatus.name).isEqualTo(status.name)
+            }
         }
     }
 
     @Test
     fun `SetOwnRegistrationStatus version 2 messages are built as expected`() {
-        with(retrieveRegistrationStatusMessage(50101, registrationId, RegistrationStatusV2.APPROVED.name)) {
-            assertThat(this).isInstanceOf(SetOwnRegistrationStatusV2::class.java)
-            val message = this as SetOwnRegistrationStatusV2
-            assertThat(message.newStatus).isInstanceOf(RegistrationStatusV2::class.java)
-            assertThat(message.newStatus.name).isEqualTo(RegistrationStatusV2.APPROVED.name)
+        RegistrationStatusV2.values().forEach { status ->
+            with(retrieveRegistrationStatusMessage(50101, registrationId, status.name)) {
+                assertThat(this).isInstanceOf(SetOwnRegistrationStatusV2::class.java)
+                val message = this as SetOwnRegistrationStatusV2
+                assertThat(message.newStatus).isInstanceOf(RegistrationStatusV2::class.java)
+                assertThat(message.newStatus.name).isEqualTo(status.name)
+            }
         }
     }
 
     @Test
     fun `exception is being thrown when not expected status needs to be distributed`() {
         assertThrows<IllegalArgumentException> {
-            retrieveRegistrationStatusMessage(50101, registrationId, RegistrationStatusV2.NEW.name)
-        }
-    }
-
-    @Test
-    fun `exception is being thrown when not expected platform version is being used`() {
-        assertThrows<IllegalArgumentException> {
-            retrieveRegistrationStatusMessage(634896, registrationId, RegistrationStatusV2.NEW.name)
+            retrieveRegistrationStatusMessage(50101, registrationId, "dummyStatus")
         }
     }
 }

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/VersionedMessageBuilderTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/VersionedMessageBuilderTest.kt
@@ -1,0 +1,48 @@
+package net.corda.membership.lib
+
+import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.UUID
+
+class VersionedMessageBuilderTest {
+    private companion object {
+        val registrationId = UUID.randomUUID().toString()
+    }
+
+    @Test
+    fun `SetOwnRegistrationStatus version 1 messages are built as expected`() {
+        with(retrieveRegistrationStatusMessage(50001, registrationId, RegistrationStatus.APPROVED.name)) {
+            assertThat(this).isInstanceOf(SetOwnRegistrationStatus::class.java)
+            val message = this as SetOwnRegistrationStatus
+            assertThat(message.newStatus).isInstanceOf(RegistrationStatus::class.java)
+            assertThat(message.newStatus.name).isEqualTo(RegistrationStatus.APPROVED.name)
+        }
+    }
+
+    @Test
+    fun `SetOwnRegistrationStatus version 2 messages are built as expected`() {
+        with(retrieveRegistrationStatusMessage(50101, registrationId, RegistrationStatusV2.APPROVED.name)) {
+            assertThat(this).isInstanceOf(SetOwnRegistrationStatusV2::class.java)
+            val message = this as SetOwnRegistrationStatusV2
+            assertThat(message.newStatus).isInstanceOf(RegistrationStatusV2::class.java)
+            assertThat(message.newStatus.name).isEqualTo(RegistrationStatusV2.APPROVED.name)
+        }
+    }
+
+    @Test
+    fun `exception is being thrown when not expected status needs to be distributed`() {
+        assertThrows<IllegalArgumentException> {
+            retrieveRegistrationStatusMessage(50101, registrationId, RegistrationStatusV2.NEW.name)
+        }
+    }
+
+    @Test
+    fun `exception is being thrown when not expected platform version is being used`() {
+        assertThrows<IllegalArgumentException> {
+            retrieveRegistrationStatusMessage(634896, registrationId, RegistrationStatusV2.NEW.name)
+        }
+    }
+}

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/VersionedMessageBuilderTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/VersionedMessageBuilderTest.kt
@@ -4,7 +4,6 @@ import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.p2p.SetOwnRegistrationStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 class VersionedMessageBuilderTest {
@@ -37,9 +36,7 @@ class VersionedMessageBuilderTest {
     }
 
     @Test
-    fun `exception is being thrown when not expected status needs to be distributed`() {
-        assertThrows<IllegalArgumentException> {
-            retrieveRegistrationStatusMessage(50101, registrationId, "dummyStatus")
-        }
+    fun `null is returned when not expected status needs to be distributed`() {
+        assertThat(retrieveRegistrationStatusMessage(50101, registrationId, "dummyStatus")).isNull()
     }
 }

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/VersionedMessageBuilderTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/VersionedMessageBuilderTest.kt
@@ -2,6 +2,7 @@ package net.corda.membership.lib
 
 import net.corda.data.membership.common.RegistrationStatus
 import net.corda.data.membership.p2p.SetOwnRegistrationStatus
+import net.corda.membership.lib.VersionedMessageBuilder.retrieveRegistrationStatusMessage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.util.UUID

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/registration/RegistrationStatusExtTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/registration/RegistrationStatusExtTest.kt
@@ -1,6 +1,6 @@
 package net.corda.membership.lib.registration
 
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.membership.lib.registration.RegistrationStatusExt.canMoveToStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
+++ b/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
@@ -12,7 +12,7 @@ class PlatformInfoProviderTest {
     lateinit var platformInfoProvider: PlatformInfoProvider
 
     private companion object {
-        const val EXPECTED_STUB_PLATFORM_VERSION = 50000
+        const val EXPECTED_STUB_PLATFORM_VERSION = 50100
     }
 
     @Test

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -12,7 +12,7 @@ class PlatformInfoProviderImpl @Activate constructor(
 ) : PlatformInfoProvider {
 
     internal companion object {
-        const val STUB_PLATFORM_VERSION = 50000
+        const val STUB_PLATFORM_VERSION = 51000
 
         private const val DEFAULT_PLATFORM_VERSION = 50000
         private const val PLATFORM_VERSION_KEY = "net.corda.platform.version"

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -12,7 +12,7 @@ class PlatformInfoProviderImpl @Activate constructor(
 ) : PlatformInfoProvider {
 
     internal companion object {
-        const val STUB_PLATFORM_VERSION = 51000
+        const val STUB_PLATFORM_VERSION = 50100
 
         private const val DEFAULT_PLATFORM_VERSION = 50000
         private const val PLATFORM_VERSION_KEY = "net.corda.platform.version"

--- a/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestMembershipPersistenceClientImpl.kt
+++ b/processors/member-processor/src/integrationTest/kotlin/net/corda/processor/member/TestMembershipPersistenceClientImpl.kt
@@ -9,7 +9,7 @@ import net.corda.data.membership.StaticNetworkInfo
 import net.corda.data.membership.common.ApprovalRuleDetails
 import net.corda.data.membership.common.ApprovalRuleType
 import net.corda.data.membership.common.RegistrationRequestDetails
-import net.corda.data.membership.common.RegistrationStatus
+import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -140,7 +140,7 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
         baseImageTag = cliBaseTag
     } else {
         String cliVersion = pluginHostVersion.replaceAll(/(.*\d)\D*$/, '$1') // drop suffix i.e beta-+
-        it.baseImageTag = (cordaCliIncluded) ? "latest-local-${cliVersion}" : "5.1.0-MGM-alpha-1684747252234"
+        it.baseImageTag = (cordaCliIncluded) ? "latest-local-${cliVersion}" : "unstable"
     }
 
     if (project.hasProperty('useDockerDaemon')) {

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -140,7 +140,7 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
         baseImageTag = cliBaseTag
     } else {
         String cliVersion = pluginHostVersion.replaceAll(/(.*\d)\D*$/, '$1') // drop suffix i.e beta-+
-        it.baseImageTag = (cordaCliIncluded) ? "latest-local-${cliVersion}" : "unstable"
+        it.baseImageTag = (cordaCliIncluded) ? "latest-local-${cliVersion}" : "unstable-5.1.0"
     }
 
     if (project.hasProperty('useDockerDaemon')) {


### PR DESCRIPTION
Adding new values for enums in avro is not considered as a backward compatible change.
We’ve added a new value STARTED_PROCESSING_BY_MGM to flag in-progress registrations. This change unfortunately broke the registration when doing cross-version testing. This PR contains the fix for this issue.