### PR TITLE
CORE-13786 - Introduce validation for registration/sync protocols

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -66,15 +66,6 @@ class MGMRegistrationService @Activate constructor(
     private val configurationGetService: ConfigurationGetService,
 ) : MemberRegistrationService {
 
-    private companion object {
-        val SUPPORTED_REGISTRATION_PROTOCOLS = setOf(
-            "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService"
-        )
-        val SUPPORTED_SYNC_PROTOCOLS = setOf(
-            "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl"
-        )
-    }
-
     /**
      * Private interface used for implementation swapping in response to lifecycle events.
      */
@@ -168,7 +159,6 @@ class MGMRegistrationService @Activate constructor(
             return try {
                 mgmRegistrationRequestHandler.throwIfRegistrationAlreadyApproved(member)
                 mgmRegistrationContextValidator.validate(context)
-                validateProtocols(context)
 
                 val mgmInfo = mgmRegistrationMemberInfoHandler.buildAndPersistMgmMemberInfo(member, context)
 
@@ -209,16 +199,6 @@ class MGMRegistrationService @Activate constructor(
         }
     }
 
-    private fun validateProtocols(context: Map<String, String>) {
-        if (context[REGISTRATION_PROTOCOL] !in SUPPORTED_REGISTRATION_PROTOCOLS) {
-            throw MGMRegistrationContextValidationException("Invalid value for key $REGISTRATION_PROTOCOL in registration context. " +
-                    "It should be one of the following values: $SUPPORTED_REGISTRATION_PROTOCOLS.", null)
-        }
-        if (context[SYNCHRONISATION_PROTOCOL] !in SUPPORTED_SYNC_PROTOCOLS) {
-            throw MGMRegistrationContextValidationException("Invalid value for key $SYNCHRONISATION_PROTOCOL in registration context. " +
-                    "It should be one of the following values: $SUPPORTED_REGISTRATION_PROTOCOLS.", null)
-        }
-    }
 
     private fun handleEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
         when (event) {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -211,10 +211,12 @@ class MGMRegistrationService @Activate constructor(
 
     private fun validateProtocols(context: Map<String, String>) {
         if (context[REGISTRATION_PROTOCOL] !in SUPPORTED_REGISTRATION_PROTOCOLS) {
-            throw MGMRegistrationContextValidationException("Invalid value for key $REGISTRATION_PROTOCOL in registration context. It should be one of the following values: $SUPPORTED_REGISTRATION_PROTOCOLS.", null)
+            throw MGMRegistrationContextValidationException("Invalid value for key $REGISTRATION_PROTOCOL in registration context. " +
+                    "It should be one of the following values: $SUPPORTED_REGISTRATION_PROTOCOLS.", null)
         }
         if (context[SYNCHRONISATION_PROTOCOL] !in SUPPORTED_SYNC_PROTOCOLS) {
-            throw MGMRegistrationContextValidationException("Invalid value for key $SYNCHRONISATION_PROTOCOL in registration context. It should be one of the following values: $SUPPORTED_REGISTRATION_PROTOCOLS.", null)
+            throw MGMRegistrationContextValidationException("Invalid value for key $SYNCHRONISATION_PROTOCOL in registration context. " +
+                    "It should be one of the following values: $SUPPORTED_REGISTRATION_PROTOCOLS.", null)
         }
     }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationService.kt
@@ -66,7 +66,7 @@ class MGMRegistrationService @Activate constructor(
     private val configurationGetService: ConfigurationGetService,
 ) : MemberRegistrationService {
 
-    companion object {
+    private companion object {
         val SUPPORTED_REGISTRATION_PROTOCOLS = setOf(
             "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService"
         )

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
@@ -56,8 +56,8 @@ class MGMRegistrationContextValidatorTest {
             get() = mutableMapOf(
                 SESSION_KEY_IDS.format(0) to "session key",
                 ECDH_KEY_ID to "ECDH key",
-                REGISTRATION_PROTOCOL to "registration protocol",
-                SYNCHRONISATION_PROTOCOL to "synchronisation protocol",
+                REGISTRATION_PROTOCOL to "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService",
+                SYNCHRONISATION_PROTOCOL to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
                 P2P_MODE to "P2P mode",
                 SESSION_KEY_POLICY to "session key policy",
                 PKI_SESSION to "session PKI property",
@@ -157,6 +157,24 @@ class MGMRegistrationContextValidatorTest {
         assertThrows<MGMRegistrationContextValidationException> {
             mgmRegistrationContextValidator.validate(testContext)
         }
+    }
+
+    @Test
+    fun `registration fails when registration protocol provided is invalid`() {
+        val contextWithInvalidProtocol = validTestContext.plus("corda.group.protocol.registration" to "invalid")
+        val exception = assertThrows<MGMRegistrationContextValidationException> {
+            mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)
+        }
+        assertThat(exception).hasMessageContaining("Invalid value for key $REGISTRATION_PROTOCOL in registration context.")
+    }
+
+    @Test
+    fun `registration fails when sync protocol provided is invalid`() {
+        val contextWithInvalidProtocol = validTestContext.plus("corda.group.protocol.synchronisation" to "invalid")
+        val exception = assertThrows<MGMRegistrationContextValidationException> {
+            mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)
+        }
+        assertThat(exception).hasMessageContaining("Invalid value for key $SYNCHRONISATION_PROTOCOL in registration context.")
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
@@ -160,7 +160,7 @@ class MGMRegistrationContextValidatorTest {
     }
 
     @Test
-    fun `registration fails when registration protocol provided is invalid`() {
+    fun `context validation fails when registration protocol provided is invalid`() {
         val contextWithInvalidProtocol = validTestContext.plus("corda.group.protocol.registration" to "invalid")
         val exception = assertThrows<MGMRegistrationContextValidationException> {
             mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)
@@ -169,7 +169,7 @@ class MGMRegistrationContextValidatorTest {
     }
 
     @Test
-    fun `registration fails when sync protocol provided is invalid`() {
+    fun `context validation fails when sync protocol provided is invalid`() {
         val contextWithInvalidProtocol = validTestContext.plus("corda.group.protocol.synchronisation" to "invalid")
         val exception = assertThrows<MGMRegistrationContextValidationException> {
             mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -599,32 +599,7 @@ class MGMRegistrationServiceTest {
 
             assertThat(exception).hasMessageContaining("Could not find virtual node info")
         }
-
-        @Test
-        fun `registration fails when registration protocol provided is invalid`() {
-            postUpEvent()
-            val contextWithInvalidProtocol = properties.plus("corda.group.protocol.registration" to "invalid")
-            registrationService.start()
-            val exception = assertThrows<InvalidMembershipRegistrationException> {
-                registrationService.register(registrationRequest, mgm, contextWithInvalidProtocol)
-            }
-
-            assertThat(exception).hasMessageContaining("Invalid value for key $REGISTRATION_PROTOCOL in registration context.")
-            registrationService.stop()
-        }
-
-        @Test
-        fun `registration fails when sync protocol provided is invalid`() {
-            postUpEvent()
-            val contextWithInvalidProtocol = properties.plus("corda.group.protocol.synchronisation" to "invalid")
-            registrationService.start()
-            val exception = assertThrows<InvalidMembershipRegistrationException> {
-                registrationService.register(registrationRequest, mgm, contextWithInvalidProtocol)
-            }
-
-            assertThat(exception).hasMessageContaining("Invalid value for key $SYNCHRONISATION_PROTOCOL in registration context.")
-            registrationService.stop()
-        }
+        
     }
 
     @Nested

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationServiceTest.kt
@@ -267,7 +267,7 @@ class MGMRegistrationServiceTest {
         "corda.session.keys.0.id" to SESSION_KEY_ID,
         "corda.ecdh.key.id" to ECDH_KEY_ID,
         "corda.group.protocol.registration"
-                to "net.corda.membership.impl.registration.dynamic.MemberRegistrationService",
+                to "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService",
         "corda.group.protocol.synchronisation"
                 to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
         "corda.group.protocol.p2p.mode" to "AUTHENTICATION_ENCRYPTION",
@@ -413,7 +413,7 @@ class MGMRegistrationServiceTest {
                 .containsExactlyInAnyOrderElementsOf(
                     mapOf(
                         "protocol.registration"
-                                to "net.corda.membership.impl.registration.dynamic.MemberRegistrationService",
+                                to "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService",
                         "protocol.synchronisation"
                                 to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
                         "protocol.p2p.mode" to "AUTHENTICATION_ENCRYPTION",
@@ -598,6 +598,32 @@ class MGMRegistrationServiceTest {
             }
 
             assertThat(exception).hasMessageContaining("Could not find virtual node info")
+        }
+
+        @Test
+        fun `registration fails when registration protocol provided is invalid`() {
+            postUpEvent()
+            val contextWithInvalidProtocol = properties.plus("corda.group.protocol.registration" to "invalid")
+            registrationService.start()
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationRequest, mgm, contextWithInvalidProtocol)
+            }
+
+            assertThat(exception).hasMessageContaining("Invalid value for key $REGISTRATION_PROTOCOL in registration context.")
+            registrationService.stop()
+        }
+
+        @Test
+        fun `registration fails when sync protocol provided is invalid`() {
+            postUpEvent()
+            val contextWithInvalidProtocol = properties.plus("corda.group.protocol.synchronisation" to "invalid")
+            registrationService.start()
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationRequest, mgm, contextWithInvalidProtocol)
+            }
+
+            assertThat(exception).hasMessageContaining("Invalid value for key $SYNCHRONISATION_PROTOCOL in registration context.")
+            registrationService.stop()
         }
     }
 


### PR DESCRIPTION
## Changes
Introducing some validation for registration/sync protocols, so that registration with invalid values can be switched to `INVALID` with an explanatory reason.

## Testing
Tested e2e using the combined worker and adjusting the MGM plugin to send an invalid registration protocol.
Before:
![before](https://github.com/corda/corda-runtime-os/assets/6065016/8661153f-ab0e-4f64-bf57-6de14b62033b)
```
{
  "registrationId": "3b52633f-060c-43fe-9ac9-a228948bb419",
  "registrationSent": "2023-07-07T10:26:03.460Z",
  "registrationUpdated": "2023-07-07T10:26:09.188Z",
  "registrationStatus": "APPROVED",
  "memberInfoSubmitted": {
    "data": {
      "registrationProtocolVersion": "1",
      "corda.session.keys.0.id": "231E2AD5CB51",
      "corda.ecdh.key.id": "3B6B5A6FF799",
      "corda.group.protocol.registration": "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationServiceTest",
      "corda.group.protocol.synchronisation": "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
      "corda.group.protocol.p2p.mode": "Authenticated_Encryption",
      "corda.group.key.session.policy": "Distinct",
      "corda.group.tls.type": "OneWay",
      "corda.group.pki.session": "NoPKI",
      "corda.group.pki.tls": "Standard",
      "corda.group.tls.version": "1.3",
      "corda.endpoints.0.connectionURL": "https://localhost:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "corda.group.trustroot.tls.0": "-----BEGIN CERTIFICATE-----\nMIID1zCCAj+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAeMQswCQYDVQQGEwJVSzEP\nMA0GA1UEAwwGcjMuY29tMB4XDTIzMDcwNzA5NDgxOVoXDTIzMDgwNjA5NDgxOVow\nHjELMAkGA1UEBhMCVUsxDzANBgNVBAMMBnIzLmNvbTCCAaIwDQYJKoZIhvcNAQEB\nBQADggGPADCCAYoCggGBAJPv9DK4SDMiTeMTNNdFKReChlLr06l8Pzj9KimQCXDG\noob89WAvVmxLOF7Wl4Tdgg+vBhkbP2F96mS2rYm9p5e6tPAo3EFaP07tUEp6raMz\nKeptw8emFFkmg24ORSNpSy6sIC2lEVC2A7R00+z2BeNc7HH67QR2JN7Wrw8rYI+g\nnx2bGNl7o8jZOtlI/r1POjHgXVGmcVJjkH1lxk2E2zC8UW/9Xc94gmHXAd9NkpaT\nTJsuS+wzDGHmQKzmW3O5C+GRlaq3y6j68dA7E1pZurCaxaWY171Cf5bSVZmouXbA\nI4GpQjoPrjqDyIWAjYmtRYpehMWbkNpSPA5TOjfdS5+Yi72mUoHjw+pzzxBf8aZA\nFNtxCArL+nFP5gdx4MDdNdw6u2jevauX/zp9Sq2SrEliSiR2h7PyEVCxymdVvORi\nXQv5IHSk8B5qq1hO4dJdAifbWM2CYNO/uPscWBbWXl8exOX0J8m/oBJoEikXk6WF\nqFxBMzz0H4DYc1xtDC0kewIDAQABoyAwHjAPBgNVHRMBAf8EBTADAQH/MAsGA1Ud\nDwQEAwIBrjANBgkqhkiG9w0BAQsFAAOCAYEAJDrbIM9DEE5IhBT5EoULsYMCkJEN\n/V6CY4YvqB8NdGoPIMWUsJa9mPxaUCS4ote1polciGHEP8P1JYqMmd7FEjSTmpOz\njIRPvqE/tkcBPn+NLWpAW4NPeCRE3CutZSe6Gzp+PLuRN9fknBLhb8cFSKQxbhWv\nVzWtNZveDOTXfS4/PEWzCwvLxn/tMkBweSoTDCaKNkx3rhwjdBKE0WlhoKPwGqF3\n+bmbIdN0llikpEXBWUygkH3YUA+QHhzdvbVZsjOLsfcZyPpNwTjsiMJG4aEYmlE3\ndtKYmnruLeefty1gBMq71ArmRSvaqvKEkA6jL+kAeC6IMLPj6kfZWfHmJCem9t4B\nxYUlfptmdVS5zodaHHL4eb/cL++pkUSQh4sZjBojIGy/5nCCCTcl2iN6s+7YSgkr\nymzdJeLyuzvUR8/MAjQA1nWImXX8H3H38a94Ru5uSr++J5EzkQ+BrKv+K8C8/RUg\nr1pBci/QHNE2u33eJC56pIYavthnDkcDpWnZ\n-----END CERTIFICATE-----\n"
    }
  },
  "reason": null,
  "serial": 0
}
```


After:

![after](https://github.com/corda/corda-runtime-os/assets/6065016/dd47cce6-5c69-4a5e-a3a2-c7d85a0de906)
```
{
  "registrationId": "37781b9f-3e32-4fdd-89ea-bfb854eeaa20",
  "registrationSent": "2023-07-07T10:31:29.949Z",
  "registrationUpdated": "2023-07-07T10:31:30.818Z",
  "registrationStatus": "INVALID",
  "memberInfoSubmitted": {
    "data": {
      "registrationProtocolVersion": "1",
      "corda.session.keys.0.id": "4B54B0D8D172",
      "corda.ecdh.key.id": "F9881590AB7B",
      "corda.group.protocol.registration": "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationServiceTest",
      "corda.group.protocol.synchronisation": "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
      "corda.group.protocol.p2p.mode": "Authenticated_Encryption",
      "corda.group.key.session.policy": "Distinct",
      "corda.group.tls.type": "OneWay",
      "corda.group.pki.session": "NoPKI",
      "corda.group.pki.tls": "Standard",
      "corda.group.tls.version": "1.3",
      "corda.endpoints.0.connectionURL": "https://localhost:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "corda.group.trustroot.tls.0": "-----BEGIN CERTIFICATE-----\nMIID1zCCAj+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAeMQswCQYDVQQGEwJVSzEP\nMA0GA1UEAwwGcjMuY29tMB4XDTIzMDcwNzA5NDgxOVoXDTIzMDgwNjA5NDgxOVow\nHjELMAkGA1UEBhMCVUsxDzANBgNVBAMMBnIzLmNvbTCCAaIwDQYJKoZIhvcNAQEB\nBQADggGPADCCAYoCggGBAJPv9DK4SDMiTeMTNNdFKReChlLr06l8Pzj9KimQCXDG\noob89WAvVmxLOF7Wl4Tdgg+vBhkbP2F96mS2rYm9p5e6tPAo3EFaP07tUEp6raMz\nKeptw8emFFkmg24ORSNpSy6sIC2lEVC2A7R00+z2BeNc7HH67QR2JN7Wrw8rYI+g\nnx2bGNl7o8jZOtlI/r1POjHgXVGmcVJjkH1lxk2E2zC8UW/9Xc94gmHXAd9NkpaT\nTJsuS+wzDGHmQKzmW3O5C+GRlaq3y6j68dA7E1pZurCaxaWY171Cf5bSVZmouXbA\nI4GpQjoPrjqDyIWAjYmtRYpehMWbkNpSPA5TOjfdS5+Yi72mUoHjw+pzzxBf8aZA\nFNtxCArL+nFP5gdx4MDdNdw6u2jevauX/zp9Sq2SrEliSiR2h7PyEVCxymdVvORi\nXQv5IHSk8B5qq1hO4dJdAifbWM2CYNO/uPscWBbWXl8exOX0J8m/oBJoEikXk6WF\nqFxBMzz0H4DYc1xtDC0kewIDAQABoyAwHjAPBgNVHRMBAf8EBTADAQH/MAsGA1Ud\nDwQEAwIBrjANBgkqhkiG9w0BAQsFAAOCAYEAJDrbIM9DEE5IhBT5EoULsYMCkJEN\n/V6CY4YvqB8NdGoPIMWUsJa9mPxaUCS4ote1polciGHEP8P1JYqMmd7FEjSTmpOz\njIRPvqE/tkcBPn+NLWpAW4NPeCRE3CutZSe6Gzp+PLuRN9fknBLhb8cFSKQxbhWv\nVzWtNZveDOTXfS4/PEWzCwvLxn/tMkBweSoTDCaKNkx3rhwjdBKE0WlhoKPwGqF3\n+bmbIdN0llikpEXBWUygkH3YUA+QHhzdvbVZsjOLsfcZyPpNwTjsiMJG4aEYmlE3\ndtKYmnruLeefty1gBMq71ArmRSvaqvKEkA6jL+kAeC6IMLPj6kfZWfHmJCem9t4B\nxYUlfptmdVS5zodaHHL4eb/cL++pkUSQh4sZjBojIGy/5nCCCTcl2iN6s+7YSgkr\nymzdJeLyuzvUR8/MAjQA1nWImXX8H3H38a94Ru5uSr++J5EzkQ+BrKv+K8C8/RUg\nr1pBci/QHNE2u33eJC56pIYavthnDkcDpWnZ\n-----END CERTIFICATE-----\n"
    }
  },
  "reason": "Invalid value for key corda.group.protocol.registration in registration context. It should be one of the following values: [net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService].",
  "serial": null
}
```