### PR TITLE
CORE-14538: Handle "%" symbol in start flow requests

### DIFF
--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
@@ -748,7 +748,6 @@ class RestServerRequestsTest : RestServerTestBase() {
     }
 
     @Test
-    @Disabled("Due to https://r3-cev.atlassian.net/browse/CORE-14538")
     fun `Call update on test entity with percentage symbol`() {
         val createEntityResponse = client.call(
             PUT,

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientHttpRequestContext.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientHttpRequestContext.kt
@@ -32,9 +32,6 @@ internal class ClientHttpRequestContext(private val ctx: Context) : ClientReques
     override val path: String
         get() = ctx.path()
 
-    override val formParams: Map<String, List<String>>
-        get() = ctx.formParamMap()
-
     override val body: String
         get() = ctx.body()
 
@@ -42,6 +39,8 @@ internal class ClientHttpRequestContext(private val ctx: Context) : ClientReques
         get() = ctx.jsonMapper()
 
     override fun <T> bodyAsClass(clazz: Class<T>): T = ctx.bodyAsClass(clazz)
+
+    override fun formParamMap(): Map<String, List<String>> = ctx.formParamMap()
 
     override fun uploadedFiles(fileName: String): List<UploadedFile> = ctx.uploadedFiles(fileName)
 

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientRequestContext.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientRequestContext.kt
@@ -52,11 +52,6 @@ interface ClientRequestContext {
     val path: String
 
     /**
-     * Gets a map with all the form param keys and values.
-     */
-    val formParams: Map<String, List<String>> get() = emptyMap()
-
-    /**
      * Gets the request body as a [String].
      */
     val body: String get() = throw UnsupportedOperationException()
@@ -70,6 +65,11 @@ interface ClientRequestContext {
      * Maps a JSON body to a Java/Kotlin class using the registered [io.javalin.plugin.json.JsonMapper]
      */
     fun <T> bodyAsClass(clazz: Class<T>): T = throw UnsupportedOperationException()
+
+    /**
+     * Gets a map with all the form param keys and values.
+     */
+    fun formParamMap(): Map<String, List<String>>
 
     /**
      * Gets a list of [UploadedFile]s for the specified name, or empty list.

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientWsRequestContext.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientWsRequestContext.kt
@@ -1,6 +1,7 @@
 package net.corda.rest.server.impl.context
 
 import io.javalin.websocket.WsContext
+import java.lang.UnsupportedOperationException
 
 /**
  * Implementation of [ClientRequestContext] which implements functionality using [WsContext].
@@ -24,6 +25,10 @@ class ClientWsRequestContext(private val ctx: WsContext) : ClientRequestContext 
         // `path()` is not accessible in the context, the best we can do is to use `matchedPath` which will not have
         // path parameters resolved.
         get() = ctx.matchedPath()
+
+    override fun formParamMap(): Map<String, List<String>> {
+        throw UnsupportedOperationException()
+    }
 
     override val queryString: String?
         get() = ctx.queryString()

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/ParameterRetriever.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/ParameterRetriever.kt
@@ -179,7 +179,8 @@ private class MultipartParameterRetriever(private val parameter: Parameter) : Pa
                 return uploadedFiles.first()
             }
 
-            val formParameterAsList = ctx.formParamMap()[parameter.name]
+            val formParamMap = ctx.formParamMap().mapKeys { it.key.lowercase() }
+            val formParameterAsList = formParamMap[parameter.name.lowercase()]
 
             if (!parameter.nullable && formParameterAsList.isNullOrEmpty()) {
                 throw BadRequestException("Missing form parameter \"${parameter.name}\".")

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/ParameterRetriever.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/ParameterRetriever.kt
@@ -159,7 +159,7 @@ private class MultipartParameterRetriever(private val parameter: Parameter) : Pa
     }
 
     @Suppress("ComplexMethod")
-    override fun apply(ctx: ParametersRetrieverContext): Any {
+    override fun apply(ctx: ParametersRetrieverContext): Any? {
         try {
             log.trace { "Cast \"${parameter.name}\" to body parameter." }
 
@@ -179,9 +179,9 @@ private class MultipartParameterRetriever(private val parameter: Parameter) : Pa
                 return uploadedFiles.first()
             }
 
-            val formParameterAsList = ctx.formParams(parameter.name)
+            val formParameterAsList = ctx.formParamMap()[parameter.name]
 
-            if (!parameter.nullable && formParameterAsList.isEmpty()) {
+            if (!parameter.nullable && formParameterAsList.isNullOrEmpty()) {
                 throw BadRequestException("Missing form parameter \"${parameter.name}\".")
             }
 
@@ -190,7 +190,7 @@ private class MultipartParameterRetriever(private val parameter: Parameter) : Pa
             if (Collection::class.java.isAssignableFrom(parameter.classType)) {
                 return formParameterAsList
             }
-            return formParameterAsList.first()
+            return formParameterAsList?.first()
         } catch (e: Exception) {
             "Error during Cast \"${parameter.name}\" to multipart form parameter".let {
                 log.warn("$it: ${e.message}")

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/ParametersRetrieverContext.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/ParametersRetrieverContext.kt
@@ -1,6 +1,5 @@
 package net.corda.rest.server.impl.internal
 
-import com.fasterxml.jackson.databind.node.ObjectNode
 import io.javalin.http.util.ContextUtil
 import net.corda.rest.HttpFileUpload
 import net.corda.rest.server.impl.context.ClientRequestContext


### PR DESCRIPTION
This PR removes the `formParams` property in `ClientRequestContext`, which was throwing an error handling certain requests. Instead, we now use a function which calls the `formParamMap` method from javalin, only when we need to access form parameters. 

