### PR TITLE
Add Structured GitHub Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+## Security
+[R3](https://r3.com/), the company behind [Corda](https://corda.net/), welcomes collaboration with the security community and takes the security of our software products and services seriously. This includes all source code repositories managed through our GitHub organizations including [corda-runtime-os] and [others](https://github.com/orgs/corda/repositories).
+
+Please note that [corda-runtime-os](https://github.com/corda/corda-runtime-os) pre-release software and is not yet intended to facilitate full CorDapp development.
+
+## Reporting Security Issues
+If you believe you have found a security vulnerability in any R3-owned repository, **please do not report security vulnerabilities through public GitHub issues**.
+
+### Other versions of Corda
+For Corda 4 and below, please reference the [following repository](https://github.com/corda/corda/security).
+
+### Related to Corda 5
+For others, we encourage you to conact the R3 engieering team.
+* Slack - [cordaledger.slack.com](cordaledger.slack.com)
+* Our Blog - [corda.net/blog/](corda.net/blog/)
+* Community Forum - [community.r3.com](community.r3.com)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 ## Security
-[R3](https://r3.com/), the company behind [Corda](https://corda.net/), welcomes collaboration with the security community and takes the security of our software products and services seriously. This includes all source code repositories managed through our GitHub organizations including [corda-runtime-os] and [others](https://github.com/orgs/corda/repositories).
+[R3](https://r3.com/), the company behind [Corda](https://corda.net/), welcomes collaboration with the security community and takes the security of our software products and services seriously. This includes all source code repositories managed through our GitHub organizations including [corda-runtime-os](https://github.com/corda/corda-runtime-os) and [others](https://github.com/orgs/corda/repositories).
 
 Please note that [corda-runtime-os](https://github.com/corda/corda-runtime-os) pre-release software and is not yet intended to facilitate full CorDapp development.
 


### PR DESCRIPTION
## Proposed Change
This does nothing but add a structured Security Policy to the GitHub repository. It has no functional impact on the codebase.

I used a mix of existing wording from the repository's README and [R3's Vulnerability Disclosure Program](https://hackerone.com/r3).

## Benefit
Adding the security policy as a `SECURITY.md` at the root of the repository will make it indexible by GitHub - enabling the **Security Policy** option under the **Security** tab, and any expanded functionality GitHub introduces based on it. This metadata is also picked up by sources like Snyk Advisor.
![image](https://github.com/corda/corda-runtime-os/assets/34169713/f37c35b6-853a-4599-9333-07b7e0d4f999)

## Notes
If there's a clearer contact resource than Slack community members should use (e.g., if there's a security@r3.com), it might be worth adding here. Let me know. I noticed [https://www.corda.net/participate/security.html](https://www.corda.net/participate/security.html) just redirects to [https://developer.r3.com/](https://developer.r3.com/).