### PR TITLE
CORE-15089: Use correct version of Kafka client across all the CLI plugins

### DIFF
--- a/buildSrc/src/main/groovy/corda.cli-plugin-packager.gradle
+++ b/buildSrc/src/main/groovy/corda.cli-plugin-packager.gradle
@@ -23,7 +23,6 @@ configurations {
         exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.databind'
         exclude group: 'com.fasterxml.jackson.annotation'
-        exclude group: 'org.apache.servicemix.bundles'
         exclude group: 'info.picocli.picocli'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -136,7 +136,7 @@ artifactoryPluginVersion = 4.28.2
 pf4jVersion=3.9.0
 
 # corda-cli plugin host
-pluginHostVersion=5.1.0-beta+
+pluginHostVersion=5.1.0-alpha-1687960187821
 systemLambdaVersion=1.2.1
 
 # DB integration tests

--- a/gradle.properties
+++ b/gradle.properties
@@ -136,7 +136,7 @@ artifactoryPluginVersion = 4.28.2
 pf4jVersion=3.9.0
 
 # corda-cli plugin host
-pluginHostVersion=5.1.0-alpha-1687960187821
+pluginHostVersion=5.1.0-beta+
 systemLambdaVersion=1.2.1
 
 # DB integration tests

--- a/tools/plugins/preinstall/build.gradle
+++ b/tools/plugins/preinstall/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation "io.fabric8:kubernetes-client:6.5.1"
 
     implementation "org.postgresql:postgresql:$postgresDriverVersion"
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    implementation "org.apache.kafka:kafka-clients:$kafkaClientVersion"
 }
 
 cliPlugin {

--- a/tools/plugins/preinstall/build.gradle
+++ b/tools/plugins/preinstall/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation "io.fabric8:kubernetes-client:6.5.1"
 
     implementation "org.postgresql:postgresql:$postgresDriverVersion"
-    implementation "org.apache.kafka:kafka-clients:$kafkaClientVersion"
+    implementation "org.apache.kafka:kafka-clients:3.3.1"
 }
 
 cliPlugin {

--- a/tools/plugins/preinstall/build.gradle
+++ b/tools/plugins/preinstall/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation "io.fabric8:kubernetes-client:6.5.1"
 
     implementation "org.postgresql:postgresql:$postgresDriverVersion"
-    implementation "org.apache.kafka:kafka-clients:3.3.1"
+    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
 }
 
 cliPlugin {

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckKafka.kt
@@ -38,8 +38,16 @@ class CheckKafka : Callable<Int>, PluginContext() {
         private val admin: AdminClient?
 
         init {
-            admin = AdminClient.create(props)
-            report.addEntry(ReportEntry("Created admin client successfully", true))
+            // Switch ClassLoader so LoginModules can be found
+            val contextCL = Thread.currentThread().contextClassLoader
+            try {
+                Thread.currentThread().contextClassLoader = this::class.java.classLoader
+
+                admin = AdminClient.create(props)
+                report.addEntry(ReportEntry("Created admin client successfully", true))
+            } finally {
+                Thread.currentThread().contextClassLoader = contextCL
+            }
         }
 
         open fun getNodes(): Collection<Node> {

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     compileOnly platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-topic-schema:$cordaApiVersion"
-    compileOnly "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
 
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib'
     testImplementation "org.mockito:mockito-core:$mockitoVersion"


### PR DESCRIPTION
Requires merging: https://github.com/corda/corda-cli-plugin-host/pull/175 first

Also this PR enables packaging of Kafka Client inside plugins rather than relying on CLI Plugin Host providing it.