### PR TITLE
CORE-14145: Use group reader before going to db

### DIFF
--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImpl.kt
@@ -116,5 +116,8 @@ internal class MembershipPersistenceOperationImpl<T>(
             key = request.context.requestId,
             value = MembershipPersistenceAsyncRequest(request),
         ),
-    )
+    ).also {
+        val requestId = request.context.requestId
+        logger.info("Sending async membership persistence RPC request ID: $requestId.")
+    }
 }

--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImpl.kt
@@ -117,7 +117,6 @@ internal class MembershipPersistenceOperationImpl<T>(
             value = MembershipPersistenceAsyncRequest(request),
         ),
     ).also {
-        val requestId = request.context.requestId
-        logger.info("Sending async membership persistence RPC request ID: $requestId.")
+        logger.info("Sending async membership persistence RPC request ID: ${request.context.requestId}.")
     }
 }

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncProcessor.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncProcessor.kt
@@ -31,6 +31,10 @@ internal class MembershipPersistenceAsyncProcessor(
                 markForDLQ = true,
             )
         }
+        logger.info(
+            "Received membership async persistence request: " +
+                "${request.request.request::class.java} ID: ${request.request.context.requestId}"
+        )
         return try {
             handlers.handle(request.request)
             StateAndEventProcessor.Response(

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessor.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessor.kt
@@ -24,7 +24,10 @@ internal class MembershipPersistenceRPCProcessor(
         request: MembershipPersistenceRequest,
         respFuture: CompletableFuture<MembershipPersistenceResponse>
     ) {
-        logger.info("Received membership persistence request: ${request.request::class.java}")
+        logger.info(
+            "Received membership persistence request: ${request.request::class.java} " +
+                "ID: ${request.context.requestId}"
+        )
         val result = try {
             val result = handlerFactories.handle(
                 request,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -232,6 +232,13 @@ class StaticMemberRegistrationService(
                 ex,
             )
         }
+        val membershipGroupReader = membershipGroupReaderProvider.getGroupReader(member)
+        if (membershipGroupReader.lookup(member.x500Name)?.isActive == true) {
+            throw InvalidMembershipRegistrationException(
+                "The member ${member.x500Name} had been registered successfully in the group ${member.groupId}. " +
+                    "Can not re-register."
+            )
+        }
         val latestStatuses = membershipQueryClient.queryRegistrationRequests(
             member,
             member.x500Name,
@@ -254,7 +261,6 @@ class StaticMemberRegistrationService(
                 requireNotNull(this) { "Could not find static member list in group policy file." }
                 map { StaticMember(it, endpointInfoFactory::create) }
             }
-            val membershipGroupReader = membershipGroupReaderProvider.getGroupReader(member)
             val (memberInfo, records) = parseMemberTemplate(
                 member,
                 groupPolicy,

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -564,7 +564,7 @@ class StaticMemberRegistrationServiceTest {
     @Nested
     inner class FailedRegistrationTests {
         @Test
-        fun `it fails when the member is active`() {
+        fun `it fails when the member is active in DB`() {
             val status = mock<RegistrationRequestDetails> {
                 on { registrationId } doReturn "ID"
             }
@@ -575,6 +575,20 @@ class StaticMemberRegistrationServiceTest {
                     listOf(RegistrationStatus.APPROVED),
                 )
             ).doReturn(MembershipQueryResult.Success(listOf(status)))
+            setUpPublisher()
+            registrationService.start()
+
+            assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationId, alice, mockContext)
+            }
+        }
+
+        @Test
+        fun `it fails when the member is active in group reader`() {
+            val activeMemberInfo = mock<MemberInfo> {
+                on { isActive } doReturn true
+            }
+            whenever(groupReader.lookup(aliceName)).doReturn(activeMemberInfo)
             setUpPublisher()
             registrationService.start()
 


### PR DESCRIPTION
Adds some more logs to the membership persistence for asynchronous communication.
Ensure that we check the membership group reader (accessible from memory) before going to the persistence layer (for static registration).