### PR TITLE
CORE-15309 Flow Mapper format error

### DIFF
--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
@@ -35,7 +35,6 @@ class FlowMapperMessageProcessor(
 
     private val sessionP2PTtl = flowConfig.getLong(FlowConfig.SESSION_P2P_TTL)
 
-    private val errorMsg = "This event is expired and will be %. Event: % State: %"
     private val clock = UTCClock()
 
     override fun onNext(
@@ -62,9 +61,7 @@ class FlowMapperMessageProcessor(
                     val result = executor.execute()
                     StateAndEventProcessor.Response(result.flowMapperState, result.outputEvents)
                 } else {
-                    logger.debug {
-                        errorMsg.format("ignored", event, state)
-                    }
+                    logger.debug { "This event is expired and will be ignored. Event: $event State: $state" }
                     CordaMetrics.Metric.FlowMapperExpiredSessionEventCount.builder()
                         .build().increment()
                     StateAndEventProcessor.Response(state, emptyList())


### PR DESCRIPTION
An error occurs trying to format a string in the flow mapper, which brings down its processor and prevents events from being processed.

This formatting error has now been resolved.