### PR TITLE
CORE-15354 - Improve reason for failed registration in case of timeout

### DIFF
--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsAsyncProcessor.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsAsyncProcessor.kt
@@ -196,10 +196,10 @@ internal class MemberOpsAsyncProcessor(
         val cause = state?.cause
         if (cause is SentToMgmWaitingForNetwork) {
             if (cause.stopRetriesAfter.isBefore(clock.instant())) {
-                val message = "Registration request ${state.request} was not received by the MGM after many attempts."
+                val message = "Registration request was not acknowledged as received by the MGM after many attempts to send it."
                 logger.warn(
-                    "Registration request ${state.request} was not received by the MGM after many attempts." +
-                        "Will not retry it.",
+                    "Registration request ${state.request.requestId} was not acknowledged as received by the MGM " +
+                            "after many attempts to send it. No more retries will be attempted and the request will be marked as FAILED.",
                 )
                 return persistAndCreateFailureWithoutRetryResponse(
                     holdingIdentity,

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsAsyncProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsAsyncProcessorTest.kt
@@ -45,6 +45,8 @@ class MemberOpsAsyncProcessorTest {
     private companion object {
         const val FAILURE_REASON = "oops"
         const val SERIAL = 1L
+        const val TIMEOUT_REQUEST_FAILED_REASON =
+            "Registration request was not acknowledged as received by the MGM after many attempts to send it."
     }
 
     private val shortHash = ShortHash.of("123123123123")
@@ -242,6 +244,8 @@ class MemberOpsAsyncProcessorTest {
                         null,
                     ),
                 )
+            verify(membershipPersistenceClient)
+                .setRegistrationRequestStatus(identity, id.toString(), RegistrationStatus.FAILED, TIMEOUT_REQUEST_FAILED_REASON)
         }
 
         @Test


### PR DESCRIPTION
In cases where a member didn't get any update from the MGM for a registration request, the reason was including the full registration request that was then getting cropped, so it wasn't clear what the reason was. Cleaned up the message and clarified it a bit to make it a bit easier for the user to understand. 