### PR TITLE
ES-588: Removed Kafka preinstall checks properties logging

### DIFF
--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
@@ -152,8 +152,6 @@ class CheckKafka : Callable<Int>, PluginContext() {
             return
         }
 
-        logger.info(props.entries.joinToString(separator = ",\n"))
-
         try {
             checkConnectionAndBrokers(component, KafkaAdmin(props, report), replicas)
         } catch (e: KafkaException) {


### PR DESCRIPTION
Removed Kafka preinstall checks properties logging for not logging the Kafka access credentials during the preinstall