### PR TITLE
CORE-14873: Correct set `PATH` for CLI on Windows

### DIFF
--- a/tools/plugins/installScripts/install.ps1
+++ b/tools/plugins/installScripts/install.ps1
@@ -19,10 +19,21 @@ $cliCommand = "`"$ENV:JAVA_HOME\bin\java`" -Dpf4j.pluginsDir=`"$cliHomeDir\plugi
 New-Item "$cliHomeDir\corda-cli.cmd" -ItemType File -Value $cliCommand
 
 if($addToPath) {
-    Write-Output "Adding corda-cli to path"
 
-    Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path
-    $old = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path).path
-    $new = "$old;$cliHomeDir"
-    Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name path -Value $new
+    # Set permanently for the User
+    $old = [Environment]::GetEnvironmentVariable('PATH', 'User')
+    if (-Not $old.ToLower().Contains($cliHomeDir.ToLower())) {
+        Write-Output "Adding '$cliHomeDir' to path of User profile"
+        $new = "$old;$cliHomeDir"
+        [Environment]::SetEnvironmentVariable('PATH', $new, 'User')
+    }
+
+    # Set in the current terminal
+    $old = [Environment]::GetEnvironmentVariable('PATH')
+    if (-Not $old.ToLower().Contains($cliHomeDir.ToLower())) {
+        Write-Output "Adding '$cliHomeDir' to path of current session"
+        $new = "$old;$cliHomeDir"
+        [Environment]::SetEnvironmentVariable('PATH', $new)
+    }
+
 }


### PR DESCRIPTION
Test evidence:
```
PS Z:\corda-runtime-os\tools\plugins\build\cli> .\install.ps1 true
Removing previous cli version if exists
Deleting: C:\Users\ViktorKolomeyko\.corda\cli
Creating corda-cli dir at C:\Users\ViktorKolomeyko\.corda\cli

    Directory: C:\Users\ViktorKolomeyko\.corda

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----        23/06/2023     14:26                cli
Copying files and plugins
Creating corda-cli Script

    Directory: C:\Users\ViktorKolomeyko\.corda\cli

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----        23/06/2023     14:26            166 corda-cli.cmd
Adding 'C:\Users\ViktorKolomeyko\.corda\cli' to path of User profile
Adding 'C:\Users\ViktorKolomeyko\.corda\cli' to path of current session

PS Z:\corda-runtime-os\tools\plugins\build\cli> corda-cli.cmd -h

Z:\corda-runtime-os\tools\plugins\build\cli>"Z:\tools\adoptOpenJDK-11.0.9.11\bin\java" -Dpf4j.pluginsDir="C:\Users\ViktorKolomeyko\.corda\cli\plugins" -jar "C:\Users\ViktorKolomeyko\.corda\cli\corda-cli.jar" -h
Usage: corda-cli [-h] [COMMAND]
  -h, -?, -help, --help   Display help and exit.
Commands:
  set-node        Sets the current target for http requests.
  vnode           Manages a virtual node
  mgm             Plugin for membership operations.
  package         Plugin for CPB, CPI operations.
  database        Does Database bootstrapping and upgrade
  preinstall      Preinstall checks for Corda.
  topic           Plugin for Kafka topic operations.
  secret-config   Generate secret Config values which can be inserted into your
                    Corda Config, removing the need to put sensitive values in
                    plain text. The output will depend on the type of secrets
                    service being used. See 'type' for more information.
  initial-config  Create SQL files to write the initial config to a new cluster
  initial-rbac    Creates common RBAC roles
  network         Plugin for interacting with a network.
```