### PR TITLE
Add GitHub Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+## Contributing
+We encourage you to use this code to explore how Corda 5 will work, rebuild it, and experiment with deploying it locally. We'd love your comments and feedback! But be warned it is pre-release software and is not yet intended to facilitate full CorDapp development.
+
+Note that there is a large engineering team at R3 working on this codebase so if you see something wrong or missing, we encourage you to contact us before working on any significant PRs of your own: it's possible we may already be working on the same thing or we may have tips on how best to structure your work to maximise the chance of it being merged into the codebase.
+
+The best way to stay up-to-date with Corda is to monitor the following resources:
+
+* Slack - [cordaledger.slack.com](cordaledger.slack.com)
+* Our Blog - [corda.net/blog/](corda.net/blog/)
+* Community Forum - [community.r3.com](community.r3.com)


### PR DESCRIPTION
All this does is add the information effectively communicated already in the README as a structured contributing guide.

## Benefit
Having the info here will prompt new contributors in GitHub to review the information when reporting a GitHub Issue or opening a pull request for the first time. So the GitHub interface will help you reiterate the info.
![image](https://github.com/corda/corda-runtime-os/assets/34169713/87b50cd9-f830-4d0f-9515-48eb040a562d)