### PR TITLE
CORE-15219: Added request id to flow invocation logs

### DIFF
--- a/libs/tracing/src/main/kotlin/net/corda/tracing/impl/BraveTracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/impl/BraveTracingService.kt
@@ -4,6 +4,7 @@ import brave.Tracer
 import brave.Tracing
 import brave.baggage.BaggagePropagation
 import brave.baggage.BaggagePropagationConfig
+import brave.baggage.CorrelationScopeConfig
 import brave.context.slf4j.MDCScopeDecorator
 import brave.propagation.B3Propagation
 import brave.propagation.ThreadLocalCurrentTraceContext
@@ -44,7 +45,7 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String, samp
 
         val braveCurrentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
             .addScopeDecorator(MDCScopeDecorator.newBuilder()
-                .add(SingleCorrelationField.create(BraveBaggageFields.REQUEST_ID))
+                .add(CorrelationScopeConfig.SingleCorrelationField.create(BraveBaggageFields.REQUEST_ID))
                 .build())
             .build()
 

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/impl/BraveTracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/impl/BraveTracingService.kt
@@ -43,7 +43,9 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String, samp
     private val tracing: Tracing by lazy {
 
         val braveCurrentTraceContext = ThreadLocalCurrentTraceContext.newBuilder()
-            .addScopeDecorator(MDCScopeDecorator.get())
+            .addScopeDecorator(MDCScopeDecorator.newBuilder()
+                .add(SingleCorrelationField.create(BraveBaggageFields.REQUEST_ID))
+                .build())
             .build()
 
         val sampler = when (samplesPerSecond) {


### PR DESCRIPTION
When the combined worker is ran with tracing enabled, the flow-related logs contain the trace ID, however there is no mapping between flow client ID / request ID and the trace ID. This change adds the request ID to the logs' context by adding the appropriate baggageField to the `MDCScopeDecorator.` Now given a flow client ID / request ID, its possible to present all logs related to this flow (via the trace ID mapping).