### PR TITLE
CORE-14775 Increasing smoke test timeout [do not merge]

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -31,6 +31,10 @@ pipeline {
         }
     }
 
+triggers {
+        cron('H H/2 * * *')
+    }
+
     environment {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         BUILD_CACHE_CREDENTIALS = credentials('gradle-ent-cache-credentials')
@@ -109,7 +113,7 @@ pipeline {
         }
         stage('smoketests') {
                 options {
-                    timeout(time: 30, unit: 'MINUTES')
+                    timeout(time: 120, unit: 'MINUTES')
                 }
                 steps {
                    gradlew('smoketest -PisCombinedWorker=true')

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -31,10 +31,6 @@ pipeline {
         }
     }
 
-triggers {
-        cron('H H/2 * * *')
-    }
-
     environment {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         BUILD_CACHE_CREDENTIALS = credentials('gradle-ent-cache-credentials')

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -32,7 +32,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -567,7 +566,6 @@ class FlowTests {
     }
 
     @Test
-    @Disabled
     fun `Flow Session - Initiate multiple sessions and exercise the flow messaging apis`() {
 
         val requestBody = RpcSmokeTestInput().apply {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -2,9 +2,9 @@ package net.corda.e2etest.utilities
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.apache.commons.text.StringEscapeUtils.escapeJson
 import java.time.Duration
 import java.util.UUID
+import org.apache.commons.text.StringEscapeUtils.escapeJson
 
 const val SMOKE_TEST_CLASS_NAME = "com.r3.corda.testing.smoketests.flow.RpcSmokeTestFlow"
 const val RPC_FLOW_STATUS_SUCCESS = "COMPLETED"
@@ -75,7 +75,7 @@ fun ClusterInfo.awaitRpcFlowFinished(holdingId: String, requestId: String): Flow
             assertWithRetry {
                 command { flowStatus(holdingId, requestId) }
                 //CORE-6118 - tmp increase this timeout to a large number to allow tests to pass while slow flow sessions are investigated
-                timeout(Duration.ofMinutes(6))
+                timeout(Duration.ofMinutes(30))
                 condition {
                     it.code == 200 &&
                             (it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_SUCCESS ||
@@ -97,7 +97,7 @@ fun ClusterInfo.getFlowStatus(holdingId: String, requestId: String, expectedCode
         ObjectMapper().readValue(
             assertWithRetry {
                 command { flowStatus(holdingId, requestId) }
-                timeout(Duration.ofMinutes(6))
+                timeout(Duration.ofMinutes(30))
                 condition {
                     it.code == expectedCode
                 }


### PR DESCRIPTION
It was found that, after removing the scheduled wakeup events, external events which have hit transient errors are taking some time (~15 minutes) to retry. I've increased the smoke test timeout from 6 minutes to 30 minutes to try to determine if the flaky flow tests are timing out due to external event transient failures.