### PR TITLE
ES-764: fix helm publishing job 

### DIFF
--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -14,15 +14,11 @@ pipeline {
         kubernetes {
             cloud "eks-e2e"
             yaml kubernetesBuildAgentYaml('build', buildEnvironment, cpus)
+            yamlMergeStrategy merge() // important to keep tolerations from the inherited template
             idleMinutes 15
             podRetention always()
-            nodeSelector ([
-                    "kubernetes.io/arch=${buildEnvironment.buildArchitecture.toString().toLowerCase()}",
-                    "kubernetes.io/os=${buildEnvironment.buildOperatingSystem.toString().toLowerCase()}",
-                    "role=jenkins-agent"
-            ].join(','))
             label ([
-                    "kubernetes-build-agent",
+                    "gradle-build",
                     "${cpus}cpus",
                     "${buildEnvironment.buildArchitecture.toString().toLowerCase()}",
                     "${buildEnvironment.buildOperatingSystem.toString().toLowerCase()}"


### PR DESCRIPTION
Due to recent EKS infra changes related to expect node labels, the following modifications are requires

- `kubernetes-build-agent `updated to `gradle-build`
- yamlMergeStrategy added - this ensures correct yaml is generated for pod definitions 

Pipelines are blocked without this change, no functional application code changes.

kubernetes-build-agent label is no longer mapped to an agent as a result, when this job is kicked off, it can not acquire an Agent and just hangs.
 