### PR TITLE
CORE-15389: Add test to verify the message if root CA is incorrect in verification

### DIFF
--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2VerifierTest.kt
@@ -79,7 +79,8 @@ class CpbV2VerifierTest {
         val exception = assertThrows<CertPathValidatorException> {
             verify(cpb, setOf(CA1))
         }
-        assertEquals("Error validating code signer's certificate path, X.509 name: CN=Corda Dev Root CA,OU=R3,O=Corda,L=Dublin,C=IE. Path does not chain with any of the trust anchors", exception.message)
+        assertEquals("Error validating code signer's certificate path, X.509 name: CN=Corda Dev Root CA,OU=R3," +
+                "O=Corda,L=Dublin,C=IE. Path does not chain with any of the trust anchors", exception.message)
     }
 
     @Test

--- a/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2VerifierTest.kt
+++ b/libs/packaging/packaging-verify/src/test/kotlin/net/corda/libs/packaging/verify/internal/cpb/CpbV2VerifierTest.kt
@@ -7,7 +7,9 @@ import net.corda.libs.packaging.core.exception.InvalidSignatureException
 import net.corda.libs.packaging.testutils.TestUtils
 import net.corda.libs.packaging.testutils.TestUtils.ALICE
 import net.corda.libs.packaging.testutils.TestUtils.BOB
+import net.corda.libs.packaging.testutils.TestUtils.CA1
 import net.corda.libs.packaging.testutils.TestUtils.ROOT_CA
+import net.corda.libs.packaging.testutils.TestUtils.ROOT_CA_SIGNER
 import net.corda.libs.packaging.testutils.TestUtils.addFile
 import net.corda.libs.packaging.testutils.TestUtils.base64ToBytes
 import net.corda.libs.packaging.testutils.TestUtils.signedBy
@@ -26,11 +28,13 @@ import java.io.BufferedReader
 import java.io.ByteArrayInputStream
 import java.security.DigestInputStream
 import java.security.MessageDigest
+import java.security.cert.CertPathValidatorException
+import java.security.cert.X509Certificate
 
 class CpbV2VerifierTest {
-    private fun verify(cpb: InMemoryZipFile) {
+    private fun verify(cpb: InMemoryZipFile, trustedCerts: Collection<X509Certificate> = setOf(ROOT_CA)) {
         cpb.use {
-            CpbV2Verifier(JarReader("test.cpb", cpb.inputStream(), setOf(ROOT_CA))).verify()
+            CpbV2Verifier(JarReader("test.cpb", cpb.inputStream(), trustedCerts)).verify()
         }
     }
 
@@ -53,6 +57,29 @@ class CpbV2VerifierTest {
             verify(cpb)
         }
         assertEquals("File testCpk1-1.0.0.0.jar is not signed in package \"test.cpb\"", exception.message)
+    }
+
+    @Test
+    fun `successfully verifies if CPB signed by correct Root CA`() {
+        val cpb = TestCpbV2Builder()
+            .signers(ALICE, ROOT_CA_SIGNER)
+            .build()
+
+        assertDoesNotThrow {
+            verify(cpb, setOf(ROOT_CA))
+        }
+    }
+
+    @Test
+    fun `throws if CPB signed by different Root CA`() {
+        val cpb = TestCpbV2Builder()
+            .signers(ALICE, ROOT_CA_SIGNER)
+            .build()
+
+        val exception = assertThrows<CertPathValidatorException> {
+            verify(cpb, setOf(CA1))
+        }
+        assertEquals("Error validating code signer's certificate path, X.509 name: CN=Corda Dev Root CA,OU=R3,O=Corda,L=Dublin,C=IE. Path does not chain with any of the trust anchors", exception.message)
     }
 
     @Test

--- a/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/TestUtils.kt
+++ b/testing/packaging-test-utilities/src/main/kotlin/net/corda/libs/packaging/testutils/TestUtils.kt
@@ -23,8 +23,9 @@ object TestUtils {
     val KEY_STORE_PASSWORD = KEY_PASSWORD
     val ALICE = Signer("alice", privateKeyEntry("alice", resourceInputStream("alice.p12")))
     val BOB = Signer("bob", privateKeyEntry("bob", resourceInputStream("bob.p12")))
+    val ROOT_CA_SIGNER = Signer("rootca", privateKeyEntry("rootca", resourceInputStream("rootca.p12")))
     val ROOT_CA = certificate("rootca", resourceInputStream("rootca.p12"))
-    internal val CA1 = certificate("ca1", resourceInputStream("ca1.p12"))
+    val CA1 = certificate("ca1", resourceInputStream("ca1.p12"))
     internal val CA2 = certificate("ca2", resourceInputStream("ca2.p12"))
     internal val CODE_SIGNER_ALICE = codeSigner("alice", resourceInputStream("alice.p12"))
     const val EXTERNAL_CHANNELS_CONFIG_FILE_CONTENT = "{}"


### PR DESCRIPTION
New tests:
- Valid scenario when root CA is included in the signature of CPB.
- Negative scenario when different root CA is used to verify the signature of CPB which was signed with another root CA. It also checks the error message. 