### PR TITLE
CORE-14709: Adding apiVersion dimension to REST API - fix test exception when introducing new endpoint

### DIFF
--- a/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/diff/OpenApiDiff.kt
+++ b/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/diff/OpenApiDiff.kt
@@ -84,9 +84,13 @@ private fun List<Tag>?.diff(baseline: List<Tag>?): List<String> {
 
     val currentSorted = this.sortedBy { it.name }
     val baselineSorted = baseline.sortedBy { it.name }
-    (currentSorted.indices).forEach { i ->
-        if (currentSorted[i] != baselineSorted[i]) {
-            differences.add("Tags do not match. Current tag: ${currentSorted[i]} is different to baseline: ${baselineSorted[i]}")
+    if (currentSorted.size != baselineSorted.size) {
+        differences.add("Number of tags doesn't match. Current=${currentSorted.size} is different to baseline: ${baselineSorted.size}")
+    } else {
+        (currentSorted.indices).forEach { i ->
+            if (currentSorted[i] != baselineSorted[i]) {
+                differences.add("Tags do not match. Current tag: ${currentSorted[i]} is different to baseline: ${baselineSorted[i]}")
+            }
         }
     }
 

--- a/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/diff/OpenApiDiff.kt
+++ b/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/diff/OpenApiDiff.kt
@@ -80,13 +80,9 @@ private fun List<Tag>?.diff(baseline: List<Tag>?): List<String> {
         currentSet.subtract(baselineSet).forEach {
             differences.add("Tag in current but not in baseline: $it")
         }
-    }
-
-    val currentSorted = this.sortedBy { it.name }
-    val baselineSorted = baseline.sortedBy { it.name }
-    if (currentSorted.size != baselineSorted.size) {
-        differences.add("Number of tags doesn't match. Current=${currentSorted.size} is different to baseline: ${baselineSorted.size}")
     } else {
+        val currentSorted = this.sortedBy { it.name }
+        val baselineSorted = baseline.sortedBy { it.name }
         (currentSorted.indices).forEach { i ->
             if (currentSorted[i] != baselineSorted[i]) {
                 differences.add("Tags do not match. Current tag: ${currentSorted[i]} is different to baseline: ${baselineSorted[i]}")


### PR DESCRIPTION
After changes introduced in  CORE-14709, when a baseline was not updated for a new endpoint (the new endpoint was present in the baseline but with an older "content"/"format" ) the `OpenApiCompatibilityTest` threw Runtime Exception `Index out of bounds` and it didn't produce the error report and a new baseline.
A sample error from a sibling branch: 
https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-runtime-os/detail/PR-4239/1/tests/