### PR TITLE
CORE-14685: Separate UniquenessChecker and BackingStore from Lifecycle.

### DIFF
--- a/components/uniqueness/backing-store-impl/src/backingStoreBenchmark/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplBenchmark.kt
+++ b/components/uniqueness/backing-store-impl/src/backingStoreBenchmark/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplBenchmark.kt
@@ -116,15 +116,18 @@ class JPABackingStoreImplBenchmark {
             JPABackingStoreEntities.classes
         )
 
-        backingStore = JPABackingStoreImpl(
+        val jpaEntitiesRegistry = JpaEntitiesRegistryImpl()
+        val dbConnectionManager = mock<DbConnectionManager>().apply {
+            whenever(getOrCreateEntityManagerFactory(
+                eq(holdingIdentityDbName), any(), any()
+            )) doReturn holdingIdentityDb
+            whenever(getClusterDataSource()) doReturn clusterDbConfig.dataSource
+        }
+        backingStore = JPABackingStoreLifecycleImpl(
             mock(),
-            JpaEntitiesRegistryImpl(),
-            mock<DbConnectionManager>().apply {
-                whenever(getOrCreateEntityManagerFactory(
-                    eq(holdingIdentityDbName), any(), any()
-                )) doReturn holdingIdentityDb
-                whenever(getClusterDataSource()) doReturn clusterDbConfig.dataSource
-            }
+            jpaEntitiesRegistry,
+            dbConnectionManager,
+            JPABackingStoreImpl(jpaEntitiesRegistry, dbConnectionManager)
         ).apply {
             eventHandler(RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), mock())
         }

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreLifecycleImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreLifecycleImpl.kt
@@ -1,0 +1,90 @@
+package net.corda.uniqueness.backingstore.impl
+
+import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.schema.CordaDb
+import net.corda.lifecycle.DependentComponents
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleEvent
+import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.lifecycle.StartEvent
+import net.corda.lifecycle.StopEvent
+import net.corda.lifecycle.createCoordinator
+import net.corda.orm.JpaEntitiesRegistry
+import net.corda.orm.JpaEntitiesSet
+import net.corda.uniqueness.backingstore.BackingStore
+import net.corda.uniqueness.backingstore.BackingStoreLifecycle
+import net.corda.utilities.VisibleForTesting
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+
+@Suppress("unused")
+/**
+ * JPA backing store implementation, which uses a JPA compliant database to persist data.
+ */
+@Component(service = [BackingStoreLifecycle::class])
+open class JPABackingStoreLifecycleImpl @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    coordinatorFactory: LifecycleCoordinatorFactory,
+    @Reference(service = JpaEntitiesRegistry::class)
+    private val jpaEntitiesRegistry: JpaEntitiesRegistry,
+    @Reference(service = DbConnectionManager::class)
+    private val dbConnectionManager: DbConnectionManager,
+    @Reference(service = BackingStore::class)
+    private val backingStore: BackingStore
+) : BackingStoreLifecycle, BackingStore by backingStore {
+
+    private companion object {
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    private val lifecycleCoordinator: LifecycleCoordinator = coordinatorFactory
+        .createCoordinator<BackingStoreLifecycle>(::eventHandler)
+
+    private val dependentComponents = DependentComponents.of(
+        ::dbConnectionManager
+    )
+
+    private lateinit var jpaEntities: JpaEntitiesSet
+
+    override val isRunning: Boolean
+        get() = lifecycleCoordinator.isRunning
+
+    override fun start() {
+        log.info("Backing store starting")
+        lifecycleCoordinator.start()
+    }
+
+    override fun stop() {
+        log.info("Backing store stopping")
+        lifecycleCoordinator.stop()
+    }
+
+    @VisibleForTesting
+    fun eventHandler(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
+        log.info("Backing store received event $event")
+        when (event) {
+            is StartEvent -> {
+                dependentComponents.registerAndStartAll(coordinator)
+            }
+            is StopEvent -> {
+                dependentComponents.stopAll()
+            }
+            is RegistrationStatusChangeEvent -> {
+                jpaEntities = jpaEntitiesRegistry.get(CordaDb.Uniqueness.persistenceUnitName)
+                    ?: throw IllegalStateException(
+                        "persistenceUnitName " +
+                                "${CordaDb.Uniqueness.persistenceUnitName} is not registered."
+                    )
+
+                log.info("Backing store is ${event.status}")
+                coordinator.updateStatus(event.status)
+            }
+            else -> {
+                log.warn("Unexpected event ${event}, ignoring")
+            }
+        }
+    }
+}

--- a/components/uniqueness/backing-store-impl/src/test/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplTests.kt
+++ b/components/uniqueness/backing-store-impl/src/test/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplTests.kt
@@ -39,7 +39,7 @@ import org.mockito.kotlin.doReturn
 import java.sql.Connection
 import java.time.LocalDate
 import java.time.ZoneOffset
-import java.util.*
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -47,7 +47,7 @@ import javax.persistence.TypedQuery
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JPABackingStoreImplTests {
-    private lateinit var backingStoreImpl: JPABackingStoreImpl
+    private lateinit var backingStoreImpl: JPABackingStoreLifecycleImpl
 
     private lateinit var lifecycleCoordinator: LifecycleCoordinator
     private lateinit var lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
@@ -137,10 +137,11 @@ class JPABackingStoreImplTests {
             whenever(getOrCreateEntityManagerFactory(any(), any(), any())) doReturn entityManagerFactory
         }
 
-        backingStoreImpl = JPABackingStoreImpl(
+        backingStoreImpl = JPABackingStoreLifecycleImpl(
             lifecycleCoordinatorFactory,
             jpaEntitiesRegistry,
-            dbConnectionManager
+            dbConnectionManager,
+            JPABackingStoreImpl(jpaEntitiesRegistry, dbConnectionManager)
         )
     }
 

--- a/components/uniqueness/backing-store/src/main/kotlin/net/corda/uniqueness/backingstore/BackingStore.kt
+++ b/components/uniqueness/backing-store/src/main/kotlin/net/corda/uniqueness/backingstore/BackingStore.kt
@@ -45,8 +45,9 @@ import net.corda.virtualnode.HoldingIdentity
  * }
  * ```
  */
+interface BackingStoreLifecycle : BackingStore, Lifecycle
 
-interface BackingStore : Lifecycle {
+interface BackingStore {
 
     /**
      * Opens a new session with the backing store and runs the supplied block of code in the

--- a/components/uniqueness/uniqueness-checker-client-service-impl/build.gradle
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
-    implementation platform('net.corda:corda-api:$cordaApiVersion')
+    implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     implementation 'net.corda:corda-application'
     implementation 'net.corda:corda-base'

--- a/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/UniquenessCheckClientExternalEventFactory.kt
+++ b/components/uniqueness/uniqueness-checker-client-service-impl/src/main/kotlin/net/corda/uniqueness/client/impl/UniquenessCheckClientExternalEventFactory.kt
@@ -10,12 +10,11 @@ import net.corda.schema.Schemas
 import net.corda.uniqueness.datamodel.common.toUniquenessResult
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.virtualnode.toAvro
-import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import java.time.Instant
 
 @Component(service = [ExternalEventFactory::class])
-class UniquenessCheckExternalEventFactory @Activate constructor():
+class UniquenessCheckExternalEventFactory :
     ExternalEventFactory<UniquenessCheckExternalEventParams, UniquenessCheckResponseAvro, UniquenessCheckResult> {
 
     override val responseType = UniquenessCheckResponseAvro::class.java

--- a/components/uniqueness/uniqueness-checker-impl/build.gradle
+++ b/components/uniqueness/uniqueness-checker-impl/build.gradle
@@ -17,10 +17,10 @@ dependencies {
     implementation 'net.corda:corda-topic-schema'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
+    api project(":components:uniqueness:uniqueness-checker")
     implementation project(":components:configuration:configuration-read-service")
     implementation project(":components:uniqueness:backing-store")
     implementation project(":components:uniqueness:backing-store-impl")
-    implementation project(":components:uniqueness:uniqueness-checker")
     implementation project(':libs:configuration:configuration-core')
     implementation project(':libs:configuration:configuration-datamodel')
     implementation project(':libs:flows:external-event-responses')

--- a/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
@@ -11,8 +11,6 @@ import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.db.testkit.DbUtils
 import net.corda.db.testkit.TestDbInfo
-import net.corda.lifecycle.LifecycleStatus
-import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.orm.impl.JpaEntitiesRegistryImpl
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.AutoTickTestClock
@@ -47,7 +45,8 @@ import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
-import java.util.*
+import java.util.LinkedList
+import java.util.UUID
 import javax.persistence.EntityManagerFactory
 import kotlin.test.assertEquals
 
@@ -73,7 +72,7 @@ class UniquenessCheckerImplDBIntegrationTests {
         VirtualNodeDbType.UNIQUENESS.getSchemaName(defaultHoldingIdentity.shortHash)
     private val defaultHoldingIdentityDb: EntityManagerFactory
 
-    // Additional holding identites
+    // Additional holding identities
     private val bobHoldingIdentity = createTestHoldingIdentity(
         "C=GB, L=London, O=Bob", groupId)
     private val bobHoldingIdentityDbName =
@@ -195,7 +194,6 @@ class UniquenessCheckerImplDBIntegrationTests {
         testClock = AutoTickTestClock(baseTime, Duration.ofSeconds(1))
 
         val backingStore = JPABackingStoreImpl(
-            mock(),
             JpaEntitiesRegistryImpl(),
             mock<DbConnectionManager>().apply {
                 whenever(getOrCreateEntityManagerFactory(
@@ -210,15 +208,7 @@ class UniquenessCheckerImplDBIntegrationTests {
             }
         )
 
-        uniquenessChecker = BatchedUniquenessCheckerImpl(
-            mock(),
-            mock(),
-            mock(),
-            mock(),
-            testClock,
-            backingStore)
-
-        backingStore.eventHandler(RegistrationStatusChangeEvent(mock(), LifecycleStatus.UP), mock())
+        uniquenessChecker = BatchedUniquenessCheckerImpl(backingStore, testClock)
     }
 
     @Nested

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerLifecycleImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerLifecycleImpl.kt
@@ -1,0 +1,129 @@
+package net.corda.uniqueness.checker.impl
+
+import net.corda.configuration.read.ConfigChangedEvent
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.configuration.helper.getConfig
+import net.corda.lifecycle.DependentComponents
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleEvent
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.lifecycle.StartEvent
+import net.corda.lifecycle.StopEvent
+import net.corda.lifecycle.createCoordinator
+import net.corda.messaging.api.subscription.config.SubscriptionConfig
+import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.schema.Schemas
+import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
+import net.corda.uniqueness.backingstore.BackingStoreLifecycle
+import net.corda.uniqueness.checker.UniquenessChecker
+import net.corda.uniqueness.checker.UniquenessCheckerLifecycle
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
+
+/**
+ * A batched implementation of the uniqueness checker component, which processes batches of requests
+ * together in order to provide higher performance under load.
+ */
+@Component(service = [UniquenessCheckerLifecycle::class])
+@Suppress("LongParameterList")
+class BatchedUniquenessCheckerLifecycleImpl @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    coordinatorFactory: LifecycleCoordinatorFactory,
+    @Reference(service = ConfigurationReadService::class)
+    private val configurationReadService: ConfigurationReadService,
+    @Reference(service = SubscriptionFactory::class)
+    private val subscriptionFactory: SubscriptionFactory,
+    @Reference(service = ExternalEventResponseFactory::class)
+    private val externalEventResponseFactory: ExternalEventResponseFactory,
+    @Reference(service = BackingStoreLifecycle::class)
+    private val backingStore: BackingStoreLifecycle,
+    @Reference(service = UniquenessChecker::class)
+    uniquenessChecker: UniquenessChecker
+) : UniquenessCheckerLifecycle, UniquenessChecker by uniquenessChecker {
+    private companion object {
+        const val GROUP_NAME = "uniqueness.checker"
+
+        const val CONFIG_HANDLE = "CONFIG_HANDLE"
+        const val SUBSCRIPTION = "SUBSCRIPTION"
+
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    private val lifecycleCoordinator: LifecycleCoordinator =
+        coordinatorFactory.createCoordinator<UniquenessCheckerLifecycle>(::eventHandler)
+
+    private val dependentComponents = DependentComponents.of(
+        ::backingStore
+    )
+
+    override val isRunning: Boolean
+        get() = lifecycleCoordinator.isRunning
+
+    override fun start() {
+        log.info("Uniqueness checker starting")
+        lifecycleCoordinator.start()
+    }
+
+    override fun stop() {
+        log.info("Uniqueness checker stopping")
+        lifecycleCoordinator.stop()
+    }
+
+    private fun eventHandler(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
+        log.info("Uniqueness checker received event $event")
+        when (event) {
+            is StartEvent -> {
+                configurationReadService.start()
+                dependentComponents.registerAndStartAll(coordinator)
+            }
+            is StopEvent -> {
+                dependentComponents.stopAll()
+            }
+            is RegistrationStatusChangeEvent -> {
+                log.info("Uniqueness checker is ${event.status}")
+
+                if (event.status == LifecycleStatus.UP) {
+                    coordinator.createManagedResource(CONFIG_HANDLE) {
+                        configurationReadService.registerComponentForUpdates(
+                            coordinator,
+                            setOf(MESSAGING_CONFIG)
+                        )
+                    }
+                } else {
+                    coordinator.closeManagedResources(setOf(CONFIG_HANDLE))
+                }
+
+                coordinator.updateStatus(event.status)
+            }
+            is ConfigChangedEvent -> {
+                log.info("Received configuration change event, (re)initialising subscription")
+                initialiseSubscription(event.config.getConfig(MESSAGING_CONFIG))
+            }
+            else -> {
+                log.warn("Unexpected event ${event}, ignoring")
+            }
+        }
+    }
+
+    private fun initialiseSubscription(config: SmartConfig) {
+        lifecycleCoordinator.createManagedResource(SUBSCRIPTION) {
+            subscriptionFactory.createDurableSubscription(
+                SubscriptionConfig(GROUP_NAME, Schemas.UniquenessChecker.UNIQUENESS_CHECK_TOPIC),
+                UniquenessCheckMessageProcessor(
+                    this,
+                    externalEventResponseFactory
+                ),
+                config,
+                null
+            ).also {
+                it.start()
+            }
+        }
+    }
+}

--- a/components/uniqueness/uniqueness-checker-impl/src/test/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/test/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplTests.kt
@@ -44,7 +44,8 @@ import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
-import java.util.*
+import java.util.LinkedList
+import java.util.UUID
 import kotlin.test.assertEquals
 
 /**
@@ -136,13 +137,7 @@ class UniquenessCheckerImplTests {
 
         backingStore = spy(BackingStoreImplFake(mock()))
 
-        uniquenessChecker = BatchedUniquenessCheckerImpl(
-            mock(),
-            mock(),
-            mock(),
-            mock(),
-            testClock,
-            backingStore)
+        uniquenessChecker = BatchedUniquenessCheckerImpl(backingStore, testClock)
     }
 
     @Nested
@@ -1468,12 +1463,9 @@ class UniquenessCheckerImplTests {
                 .doThrow(UnsupportedOperationException())
 
             val exceptionThrowingUniquenessChecker = BatchedUniquenessCheckerImpl(
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                testClock,
-                exceptionThrowingBackingStore)
+                exceptionThrowingBackingStore,
+                testClock
+            )
 
             exceptionThrowingUniquenessChecker.processRequests(
                 listOf(

--- a/components/uniqueness/uniqueness-checker/src/main/kotlin/net/corda/uniqueness/checker/UniquenessChecker.kt
+++ b/components/uniqueness/uniqueness-checker/src/main/kotlin/net/corda/uniqueness/checker/UniquenessChecker.kt
@@ -5,9 +5,11 @@ import net.corda.data.uniqueness.UniquenessCheckResponseAvro
 import net.corda.lifecycle.Lifecycle
 
 /**
- * Interface for the uniqueness checking component.
+ * Interface for the uniqueness checking components.
  */
-interface UniquenessChecker : Lifecycle {
+interface UniquenessCheckerLifecycle : UniquenessChecker, Lifecycle
+
+interface UniquenessChecker {
     /**
      * Performs uniqueness checking against a list of requests and returns a map of requests and
      * their corresponding responses.

--- a/processors/uniqueness-processor/src/main/kotlin/net/corda/processors/uniqueness/internal/UniquenessProcessorImpl.kt
+++ b/processors/uniqueness-processor/src/main/kotlin/net/corda/processors/uniqueness/internal/UniquenessProcessorImpl.kt
@@ -9,7 +9,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.processors.uniqueness.UniquenessProcessor
-import net.corda.uniqueness.checker.UniquenessChecker
+import net.corda.uniqueness.checker.UniquenessCheckerLifecycle
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -22,8 +22,8 @@ import org.slf4j.LoggerFactory
 class UniquenessProcessorImpl @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val coordinatorFactory: LifecycleCoordinatorFactory,
-    @Reference(service = UniquenessChecker::class)
-    private val uniquenessChecker: UniquenessChecker
+    @Reference(service = UniquenessCheckerLifecycle::class)
+    private val uniquenessChecker: UniquenessCheckerLifecycle
 ) : UniquenessProcessor {
 
     companion object {

--- a/testing/uniqueness/backing-store-fake/src/main/kotlin/net/corda/uniqueness/backingstore/impl/fake/BackingStoreImplFake.kt
+++ b/testing/uniqueness/backing-store-fake/src/main/kotlin/net/corda/uniqueness/backingstore/impl/fake/BackingStoreImplFake.kt
@@ -15,6 +15,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.uniqueness.backingstore.BackingStore
+import net.corda.uniqueness.backingstore.BackingStoreLifecycle
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateDetailsImpl
 import net.corda.uniqueness.datamodel.internal.UniquenessCheckRequestInternal
 import net.corda.uniqueness.datamodel.internal.UniquenessCheckTransactionDetailsInternal
@@ -31,19 +32,19 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 @ServiceRanking(Int.MAX_VALUE)
-@Component(service = [BackingStore::class])
+@Component(service = [BackingStoreLifecycle::class, BackingStore::class])
 @Suppress("ForbiddenComment")
 open class BackingStoreImplFake @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     coordinatorFactory: LifecycleCoordinatorFactory
-) : BackingStore {
+) : BackingStoreLifecycle {
 
     private companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     private val lifecycleCoordinator: LifecycleCoordinator = coordinatorFactory
-        .createCoordinator<BackingStore>(::eventHandler)
+        .createCoordinator<BackingStoreLifecycle>(::eventHandler)
 
     override val isRunning: Boolean
         get() = lifecycleCoordinator.isRunning


### PR DESCRIPTION
Splice `Lifecycle` from `UniquenessChecker` and `BackingStore` so that these components become available without also needing the lifecycle layer.

The lifecycle functionality has been moved to `UniquenessCheckerLifecycle` and `BackingStoreLifecycle`, which host the `UniquenessChecker` and `BackingStore` components respectively.

The underlying objective is for `UniquenessCheckMessageProcessor` not to depend on any components from the "lifecycle" layer, in the same way that:
- `VerifiactionRequestProcessor`
- `PersistenceRequestProcessor`
- `EntityMessageProcessor`

and others already do not.

---
In simple terms, I am replacing an interface like this:
```kotlin
interface Foo : Lifecycle
```
with two interfaces like this:
```kotlin
interface Foo
interface FooLifecycle : Foo, Lifecycle
```
I then split the `FooImpl` class into two like this:
```kotlin
@Component(service = [ Foo::class ])
class FooImpl : Foo

@Component(service = [ FooLifecycle::class ])
class FooLifecycleImpl @Activate constructor(
    @Refererence
    private val foo: Foo
) : FooLifecycle, Foo by foo
```