### PR TITLE
CORE-15065 - Tag multi cluster tests

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/MultiClusterDynamicNetworkTest.kt
@@ -18,6 +18,7 @@ import net.corda.applications.workers.rest.utils.setSslConfiguration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -25,6 +26,7 @@ import java.nio.file.Path
 /**
  * Three clusters are required for running this test. See `resources/RunNetworkTests.md` for more details.
  */
+@Tag("MultiCluster")
 class MultiClusterDynamicNetworkTest {
     @TempDir
     lateinit var tempDir: Path

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/SessionCertificateTest.kt
@@ -16,10 +16,12 @@ import net.corda.applications.workers.rest.utils.onboardMgm
 import net.corda.applications.workers.rest.utils.setSslConfiguration
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
+@Tag("MultiCluster")
 class SessionCertificateTest {
     @TempDir
     lateinit var tempDir: Path


### PR DESCRIPTION
Tag multi cluster tests, so that they can subsequently be split into a separate job. 