### PR TITLE
CORE-15062: Remove special SerializationService handling for FLOW sandboxes.

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceInternalImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceInternalImpl.kt
@@ -7,6 +7,7 @@ import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.utilities.reflection.castIfPossible
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.serialization.SerializedBytes
+import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -14,17 +15,14 @@ import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 
 /**
- * This is a platform service that uses the current sandbox's [SerializationService].
+ * This is a platform singleton service that uses the current sandbox's [SerializationService].
  */
-@Component(service = [SerializationServiceInternal::class])
+@Component(service = [SerializationServiceInternal::class, SingletonSerializeAsToken::class])
 class SerializationServiceInternalImpl @Activate constructor(
     @Reference(service = CurrentSandboxGroupContext::class)
     private val currentSandboxGroupContext: CurrentSandboxGroupContext
-) : SerializationServiceInternal {
-
-    private companion object {
-        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
-    }
+) : SerializationServiceInternal, SingletonSerializeAsToken {
+    private val log = LoggerFactory.getLogger(this::class.java)
 
     private val serializationService
         get(): SerializationService {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceInternalImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/serialization/SerializationServiceInternalImpl.kt
@@ -1,31 +1,26 @@
 package net.corda.flow.application.serialization
 
 import net.corda.flow.pipeline.exceptions.FlowFatalException
-import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
-import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.RequireSandboxAMQP.AMQP_SERIALIZATION_SERVICE
 import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.utilities.reflection.castIfPossible
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.serialization.SerializedBytes
-import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
 
-@Component(
-    service = [SerializationService::class, SerializationServiceInternal::class, UsedByFlow::class],
-    property = [CORDA_SYSTEM_SERVICE],
-    scope = PROTOTYPE
-)
-class SerializationServiceImpl @Activate constructor(
+/**
+ * This is a platform service that uses the current sandbox's [SerializationService].
+ */
+@Component(service = [SerializationServiceInternal::class])
+class SerializationServiceInternalImpl @Activate constructor(
     @Reference(service = CurrentSandboxGroupContext::class)
     private val currentSandboxGroupContext: CurrentSandboxGroupContext
-) : SerializationServiceInternal, UsedByFlow, SingletonSerializeAsToken {
+) : SerializationServiceInternal {
 
     private companion object {
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/SerializationServiceInternalImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/SerializationServiceInternalImplTest.kt
@@ -1,7 +1,7 @@
 package net.corda.flow.fiber
 
 import net.corda.flow.ALICE_X500_HOLDING_IDENTITY
-import net.corda.flow.application.serialization.SerializationServiceImpl
+import net.corda.flow.application.serialization.SerializationServiceInternalImpl
 import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.RequireSandboxAMQP.AMQP_SERIALIZATION_SERVICE
@@ -19,7 +19,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
-class SerializationServiceImplTest {
+class SerializationServiceInternalImplTest {
 
     private class TestObject
     private val currentSandboxGroupContext : CurrentSandboxGroupContext = mock()
@@ -32,7 +32,7 @@ class SerializationServiceImplTest {
     private val byteArray = "bytes".toByteArray()
 
 
-    private val flowFiberSerializationService = SerializationServiceImpl(currentSandboxGroupContext)
+    private val flowFiberSerializationService = SerializationServiceInternalImpl(currentSandboxGroupContext)
 
     @BeforeEach
     fun setup() {

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
@@ -71,13 +71,10 @@ class AMQPSerializationProvider @Activate constructor(
     override fun accept(context: MutableSandboxGroupContext) {
         val factory = createSerializerFactory(context)
 
-        val serializationOutput = SerializationOutput(factory)
-        val deserializationInput = DeserializationInput(factory)
-
         val serializationService = SerializationMetricsWrapper(
             serializationService = SerializationServiceImpl(
-                serializationOutput,
-                deserializationInput,
+                SerializationOutput(factory),
+                DeserializationInput(factory),
                 AMQP_STORAGE_CONTEXT.withSandboxGroup(context.sandboxGroup) //todo double check in CORE-12472
             ),
             context

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/SerializationServiceProxy.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/SerializationServiceProxy.kt
@@ -1,26 +1,33 @@
 package net.corda.sandbox.serialization.amqp
 
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
+import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByPersistence
 import net.corda.sandbox.type.UsedByVerification
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.serialization.SerializedBytes
+import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 /**
- * A [SerializationService] component for persistence and verification sandboxes.
- * Flow sandboxes already have a special "fiber-aware" component of their own.
+ * A [SerializationService] component for flow, persistence and verification sandboxes.
+ * Flow sandboxes expect to be able to `@CordaInject` this [SerializationService], either
+ * directly or via a `@CordaSystemFlow`, and so we also declare it as a "system service".
  */
 @Component(
     service = [
         SerializationService::class,
         SerializationServiceProxy::class,
+        UsedByFlow::class,
         UsedByPersistence::class,
         UsedByVerification::class
     ],
+    property = [ CORDA_SYSTEM_SERVICE ],
     scope = PROTOTYPE
 )
-class SerializationServiceProxy : SerializationService, UsedByPersistence, UsedByVerification {
+class SerializationServiceProxy
+    : SerializationService, SingletonSerializeAsToken, UsedByFlow, UsedByPersistence, UsedByVerification {
     private var serializationService: SerializationService? = null
 
     fun wrap(serializer: SerializationService) {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationServiceImpl.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationServiceImpl.kt
@@ -6,7 +6,6 @@ import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.serialization.SerializationContext
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.serialization.SerializedBytes
-import net.corda.v5.serialization.SingletonSerializeAsToken
 import java.security.AccessController
 import java.security.PrivilegedActionException
 import java.security.PrivilegedExceptionAction
@@ -47,17 +46,3 @@ class SerializationServiceImpl(
         }
     }
 }
-
-/**
- * P2P implementation of [SerializationService] and [P2pSerializationService].
- *
- * Extends [SingletonSerializeAsToken] so that it can be used within flows.
- */
-internal class P2pSerializationServiceImpl(delegate: SerializationService) : SingletonSerializeAsToken,
-    SerializationService by delegate, P2pSerializationService
-
-/**
- * Storage implementation of [SerializationService] and [StorageSerializationService].
- */
-internal class StorageSerializationServiceImpl(delegate: SerializationService) : SerializationService by delegate,
-    StorageSerializationService

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupType.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupType.kt
@@ -9,7 +9,16 @@ import net.corda.sandbox.type.UsedByVerification
  */
 enum class SandboxGroupType(
     private val typeName: String,
+
+    /**
+     * Marker interface for all OSGi `PROTOTYPE` services
+     * that Corda must create for this sandbox type.
+     */
     val serviceMarkerType: Class<*>,
+
+    /**
+     * Does this sandbox type support `@CordaInject`?
+     */
     val hasInjection: Boolean
 ) {
     FLOW("flow", UsedByFlow::class.java, hasInjection = true),

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupType.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxGroupType.kt
@@ -7,10 +7,14 @@ import net.corda.sandbox.type.UsedByVerification
 /**
  * Enumeration of various sandbox group types.
  */
-enum class SandboxGroupType(private val typeName: String, val serviceMarkerType: Class<*>) {
-    FLOW("flow", UsedByFlow::class.java),
-    VERIFICATION("verification", UsedByVerification::class.java),
-    PERSISTENCE("persistence", UsedByPersistence::class.java);
+enum class SandboxGroupType(
+    private val typeName: String,
+    val serviceMarkerType: Class<*>,
+    val hasInjection: Boolean
+) {
+    FLOW("flow", UsedByFlow::class.java, hasInjection = true),
+    VERIFICATION("verification", UsedByVerification::class.java, hasInjection = false),
+    PERSISTENCE("persistence", UsedByPersistence::class.java, hasInjection = false);
 
     override fun toString(): String = typeName
 


### PR DESCRIPTION
Convert `SandboxSerializationInternal` service into a platform service, since it obtains its sandbox `SerializationService` using platform service `CurrentSandboxGroupContext`, and has no sandbox services as dependencies.

This means that we can create `FLOW` sandboxes' `SerializationService` in the same way as `PERSISTENCE` and `VERIFICATION` sandboxes.

It also means that flows can now only `@CordaInject` a `SerializationService` instance and not a `SerializationServiceInternal`, but this is something that can only be relevant to flows which are also `@CordaSystemFlow` anyway.

---
Since only `FLOW` sandboxes currently support `@CordaInject`, we can disable this support for `PERSISTENCE` and `VERIFICATION` sandboxes.