### PR TITLE
CORE-15077 - Improve reason messages when key IDs are invalid

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/ContextUtils.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/ContextUtils.kt
@@ -1,0 +1,9 @@
+package net.corda.membership.impl.registration.dynamic.mgm
+
+import net.corda.membership.lib.MemberInfoExtension
+
+class ContextUtils {
+    companion object {
+        val sessionKeyRegex = String.format("${MemberInfoExtension.PARTY_SESSION_KEYS}.id", "[0-9]+").toRegex()
+    }
+}

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/ContextUtils.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/ContextUtils.kt
@@ -2,8 +2,6 @@ package net.corda.membership.impl.registration.dynamic.mgm
 
 import net.corda.membership.lib.MemberInfoExtension
 
-class ContextUtils {
-    companion object {
-        val sessionKeyRegex = String.format("${MemberInfoExtension.PARTY_SESSION_KEYS}.id", "[0-9]+").toRegex()
-    }
+internal object ContextUtils {
+    val sessionKeyRegex = String.format("${MemberInfoExtension.PARTY_SESSION_KEYS}.id", "[0-9]+").toRegex()
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidator.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidator.kt
@@ -3,7 +3,7 @@ package net.corda.membership.impl.registration.dynamic.mgm
 import net.corda.configuration.read.ConfigurationGetService
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.ShortHashException
-import net.corda.membership.impl.registration.dynamic.mgm.ContextUtils.Companion.sessionKeyRegex
+import net.corda.membership.impl.registration.dynamic.mgm.ContextUtils.sessionKeyRegex
 import net.corda.membership.impl.registration.dynamic.verifiers.OrderVerifier
 import net.corda.membership.impl.registration.dynamic.verifiers.P2pEndpointVerifier
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.TlsType

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidator.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidator.kt
@@ -1,6 +1,9 @@
 package net.corda.membership.impl.registration.dynamic.mgm
 
 import net.corda.configuration.read.ConfigurationGetService
+import net.corda.crypto.core.ShortHash
+import net.corda.crypto.core.ShortHashException
+import net.corda.membership.impl.registration.dynamic.mgm.ContextUtils.Companion.sessionKeyRegex
 import net.corda.membership.impl.registration.dynamic.verifiers.OrderVerifier
 import net.corda.membership.impl.registration.dynamic.verifiers.P2pEndpointVerifier
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.TlsType
@@ -93,6 +96,7 @@ internal class MGMRegistrationContextValidator(
             context[key] ?: throw IllegalArgumentException(errorMessageMap[key])
         }
         validateProtocols(context)
+        validateKeys(context)
         p2pEndpointVerifier.verifyContext(context)
         if (context[PKI_SESSION] != NO_PKI.toString()) {
             context.keys.filter { TRUSTSTORE_SESSION.format("[0-9]+").toRegex().matches(it) }.apply {
@@ -135,6 +139,26 @@ internal class MGMRegistrationContextValidator(
         if (context[SYNCHRONISATION_PROTOCOL] !in SUPPORTED_SYNC_PROTOCOLS) {
             throw MGMRegistrationContextValidationException("Invalid value for key $SYNCHRONISATION_PROTOCOL in registration context. " +
                     "It should be one of the following values: $SUPPORTED_SYNC_PROTOCOLS.", null)
+        }
+    }
+
+    private fun validateKeys(context: Map<String, String>) {
+        val ecdhKeyId = context[ECDH_KEY_ID]
+        require(ecdhKeyId != null) { "No ECDH key ID was provided under $ECDH_KEY_ID." }
+        validateKey(ECDH_KEY_ID, ecdhKeyId)
+
+        context.filterKeys { key ->
+            sessionKeyRegex.matches(key)
+        }.forEach {
+            validateKey(it.key, it.value)
+        }
+    }
+
+    private fun validateKey(contextKey: String, keyId: String) {
+        try {
+            ShortHash.parse(keyId)
+        } catch (e: ShortHashException) {
+            throw MGMRegistrationContextValidationException("Invalid value for key ID $contextKey. ${e.message}", e)
         }
     }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -10,7 +10,7 @@ import net.corda.crypto.core.fullId
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.libs.platform.PlatformInfoProvider
-import net.corda.membership.impl.registration.dynamic.mgm.ContextUtils.Companion.sessionKeyRegex
+import net.corda.membership.impl.registration.dynamic.mgm.ContextUtils.sessionKeyRegex
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationMemberInfoHandler.kt
@@ -10,6 +10,7 @@ import net.corda.crypto.core.fullId
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.membership.impl.registration.dynamic.mgm.ContextUtils.Companion.sessionKeyRegex
 import net.corda.membership.lib.MemberInfoExtension.Companion.CREATION_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.ECDH_KEY
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
@@ -20,7 +21,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
-import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS_PEM
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
@@ -56,7 +56,6 @@ internal class MGMRegistrationMemberInfoHandler(
         const val SERIAL_CONST = "1"
         val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         val keyIdList = listOf(SESSION_KEYS, ECDH_KEY_ID)
-        val sessionKeyRegex = String.format("$PARTY_SESSION_KEYS.id", "[0-9]+").toRegex()
     }
 
     @Throws(MGMRegistrationMemberInfoHandlingException::class)

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -152,6 +152,9 @@ class DynamicMemberRegistrationServiceTest {
         val MEMBER_CONTEXT_BYTES = "2222".toByteArray()
         val REQUEST_BYTES = "3333".toByteArray()
         val UNAUTH_REQUEST_BYTES = "4444".toByteArray()
+        const val SESSION_KEY_ID_KEY = "corda.session.keys.0.id"
+        const val LEDGER_KEY_ID_KEY = "corda.ledger.keys.0.id"
+        const val NOTARY_KEY_ID_KEY = "corda.notary.keys.0.id"
     }
 
     private val ecdhKey: PublicKey = mock()
@@ -362,11 +365,11 @@ class DynamicMemberRegistrationServiceTest {
     )
 
     private val context = mapOf(
-        "corda.session.keys.0.id" to SESSION_KEY_ID,
+        SESSION_KEY_ID_KEY to SESSION_KEY_ID,
         SESSION_KEYS_SIGNATURE_SPEC.format(0) to SignatureSpecs.ECDSA_SHA512.signatureName,
         URL_KEY.format(0) to "https://localhost:1080",
         PROTOCOL_VERSION.format(0) to "1",
-        "corda.ledger.keys.0.id" to LEDGER_KEY_ID,
+        LEDGER_KEY_ID_KEY to LEDGER_KEY_ID,
         LEDGER_KEY_SIGNATURE_SPEC.format(0) to SignatureSpecs.ECDSA_SHA512.signatureName,
         PRE_AUTH_TOKEN to UUID(0, 1).toString(),
         "$CUSTOM_KEY_PREFIX.0" to "test",
@@ -494,11 +497,11 @@ class DynamicMemberRegistrationServiceTest {
         @Test
         fun `registration request contains serial from registration context when included`() {
             val context = mapOf(
-                "corda.session.keys.0.id" to SESSION_KEY_ID,
+                SESSION_KEY_ID_KEY to SESSION_KEY_ID,
                 "corda.session.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
                 "corda.endpoints.0.connectionURL" to "https://localhost:1080",
                 "corda.endpoints.0.protocolVersion" to "1",
-                "corda.ledger.keys.0.id" to LEDGER_KEY_ID,
+                LEDGER_KEY_ID_KEY to LEDGER_KEY_ID,
                 "corda.ledger.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
                 "corda.serial" to "12"
             )
@@ -641,7 +644,7 @@ class DynamicMemberRegistrationServiceTest {
             val context = mapOf(
                 "corda.endpoints.0.connectionURL" to "https://localhost:1080",
                 "corda.endpoints.0.protocolVersion" to "1",
-                "corda.ledger.keys.0.id" to LEDGER_KEY_ID,
+                LEDGER_KEY_ID_KEY to LEDGER_KEY_ID,
                 "corda.ledger.keys.0.signature.spec" to SignatureSpecs.ECDSA_SHA512.signatureName,
             ) +
                 keys.map { "corda.session.keys.${it.index}.id" to it.keyId.value } +
@@ -731,10 +734,10 @@ class DynamicMemberRegistrationServiceTest {
         @ParameterizedTest
         @ValueSource(
             strings = arrayOf(
-                "corda.session.keys.0.id",
+                SESSION_KEY_ID_KEY,
                 "corda.endpoints.0.connectionURL",
                 "corda.endpoints.0.protocolVersion",
-                "corda.ledger.keys.0.id",
+                LEDGER_KEY_ID_KEY,
             )
         )
         fun `registration fails when one context property is missing`(propertyName: String) {
@@ -782,7 +785,7 @@ class DynamicMemberRegistrationServiceTest {
         fun `registration request fails when the session keys are missing`() {
             postConfigChangedEvent()
             registrationService.start()
-            val badContext = context - "corda.session.keys.0.id"
+            val badContext = context - SESSION_KEY_ID_KEY
 
             val exception = assertThrows<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, badContext)
@@ -790,6 +793,54 @@ class DynamicMemberRegistrationServiceTest {
 
             assertThat(exception).hasMessageContaining("No session key ID was provided")
         }
+
+        @Test
+        fun `registration request fails when the session keys are invalid`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            val contextWithInvalidSessionKey = context.plus(SESSION_KEY_ID_KEY to " ")
+
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, contextWithInvalidSessionKey)
+            }
+
+            assertThat(exception).hasMessageContaining("Invalid value for key ID $SESSION_KEY_ID_KEY.")
+            assertThat(exception).hasMessageContaining("Hex string has length of 1 but should be 12 characters")
+        }
+
+        @Test
+        fun `registration request fails when the ledger key is invalid`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            val contextWithInvalidLedgerKey = context.plus(LEDGER_KEY_ID_KEY to " ")
+
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, contextWithInvalidLedgerKey)
+            }
+
+            assertThat(exception).hasMessageContaining("Invalid value for key ID $LEDGER_KEY_ID_KEY.")
+            assertThat(exception).hasMessageContaining("Hex string has length of 1 but should be 12 characters")
+        }
+
+        @Test
+        fun `registration request fails when the notary key is invalid`() {
+            postConfigChangedEvent()
+            registrationService.start()
+            val contextWithInvalidNotaryKey = context + mapOf(
+                String.format(ROLES_PREFIX, 0) to "notary",
+                NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+                NOTARY_KEY_ID_KEY to " ",
+            )
+
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, contextWithInvalidNotaryKey)
+            }
+
+            assertThat(exception).hasMessageContaining("Invalid value for key ID $NOTARY_KEY_ID_KEY.")
+            assertThat(exception).hasMessageContaining("Hex string has length of 1 but should be 12 characters")
+        }
+
+
 
         @Test
         fun `registration fails if custom field validation fails`() {
@@ -966,7 +1017,7 @@ class DynamicMemberRegistrationServiceTest {
                 on { entries } doReturn previousRegistrationContext.entries + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
-                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                    NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 ).entries
             }
             val newContext = mock<MemberContext> {
@@ -1018,7 +1069,7 @@ class DynamicMemberRegistrationServiceTest {
             val newContextEntries = context.toMutableMap().apply {
                 put(String.format(ROLES_PREFIX, 0), "notary")
                 put(NOTARY_SERVICE_NAME, "O=MyNotaryService, L=London, C=GB")
-                put("corda.notary.keys.0.id",  NOTARY_KEY_ID)
+                put(NOTARY_KEY_ID_KEY,  NOTARY_KEY_ID)
             }.entries
             val newContext = mock<MemberContext> {
                 on { entries } doReturn newContextEntries
@@ -1069,7 +1120,7 @@ class DynamicMemberRegistrationServiceTest {
                 context + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
-                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                    NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
 
             assertDoesNotThrow {
@@ -1084,7 +1135,7 @@ class DynamicMemberRegistrationServiceTest {
                 context + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
-                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                    NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
 
             assertThrows<InvalidMembershipRegistrationException> {
@@ -1100,7 +1151,7 @@ class DynamicMemberRegistrationServiceTest {
                 context + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
-                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                    NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
 
             registrationService.register(registrationResultId, member, testProperties)
@@ -1108,7 +1159,7 @@ class DynamicMemberRegistrationServiceTest {
             assertThat(memberContext.firstValue.toMap())
                 .containsEntry(String.format(ROLES_PREFIX, 0), "notary")
                 .containsKey(NOTARY_SERVICE_NAME)
-                .containsEntry("corda.notary.keys.0.id", NOTARY_KEY_ID)
+                .containsEntry(NOTARY_KEY_ID_KEY, NOTARY_KEY_ID)
                 .containsEntry(String.format(NOTARY_KEY_PEM, 0), "1234")
                 .containsKey(String.format(NOTARY_KEY_HASH, 0))
                 .containsEntry(String.format(NOTARY_KEY_SPEC, 0), SignatureSpecs.ECDSA_SHA256.signatureName)
@@ -1144,7 +1195,7 @@ class DynamicMemberRegistrationServiceTest {
                 context + mapOf(
                     ROLES_PREFIX to "notary",
                     NOTARY_SERVICE_NAME to "Hello world",
-                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                    NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
 
             assertThrows<InvalidMembershipRegistrationException> {
@@ -1158,7 +1209,7 @@ class DynamicMemberRegistrationServiceTest {
                 context + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
-                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                    NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
 
             assertDoesNotThrow {
@@ -1188,7 +1239,7 @@ class DynamicMemberRegistrationServiceTest {
                     String.format(ROLES_PREFIX, 0) to "notary",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
                     String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS, 5) to "1",
-                    "corda.notary.keys.0.id" to LEDGER_KEY_ID,
+                    NOTARY_KEY_ID_KEY to LEDGER_KEY_ID,
                 )
 
             assertThrows<InvalidMembershipRegistrationException> {
@@ -1203,7 +1254,7 @@ class DynamicMemberRegistrationServiceTest {
                 context.filterNot { it.key.startsWith("corda.ledger") } + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
-                    "corda.notary.keys.0.id" to NOTARY_KEY_ID,
+                    NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
             registrationService.start()
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
@@ -179,9 +179,9 @@ class MGMRegistrationContextValidatorTest {
 
     @Test
     fun `context validation fails when session key ID is invalid`() {
-        val contextWithInvalidProtocol = validTestContext.plus(SESSION_KEY_IDS.format(0) to " ")
+        val contextWithInvalidSessionKey = validTestContext.plus(SESSION_KEY_IDS.format(0) to " ")
         val exception = assertThrows<MGMRegistrationContextValidationException> {
-            mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)
+            mgmRegistrationContextValidator.validate(contextWithInvalidSessionKey)
         }
         assertThat(exception).hasMessageContaining("Invalid value for key ID ${SESSION_KEY_IDS.format(0)}.")
         assertThat(exception).hasMessageContaining("Hex string has length of 1 but should be 12 characters")
@@ -189,9 +189,9 @@ class MGMRegistrationContextValidatorTest {
 
     @Test
     fun `context validation fails when ECDH key ID is invalid`() {
-        val contextWithInvalidProtocol = validTestContext.plus(ECDH_KEY_ID to " ")
+        val contextWithInvalidECDHKey = validTestContext.plus(ECDH_KEY_ID to " ")
         val exception = assertThrows<MGMRegistrationContextValidationException> {
-            mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)
+            mgmRegistrationContextValidator.validate(contextWithInvalidECDHKey)
         }
         assertThat(exception).hasMessageContaining("Invalid value for key ID $ECDH_KEY_ID.")
         assertThat(exception).hasMessageContaining("Hex string has length of 1 but should be 12 characters")

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/mgm/MGMRegistrationContextValidatorTest.kt
@@ -54,8 +54,8 @@ class MGMRegistrationContextValidatorTest {
 
         private val validTestContext
             get() = mutableMapOf(
-                SESSION_KEY_IDS.format(0) to "session key",
-                ECDH_KEY_ID to "ECDH key",
+                SESSION_KEY_IDS.format(0) to "6819537D96BB",
+                ECDH_KEY_ID to "EB8B54665D2E",
                 REGISTRATION_PROTOCOL to "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService",
                 SYNCHRONISATION_PROTOCOL to "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
                 P2P_MODE to "P2P mode",
@@ -175,6 +175,26 @@ class MGMRegistrationContextValidatorTest {
             mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)
         }
         assertThat(exception).hasMessageContaining("Invalid value for key $SYNCHRONISATION_PROTOCOL in registration context.")
+    }
+
+    @Test
+    fun `context validation fails when session key ID is invalid`() {
+        val contextWithInvalidProtocol = validTestContext.plus(SESSION_KEY_IDS.format(0) to " ")
+        val exception = assertThrows<MGMRegistrationContextValidationException> {
+            mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)
+        }
+        assertThat(exception).hasMessageContaining("Invalid value for key ID ${SESSION_KEY_IDS.format(0)}.")
+        assertThat(exception).hasMessageContaining("Hex string has length of 1 but should be 12 characters")
+    }
+
+    @Test
+    fun `context validation fails when ECDH key ID is invalid`() {
+        val contextWithInvalidProtocol = validTestContext.plus(ECDH_KEY_ID to " ")
+        val exception = assertThrows<MGMRegistrationContextValidationException> {
+            mgmRegistrationContextValidator.validate(contextWithInvalidProtocol)
+        }
+        assertThat(exception).hasMessageContaining("Invalid value for key ID $ECDH_KEY_ID.")
+        assertThat(exception).hasMessageContaining("Hex string has length of 1 but should be 12 characters")
     }
 
     @Test


### PR DESCRIPTION
## Changes
When key IDs specified during registration were invalid, the registration request was switched to `FAILED`. With these 
changes, the registration will be switched to `INVALID` instead and the reason message will be slightly more explanatory. 

## Testing
I added unit tests, but also tested e2e by adjusting the MGM plugin to send registrations with invalid keys.
Before:
![before](https://github.com/corda/corda-runtime-os/assets/6065016/5b1740b2-8e54-40be-ad17-1e2af52187bc)
```
{
  "registrationId": "c59cd06b-5ae6-47dc-bbe6-ca4bbc939921",
  "registrationSent": "2023-07-12T08:30:14.862Z",
  "registrationUpdated": "2023-07-12T08:32:13.330Z",
  "registrationStatus": "FAILED",
  "memberInfoSubmitted": {
    "data": {
      "registrationProtocolVersion": "1",
      "corda.session.keys.0.id": "2262409CED52",
      "corda.ecdh.key.id": "",
      "corda.group.protocol.registration": "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService",
      "corda.group.protocol.synchronisation": "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
      "corda.group.protocol.p2p.mode": "Authenticated_Encryption",
      "corda.group.key.session.policy": "Distinct",
      "corda.group.tls.type": "OneWay",
      "corda.group.pki.session": "NoPKI",
      "corda.group.pki.tls": "Standard",
      "corda.group.tls.version": "1.3",
      "corda.endpoints.0.connectionURL": "https://localhost:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "corda.group.trustroot.tls.0": "-----BEGIN CERTIFICATE-----\nMIID1zCCAj+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAeMQswCQYDVQQGEwJVSzEP\nMA0GA1UEAwwGcjMuY29tMB4XDTIzMDcwNzA5NDgxOVoXDTIzMDgwNjA5NDgxOVow\nHjELMAkGA1UEBhMCVUsxDzANBgNVBAMMBnIzLmNvbTCCAaIwDQYJKoZIhvcNAQEB\nBQADggGPADCCAYoCggGBAJPv9DK4SDMiTeMTNNdFKReChlLr06l8Pzj9KimQCXDG\noob89WAvVmxLOF7Wl4Tdgg+vBhkbP2F96mS2rYm9p5e6tPAo3EFaP07tUEp6raMz\nKeptw8emFFkmg24ORSNpSy6sIC2lEVC2A7R00+z2BeNc7HH67QR2JN7Wrw8rYI+g\nnx2bGNl7o8jZOtlI/r1POjHgXVGmcVJjkH1lxk2E2zC8UW/9Xc94gmHXAd9NkpaT\nTJsuS+wzDGHmQKzmW3O5C+GRlaq3y6j68dA7E1pZurCaxaWY171Cf5bSVZmouXbA\nI4GpQjoPrjqDyIWAjYmtRYpehMWbkNpSPA5TOjfdS5+Yi72mUoHjw+pzzxBf8aZA\nFNtxCArL+nFP5gdx4MDdNdw6u2jevauX/zp9Sq2SrEliSiR2h7PyEVCxymdVvORi\nXQv5IHSk8B5qq1hO4dJdAifbWM2CYNO/uPscWBbWXl8exOX0J8m/oBJoEikXk6WF\nqFxBMzz0H4DYc1xtDC0kewIDAQABoyAwHjAPBgNVHRMBAf8EBTADAQH/MAsGA1Ud\nDwQEAwIBrjANBgkqhkiG9w0BAQsFAAOCAYEAJDrbIM9DEE5IhBT5EoULsYMCkJEN\n/V6CY4YvqB8NdGoPIMWUsJa9mPxaUCS4ote1polciGHEP8P1JYqMmd7FEjSTmpOz\njIRPvqE/tkcBPn+NLWpAW4NPeCRE3CutZSe6Gzp+PLuRN9fknBLhb8cFSKQxbhWv\nVzWtNZveDOTXfS4/PEWzCwvLxn/tMkBweSoTDCaKNkx3rhwjdBKE0WlhoKPwGqF3\n+bmbIdN0llikpEXBWUygkH3YUA+QHhzdvbVZsjOLsfcZyPpNwTjsiMJG4aEYmlE3\ndtKYmnruLeefty1gBMq71ArmRSvaqvKEkA6jL+kAeC6IMLPj6kfZWfHmJCem9t4B\nxYUlfptmdVS5zodaHHL4eb/cL++pkUSQh4sZjBojIGy/5nCCCTcl2iN6s+7YSgkr\nymzdJeLyuzvUR8/MAjQA1nWImXX8H3H38a94Ru5uSr++J5EzkQ+BrKv+K8C8/RUg\nr1pBci/QHNE2u33eJC56pIYavthnDkcDpWnZ\n-----END CERTIFICATE-----\n"
    }
  },
  "reason": "Registration failed. Reason: net.corda.crypto.core.ShortHashException: Hex string has length of 0 but should be 12 characters",
  "serial": null
}
```
After (example from ECDH key):
![after-ecdh](https://github.com/corda/corda-runtime-os/assets/6065016/7707ea46-271e-4261-9311-58ec934891a3)
```
{
  "registrationId": "ad03f700-6aee-4710-92c2-b2d21b939235",
  "registrationSent": "2023-07-12T09:18:44.804Z",
  "registrationUpdated": "2023-07-12T09:18:46.973Z",
  "registrationStatus": "INVALID",
  "memberInfoSubmitted": {
    "data": {
      "registrationProtocolVersion": "1",
      "corda.session.keys.0.id": "9535610CF553",
      "corda.ecdh.key.id": "",
      "corda.group.protocol.registration": "net.corda.membership.impl.registration.dynamic.member.DynamicMemberRegistrationService",
      "corda.group.protocol.synchronisation": "net.corda.membership.impl.synchronisation.MemberSynchronisationServiceImpl",
      "corda.group.protocol.p2p.mode": "Authenticated_Encryption",
      "corda.group.key.session.policy": "Distinct",
      "corda.group.tls.type": "OneWay",
      "corda.group.pki.session": "NoPKI",
      "corda.group.pki.tls": "Standard",
      "corda.group.tls.version": "1.3",
      "corda.endpoints.0.connectionURL": "https://localhost:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "corda.group.trustroot.tls.0": "-----BEGIN CERTIFICATE-----\nMIID1zCCAj+gAwIBAgIBAjANBgkqhkiG9w0BAQsFADAeMQswCQYDVQQGEwJVSzEP\nMA0GA1UEAwwGcjMuY29tMB4XDTIzMDcwNzA5NDgxOVoXDTIzMDgwNjA5NDgxOVow\nHjELMAkGA1UEBhMCVUsxDzANBgNVBAMMBnIzLmNvbTCCAaIwDQYJKoZIhvcNAQEB\nBQADggGPADCCAYoCggGBAJPv9DK4SDMiTeMTNNdFKReChlLr06l8Pzj9KimQCXDG\noob89WAvVmxLOF7Wl4Tdgg+vBhkbP2F96mS2rYm9p5e6tPAo3EFaP07tUEp6raMz\nKeptw8emFFkmg24ORSNpSy6sIC2lEVC2A7R00+z2BeNc7HH67QR2JN7Wrw8rYI+g\nnx2bGNl7o8jZOtlI/r1POjHgXVGmcVJjkH1lxk2E2zC8UW/9Xc94gmHXAd9NkpaT\nTJsuS+wzDGHmQKzmW3O5C+GRlaq3y6j68dA7E1pZurCaxaWY171Cf5bSVZmouXbA\nI4GpQjoPrjqDyIWAjYmtRYpehMWbkNpSPA5TOjfdS5+Yi72mUoHjw+pzzxBf8aZA\nFNtxCArL+nFP5gdx4MDdNdw6u2jevauX/zp9Sq2SrEliSiR2h7PyEVCxymdVvORi\nXQv5IHSk8B5qq1hO4dJdAifbWM2CYNO/uPscWBbWXl8exOX0J8m/oBJoEikXk6WF\nqFxBMzz0H4DYc1xtDC0kewIDAQABoyAwHjAPBgNVHRMBAf8EBTADAQH/MAsGA1Ud\nDwQEAwIBrjANBgkqhkiG9w0BAQsFAAOCAYEAJDrbIM9DEE5IhBT5EoULsYMCkJEN\n/V6CY4YvqB8NdGoPIMWUsJa9mPxaUCS4ote1polciGHEP8P1JYqMmd7FEjSTmpOz\njIRPvqE/tkcBPn+NLWpAW4NPeCRE3CutZSe6Gzp+PLuRN9fknBLhb8cFSKQxbhWv\nVzWtNZveDOTXfS4/PEWzCwvLxn/tMkBweSoTDCaKNkx3rhwjdBKE0WlhoKPwGqF3\n+bmbIdN0llikpEXBWUygkH3YUA+QHhzdvbVZsjOLsfcZyPpNwTjsiMJG4aEYmlE3\ndtKYmnruLeefty1gBMq71ArmRSvaqvKEkA6jL+kAeC6IMLPj6kfZWfHmJCem9t4B\nxYUlfptmdVS5zodaHHL4eb/cL++pkUSQh4sZjBojIGy/5nCCCTcl2iN6s+7YSgkr\nymzdJeLyuzvUR8/MAjQA1nWImXX8H3H38a94Ru5uSr++J5EzkQ+BrKv+K8C8/RUg\nr1pBci/QHNE2u33eJC56pIYavthnDkcDpWnZ\n-----END CERTIFICATE-----\n"
    }
  },
  "reason": "Onboarding MGM failed. Unexpected error occurred during context validation. Invalid value for key ID corda.ecdh.key.id. Hex string has length of 0 but should be 12 characters",
  "serial": null
}
```