### PR TITLE
CORE-14573: Wrong status code reported for incorrect tenantId

### DIFF
--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
@@ -458,12 +458,13 @@ class CertificatesRestResourceImpl @Activate constructor(
             false
         }
 
-        val isValidClusterTenant = tenantId in allClusterTenants
-
-        if ((!isValidShortHash && !isValidClusterTenant) || ( isValidShortHash && !isValidClusterTenant && !isVirtualNodeRegisteredForTenant)) {
+        if (tenantId in allClusterTenants) return
+        if (!isValidShortHash) throw InvalidInputDataException("Provided tenantId $tenantId is not a cluster tenant " +
+                "and is not the right size of a holding ID.")
+        if (!isVirtualNodeRegisteredForTenant) {
             throw InvalidInputDataException(
-                "Provided tenantId ($tenantId) was not valid. " +
-                        "It needs to be either a cluster tenant ($P2P or $REST) or a valid holding identity ID."
+                "Provided tenantId ($tenantId) was not valid. It needs to be either a cluster tenant ($P2P or $REST) " +
+                        "or a valid virtual node holding identity ID."
             )
         }
     }

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
@@ -9,6 +9,7 @@ import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts
 import net.corda.crypto.core.CryptoTenants.P2P
 import net.corda.crypto.core.CryptoTenants.REST
+import net.corda.crypto.core.CryptoTenants.allClusterTenants
 import net.corda.crypto.core.DefaultSignatureOIDMap
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.ShortHashException
@@ -25,6 +26,7 @@ import net.corda.membership.rest.v1.CertificatesRestResource
 import net.corda.membership.rest.v1.CertificatesRestResource.Companion.SIGNATURE_SPEC
 import net.corda.rest.HttpFileUpload
 import net.corda.rest.PluggableRestResource
+import net.corda.rest.exception.BadRequestException
 import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.rest.messagebus.MessageBusUtils.tryWithExceptionHandling
