### PR TITLE
CORE-13565 Add extra datasource properties to db bootstrap config

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -516,7 +516,9 @@ a second init container to execute the output SQL to the relevant database
              {{- " '--name'" -}}, 'corda-{{ .longName | default .name }}', 
              {{- " '--jdbc-url'" -}}, 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}', 
              {{- " '--jdbc-pool-max-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxSize | quote }},
-             {{- " '--jdbc-pool-min-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize | quote }},
+             {{- with (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize -}}
+                {{- " '--jdbc-pool-min-size'" -}}, {{ . | quote }},
+             {{- end -}}
              {{- " '--idle-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.idleTimeoutSeconds | quote }},
              {{- " '--max-lifetime'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxLifetimeSeconds | quote }},
              {{- " '--keepalive-time'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.keepaliveTimeSeconds | quote }},

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -515,11 +515,11 @@ a second init container to execute the output SQL to the relevant database
          {{- if and (not (eq .name "rest")) (not (eq .subCommand "create-crypto-config")) -}}
              {{- " '--name'" -}}, 'corda-{{ .longName | default .name }}', 
              {{- " '--jdbc-url'" -}}, 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}', 
-             {{- " '--jdbc-pool-max-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxSize | quote }}
-             {{- " '--jdbc-pool-min-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize | quote }}
-             {{- " '--idle-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.idleTimeoutSeconds | quote }}
-             {{- " '--max-lifetime'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxLifetimeSeconds | quote }}
-             {{- " '--keepalive-time'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.keepaliveTimeSeconds | quote }}
+             {{- " '--jdbc-pool-max-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxSize | quote }},
+             {{- " '--jdbc-pool-min-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize | quote }},
+             {{- " '--idle-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.idleTimeoutSeconds | quote }},
+             {{- " '--max-lifetime'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxLifetimeSeconds | quote }},
+             {{- " '--keepalive-time'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.keepaliveTimeSeconds | quote }},
              {{- " '--validation-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.validationTimeoutSeconds | quote }}, {{- " " -}}
          {{- end -}}         
          

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -516,6 +516,11 @@ a second init container to execute the output SQL to the relevant database
              {{- " '--name'" -}}, 'corda-{{ .longName | default .name }}', 
              {{- " '--jdbc-url'" -}}, 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}', 
              {{- " '--jdbc-pool-max-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxSize | quote }}, {{- " " -}}
+             {{- " '--jdbc-pool-min-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize | quote }}, {{- " " -}}
+             {{- " '--idle-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.idleTimeoutSeconds | quote }}, {{- " " -}}
+             {{- " '--max-lifetime'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxLifetimeSeconds | quote }}, {{- " " -}}
+             {{- " '--keepalive-time'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.keepaliveTimeSeconds | quote }}, {{- " " -}}
+             {{- " '--validation-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.validationTimeoutSeconds | quote }}, {{- " " -}}
          {{- end -}}         
          
          {{- if not (eq .name "rest") -}}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -515,11 +515,11 @@ a second init container to execute the output SQL to the relevant database
          {{- if and (not (eq .name "rest")) (not (eq .subCommand "create-crypto-config")) -}}
              {{- " '--name'" -}}, 'corda-{{ .longName | default .name }}', 
              {{- " '--jdbc-url'" -}}, 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}', 
-             {{- " '--jdbc-pool-max-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxSize | quote }}, {{- " " -}}
-             {{- " '--jdbc-pool-min-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize | quote }}, {{- " " -}}
-             {{- " '--idle-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.idleTimeoutSeconds | quote }}, {{- " " -}}
-             {{- " '--max-lifetime'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxLifetimeSeconds | quote }}, {{- " " -}}
-             {{- " '--keepalive-time'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.keepaliveTimeSeconds | quote }}, {{- " " -}}
+             {{- " '--jdbc-pool-max-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxSize | quote }}
+             {{- " '--jdbc-pool-min-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize | quote }}
+             {{- " '--idle-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.idleTimeoutSeconds | quote }}
+             {{- " '--max-lifetime'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxLifetimeSeconds | quote }}
+             {{- " '--keepalive-time'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.keepaliveTimeSeconds | quote }}
              {{- " '--validation-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.validationTimeoutSeconds | quote }}, {{- " " -}}
          {{- end -}}         
          

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -271,6 +271,11 @@ spec:
           - "-ddatabase.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" $.Values.db.cluster.host }}:{{ $.Values.db.cluster.port }}/{{ $.Values.db.cluster.database }}?currentSchema={{ $.Values.db.cluster.schema }}"
           - "-ddatabase.jdbc.directory=/opt/jdbc-driver"
           - "-ddatabase.pool.max_size={{ .clusterDbConnectionPool.maxSize }}"
+          - "-ddatabase.pool.min_size={{ .clusterDbConnectionPool.minSize }}"
+          - "-ddatabase.pool.idleTimeoutSeconds={{ .clusterDbConnectionPool.idleTimeoutSeconds }}"
+          - "-ddatabase.pool.maxLifetimeSeconds={{ .clusterDbConnectionPool.maxLifetimeSeconds }}"
+          - "-ddatabase.pool.keepaliveTimeSeconds={{ .clusterDbConnectionPool.keepaliveTimeSeconds }}"
+          - "-ddatabase.pool.validationTimeoutSeconds={{ .clusterDbConnectionPool.validationTimeoutSeconds }}"
           {{- end }}
           {{- if $.Values.tracing.endpoint }}
           - "--send-trace-to={{ $.Values.tracing.endpoint }}"

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -271,7 +271,9 @@ spec:
           - "-ddatabase.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" $.Values.db.cluster.host }}:{{ $.Values.db.cluster.port }}/{{ $.Values.db.cluster.database }}?currentSchema={{ $.Values.db.cluster.schema }}"
           - "-ddatabase.jdbc.directory=/opt/jdbc-driver"
           - "-ddatabase.pool.max_size={{ .clusterDbConnectionPool.maxSize }}"
+          {{- if .clusterDbConnectionPool.minSize }}
           - "-ddatabase.pool.min_size={{ .clusterDbConnectionPool.minSize }}"
+          {{- end }}
           - "-ddatabase.pool.idleTimeoutSeconds={{ .clusterDbConnectionPool.idleTimeoutSeconds }}"
           - "-ddatabase.pool.maxLifetimeSeconds={{ .clusterDbConnectionPool.maxLifetimeSeconds }}"
           - "-ddatabase.pool.keepaliveTimeSeconds={{ .clusterDbConnectionPool.keepaliveTimeSeconds }}"

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1209,25 +1209,25 @@
                                             "type": "integer",
                                             "default": 120,
                                             "minimum": 0,
-                                            "title": "TODO"
+                                            "title": "maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool"
                                         },
                                         "maxLifetimeSeconds": {
                                             "type": "integer",
                                             "default": 1800,
                                             "minimum": 1,
-                                            "title": "TODO"
+                                            "title": "maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached \"maxLifetime\" timeout, it will be removed from the pool only when it becomes idle"
                                         },
                                         "keepaliveTimeSeconds": {
                                             "type": "integer",
                                             "default": 0,
                                             "minimum": 0,
-                                            "title": "TODO"
+                                            "title": "interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled"
                                         },
                                         "validationTimeoutSeconds": {
                                             "type": "integer",
                                             "minimum": 1,
                                             "default": 5,
-                                            "title": "TODO"
+                                            "title": "maximum time (in seconds) that the pool will wait for a connection to be validated as alive"
                                         }
                                     }
                                 }
@@ -1285,25 +1285,25 @@
                                             "type": "integer",
                                             "default": 120,
                                             "minimum": 0,
-                                            "title": "TODO"
+                                            "title": "maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool"
                                         },
                                         "maxLifetimeSeconds": {
                                             "type": "integer",
                                             "default": 1800,
                                             "minimum": 1,
-                                            "title": "TODO"
+                                            "title": "maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached \"maxLifetime\" timeout, it will be removed from the pool only when it becomes idle"
                                         },
                                         "keepaliveTimeSeconds": {
                                             "type": "integer",
                                             "default": 0,
                                             "minimum": 0,
-                                            "title": "TODO"
+                                            "title": "interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled"
                                         },
                                         "validationTimeoutSeconds": {
                                             "type": "integer",
                                             "minimum": 1,
                                             "default": 5,
-                                            "title": "TODO"
+                                            "title": "maximum time (in seconds) that the pool will wait for a connection to be validated as alive"
                                         }
                                     }
                                 }

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -741,7 +741,11 @@
                                     "default": {},
                                     "title": "JDBC connection pool configuration for crypto DB",
                                     "required": [
-                                        "maxSize"
+                                        "maxSize",
+                                        "idleTimeoutSeconds",
+                                        "maxLifetimeSeconds",
+                                        "keepaliveTimeSeconds",
+                                        "validationTimeoutSeconds"
                                     ],
                                     "additionalProperties": false,
                                     "properties": {
@@ -752,6 +756,43 @@
                                             "examples": [
                                                 5
                                             ]
+                                        },
+                                        "minSize": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "default": null,
+                                            "title": "minimum JDBC connection pool size for crypto DB"
+                                        },
+                                        "idleTimeoutSeconds": {
+                                            "type": "integer",
+                                            "default": 120,
+                                            "minimum": 0,
+                                            "title": "maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool"
+                                        },
+                                        "maxLifetimeSeconds": {
+                                            "type": "integer",
+                                            "default": 1800,
+                                            "minimum": 1,
+                                            "title": "maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached \"maxLifetime\" timeout, it will be removed from the pool only when it becomes idle"
+                                        },
+                                        "keepaliveTimeSeconds": {
+                                            "type": "integer",
+                                            "default": 0,
+                                            "minimum": 0,
+                                            "title": "interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled"
+                                        },
+                                        "validationTimeoutSeconds": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "default": 5,
+                                            "title": "maximum time (in seconds) that the pool will wait for a connection to be validated as alive"
                                         }
                                     },
                                     "examples": [{
@@ -801,7 +842,11 @@
                                     "default": {},
                                     "title": "JDBC connection pool configuration for RBAC DB",
                                     "required": [
-                                        "maxSize"
+                                        "maxSize",
+                                        "idleTimeoutSeconds",
+                                        "maxLifetimeSeconds",
+                                        "keepaliveTimeSeconds",
+                                        "validationTimeoutSeconds"
                                     ],
                                     "properties": {
                                         "maxSize": {
@@ -811,6 +856,43 @@
                                             "examples": [
                                                 5
                                             ]
+                                        },
+                                        "minSize": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "default": null,
+                                            "title": "minimum JDBC connection pool size for RBAC DB"
+                                        },
+                                        "idleTimeoutSeconds": {
+                                            "type": "integer",
+                                            "default": 120,
+                                            "minimum": 0,
+                                            "title": "maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool"
+                                        },
+                                        "maxLifetimeSeconds": {
+                                            "type": "integer",
+                                            "default": 1800,
+                                            "minimum": 1,
+                                            "title": "maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached \"maxLifetime\" timeout, it will be removed from the pool only when it becomes idle"
+                                        },
+                                        "keepaliveTimeSeconds": {
+                                            "type": "integer",
+                                            "default": 0,
+                                            "minimum": 0,
+                                            "title": "interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled"
+                                        },
+                                        "validationTimeoutSeconds": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "default": 5,
+                                            "title": "maximum time (in seconds) that the pool will wait for a connection to be validated as alive"
                                         }
                                     },
                                     "examples": [{

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1183,6 +1183,7 @@
                                     "required": [
                                         "maxSize"
                                     ],
+                                    "additionalProperties": false,
                                     "properties": {
                                         "maxSize": {
                                             "type": "integer",
@@ -1259,6 +1260,7 @@
                                     "required": [
                                         "maxSize"
                                     ],
+                                    "additionalProperties": false,
                                     "properties": {
                                         "maxSize": {
                                             "type": "integer",

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -768,7 +768,7 @@
                                                 }
                                             ],
                                             "default": null,
-                                            "title": "minimum JDBC connection pool size for crypto DB"
+                                            "title": "minimum JDBC connection pool size for crypto DB; null value means pool's min size will default to pool's max size value"
                                         },
                                         "idleTimeoutSeconds": {
                                             "type": "integer",
@@ -868,7 +868,7 @@
                                                 }
                                             ],
                                             "default": null,
-                                            "title": "minimum JDBC connection pool size for RBAC DB"
+                                            "title": "minimum JDBC connection pool size for RBAC DB; null value means pool's min size will default to pool's max size value"
                                         },
                                         "idleTimeoutSeconds": {
                                             "type": "integer",
@@ -1290,7 +1290,7 @@
                                                 }
                                             ],
                                             "default": null,
-                                            "title": "crypto worker minimum JDBC connection pool size for cluster DB"
+                                            "title": "crypto worker minimum JDBC connection pool size for cluster DB; null value means pool's min size will default to pool's max size value"
                                         },
                                         "idleTimeoutSeconds": {
                                             "type": "integer",
@@ -1371,7 +1371,7 @@
                                                 }
                                             ],
                                             "default": null,
-                                            "title": "DB worker minimum JDBC connection pool size for cluster DB"
+                                            "title": "DB worker minimum JDBC connection pool size for cluster DB; null value means pool's min size will default to pool's max size value"
                                         },
                                         "idleTimeoutSeconds": {
                                             "type": "integer",

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1181,7 +1181,12 @@
                                     "default": {},
                                     "title": "crypto worker JDBC connection pool configuration for cluster DB",
                                     "required": [
-                                        "maxSize"
+                                        "maxSize",
+                                        "minSize",
+                                        "idleTimeoutSeconds",
+                                        "maxLifetimeSeconds",
+                                        "keepaliveTimeSeconds",
+                                        "validationTimeoutSeconds"
                                     ],
                                     "additionalProperties": false,
                                     "properties": {
@@ -1258,7 +1263,12 @@
                                     "default": {},
                                     "title": "DB worker JDBC connection pool configuration for cluster DB",
                                     "required": [
-                                        "maxSize"
+                                        "maxSize",
+                                        "minSize",
+                                        "idleTimeoutSeconds",
+                                        "maxLifetimeSeconds",
+                                        "keepaliveTimeSeconds",
+                                        "validationTimeoutSeconds"
                                     ],
                                     "additionalProperties": false,
                                     "properties": {

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1182,7 +1182,6 @@
                                     "title": "crypto worker JDBC connection pool configuration for cluster DB",
                                     "required": [
                                         "maxSize",
-                                        "minSize",
                                         "idleTimeoutSeconds",
                                         "maxLifetimeSeconds",
                                         "keepaliveTimeSeconds",
@@ -1264,7 +1263,6 @@
                                     "title": "DB worker JDBC connection pool configuration for cluster DB",
                                     "required": [
                                         "maxSize",
-                                        "minSize",
                                         "idleTimeoutSeconds",
                                         "maxLifetimeSeconds",
                                         "keepaliveTimeSeconds",

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1191,6 +1191,43 @@
                                             "examples": [
                                                 5
                                             ]
+                                        },
+                                        "minSize": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "default": null,
+                                            "title": "crypto worker minimum JDBC connection pool size for cluster DB"
+                                        },
+                                        "idleTimeoutSeconds": {
+                                            "type": "integer",
+                                            "default": 120,
+                                            "minimum": 0,
+                                            "title": "TODO"
+                                        },
+                                        "maxLifetimeSeconds": {
+                                            "type": "integer",
+                                            "default": 1800,
+                                            "minimum": 1,
+                                            "title": "TODO"
+                                        },
+                                        "keepaliveTimeSeconds": {
+                                            "type": "integer",
+                                            "default": 0,
+                                            "minimum": 0,
+                                            "title": "TODO"
+                                        },
+                                        "validationTimeoutSeconds": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "default": 5,
+                                            "title": "TODO"
                                         }
                                     }
                                 }
@@ -1230,6 +1267,43 @@
                                             "examples": [
                                                 5
                                             ]
+                                        },
+                                        "minSize": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "integer",
+                                                    "minimum": 0
+                                                },
+                                                {
+                                                    "type": "null"
+                                                }
+                                            ],
+                                            "default": null,
+                                            "title": "DB worker minimum JDBC connection pool size for cluster DB"
+                                        },
+                                        "idleTimeoutSeconds": {
+                                            "type": "integer",
+                                            "default": 120,
+                                            "minimum": 0,
+                                            "title": "TODO"
+                                        },
+                                        "maxLifetimeSeconds": {
+                                            "type": "integer",
+                                            "default": 1800,
+                                            "minimum": 1,
+                                            "title": "TODO"
+                                        },
+                                        "keepaliveTimeSeconds": {
+                                            "type": "integer",
+                                            "default": 0,
+                                            "minimum": 0,
+                                            "title": "TODO"
+                                        },
+                                        "validationTimeoutSeconds": {
+                                            "type": "integer",
+                                            "minimum": 1,
+                                            "default": 5,
+                                            "title": "TODO"
                                         }
                                     }
                                 }

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -449,6 +449,16 @@ workers:
     clusterDbConnectionPool:
       # -- crypto worker maximum JDBC connection pool size for cluster DB
       maxSize: 5
+      # -- DB worker minimum JDBC connection pool size for cluster DB
+      minSize: null
+      # -- TODO
+      idleTimeoutSeconds: 120
+      # -- TODO
+      maxLifetimeSeconds: 1800
+      # -- TODO
+      keepaliveTimeSeconds: 0
+      # -- TODO
+      validationTimeoutSeconds: 5
     # crypto worker Kafka configuration
     kafka:
       # if kafka.sasl.enabled, the credentials to connect to Kafka with for the crypto worker
@@ -520,6 +530,16 @@ workers:
     clusterDbConnectionPool:
       # -- DB worker maximum JDBC connection pool size for cluster DB
       maxSize: 5
+      # -- DB worker minimum JDBC connection pool size for cluster DB
+      minSize: null
+      # -- TODO
+      idleTimeoutSeconds: 120
+      # -- TODO
+      maxLifetimeSeconds: 1800
+      # -- TODO
+      keepaliveTimeSeconds: 0
+      # -- TODO
+      validationTimeoutSeconds: 5
     # DB worker Kafka configuration
     kafka:
       # if kafka.sasl.enabled, the credentials to connect to Kafka with for the DB worker

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -246,6 +246,16 @@ bootstrap:
       dbConnectionPool:
         # -- maximum JDBC connection pool size for crypto DB
         maxSize: 5
+        # -- minimum JDBC connection pool size for crypto DB
+        minSize: null
+        # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
+        idleTimeoutSeconds: 120
+        # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+        maxLifetimeSeconds: 1800
+        # -- interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled
+        keepaliveTimeSeconds: 0
+        # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+        validationTimeoutSeconds: 5
       # the username configuration
       username:
         # -- the username, defaults to a value randomly-generated on install
@@ -279,6 +289,16 @@ bootstrap:
       dbConnectionPool:
         # -- maximum JDBC connection pool size for RBAC DB
         maxSize: 5
+        # -- minimum JDBC connection pool size for RBAC DB
+        minSize: null
+        # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
+        idleTimeoutSeconds: 120
+        # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+        maxLifetimeSeconds: 1800
+        # -- interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled
+        keepaliveTimeSeconds: 0
+        # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+        validationTimeoutSeconds: 5
       # the username configuration
       username:
         # -- the username, defaults to a value randomly-generated on install

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -449,15 +449,15 @@ workers:
     clusterDbConnectionPool:
       # -- crypto worker maximum JDBC connection pool size for cluster DB
       maxSize: 5
-      # -- DB worker minimum JDBC connection pool size for cluster DB
+      # -- crypto worker minimum JDBC connection pool size for cluster DB
       minSize: null
-      # -- TODO
+      # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
       idleTimeoutSeconds: 120
-      # -- TODO
+      # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
       maxLifetimeSeconds: 1800
-      # -- TODO
+      # -- interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled
       keepaliveTimeSeconds: 0
-      # -- TODO
+      # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
       validationTimeoutSeconds: 5
     # crypto worker Kafka configuration
     kafka:
@@ -532,13 +532,13 @@ workers:
       maxSize: 5
       # -- DB worker minimum JDBC connection pool size for cluster DB
       minSize: null
-      # -- TODO
+      # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
       idleTimeoutSeconds: 120
-      # -- TODO
+      # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
       maxLifetimeSeconds: 1800
-      # -- TODO
+      # -- interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled
       keepaliveTimeSeconds: 0
-      # -- TODO
+      # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
       validationTimeoutSeconds: 5
     # DB worker Kafka configuration
     kafka:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -246,7 +246,7 @@ bootstrap:
       dbConnectionPool:
         # -- maximum JDBC connection pool size for crypto DB
         maxSize: 5
-        # -- minimum JDBC connection pool size for crypto DB
+        # -- minimum JDBC connection pool size for crypto DB; null value means pool's min size will default to pool's max size value
         minSize: null
         # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
         idleTimeoutSeconds: 120
@@ -289,7 +289,7 @@ bootstrap:
       dbConnectionPool:
         # -- maximum JDBC connection pool size for RBAC DB
         maxSize: 5
-        # -- minimum JDBC connection pool size for RBAC DB
+        # -- minimum JDBC connection pool size for RBAC DB; null value means pool's min size will default to pool's max size value
         minSize: null
         # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
         idleTimeoutSeconds: 120
@@ -469,7 +469,7 @@ workers:
     clusterDbConnectionPool:
       # -- crypto worker maximum JDBC connection pool size for cluster DB
       maxSize: 5
-      # -- crypto worker minimum JDBC connection pool size for cluster DB
+      # -- crypto worker minimum JDBC connection pool size for cluster DB; null value means pool's min size will default to pool's max size value
       minSize: null
       # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
       idleTimeoutSeconds: 120
@@ -550,7 +550,7 @@ workers:
     clusterDbConnectionPool:
       # -- DB worker maximum JDBC connection pool size for cluster DB
       maxSize: 5
-      # -- DB worker minimum JDBC connection pool size for cluster DB
+      # -- DB worker minimum JDBC connection pool size for cluster DB; null value means pool's min size will default to pool's max size value
       minSize: null
       # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
       idleTimeoutSeconds: 120


### PR DESCRIPTION
* adds extra datasource properties to Cluster DB config values and passes them in to DB aware workers start up arguments (for Crypto & DB workers)
* adds extra datasource properties to DB config values and passes them in to `create-db-config` CLI command (for `CRYPTO` & `RBAC` schemas)