### PR TITLE
CORE-13796: Remove dependency on Kafka Client from `:libs:tracing`

### DIFF
--- a/libs/tracing/build.gradle
+++ b/libs/tracing/build.gradle
@@ -27,13 +27,6 @@ dependencies {
     implementation("io.zipkin.reporter2:zipkin-sender-urlconnection:$zipkinVersion")
     implementation("io.zipkin.brave:brave-context-slf4j:$braveVersion")
     implementation("io.zipkin.brave:brave-instrumentation-servlet:$braveVersion")
-    implementation ("org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion") {
-        // Need to explicitly exclude this dependency (which seems non-essential), however it will prevent running
-        // Combined Worker on Mac M1. Please see README of Combined worker for more details.
-        // We should not need this dependency as long as we are not using `snappy` compression type in Kafka
-        // topics configuration.
-        exclude group: 'org.xerial.snappy'
-    }
 
     implementation "io.javalin:javalin-osgi:$javalinVersion"
     constraints {


### PR DESCRIPTION
This was a left over from early implementation of tracing functionality.