### PR TITLE
CORE-14536: Make static registration with notery more idempotent

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -593,15 +593,15 @@ class StaticMemberRegistrationService(
 
             // If the current member is a notary then the group parameters need to be updated
             memberInfo.notaryDetails?.let { notary ->
-                val currentProtocolVersions = membershipGroupReaderProvider.getGroupReader(memberInfo.holdingIdentity)
+                val currentProtocolVersions = membershipGroupReader
                     .notaryVirtualNodeLookup
                     .getNotaryVirtualNodes(notary.serviceName)
                     .filter { it.name != memberInfo.name }
                     .map { it.notaryDetails!!.serviceProtocolVersions.toHashSet() }
                     .reduceOrNull { acc, it -> acc.apply { retainAll(it) } }
                     ?: emptySet()
-                val latestGroupParameters = membershipGroupReader.groupParameters?.toAvro() ?: currentStaticNetworkInfo.groupParameters
-                latestGroupParameters.addNotary(
+                val latestGroupParameters = currentStaticNetworkInfo.groupParameters
+                latestGroupParameters?.addNotary(
                     memberInfo,
                     currentProtocolVersions,
                     keyEncodingService,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticNetworkGroupParametersUtils.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticNetworkGroupParametersUtils.kt
@@ -17,16 +17,11 @@ import net.corda.membership.network.writer.staticnetwork.StaticNetworkUtils.mgmS
 import net.corda.membership.network.writer.staticnetwork.StaticNetworkInfoMappingUtils.toCorda
 import net.corda.utilities.time.Clock
 import net.corda.v5.membership.MemberInfo
-import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 import java.security.Signature
 
 
 object StaticNetworkGroupParametersUtils {
-
-    private const val SIGNATURE_SPEC_CONTEXT_KEY = "corda.membership.signature.spec"
-    private val logger = LoggerFactory.getLogger(this::class.java)
-
     /**
      * Adds a notary to the group parameters. Adds new (or rotated) notary keys if the specified notary service exists,
      * or creates a new notary service.


### PR DESCRIPTION
This change allows the static registration to retry if the persistence had failed with a notary member.

1. It will allow a member with the same name and same notary service to try and register again.
2. It will use the group parameters from the bus (if available) instead of the database - the bus is published before the database (the static network info) is persisted.
3. It will not try to update the static member info if there are no changes to the group parameters.