### PR TITLE
CORE-15087 update platform version 5.1

### DIFF
--- a/applications/examples/sandbox-app/example-cpi/build.gradle
+++ b/applications/examples/sandbox-app/example-cpi/build.gradle
@@ -9,7 +9,7 @@ group 'com.example.vnode'
 version = '1.0-SNAPSHOT'
 
 cordapp {
-    targetPlatformVersion 50000 as Integer
+    targetPlatformVersion platformVersion.toInteger()
     workflow {
         name 'Corda Example CPK'
         versionId 1

--- a/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
+++ b/components/chunking/chunk-db-write-impl/src/integrationTest/kotlin/net/corda/chunking/db/impl/tests/DatabaseCpiPersistenceTest.kt
@@ -90,7 +90,7 @@ internal class DatabaseCpiPersistenceTest {
         emConfig
     )
     private val platformInfoProvider: PlatformInfoProvider = mock {
-        on { activePlatformVersion } doReturn 50000
+        on { activePlatformVersion } doReturn 12345
         on { localWorkerSoftwareVersion } doReturn "5.0.0"
     }
     private val mgmPubKeyStr = "PUB-KEY"

--- a/components/configuration/configuration-rest-resource-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/ConfigRestResourceImplTests.kt
+++ b/components/configuration/configuration-rest-resource-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/ConfigRestResourceImplTests.kt
@@ -58,7 +58,7 @@ class ConfigRestResourceImplTests {
         }
     }
 
-    private val req = UpdateConfigParameters("section", 50000, TestJsonObject("a=b"), ConfigSchemaVersion(888, 0))
+    private val req = UpdateConfigParameters("section", 45678, TestJsonObject("a=b"), ConfigSchemaVersion(888, 0))
     private val successFuture = CompletableFuture.supplyAsync {
         ConfigurationManagementResponse(
             true, null, req.section, req.config.escapedJson, ConfigurationSchemaVersion(

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
@@ -68,7 +68,7 @@ class FlowRunnerImplTest {
     private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService>()
     private val sandboxDependencyInjector = mock<SandboxDependencyInjector>()
     private val fiberFuture = mock<FiberFuture>()
-    private val platformInfoProvider = mock<PlatformInfoProvider> { on { localWorkerPlatformVersion} doReturn 50000 }
+    private val platformInfoProvider = mock<PlatformInfoProvider> { on { localWorkerPlatformVersion} doReturn 67890 }
     private var flowFiberExecutionContext: FlowFiberExecutionContext
     private var flowStackItem = FlowStackItem().apply { sessions = mutableListOf() }
     private var clientFlow = mock<ClientStartableFlow>()
@@ -105,8 +105,8 @@ class FlowRunnerImplTest {
         )
         whenever(virtualNodeInfoReadService.get(any())).thenReturn(getMockVNodeInfo())
         whenever(cpiInfoReadService.get(any())).thenReturn(getMockCpiMetaData())
-        whenever(flowCheckpoint.initialPlatformVersion).thenReturn(50000)
-        whenever(platformInfoProvider.localWorkerSoftwareVersion).thenReturn("50000")
+        whenever(flowCheckpoint.initialPlatformVersion).thenReturn(67890)
+        whenever(platformInfoProvider.localWorkerSoftwareVersion).thenReturn("67890")
     }
 
     @BeforeEach

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
@@ -111,7 +111,7 @@ class FlowCheckpointImplTest {
             flowId = "F1"
             flowState = newFlowState
             pipelineState = newPipelineState
-            initialPlatformVersion = 50000
+            initialPlatformVersion = 13579
         }
     }
 
@@ -177,7 +177,7 @@ class FlowCheckpointImplTest {
     fun `existing checkpoint - sets initial platform version`() {
         val checkpoint = setupAvroCheckpoint()
 
-        assertThat(createFlowCheckpoint(checkpoint).initialPlatformVersion).isEqualTo(50000)
+        assertThat(createFlowCheckpoint(checkpoint).initialPlatformVersion).isEqualTo(13579)
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 kapt.include.compile.classpath=false
 
 # Update with new major releases, or minor releases with breaking changes. (This drives the Flow Versioning too.)
-platformVersion = 50000
+platformVersion = 50100
 
 # Versioning constants.
 ## The release/marketing version

--- a/libs/configuration/configuration-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/ConfigEntityManagerIntegrationTest.kt
+++ b/libs/configuration/configuration-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/ConfigEntityManagerIntegrationTest.kt
@@ -68,7 +68,7 @@ class ConfigEntityManagerIntegrationTest {
     @Test
     fun `can persist and read back config entities`() {
         val config = ConfigEntity(
-            "${random.nextInt()}", "a=b", 50000, 0,
+            "${random.nextInt()}", "a=b", 54321, 0,
             // truncating to millis as on windows builds the micros are lost after fetching the data from Postgres
             Instant.now().truncatedTo(ChronoUnit.MILLIS), "actor"
         )
@@ -86,7 +86,7 @@ class ConfigEntityManagerIntegrationTest {
     @Test
     fun `can persist and read back config audit entities`() {
         val config = ConfigEntity(
-            "${random.nextInt()}", "a=b", 50000, 0,
+            "${random.nextInt()}", "a=b", 98765, 0,
             // truncating to millis as on windows builds the micros are lost after fetching the data from Postgres
             Instant.now().truncatedTo(ChronoUnit.MILLIS), "joel"
         )

--- a/libs/packaging/packaging/test/contract-cpk/build.gradle
+++ b/libs/packaging/packaging/test/contract-cpk/build.gradle
@@ -17,8 +17,8 @@ tasks.named('jar', Jar) {
 }
 
 cordapp {
-    targetPlatformVersion 50000
-    minimumPlatformVersion 50000 as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
 
     contract {
         name = 'Contract cpk to be used for unit tests for the packaging module'

--- a/libs/packaging/packaging/test/workflow-cpk/build.gradle
+++ b/libs/packaging/packaging/test/workflow-cpk/build.gradle
@@ -26,8 +26,8 @@ tasks.named('jar', Jar) {
 }
 
 cordapp {
-    targetPlatformVersion 50000
-    minimumPlatformVersion 50000 as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
 
     workflow {
         name = 'Workflow cpk to be used for uniut tests for the packaging module'

--- a/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
+++ b/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
@@ -12,7 +12,7 @@ class PlatformInfoProviderTest {
     lateinit var platformInfoProvider: PlatformInfoProvider
 
     private companion object {
-        const val EXPECTED_STUB_PLATFORM_VERSION = 50000
+        const val EXPECTED_STUB_PLATFORM_VERSION = 50100
     }
 
     @Test

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -12,9 +12,9 @@ class PlatformInfoProviderImpl @Activate constructor(
 ) : PlatformInfoProvider {
 
     internal companion object {
-        const val STUB_PLATFORM_VERSION = 50000
+        const val STUB_PLATFORM_VERSION = 50100
 
-        private const val DEFAULT_PLATFORM_VERSION = 50000
+        private const val DEFAULT_PLATFORM_VERSION = 50100
         private const val PLATFORM_VERSION_KEY = "net.corda.platform.version"
     }
 

--- a/libs/platform-info/src/test/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImplTest.kt
+++ b/libs/platform-info/src/test/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImplTest.kt
@@ -12,7 +12,7 @@ import org.osgi.framework.Version
 class PlatformInfoProviderImplTest {
 
     companion object {
-        const val PLATFORM_VERSION = "50000"
+        const val PLATFORM_VERSION = "50100"
         const val SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
     }
 

--- a/libs/platform-info/src/test/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImplTest.kt
+++ b/libs/platform-info/src/test/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImplTest.kt
@@ -12,7 +12,7 @@ import org.osgi.framework.Version
 class PlatformInfoProviderImplTest {
 
     companion object {
-        const val PLATFORM_VERSION = "50100"
+        const val PLATFORM_VERSION = "12345"
         const val SOFTWARE_VERSION = "5.0.0.0-SNAPSHOT"
     }
 

--- a/libs/sandbox-internal/sandbox-cpk-one/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-one/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Sandbox CPK One'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     workflow {
         name 'Sandbox CPK-1'
         versionId 1

--- a/libs/sandbox-internal/sandbox-cpk-three/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-three/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Sandbox CPK Three'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     workflow {
         name 'Sandbox CPK-3'
         versionId 1

--- a/libs/sandbox-internal/sandbox-cpk-two/build.gradle
+++ b/libs/sandbox-internal/sandbox-cpk-two/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Sandbox CPK Two'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     workflow {
         name 'Sandbox CPK-2'
         versionId 1

--- a/libs/sandbox-internal/sandbox-irresolvable-cpk/build.gradle
+++ b/libs/sandbox-internal/sandbox-irresolvable-cpk/build.gradle
@@ -7,7 +7,7 @@ description 'Corda Sandbox Irresolvable CPK'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion 50000 as Integer
+    targetPlatformVersion platformVersion.toInteger()
     workflow {
         name 'Sandbox Irresolvable-CPK'
         versionId 1

--- a/libs/serialization/serialization-amqp/cpk-evolution-newer/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-evolution-newer/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.cordapp-cpb2'
 }
 
-ext {
-    platformVersion = 50000
-}
-
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         // Change version to 1 when rebuilding the test resources

--- a/libs/serialization/serialization-amqp/cpk-evolution-older/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-evolution-older/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.cordapp-cpb2'
 }
 
-ext {
-    platformVersion = 50000
-}
-
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         // Change version to 2 when rebuilding the test resources

--- a/libs/serialization/serialization-amqp/cpk-four/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-four/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.cordapp-cpb2'
 }
 
-ext {
-    platformVersion = 50000
-}
-
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         versionId 1

--- a/libs/serialization/serialization-amqp/cpk-one/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-one/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.cordapp-cpk2'
 }
 
-ext {
-    platformVersion = 50000
-}
-
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         versionId 1

--- a/libs/serialization/serialization-amqp/cpk-swap-original/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-swap-original/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.cordapp-cpb2'
 }
 
-ext {
-    platformVersion = 50000
-}
-
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         versionId 1

--- a/libs/serialization/serialization-amqp/cpk-swap-replacement/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-swap-replacement/build.gradle
@@ -2,13 +2,10 @@ plugins {
     id 'net.corda.plugins.cordapp-cpb2'
 }
 
-ext {
-    platformVersion = 50000
-}
 
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         versionId 1

--- a/libs/serialization/serialization-amqp/cpk-three/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-three/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.cordapp-cpk2'
 }
 
-ext {
-    platformVersion = 50000
-}
-
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         versionId 1

--- a/libs/serialization/serialization-amqp/cpk-two/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-two/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.cordapp-cpk2'
 }
 
-ext {
-    platformVersion = 50000
-}
-
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         versionId 1

--- a/libs/serialization/serialization-amqp/cpk-using-lib/build.gradle
+++ b/libs/serialization/serialization-amqp/cpk-using-lib/build.gradle
@@ -2,13 +2,9 @@ plugins {
     id 'net.corda.plugins.cordapp-cpb2'
 }
 
-ext {
-    platformVersion = 50000
-}
-
 cordapp {
-    targetPlatformVersion platformVersion as Integer
-    minimumPlatformVersion platformVersion as Integer
+    targetPlatformVersion platformVersion.toInteger()
+    minimumPlatformVersion platformVersion.toInteger()
     workflow {
         name "Test Serializable Test"
         versionId 1

--- a/libs/serialization/serialization-kryo/cpks/serializable-cpk-one/build.gradle
+++ b/libs/serialization/serialization-kryo/cpks/serializable-cpk-one/build.gradle
@@ -8,7 +8,7 @@ group 'com.example.sandbox'
 version ''
 
 ext {
-    platformVersion = 50000
+    platformVersion = platformVersion.toInteger()
 }
 
 cordapp {

--- a/libs/serialization/serialization-kryo/cpks/serializable-cpk-two/build.gradle
+++ b/libs/serialization/serialization-kryo/cpks/serializable-cpk-two/build.gradle
@@ -8,7 +8,7 @@ group 'com.example.sandbox'
 version ''
 
 ext {
-    platformVersion = 50000
+    platformVersion = platformVersion.toInteger()
 }
 
 cordapp {

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeDbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/VirtualNodeDbReconcilerReaderTest.kt
@@ -26,7 +26,7 @@ class VirtualNodeDbReconcilerReaderTest {
         val uniquenessDmlConnectionId = UUID.randomUUID()
         val uniquenessDdlConnectionId = UUID.randomUUID()
         val timestamp = Instant.now()
-        const val entityVersion = 50000
+        const val entityVersion = 24680
     }
 
     private fun mockVirtualNodeEntity(): VirtualNodeInfo {

--- a/testing/cpbs/crypto-custom-digest-one-consumer/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-one-consumer/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Crypto Custom Digest Consumer One'
 group 'com.example.crypto.consumer'
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     workflow {
         name 'Custom Crypto Digest One Consumer CPK'
         versionId 1

--- a/testing/cpbs/crypto-custom-digest-one-cpk/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-one-cpk/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Crypto Custom Digest One'
 group 'com.example.crypto'
 
 cordapp {
-    targetPlatformVersion 50000 as Integer
+    targetPlatformVersion platformVersion.toInteger()
     workflow {
         name 'Custom Crypto Digest One CPK'
         versionId 1

--- a/testing/cpbs/crypto-custom-digest-two-consumer/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-two-consumer/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Crypto Custom Digest Consumer Two'
 group 'org.example.crypto.consumer'
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     workflow {
         name 'Custom Crypto Digest Two Consumer CPK'
         versionId 1

--- a/testing/cpbs/crypto-custom-digest-two-cpk/build.gradle
+++ b/testing/cpbs/crypto-custom-digest-two-cpk/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Crypto Custom Digest Two'
 group 'org.example.crypto'
 
 cordapp {
-    targetPlatformVersion 50000 as Integer
+    targetPlatformVersion platformVersion.toInteger()
     workflow {
         name 'Custom Crypto Digest Two CPK'
         versionId 1

--- a/testing/cpbs/sandbox-scr-cpk/build.gradle
+++ b/testing/cpbs/sandbox-scr-cpk/build.gradle
@@ -8,7 +8,7 @@ group 'com.example.sandbox'
 version ''
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     workflow {
         name 'Sandbox SCR-Using-CPK'
         versionId 1

--- a/testing/cpbs/sandbox-security-manager-one/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-one/build.gradle
@@ -8,7 +8,7 @@ description 'Security Manager One'
 group 'com.example.securitymanager'
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     contract {
         name 'Security Manager One CPK'
         versionId 1

--- a/testing/cpbs/sandbox-security-manager-two/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-two/build.gradle
@@ -8,7 +8,7 @@ description 'Security Manager Two'
 group 'com.example.securitymanager'
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     contract {
         name 'Security Manager Two CPK'
         versionId 1

--- a/testing/cpbs/sandbox-singletons-cpk/build.gradle
+++ b/testing/cpbs/sandbox-singletons-cpk/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Sandbox Singletons CPK'
 group 'com.example.sandbox'
 
 cordapp {
-    targetPlatformVersion = 50000
+    targetPlatformVersion = platformVersion.toInteger()
     workflow {
         name 'Sandbox Singletons CPK'
         versionId 1


### PR DESCRIPTION
CORE-15087 update platform version to 50100 for 5.1 according spec. Centralize it. Make tests less-dependent of the main number.
