### PR TITLE
CORE-14775 Revert "CORE-14578 Add transaction ID to MDC properties (#3935)"

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoFlowOpsBusProcessor.kt
@@ -30,7 +30,6 @@ import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
 import net.corda.utilities.MDC_FLOW_ID
 import net.corda.utilities.trace
-import net.corda.utilities.translateFlowContextToMDC
 import net.corda.utilities.withMDC
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
@@ -73,7 +72,7 @@ class CryptoFlowOpsBusProcessor(
                 MDC_FLOW_ID to request.flowExternalEventContext.flowId,
                 MDC_CLIENT_ID to clientRequestId,
                 MDC_EXTERNAL_EVENT_ID to request.flowExternalEventContext.requestId
-            ) + translateFlowContextToMDC(request.flowExternalEventContext.contextProperties.toMap())
+            )
 
             withMDC(mdc) {
                 val requestPayload = request.request

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowMDCServiceImpl.kt
@@ -8,14 +8,11 @@ import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.flow.state.checkpoint.FlowState
 import net.corda.data.flow.state.external.ExternalEventStateType
 import net.corda.flow.pipeline.FlowMDCService
-import net.corda.flow.state.impl.FlowStackBasedContext
-import net.corda.flow.state.impl.FlowStackImpl
 import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
 import net.corda.utilities.MDC_FLOW_ID
 import net.corda.utilities.MDC_SESSION_EVENT_ID
 import net.corda.utilities.MDC_VNODE_ID
-import net.corda.utilities.translateFlowContextToMDC
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Component
 import org.slf4j.LoggerFactory
@@ -81,17 +78,9 @@ class FlowMDCServiceImpl : FlowMDCService {
             MDC_CLIENT_ID to startContext.requestId,
             MDC_FLOW_ID to flowId
         )
-
-        val platformProperties = state.flowState?.flowStackItems?.let { flowStackItems ->
-            FlowStackBasedContext(FlowStackImpl(flowStackItems)).flattenPlatformProperties()
-        } ?: emptyMap()
-
-        // Extract properties starting with `corda.logged`
-        val loggedContextProperties = translateFlowContextToMDC(platformProperties)
-
         setExternalEventIdIfNotComplete(flowState, mdcLogging)
         setSessionMDCFromEvent(event, mdcLogging)
-        return mdcLogging + loggedContextProperties
+        return mdcLogging
     }
 
     private fun setSessionMDCFromEvent(event: FlowEvent?, mdcLogging: MutableMap<String, String>) {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/PersistenceRequestProcessor.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/PersistenceRequestProcessor.kt
@@ -16,7 +16,6 @@ import net.corda.tracing.traceEventProcessing
 import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
 import net.corda.utilities.trace
-import net.corda.utilities.translateFlowContextToMDC
 import net.corda.utilities.withMDC
 import net.corda.v5.application.flows.FlowContextPropertyKeys.CPK_FILE_CHECKSUM
 import net.corda.virtualnode.toCorda
@@ -60,7 +59,7 @@ class PersistenceRequestProcessor(
                         mapOf(
                             MDC_CLIENT_ID to clientRequestId,
                             MDC_EXTERNAL_EVENT_ID to request.flowExternalEventContext.requestId
-                        ) + translateFlowContextToMDC(request.flowExternalEventContext.contextProperties.toMap())
+                        )
                     ) {
                         try {
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowUtils.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowUtils.kt
@@ -1,11 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality
 
-import net.corda.flow.state.asFlowContext
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
-import net.corda.utilities.MDC_LOGGED_PREFIX
-import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.VisibilityChecker
 
 @Suspendable
@@ -22,11 +18,4 @@ fun UtxoSignedTransactionInternal.getVisibleStateIndexes(checker: VisibilityChec
     }
 
     return result
-}
-
-@Suspendable
-fun addTransactionIdToFlowContext(flowEngine: FlowEngine, transactionId: SecureHash) {
-    flowEngine.flowContextProperties
-        .asFlowContext
-        .platformProperties["$MDC_LOGGED_PREFIX.transactionId"] = transactionId.toString()
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -6,7 +6,6 @@ import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesExce
 import net.corda.ledger.notary.worker.selection.NotaryVirtualNodeSelectorService
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
-import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.sandbox.CordaSystemFlow
@@ -51,7 +50,6 @@ class UtxoFinalityFlowV1(
 
     @Suspendable
     override fun call(): UtxoSignedTransaction {
-        addTransactionIdToFlowContext(flowEngine, transactionId)
         log.trace("Starting finality flow for transaction: $transactionId")
         verifyExistingSignatures(initialTransaction)
         verifyTransaction(initialTransaction)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -4,7 +4,6 @@ import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
-import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
 import net.corda.ledger.utxo.flow.impl.flows.finality.v1.FinalityNotarizationFailureType.Companion.toFinalityNotarizationFailureType
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
@@ -35,7 +34,6 @@ class UtxoReceiveFinalityFlowV1(
     override fun call(): UtxoSignedTransaction {
         val initialTransaction = receiveTransactionAndBackchain()
         val transactionId = initialTransaction.id
-        addTransactionIdToFlowContext(flowEngine, transactionId)
         verifyExistingSignatures(initialTransaction, session)
         verifyTransaction(initialTransaction)
         var transaction = if (validateTransaction(initialTransaction)) {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -4,8 +4,6 @@ import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
-import net.corda.flow.state.ContextPlatformProperties
-import net.corda.flow.state.FlowContext
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
@@ -77,15 +75,7 @@ class UtxoFinalityFlowV1Test {
     private val transactionSignatureService = mock<TransactionSignatureService>()
     private val persistenceService = mock<UtxoLedgerPersistenceService>()
     private val transactionVerificationService = mock<UtxoLedgerTransactionVerificationService>()
-    private val platformProperties = mock<ContextPlatformProperties>().also { properties ->
-        whenever(properties.set(any(), any())).thenAnswer {}
-    }
-    private val flowContextProperties = mock<FlowContext>().also {
-        whenever(it.platformProperties).thenReturn(platformProperties)
-    }
-    private val flowEngine = mock<FlowEngine>().also {
-        whenever(it.flowContextProperties).thenReturn(flowContextProperties)
-    }
+    private val flowEngine = mock<FlowEngine>()
     private val flowMessaging = mock<FlowMessaging>()
     private val virtualNodeSelectorService = mock<NotaryVirtualNodeSelectorService>()
     private val visibilityChecker = mock<VisibilityChecker>()

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -4,8 +4,6 @@ import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.fullIdHash
-import net.corda.flow.state.ContextPlatformProperties
-import net.corda.flow.state.FlowContext
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.testkit.publicKeyExample
@@ -59,17 +57,8 @@ class UtxoReceiveFinalityFlowV1Test {
     private val memberLookup = mock<MemberLookup>()
     private val persistenceService = mock<UtxoLedgerPersistenceService>()
     private val transactionVerificationService = mock<UtxoLedgerTransactionVerificationService>()
+    private val flowEngine = mock<FlowEngine>()
     private val visibilityChecker = mock<VisibilityChecker>()
-
-    private val platformProperties = mock<ContextPlatformProperties>().also { properties ->
-        whenever(properties.set(any(), any())).thenAnswer {}
-    }
-    private val flowContextProperties = mock<FlowContext>().also {
-        whenever(it.platformProperties).thenReturn(platformProperties)
-    }
-    private val flowEngine = mock<FlowEngine>().also {
-        whenever(it.flowContextProperties).thenReturn(flowContextProperties)
-    }
 
     private val session = mock<FlowSession>()
 

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessor.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessor.kt
@@ -16,7 +16,6 @@ import net.corda.tracing.traceEventProcessingSingle
 import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
 import net.corda.utilities.trace
-import net.corda.utilities.translateFlowContextToMDC
 import net.corda.utilities.withMDC
 import net.corda.virtualnode.toCorda
 import org.slf4j.LoggerFactory
@@ -58,7 +57,7 @@ class VerificationRequestProcessor(
                         mapOf(
                             MDC_CLIENT_ID to clientRequestId,
                             MDC_EXTERNAL_EVENT_ID to request.flowExternalEventContext.requestId
-                        ) + translateFlowContextToMDC(request.flowExternalEventContext.contextProperties.toMap())
+                        )
                     ) {
                         try {
                             val sandbox = verificationSandboxService.get(holdingIdentity, request.cpkMetadata)

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityMessageProcessor.kt
@@ -27,7 +27,6 @@ import net.corda.tracing.traceEventProcessingNullableSingle
 import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
 import net.corda.utilities.debug
-import net.corda.utilities.translateFlowContextToMDC
 import net.corda.utilities.withMDC
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.toCorda
@@ -94,7 +93,7 @@ class EntityMessageProcessor(
             mapOf(
                 MDC_CLIENT_ID to clientRequestId,
                 MDC_EXTERNAL_EVENT_ID to request.flowExternalEventContext.requestId
-            ) + translateFlowContextToMDC(request.flowExternalEventContext.contextProperties.toMap())
+            )
         ) {
             val startTime = System.nanoTime()
             var requestOutcome = "FAILED"

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
@@ -1,6 +1,5 @@
 package net.corda.utilities
 
-import net.corda.v5.application.flows.FlowContextProperties.CORDA_RESERVED_PREFIX
 import java.io.OutputStream
 import java.io.PrintStream
 import java.time.Duration
@@ -21,8 +20,6 @@ const val MDC_FLOW_ID = "flow.id"
 const val MDC_VNODE_ID = "vnode.id"
 const val MDC_SESSION_EVENT_ID = "session.event.id"
 const val MDC_EXTERNAL_EVENT_ID = "corda.external.event.id"
-
-const val MDC_LOGGED_PREFIX = "corda.logged"
 
 inline fun <T> logElapsedTime(label: String, logger: Logger, body: () -> T): T {
     // Use nanoTime as it's monotonic.
@@ -79,14 +76,6 @@ fun <R> withMDC(mdcProperties: Map<String, String>, block: () -> R) : R {
     } finally {
         clearMDC(mdcProperties)
     }
-}
-
-fun translateFlowContextToMDC(
-    flowContextProperties: Map<String, String>
-): Map<String, String> = flowContextProperties.filter {
-    it.key.startsWith(MDC_LOGGED_PREFIX)
-}.mapKeys {
-    it.key.replace("$MDC_LOGGED_PREFIX.", CORDA_RESERVED_PREFIX)
 }
 
 /**


### PR DESCRIPTION
This PR is part of the effort to debug [CORE-14775](https://r3-cev.atlassian.net/browse/CORE-14775). We can see on [gradle enterprise](https://gradle.dev.r3.com/scans/tests?search.relativeStartTime=P28D&search.tags=CI,release/os/5.0&search.timeZoneId=Europe/Dublin&tests.container=net.corda.applications.workers.smoketest.flow.FlowTests&tests.expandedTests=WzMsNl0&tests.test=Flow%20Session%20-%20Initiate%20multiple%20sessions%20and%20exercise%20the%20flow%20messaging%20apis()) that the test `Flow Session - Initiate multiple sessions and exercise the flow messaging apis() on combined worker failing with flow still running` on the release branch started failing intermittently.

The purpose of this PR is to isolate the change that caused this failure to begin.

This PR checks out a known failing point in time and reverts the commit 8f1184558b1ce94a56928998daf1a2d0a23eb5f1.

[CORE-14775]: https://r3-cev.atlassian.net/browse/CORE-14775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