### PR TITLE
CORE-8958 centralize platform versions

### DIFF
--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation project(':libs:ledger:ledger-utxo-data')
     implementation project(':libs:ledger:ledger-utxo-transaction-verifier')
     implementation project(':libs:metrics')
+    implementation project(':libs:platform-info')
     implementation project(':libs:sandbox')
     implementation project(':libs:serialization:json-validator')
     implementation project(':libs:serialization:serialization-checkpoint-api')

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlow.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.utxo.flow.impl.flows.backchain
 import net.corda.flow.application.services.VersioningService
 import net.corda.flow.application.versioning.VersionedReceiveFlowFactory
 import net.corda.ledger.utxo.flow.impl.flows.backchain.v1.TransactionBackchainResolutionFlowV1
+import net.corda.libs.platform.PlatformVersion.CORDA_5_1
 import net.corda.sandbox.CordaSystemFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.SubFlow
@@ -54,12 +55,12 @@ class TransactionBackchainResolutionFlowVersionedFlowFactory(
 
     override fun create(version: Int, session: FlowSession): SubFlow<Unit> {
         return when {
-            version >= 50100 -> TransactionBackchainResolutionFlowV1(
+            version >= CORDA_5_1.platformVersion -> TransactionBackchainResolutionFlowV1(
                 initialTransactionIds,
                 session,
                 TransactionBackChainResolutionVersion.V2
             )
-            version in 1..50099 -> TransactionBackchainResolutionFlowV1(
+            version in 1 until CORDA_5_1.platformVersion -> TransactionBackchainResolutionFlowV1(
                 initialTransactionIds,
                 session,
                 TransactionBackChainResolutionVersion.V1

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlow.kt
@@ -55,12 +55,12 @@ class TransactionBackchainResolutionFlowVersionedFlowFactory(
 
     override fun create(version: Int, session: FlowSession): SubFlow<Unit> {
         return when {
-            version >= CORDA_5_1.platformVersion -> TransactionBackchainResolutionFlowV1(
+            version >= CORDA_5_1.value -> TransactionBackchainResolutionFlowV1(
                 initialTransactionIds,
                 session,
                 TransactionBackChainResolutionVersion.V2
             )
-            version in 1 until CORDA_5_1.platformVersion -> TransactionBackchainResolutionFlowV1(
+            version in 1 until CORDA_5_1.value -> TransactionBackchainResolutionFlowV1(
                 initialTransactionIds,
                 session,
                 TransactionBackChainResolutionVersion.V1

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlow.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.utxo.flow.impl.flows.backchain
 import net.corda.flow.application.services.VersioningService
 import net.corda.flow.application.versioning.VersionedSendFlowFactory
 import net.corda.ledger.utxo.flow.impl.flows.backchain.v1.TransactionBackchainSenderFlowV1
+import net.corda.libs.platform.PlatformVersion.CORDA_5_1
 import net.corda.sandbox.CordaSystemFlow
 import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.flows.SubFlow
@@ -53,12 +54,12 @@ class TransactionBackchainSenderFlowVersionedFlowFactory(
 
     override fun create(version: Int, sessions: List<FlowSession>): SubFlow<Unit> {
         return when {
-            version >= 50100 -> TransactionBackchainSenderFlowV1(
+            version >= CORDA_5_1.platformVersion -> TransactionBackchainSenderFlowV1(
                 headTransactionIds,
                 sessions.single(),
                 TransactionBackChainResolutionVersion.V2
             )
-            version in 1..50099 -> TransactionBackchainSenderFlowV1(
+            version in 1 until CORDA_5_1.platformVersion -> TransactionBackchainSenderFlowV1(
                 headTransactionIds,
                 sessions.single(),
                 TransactionBackChainResolutionVersion.V1

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlow.kt
@@ -54,12 +54,12 @@ class TransactionBackchainSenderFlowVersionedFlowFactory(
 
     override fun create(version: Int, sessions: List<FlowSession>): SubFlow<Unit> {
         return when {
-            version >= CORDA_5_1.platformVersion -> TransactionBackchainSenderFlowV1(
+            version >= CORDA_5_1.value -> TransactionBackchainSenderFlowV1(
                 headTransactionIds,
                 sessions.single(),
                 TransactionBackChainResolutionVersion.V2
             )
-            version in 1 until CORDA_5_1.platformVersion -> TransactionBackchainSenderFlowV1(
+            version in 1 until CORDA_5_1.value -> TransactionBackchainSenderFlowV1(
                 headTransactionIds,
                 sessions.single(),
                 TransactionBackChainResolutionVersion.V1

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlowVersionedFlowFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlowVersionedFlowFactoryTest.kt
@@ -23,7 +23,7 @@ class TransactionBackchainResolutionFlowVersionedFlowFactoryTest {
     }
 
     @Test
-    fun `with last 5_0 platform version creates TransactionBackchainResolutionFlowV1`() {
+    fun `with last potential 5_0 platform version creates TransactionBackchainResolutionFlowV1`() {
         val flow = factory.create(CORDA_5_1.value - 1, mock())
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainResolutionFlowV1::class.java)
         assertSame(

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlowVersionedFlowFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlowVersionedFlowFactoryTest.kt
@@ -24,7 +24,7 @@ class TransactionBackchainResolutionFlowVersionedFlowFactoryTest {
 
     @Test
     fun `with last 5_0 platform version creates TransactionBackchainResolutionFlowV1`() {
-        val flow = factory.create(CORDA_5_1.platformVersion - 1, mock())
+        val flow = factory.create(CORDA_5_1.value - 1, mock())
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainResolutionFlowV1::class.java)
         assertSame(
             TransactionBackChainResolutionVersion.V1,
@@ -34,7 +34,7 @@ class TransactionBackchainResolutionFlowVersionedFlowFactoryTest {
 
     @Test
     fun `with first 5_1 platform version creates TransactionBackchainResolutionFlowV2`() {
-        val flow = factory.create(CORDA_5_1.platformVersion, mock())
+        val flow = factory.create(CORDA_5_1.value, mock())
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainResolutionFlowV1::class.java)
         assertSame(
             TransactionBackChainResolutionVersion.V2,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlowVersionedFlowFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainResolutionFlowVersionedFlowFactoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.flows.backchain
 
 import net.corda.ledger.utxo.flow.impl.flows.backchain.v1.TransactionBackchainResolutionFlowV1
+import net.corda.libs.platform.PlatformVersion.CORDA_5_1
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -22,8 +23,8 @@ class TransactionBackchainResolutionFlowVersionedFlowFactoryTest {
     }
 
     @Test
-    fun `with platform version 50099 creates TransactionBackchainResolutionFlowV1`() {
-        val flow = factory.create(50099, mock())
+    fun `with last 5_0 platform version creates TransactionBackchainResolutionFlowV1`() {
+        val flow = factory.create(CORDA_5_1.platformVersion - 1, mock())
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainResolutionFlowV1::class.java)
         assertSame(
             TransactionBackChainResolutionVersion.V1,
@@ -32,8 +33,8 @@ class TransactionBackchainResolutionFlowVersionedFlowFactoryTest {
     }
 
     @Test
-    fun `with platform version 50100 creates TransactionBackchainResolutionFlowV2`() {
-        val flow = factory.create(50100, mock())
+    fun `with first 5_1 platform version creates TransactionBackchainResolutionFlowV2`() {
+        val flow = factory.create(CORDA_5_1.platformVersion, mock())
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainResolutionFlowV1::class.java)
         assertSame(
             TransactionBackChainResolutionVersion.V2,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlowVersionedFlowFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlowVersionedFlowFactoryTest.kt
@@ -23,7 +23,7 @@ class TransactionBackchainSenderFlowVersionedFlowFactoryTest {
     }
 
     @Test
-    fun `with last 5_0 platform version creates TransactionBackchainSenderFlowV1`() {
+    fun `with last potential 5_0 platform version creates TransactionBackchainSenderFlowV1`() {
         val flow = factory.create(CORDA_5_1.value - 1, listOf(mock()))
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainSenderFlowV1::class.java)
         assertSame(

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlowVersionedFlowFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlowVersionedFlowFactoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.flows.backchain
 
 import net.corda.ledger.utxo.flow.impl.flows.backchain.v1.TransactionBackchainSenderFlowV1
+import net.corda.libs.platform.PlatformVersion.CORDA_5_1
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -22,8 +23,8 @@ class TransactionBackchainSenderFlowVersionedFlowFactoryTest {
     }
 
     @Test
-    fun `with platform version 50099 creates TransactionBackchainSenderFlowV1`() {
-        val flow = factory.create(50099, listOf(mock()))
+    fun `with last 5_0 platform version creates TransactionBackchainSenderFlowV1`() {
+        val flow = factory.create(CORDA_5_1.platformVersion - 1, listOf(mock()))
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainSenderFlowV1::class.java)
         assertSame(
             TransactionBackChainResolutionVersion.V1,
@@ -32,8 +33,8 @@ class TransactionBackchainSenderFlowVersionedFlowFactoryTest {
     }
 
     @Test
-    fun `with platform version 50100 creates TransactionBackchainSenderFlowV2`() {
-        val flow = factory.create(50100, listOf(mock()))
+    fun `with first 5_1 platform version creates TransactionBackchainSenderFlowV2`() {
+        val flow = factory.create(CORDA_5_1.platformVersion, listOf(mock()))
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainSenderFlowV1::class.java)
         assertSame(
             TransactionBackChainResolutionVersion.V2,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlowVersionedFlowFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainSenderFlowVersionedFlowFactoryTest.kt
@@ -24,7 +24,7 @@ class TransactionBackchainSenderFlowVersionedFlowFactoryTest {
 
     @Test
     fun `with last 5_0 platform version creates TransactionBackchainSenderFlowV1`() {
-        val flow = factory.create(CORDA_5_1.platformVersion - 1, listOf(mock()))
+        val flow = factory.create(CORDA_5_1.value - 1, listOf(mock()))
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainSenderFlowV1::class.java)
         assertSame(
             TransactionBackChainResolutionVersion.V1,
@@ -34,7 +34,7 @@ class TransactionBackchainSenderFlowVersionedFlowFactoryTest {
 
     @Test
     fun `with first 5_1 platform version creates TransactionBackchainSenderFlowV2`() {
-        val flow = factory.create(CORDA_5_1.platformVersion, listOf(mock()))
+        val flow = factory.create(CORDA_5_1.value, listOf(mock()))
         assertThat(flow).isExactlyInstanceOf(TransactionBackchainSenderFlowV1::class.java)
         assertSame(
             TransactionBackChainResolutionVersion.V2,

--- a/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
+++ b/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.platform.test
 
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.libs.platform.PlatformVersion.CORDA_5_1
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -12,7 +13,7 @@ class PlatformInfoProviderTest {
     lateinit var platformInfoProvider: PlatformInfoProvider
 
     private companion object {
-        const val EXPECTED_STUB_PLATFORM_VERSION = 50100
+        val EXPECTED_STUB_PLATFORM_VERSION = CORDA_5_1.platformVersion
     }
 
     @Test

--- a/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
+++ b/libs/platform-info/src/integrationTest/kotlin/net/corda/libs/platform/test/PlatformInfoProviderTest.kt
@@ -13,7 +13,7 @@ class PlatformInfoProviderTest {
     lateinit var platformInfoProvider: PlatformInfoProvider
 
     private companion object {
-        val EXPECTED_STUB_PLATFORM_VERSION = CORDA_5_1.platformVersion
+        val EXPECTED_STUB_PLATFORM_VERSION = CORDA_5_1.value
     }
 
     @Test

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/PlatformVersion.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/PlatformVersion.kt
@@ -1,0 +1,6 @@
+package net.corda.libs.platform
+
+enum class PlatformVersion(val platformVersion: Int) {
+    CORDA_5_0(50000),
+    CORDA_5_1(50100),
+}

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/PlatformVersion.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/PlatformVersion.kt
@@ -1,6 +1,6 @@
 package net.corda.libs.platform
 
-enum class PlatformVersion(val platformVersion: Int) {
+enum class PlatformVersion(val value: Int) {
     CORDA_5_0(50000),
     CORDA_5_1(50100),
 }

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -13,9 +13,9 @@ class PlatformInfoProviderImpl @Activate constructor(
 ) : PlatformInfoProvider {
 
     internal companion object {
-        val STUB_PLATFORM_VERSION = CORDA_5_1.platformVersion
+        val STUB_PLATFORM_VERSION = CORDA_5_1.value
 
-        private val DEFAULT_PLATFORM_VERSION = CORDA_5_1.platformVersion
+        private val DEFAULT_PLATFORM_VERSION = CORDA_5_1.value
         private const val PLATFORM_VERSION_KEY = "net.corda.platform.version"
     }
 

--- a/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
+++ b/libs/platform-info/src/main/kotlin/net/corda/libs/platform/impl/PlatformInfoProviderImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.platform.impl
 
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.libs.platform.PlatformVersion.CORDA_5_1
 import org.osgi.framework.BundleContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -12,9 +13,9 @@ class PlatformInfoProviderImpl @Activate constructor(
 ) : PlatformInfoProvider {
 
     internal companion object {
-        const val STUB_PLATFORM_VERSION = 50100
+        val STUB_PLATFORM_VERSION = CORDA_5_1.platformVersion
 
-        private const val DEFAULT_PLATFORM_VERSION = 50100
+        private val DEFAULT_PLATFORM_VERSION = CORDA_5_1.platformVersion
         private const val PLATFORM_VERSION_KEY = "net.corda.platform.version"
     }
 


### PR DESCRIPTION
Introduce `net.corda.libs.platform.PlatformVersion` and use it.