### PR TITLE
CORE-14335: cache signing keys based on public key, irrespecitve of tenant ID

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/CryptoOperationsTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/CryptoOperationsTests.kt
@@ -87,10 +87,10 @@ class CryptoOperationsTests {
         @JvmStatic
         @BeforeAll
         fun setup() {
-            factory = TestServicesFactory()
+            tenantId = UUID.randomUUID().toString()
+            factory = TestServicesFactory(tenantId)
             schemeMetadata = factory.schemeMetadata
             verifier = factory.verifier
-            tenantId = UUID.randomUUID().toString()
             category = CryptoConsts.Categories.LEDGER
             CryptoConsts.Categories.all.forEach {
                 factory.tenantInfoService.populate(tenantId, it, factory.cryptoService)

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
@@ -20,7 +20,6 @@ import net.corda.crypto.core.SigningKeyInfo
 import net.corda.crypto.core.aes.WrappingKeyImpl
 import net.corda.crypto.persistence.WrappingKeyInfo
 import net.corda.crypto.softhsm.impl.SoftCryptoService
-import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.lifecycle.LifecycleStatus
@@ -149,9 +148,6 @@ class TestServicesFactory {
     val secondLevelWrappingKeyWrapped = rootWrappingKey.wrap(secondLevelWrappingKey)
     val secondLevelWrappingKeyInfo = WrappingKeyInfo(1, "AES", secondLevelWrappingKeyWrapped, 1, "root")
     val wrappingRepository = TestWrappingRepository(secondLevelWrappingKeyInfo)
-    val association = mock<HSMAssociationInfo> {
-        on { masterKeyAlias }.thenReturn("second")
-    }
     val signingKeyInfoCache: Cache<PublicKey, SigningKeyInfo> = CacheFactoryImpl().build(
         "test private key cache", Caffeine.newBuilder()
             .expireAfterAccess(3600, TimeUnit.MINUTES)

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestServicesFactory.kt
@@ -38,7 +38,7 @@ import kotlin.test.assertEquals
  * Provide instances of high level crypto services, with no database underneath, for
  * use for integration test cases that don't involve in-memory databases.
  */
-class TestServicesFactory {
+class TestServicesFactory(val tenantId:String = "test") {
     companion object {
         const val CTX_TRACKING = "ctxTrackingId"
         const val CUSTOM1_HSM_ID = "CUSTOM1"
@@ -138,7 +138,7 @@ class TestServicesFactory {
         }
     }
 
-    val signingRepository: TestSigningRepository by lazy { TestSigningRepository() }
+    val signingRepository: TestSigningRepository by lazy { TestSigningRepository(tenantId) }
 
     val tenantInfoService: TestTenantInfoService by lazy { TestTenantInfoService() }
 

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
@@ -23,7 +23,7 @@ import java.time.Instant
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
-class TestSigningRepository: SigningRepository {
+class TestSigningRepository(val tenantId: String = "test"): SigningRepository {
     private val lock = ReentrantLock()
     private val keys = mutableMapOf<ShortHash, SigningKeyInfo>()
 
@@ -32,7 +32,7 @@ class TestSigningRepository: SigningRepository {
         return SigningKeyInfo(
             id = publicKeyShortHashFromBytes(encodedKey),
             fullId = publicKeyHashFromBytes(encodedKey),
-            tenantId = "test",
+            tenantId = tenantId,
             category = context.category,
             alias = context.alias,
             hsmAlias = null,

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -474,6 +474,7 @@ open class SoftCryptoService(
                 }
             }.filterNotNull()
 
+        // This is a full table scan
         val cachedMap = signingKeyInfoCache.asMap().filter {
             fullKeyIds.contains(it.key.fullIdHash())
         }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -458,7 +458,7 @@ open class SoftCryptoService(
                 }
             }
         }
-        return signingKeyInfoList.filter { it?.tenantId == tenantId }.toCollection()
+        return signingKeyInfoList.filterNotNull().filter { it.tenantId == tenantId }
     }
 
     override fun lookupSigningKeysByPublicKeyHashes(

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceCachingTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceCachingTests.kt
@@ -8,7 +8,10 @@ import net.corda.crypto.cipher.suite.KeyMaterialSpec
 import net.corda.crypto.cipher.suite.sha256Bytes
 import net.corda.crypto.core.CryptoConsts
 import net.corda.crypto.core.CryptoTenants
+import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.aes.WrappingKeyImpl
+import net.corda.crypto.core.fullIdHash
+import net.corda.crypto.core.publicKeyIdFromBytes
 import net.corda.crypto.persistence.WrappingKeyInfo
 import net.corda.crypto.softhsm.TenantInfoService
 import net.corda.crypto.softhsm.WrappingRepository
@@ -17,6 +20,7 @@ import net.corda.crypto.softhsm.impl.infra.TestSigningRepository
 import net.corda.crypto.softhsm.impl.infra.TestWrappingRepository
 import net.corda.crypto.softhsm.impl.infra.makePrivateKeyCache
 import net.corda.crypto.softhsm.impl.infra.makeShortHashCache
+import net.corda.crypto.softhsm.impl.infra.makeSigningKeyInfoCache
 import net.corda.crypto.softhsm.impl.infra.makeSoftCryptoService
 import net.corda.crypto.softhsm.impl.infra.makeWrappingKeyCache
 import net.corda.v5.base.util.EncodingUtils
@@ -28,7 +32,9 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.mock
 import java.security.KeyPairGenerator
 import java.security.Provider
+import java.security.PublicKey
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -51,6 +57,7 @@ class SoftCryptoServiceCachingTests {
         val privateKeyCache = if (cachePrivateKeys) makePrivateKeyCache() else null
         val wrappingKeyCache = makeWrappingKeyCache()
         val shortHashCache = makeShortHashCache()
+        val signingKeyInfoCache = makeSigningKeyInfoCache()
         val wrappingKeyAlias = "wrapper1"
         val wrapCount = AtomicInteger()
         val unwrapCount = AtomicInteger()
@@ -87,6 +94,7 @@ class SoftCryptoServiceCachingTests {
                 }
             },
             signingRepositoryFactory = { TestSigningRepository() },
+            signingKeyInfoCache = signingKeyInfoCache,
             tenantInfoService = tenantInfoService
         )
         val rsaScheme =
@@ -156,7 +164,6 @@ class SoftCryptoServiceCachingTests {
 
         val myCryptoService =
             makeSoftCryptoService(
-                shortHashCache = makeShortHashCache(),
                 privateKeyCache = privateKeyCache,
                 wrappingKeyCache = null,
                 schemeMetadata = schemeMetadata,
@@ -212,8 +219,6 @@ class SoftCryptoServiceCachingTests {
             rootWrappingKey = rootWrappingKey,
             wrappingKeyCache = wrappingKeyCache,
             privateKeyCache = makePrivateKeyCache(),
-            shortHashCache = makeShortHashCache()
-            
         )
 
         // starting fresh, all 3 aliases are missing from both store and cache
@@ -256,4 +261,78 @@ class SoftCryptoServiceCachingTests {
         assertNull(countingWrappingRepository.findKey(unknownAlias))
         assertNull(countingWrappingRepository.findKey(cacheAlias))
     }
+    
+    @Test
+    fun `Lookup by short hashes of keys for multiple tenants which are cached does not go to database`() {
+        val schemeMetadata = CipherSchemeMetadataImpl()
+        val tenants = listOf(0,1)
+        val tenantIds = tenants.map { UUID.randomUUID().toString() }
+        val knownWrappingKeyAliases = tenants.map { UUID.randomUUID().toString() }
+        val rootWrappingKey = WrappingKeyImpl.generateWrappingKey(schemeMetadata)
+        val knownWrappingKeys= tenants.map { WrappingKeyImpl.generateWrappingKey(schemeMetadata) }
+        val knownWrappingKeyMaterials = knownWrappingKeys.map { rootWrappingKey.wrap(it) }
+        
+        val tenantWrappingRepositories = tenants.map {
+            TestWrappingRepository(
+                ConcurrentHashMap(
+                    listOf(
+                        knownWrappingKeyAliases.elementAt(it) to WrappingKeyInfo(
+                            WRAPPING_KEY_ENCODING_VERSION,
+                            knownWrappingKeys.elementAt(it).algorithm,
+                            knownWrappingKeyMaterials.elementAt(it),
+                            1,
+                            "root",
+                        )
+                    ).toMap()
+                )
+            )
+        }        
+        val shortHashCache = makeShortHashCache()
+        val cryptoService = SoftCryptoService(
+            wrappingRepositoryFactory= {  tenantId -> tenantWrappingRepositories.elementAt(tenantIds.indexOf(tenantId)) },
+            schemeMetadata = schemeMetadata,
+            privateKeyCache = makePrivateKeyCache(),
+            shortHashCache = shortHashCache,
+            signingKeyInfoCache = makeSigningKeyInfoCache(),
+            keyPairGeneratorFactory = { algorithm: String, provider: Provider ->
+                KeyPairGenerator.getInstance(algorithm, provider)
+            },
+            wrappingKeyFactory = { it -> WrappingKeyImpl.generateWrappingKey(it) },
+            wrappingKeyCache = makeWrappingKeyCache(),
+            signingRepositoryFactory = { TestSigningRepository() },
+            defaultUnmanagedWrappingKeyName = "root",
+            digestService = PlatformDigestServiceImpl(schemeMetadata),
+            tenantInfoService = mock(),
+            unmanagedWrappingKeys = mapOf("root" to rootWrappingKey)
+            )
+        val rsa = cryptoService.supportedSchemes.filter { it.key.codeName == RSA_CODE_NAME }.toList().first().first
+        val keyPairs = tenants.map {
+            cryptoService.generateKeyPair(
+                tenantIds.elementAt(it),
+                CryptoConsts.Categories.LEDGER,
+                "key-$it",
+                null,
+                rsa,
+                mapOf("parentKeyAlias" to knownWrappingKeyAliases.elementAt(it))
+            )
+        }
+        val shortHashes = tenants.map {
+            val key = keyPairs.elementAt(it).publicKey
+            makeShortHash(schemeMetadata, key)
+        }
+        tenants.map {
+            assertThat( shortHashCache.getIfPresent(shortHashes.elementAt(it))).isNotNull()
+        }
+        assertThat(shortHashCache.getIfPresent(makeShortHash(schemeMetadata,  keyPairs.elementAt(0).publicKey)))
+        cryptoService.lookupSigningKeysByPublicKeyHashes(tenantIds.elementAt(0), listOf(keyPairs.elementAt(0).publicKey.fullIdHash()))
+    }
+
+    private fun makeShortHash(
+        schemeMetadata: CipherSchemeMetadataImpl,
+        key: PublicKey
+    ): ShortHash {
+        val keyBytes = schemeMetadata.encodeAsByteArray(key)
+        return ShortHash.of(publicKeyIdFromBytes(keyBytes))
+    }
+
 }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
@@ -420,7 +420,7 @@ class SoftCryptoServiceGeneralTests {
         on { hash(any<ByteArray>(), any()) } doReturn SecureHashUtils.randomSecureHash()
     }
 
-    private fun makeCache(): Cache<ShortHashCacheKey, SigningKeyInfo> =
+    private fun makeCache(): Cache<PublicKey, SigningKeyInfo> =
         Caffeine.newBuilder()
             .expireAfterAccess(3600, TimeUnit.MINUTES)
             .maximumSize(3).build()
@@ -558,7 +558,8 @@ class SoftCryptoServiceGeneralTests {
         Assertions.assertSame(exception, thrown)
         verify(repo, times(2)).findKey(ArgumentMatchers.anyString())
     }
-    
+
+
     @Test
     @Suppress("ComplexMethod", "MaxLineLength")
     fun `Should save generated key with alias`() {
@@ -587,11 +588,12 @@ class SoftCryptoServiceGeneralTests {
             digestService = PlatformDigestServiceImpl(schemeMetadata),
             wrappingKeyCache = null,
             privateKeyCache = null,
-            shortHashCache = makeShortHashCache(),
+            shortHashCache = null,
             keyPairGeneratorFactory = { algorithm: String, provider: Provider ->
                 KeyPairGenerator.getInstance(algorithm, provider)
             },
             wrappingKeyFactory = { WrappingKeyImpl.generateWrappingKey(it) },
+            signingKeyInfoCache = makeSigningKeyInfoCache(),
             tenantInfoService = makeTenantInfoService(masterKeyAlias)
         ) {
             override fun generateKeyPair(spec: KeyGenerationSpec, context: Map<String, String>): GeneratedWrappedKey =

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceOperationsTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceOperationsTests.kt
@@ -110,6 +110,7 @@ class SoftCryptoServiceOperationsTests {
             shortHashCache = shortHashCache,
             signingRepositoryFactory = { signingRepository },
             privateKeyCache = null,
+            signingKeyInfoCache = mock(),
             tenantInfoService = mock()
         )
         private val category = CryptoConsts.Categories.LEDGER

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/MakeCache.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/MakeCache.kt
@@ -3,9 +3,9 @@ package net.corda.crypto.softhsm.impl.infra
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.cache.caffeine.CacheFactoryImpl
+import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.SigningKeyInfo
 import net.corda.crypto.core.aes.WrappingKey
-import net.corda.crypto.softhsm.impl.ShortHashCacheKey
 import java.security.PrivateKey
 import java.security.PublicKey
 import java.util.concurrent.TimeUnit
@@ -28,7 +28,7 @@ fun makeSigningKeyInfoCache(): Cache<PublicKey, SigningKeyInfo> = CacheFactoryIm
         .maximumSize(100)
 )
 
-fun makeShortHashCache(): Cache<ShortHashCacheKey, SigningKeyInfo> = CacheFactoryImpl().build(
+fun makeShortHashCache(): Cache<ShortHash, PublicKey> = CacheFactoryImpl().build(
     "test short hash cache", Caffeine.newBuilder()
         .expireAfterAccess(3600, TimeUnit.MINUTES)
         .maximumSize(100)

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/MakeCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/MakeCryptoService.kt
@@ -5,13 +5,12 @@ import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.cipher.suite.impl.PlatformDigestServiceImpl
 import net.corda.crypto.cipher.suite.CipherSchemeMetadata
 import net.corda.crypto.core.CryptoService
-import net.corda.crypto.core.SigningKeyInfo
+import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.core.aes.WrappingKeyImpl
 import net.corda.crypto.softhsm.SigningRepository
 import net.corda.crypto.softhsm.TenantInfoService
 import net.corda.crypto.softhsm.WrappingRepository
-import net.corda.crypto.softhsm.impl.ShortHashCacheKey
 import net.corda.crypto.softhsm.impl.SoftCryptoService
 import org.mockito.kotlin.mock
 import java.security.KeyPairGenerator
@@ -24,7 +23,7 @@ import java.security.PublicKey
 fun makeSoftCryptoService(
     privateKeyCache: Cache<PublicKey, PrivateKey>? = null,
     wrappingKeyCache: Cache<String, WrappingKey>? = null,
-    shortHashCache: Cache<ShortHashCacheKey, SigningKeyInfo>? = null,
+    shortHashCache: Cache<ShortHash, PublicKey>?= null,
     schemeMetadata: CipherSchemeMetadataImpl = CipherSchemeMetadataImpl(),
     rootWrappingKey: WrappingKey = WrappingKeyImpl.generateWrappingKey(schemeMetadata),
     wrappingKeyFactory: (schemeMetadata: CipherSchemeMetadata) -> WrappingKey = { it ->
@@ -32,7 +31,7 @@ fun makeSoftCryptoService(
     },
     wrappingRepository: WrappingRepository = TestWrappingRepository(),
     signingRepository: SigningRepository = TestSigningRepository(),
-    tenantInfoService: TenantInfoService = mock(),
+    tenantInfoService: TenantInfoService = mock()
 ): CryptoService {
     return SoftCryptoService(
         wrappingRepositoryFactory = { wrappingRepository },
@@ -43,11 +42,12 @@ fun makeSoftCryptoService(
         digestService = PlatformDigestServiceImpl(schemeMetadata),
         wrappingKeyCache = wrappingKeyCache,
         privateKeyCache = privateKeyCache,
-        shortHashCache =  shortHashCache ?: makeShortHashCache(),
+        shortHashCache =  shortHashCache,
         keyPairGeneratorFactory = { algorithm: String, provider: Provider ->
             KeyPairGenerator.getInstance(algorithm, provider)
         },
         wrappingKeyFactory = wrappingKeyFactory,
+        signingKeyInfoCache =  makeSigningKeyInfoCache(),
         tenantInfoService =  tenantInfoService
     )
 }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoService.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoService.kt
@@ -110,7 +110,9 @@ interface CryptoService {
     ): ByteArray
 
     /**
-     * Generates a new key to be used as a wrapping key. 
+     * Optional, generates a new key to be used as a wrapping key. Some implementations may not have the notion of
+     * the wrapping key in such cases the implementation should do nothing (note that REQUIRE_WRAPPING_KEY should not
+     * be listed for such implementations).
      *
      * @param wrappingKeyAlias the alias of the key to be used as a wrapping key.
      * @param failIfExists a flag indicating whether the method should fail if a key already exists under
@@ -128,7 +130,7 @@ interface CryptoService {
     )
 
     /**
-     * Deletes the key corresponding to the specified alias.
+     * Optional, deletes the key corresponding to the input alias of the service supports the operations .
      * This method doesn't throw if the alias is not found, instead it has to return 'false'.
      *
      * @param alias the alias (as it stored in HSM) of the key being deleted.

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -245,7 +245,7 @@ class CryptoProcessorImpl @Activate constructor(
                 .maximumSize(maximumSize)
         )
         val shortHashCache: Cache<ShortHash, PublicKey> = CacheFactoryImpl().build(
-            "Signing-Key-Cache",
+            "Short-Hash-Signing-Key-Cache",
             Caffeine.newBuilder()
                 .expireAfterAccess(expireAfterAccessMins, TimeUnit.MINUTES)
                 .maximumSize(maximumSize)

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -23,6 +23,7 @@ import net.corda.crypto.config.impl.retrying
 import net.corda.crypto.core.CryptoConsts
 import net.corda.crypto.core.CryptoService
 import net.corda.crypto.core.CryptoTenants
+import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.SigningKeyInfo
 import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.core.aes.WrappingKeyImpl
@@ -34,7 +35,6 @@ import net.corda.crypto.service.impl.bus.CryptoOpsBusProcessor
 import net.corda.crypto.service.impl.bus.HSMRegistrationBusProcessor
 import net.corda.crypto.softhsm.TenantInfoService
 import net.corda.crypto.softhsm.impl.HSMRepositoryImpl
-import net.corda.crypto.softhsm.impl.ShortHashCacheKey
 import net.corda.crypto.softhsm.impl.SigningRepositoryImpl
 import net.corda.crypto.softhsm.impl.SoftCryptoService
 import net.corda.crypto.softhsm.impl.WrappingRepositoryImpl
@@ -238,7 +238,13 @@ class CryptoProcessorImpl @Activate constructor(
                 .expireAfterAccess(expireAfterAccessMins, TimeUnit.MINUTES)
                 .maximumSize(maximumSize)
         )
-        val shortHashCache: Cache<ShortHashCacheKey, SigningKeyInfo> = CacheFactoryImpl().build(
+        val signingKeyInfoCache: Cache<PublicKey, SigningKeyInfo> = CacheFactoryImpl().build(
+            "Signing-Key-Cache",
+            Caffeine.newBuilder()
+                .expireAfterAccess(expireAfterAccessMins, TimeUnit.MINUTES)
+                .maximumSize(maximumSize)
+        )
+        val shortHashCache: Cache<ShortHash, PublicKey> = CacheFactoryImpl().build(
             "Signing-Key-Cache",
             Caffeine.newBuilder()
                 .expireAfterAccess(expireAfterAccessMins, TimeUnit.MINUTES)
@@ -283,6 +289,7 @@ class CryptoProcessorImpl @Activate constructor(
             wrappingKeyCache = wrappingKeyCache,
             privateKeyCache = privateKeyCache,
             shortHashCache = shortHashCache,
+            signingKeyInfoCache = signingKeyInfoCache,
             keyPairGeneratorFactory = keyPairGeneratorFactory, 
             wrappingKeyFactory = wrappingKeyFactory,
             tenantInfoService = tenantInfoService


### PR DESCRIPTION
Keep a single cache mapping signing key hashes to metadata about that key, shared across the entire crypto processor instance, plus a cache of short hashes to full hashes. Previously, the crypto processor stored a cache per tenant ID (i.e. per vnode), and would not store information about signing keys owned by other tenants. Therefore, we saw various flows repeatedly check ownership of a signing key and the crypto processor going to the database each time. (While this was being implemented, we also arranged for the ledger to cache key ownership. That reduces but does not eliminate the benefit of this change).

To facilitate this change, we combine the signing service with the crypto service, and remove more of the support for non-soft HSMs. That removes around 2300 lines of code; those layers and conditonals will all have tiny performance impacts. We had cleanup tickets in the backlog about all these changes, which this PR implements in order to provide a viable implementation of the new caching strategy. In particular:

- CORE-15297: limit use of OSGi to the top level crypto processor instance
- CORE-15276: remove the unused crypto throttling layer, which was never triggered. The architectural choice of Corda 5 is to retry from the top, not at each layer, and crypto is never at the top. Mutliple levels of retires are problematic.
- CORE-15277: move the handling of exceptions out of a proxy layer into particular places where exceptions are expected. The main motivation was to reduce the number of places we have to touch on each interface change.

This required some movement of pieces to keep the package import graph from becoming cyclic with the above changes. In particular SigningKeyInfo and SigningKeySaveContext more into the persistence package.
remove many test cases, which are testing layers that no longer exist, and move other test cases to reflect the newly simplified structure.
