### PR TITLE
CORE-14749 Skip event bus for events for the same topic/key

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -244,7 +244,11 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
                     val event = eventsToProcess.removeFirst()
                     stateAndEventConsumer.resetPollInterval()
                     processEvent(event, outputRecords, newEventsToProcess, updatedStates)
-                    eventsToProcess.addAll(newEventsToProcess.map { toCordaConsumerRecord(event, it) })
+                    eventsToProcess.addAll(newEventsToProcess.map {
+                        val ret = toCordaConsumerRecord(event, it)
+                        log.info("~~~~ $ret")
+                        ret
+                    })
                     newEventsToProcess.clear()
                 }
             }
@@ -303,6 +307,16 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
         val (eventsToProcess, outputEvents) = thisEventUpdates?.responseEvents?.partition {
             it.topic == event.topic && processor.eventValueClass.isInstance(it.value) && it.key == key
         } ?: Pair(emptyList(), emptyList())
+
+        log.info("**** events to process contains: ${eventsToProcess.size} events:")
+        eventsToProcess.forEach {
+            log.info("****\t- key:${it.key} :: class:${it.value?.javaClass?.name ?: "null"} :: topic: ${it.topic}")
+        }
+
+        log.info("**** output events contains: ${outputEvents.size} events:")
+        outputEvents.forEach {
+            log.info("****\t- key:${it.key} :: class:${it.value?.javaClass?.name ?: "null"} :: topic: ${it.topic}")
+        }
 
         when {
             thisEventUpdates == null -> {


### PR DESCRIPTION
Allow Subscription Processors to feed subset of events back into itself without going to bus first