### PR TITLE
CORE-14869 & CORE-14872 Fix retry of initial registration

### DIFF
--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandler.kt
@@ -45,45 +45,61 @@ internal class PersistMemberInfoHandler(
 
     override fun invoke(context: MembershipRequestContext, request: PersistMemberInfo) {
         if (request.members.isNotEmpty()) {
-            logger.info("Persisting member information.")
             transaction(context.holdingIdentity.toCorda().shortHash) { em ->
                 request.members.forEach {
-                    val memberInfo = memberInfoFactory.create(it.persistentMemberInfo)
-                    val currentMemberInfo = em.find(
+                    val newMemberInfo = memberInfoFactory.create(it.persistentMemberInfo)
+                    logger.info(
+                        "Persisting member information representing ${newMemberInfo.name} as viewed " +
+                                "by ${context.holdingIdentity.x500Name} in group ${context.holdingIdentity.groupId}."
+                    )
+                    val oldMemberInfo = em.find(
                         MemberInfoEntity::class.java,
                         MemberInfoEntityPrimaryKey(
-                            memberInfo.groupId,
-                            memberInfo.name.toString(),
-                            memberInfo.status == MEMBER_STATUS_PENDING
+                            newMemberInfo.groupId,
+                            newMemberInfo.name.toString(),
+                            newMemberInfo.status == MEMBER_STATUS_PENDING
                         ),
                         LockModeType.PESSIMISTIC_WRITE
                     )
-                    if (currentMemberInfo?.serialNumber == memberInfo.serial) {
-                        val currentMemberContext = deserialize(currentMemberInfo.memberContext)
-                        val currentMgmContext = deserialize(currentMemberInfo.mgmContext)
+                    val updatingPendingInfo = oldMemberInfo?.status == MEMBER_STATUS_PENDING
+                            && newMemberInfo.status == MEMBER_STATUS_PENDING
+                    val updatingSerialNumber = oldMemberInfo?.serialNumber != newMemberInfo.serial
+                    if (!updatingSerialNumber && !updatingPendingInfo) {
+                        val currentMemberContext = deserialize(oldMemberInfo.memberContext)
+                        val currentMgmContext = deserialize(oldMemberInfo.mgmContext)
                         if (currentMemberContext.items != it.persistentMemberInfo.memberContext.items) {
                             throw MembershipPersistenceException("Cannot update member info with same serial number " +
-                                "(${memberInfo.serial}): member context differs from original.")
+                                "(${newMemberInfo.serial}): member context differs from original.")
                         }
                         if (currentMgmContext.toMap().removeTime() != it.persistentMemberInfo.mgmContext.toMap().removeTime()) {
                             throw MembershipPersistenceException("Cannot update member info with same serial number " +
-                                "(${memberInfo.serial}): mgm context differs from original.")
+                                "(${newMemberInfo.serial}): mgm context differs from original.")
                         }
                         return@forEach
                     }
-
+                    else if (!updatingSerialNumber && updatingPendingInfo) {
+                        /**
+                         * If persisting a pending member info and the existing member info is pending with the same
+                         * serial number, delete the existing one and add the new pending info instead. This is because
+                         * the member info entity contains non-updatable fields such as the signature info, and we
+                         * cannot store new signature information as a result with removing the existing member info.
+                         * This can occur for example if a registration is declined by the mgm and submitted again by
+                         * the client.
+                         */
+                        em.remove(oldMemberInfo)
+                    }
                     val entity = MemberInfoEntity(
-                        memberInfo.groupId,
-                        memberInfo.name.toString(),
-                        memberInfo.status == MEMBER_STATUS_PENDING,
-                        memberInfo.status,
+                        newMemberInfo.groupId,
+                        newMemberInfo.name.toString(),
+                        newMemberInfo.status == MEMBER_STATUS_PENDING,
+                        newMemberInfo.status,
                         clock.instant(),
                         serializeContext(it.persistentMemberInfo.memberContext),
                         it.memberSignature.publicKey.array(),
                         it.memberSignature.bytes.array(),
                         it.memberSignatureSpec.signatureName,
                         serializeContext(it.persistentMemberInfo.mgmContext),
-                        memberInfo.serial,
+                        newMemberInfo.serial,
                     )
                     em.merge(entity)
                 }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -221,7 +221,6 @@ class PersistMemberInfoHandlerTest {
             assertThat(entity.memberSignatureContent).isEqualTo(signature.bytes.array())
             assertThat(entity.memberSignatureSpec).isEqualTo(signatureSpec.signatureName)
         }
-        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
@@ -239,7 +238,6 @@ class PersistMemberInfoHandlerTest {
         )
 
         verify(entityManager, never()).merge(any<MemberInfoEntity>())
-        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
@@ -256,7 +254,6 @@ class PersistMemberInfoHandlerTest {
         }
 
         verify(entityManager, never()).merge(any<MemberInfoEntity>())
-        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
@@ -273,7 +270,6 @@ class PersistMemberInfoHandlerTest {
         }
 
         verify(entityManager, never()).merge(any<MemberInfoEntity>())
-        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
@@ -308,11 +304,10 @@ class PersistMemberInfoHandlerTest {
         persistMemberInfoHandler.invoke(requestContext, PersistMemberInfo(listOf(memberInfo)))
 
         verify(entityManager, never()).merge(any<MemberInfoEntity>())
-        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
-    fun `invoke deletes and persists if updating pending member info with same serial number`() {
+    fun `invoke does not throw error if updating pending member info with another pending member info with the same serial number`() {
         val serialNumber = 1L
         val memberContext = mock<MemberContext> {
             on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn ourGroupId
@@ -350,7 +345,6 @@ class PersistMemberInfoHandlerTest {
             PersistMemberInfo(listOf(memberInfo))
         )
 
-        verify(entityManager).remove(eq(existingMemberInfo))
         verify(entityManager).merge(any<MemberInfoEntity>())
     }
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -1,10 +1,10 @@
 package net.corda.membership.impl.persistence.service.handler
 
-import net.corda.crypto.cipher.suite.KeyEncodingService
-import net.corda.crypto.core.ShortHash
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
+import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.ShortHash
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureSpec
@@ -20,7 +20,10 @@ import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
 import net.corda.membership.lib.MemberInfoExtension
+import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
+import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
+import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
 import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.MemberInfoFactory
@@ -59,6 +62,9 @@ import javax.persistence.LockModeType
 class PersistMemberInfoHandlerTest {
     private companion object {
         const val SERIAL_NUMBER = 1L
+
+        val serializedMemberContext = "123".toByteArray()
+        val serializedMgmContext = "456".toByteArray()
     }
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourGroupId = UUID.randomUUID().toString()
@@ -74,7 +80,7 @@ class PersistMemberInfoHandlerTest {
         ByteBuffer.wrap("memberSignatureKey".toByteArray()),
         ByteBuffer.wrap("memberSignatureContent".toByteArray())
     )
-    private val signatureSpec= CryptoSignatureSpec("", null, null)
+    private val signatureSpec = CryptoSignatureSpec("", null, null)
     private val mgmProvidedContext: MGMContext = mock()
     private val ourMemberInfo: MemberInfo = mock {
         on { memberProvidedContext } doReturn memberProvidedContext
@@ -104,9 +110,12 @@ class PersistMemberInfoHandlerTest {
     }
 
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(
-            eq(vaultDmlConnectionId),
-            any()) } doReturn entityManagerFactory
+        on {
+            createEntityManagerFactory(
+                eq(vaultDmlConnectionId),
+                any()
+            )
+        } doReturn entityManagerFactory
     }
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {
         on { get(eq(CordaDb.Vault.persistenceUnitName)) } doReturn mock()
@@ -120,7 +129,7 @@ class PersistMemberInfoHandlerTest {
     private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>>()
     private val cordaAvroSerializationFactory: CordaAvroSerializationFactory = mock {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValueSerializer
-        on { createAvroDeserializer<KeyValuePairList>(any(), any())} doReturn keyValuePairListDeserializer
+        on { createAvroDeserializer<KeyValuePairList>(any(), any()) } doReturn keyValuePairListDeserializer
     }
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
         on { getByHoldingIdentityShortHash(eq(ourHoldingIdentity.shortHash)) } doReturn virtualNodeInfo
@@ -212,30 +221,17 @@ class PersistMemberInfoHandlerTest {
             assertThat(entity.memberSignatureContent).isEqualTo(signature.bytes.array())
             assertThat(entity.memberSignatureSpec).isEqualTo(signatureSpec.signatureName)
         }
+        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
     fun `invoke does not persist if version already persisted`() {
         val memberInfo = getPersistentSignedMemberInfo()
         val requestContext = getMemberRequestContext()
-        val serializedMemberContext = "123".toByteArray()
-        val serializedMgmContext = "456".toByteArray()
-        whenever(keyValuePairListDeserializer.deserialize(serializedMemberContext)).doReturn(KeyValuePairList(emptyList()))
-        whenever(keyValuePairListDeserializer.deserialize(serializedMgmContext)).doReturn(KeyValuePairList(emptyList()))
-        val memberInfoEntity = mock<MemberInfoEntity> {
-            on { serialNumber } doReturn SERIAL_NUMBER
-            on { memberContext } doReturn serializedMemberContext
-            on { mgmContext } doReturn serializedMgmContext
-        }
-        whenever(entityManager.find(
-            eq(MemberInfoEntity::class.java),
-            eq(MemberInfoEntityPrimaryKey(
-                requestContext.holdingIdentity.groupId,
-                requestContext.holdingIdentity.x500Name.toString(),
-                false)
-            ),
-            any<LockModeType>())
-        ).doReturn (memberInfoEntity)
+
+        mockMemberContext()
+        mockMgmContext()
+        mockExistingMemberInfo(requestContext.holdingIdentity)
 
         persistMemberInfoHandler.invoke(
             requestContext,
@@ -243,69 +239,41 @@ class PersistMemberInfoHandlerTest {
         )
 
         verify(entityManager, never()).merge(any<MemberInfoEntity>())
+        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
     fun `invoke throws if already persisted member context differs`() {
         val memberInfo = getPersistentSignedMemberInfo()
         val requestContext = getMemberRequestContext()
-        val serializedMemberContext = "123".toByteArray()
-        val serializedMgmContext = "456".toByteArray()
-        whenever(keyValuePairListDeserializer.deserialize(eq(serializedMemberContext))).doReturn(
-            KeyValuePairList(mutableListOf(KeyValuePair("100", "b")))
-        )
-        whenever(keyValuePairListDeserializer.deserialize(eq(serializedMgmContext))).doReturn(KeyValuePairList(emptyList()))
-        val memberInfoEntity = mock<MemberInfoEntity> {
-            on { serialNumber } doReturn SERIAL_NUMBER
-            on { memberContext } doReturn serializedMemberContext
-            on { mgmContext } doReturn serializedMgmContext
-        }
-        whenever(entityManager.find(
-            eq(MemberInfoEntity::class.java),
-            eq(MemberInfoEntityPrimaryKey(
-                requestContext.holdingIdentity.groupId,
-                requestContext.holdingIdentity.x500Name.toString(),
-                false)
-            ),
-            any<LockModeType>())
-        ).doReturn (memberInfoEntity)
+
+        mockMemberContext(KeyValuePairList(mutableListOf(KeyValuePair("100", "b"))))
+        mockMgmContext()
+        mockExistingMemberInfo(requestContext.holdingIdentity)
 
         assertThrows<MembershipPersistenceException> {
             persistMemberInfoHandler.invoke(requestContext, PersistMemberInfo(listOf(memberInfo)))
         }
 
         verify(entityManager, never()).merge(any<MemberInfoEntity>())
+        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
     fun `invoke throws if already persisted mgm context differs`() {
         val memberInfo = getPersistentSignedMemberInfo()
         val requestContext = getMemberRequestContext()
-        val serializedMemberContext = "123".toByteArray()
-        val serializedMgmContext = "456".toByteArray()
-        whenever(keyValuePairListDeserializer.deserialize(serializedMemberContext)).doReturn(KeyValuePairList(emptyList()))
-        whenever(keyValuePairListDeserializer.deserialize(eq(serializedMgmContext))).doReturn(
-            KeyValuePairList(mutableListOf(KeyValuePair("100", "b")))
-        )
-        val memberInfoEntity = mock<MemberInfoEntity> {
-            on { serialNumber } doReturn SERIAL_NUMBER
-            on { memberContext } doReturn serializedMemberContext
-            on { mgmContext } doReturn serializedMgmContext
-        }
-        whenever(entityManager.find(
-            eq(MemberInfoEntity::class.java),
-            eq(MemberInfoEntityPrimaryKey(
-                requestContext.holdingIdentity.groupId,
-                requestContext.holdingIdentity.x500Name.toString(),
-                false)
-            ),            any<LockModeType>())
-        ).doReturn (memberInfoEntity)
+
+        mockMemberContext()
+        mockMgmContext(KeyValuePairList(mutableListOf(KeyValuePair("100", "b"))))
+        mockExistingMemberInfo(requestContext.holdingIdentity)
 
         assertThrows<MembershipPersistenceException> {
             persistMemberInfoHandler.invoke(requestContext, PersistMemberInfo(listOf(memberInfo)))
         }
 
         verify(entityManager, never()).merge(any<MemberInfoEntity>())
+        verify(entityManager, never()).remove(any<MemberInfoEntity>())
     }
 
     @Test
@@ -314,41 +282,125 @@ class PersistMemberInfoHandlerTest {
             PersistentMemberInfo(
                 ourHoldingIdentity.toAvro(),
                 KeyValuePairList(emptyList()),
-                KeyValuePairList(mutableListOf(
-                    KeyValuePair(MemberInfoExtension.CREATION_TIME, "a"),
-                    KeyValuePair(MemberInfoExtension.MODIFIED_TIME, "b")
-                ))
+                KeyValuePairList(
+                    mutableListOf(
+                        KeyValuePair(MemberInfoExtension.CREATION_TIME, "a"),
+                        KeyValuePair(MemberInfoExtension.MODIFIED_TIME, "b")
+                    )
+                )
             ),
             signature,
             signatureSpec,
         )
         val requestContext = getMemberRequestContext()
-        val serializedMemberContext = "123".toByteArray()
-        val serializedMgmContext = "456".toByteArray()
-        whenever(keyValuePairListDeserializer.deserialize(serializedMemberContext)).doReturn(KeyValuePairList(emptyList()))
-        whenever(keyValuePairListDeserializer.deserialize(eq(serializedMgmContext))).doReturn(
-            KeyValuePairList(mutableListOf(
-                KeyValuePair(MemberInfoExtension.CREATION_TIME, "c"),
-                KeyValuePair(MemberInfoExtension.MODIFIED_TIME, "d")
-            ))
+
+        mockMemberContext()
+        mockMgmContext(
+            KeyValuePairList(
+                mutableListOf(
+                    KeyValuePair(MemberInfoExtension.CREATION_TIME, "c"),
+                    KeyValuePair(MemberInfoExtension.MODIFIED_TIME, "d")
+                )
+            )
         )
-        val memberInfoEntity = mock<MemberInfoEntity> {
-            on { serialNumber } doReturn SERIAL_NUMBER
-            on { memberContext } doReturn serializedMemberContext
-            on { mgmContext } doReturn serializedMgmContext
-        }
-        whenever(entityManager.find(
-            eq(MemberInfoEntity::class.java),
-            eq(MemberInfoEntityPrimaryKey(
-                requestContext.holdingIdentity.groupId,
-                requestContext.holdingIdentity.x500Name.toString(),
-                false)
-            ),
-            any<LockModeType>())
-        ).doReturn (memberInfoEntity)
+        mockExistingMemberInfo(requestContext.holdingIdentity)
 
         persistMemberInfoHandler.invoke(requestContext, PersistMemberInfo(listOf(memberInfo)))
 
         verify(entityManager, never()).merge(any<MemberInfoEntity>())
+        verify(entityManager, never()).remove(any<MemberInfoEntity>())
+    }
+
+    @Test
+    fun `invoke deletes and persists if updating pending member info with same serial number`() {
+        val serialNumber = 1L
+        val memberContext = mock<MemberContext> {
+            on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn ourGroupId
+            on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_PENDING
+        }
+        val mgmContext = mock<MGMContext> {
+            on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_PENDING
+        }
+        val newMemberInfo = mock<MemberInfo> {
+            on { memberProvidedContext } doReturn memberContext
+            on { mgmProvidedContext } doReturn mgmContext
+            on { it.serial } doReturn serialNumber
+            on { it.name } doReturn ourX500Name
+        }
+        val memberInfo = getPersistentSignedMemberInfo()
+        whenever(memberInfoFactory.create(eq(memberInfo.persistentMemberInfo))).doReturn(newMemberInfo)
+
+        val requestContext = getMemberRequestContext()
+
+        val existingMemberInfo = mockMemberInfoEntity(
+            memberStatus = MEMBER_STATUS_PENDING,
+            serialNumber = serialNumber
+        )
+        mockExistingMemberInfo(
+            requestContext.holdingIdentity,
+            true,
+            existingMemberInfo
+        )
+
+        mockMemberContext()
+        mockMgmContext()
+
+        persistMemberInfoHandler.invoke(
+            requestContext,
+            PersistMemberInfo(listOf(memberInfo))
+        )
+
+        verify(entityManager).remove(eq(existingMemberInfo))
+        verify(entityManager).merge(any<MemberInfoEntity>())
+    }
+
+    private fun mockExistingMemberInfo(
+        holdingIdentity: net.corda.data.identity.HoldingIdentity,
+        isPending: Boolean = false,
+        existingMemberInfoEntity: MemberInfoEntity = mockMemberInfoEntity()
+    ) {
+        whenever(
+            entityManager.find(
+                eq(MemberInfoEntity::class.java),
+                eq(
+                    MemberInfoEntityPrimaryKey(
+                        holdingIdentity.groupId,
+                        holdingIdentity.x500Name,
+                        isPending
+                    )
+                ),
+                any<LockModeType>()
+            )
+        ).doReturn(existingMemberInfoEntity)
+    }
+
+    private fun mockMemberInfoEntity(
+        memberStatus: String? = null,
+        serialNumber: Long = SERIAL_NUMBER,
+        memberContext: ByteArray = serializedMemberContext,
+        mgmContext: ByteArray = serializedMgmContext,
+    ): MemberInfoEntity {
+        return mock {
+            memberStatus?.let { on { this.status } doReturn it }
+            on { this.serialNumber } doReturn serialNumber
+            on { this.memberContext } doReturn memberContext
+            on { this.mgmContext } doReturn mgmContext
+        }
+    }
+
+    private fun mockMemberContext(
+        deserialised: KeyValuePairList = KeyValuePairList(emptyList())
+    ) {
+        whenever(
+            keyValuePairListDeserializer.deserialize(serializedMemberContext)
+        ).doReturn(deserialised)
+    }
+
+    private fun mockMgmContext(
+        deserialised: KeyValuePairList = KeyValuePairList(emptyList())
+    ) {
+        whenever(
+            keyValuePairListDeserializer.deserialize(serializedMgmContext)
+        ).doReturn(deserialised)
     }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -364,5 +364,4 @@ internal class StartRegistrationHandler(
             }
         }
     }
-
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -106,6 +106,13 @@ internal class StartRegistrationHandler(
                 .getOrThrow()
 
             logger.info("Registering $pendingMemberHoldingId with MGM for holding identity: $mgmHoldingId")
+            validateRegistrationRequest(registrationRequest.serial != null) {
+                "Serial on the registration request cannot be null."
+            }
+            validateRegistrationRequest(registrationRequest.serial!! >= 0) {
+                "Serial cannot be negative on the registration request."
+            }
+
             val pendingMemberInfo = buildPendingMemberInfo(registrationRequest)
             val persistentMemberInfo = PersistentMemberInfo.newBuilder()
                 .setMemberContext(pendingMemberInfo.memberProvidedContext.toAvro())
@@ -122,12 +129,6 @@ internal class StartRegistrationHandler(
             // after this point
             outputRecords.add(pendingMemberRecord)
 
-            validateRegistrationRequest(registrationRequest.serial != null) {
-                "Serial on the registration request cannot be null."
-            }
-            validateRegistrationRequest(registrationRequest.serial!! >= 0) {
-                "Serial cannot be negative on the registration request."
-            }
             validatePreAuthTokenUsage(mgmHoldingId, pendingMemberInfo, registrationRequest)
             // Parse the registration request and verify contents
             // The MemberX500Name matches the source MemberX500Name from the P2P messaging
@@ -253,7 +254,7 @@ internal class StartRegistrationHandler(
                 CREATION_TIME to now,
                 MODIFIED_TIME to now,
                 STATUS to MEMBER_STATUS_PENDING,
-                SERIAL to ((registrationRequest.serial ?: 0) + 1).toString(),
+                SERIAL to (registrationRequest.serial!! + 1).toString(),
             )
         )
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -365,7 +365,4 @@ internal class StartRegistrationHandler(
         }
     }
 
-    private fun Collection<MemberInfo>.containsSingleMemberInfoFromFailedRegistration(): Boolean {
-        return size == 1 && first().let { it.serial == 0L && it.status == MEMBER_STATUS_PENDING }
-    }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -349,7 +349,20 @@ class StartRegistrationHandlerTest {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
             assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
-            assertThat(outputStates).isNotEmpty.hasSize(1)
+            assertThat(outputStates).isNotEmpty.hasSize(2)
+
+            assertDeclinedRegistration()
+        }
+    }
+
+    @Test
+    fun `declined if serial in the registration request is negative`() {
+        val startRegistrationCommand = getStartRegistrationCommand(serial = -1)
+        with(handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))) {
+            assertThat(updatedState).isNotNull
+            assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
+            assertThat(outputStates).isNotEmpty.hasSize(2)
 
             assertDeclinedRegistration()
         }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -349,7 +349,7 @@ class StartRegistrationHandlerTest {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
             assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
-            assertThat(outputStates).isNotEmpty.hasSize(2)
+            assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
         }
@@ -362,7 +362,7 @@ class StartRegistrationHandlerTest {
             assertThat(updatedState).isNotNull
             assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
             assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
-            assertThat(outputStates).isNotEmpty.hasSize(2)
+            assertThat(outputStates).isNotEmpty.hasSize(1)
 
             assertDeclinedRegistration()
         }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -33,6 +33,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PEND
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.MemberInfoFactory
@@ -165,11 +166,16 @@ class StartRegistrationHandlerTest {
         on { parse(eq(MODIFIED_TIME), eq(Instant::class.java)) } doReturn clock.instant()
         on { entries } doReturn emptySet()
     }
+    private val pendingMemberMgmContext: MGMContext = mock {
+        on { parse(eq(MODIFIED_TIME), eq(Instant::class.java)) } doReturn clock.instant()
+        on { entries } doReturn emptySet()
+        on { parse(eq(STATUS), eq(String::class.java)) } doReturn MEMBER_STATUS_PENDING
+    }
     private val pendingMemberInfo: MemberInfo = mock {
         on { name } doReturn aliceX500Name
         on { isActive } doReturn true
         on { memberProvidedContext } doReturn memberMemberContext
-        on { mgmProvidedContext } doReturn memberMgmContext
+        on { mgmProvidedContext } doReturn pendingMemberMgmContext
         on { status } doReturn MEMBER_STATUS_PENDING
         on { serial } doReturn 1L
     }
@@ -496,6 +502,29 @@ class StartRegistrationHandlerTest {
             verify = true,
             verifyCustomFields = true,
             queryMemberInfo = true,
+        )
+    }
+
+    @Test
+    fun `not declined if member already exists in a pending state`() {
+        whenever(membershipQueryClient.queryMemberInfo(eq(mgmHoldingIdentity.toCorda()), any()))
+            .doReturn(MembershipQueryResult.Success(listOf(pendingMemberInfo)))
+        with(
+            handler.invoke(null, Record(testTopic, testTopicKey, startRegistrationCommand))
+        ) {
+            assertThat(updatedState).isNotNull
+            assertThat(updatedState!!.registrationId).isEqualTo(registrationId)
+            assertThat(updatedState!!.registeringMember).isEqualTo(aliceHoldingIdentity)
+            assertThat(outputStates).isNotEmpty.hasSize(3)
+
+            assertRegistrationStarted()
+        }
+        verifyServices(
+            persistRegistrationRequest = true,
+            verify = true,
+            verifyCustomFields = true,
+            queryMemberInfo = true,
+            persistMemberInfo = true
         )
     }
 

--- a/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
+++ b/components/membership/synchronisation-impl/src/main/kotlin/net/corda/membership/impl/synchronisation/MemberSynchronisationServiceImpl.kt
@@ -288,7 +288,7 @@ class MemberSynchronisationServiceImpl internal constructor(
         override fun processMembershipUpdates(updates: ProcessMembershipUpdates) {
             val viewOwningMember = updates.synchronisationMetaData.member.toCorda()
             val mgm = updates.synchronisationMetaData.mgm.toCorda()
-            logger.debug { "Member $viewOwningMember received membership updates from $mgm." }
+            logger.info("Member $viewOwningMember received membership updates from $mgm.")
 
             try {
                 cancelCurrentRequestAndScheduleNewOne(viewOwningMember, mgm)

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MemberInfoEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MemberInfoEntity.kt
@@ -40,15 +40,15 @@ class MemberInfoEntity(
     @Column(name = "member_context", nullable = false)
     val memberContext: ByteArray,
 
-    @Column(name = "member_signature_key", nullable = false, updatable = false, columnDefinition = "BLOB")
+    @Column(name = "member_signature_key", nullable = false, columnDefinition = "BLOB")
     val memberSignatureKey: ByteArray,
 
-    @Column(name = "member_signature_content", nullable = false, updatable = false, columnDefinition = "BLOB")
+    @Column(name = "member_signature_content", nullable = false, columnDefinition = "BLOB")
     val memberSignatureContent: ByteArray,
 
     // TODO Are we going to be storing `ParameterizedSignatureSpec` here?
     //  If so need to consider saving extra signature spec parameters as recorded in https://r3-cev.atlassian.net/browse/CORE-11685
-    @Column(name = "member_signature_spec", nullable = false, updatable = false)
+    @Column(name = "member_signature_spec", nullable = false)
     val memberSignatureSpec: String,
 
     @Column(name = "mgm_context", nullable = false)


### PR DESCRIPTION
Retrying an initial registration after it had been declined was not working since the MGM created a pending member info when it processed the initial registration the first time and the logic in place assumed that during the second attempt, the name was already taken by a different member. 
This change should allow a new registration to go through if the previous version of the member info was never approved.

An additional problem was found after resolving that which was that the member signature verification failed after member list distribution. This was because the persisted member info has non updateable fields around the member signatures and so the old member signatures were stored after persisting pending member info again for the same serial number. These are being switched to updateable now in line with what has been done in 5.1 as part of the re-registration work.