### PR TITLE
CORE-14767: Changes to `corda.tlsSecret` logic in Helm

### DIFF
--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -571,10 +571,21 @@ TLS Secret creation
 {{- $annotationValue := get $existingSecret.metadata.annotations $altNameAnnotationKey }}
 {{- $create = not ( eq $annotationValue $altNamesAsString ) }}
 {{- end }}
+{{- $crtSecretValue := "to be defined" }}
+{{- $keySecretValue := "to be defined" }}
+{{- $caSecretValue := "to be defined" }}
 {{- if $create }}
-{{- $caName := printf "%s Self-Signed Certification Authority" $purpose }}
-{{- $ca := genCA $caName 1000 }}
-{{- $cert := genSignedCert $serviceName nil $altNames 365 $ca }}
+{{-   $caName := printf "%s Self-Signed Certification Authority" $purpose }}
+{{-   $ca := genCA $caName 1000 }}
+{{-   $cert := genSignedCert $serviceName nil $altNames 365 $ca }}
+{{-   $crtSecretValue = $cert.Cert | b64enc | quote }}
+{{-   $keySecretValue = $cert.Key | b64enc | quote }}
+{{-   $caSecretValue = $ca.Cert | b64enc | quote }}
+{{- else }}
+{{-   $crtSecretValue = get $existingSecret.data $crtSecretKey }}
+{{-   $keySecretValue = get $existingSecret.data $keySecretKey }}
+{{-   $caSecretValue = get $existingSecret.data $caSecretKey }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -586,8 +597,7 @@ metadata:
     {{- include "corda.labels" $ | nindent 4 }}
 type: Opaque
 data:
-  {{ $crtSecretKey }}: {{ $cert.Cert | b64enc | quote }}
-  {{ $keySecretKey }}: {{ $cert.Key | b64enc | quote }}
-  {{ $caSecretKey }}: {{ $ca.Cert | b64enc | quote }}
-{{- end }}
+  {{ $crtSecretKey }}: {{ $crtSecretValue }}
+  {{ $keySecretKey }}: {{ $keySecretValue }}
+  {{ $caSecretKey }}: {{ $caSecretValue }}
 {{- end }}


### PR DESCRIPTION
Affects when there is existing secret in place, and we are performing Helm Upgrade operation.

I have tested the change locally to prove that the secret is not getting dropped on Helm Upgrade:
```
PS Z:\corda-runtime-os> kubectl get secrets corda-rest-tls -o wide
NAME             TYPE     DATA   AGE
corda-rest-tls   Opaque   3      2m6s
PS Z:\corda-runtime-os> helm upgrade corda -n corda charts/corda --values values-prereqs.yaml --wait
Release "corda" has been upgraded. Happy Helming!
NAME: corda
LAST DEPLOYED: Wed Jun 21 11:56:47 2023
NAMESPACE: corda
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
1. Extract the username and password for the REST API admin created during bootstrap:
kubectl get secret corda-rest-api-admin -o go-template='{{ .data.username | base64decode }}'
kubectl get secret corda-rest-api-admin -o go-template='{{ .data.password | base64decode }}'

2. Expose the API endpoint on localhost by running this command:
kubectl port-forward --namespace corda deployment/corda-rest-worker 8888 &

3. The API endpoint definition can then be accessed via: https://localhost:8888/api/v1/swagger

For more information, see the Corda 5 documentation at docs.r3.com.
PS Z:\corda-runtime-os> kubectl get secrets corda-rest-tls -o wide
NAME             TYPE     DATA   AGE
corda-rest-tls   Opaque   3      2m29s
```
Whereas before my change it was dropped on upgrade.