### PR TITLE
CORE-15096: Optimise regex for array class names.

### DIFF
--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/utilities/BundleUtils.kt
@@ -23,7 +23,7 @@ internal class BundleUtils @Activate constructor(
     private val bundleContext: BundleContext
 ) {
     private val systemBundle = bundleContext.getBundle(SYSTEM_BUNDLE_ID)
-    private val arrayType = "\\[++(([BCDFIJSZ])|L(.+);)".toRegex()
+    private val arrayType = "\\[++(([BCDFIJSZ])|L([^;]++);)".toRegex()
 
     /** Determine which packages the system bundle exports by examining its capabilities. */
     private val systemPackageNames = unmodifiableSet(systemBundle.adapt(BundleWiring::class.java)


### PR DESCRIPTION
Optimise the group to match everything _except_ for a semi-colon, which is used as the terminator. This means that the group never needs to give anything back, i.e. it can become "greedy".