### PR TITLE
ES-807: Ensure Interop branches dont raise Jira tickets nightly

### DIFF
--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -3,5 +3,6 @@
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5',
     snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d",
-    cpuCount: 7
+    cpuCount: 7,
+    generateJira: false
 )


### PR DESCRIPTION
- update snyk nightly scan config so as not to create Jira tickets for interop branch, due to excess noise on triage meetings.

Fixes will be consumed from default release branches with regular merges up / down. This does not affect security scans on the snyk server where reportes for this branch will still be available for the interop team to keep on top of.   