### PR TITLE
ES-852/Update c5 repos to use public artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ allprojects {
         mavenLocal()
 
         maven {
-            url = "$artifactoryContextUrl/corda-dependencies"
+            url = "${publicArtifactURL}/corda-dependencies"
             content {
                 // For Quasar release.
                 includeGroup 'co.paralleluniverse'
@@ -203,7 +203,7 @@ allprojects {
             exclusiveContent {
                 forRepository {
                     maven {
-                        url "$artifactoryContextUrl/corda-dependencies"
+                        url "${publicArtifactURL}/corda-dependencies"
                     }
                 }
                 filter {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 # General repository setup properties
 artifactoryContextUrl=https://software.r3.com/artifactory
+publicArtifactURL = https://download.corda.net/maven
 kotlin.code.style=official
 kotlinVersion=1.8.21
 kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
A number of artifactory repos are migrating to be private, to ensure the open source community can continue to build Corda. These have been mirrored at https://download.corda.net/maven

Tested : https://gradle.dev.r3.com/s/ki7mxc3xq4aam