### PR TITLE
CORE-14573: Wrong status code reported for incorrect tenantId

### DIFF
--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
@@ -8,7 +8,6 @@ import net.corda.crypto.cipher.suite.schemes.GOST3410_GOST3411_TEMPLATE
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.crypto.core.CryptoConsts
 import net.corda.crypto.core.CryptoTenants.P2P
-import net.corda.crypto.core.CryptoTenants.REST
 import net.corda.crypto.core.CryptoTenants.allClusterTenants
 import net.corda.crypto.core.DefaultSignatureOIDMap
 import net.corda.crypto.core.ShortHash
@@ -27,7 +26,6 @@ import net.corda.membership.rest.v1.CertificatesRestResource
 import net.corda.membership.rest.v1.CertificatesRestResource.Companion.SIGNATURE_SPEC
 import net.corda.rest.HttpFileUpload
 import net.corda.rest.PluggableRestResource
-import net.corda.rest.exception.BadRequestException
 import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.rest.messagebus.MessageBusUtils.tryWithExceptionHandling
@@ -444,33 +442,17 @@ class CertificatesRestResourceImpl @Activate constructor(
     }
 
     private fun validateTenantId(tenantId: String) {
-        val isValidShortHash = try {
-            ShortHash.parse(tenantId)
-            true
-        } catch (e: ShortHashException) {
-            false
-        }
-
-        // Check if a virtual node is registered for given tenantId
-        val isVirtualNodeRegisteredForTenant = try {
-            virtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(tenantId)
-            true
-        } catch(e: BadRequestException) {
-            false
-        }
-        catch (e: ResourceNotFoundException) {
-            false
-        }
-
         if (tenantId in allClusterTenants) return
-        if (!isValidShortHash) throw InvalidInputDataException("Provided tenantId $tenantId is not a cluster tenant " +
-                "and is not the right size of a holding ID.")
-        if (!isVirtualNodeRegisteredForTenant) {
-            throw InvalidInputDataException(
-                "Provided tenantId ($tenantId) was not valid. It needs to be either a cluster tenant ($P2P or $REST) " +
-                        "or a valid virtual node holding identity ID."
-            )
+
+        try {
+            ShortHash.parse(tenantId)
+        } catch (e: ShortHashException) {
+            throw InvalidInputDataException("Provided tenantId $tenantId is not a cluster tenant or " +
+                    "a valid holding identity ID.")
         }
+
+        // Check if a virtual node exists for given tenantId, if not, it throws ResourceNotFoundException
+        virtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(tenantId)
     }
 
     private fun validateHostname(hostname: String): Boolean {

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
@@ -120,6 +120,8 @@ class CertificatesRestResourceImpl @Activate constructor(
         contextMap: Map<String, String?>?,
     ): String {
         validateTenantId(tenantId)
+        // Check if a virtual node is registered for given tenantId
+        virtualNodeInfoReadService.getByHoldingIdentityShortHashOrThrow(tenantId)
 
         val key = tryWithExceptionHandling(logger, "find key with ID $keyId for $tenantId") {
             cryptoOpsClient.lookupKeysByIds(

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
@@ -462,12 +462,13 @@ class CertificatesRestResourceImpl @Activate constructor(
             false
         }
 
-        val isValidClusterTenant = tenantId in allClusterTenants
-
-        if ((!isValidShortHash && !isValidClusterTenant) || ( isValidShortHash && !isValidClusterTenant && !isVirtualNodeRegisteredForTenant)) {
+        if (tenantId in allClusterTenants) return
+        if (!isValidShortHash) throw InvalidInputDataException("Provided tenantId $tenantId is not a cluster tenant " +
+                "and is not the right size of a holding ID.")
+        if (!isVirtualNodeRegisteredForTenant) {
             throw InvalidInputDataException(
-                "Provided tenantId ($tenantId) was not valid. " +
-                        "It needs to be either a cluster tenant ($P2P or $REST) or a valid holding identity ID."
+                "Provided tenantId ($tenantId) was not valid. It needs to be either a cluster tenant ($P2P or $REST) " +
+                        "or a valid virtual node holding identity ID."
             )
         }
     }

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImpl.kt
@@ -447,8 +447,7 @@ class CertificatesRestResourceImpl @Activate constructor(
         try {
             ShortHash.parse(tenantId)
         } catch (e: ShortHashException) {
-            throw InvalidInputDataException("Provided tenantId $tenantId is not a cluster tenant or " +
-                    "a valid holding identity ID.")
+            throw InvalidInputDataException("Provided tenantId $tenantId is not a valid holding identity ID.")
         }
 
         // Check if a virtual node exists for given tenantId, if not, it throws ResourceNotFoundException

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
@@ -175,17 +175,7 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it throws exception if key is not available`() {
             whenever(cryptoOpsClient.lookupKeysByIds(any(), any())).doReturn(emptyList())
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -200,18 +190,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throws ServiceUnavailableException when repartition event happens while trying to retrieve key`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
-
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             whenever(cryptoOpsClient.lookupKeysByIds(any(), any())).doThrow(CordaRPCAPIPartitionException("repartition event"))
 
             val details = assertThrows<ServiceUnavailableException> {
@@ -229,17 +208,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it sign the request`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -279,17 +248,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it returns the correct signature`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -304,17 +263,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it adds alternative subject names when some are provided`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -347,17 +296,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will not adds alternative subject names when none are provided`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -415,17 +354,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will use the correct x500 name`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -472,17 +401,7 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it will generate a CSR for a valid member name for TLS certificate`() {
             whenever(key.category).doReturn(CryptoConsts.Categories.TLS)
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             val csr = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -650,17 +569,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throws exception if Signature OID can not be inferred`() {
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -676,17 +585,7 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it throws exception if key code name is invalid`() {
             whenever(key.schemeCodeName).doReturn("Nop")
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(holdingIdentityShortHash)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -733,6 +632,20 @@ class CertificatesRestResourceImplTest {
             return PEMParser(this.reader()).use { parser ->
                 parser.readObject() as PKCS10CertificationRequest
             }
+        }
+
+        private fun registerVirtualNodeForTenantId(holdingIdentityShortHash: String) {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
         }
     }
 

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
@@ -175,6 +175,17 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it throws exception if key is not available`() {
             whenever(cryptoOpsClient.lookupKeysByIds(any(), any())).doReturn(emptyList())
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -189,6 +200,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throws ServiceUnavailableException when repartition event happens while trying to retrieve key`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             whenever(cryptoOpsClient.lookupKeysByIds(any(), any())).doThrow(CordaRPCAPIPartitionException("repartition event"))
 
             val details = assertThrows<ServiceUnavailableException> {
@@ -206,6 +229,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it sign the request`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -244,6 +279,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it returns the correct signature`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -257,6 +304,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it adds alternative subject names when some are provided`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -288,6 +347,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will not adds alternative subject names when none are provided`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -344,6 +415,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will use the correct x500 name`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             val pem = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
                 keyId,
@@ -389,6 +472,17 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it will generate a CSR for a valid member name for TLS certificate`() {
             whenever(key.category).doReturn(CryptoConsts.Categories.TLS)
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
 
             val csr = certificatesOps.generateCsr(
                 holdingIdentityShortHash,
@@ -556,6 +650,18 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throws exception if Signature OID can not be inferred`() {
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
+
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -570,6 +676,17 @@ class CertificatesRestResourceImplTest {
         @Test
         fun `it throws exception if key code name is invalid`() {
             whenever(key.schemeCodeName).doReturn("Nop")
+            val nodeHoldingIdentity = mock<HoldingIdentity> {
+                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
+            }
+            val nodeInfo = mock<VirtualNodeInfo> {
+                on { holdingIdentity } doReturn nodeHoldingIdentity
+            }
+            whenever(
+                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
+                    ShortHash.of(holdingIdentityShortHash)
+                )
+            ).doReturn(nodeInfo)
 
             assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
@@ -589,6 +706,21 @@ class CertificatesRestResourceImplTest {
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     invalidTenantId,
+                    keyId,
+                    x500Name,
+                    null,
+                    null,
+                )
+            }
+        }
+
+        @Test
+        fun `it throws exception if tenant ID does not have virtual node registered`() {
+            val notRegisteredTenantId = "ABA912AC2439"
+            whenever(virtualNodeInfoReadService.getByHoldingIdentityShortHash(ShortHash.of(notRegisteredTenantId))).thenReturn(null)
+            assertThrows<InvalidInputDataException> {
+                certificatesOps.generateCsr(
+                    notRegisteredTenantId,
                     keyId,
                     x500Name,
                     null,

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/CertificatesRestResourceImplTest.kt
@@ -315,6 +315,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throw an exception if the subject alternative name is invalid`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -328,6 +329,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throw an exception if the subject alternative name is empty`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -341,6 +343,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it throw an exception if the subject alternative name is not a domain name`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -372,6 +375,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will throw an exception for invalid X500 name`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             assertThrows<InvalidInputDataException> {
                 certificatesOps.generateCsr(
                     holdingIdentityShortHash,
@@ -385,6 +389,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will throw an exception for invalid member name for TLS certificate`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             whenever(key.category).doReturn(CryptoConsts.Categories.TLS)
 
             assertThrows<InvalidInputDataException> {
@@ -416,6 +421,7 @@ class CertificatesRestResourceImplTest {
 
         @Test
         fun `it will throw an exception for invalid name for session certificate`() {
+            registerVirtualNodeForTenantId(holdingIdentityShortHash)
             whenever(key.category).doReturn(CryptoConsts.Categories.SESSION_INIT)
 
             assertThrows<InvalidInputDataException> {
@@ -529,17 +535,7 @@ class CertificatesRestResourceImplTest {
         fun `it will throw an exception for session certificate member key where the member name is not correct`() {
             whenever(key.category).doReturn(CryptoConsts.Categories.SESSION_INIT)
             val tenantId = "123123123123"
-            val nodeHoldingIdentity = mock<HoldingIdentity> {
-                on { x500Name } doReturn MemberX500Name.parse("O=Alice, L=LDN, C=GB")
-            }
-            val nodeInfo = mock<VirtualNodeInfo> {
-                on { holdingIdentity } doReturn nodeHoldingIdentity
-            }
-            whenever(
-                virtualNodeInfoReadService.getByHoldingIdentityShortHash(
-                    ShortHash.of(tenantId)
-                )
-            ).doReturn(nodeInfo)
+            registerVirtualNodeForTenantId(tenantId)
             whenever(
                 cryptoOpsClient.sign(
                     eq(tenantId),
@@ -617,7 +613,7 @@ class CertificatesRestResourceImplTest {
         fun `it throws exception if tenant ID does not have virtual node registered`() {
             val notRegisteredTenantId = "ABA912AC2439"
             whenever(virtualNodeInfoReadService.getByHoldingIdentityShortHash(ShortHash.of(notRegisteredTenantId))).thenReturn(null)
-            assertThrows<InvalidInputDataException> {
+            assertThrows<ResourceNotFoundException> {
                 certificatesOps.generateCsr(
                     notRegisteredTenantId,
                     keyId,


### PR DESCRIPTION
When requesting a CSR for a tenant, we were not checking if a virtual node is registered for the tenant.
ValidateTenantId check was updated and it now returns 404 RESOURCE_NOT_FOUND if virtual node is not registered for the tenant.
As we do this check early on, tests had to be updated too to make sure they test the original functionality.