### PR TITLE
CORE-14885: Undo temporary logging

### DIFF
--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -406,7 +406,7 @@ internal class VirtualNodeRestResourceImpl(
         val instant = clock.instant()
         // Lookup actor to keep track of which REST user triggered an update
         val actor = restContextProvider.principal
-        logger.info("Received request to update state for $virtualNodeShortId to $newState by $actor at $instant")
+        logger.debug { "Received request to update state for $virtualNodeShortId to $newState by $actor at $instant" }
 
         val virtualNodeState = when (validateStateChange(virtualNodeShortId, newState)
         ) {
@@ -426,14 +426,10 @@ internal class VirtualNodeRestResourceImpl(
         val resp = tryWithExceptionHandling(logger, "Update vNode state") {
             sendAndReceive(rpcRequest)
         }
-        logger.info("Received response to update for $virtualNodeShortId to $newState by $actor")
+        logger.debug { "Received response to update for $virtualNodeShortId to $newState by $actor" }
 
         return when (val resolvedResponse = resp.responseType) {
             is VirtualNodeStateChangeResponse -> {
-                logger.info("Updated states in response for $virtualNodeShortId: ${resolvedResponse.flowOperationalStatus}, " +
-                        "${resolvedResponse.flowP2pOperationalStatus}, ${resolvedResponse.flowStartOperationalStatus}, " +
-                        "${resolvedResponse.vaultDbOperationalStatus}")
-
                 resolvedResponse.run {
                     ChangeVirtualNodeStateResponse(holdingIdentityShortHash, newState)
                 }


### PR DESCRIPTION
This logging was used to trace through some flakey test behavior we were getting in Virtual Node e2e tests. The issue has been addressed in https://github.com/corda/corda-e2e-tests/pull/132