### PR TITLE
CORE-13126 remove initiator from list of members to finalize

### DIFF
--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/UtxoDemoEvolveFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/UtxoDemoEvolveFlow.kt
@@ -87,7 +87,7 @@ class UtxoDemoEvolveFlow : ClientStartableFlow {
                 .addSignatories(output.participants)
                 .toSignedTransaction()
 
-            val sessions = members.map { flowMessaging.initiateFlow(it.name) }
+            val sessions = (members - memberLookup.myInfo()).map { flowMessaging.initiateFlow(it.name) }
 
             val finalizationResult = utxoLedgerService.finalize(
                     signedTransaction,


### PR DESCRIPTION
The initiator should not call the finalization against itself, since it is unnecessary and makes the test slower.