### PR TITLE
CORE-14592: Fix incorrect error code 500 response for negative scenario when using external messaging service

### DIFF
--- a/components/virtual-node/cpi-upload-rest-service/build.gradle
+++ b/components/virtual-node/cpi-upload-rest-service/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:messaging:messaging')
     implementation project(':libs:virtual-node:cpi-upload-endpoints')
+    implementation project(':libs:configuration:configuration-validation')
     api project(':libs:virtual-node:cpi-upload-manager')
     implementation project(':libs:virtual-node:virtual-node-endpoints')
     implementation project(':libs:packaging:packaging-core')

--- a/components/virtual-node/cpi-upload-rest-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
+++ b/components/virtual-node/cpi-upload-rest-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
@@ -6,6 +6,7 @@ import net.corda.cpi.upload.endpoints.common.CpiUploadRestResourceHandler
 import net.corda.cpi.upload.endpoints.service.CpiUploadService
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.chunking.UploadStatus
+import net.corda.libs.configuration.validation.ConfigurationValidationException
 import net.corda.rest.HttpFileUpload
 import net.corda.rest.PluggableRestResource
 import net.corda.rest.exception.BadRequestException
@@ -98,6 +99,7 @@ class CpiUploadRestResourceImpl @Activate constructor(
         // i.e. "name version (groupId)"
         when (ex.errorType) {
             ValidationException::class.java.name -> throw BadRequestException(ex.errorMessage, details)
+            ConfigurationValidationException::class.java.name -> throw BadRequestException(ex.errorMessage, details)
             DuplicateCpiUploadException::class.java.name -> throw ResourceAlreadyExistsException(ex.errorMessage)
             else -> throw InternalServerException(ex.toString(), details)
         }


### PR DESCRIPTION
- Add a BadRequestException for type ConfigurationValidationException, so that error code 400 is received instead of 500 for negative scenarios when using the external messaging service, since it is not a server error.
- E2E test for this scenario: [CORE 14592: Change invalid channel config test to check for code 400 #137](https://github.com/corda/corda-e2e-tests/pull/137)