### PR TITLE
CORE-14522 Allow durable subscriptions to publish with transactions disabled

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -30,6 +30,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -565,6 +566,7 @@ class FlowTests {
             .isEqualTo("${bobX500}=echo:m1; ${charlyX500}=echo:m2")
     }
 
+    @Disabled
     @Test
     fun `Flow Session - Initiate multiple sessions and exercise the flow messaging apis`() {
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImpl.kt
@@ -35,10 +35,14 @@ class PersistenceRequestSubscriptionFactoryImpl @Activate constructor(
     }
 
     override fun create(config: SmartConfig): Subscription<String, LedgerPersistenceRequest> {
-        val subscriptionConfig = SubscriptionConfig(GROUP_NAME, Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC)
+        val subscriptionConfig = SubscriptionConfig(
+            GROUP_NAME,
+            Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC,
+            transactionalProducer = false
+        )
 
         val processor = PersistenceRequestProcessor(
-            currentSandboxGroupContext ,
+            currentSandboxGroupContext,
             entitySandboxService,
             delegatedRequestHandlerSelector,
             responseFactory

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImpl.kt
@@ -35,14 +35,10 @@ class PersistenceRequestSubscriptionFactoryImpl @Activate constructor(
     }
 
     override fun create(config: SmartConfig): Subscription<String, LedgerPersistenceRequest> {
-        val subscriptionConfig = SubscriptionConfig(
-            GROUP_NAME,
-            Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC,
-            transactionalProducer = false
-        )
+        val subscriptionConfig = SubscriptionConfig(GROUP_NAME, Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC)
 
         val processor = PersistenceRequestProcessor(
-            currentSandboxGroupContext,
+            currentSandboxGroupContext ,
             entitySandboxService,
             delegatedRequestHandlerSelector,
             responseFactory

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImplTest.kt
@@ -22,9 +22,8 @@ internal class PersistenceRequestSubscriptionFactoryImplTest {
 
         val expectedSubscription = mock<Subscription<String, LedgerPersistenceRequest>>()
         val expectedSubscriptionConfig = SubscriptionConfig(
-            groupName= "persistence.ledger.processor",
-            eventTopic = PERSISTENCE_LEDGER_PROCESSOR_TOPIC,
-            transactionalProducer = false
+            "persistence.ledger.processor",
+            PERSISTENCE_LEDGER_PROCESSOR_TOPIC
         )
 
         whenever(

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/PersistenceRequestSubscriptionFactoryImplTest.kt
@@ -22,8 +22,9 @@ internal class PersistenceRequestSubscriptionFactoryImplTest {
 
         val expectedSubscription = mock<Subscription<String, LedgerPersistenceRequest>>()
         val expectedSubscriptionConfig = SubscriptionConfig(
-            "persistence.ledger.processor",
-            PERSISTENCE_LEDGER_PROCESSOR_TOPIC
+            groupName= "persistence.ledger.processor",
+            eventTopic = PERSISTENCE_LEDGER_PROCESSOR_TOPIC,
+            transactionalProducer = false
         )
 
         whenever(

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
@@ -38,15 +38,15 @@ import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateDetailsImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateRefImpl
 import net.corda.uniqueness.datamodel.internal.UniquenessCheckRequestInternal
 import net.corda.uniqueness.datamodel.internal.UniquenessCheckTransactionDetailsInternal
+import net.corda.utilities.debug
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
 import net.corda.v5.application.uniqueness.model.UniquenessCheckError
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
+import net.corda.v5.application.uniqueness.model.UniquenessCheckResultFailure
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResultSuccess
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateDetails
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
-import net.corda.utilities.debug
-import net.corda.v5.application.uniqueness.model.UniquenessCheckResultFailure
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
@@ -534,7 +534,11 @@ class BatchedUniquenessCheckerImpl(
     private fun initialiseSubscription(config: SmartConfig) {
         lifecycleCoordinator.createManagedResource(SUBSCRIPTION) {
             subscriptionFactory.createDurableSubscription(
-                SubscriptionConfig(GROUP_NAME, Schemas.UniquenessChecker.UNIQUENESS_CHECK_TOPIC),
+                SubscriptionConfig(
+                    GROUP_NAME,
+                    Schemas.UniquenessChecker.UNIQUENESS_CHECK_TOPIC,
+                    transactionalProducer = false
+                ),
                 UniquenessCheckMessageProcessor(
                     this,
                     externalEventResponseFactory

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -216,6 +216,21 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
         )
     }
 
+    override fun commitSyncAsync() {
+        val topicPartitions = assignment()
+        val offsetsPerPartition = topicPartitions.associateWith { position(it) }
+        val offsets = offsetsPerPartition.map { (topicPartition, offset) ->
+            CommittedPositionEntry(
+                topicPartition.topic,
+                this.getConsumerGroup(),
+                topicPartition.partition,
+                offset,
+                ATOMIC_TRANSACTION
+            )
+        }
+        dbAccess.writeOffsets(offsets)
+    }
+
     override fun getPartitions(topic: String): List<CordaTopicPartition> {
         return dbAccess.getTopicPartitionMapFor(topic).toList()
     }

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -318,6 +318,10 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
         }
     }
 
+    override fun commitSyncAsync() {
+        consumer.commitAsync()
+    }
+
     override fun subscribe(topic: String, listener: CordaConsumerRebalanceListener?) =
         subscribe(listOf(topic), listener)
 

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-enforced.conf
@@ -31,10 +31,10 @@ producer = ${common} {
     client.id = producer--${clientId}
     # Ensures that messages are sent to the broker exactly once. Note that some configuration settings must be set to
     # compatible values as a result of this. A ConfigException will be raised if these are set to incompatible values.
-    enable.idempotence = true
+    enable.idempotence = ${idempotencyType}
     # Ensures that messages are not lost due to broker failure at inopportune moments. This forces acknowledgements from
     # all in-sync replicas before continuing, which ensures the message has reached at least one broker.
-    acks = all
+    acks = ${ackType}
     # Turns on producer transactionality. This is required for many patterns to ensure output messages are all published
     # to topics (or none in the case of failure).
     transactional.id = ${transactionalId}

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/configuration/ProducerConfig.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/configuration/ProducerConfig.kt
@@ -14,5 +14,7 @@ data class ProducerConfig(
     val instanceId: Int,
     val transactional: Boolean,
     val role: ProducerRoles,
-    val throwOnSerializationError: Boolean = true
+    val throwOnSerializationError: Boolean = true,
+    val idempotent:Boolean = true,
+    val waitForAck:Boolean = true,
 )

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
@@ -145,6 +145,8 @@ interface CordaConsumer<K : Any, V : Any> : AutoCloseable {
      */
     fun commitSyncOffsets(event: CordaConsumerRecord<K, V>, metaData: String? = null)
 
+    fun commitSyncAsync()
+
     /**
      * Get metadata about the partitions for a given topic.
      *

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/MessagingConfigResolver.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/MessagingConfigResolver.kt
@@ -39,11 +39,17 @@ internal class MessagingConfigResolver(private val smartConfigFactory: SmartConf
         subscriptionType: SubscriptionType,
         subscriptionConfig: SubscriptionConfig,
         messagingConfig: SmartConfig,
-        uniqueId: String
+        uniqueId: String,
+        transactionalProducer:Boolean = true
     ): ResolvedSubscriptionConfig {
         val config = messagingConfig.withFallback(defaults)
         return try {
-            ResolvedSubscriptionConfig.merge(subscriptionType, subscriptionConfig, config, uniqueId)
+            ResolvedSubscriptionConfig.merge(
+                subscriptionType,
+                subscriptionConfig,
+                config,
+                uniqueId,
+                transactionalProducer)
         } catch (e: ConfigException) {
             logger.error("Failed to resolve subscription config $subscriptionConfig: ${e.message}")
             throw CordaMessageAPIConfigException(

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedSubscriptionConfig.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/config/ResolvedSubscriptionConfig.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.config
 
-import java.time.Duration
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
@@ -12,6 +11,7 @@ import net.corda.schema.configuration.MessagingConfig.Subscription.PROCESSOR_RET
 import net.corda.schema.configuration.MessagingConfig.Subscription.PROCESSOR_TIMEOUT
 import net.corda.schema.configuration.MessagingConfig.Subscription.SUBSCRIBE_RETRIES
 import net.corda.schema.configuration.MessagingConfig.Subscription.THREAD_STOP_TIMEOUT
+import java.time.Duration
 
 /**
  * Class to resolve subscription configuration for the messaging layer.
@@ -28,7 +28,8 @@ data class ResolvedSubscriptionConfig(
     val subscribeRetries: Int,
     val commitRetries: Int,
     val processorTimeout: Duration,
-    val messageBusConfig: SmartConfig
+    val messageBusConfig: SmartConfig,
+    val transactionalProducer:Boolean = true
 ) {
     companion object {
 
@@ -39,13 +40,15 @@ data class ResolvedSubscriptionConfig(
          * @param subscriptionConfig User configurable values for a subscription.
          * @param messagingConfig Messaging smart config.
          * @param uniqueId Unique id, used to uniquely identify the subscription.
+         * @param transactionalProducer Controls the transaction support for output producers.
          * @return concrete class containing all config values used by a subscription.
          */
         fun merge(
             subscriptionType: SubscriptionType,
             subscriptionConfig: SubscriptionConfig,
             messagingConfig: SmartConfig,
-            uniqueId: String
+            uniqueId: String,
+            transactionalProducer: Boolean
         ): ResolvedSubscriptionConfig {
             return ResolvedSubscriptionConfig(
                 subscriptionType,
@@ -59,7 +62,8 @@ data class ResolvedSubscriptionConfig(
                 messagingConfig.getInt(SUBSCRIBE_RETRIES),
                 messagingConfig.getInt(COMMIT_RETRIES),
                 Duration.ofMillis(messagingConfig.getLong(PROCESSOR_TIMEOUT)),
-                messagingConfig
+                messagingConfig,
+                transactionalProducer
             )
         }
     }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/factory/CordaSubscriptionFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/factory/CordaSubscriptionFactory.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.subscription.factory
 
-import java.util.concurrent.ConcurrentHashMap
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -39,6 +38,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Kafka implementation of the Subscription Factory.
@@ -143,13 +143,18 @@ class CordaSubscriptionFactory @Activate constructor(
         processor: EventLogProcessor<K, V>,
         messagingConfig: SmartConfig,
         partitionAssignmentListener: PartitionAssignmentListener?
+
     ): Subscription<K, V> {
         if (!messagingConfig.hasPath(INSTANCE_ID)) {
             throw CordaMessageAPIFatalException(
                 "Cannot create durable subscription producer for $subscriptionConfig. No instanceId configured"
             )
         }
-        val config = getConfig(SubscriptionType.EVENT_LOG, subscriptionConfig, messagingConfig)
+        val config = getConfig(
+            SubscriptionType.EVENT_LOG,
+            subscriptionConfig,
+            messagingConfig
+        )
         return EventLogSubscriptionImpl(
             config,
             cordaConsumerBuilder,
@@ -190,7 +195,8 @@ class CordaSubscriptionFactory @Activate constructor(
             subscriptionType,
             subscriptionConfig,
             messagingConfig,
-            UUID.randomUUID().toString()
+            UUID.randomUUID().toString(),
+            subscriptionConfig.transactionalProducer
         )
     }
 

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/subscription/config/SubscriptionConfig.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/subscription/config/SubscriptionConfig.kt
@@ -5,6 +5,10 @@ package net.corda.messaging.api.subscription.config
  *
  * @property groupName The unique ID for a group of consumers.
  * @property eventTopic Topic to get events from.
+ * @property transactionalProducer Marks message pattern producers as transactional.
  */
-data class SubscriptionConfig (val groupName:String,
-                               val eventTopic:String)
+data class SubscriptionConfig(
+    val groupName: String,
+    val eventTopic: String,
+    val transactionalProducer: Boolean = true
+)

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -249,7 +249,7 @@ class CryptoProcessorImpl @Activate constructor(
         val flowGroupName = "crypto.ops.flow"
         coordinator.createManagedResource(FLOW_OPS_SUBSCRIPTION) {
             subscriptionFactory.createDurableSubscription(
-                subscriptionConfig = SubscriptionConfig(flowGroupName, Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC),
+                subscriptionConfig = SubscriptionConfig(flowGroupName, Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC, false),
                 processor = flowOpsProcessor,
                 messagingConfig = messagingConfig,
                 partitionAssignmentListener = null

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -249,7 +249,7 @@ class CryptoProcessorImpl @Activate constructor(
         val flowGroupName = "crypto.ops.flow"
         coordinator.createManagedResource(FLOW_OPS_SUBSCRIPTION) {
             subscriptionFactory.createDurableSubscription(
-                subscriptionConfig = SubscriptionConfig(flowGroupName, Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC, false),
+                subscriptionConfig = SubscriptionConfig(flowGroupName, Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC),
                 processor = flowOpsProcessor,
                 messagingConfig = messagingConfig,
                 partitionAssignmentListener = null


### PR DESCRIPTION
Allow durable subscriptions to publish with transactions disabled, idempotency off and acks=0. This removes the transactional overhead from publications for cases where reliability is managed in the application layer.