### PR TITLE
CORE-14798 - Review context validation for re-registration

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -16,14 +16,18 @@ import net.corda.membership.impl.registration.dynamic.handler.MissingRegistratio
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
 import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
-import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
+import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
+import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEYS
+import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
+import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.lib.MemberInfoExtension.Companion.groupId
@@ -160,9 +164,11 @@ internal class StartRegistrationHandler(
                 val pendingContext = pendingMemberInfo.memberProvidedContext.toMap()
                 val diff = ((pendingContext.entries - previousContext.entries) + (previousContext.entries - pendingContext.entries))
                     .filter {
-                        it.key.startsWith(MemberInfoExtension.ENDPOINTS) ||
-                                it.key.startsWith(MemberInfoExtension.SESSION_KEYS) ||
-                                it.key.startsWith(MemberInfoExtension.LEDGER_KEYS)
+                        it.key.startsWith(ENDPOINTS) ||
+                                it.key.startsWith(SESSION_KEYS) ||
+                                it.key.startsWith(LEDGER_KEYS) ||
+                                it.key.startsWith(ROLES_PREFIX) ||
+                                it.key.startsWith(NOTARY_KEYS)
                     }
                 validateRegistrationRequest(
                     diff.isEmpty()

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -16,13 +16,13 @@ import net.corda.membership.impl.registration.dynamic.handler.MissingRegistratio
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
 import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
+import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
-import net.corda.membership.lib.MemberInfoExtension.Companion.REGISTRATION_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
@@ -159,7 +159,11 @@ internal class StartRegistrationHandler(
                 val previousContext = previous.memberProvidedContext.toMap()
                 val pendingContext = pendingMemberInfo.memberProvidedContext.toMap()
                 val diff = ((pendingContext.entries - previousContext.entries) + (previousContext.entries - pendingContext.entries))
-                    .filterNot { it.key.startsWith(CUSTOM_KEY_PREFIX) || it.key == REGISTRATION_ID }
+                    .filter {
+                        it.key.startsWith(MemberInfoExtension.ENDPOINTS) ||
+                                it.key.startsWith(MemberInfoExtension.SESSION_KEYS) ||
+                                it.key.startsWith(MemberInfoExtension.LEDGER_KEYS)
+                    }
                 validateRegistrationRequest(
                     diff.isEmpty()
                 ) { "Only custom fields with the '$CUSTOM_KEY_PREFIX' prefix may be updated during re-registration." }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -24,7 +24,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTI
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
-import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -17,7 +17,6 @@ import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandle
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
 import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
-import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
@@ -171,8 +170,7 @@ internal class StartRegistrationHandler(
                     }
                 validateRegistrationRequest(
                     diff.isEmpty()
-                ) { "Only custom fields with the '$CUSTOM_KEY_PREFIX' prefix and cpi/platform information " +
-                        "may be updated during re-registration." }
+                ) { "Fields ${diff.map { it.key }} cannot be added, removed or updated during re-registration." }
             }
 
             // The group ID matches the group ID of the MGM

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -168,11 +168,12 @@ internal class StartRegistrationHandler(
                                 it.key.startsWith(SESSION_KEYS) ||
                                 it.key.startsWith(LEDGER_KEYS) ||
                                 it.key.startsWith(ROLES_PREFIX) ||
-                                it.key.startsWith(NOTARY_KEYS)
+                                it.key.startsWith("corda.notary")
                     }
                 validateRegistrationRequest(
                     diff.isEmpty()
-                ) { "Only custom fields with the '$CUSTOM_KEY_PREFIX' prefix may be updated during re-registration." }
+                ) { "Only custom fields with the '$CUSTOM_KEY_PREFIX' prefix and cpi/platform information " +
+                        "may be updated during re-registration." }
             }
 
             // The group ID matches the group ID of the MGM

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -60,6 +60,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES_
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_ROLE
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS
@@ -449,7 +450,11 @@ class DynamicMemberRegistrationService @Activate constructor(
 
             previousRegistrationContext?.let { previous ->
                 ((newRegistrationContext.entries - previous.entries) + (previous.entries - newRegistrationContext.entries)).filter {
-                    it.key.startsWith(ENDPOINTS) || it.key.startsWith(SESSION_KEYS) || it.key.startsWith(LEDGER_KEYS)
+                    it.key.startsWith(ENDPOINTS) ||
+                            it.key.startsWith(SESSION_KEYS) ||
+                            it.key.startsWith(LEDGER_KEYS) ||
+                            it.key.startsWith(ROLES_PREFIX) ||
+                            it.key.startsWith(NOTARY_KEYS)
                 }.apply {
                     require(isEmpty()) {
                         throw InvalidMembershipRegistrationException(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -454,7 +454,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                             it.key.startsWith(SESSION_KEYS) ||
                             it.key.startsWith(LEDGER_KEYS) ||
                             it.key.startsWith(ROLES_PREFIX) ||
-                            it.key.startsWith(NOTARY_KEYS)
+                            it.key.startsWith("corda.notary")
                 }.apply {
                     require(isEmpty()) {
                         throw InvalidMembershipRegistrationException(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -51,7 +51,6 @@ import net.corda.membership.impl.registration.MemberRole.Companion.toMemberInfo
 import net.corda.membership.impl.registration.dynamic.verifiers.OrderVerifier
 import net.corda.membership.impl.registration.dynamic.verifiers.P2pEndpointVerifier
 import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
-import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS
@@ -457,9 +456,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                 }.apply {
                     require(isEmpty()) {
                         throw InvalidMembershipRegistrationException(
-                            "Registration failed. The registration context is invalid: Only custom fields with the " +
-                                    "'$CUSTOM_KEY_PREFIX' prefix and cpi/platform information " +
-                                    "may be updated during re-registration."
+                            "Fields ${this.map { it.key }} cannot be added, removed or updated during re-registration."
                         )
                     }
                 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -60,7 +60,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_HASHES_
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
-import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_ROLE
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -52,6 +52,7 @@ import net.corda.membership.impl.registration.dynamic.verifiers.OrderVerifier
 import net.corda.membership.impl.registration.dynamic.verifiers.P2pEndpointVerifier
 import net.corda.membership.impl.registration.dynamic.verifiers.RegistrationContextCustomFieldsVerifier
 import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
+import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_KEY
@@ -447,13 +448,14 @@ class DynamicMemberRegistrationService @Activate constructor(
                     tlsSubject
 
             previousRegistrationContext?.let { previous ->
-                ((newRegistrationContext.entries - previous.entries) + (previous.entries - newRegistrationContext.entries)).filterNot {
-                    it.key.startsWith(CUSTOM_KEY_PREFIX) || it.key == REGISTRATION_ID
+                ((newRegistrationContext.entries - previous.entries) + (previous.entries - newRegistrationContext.entries)).filter {
+                    it.key.startsWith(ENDPOINTS) || it.key.startsWith(SESSION_KEYS) || it.key.startsWith(LEDGER_KEYS)
                 }.apply {
                     require(isEmpty()) {
                         throw InvalidMembershipRegistrationException(
                             "Registration failed. The registration context is invalid: Only custom fields with the " +
-                                    "'$CUSTOM_KEY_PREFIX' prefix may be updated during re-registration."
+                                    "'$CUSTOM_KEY_PREFIX' prefix and cpi/platform information " +
+                                    "may be updated during re-registration."
                         )
                     }
                 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -733,7 +733,7 @@ class StartRegistrationHandlerTest {
     }
 
     @Test
-    fun `declined if non-custom properties are added during re-registration`() {
+    fun `declined if non-custom, non-platform or non-cpi related properties are added during re-registration`() {
         val contextWithUpdates = mock<MemberContext> {
             on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
             on { parseList(eq(ENDPOINTS), eq(EndpointInfo::class.java)) } doReturn listOf(mock())
@@ -749,7 +749,7 @@ class StartRegistrationHandlerTest {
     }
 
     @Test
-    fun `declined if non-custom properties are removed during re-registration`() {
+    fun `declined if non-custom, non-platform or non-cpi related properties are removed during re-registration`() {
         val contextWithUpdates = mock<MemberContext> {
             on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
             on { parseList(eq(ENDPOINTS), eq(EndpointInfo::class.java)) } doReturn listOf(mock())
@@ -765,7 +765,7 @@ class StartRegistrationHandlerTest {
     }
 
     @Test
-    fun `declined if when non-custom, non-platform or non-cpi related properties are updated during re-registration`() {
+    fun `declined if non-custom, non-platform or non-cpi related properties are updated during re-registration`() {
         val newContextEntries = memberContextEntries.toMutableMap().apply {
             put("${ROLES_PREFIX}0", "changed")
         }.entries

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -765,7 +765,7 @@ class StartRegistrationHandlerTest {
     }
 
     @Test
-    fun `declined if non-custom properties are updated during re-registration`() {
+    fun `declined if when non-custom, non-platform or non-cpi related properties are updated during re-registration`() {
         val newContextEntries = memberContextEntries.toMutableMap().apply {
             put("${ROLES_PREFIX}0", "changed")
         }.entries

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -767,7 +767,7 @@ class StartRegistrationHandlerTest {
     @Test
     fun `declined if non-custom, non-platform or non-cpi related properties are updated during re-registration`() {
         val newContextEntries = memberContextEntries.toMutableMap().apply {
-            put("${ROLES_PREFIX}0", "changed")
+            put("${ROLES_PREFIX}.0", "changed")
         }.entries
         val contextWithUpdates = mock<MemberContext> {
             on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -983,7 +983,7 @@ class DynamicMemberRegistrationServiceTest {
             val exception = assertThrows<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, newContext.toMap())
             }
-            assertThat(exception).hasMessageContaining("Only custom fields")
+            assertThat(exception).hasMessageContaining("cannot be added, removed or updated")
         }
 
         @Test
@@ -1009,7 +1009,7 @@ class DynamicMemberRegistrationServiceTest {
             val exception = assertThrows<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, newContext.toMap())
             }
-            assertThat(exception).hasMessageContaining("Only custom fields")
+            assertThat(exception).hasMessageContaining("cannot be added, removed or updated")
         }
 
         @Test
@@ -1018,8 +1018,9 @@ class DynamicMemberRegistrationServiceTest {
                 on { entries } doReturn previousRegistrationContext.entries
             }
             val newContextEntries = context.toMutableMap().apply {
-                put(URL_KEY.format(1), "https://localhost:1080")
-                put(PROTOCOL_VERSION.format(1), "1")
+                put(String.format(ROLES_PREFIX, 0), "notary")
+                put(NOTARY_SERVICE_NAME, "O=MyNotaryService, L=London, C=GB")
+                put("corda.notary.keys.0.id",  NOTARY_KEY_ID)
             }.entries
             val newContext = mock<MemberContext> {
                 on { entries } doReturn newContextEntries
@@ -1033,7 +1034,7 @@ class DynamicMemberRegistrationServiceTest {
             val exception = assertThrows<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, newContext.toMap())
             }
-            assertThat(exception).hasMessageContaining("Only custom fields")
+            assertThat(exception).hasMessageContaining("cannot be added, removed or updated")
         }
     }
 


### PR DESCRIPTION
Reregistration only works for the keys beginning with ext so members who registered on Corda 5.0 on a cluster which was then updated to Corda 5.1 cannot reregister since corda.softwareVersion changes.

**Testing**
1) Registered MGM and member on 5.0 cluster.
2) Did a platform upgrade using the image from this PR.
3) Re-registered member with additional field `ext.sample`:
![Screenshot 2023-06-26 at 12 49 35](https://github.com/corda/corda-runtime-os/assets/61757742/8ed5f6be-c00c-451f-8887-840b594bbc6a)
Lookup shows that member is on 50100 version after upgrade and has the new field in their member provided context:
![Screenshot 2023-06-26 at 12 49 52](https://github.com/corda/corda-runtime-os/assets/61757742/3506554e-a419-473f-9243-6335d1935783)
4) Re-registered member by using new protocol version for endpoints, the request got invalidated due to failing on the validation logic:
![Screenshot 2023-06-26 at 12 51 00](https://github.com/corda/corda-runtime-os/assets/61757742/a065e25e-e6d1-415d-9c58-fbe4c6aaecdf)
5) Re-registered member by using an additional non-existing corda field `corda.sample`, the request got invalidated due to failing on the schema validation logic:
![Screenshot 2023-06-26 at 12 51 45](https://github.com/corda/corda-runtime-os/assets/61757742/6feb3613-e4e7-4d71-9ad6-1024c239462b)