@@ -116,8 +118,6 @@ class CertificatesRestResourceImpl @Activate constructor(
         contextMap: Map<String, String?>?,
     ): String {
         validateTenantId(tenantId)
-        // Check if a virtual node is registered for given tenantId
-        virtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(tenantId)
 
         val key = tryWithExceptionHandling(logger, "find key with ID $keyId for $tenantId") {
             cryptoOpsClient.lookupKeysByIds(
@@ -446,9 +446,21 @@ class CertificatesRestResourceImpl @Activate constructor(
         } catch (e: ShortHashException) {
             false
         }
-        val isValidClusterTenant = (tenantId == P2P || tenantId == REST)
 
-        if (!isValidShortHash && !isValidClusterTenant) {
+        // Check if a virtual node is registered for given tenantId
+        val isVirtualNodeRegisteredForTenant = try {
+            virtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(tenantId)
+            true
+        } catch(e: BadRequestException) {
+            false
+        }
+        catch (e: ResourceNotFoundException) {
+            false
+        }
+
+        val isValidClusterTenant = tenantId in allClusterTenants
+
+        if ((!isValidShortHash && !isValidClusterTenant) || ( isValidShortHash && !isValidClusterTenant && !isVirtualNodeRegisteredForTenant)) {
             throw InvalidInputDataException(
                 "Provided tenantId ($tenantId) was not valid. " +
                         "It needs to be either a cluster tenant ($P2P or $REST) or a valid holding identity ID."

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
@@ -116,6 +116,8 @@ class CertificatesRestResourceImpl @Activate constructor(
         contextMap: Map<String, String?>?,
     ): String {
         validateTenantId(tenantId)
+        // Check if a virtual node is registered for given tenantId
+        virtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(tenantId)
 
         val key = tryWithExceptionHandling(logger, "find key with ID $keyId for $tenantId") {
             cryptoOpsClient.lookupKeysByIds(

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
@@ -174,6 +174,17 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it throws exception if key is not available`() {
             whenever(cryptoOpsClient.lookupKeysByIds(any(), any())).doReturn(emptyList())
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -188,6 +199,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throws ServiceUnavailableException when repartition event happens while trying to retrieve key`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             whenever(cryptoOpsClient.lookupKeysByIds(any(), any())).doThrow(CordaRPCAPIPartitionException("repartition event"))
 
             val details = assertThrows<ServiceUnavailableException> {
@@ -205,6 +228,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it sign the request`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -243,6 +278,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it returns the correct signature`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -256,6 +303,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it adds alternative subject names when some are provided`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -287,6 +346,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will not adds alternative subject names when none are provided`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -343,6 +414,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will use the correct x500 name`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -388,6 +471,17 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it will generate a CSR for a valid member name for TLS certificate`() {
             whenever(key.category).doReturn(CryptoConsts.Categories.TLS)
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
 
             val csr = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -555,6 +649,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throws exception if Signature OID can not be inferred`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -569,6 +675,17 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it throws exception if key code name is invalid`() {
             whenever(key.schemeCodeName).doReturn("Nop")
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -588,6 +705,21 @@ class CertificatesRestResourceImplTest {
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     invalidTenantId,
+                    keyId,
+                    x500Name,
+                    null,
+                    null,
+                )
+            }
+        }
+
+        @Test
+        fun `it throws exception if tenant ID does not have virtual node registered`() {
+            val notRegisteredTenantId = "ABA912AC2439"
+            whenever(virtualNodeInfoReadService.getByHoldingIdentityShortHash(ShortHash.of(notRegisteredTenantId))).thenReturn(null)
+            assertThrows<InvalidInputDataException> {
+                certificatesOps.generateCsr(
+                    notRegisteredTenantId,
                     keyId,
                     x500Name,
                     null,

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
@@ -174,17 +174,7 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it throws exception if key is not available`() {
             whenever(cryptoOpsClient.lookupKeysByIds(any(), any())).doReturn(emptyList())
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -199,18 +189,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throws ServiceUnavailableException when repartition event happens while trying to retrieve key`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
-
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             whenever(cryptoOpsClient.lookupKeysByIds(any(), any())).doThrow(CordaRPCAPIPartitionException("repartition event"))
 
             val details = assertThrows<ServiceUnavailableException> {
@@ -228,17 +207,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it sign the request`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -278,17 +247,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it returns the correct signature`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -303,17 +262,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it adds alternative subject names when some are provided`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -346,17 +295,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will not adds alternative subject names when none are provided`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -414,17 +353,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will use the correct x500 name`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -471,17 +400,7 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it will generate a CSR for a valid member name for TLS certificate`() {
             whenever(key.category).doReturn(CryptoConsts.Categories.TLS)
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val csr = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -649,17 +568,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throws exception if Signature OID can not be inferred`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -675,17 +584,7 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it throws exception if key code name is invalid`() {
             whenever(key.schemeCodeName).doReturn("Nop")
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -732,6 +631,20 @@ class CertificatesRestResourceImplTest {
             return PEMParser(this.reader()).use { parser ->
                 parser.readObject() as PKCS10CertificationRequest
             }
+        }
+
+        private fun registerVirtualNodeForTenantId(holdingIdentityShortHash: String) {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
         }
     }
 

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
@@ -314,6 +314,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throw an exception if the subject alternative name is invalid`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -327,6 +328,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throw an exception if the subject alternative name is empty`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -340,6 +342,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throw an exception if the subject alternative name is not a domain name`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -371,6 +374,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will throw an exception for invalid X500 name`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -384,6 +388,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will throw an exception for invalid member name for TLS certificate`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             whenever(key.category).doReturn(CryptoConsts.Categories.TLS)
 
             assertThrows<InvalidInputDataException> {
@@ -415,6 +420,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will throw an exception for invalid name for session certificate`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             whenever(key.category).doReturn(CryptoConsts.Categories.SESSION_INIT)
 
             assertThrows<InvalidInputDataException> {
@@ -528,17 +534,7 @@ class CertificatesRestResourceImplTest {
         fun `it will throw an exception for session certificate member key where the member name is not correct`() {
             whenever(key.category).doReturn(CryptoConsts.Categories.SESSION_INIT)
             val tenantId = "123123123123"
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(tenantId)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(tenantId)
             whenever(
                 cryptoOpsClient.sign(
                     eq(tenantId),
@@ -616,7 +612,7 @@ class CertificatesRestResourceImplTest {
         fun `it throws exception if tenant ID does not have virtual node registered`() {
             val notRegisteredTenantId = "ABA912AC2439"
             whenever(virtualNodeInfoReadService.getByHoldingIdentityShortHash(ShortHash.of(notRegisteredTenantId))).thenReturn(null)
-            assertThrows<InvalidInputDataException> {
+            assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
                     notRegisteredTenantId,
                     keyId,


### PR DESCRIPTION
When requesting a CSR for a tenant, we were not checking if a virtual node is registered for the tenant.
ValidateTenantId check was updated and it now returns 400 Bad Request if virtual node is not registered for the tenant.
As we do this check early on, tests had to be updated too to make sure they test the original functionality.