### PR TITLE
CORE-14658: check content was found when parsing PEM format keys, to turn null pointer exception into a useful exception

### DIFF
--- a/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataTests.kt
+++ b/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataTests.kt
@@ -552,21 +552,9 @@ class CipherSchemeMetadataTests {
     
     @Test
     fun `Should fail gracefully with a correupted PEM file`() {
-        // note deliberate typo "BENIGN" rather than "BEGIN"
-        val bad = """-----BENIGN PUBLIC KEY-----
-                MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAtkTc9q3S7hVqHzlMY7gl
-        KaJyfWhajLBvWO56VGci4udvnZuAZnLJDPjDgESPFQpm7NMXceZ6czXyf2t5FQ98
-        chtJbCX9/vHUK2lKueL+mK8seOuseSwCnDkU0qxRYFX1Im0p3oKefzrkDgCiQKYt
-        XU7tKUekaJF5J/nrVZYNVPpvaM9uLjOK2Ajwt/qlS3lIoeD1prDNUAe1mKxk+Pol
-        mmTz12mjXgzXm2HUhfxGk8FdRV+1eCVyZoZ8CGjJ4TJSYDrsDBp49Yp9cgxlMEpL
-                SSRcYhr9FaZ2uW29tCrvjOqcsGaoC5WqJJWkIOOW7svIjEbfxpQUNqF7Ply4d91D
-        lRGCaxZWSqvfgym8lCEsZWDto3zwBoUtMKiRyWbJXRpcnXp5klpsrfErzSp+ea0E
-        kuJBtvnNWJNXCwWxLi1J670Dg5y334m8E97guiYInfLzKMWRdMeBTr7y2ttgGwhG
-        zi+wP4qg/xBhaNKBlcHjwTBF9caR+ZNvAl4JA3UH3z1tAgMBAAE=
-            -----END PUBLIC KEY-----
-        """
-        
-        schemeMetadata.decodePublicKey(bad)
+        assertThrows<IllegalArgumentException> {
+            schemeMetadata.decodePublicKey("junk")
+        }
     }
     
     @ParameterizedTest

--- a/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataTests.kt
+++ b/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataTests.kt
@@ -549,6 +549,26 @@ class CipherSchemeMetadataTests {
         )
     }
 
+    
+    @Test
+    fun `Should fail gracefully with a correupted PEM file`() {
+        // note deliberate typo "BENIGN" rather than "BEGIN"
+        val bad = """-----BENIGN PUBLIC KEY-----
+                MIIBojANBgkqhkiG9w0BAQEFAAOCAY8AMIIBigKCAYEAtkTc9q3S7hVqHzlMY7gl
+        KaJyfWhajLBvWO56VGci4udvnZuAZnLJDPjDgESPFQpm7NMXceZ6czXyf2t5FQ98
+        chtJbCX9/vHUK2lKueL+mK8seOuseSwCnDkU0qxRYFX1Im0p3oKefzrkDgCiQKYt
+        XU7tKUekaJF5J/nrVZYNVPpvaM9uLjOK2Ajwt/qlS3lIoeD1prDNUAe1mKxk+Pol
+        mmTz12mjXgzXm2HUhfxGk8FdRV+1eCVyZoZ8CGjJ4TJSYDrsDBp49Yp9cgxlMEpL
+                SSRcYhr9FaZ2uW29tCrvjOqcsGaoC5WqJJWkIOOW7svIjEbfxpQUNqF7Ply4d91D
+        lRGCaxZWSqvfgym8lCEsZWDto3zwBoUtMKiRyWbJXRpcnXp5klpsrfErzSp+ea0E
+        kuJBtvnNWJNXCwWxLi1J670Dg5y334m8E97guiYInfLzKMWRdMeBTr7y2ttgGwhG
+        zi+wP4qg/xBhaNKBlcHjwTBF9caR+ZNvAl4JA3UH3z1tAgMBAAE=
+            -----END PUBLIC KEY-----
+        """
+        
+        schemeMetadata.decodePublicKey(bad)
+    }
+    
     @ParameterizedTest
     @MethodSource("signingKeyPairs")
     @Suppress("MaxLineLength")

--- a/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataTests.kt
+++ b/libs/crypto/cipher-suite-impl/src/test/kotlin/net/corda/cipher/suite/impl/CipherSchemeMetadataTests.kt
@@ -551,7 +551,7 @@ class CipherSchemeMetadataTests {
 
     
     @Test
-    fun `Should fail gracefully with a correupted PEM file`() {
+    fun `Should fail gracefully with a corrupted PEM file`() {
         assertThrows<IllegalArgumentException> {
             schemeMetadata.decodePublicKey("junk")
         }

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CipherSchemeMetadataProvider.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CipherSchemeMetadataProvider.kt
@@ -218,7 +218,7 @@ class CipherSchemeMetadataProvider : KeyEncodingService {
     private fun parsePemContent(pem: String): ByteArray =
         StringReader(pem).use { strReader ->
             return PemReader(strReader).use { pemReader ->
-                pemReader.readPemObject().content
+                pemReader.readPemObject()?.content?: throw IllegalArgumentException("Key not found in PEM file")
             }
         }
 

--- a/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CipherSchemeMetadataProvider.kt
+++ b/libs/crypto/crypto-impl/src/main/kotlin/net/corda/crypto/impl/CipherSchemeMetadataProvider.kt
@@ -218,7 +218,7 @@ class CipherSchemeMetadataProvider : KeyEncodingService {
     private fun parsePemContent(pem: String): ByteArray =
         StringReader(pem).use { strReader ->
             return PemReader(strReader).use { pemReader ->
-                pemReader.readPemObject()?.content?: throw IllegalArgumentException("Key not found in PEM file")
+                pemReader.readPemObject()?.content?: throw IllegalArgumentException("Key not found in PEM format")
             }
         }
 


### PR DESCRIPTION
Introduce a test which is simply paring a PEM file without a valid key within it. That currently throws null pointer exception, since we deference the content without checking anything was foud. Instead, throw IllegalArgumentException which seems to be consensus exception type for bad input.