### PR TITLE
CORE-14335: pass signing repository into crypto service

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
@@ -201,6 +201,9 @@ class TestServicesFactory {
                 wrappingKeyFactory = {
                     WrappingKeyImpl.generateWrappingKey(it)
                 },
+                signingRepositoryFactory =  {
+                    signingRepository
+                }
             ),
             recordedCryptoContexts
         )

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -22,6 +22,7 @@ import net.corda.crypto.hes.core.impl.deriveDHSharedSecret
 import net.corda.crypto.impl.SignatureInstances
 import net.corda.crypto.impl.getSigningData
 import net.corda.crypto.persistence.WrappingKeyInfo
+import net.corda.crypto.softhsm.SigningRepositoryFactory
 import net.corda.crypto.softhsm.WrappingRepositoryFactory
 import net.corda.crypto.softhsm.deriveSupportedSchemes
 import net.corda.metrics.CordaMetrics
@@ -45,6 +46,8 @@ const val PRIVATE_KEY_ENCODING_VERSION: Int = 1
  *
  * @param wrappingRepositoryFactory which provides a factory for [WrappingRepository], which provides save and
  *        find operations for wrapping keys on a specific tenant.
+ * @param signingRepositoryFactory which provides a factory for [SigningRepository], which provides save and
+ *        find operations for signing keys fon a specific tenant.
  * @param schemeMetadata which specifies encryption schemes, digests schemes and a source of randomness
  * @param defaultUnmanagedWrappingKeyName The unmanaged wrapping key that will be used by default for new wrapping keys
  * @param digestService supply a platform digest service instance; if not one will be constructed
@@ -59,6 +62,7 @@ const val PRIVATE_KEY_ENCODING_VERSION: Int = 1
 @Suppress("LongParameterList")
 class SoftCryptoService(
     private val wrappingRepositoryFactory: WrappingRepositoryFactory,
+    private val signingRepositoryFactory: SigningRepositoryFactory,
     private val schemeMetadata: CipherSchemeMetadata,
     private val defaultUnmanagedWrappingKeyName: String,
     private val unmanagedWrappingKeys: Map<String, WrappingKey>,

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceCachingTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceCachingTests.kt
@@ -13,6 +13,7 @@ import net.corda.crypto.core.aes.WrappingKeyImpl
 import net.corda.crypto.persistence.WrappingKeyInfo
 import net.corda.crypto.softhsm.WrappingRepository
 import net.corda.crypto.softhsm.impl.infra.CountingWrappingKey
+import net.corda.crypto.softhsm.impl.infra.TestSigningRepository
 import net.corda.crypto.softhsm.impl.infra.TestWrappingRepository
 import net.corda.crypto.softhsm.impl.infra.makePrivateKeyCache
 import net.corda.crypto.softhsm.impl.infra.makeSoftCryptoService
@@ -76,7 +77,8 @@ class SoftCryptoServiceCachingTests {
                     CryptoTenants.CRYPTO -> clusterWrappingRepository
                     else -> vnodeWrappingRepository
                 }
-            }
+            },
+            signingRepositoryFactory = { TestSigningRepository() }
         )
         val rsaScheme =
             myCryptoService.supportedSchemes.filter { it.key.codeName == RSA_CODE_NAME }.toList().first().first

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceOperationsTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceOperationsTests.kt
@@ -17,6 +17,7 @@ import net.corda.crypto.core.CryptoTenants
 import net.corda.crypto.core.aes.WrappingKeyImpl
 import net.corda.crypto.impl.CipherSchemeMetadataProvider
 import net.corda.crypto.persistence.WrappingKeyInfo
+import net.corda.crypto.softhsm.SigningRepository
 import net.corda.crypto.softhsm.deriveSupportedSchemes
 import net.corda.crypto.softhsm.impl.infra.TestWrappingRepository
 import net.corda.crypto.softhsm.impl.infra.makeWrappingKeyCache
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.mock
 import java.security.InvalidParameterException
 import java.security.KeyPairGenerator
 import java.security.Provider
