### PR TITLE
CORE-9483 Enable sending of primitives across sessions

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -211,7 +211,9 @@ class FlowTests {
         assertThat(flowResult.flowError).isNull()
         assertThat(flowResult.json.command).isEqualTo("flow_session_primitives")
         assertThat(flowResult.json.result)
-            .isEqualTo("${bobX500}=Successfully received 8 items.")
+            .isEqualTo("Successfully received 8 items.\n" +
+                    "Successfully received 8 items from receiveAll.\n" +
+                    "Successfully received 8 items from receiveAllMap.\n")
     }
 
     @Test

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -196,6 +196,25 @@ class FlowTests {
     }
 
     @Test
+    fun `Flow Session - Send and receive primitive values across a session`() {
+        val requestBody = RpcSmokeTestInput().apply {
+            command = "flow_session_primitives"
+            data = mapOf("sessions" to bobX500)
+        }
+
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+
+        val flowResult = awaitRestFlowResult(bobHoldingId, requestId)
+
+        assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(flowResult.json).isNotNull
+        assertThat(flowResult.flowError).isNull()
+        assertThat(flowResult.json.command).isEqualTo("flow_session_primitives")
+        assertThat(flowResult.json.result)
+            .isEqualTo("${bobX500}=Successfully received 8 items.")
+    }
+
+    @Test
     fun `Persistence - persist a single entity`() {
         val id = UUID.randomUUID()
         val flowResult = persistDog(id)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -428,27 +428,6 @@ class FlowTests {
     }
 
     @Test
-    fun `Flow Session - Send and receive primitive values across a session`() {
-        val requestBody = RpcSmokeTestInput().apply {
-            command = "flow_session_primitives"
-            data = mapOf("sessions" to bobX500)
-        }
-
-        val requestId = startRpcFlow(bobHoldingId, requestBody)
-
-        val flowResult = awaitRestFlowResult(bobHoldingId, requestId)
-
-        assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
-        assertThat(flowResult.json).isNotNull
-        assertThat(flowResult.flowError).isNull()
-        assertThat(flowResult.json.command).isEqualTo("flow_session_primitives")
-        assertThat(flowResult.json.result)
-            .isEqualTo("Successfully received 8 items.\n" +
-                    "Successfully received 8 items from receiveAll.\n" +
-                    "Successfully received 8 items from receiveAllMap.\n")
-    }
-
-    @Test
     fun `Crypto - Sign and verify bytes`() {
         val requestBody = RpcSmokeTestInput().apply {
             command = "crypto_sign_and_verify"

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -428,6 +428,27 @@ class FlowTests {
     }
 
     @Test
+    fun `Flow Session - Send and receive primitive values across a session`() {
+        val requestBody = RpcSmokeTestInput().apply {
+            command = "flow_session_primitives"
+            data = mapOf("sessions" to bobX500)
+        }
+
+        val requestId = startRpcFlow(bobHoldingId, requestBody)
+
+        val flowResult = awaitRestFlowResult(bobHoldingId, requestId)
+
+        assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        assertThat(flowResult.json).isNotNull
+        assertThat(flowResult.flowError).isNull()
+        assertThat(flowResult.json.command).isEqualTo("flow_session_primitives")
+        assertThat(flowResult.json.result)
+            .isEqualTo("Successfully received 8 items.\n" +
+                    "Successfully received 8 items from receiveAll.\n" +
+                    "Successfully received 8 items from receiveAllMap.\n")
+    }
+
+    @Test
     fun `Crypto - Sign and verify bytes`() {
         val requestBody = RpcSmokeTestInput().apply {
             command = "crypto_sign_and_verify"

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/PersistenceServiceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/PersistenceServiceImpl.kt
@@ -36,7 +36,6 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun <R : Any> find(entityClass: Class<R>, primaryKey: Any): R? {
-        requireBoxedType(entityClass)
         return wrapWithPersistenceException {
             externalEventExecutor.execute(
                 FindExternalEventFactory::class.java,
@@ -47,7 +46,6 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun <R : Any> find(entityClass: Class<R>, primaryKeys: List<*>): List<R> {
-        requireBoxedType(entityClass)
         return wrapWithPersistenceException {
             externalEventExecutor.execute(
                 FindExternalEventFactory::class.java,
@@ -58,13 +56,11 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun <R : Any> findAll(entityClass: Class<R>): PagedQuery<R> {
-        requireBoxedType(entityClass)
         return pagedQueryFactory.createPagedFindQuery(entityClass)
     }
 
     @Suspendable
     override fun <R : Any> merge(entity: R): R? {
-        requireBoxedType(entity.javaClass)
         return wrapWithPersistenceException {
             externalEventExecutor.execute(
                 MergeExternalEventFactory::class.java,
@@ -76,7 +72,6 @@ class PersistenceServiceImpl @Activate constructor(
     @Suspendable
     override fun <R : Any> merge(entities: List<R>): List<R> {
         return if (entities.isNotEmpty()) {
-            requireBoxedType(entities)
             val mergedEntities = wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     MergeExternalEventFactory::class.java,
@@ -96,7 +91,6 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun persist(entity: Any) {
-        requireBoxedType(entity.javaClass)
         wrapWithPersistenceException {
             externalEventExecutor.execute(
                 PersistExternalEventFactory::class.java,
@@ -108,7 +102,6 @@ class PersistenceServiceImpl @Activate constructor(
     @Suspendable
     override fun persist(entities: List<*>) {
         if (entities.isNotEmpty()) {
-            requireBoxedType(entities)
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     PersistExternalEventFactory::class.java,
@@ -120,7 +113,6 @@ class PersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun remove(entity: Any) {
-        requireBoxedType(entity.javaClass)
         wrapWithPersistenceException {
             externalEventExecutor.execute(
                 RemoveExternalEventFactory::class.java,
@@ -132,7 +124,6 @@ class PersistenceServiceImpl @Activate constructor(
     @Suspendable
     override fun remove(entities: List<*>) {
         if (entities.isNotEmpty()) {
-            requireBoxedType(entities)
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     RemoveExternalEventFactory::class.java,
@@ -147,23 +138,7 @@ class PersistenceServiceImpl @Activate constructor(
         queryName: String,
         entityClass: Class<T>
     ): ParameterizedQuery<T> {
-        requireBoxedType(entityClass)
         return pagedQueryFactory.createNamedParameterizedQuery(queryName, entityClass)
-    }
-
-    /**
-     * Required to prevent class cast exceptions during AMQP serialization of primitive types.
-     */
-    private fun requireBoxedType(type: Class<*>) {
-        require(!type.isPrimitive) { "Cannot perform persistence operation on primitive type ${type.name}" }
-    }
-
-    private fun requireBoxedType(objects: List<*>) {
-        for (obj in objects) {
-            if (obj != null) {
-                requireBoxedType(obj.javaClass)
-            }
-        }
     }
 
     private fun serialize(payload: Any): ByteBuffer {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
@@ -105,7 +105,7 @@ class FlowSessionImpl(
 
         setSessionConfirmed()
 
-        return processReceivedPayload(receiveType, received)
+        return processReceivedPayload(received, receiveType)
     }
 
     @Suspendable
@@ -116,7 +116,7 @@ class FlowSessionImpl(
 
         setSessionConfirmed()
 
-        return processReceivedPayload(receiveType, received)
+        return processReceivedPayload(received, receiveType)
     }
 
     @Suspendable
@@ -142,7 +142,7 @@ class FlowSessionImpl(
         return serializationService.serialize(payload).bytes
     }
 
-    private fun <R : Any> processReceivedPayload(receiveType: Class<R>, received: Map<String, ByteArray>): R {
+    private fun <R : Any> processReceivedPayload(received: Map<String, ByteArray>, receiveType: Class<R>): R {
         return if (receiveType.isPrimitive) {
             deserializeReceivedPayload(received, receiveType.kotlin.javaObjectType)
         } else {

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -116,24 +116,4 @@ public class FlowSessionImplJavaTest {
         when(flowSandboxGroupContext.getCheckpointSerializer()).thenReturn(checkpointSerializer);
         when(flowFiberService.getExecutingFiber()).thenReturn(flowFiber);
     }
-
-    @Test
-    public void passingABoxedTypeToSendAndReceiveWillNotThrowAnException() {
-        session.sendAndReceive(Integer.class, 1);
-    }
-
-    @Test
-    public void passingAPrimitiveReceiveTypeToSendAndReceiveWillThrowAnException() {
-        assertThrows(IllegalArgumentException.class, () -> session.sendAndReceive(int.class, 1));
-    }
-
-    @Test
-    public void passingABoxedTypeToReceiveWillNotThrowAnException() {
-        session.receive(Integer.class);
-    }
-
-    @Test
-    public void passingAPrimitiveReceiveTypeToReceiveWillThrowAnException() {
-        assertThrows(IllegalArgumentException.class, () -> session.receive(int.class));
-    }
 }

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationHelper.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationHelper.kt
@@ -121,7 +121,7 @@ fun requireCordaSerializable(type: Any?) {
             if (!hasCordaSerializable(type.asClass()) && type.asClass() != java.lang.Comparable::class.java) {
                 throw AMQPNotSerializableException(
                     type,
-                    "Class \"${type.asClass().name}\" is not annotated with @CordaSerializable.")
+                    "Class \"${type}\" is not annotated with @CordaSerializable.")
             }
         }
         is Collection<*> -> {

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationHelper.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationHelper.kt
@@ -117,33 +117,19 @@ internal fun Type.isSubClassOf(type: Type): Boolean {
 /**
  * Enforces that the given [type] is Corda serializable (if it has or inherits the [CordaSerializable] annotation),
  * or if it's an instance of the [java.lang.Comparable] interface. If not, an exception will be thrown.
- * If the passed [type] is a [Collection], this function will be recursively called for each item.
  *
  * @param type The type to be checked for Corda serializability.
  * @throws AMQPNotSerializableException if [type] is not annotated with [CordaSerializable]
  *                                      and is not an instance of [java.lang.Comparable].
- * @throws AMQPNoTypeNotSerializableException if [type] is not a valid type, or null, and cannot be serialized.
  *
  * @see [CORDA-2782] for the special exemption made for `Comparable`.
  */
-fun requireCordaSerializable(type: Any?) {
-    when (type) {
-        is Type -> {
-            // See CORDA-2782 for explanation of the special exemption made for Comparable
-            if (!hasCordaSerializable(type.asClass()) && type.asClass() != java.lang.Comparable::class.java) {
-                throw AMQPNotSerializableException(
-                    type,
-                    "Class \"${type}\" is not annotated with @CordaSerializable.")
-            }
-        }
-        is Collection<*> -> {
-            type.forEach { requireCordaSerializable(it) }
-        }
-        else -> {
-            throw AMQPNoTypeNotSerializableException(
-                "Class is not a valid type and cannot be serialized."
-            )
-        }
+fun requireCordaSerializable(type: Type) {
+    // See CORDA-2782 for explanation of the special exemption made for Comparable
+    if (!hasCordaSerializable(type.asClass()) && type.asClass() != java.lang.Comparable::class.java) {
+        throw AMQPNotSerializableException(
+            type,
+            "Class \"$type\" is not annotated with @CordaSerializable.")
     }
 }
 

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationHelper.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationHelper.kt
@@ -115,8 +115,8 @@ internal fun Type.isSubClassOf(type: Type): Boolean {
 }
 
 /**
- * Checks if the given [type] is Corda serializable (if it has or inherits the [CordaSerializable] annotation),
- * or if it's an instance of the [java.lang.Comparable] interface.
+ * Enforces that the given [type] is Corda serializable (if it has or inherits the [CordaSerializable] annotation),
+ * or if it's an instance of the [java.lang.Comparable] interface. If not, an exception will be thrown.
  * If the passed [type] is a [Collection], this function will be recursively called for each item.
  *
  * @param type The type to be checked for Corda serializability.

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationHelper.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationHelper.kt
@@ -114,6 +114,18 @@ internal fun Type.isSubClassOf(type: Type): Boolean {
     return TypeToken.of(this).isSubtypeOf(TypeToken.of(type).rawType)
 }
 
+/**
+ * Checks if the given [type] is Corda serializable (if it has or inherits the [CordaSerializable] annotation),
+ * or if it's an instance of the [java.lang.Comparable] interface.
+ * If the passed [type] is a [Collection], this function will be recursively called for each item.
+ *
+ * @param type The type to be checked for Corda serializability.
+ * @throws AMQPNotSerializableException if [type] is not annotated with [CordaSerializable]
+ *                                      and is not an instance of [java.lang.Comparable].
+ * @throws AMQPNoTypeNotSerializableException if [type] is not a valid type, or null, and cannot be serialized.
+ *
+ * @see [CORDA-2782] for the special exemption made for `Comparable`.
+ */
 fun requireCordaSerializable(type: Any?) {
     when (type) {
         is Type -> {

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationHelperTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationHelperTests.kt
@@ -59,7 +59,7 @@ class SerializationHelperTests {
         }
 
         assertEquals(
-            "Class \"java.lang.Object\" is not annotated with @CordaSerializable.",
+            "Class \"class java.lang.Object\" is not annotated with @CordaSerializable.",
             exception.msg
         )
     }

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationHelperTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationHelperTests.kt
@@ -1,0 +1,113 @@
+package net.corda.internal.serialization.amqp
+
+import com.google.common.reflect.TypeToken
+import net.corda.v5.base.annotations.CordaSerializable
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SerializationHelperTests {
+    @Test
+    fun `asClass should correctly convert type to class`() {
+        val type = object : TypeToken<List<String>>() {}.type
+        val clazz = type.asClass()
+
+        assertEquals(List::class.java, clazz)
+    }
+
+    @Test
+    fun `isArray should correctly determine if type is an array type`() {
+        val arrayType = object : TypeToken<Array<String>>() {}.type
+        val listType = object : TypeToken<List<String>>() {}.type
+
+        val isArray = arrayType.isArray()
+        val isNotArray = listType.isArray()
+
+        assertTrue(isArray)
+        assertTrue(!isNotArray)
+    }
+
+    @Test
+    fun `isSubClassOf should correctly determine if type is a subclass of another type`() {
+        val subType = object : TypeToken<List<String>>() {}.type
+        val superType = object : TypeToken<Collection<String>>() {}.type
+
+        val isSubClass = subType.isSubClassOf(superType)
+        val isNotSubClass = superType.isSubClassOf(subType)
+
+        assertTrue(isSubClass)
+        assertTrue(!isNotSubClass)
+    }
+
+    @Test
+    fun `requireCordaSerializable should not throw an exception for CordaSerializable types`() {
+        @CordaSerializable
+        class TestCordaSerializableType
+        assertDoesNotThrow {
+            requireCordaSerializable(TestCordaSerializableType::class.java)
+        }
+    }
+
+    @Test
+    fun `requireCordaSerializable should throw an exception for non-CordaSerializable types`() {
+        val nonCordaSerializableType = Object::class.java
+
+        val exception = assertThrows(AMQPNotSerializableException::class.java) {
+            requireCordaSerializable(nonCordaSerializableType)
+        }
+
+        assertEquals(
+            "Class \"java.lang.Object\" is not annotated with @CordaSerializable.",
+            exception.msg
+        )
+    }
+
+    @Test
+    fun `requireCordaSerializable should throw an exception for null values`() {
+        val exception = assertThrows(AMQPNotSerializableException::class.java) {
+            requireCordaSerializable(null)
+        }
+
+        assertEquals(
+            "Class is not a valid type and cannot be serialized.",
+            exception.msg
+        )
+    }
+
+    @Test
+    fun `requireCordaSerializable should throw an exception for null values within a collection`() {
+        @CordaSerializable
+        class TestCordaSerializableType
+
+        val exception = assertThrows(AMQPNotSerializableException::class.java) {
+            requireCordaSerializable(listOf(TestCordaSerializableType::class.java, null))
+        }
+
+        assertEquals(
+            "Class is not a valid type and cannot be serialized.",
+            exception.msg
+        )
+    }
+
+    @Test
+    fun `hasCordaSerializable should correctly determine if a type is CordaSerializable`() {
+        @CordaSerializable
+        class TestCordaSerializableType
+        class TestNonCordaSerializableType
+
+        assertTrue(hasCordaSerializable(TestCordaSerializableType::class.java))
+        assertTrue(!hasCordaSerializable(TestNonCordaSerializableType::class.java))
+    }
+
+    @Test
+    fun `hasCordaSerializable should correctly determine if a type is derived from a CordaSerializable type`() {
+        @CordaSerializable
+        open class TestCordaSerializable
+        class TestInheritedCordaSerializableType : TestCordaSerializable()
+
+        assertTrue(hasCordaSerializable(TestCordaSerializable::class.java))
+        assertTrue(hasCordaSerializable(TestInheritedCordaSerializableType::class.java))
+    }
+}

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationHelperTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationHelperTests.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.test.assertNotEquals
 
 class SerializationHelperTests {
     @Test
@@ -23,6 +24,21 @@ class SerializationHelperTests {
         val listType = object : TypeToken<List<String>>() {}.type
 
         val isArray = arrayType.isArray()
+        val isNotArray = listType.isArray()
+
+        assertTrue(isArray)
+        assertTrue(!isNotArray)
+    }
+
+    @Test
+    fun `isArray should correctly determine if type is an array type for c-style arrays`() {
+        val defaultArrayType = object : TypeToken<Array<Int>>() {}.type
+        val cStyleArrayType = intArrayOf(1, 2, 3).javaClass
+        val listType = object : TypeToken<List<String>>() {}.type
+
+        assertNotEquals(defaultArrayType, cStyleArrayType)
+
+        val isArray = cStyleArrayType.isArray()
         val isNotArray = listType.isArray()
 
         assertTrue(isArray)

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationHelperTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationHelperTests.kt
@@ -81,33 +81,6 @@ class SerializationHelperTests {
     }
 
     @Test
-    fun `requireCordaSerializable should throw an exception for null values`() {
-        val exception = assertThrows(AMQPNotSerializableException::class.java) {
-            requireCordaSerializable(null)
-        }
-
-        assertEquals(
-            "Class is not a valid type and cannot be serialized.",
-            exception.msg
-        )
-    }
-
-    @Test
-    fun `requireCordaSerializable should throw an exception for null values within a collection`() {
-        @CordaSerializable
-        class TestCordaSerializableType
-
-        val exception = assertThrows(AMQPNotSerializableException::class.java) {
-            requireCordaSerializable(listOf(TestCordaSerializableType::class.java, null))
-        }
-
-        assertEquals(
-            "Class is not a valid type and cannot be serialized.",
-            exception.msg
-        )
-    }
-
-    @Test
     fun `hasCordaSerializable should correctly determine if a type is CordaSerializable`() {
         @CordaSerializable
         class TestCordaSerializableType

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/BlockingQueueFlowSession.kt
@@ -65,7 +65,6 @@ abstract class BlockingQueueFlowSession(
      */
     override fun <R : Any> receive(receiveType: Class<R>): R {
         state.closedCheck()
-        requireBoxedType(receiveType)
         val start = configuration.clock.instant()
         while (true) {
             checkTimeout(start)
@@ -91,10 +90,6 @@ abstract class BlockingQueueFlowSession(
         }
     }
 
-    private fun requireBoxedType(type: Class<*>) {
-        require(!type.isPrimitive) { "Cannot receive primitive type $type" }
-    }
-
     /**
      * @param receiveType The class of the received payload.
      * @param payload The payload to send.
@@ -103,7 +98,6 @@ abstract class BlockingQueueFlowSession(
      * @see [BlockingQueueFlowSession.receive] for details of thrown exceptions.
      */
     override fun <R : Any> sendAndReceive(receiveType: Class<R>, payload: Any): R {
-        requireBoxedType(receiveType)
         send(payload)
         return receive(receiveType)
     }

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/messaging/ConcurrentFlowMessaging.kt
@@ -130,12 +130,10 @@ class ConcurrentFlowMessaging(
      * Not yet implemented.
      */
     override fun <R : Any> receiveAll(receiveType: Class<out R>, sessions: Set<FlowSession>): List<R> {
-        requireBoxedType(receiveType)
         return sessions.map { it.receive(receiveType) }
     }
 
     override fun receiveAllMap(sessions: Map<FlowSession, Class<out Any>>): Map<FlowSession, Any> {
-        sessions.mapKeys { requireBoxedType(it.value) }
         return sessions.mapValues { it.key.receive(it.value) }
     }
 
@@ -145,10 +143,6 @@ class ConcurrentFlowMessaging(
 
     override fun sendAllMap(payloadsPerSession: Map<FlowSession, Any>) {
         payloadsPerSession.keys.forEach { it.send(payloadsPerSession[it]!!) }
-    }
-
-    private fun requireBoxedType(type: Class<*>) {
-        require(!type.isPrimitive) { "Cannot receive primitive type $type" }
     }
 
     override fun close() {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RpcSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RpcSmokeTestFlow.kt
@@ -262,7 +262,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
                 SendReceivePrimitiveMessagingFlow(MemberX500Name.parse(x500))
             )
 
-            outputs.add("${x500}=${response}")
+            outputs.add(response)
         }
 
         return outputs.joinToString("; ")

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/SendReceivePrimitiveMessagingFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/SendReceivePrimitiveMessagingFlow.kt
@@ -1,0 +1,101 @@
+package com.r3.corda.testing.smoketests.flow
+
+import net.corda.v5.application.flows.CordaInject
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
+import net.corda.v5.application.flows.ResponderFlow
+import net.corda.v5.application.flows.SubFlow
+import net.corda.v5.application.marshalling.JsonMarshallingService
+import net.corda.v5.application.messaging.FlowMessaging
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.types.MemberX500Name
+import org.slf4j.LoggerFactory
+
+val payloads = listOf(
+    42.toByte(),    // Byte
+    1234.toShort(), // Short
+    56789,          // Int
+    123456789L,     // Long
+    3.14f,          // Float
+    2.71828,        // Double
+    'A',            // Char
+    true            // Bool
+)
+
+@InitiatingFlow(protocol = "SendReceivePrimitiveProtocol")
+class SendReceivePrimitiveMessagingFlow(
+    private val x500Name: MemberX500Name,
+) : SubFlow<String> {
+
+    private companion object {
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    @CordaInject
+    lateinit var flowEngine: FlowEngine
+
+    @CordaInject
+    lateinit var flowMessaging: FlowMessaging
+
+    @CordaInject
+    lateinit var jsonMarshallingService: JsonMarshallingService
+
+    @Suspendable
+    override fun call(): String {
+        log.info("Send and receive is starting... [${flowEngine.flowId}]")
+        log.info("Preparing to initiate flow with member from group: $x500Name")
+
+        val session = flowMessaging.initiateFlow(x500Name)
+        log.info("Called initiate sessions")
+
+        for ((index, payload) in payloads.withIndex()) {
+            log.info("Sending ${payload::class.java.name} payload")
+            when (index / 3) {
+                0 -> session.send(payload)                                  // SessionManagerImpl::send()
+                1 -> flowMessaging.sendAll(payload, setOf(session))         // FlowMessagingImpl::sendAll()
+                2 -> flowMessaging.sendAllMap(mapOf(session to payload))    // FlowMessagingImpl::sendAllMap()
+            }
+        }
+
+        val received = session.receive(String::class.java)
+        log.info("Received from initiated: $received")
+
+        log.info("Closing session 1")
+        session.close()
+
+        log.info("Closed session")
+
+        return received
+    }
+}
+
+@InitiatedBy(protocol = "SendReceivePrimitiveProtocol")
+class SendReceivePrimitiveInitiatedFlow : ResponderFlow {
+
+    private companion object {
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    @CordaInject
+    private lateinit var flowEngine: FlowEngine
+
+    @Suspendable
+    override fun call(session: FlowSession) {
+        log.info("I have been called [${flowEngine.flowId}]")
+
+        val receivedList = payloads.map { payload ->
+            val received = session.receive(payload::class.java)
+            log.info("Received ${received::class.java} with value: " +
+                    "$received.Expected type was ${payload::class.java}.")
+            received
+        }
+
+        session.send("Successfully received ${receivedList.size} items.")
+
+        log.info("Closing initiated session")
+        session.close()
+        log.info("Closed initiated session")
+    }
+}

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/SendReceivePrimitiveMessagingFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/SendReceivePrimitiveMessagingFlow.kt
@@ -12,6 +12,7 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 import org.slf4j.LoggerFactory
+import java.lang.StringBuilder
 
 val payloads = listOf(
     42.toByte(),    // Byte
@@ -50,6 +51,29 @@ class SendReceivePrimitiveMessagingFlow(
         val session = flowMessaging.initiateFlow(x500Name)
         log.info("Called initiate sessions")
 
+        val received = StringBuilder()
+
+        // Send the payloads 3 times to test receive(), receiveAll() and receiveAllMap() on the counterparty side
+        repeat(3) {
+            sendPayloads(session)
+            received.appendLine(session.receive(String::class.java))
+            log.info("Received from initiated: $received")
+        }
+
+        log.info("Closing session 1")
+        session.close()
+        log.info("Closed session")
+
+        return received.toString()
+    }
+
+    /**
+     * Send our payloads to the provided [FlowSession], with sends divided across all three implementations.
+     *
+     * @param session the [FlowSession] to send our payloads to.
+     */
+    @Suspendable
+    private fun sendPayloads(session: FlowSession) {
         for ((index, payload) in payloads.withIndex()) {
             log.info("Sending ${payload::class.java.name} payload")
             when (index / 3) {
@@ -58,16 +82,6 @@ class SendReceivePrimitiveMessagingFlow(
                 2 -> flowMessaging.sendAllMap(mapOf(session to payload))    // FlowMessagingImpl::sendAllMap()
             }
         }
-
-        val received = session.receive(String::class.java)
-        log.info("Received from initiated: $received")
-
-        log.info("Closing session 1")
-        session.close()
-
-        log.info("Closed session")
-
-        return received
     }
 }
 
@@ -81,21 +95,52 @@ class SendReceivePrimitiveInitiatedFlow : ResponderFlow {
     @CordaInject
     private lateinit var flowEngine: FlowEngine
 
+    @CordaInject
+    lateinit var flowMessaging: FlowMessaging
+
     @Suspendable
     override fun call(session: FlowSession) {
         log.info("I have been called [${flowEngine.flowId}]")
 
-        val receivedList = payloads.map { payload ->
-            val received = session.receive(payload::class.java)
-            log.info("Received ${received::class.java} with value: " +
-                    "$received.Expected type was ${payload::class.java}.")
-            received
+        // Testing FlowSessionImpl::receive()
+        val receivedList = receivePayloads(methodName = "receive") { payload ->
+            session.receive(payload::class.java)
         }
-
         session.send("Successfully received ${receivedList.size} items.")
+
+        // Testing FlowMessaging::receiveAll()
+        val receiveAllList = receivePayloads(methodName = "receiveAll") { payload ->
+            flowMessaging.receiveAll(payload::class.java, setOf(session))
+        }
+        session.send("Successfully received ${receiveAllList.size} items from receiveAll.")
+
+        // Testing FlowMessaging::receiveAllMap()
+        val receiveAllMap = receivePayloads(methodName = "receiveAllMap") { payload ->
+            flowMessaging.receiveAllMap(mapOf(session to payload::class.java))
+        }
+        session.send("Successfully received ${receiveAllMap.size} items from receiveAllMap.")
 
         log.info("Closing initiated session")
         session.close()
         log.info("Closed initiated session")
+    }
+
+    /**
+     * For each item in [payloads] we make a single receive call using the passed [action] and return the result.
+     * The received value is also logged, along with the [methodName] passed to the function.
+     * Importantly, we try to receive the [payloads] in the same order as they're sent by the counterparty flow.
+     *
+     * @param methodName the name of the method being logged
+     * @param action the action to perform on each payload (must not return null)
+     * @return list of received items
+     */
+    @Suspendable
+    private fun <T> receivePayloads(methodName: String, action: (Any) -> T): List<T> {
+        return payloads.map { payload ->
+            val received = action(payload)
+            log.info("Method: $methodName - Received ${received!!::class.java} with value: " +
+                    "$received. Expected type was ${payload::class.java}.")
+            received
+        }
     }
 }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/corda/corda-runtime-os/pull/3768, which renders the original obsolete.

## Background
Historically, the sending and receiving of primitive types across sessions caused failures at runtime and, for this reason, checks were added to prevent this from being done. The investigation as part of CORE-9483 revealed that there were multiple independent causes for these failures; the core serializer bugs preventing the AMQP serialization of raw primitives was fixed by @chrisr3 in PR https://github.com/corda/corda-runtime-os/pull/3904, and so this PR handles the final issues on the flow session side.

## Overview
We expose APIs for sending and receiving data across sessions in both the `FlowSessionImpl` and the `FlowMessagingImpl` classes which generally follow the form:
```
send(Object payload) // Java
send(payload: Any)   // Kotlin
```
```
receive(Class<R> receiveType)   // Java
receive(receiveType: Class<R>)  // Kotlin
```
When we send a payload, its type is inferred and it's serialized as such before being sent to the counterparty. When we receive an payload, we must specify the expected type so that it can be deserialized and used by the client code.

Notably, where `send` accepts _any_ object, `receive` accepts the generic type `Class<R>` which carries more information and is required for the runtime reflection which allows us to cast and use the deserialized bytes correctly.

## Problem
When we try to send a primitive value, it will be autoboxed at runtime and therefore will be serialized as a boxed class before sending. However, the corresponding receive call will still be expecting a primitive type back and will fail when trying to deserialize the received bytes as such.

## Fix
To fix this, we simply add a check to the `receive` calls. If we're trying to receive a primitive type, we should interpret the received bytes as the boxed representation of that type (as we can guarantee it's been boxed when passing through the `send(Object)` interface). It can then be implicit cast back to the expected value by the `<R>` return type of the receive functions.

This PR implements that change and removes the `requireBoxType` checks which are no longer needed. It also adds some unit testing to `SerializationHelper.kt` as I noticed there was none there when checking through the code.