### PR TITLE
CORE-15068 Reduce the external event retry period

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
@@ -17,7 +17,7 @@ import java.time.Duration
 import java.time.Instant
 
 @Component(service = [FlowEventHandler::class])
-class ExternalEventResponseHandler @Activate constructor(
+class ExternalEventResponseHandler(
     private val clock: Clock,
     @Reference(service = ExternalEventManager::class)
     private val externalEventManager: ExternalEventManager
@@ -27,7 +27,9 @@ class ExternalEventResponseHandler @Activate constructor(
         val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    @Activate constructor(
+    @Suppress("Unused")
+    @Activate
+    constructor(
         @Reference(service = ExternalEventManager::class)
         externalEventManager: ExternalEventManager
     ) : this(UTCClock(), externalEventManager)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
@@ -19,7 +19,6 @@ import java.time.Instant
 @Component(service = [FlowEventHandler::class])
 class ExternalEventResponseHandler(
     private val clock: Clock,
-    @Reference(service = ExternalEventManager::class)
     private val externalEventManager: ExternalEventManager
 ) : FlowEventHandler<ExternalEventResponse> {
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
@@ -14,7 +14,6 @@ import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.time.Instant
 
 @Component(service = [FlowEventHandler::class])
 class ExternalEventResponseHandler(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
@@ -74,8 +74,12 @@ class ExternalEventResponseHandler(
         checkpoint.externalEventState = updatedExternalEventState
 
         if (updatedExternalEventState.status.type == ExternalEventStateType.RETRY) {
-            val sleepDuration = Duration.between(clock.instant(), updatedExternalEventState.sendTimestamp).toMillis().toInt()
-            checkpoint.setFlowSleepDuration(if (sleepDuration > 0) sleepDuration else 0)
+            checkpoint.setFlowSleepDuration(
+                Duration.between(
+                    clock.instant(),
+                    updatedExternalEventState.sendTimestamp
+                ).toMillis().toInt().coerceAtLeast(0)
+            )
         }
 
         return context

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandler.kt
@@ -1,24 +1,36 @@
 package net.corda.flow.pipeline.handlers.events
 
 import net.corda.data.flow.event.external.ExternalEventResponse
+import net.corda.data.flow.state.external.ExternalEventStateType
 import net.corda.flow.external.events.impl.ExternalEventManager
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowEventException
 import net.corda.utilities.debug
+import net.corda.utilities.time.Clock
+import net.corda.utilities.time.UTCClock
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.Duration
+import java.time.Instant
 
 @Component(service = [FlowEventHandler::class])
 class ExternalEventResponseHandler @Activate constructor(
+    private val clock: Clock,
     @Reference(service = ExternalEventManager::class)
     private val externalEventManager: ExternalEventManager
 ) : FlowEventHandler<ExternalEventResponse> {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
+
+    @Activate constructor(
+        @Reference(service = ExternalEventManager::class)
+        externalEventManager: ExternalEventManager
+    ) : this(UTCClock(), externalEventManager)
 
     override val type = ExternalEventResponse::class.java
 
@@ -54,10 +66,17 @@ class ExternalEventResponseHandler @Activate constructor(
             )
         }
 
-        checkpoint.externalEventState = externalEventManager.processResponse(
+        val updatedExternalEventState = externalEventManager.processResponse(
             externalEventState,
             externalEventResponse
         )
+
+        checkpoint.externalEventState = updatedExternalEventState
+
+        if (updatedExternalEventState.status.type == ExternalEventStateType.RETRY) {
+            val sleepDuration = Duration.between(clock.instant(), updatedExternalEventState.sendTimestamp).toMillis().toInt()
+            checkpoint.setFlowSleepDuration(if (sleepDuration > 0) sleepDuration else 0)
+        }
 
         return context
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/ExternalEventResponseHandlerTest.kt
@@ -2,24 +2,37 @@ package net.corda.flow.pipeline.handlers.events
 
 import net.corda.data.flow.event.external.ExternalEventResponse
 import net.corda.data.flow.state.external.ExternalEventState
+import net.corda.data.flow.state.external.ExternalEventStateStatus
+import net.corda.data.flow.state.external.ExternalEventStateType
 import net.corda.flow.REQUEST_ID_1
 import net.corda.flow.external.events.impl.ExternalEventManager
 import net.corda.flow.pipeline.exceptions.FlowEventException
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.test.utils.buildFlowEventContext
+import net.corda.utilities.seconds
+import net.corda.utilities.time.Clock
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class ExternalEventResponseHandlerTest {
 
     private val externalEventResponse = ExternalEventResponse()
 
     private val checkpoint = mock<FlowCheckpoint>()
+    private val clock = mock<Clock>()
     private val externalEventManager = mock<ExternalEventManager>()
-    private val externalEventResponseHandler = ExternalEventResponseHandler(externalEventManager)
+    private val argumentCaptor = argumentCaptor<Int>()
+    private val externalEventResponseHandler = ExternalEventResponseHandler(clock, externalEventManager)
 
     @Test
     fun `throws a flow event exception if the checkpoint does not exist`() {
@@ -47,7 +60,10 @@ class ExternalEventResponseHandlerTest {
     @Test
     fun `processes the received event if the flow is waiting for an external event response`() {
         val externalEventState = ExternalEventState()
-        val updatedExternalEventState = ExternalEventState().apply { REQUEST_ID_1 }
+        val updatedExternalEventState = ExternalEventState().apply {
+            requestId = REQUEST_ID_1
+            status = ExternalEventStateStatus(ExternalEventStateType.OK, null)
+        }
         whenever(checkpoint.doesExist).thenReturn(true)
         whenever(checkpoint.externalEventState).thenReturn(externalEventState)
         whenever(externalEventManager.processResponse(externalEventState, externalEventResponse)).thenReturn(updatedExternalEventState)
@@ -56,5 +72,52 @@ class ExternalEventResponseHandlerTest {
 
         externalEventResponseHandler.preProcess(context)
         verify(checkpoint).externalEventState = updatedExternalEventState
+        verify(checkpoint, never()).setFlowSleepDuration(any())
+    }
+
+    @Test
+    fun `sets the max flow sleep duration when the external event state is in a retry state`() {
+        val now = Instant.now()
+        val externalEventState = ExternalEventState()
+        val updatedExternalEventState = ExternalEventState().apply {
+            requestId = REQUEST_ID_1
+            status = ExternalEventStateStatus(ExternalEventStateType.RETRY, null)
+            sendTimestamp = now.plus(10, ChronoUnit.SECONDS)
+        }
+        whenever(checkpoint.doesExist).thenReturn(true)
+        whenever(checkpoint.externalEventState).thenReturn(externalEventState)
+        whenever(externalEventManager.processResponse(externalEventState, externalEventResponse)).thenReturn(updatedExternalEventState)
+        whenever(clock.instant()).thenReturn(now)
+        doNothing().whenever(checkpoint).setFlowSleepDuration(argumentCaptor.capture())
+
+        val context = buildFlowEventContext(checkpoint, externalEventResponse)
+
+        externalEventResponseHandler.preProcess(context)
+        verify(checkpoint).externalEventState = updatedExternalEventState
+        verify(checkpoint).setFlowSleepDuration(any())
+        assertThat(argumentCaptor.firstValue).isEqualTo(10.seconds.toMillis().toInt())
+    }
+
+    @Test
+    fun `sets the max flow sleep duration when the external event state is in a retry state and send timestamp is in the past`() {
+        val now = Instant.now()
+        val externalEventState = ExternalEventState()
+        val updatedExternalEventState = ExternalEventState().apply {
+            requestId = REQUEST_ID_1
+            status = ExternalEventStateStatus(ExternalEventStateType.RETRY, null)
+            sendTimestamp = now.minus(10, ChronoUnit.SECONDS)
+        }
+        whenever(checkpoint.doesExist).thenReturn(true)
+        whenever(checkpoint.externalEventState).thenReturn(externalEventState)
+        whenever(externalEventManager.processResponse(externalEventState, externalEventResponse)).thenReturn(updatedExternalEventState)
+        whenever(clock.instant()).thenReturn(now)
+        doNothing().whenever(checkpoint).setFlowSleepDuration(argumentCaptor.capture())
+
+        val context = buildFlowEventContext(checkpoint, externalEventResponse)
+
+        externalEventResponseHandler.preProcess(context)
+        verify(checkpoint).externalEventState = updatedExternalEventState
+        verify(checkpoint).setFlowSleepDuration(any())
+        assertThat(argumentCaptor.firstValue).isEqualTo(0)
     }
 }


### PR DESCRIPTION
The external event retry period relies on other events to come in after the retry period has elapsed.

Due to the increase duration between flow wakeup events, it caused flows that have to retry external events to wait a significantly long time to retry.

When an external event must be retried, it now will schedule a wakeup that matches the `sendTimestamp` set when sending the previous attempt for the external event. Therefore, decoupling the retry period from the general wakeup period of flows.