### PR TITLE
CORE-15296: Introduce `EndpointMinMaxVersionValidator`

### DIFF
--- a/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/EndpointMinMaxVersionValidator.kt
+++ b/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/EndpointMinMaxVersionValidator.kt
@@ -1,0 +1,35 @@
+package net.corda.rest.tools.annotations.validation
+
+import net.corda.rest.RestResource
+import net.corda.rest.tools.annotations.validation.utils.endpoints
+import net.corda.rest.tools.annotations.validation.utils.isEqualOrChildOf
+import net.corda.rest.tools.annotations.validation.utils.restApiVersions
+import java.lang.reflect.Method
+
+/**
+ * Validates that for every method in the class `minVersion` is less than `maxVersion` and also that the two versions
+ * are related
+ */
+internal class EndpointMinMaxVersionValidator(private val clazz: Class<out RestResource>) : RestValidator {
+
+    companion object {
+        fun error(method: Method): String =
+            "Invalid combination of min/max version for endpoint " +
+                    "HTTP method in '${method.declaringClass.simpleName}.${method.name}'."
+    }
+
+    override fun validate(): RestValidationResult = validateVersions(clazz.endpoints)
+
+    private fun validateVersions(endpoints: List<Method>): RestValidationResult {
+
+        return endpoints.fold(RestValidationResult()) { total, method ->
+            method.restApiVersions.let {
+                if (it.maxVersion.isEqualOrChildOf(it.minVersion)) {
+                    total
+                } else {
+                    total + RestValidationResult(listOf(error(method)))
+                }
+            }
+        }
+    }
+}

--- a/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/RestInterfaceValidator.kt
+++ b/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/RestInterfaceValidator.kt
@@ -27,7 +27,8 @@ object RestInterfaceValidator {
             URLPathParameterNotDeclaredValidator(rpcOpsInterface),
             DurableStreamsEndPointValidator(rpcOpsInterface),
             DurableStreamsContextParameterValidator(rpcOpsInterface),
-            NestedGenericsParameterTypeValidator(rpcOpsInterface)
+            NestedGenericsParameterTypeValidator(rpcOpsInterface),
+            EndpointMinMaxVersionValidator(rpcOpsInterface)
         ).fold(RestValidationResult()) { total, next -> total + next.validate() }
 
     /**

--- a/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/utils/RestApiVersionUtils.kt
+++ b/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/utils/RestApiVersionUtils.kt
@@ -1,0 +1,17 @@
+package net.corda.rest.tools.annotations.validation.utils
+
+import net.corda.rest.annotations.RestApiVersion
+
+internal tailrec fun RestApiVersion.isEqualOrChildOf(earlierVersion: RestApiVersion): Boolean {
+
+    if (this == earlierVersion) {
+        return true
+    }
+
+    this.parentVersion.let {
+        if (it == null) {
+            return false
+        }
+        return it.isEqualOrChildOf(earlierVersion)
+    }
+}

--- a/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/EndpointMinMaxVersionValidatorTest.kt
+++ b/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/EndpointMinMaxVersionValidatorTest.kt
@@ -1,0 +1,46 @@
+package net.corda.rest.tools.annotations.validation
+
+import net.corda.rest.RestResource
+import net.corda.rest.annotations.HttpGET
+import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestApiVersion
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import kotlin.reflect.jvm.javaMethod
+
+class EndpointMinMaxVersionValidatorTest {
+
+    @Test
+    fun `validate valid versions relationship`() {
+        @Suppress("unused")
+        @HttpRestResource
+        abstract class TestInterface : RestResource {
+
+            @HttpGET(minVersion = RestApiVersion.C5_0, maxVersion = RestApiVersion.C5_2)
+            abstract fun test()
+        }
+
+        val result = EndpointMinMaxVersionValidator(TestInterface::class.java).validate()
+
+        Assertions.assertEquals(0, result.errors.size)
+    }
+
+    @Test
+    fun `validate invalid versions relationship`() {
+        @Suppress("unused")
+        @HttpRestResource
+        abstract class TestInterface : RestResource {
+
+            @HttpGET(minVersion = RestApiVersion.C5_2, maxVersion = RestApiVersion.C5_1)
+            abstract fun test()
+        }
+
+        val result = EndpointMinMaxVersionValidator(TestInterface::class.java).validate()
+
+        Assertions.assertEquals(1, result.errors.size)
+        Assertions.assertEquals(
+            EndpointMinMaxVersionValidator.error(TestInterface::test.javaMethod!!),
+            result.errors.single()
+        )
+    }
+}


### PR DESCRIPTION
To enforce min/max `RestApiVersion` constrains on methods.