### PR TITLE
ES-609/Update JenkinsfileSnykScan with cpuCount

### DIFF
--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -2,5 +2,6 @@
 
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5',
-    snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d"
+    snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d",
+    cpuCount: 7
 )


### PR DESCRIPTION
Cherry-picking changes from 5.1

Pending merge of: https://github.com/corda/corda-shared-build-pipeline-steps/pull/925

Not functional change required for Stable Build for Snyk scanning