### PR TITLE
CORE-15358: Avoid closing the retry manager

### DIFF
--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncRetryManager.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncRetryManager.kt
@@ -6,9 +6,9 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleEvent
 import net.corda.lifecycle.LifecycleStatus
-import net.corda.lifecycle.Resource
 import net.corda.lifecycle.TimerEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
@@ -22,11 +22,10 @@ import java.util.concurrent.TimeUnit
 
 internal class MembershipPersistenceAsyncRetryManager(
     coordinatorFactory: LifecycleCoordinatorFactory,
-    publisherFactory: PublisherFactory,
-    messagingConfig: SmartConfig,
+    private val publisherFactory: PublisherFactory,
     private val clock: Clock,
 ) :
-    StateAndEventListener<String, MembershipPersistenceAsyncRequestState>, Resource {
+    StateAndEventListener<String, MembershipPersistenceAsyncRequestState> {
 
     private companion object {
         const val PUBLISHER_NAME = "MembershipPersistenceAsyncRetryManager"
@@ -34,18 +33,9 @@ internal class MembershipPersistenceAsyncRetryManager(
         val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    private val publisher = publisherFactory.createPublisher(
-        publisherConfig = PublisherConfig(PUBLISHER_NAME),
-        messagingConfig = messagingConfig,
-    ).also {
-        it.start()
-    }
     private val coordinator =
         coordinatorFactory.createCoordinator<MembershipPersistenceAsyncRetryManager> { event, _ ->
             eventHandler(event)
-        }.also {
-            it.start()
-            it.updateStatus(LifecycleStatus.UP)
         }
 
     private data class RetryEvent(
@@ -58,7 +48,7 @@ internal class MembershipPersistenceAsyncRetryManager(
     ) {
         if (event is RetryEvent) {
             logger.info("Retrying request ${event.key}")
-            publisher.publish(
+            coordinator.getManagedResource<Publisher>(PUBLISHER_NAME)?.publish(
                 listOf(
                     event.event,
                 )
@@ -66,9 +56,22 @@ internal class MembershipPersistenceAsyncRetryManager(
         }
     }
 
-    override fun close() {
-        publisher.close()
-        coordinator.close()
+    fun start(messagingConfig: SmartConfig) {
+        coordinator.start()
+        coordinator.createManagedResource(PUBLISHER_NAME) {
+            publisherFactory.createPublisher(
+                publisherConfig = PublisherConfig(PUBLISHER_NAME),
+                messagingConfig = messagingConfig,
+            ).also {
+                it.start()
+            }
+        }
+        coordinator.updateStatus(LifecycleStatus.UP)
+    }
+
+    fun stop() {
+        coordinator.closeManagedResources(setOf(PUBLISHER_NAME))
+        coordinator.stop()
     }
 
     override fun onPartitionSynced(states: Map<String, MembershipPersistenceAsyncRequestState>) {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncRetryManagerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncRetryManagerTest.kt
@@ -16,6 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -27,12 +28,18 @@ import java.time.Instant
 
 class MembershipPersistenceAsyncRetryManagerTest {
     private val handler = argumentCaptor<LifecycleEventHandler>()
-    private val coordinator = mock<LifecycleCoordinator>()
-    private val coordinatorFactory = mock<LifecycleCoordinatorFactory>() {
-        on { createCoordinator(any(), handler.capture()) } doReturn coordinator
-    }
     private val publisher = mock<Publisher> {
         on { publish(any()) } doReturn emptyList()
+    }
+    private val coordinator = mock<LifecycleCoordinator> {
+        on { createManagedResource<Publisher>(any(), any()) } doAnswer {
+            val factory = it.getArgument<()->Publisher>(1)
+            factory()
+        }
+        on { getManagedResource<Publisher>(any()) } doReturn publisher
+    }
+    private val coordinatorFactory = mock<LifecycleCoordinatorFactory>() {
+        on { createCoordinator(any(), handler.capture()) } doReturn coordinator
     }
     private val publisherFactory = mock<PublisherFactory> {
         on { createPublisher(any(), any()) } doReturn publisher
@@ -45,38 +52,45 @@ class MembershipPersistenceAsyncRetryManagerTest {
     private val manager = MembershipPersistenceAsyncRetryManager(
         coordinatorFactory,
         publisherFactory,
-        mock(),
         clock,
 
     )
 
     @Test
-    fun `constructor start the publisher`() {
+    fun `start start the publisher`() {
+        manager.start(mock())
+
         verify(publisher).start()
     }
 
     @Test
-    fun `constructor start the coordinator`() {
+    fun `start start the coordinator`() {
+        manager.start(mock())
+
         verify(coordinator).start()
     }
 
     @Test
-    fun `constructor set state to started`() {
+    fun `start set state to started`() {
+        manager.start(mock())
+
         verify(coordinator).updateStatus(LifecycleStatus.UP)
     }
 
     @Test
-    fun `close close the publisher`() {
-        manager.close()
+    fun `stop close the publisher`() {
+        manager.start(mock())
 
-        verify(publisher).close()
+        manager.stop()
+
+        verify(coordinator).closeManagedResources(argThat { size == 1 })
     }
 
     @Test
-    fun `close close the coordinator`() {
-        manager.close()
+    fun `close stop the coordinator`() {
+        manager.stop()
 
-        verify(coordinator).close()
+        verify(coordinator).stop()
     }
 
     @Test
@@ -189,6 +203,7 @@ class MembershipPersistenceAsyncRetryManagerTest {
 
     @Test
     fun `timer will republish the command`() {
+        manager.start(mock())
         val records = argumentCaptor<List<Record<String, Any>>>()
         whenever(publisher.publish(records.capture())).doReturn(emptyList())
         val eventFactory = argumentCaptor<(String) -> TimerEvent>()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImplTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImplTest.kt
@@ -142,7 +142,7 @@ class MembershipPersistenceServiceImplTest {
             mock(),
             mock(),
         )
-        verify(coordinatorFactory).createCoordinator(any(), any())
+        verify(coordinatorFactory, times(2)).createCoordinator(any(), any())
     }
 
     @Test


### PR DESCRIPTION
The life cycle coordinator can't always manage when one closes and immediately open a coordinator with the same name. Instead, with this change the coordinator will always be alive, and we will just stop and start it when needed.