### PR TITLE
CORE-14675: Fixed vNode getting successfully upgraded with full hash

### DIFF
--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
@@ -131,7 +131,7 @@ internal class VirtualNodeValidationServiceImpl(
 
     private fun parseShortHash(virtualNodeShortId: String): ShortHash {
         return try {
-            ShortHash.of(virtualNodeShortId)
+            ShortHash.parse(virtualNodeShortId)
         } catch (e: ShortHashException) {
             throw BadRequestException("Invalid holding identity short hash${e.message?.let { ": $it" }}")
         }


### PR DESCRIPTION
Fixed the virtual node ID being incorrectly parsed causing an upgrade on the virtual node to work with the full hash when an error should be returned instead

Related to: [CORE-14675: Add test to check for error code 400 when using full hash of vNode id when upgrading vNode #133](https://github.com/corda/corda-e2e-tests/pull/133)