@@ -86,6 +88,7 @@ class SoftCryptoServiceOperationsTests {
             )
         )
         private val wrappingKeyCache = makeWrappingKeyCache()
+        private val signingRepository: SigningRepository = mock()
         private val cryptoService = SoftCryptoService(
             wrappingRepositoryFactory = {
                 when (it) {
@@ -102,6 +105,7 @@ class SoftCryptoServiceOperationsTests {
                 KeyPairGenerator.getInstance(algorithm, provider)
             },
             wrappingKeyCache = wrappingKeyCache,
+            signingRepositoryFactory = { signingRepository },
             privateKeyCache = null
         )
         private val category = CryptoConsts.Categories.LEDGER

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/MakeCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/MakeCryptoService.kt
@@ -6,6 +6,7 @@ import net.corda.cipher.suite.impl.PlatformDigestServiceImpl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.core.aes.WrappingKeyImpl
+import net.corda.crypto.softhsm.SigningRepository
 import net.corda.crypto.softhsm.WrappingRepository
 import net.corda.crypto.softhsm.impl.SoftCryptoService
 import java.security.KeyPairGenerator
@@ -23,8 +24,10 @@ fun makeSoftCryptoService(
         WrappingKeyImpl.generateWrappingKey(it)
     },
     wrappingRepository: WrappingRepository = TestWrappingRepository(),
+    signingRepository: SigningRepository = TestSigningRepository()
 ) = SoftCryptoService(
     wrappingRepositoryFactory = { wrappingRepository },
+    signingRepositoryFactory = { signingRepository },
     schemeMetadata = schemeMetadata,
     defaultUnmanagedWrappingKeyName = "root",
     unmanagedWrappingKeys = mapOf("root" to rootWrappingKey),

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestSigningRepository.kt
@@ -1,0 +1,33 @@
+package net.corda.crypto.softhsm.impl.infra
+
+import net.corda.crypto.core.ShortHash
+import net.corda.crypto.persistence.SigningKeyInfo
+import net.corda.crypto.persistence.SigningKeyOrderBy
+import net.corda.crypto.persistence.SigningPublicKeySaveContext
+import net.corda.crypto.persistence.SigningWrappedKeySaveContext
+import net.corda.crypto.softhsm.SigningRepository
+import net.corda.v5.crypto.SecureHash
+import java.security.PublicKey
+
+class TestSigningRepository : SigningRepository {
+    override fun savePublicKey(context: SigningPublicKeySaveContext): SigningKeyInfo = throw NotImplementedError()
+
+    override fun savePrivateKey(context: SigningWrappedKeySaveContext): SigningKeyInfo  = throw NotImplementedError()
+    override fun findKey(alias: String): SigningKeyInfo? =throw NotImplementedError()
+    override fun findKey(publicKey: PublicKey): SigningKeyInfo? =  throw NotImplementedError()
+
+    override fun query(
+        skip: Int,
+        take: Int,
+        orderBy: SigningKeyOrderBy,
+        filter: Map<String, String>,
+    ): Collection<SigningKeyInfo> = throw NotImplementedError()
+
+    override fun lookupByPublicKeyShortHashes(keyIds: Set<ShortHash>): Collection<SigningKeyInfo> = throw NotImplementedError()
+
+    override fun lookupByPublicKeyHashes(fullKeyIds: Set<SecureHash>): Collection<SigningKeyInfo> = throw NotImplementedError()
+
+    override fun close() {
+
+    }
+}


### PR DESCRIPTION
We are working towards improving caching of signing keys, which is currently split between `components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt` and `net/corda/crypto/service/impl/SigningServiceImpl.kt`. A practical production-grade implementation of signing key caching is best done by combing those 2 layers, which we were planning anyway (CORE-10051). To make such a combination requires the signing repository to be available for the crypto service. So, we do that here, as an incremental step.
