### PR TITLE
CORE-15052: Don't follow subscription status in MembershipPersistenceServiceImpl

### DIFF
--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
@@ -225,7 +225,7 @@ class MembershipPersistenceServiceImpl @Activate constructor(
 
         coordinator.updateStatus(
             LifecycleStatus.UP,
-            "Received config and started RPC topic subscription."
+            "Received config and started Membership persistence topic subscriptions."
         )
     }
 }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImplTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImplTest.kt
@@ -263,8 +263,6 @@ class MembershipPersistenceServiceImplTest {
             any()
         )
         verify(rpcSubscription).start()
-        verify(rpcSubscription).subscriptionName
-        verify(coordinator).followStatusChangesByName(eq(setOf(rpcSubscription.subscriptionName)))
 
         with(configCaptor.firstValue) {
             assertThat(requestTopic).isEqualTo(MEMBERSHIP_DB_RPC_TOPIC)
@@ -280,8 +278,6 @@ class MembershipPersistenceServiceImplTest {
             any()
         )
         verify(rpcSubscription, times(2)).start()
-        verify(rpcSubscription, times(3)).subscriptionName
-        verify(coordinator, times(2)).followStatusChangesByName(eq(setOf(rpcSubscription.subscriptionName)))
 
         postStopEvent()
         verify(rpcSubscription, times(2)).close()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -219,6 +219,7 @@ fun ClusterInfo.registerStaticMember(
     cluster {
         assertWithRetry {
             interval(1.seconds)
+            timeout(10.seconds)
             command { registerStaticMember(holdingIdentityShortHash, isNotary) }
             condition {
                 it.code == ResponseCode.OK.statusCode
@@ -231,7 +232,7 @@ fun ClusterInfo.registerStaticMember(
             // Use a fairly long timeout here to give plenty of time for the other side to respond. Longer
             // term this should be changed to not use the RPC message pattern and have the information available in a
             // cache on the REST worker, but for now this will have to suffice.
-            timeout(1.minutes)
+            timeout(20.seconds)
             interval(1.seconds)
             command { getRegistrationStatus(holdingIdentityShortHash) }
             condition {


### PR DESCRIPTION
* Add timeouts to the static member onboarding utility to prevent the test from running forever.
* Stop following the statuses of the subscriptions, as this is no longer needed and likely cause a timing issue.

I ran it a few times, and the issue seemed to have gone.

@fowlerrr - FYI
