### PR TITLE
CORE-15096: Restrict which classes we can load from the system bundle.

### DIFF
--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/Constants.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/Constants.kt
@@ -27,6 +27,7 @@ internal const val LIB_SINGLETON_SERVICE_FLOW_CPK_2 = "com.example.sandbox.cpk2.
 
 internal const val LIBRARY_QUERY_CLASS = "com.example.sandbox.library.SandboxQuery"
 internal const val LIBRARY_QUERY_IMPL_CLASS = "com.example.sandbox.library.impl.SandboxQueryImpl"
-internal const val SYSTEM_BUNDLE_CLASS = "org.apache.felix.framework.BundleImpl"
+internal const val FORBIDDEN_SYSTEM_BUNDLE_CLASS = "org.apache.felix.framework.BundleImpl"
+internal const val SYSTEM_BUNDLE_CLASS = "org.osgi.framework.Bundle"
 
 internal const val PRIVATE_WRAPPER_RETURN_VALUE = "String returned by WrapperImpl."

--- a/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
+++ b/libs/sandbox-internal/src/integrationTest/kotlin/net/corda/sandboxtests/SandboxClassTagTests.kt
@@ -120,6 +120,18 @@ class SandboxClassTagTests {
         assertEquals(systemBundleClass, sandboxFactory.group1.getClass(systemBundleClass.name, evolvableTag))
     }
 
+    @Test
+    fun `cannot create class tags for private system bundle classes and use them to retrieve the class`() {
+        val systemBundle = FrameworkUtil.getBundle(this::class.java).bundleContext.getBundle(SYSTEM_BUNDLE_ID)
+        val forbiddenSystemClass = systemBundle.loadClass(FORBIDDEN_SYSTEM_BUNDLE_CLASS)
+
+        val staticTag = sandboxFactory.group1.getStaticTag(forbiddenSystemClass)
+        val evolvableTag = sandboxFactory.group1.getEvolvableTag(forbiddenSystemClass)
+
+        assertThrows<SandboxException> { sandboxFactory.group1.getClass(forbiddenSystemClass.name, staticTag) }
+        assertThrows<SandboxException> { sandboxFactory.group1.getClass(forbiddenSystemClass.name, evolvableTag) }
+    }
+
     @ParameterizedTest
     @ValueSource(classes = [ Long::class, Int::class, Short::class, Byte::class, Char::class, Boolean::class, Double::class, Float::class ])
     fun `can handle primitive types`(primitiveType: Class<*>) {

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
@@ -1,10 +1,14 @@
 package net.corda.sandbox.internal.utilities
 
+import java.util.Collections.unmodifiableMap
+import java.util.Collections.unmodifiableSet
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
 import org.osgi.framework.Constants.SYSTEM_BUNDLE_ID
 import org.osgi.framework.FrameworkListener
 import org.osgi.framework.FrameworkUtil
+import org.osgi.framework.wiring.BundleRevision.PACKAGE_NAMESPACE
+import org.osgi.framework.wiring.BundleWiring
 import org.osgi.framework.wiring.FrameworkWiring
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -19,6 +23,39 @@ internal class BundleUtils @Activate constructor(
     private val bundleContext: BundleContext
 ) {
     private val systemBundle = bundleContext.getBundle(SYSTEM_BUNDLE_ID)
+    private val arrayType = "\\[++(([BCDFIJSZ])|L(.+);)".toRegex()
+
+    /** Determine which packages the system bundle exports by examining its capabilities. */
+    private val systemPackageNames = unmodifiableSet(systemBundle.adapt(BundleWiring::class.java)
+        .getCapabilities(PACKAGE_NAMESPACE)
+        .mapNotNull { capability ->
+            capability.attributes[PACKAGE_NAMESPACE].toString()
+        }.filterNotTo(linkedSetOf()) { packageName ->
+            packageName.startsWith("java.")
+        })
+
+    private val primitiveTypes = unmodifiableMap(setOf(
+        Long::class.java,
+        Int::class.java,
+        Short::class.java,
+        Byte::class.java,
+        Char::class.java,
+        Boolean::class.java,
+        Double::class.java,
+        Float::class.java
+    ).associateBy(Class<*>::getName))
+
+    private val primitiveTypeNames = unmodifiableSet(setOf("B", "C", "D", "F", "I", "J", "S", "Z"))
+
+    private fun typeNameOf(className: String): String {
+        return arrayType.matchEntire(className)?.let { it.groupValues[2] + it.groupValues[3] } ?: className
+    }
+
+    private fun isSystemType(typeName: String): Boolean {
+        return typeName in primitiveTypeNames || typeName.substringBeforeLast('.').let { packageName ->
+            packageName.startsWith("java.") || packageName in systemPackageNames
+        }
+    }
 
     /** Returns the bundle from which [klass] is loaded, or null if there is no such bundle. */
     fun getBundle(klass: Class<*>): Bundle? = FrameworkUtil.getBundle(klass) ?: try {
@@ -32,8 +69,19 @@ internal class BundleUtils @Activate constructor(
         null
     }
 
-    /** Loads OSGi framework types. Can also be used to load Java platform types. */
-    fun loadClassFromSystemBundle(className: String): Class<*> = systemBundle.loadClass(className)
+    /**
+     * Loads OSGi framework types. Can also be used to load Java platform types.
+     * Restrict which classes it can try to load by comparing this class's package
+     * name with those package names exported by the system bundle's wirings.
+     */
+    @Throws(ClassNotFoundException::class)
+    fun loadClassFromSystemBundle(className: String): Class<*> {
+        return primitiveTypes[className] ?: if (isSystemType(typeNameOf(className))) {
+            systemBundle.loadClass(className)
+        } else {
+            throw ClassNotFoundException(className)
+        }
+    }
 
     /**
      * Returns the bundle from which [serviceComponentRuntime] is loaded, or null if there is no such bundle.

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
@@ -64,6 +64,7 @@ class SandboxGroupImplTests {
         whenever(getBundle(publicClass)).thenReturn(mockPublicBundle)
         whenever(getBundle(publicLibraryClass)).thenReturn(mockPublicLibraryBundle)
         whenever(getBundle(nonSandboxClass)).thenReturn(mockNonSandboxBundle)
+        whenever(loadClassFromSystemBundle(DoesNotExist::class.java.name)).thenThrow(ClassNotFoundException())
     }
 
 
@@ -92,10 +93,12 @@ class SandboxGroupImplTests {
         val nonExistentName = DoesNotExist::class.java.name
         assertNull(sandboxGroupImpl.loadClassFromPublicBundles(nonExistentName))
         verify(mockPublicBundle).loadClass(nonExistentName)
+        verify(mockBundleUtils).loadClassFromSystemBundle(nonExistentName)
 
         // Trying to reload the same class should not invoke Bundle.loadClass again.
         assertNull(sandboxGroupImpl.loadClassFromPublicBundles(nonExistentName))
         verify(mockPublicBundle).loadClass(nonExistentName)
+        verify(mockBundleUtils).loadClassFromSystemBundle(nonExistentName)
     }
 
     @Test


### PR DESCRIPTION
The OSGi system bundle uses the JVM's Application classloader rather than a custom `BundleClassLoader`, which means that it does not respect the OSGi resolver hooks or the system bundle wirings.

Modify `BundleUtils.loadClassFromSystemBundle()` so that it can only load classes from packages that the system bundle officially exports. This protects the system bundle's private packages from being exposed to sandboxes.