### PR TITLE
CORE-15257: Handle RestApiVersions in EndpointNameConflictValidator when endpoint name conflicts occurs

### DIFF
--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/APIStructureRetriever.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/APIStructureRetriever.kt
@@ -21,8 +21,8 @@ import net.corda.rest.RestResource
 import net.corda.rest.annotations.HttpDELETE
 import net.corda.rest.annotations.HttpPUT
 import net.corda.rest.annotations.HttpWS
-import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.annotations.isRestEndpointAnnotation
+import net.corda.rest.annotations.retrieveApiVersionsSet
 import net.corda.rest.tools.annotations.extensions.name
 import net.corda.rest.tools.annotations.extensions.path
 import net.corda.rest.tools.annotations.extensions.title
@@ -86,23 +86,6 @@ internal class APIStructureRetriever(private val opsImplList: List<PluggableRest
                 throw e
             }
         }
-    }
-
-    private fun retrieveApiVersionsSet(minVersion: RestApiVersion, maxVersion: RestApiVersion): Set<RestApiVersion> {
-        val result = EnumSet.noneOf(RestApiVersion::class.java)
-
-        var current: RestApiVersion? = maxVersion
-        while (current != null) {
-            result.add(current)
-
-            // Check if we have reached the bottom
-            if (current == minVersion) {
-                break
-            }
-
-            current = current.parentVersion
-        }
-        return result
     }
 
     private fun List<Class<out RestResource>>.validated(): List<Class<out RestResource>> {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/APIStructureRetriever.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/APIStructureRetriever.kt
@@ -31,7 +31,6 @@ import net.corda.rest.tools.responseDescription
 import net.corda.utilities.debug
 import net.corda.utilities.trace
 import java.lang.reflect.Method
-import java.util.EnumSet
 import kotlin.reflect.KParameter
 import kotlin.reflect.full.createInstance
 import kotlin.reflect.jvm.kotlinFunction

--- a/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidator.kt
+++ b/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidator.kt
@@ -19,7 +19,7 @@ internal class EndpointNameConflictValidator(private val clazz: Class<out RestRe
     companion object {
         fun error(path: String?, type: EndpointType, method: Method, conflictingMethod: Method): String =
             "Duplicate endpoint path '$path' with $type HTTP method in '${method.declaringClass.simpleName}.${method.name}' " +
-                    "for version range (${method.restApiVersions.minVersion} -> ${method.restApiVersions.maxVersion})." +
+                    "for version range (${method.restApiVersions.minVersion} -> ${method.restApiVersions.maxVersion}). " +
                     "Conflicting method: '${conflictingMethod.declaringClass.simpleName}.${conflictingMethod.name}' " +
                     "with versions (${conflictingMethod.restApiVersions.minVersion} -> ${conflictingMethod.restApiVersions.maxVersion})."
     }

--- a/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidator.kt
+++ b/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidator.kt
@@ -1,10 +1,12 @@
 package net.corda.rest.tools.annotations.validation
 
 import net.corda.rest.RestResource
+import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.tools.annotations.validation.utils.EndpointType
 import net.corda.rest.tools.annotations.validation.utils.endpointPath
 import net.corda.rest.tools.annotations.validation.utils.endpointType
 import net.corda.rest.tools.annotations.validation.utils.endpoints
+import net.corda.rest.tools.annotations.validation.utils.restApiVersions
 import java.lang.reflect.Method
 
 /**
@@ -15,28 +17,36 @@ internal class EndpointNameConflictValidator(private val clazz: Class<out RestRe
 
     companion object {
         fun error(path: String?, type: EndpointType, method: Method): String =
-            "Duplicate endpoint path '$path' for $type HTTP method in '${method.declaringClass.simpleName}.${method.name}'."
+            "Duplicate endpoint path '$path' with $type HTTP method for version range (${method.restApiVersions.minVersion} -> " +
+                    "${method.restApiVersions.maxVersion}) in '${method.declaringClass.simpleName}.${method.name}'."
     }
 
     override fun validate(): RestValidationResult = validateSameTypeEndpoints(clazz.endpoints)
 
-    private fun validateSameTypeEndpoints(endpoints: List<Method>): RestValidationResult {
-        val pathsToTypes = mutableSetOf<Pair<String?, EndpointType>>()
-        return endpoints.fold(RestValidationResult()) { total, method ->
-            val endpointType = method.endpointType
-            total + pathsToTypes.validateNoDuplicatePath(method, endpointType)
+    private data class VersionRange(val minVersion: RestApiVersion, val maxVersion: RestApiVersion) {
+        fun overlapsWith(other: VersionRange): Boolean {
+            return other.minVersion <= maxVersion && other.maxVersion >= minVersion
         }
     }
 
-    private fun MutableSet<Pair<String?, EndpointType>>.validateNoDuplicatePath(
+    private fun validateSameTypeEndpoints(endpoints: List<Method>): RestValidationResult {
+        val pathsAndTypesToVersions = mutableMapOf<Pair<String?, EndpointType>, MutableList<VersionRange>>()
+        return endpoints.fold(RestValidationResult()) { total, method ->
+            val endpointType = method.endpointType
+            total + pathsAndTypesToVersions.validateNoDuplicatePath(method, endpointType)
+        }
+    }
+
+    private fun MutableMap<Pair<String?, EndpointType>, MutableList<VersionRange>>.validateNoDuplicatePath(
         method: Method,
         type: EndpointType
     ): RestValidationResult {
         val path = method.endpointPath(type)?.lowercase()
-        return if (this.contains(path to type)) {
+        val newVersionRange = VersionRange(method.restApiVersions.minVersion, method.restApiVersions.maxVersion)
+        return if (this[path to type]?.any { it.overlapsWith(newVersionRange) } == true) {
             RestValidationResult(listOf(error(path, type, method)))
         } else {
-            this.add(path to type)
+            this.getOrPut(path to type) { mutableListOf() }.add(newVersionRange)
             RestValidationResult()
         }
     }

--- a/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidatorTest.kt
+++ b/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidatorTest.kt
@@ -190,7 +190,11 @@ class EndpointNameConflictValidatorTest {
 
         val result = RestInterfaceValidator.validate(TestInterface::class.java)
 
-        assertThat(result.errors).hasSize(1).contains(error("null", EndpointType.GET, TestInterface::test2.javaMethod!!, TestInterface::test.javaMethod!!))
+        assertThat(result.errors)
+            .hasSize(1)
+            .contains(
+                error("null", EndpointType.GET, TestInterface::test2.javaMethod!!, TestInterface::test.javaMethod!!)
+            )
     }
 
     @Test

--- a/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidatorTest.kt
+++ b/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidatorTest.kt
@@ -11,6 +11,7 @@ import net.corda.rest.tools.annotations.validation.utils.EndpointType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import kotlin.reflect.jvm.javaGetter
 import kotlin.reflect.jvm.javaMethod
 
 class EndpointNameConflictValidatorTest {
@@ -48,7 +49,8 @@ class EndpointNameConflictValidatorTest {
 
         val result = EndpointNameConflictValidator(TestInterface::class.java).validate()
 
-        assertEquals(listOf(error("/test", EndpointType.GET, TestInterface::test2.javaMethod!!)), result.errors)
+        val expectedError = error("/test", EndpointType.GET, TestInterface::test2.javaMethod!!, TestInterface::test.javaMethod!!)
+        assertEquals(listOf(expectedError), result.errors)
     }
 
     @Test
@@ -66,7 +68,8 @@ class EndpointNameConflictValidatorTest {
 
         val result = EndpointNameConflictValidator(TestInterface::class.java).validate()
 
-        assertEquals(listOf(error("/test", EndpointType.GET, TestInterface::test2.javaMethod!!)), result.errors)
+        val expectedError = error("/test", EndpointType.GET, TestInterface::test2.javaMethod!!, TestInterface::test.javaMethod!!)
+        assertEquals(listOf(expectedError), result.errors)
     }
 
     @Test
@@ -84,7 +87,8 @@ class EndpointNameConflictValidatorTest {
 
         val result = EndpointNameConflictValidator(TestInterface::class.java).validate()
 
-        assertEquals(listOf(error("/test", EndpointType.GET, TestInterface::test2.javaMethod!!)), result.errors)
+        val expectedError = error("/test", EndpointType.GET, TestInterface::test2.javaMethod!!, TestInterface::test.javaMethod!!)
+        assertEquals(listOf(expectedError), result.errors)
     }
 
     @Test
@@ -102,7 +106,7 @@ class EndpointNameConflictValidatorTest {
 
         val result = EndpointNameConflictValidator(TestInterface::class.java).validate()
 
-        assertEquals(0, result.errors.size)
+        assertEquals(emptyList<String>(), result.errors)
     }
 
     @Test
@@ -142,7 +146,8 @@ class EndpointNameConflictValidatorTest {
         val result = EndpointNameConflictValidator(TestInterface::class.java).validate()
 
         assertThat(result.errors).hasSize(2).allMatch { error ->
-            error == error("test", EndpointType.GET, TestInterface::class.java.methods.first { it.name == "test" }) }
+            error == error("test", EndpointType.GET, TestInterface::class.java.methods.first { it.name == "test" },
+                TestInterface::class.java.methods.last { it.name == "test" })}
     }
 
     @Test
@@ -159,7 +164,7 @@ class EndpointNameConflictValidatorTest {
 
         val result = RestInterfaceValidator.validate(TestInterface::class.java)
 
-        assertThat(result.errors).hasSize(1).contains(error("null", EndpointType.GET, TestInterface::test2.javaMethod!!))
+        assertThat(result.errors).hasSize(1).contains(error("null", EndpointType.GET, TestInterface::test2.javaMethod!!, TestInterface::test.javaMethod!!))
     }
 
     @Test
@@ -186,9 +191,9 @@ class EndpointNameConflictValidatorTest {
         val result = RestInterfaceValidator.validate(TestInterface::class.java)
 
         assertThat(result.errors).hasSize(3).contains(
-            error("test", EndpointType.GET, TestInterface::test2.javaMethod!!),
-            error("test", EndpointType.GET, TestInterface::test3.javaMethod!!),
-            error("test", EndpointType.GET, TestInterface::test4.javaMethod!!)
+            error("test", EndpointType.GET, TestInterface::test2.javaMethod!!, TestInterface::teSt.javaMethod!!),
+            error("test", EndpointType.GET, TestInterface::test3.javaMethod!!, TestInterface::teSt.javaMethod!!),
+            error("test", EndpointType.GET, TestInterface::test4.javaMethod!!, TestInterface::teSt.javaMethod!!)
         )
     }
 
@@ -208,7 +213,7 @@ class EndpointNameConflictValidatorTest {
         val result = RestInterfaceValidator.validate(TestInterface::class.java)
 
         assertThat(result.errors).hasSize(1).contains(error("getprotocolversion", EndpointType.GET,
-            TestInterface::test.javaMethod!!))
+            TestInterface::test.javaMethod!!, RestResource::protocolVersion.javaGetter!!))
     }
 
     @Test
@@ -236,7 +241,7 @@ class EndpointNameConflictValidatorTest {
 
         assertThat(result.errors).hasSize(2).
             contains(
-                error("null", EndpointType.GET, TestInterface::test2.javaMethod!!),
-                error("null", EndpointType.POST, TestInterface::test4.javaMethod!!))
+                error("null", EndpointType.GET, TestInterface::test2.javaMethod!!, TestInterface::test.javaMethod!!),
+                error("null", EndpointType.POST, TestInterface::test4.javaMethod!!, TestInterface::test3.javaMethod!!))
     }
 }

--- a/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidatorTest.kt
+++ b/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/EndpointNameConflictValidatorTest.kt
@@ -5,6 +5,7 @@ import net.corda.rest.annotations.HttpGET
 import net.corda.rest.annotations.HttpPOST
 import net.corda.rest.annotations.RestQueryParameter
 import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.tools.annotations.validation.EndpointNameConflictValidator.Companion.error
 import net.corda.rest.tools.annotations.validation.utils.EndpointType
 import org.assertj.core.api.Assertions.assertThat
@@ -15,7 +16,25 @@ import kotlin.reflect.jvm.javaMethod
 class EndpointNameConflictValidatorTest {
 
     @Test
-    fun `validate withEndpointNameConflictOnSamePath errorListContainsError`() {
+    fun `validate withEndpointNameConflictOnSamePathDifferentVersions errorListIsEmpty`() {
+        @HttpRestResource
+        abstract class TestInterface : RestResource {
+            @HttpGET("/test", maxVersion= RestApiVersion.C5_0)
+            @Suppress("unused")
+            abstract fun test()
+
+            @HttpGET("/test", minVersion= RestApiVersion.C5_1)
+            @Suppress("unused")
+            abstract fun test2()
+        }
+
+        val result = EndpointNameConflictValidator(TestInterface::class.java).validate()
+
+        assertEquals(0, result.errors.size)
+    }
+
+    @Test
+    fun `validate withEndpointNameConflictOnSamePathSameVersions errorListContainsError`() {
         @HttpRestResource
         abstract class TestInterface : RestResource {
             @HttpGET("/test")

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/annotations/RestApiVersion.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/annotations/RestApiVersion.kt
@@ -1,5 +1,7 @@
 package net.corda.rest.annotations
 
+import java.util.EnumSet
+
 /**
  * Enum representing a registry of REST API versions.
  * It must be updated with any new Corda version for new path to become available.
@@ -12,4 +14,21 @@ enum class RestApiVersion(val versionPath: String, val parentVersion: RestApiVer
 
     // Whenever new version is added, please re-visit `HttpResource.kt` and `RestEndpoint.kt` to change default
     // version aliases.
+}
+
+fun retrieveApiVersionsSet(minVersion: RestApiVersion, maxVersion: RestApiVersion): Set<RestApiVersion> {
+    val result = EnumSet.noneOf(RestApiVersion::class.java)
+
+    var current: RestApiVersion? = maxVersion
+    while (current != null) {
+        result.add(current)
+
+        // Check if we have reached the bottom
+        if (current == minVersion) {
+            break
+        }
+
+        current = current.parentVersion
+    }
+    return result
 }


### PR DESCRIPTION
This relaxes the requirements in EndpointNameConflictValidator to allow endpoints with the same path and endpoint type if they have different, non overlapping versions. 