### PR TITLE
CORE-15389: Populate the X509 name field if the cert verification fails

### DIFF
--- a/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/VerifyCertificates.kt
+++ b/libs/packaging/packaging-verify/src/main/kotlin/net/corda/libs/packaging/verify/VerifyCertificates.kt
@@ -53,12 +53,16 @@ internal fun validateCertPath(
         certPathValidator.validate(certPath, params)
     } catch (e: CertPathValidatorException) {
         val index: String; val cert: X509Certificate?
+
+        // If CertPathValidatorException is thrown, it MAY include the index of the cert which caused the exception
+        // but is also does not have to. We should not rely on it too much.
         if (e.index >= 0) {
             index = ", certificate at index [${e.index}]"
             cert = certPath.certificates[e.index] as? X509Certificate
         } else {
             index = ""
-            cert = if (certPath.certificates.size == 1) certPath.certificates.first() as? X509Certificate else null
+            // We do not know which certificate exactly caused the exception, show the details of the first one
+            cert = if (certPath.certificates.size >= 1) certPath.certificates.first() as? X509Certificate else null
         }
 
         val name = cert?.subjectX500Principal?.name


### PR DESCRIPTION
The signature of the notary CPB now includes the certificate chain.
We were relying on the fact that if the validation of the certificate fails, if shows the index of the certificate which failed the validation. Unfortunately the documentation says, it MAY include this index, but it doesn't have to. So we can't rely on that information. 
We now instead always print the X509 name of the first certificate in the chain if the index is not set.