### PR TITLE
CORE-14566 add corda.account for initiated flows

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/runner/impl/FlowRunnerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/runner/impl/FlowRunnerImpl.kt
@@ -96,7 +96,8 @@ class FlowRunnerImpl @Activate constructor(
 
         val localContext = remoteToLocalContextMapper(
             remoteUserContextProperties = sessionInitEvent.contextUserProperties,
-            remotePlatformContextProperties = sessionInitEvent.contextPlatformProperties
+            remotePlatformContextProperties = sessionInitEvent.contextPlatformProperties,
+            mapOf("corda.account" to "account-zero")
         )
 
         return startFlow(
@@ -157,7 +158,7 @@ class FlowRunnerImpl @Activate constructor(
     ) = virtualNodeInfoReadService.get(holdingIdentity)?.let {
         KeyValueStore().apply {
 
-            // Copy other properties first so that they wont override current values
+            // Copy other properties first so that they won't override current values
             contextProperties.items.forEach { prop ->
                 this[prop.key] = prop.value
             }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
@@ -184,7 +184,8 @@ class FlowRunnerImplTest {
         // content of the mapped local context is out of the scope of this test
         val localContextProperties = remoteToLocalContextMapper(
             remoteUserContextProperties = userContext.avro,
-            remotePlatformContextProperties = platformContext.avro
+            remotePlatformContextProperties = platformContext.avro,
+            mapOf("corda.account" to "account-zero")
         )
 
         val context = buildFlowEventContext<Any>(flowCheckpoint, sessionEvent)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/RemoteToLocalContextMapperTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/RemoteToLocalContextMapperTest.kt
@@ -15,6 +15,7 @@ class RemoteToLocalContextMapperTest {
     }
     private val platformContext = KeyValueStore().apply {
         this["platform"] = "platform"
+        this["platform_local"] = "platform_local"
         this["corda.platform"] = "platform2"
         this["corda.initiator.platform"] = "platform3"
     }
@@ -23,12 +24,13 @@ class RemoteToLocalContextMapperTest {
     fun `mapping test`() {
         val localContextProperties = remoteToLocalContextMapper(
             remoteUserContextProperties = userContext.avro,
-            remotePlatformContextProperties = platformContext.avro
+            remotePlatformContextProperties = platformContext.avro,
+            mapOf("local" to "local", "platform_local" to "platform_local2")
         )
 
-        assertThat(localContextProperties.platformProperties.items.size).isEqualTo(2)
+        assertThat(localContextProperties.platformProperties.items.size).isEqualTo(4)
         assertThat(localContextProperties.userProperties.items.size).isEqualTo(2)
-        assertThat(localContextProperties.counterpartySessionProperties.size).isEqualTo(2)
+        assertThat(localContextProperties.counterpartySessionProperties.size).isEqualTo(4)
 
         assertThat(localContextProperties.platformProperties.toMap())
             .isEqualTo(localContextProperties.counterpartySessionProperties)
@@ -37,5 +39,7 @@ class RemoteToLocalContextMapperTest {
         assertThat(localContextProperties.platformProperties.toMap()["corda.initiator.platform"]).isEqualTo("platform2")
         assertThat(localContextProperties.userProperties.toMap()["user"]).isEqualTo("user")
         assertThat(localContextProperties.platformProperties.toMap()["platform"]).isEqualTo("platform")
+        assertThat(localContextProperties.platformProperties.toMap()["local"]).isEqualTo("local")
+        assertThat(localContextProperties.platformProperties.toMap()["platform_local"]).isEqualTo("platform_local2")
     }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
@@ -59,7 +59,6 @@ class UtxoTransactionReaderImpl(
 
     private companion object {
         const val CORDA_ACCOUNT = "corda.account"
-        const val CORDA_INITIATOR_ACCOUNT = "corda.initiator.account"
     }
 
     private val serializer = sandbox.getSerializationService()
@@ -70,7 +69,7 @@ class UtxoTransactionReaderImpl(
         get() = signedTransaction.id
 
     override val account: String
-        get() = externalEventContext.contextProperties.items.find { it.key == CORDA_ACCOUNT || it.key == CORDA_INITIATOR_ACCOUNT}?.value
+        get() = externalEventContext.contextProperties.items.find { it.key == CORDA_ACCOUNT }?.value
             ?: throw NullParameterException("Flow external event context property '${CORDA_ACCOUNT}' not set")
 
     override val privacySalt: PrivacySalt


### PR DESCRIPTION
Set up context with corda account property for initiated flows
Remove the wrong logic to use the counterparties account from transaction persistence.

This is a bug fix that is currently blocking a PS engineering team from using Corda 5.

There is a matching e2e PR that introduces a test reproducing the issue found by PS, this PR fixes it: https://github.com/corda/corda-e2e-tests/pull/126