### PR TITLE
CORE-13377: Move `loginName` to path param for GET User API

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/PermissionSummaryE2eTest.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/PermissionSummaryE2eTest.kt
@@ -50,11 +50,13 @@ class PermissionSummaryE2eTest {
 
         adminTestHelper.addRoleToUser(newUser, roleId)
 
-        with(adminTestHelper.getPermissionSummary(newUser)) {
-            assertEquals(1, this.permissions.size)
-            assertEquals(permissionId, this.permissions[0].id)
-            assertEquals(permissionString, this.permissions[0].permissionString)
-            assertEquals(PermissionType.ALLOW, this.permissions[0].permissionType)
+        eventually {
+            with(adminTestHelper.getPermissionSummary(newUser)) {
+                assertEquals(1, this.permissions.size)
+                assertEquals(permissionId, this.permissions[0].id)
+                assertEquals(permissionString, this.permissions[0].permissionString)
+                assertEquals(PermissionType.ALLOW, this.permissions[0].permissionType)
+            }
         }
     }
 
@@ -87,38 +89,47 @@ class PermissionSummaryE2eTest {
         adminTestHelper.addRoleToUser(newUser1, roleId)
         adminTestHelper.addRoleToUser(newUser2, roleId)
 
-        with(adminTestHelper.getPermissionSummary(newUser1)) {
-            assertEquals(1, this.permissions.size)
-            assertEquals(permissionId1, this.permissions[0].id)
-            assertEquals(permissionString1, this.permissions[0].permissionString)
-            assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
+        eventually {
+            with(adminTestHelper.getPermissionSummary(newUser1)) {
+                assertEquals(1, this.permissions.size)
+                assertEquals(permissionId1, this.permissions[0].id)
+                assertEquals(permissionString1, this.permissions[0].permissionString)
+                assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
+            }
         }
-        with(adminTestHelper.getPermissionSummary(newUser2)) {
-            assertEquals(1, this.permissions.size)
-            assertEquals(permissionId1, this.permissions[0].id)
-            assertEquals(permissionString1, this.permissions[0].permissionString)
-            assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
+
+        eventually {
+            with(adminTestHelper.getPermissionSummary(newUser2)) {
+                assertEquals(1, this.permissions.size)
+                assertEquals(permissionId1, this.permissions[0].id)
+                assertEquals(permissionString1, this.permissions[0].permissionString)
+                assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
+            }
         }
 
         adminTestHelper.addPermissionsToRole(roleId, permissionId2)
 
-        with(adminTestHelper.getPermissionSummary(newUser1)) {
-            assertEquals(2, this.permissions.size)
-            assertEquals(permissionId1, this.permissions[0].id)
-            assertEquals(permissionString1, this.permissions[0].permissionString)
-            assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
-            assertEquals(permissionId2, this.permissions[1].id)
-            assertEquals(permissionString2, this.permissions[1].permissionString)
-            assertEquals(PermissionType.ALLOW, this.permissions[1].permissionType)
+        eventually {
+            with(adminTestHelper.getPermissionSummary(newUser1)) {
+                assertEquals(2, this.permissions.size)
+                assertEquals(permissionId1, this.permissions[0].id)
+                assertEquals(permissionString1, this.permissions[0].permissionString)
+                assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
+                assertEquals(permissionId2, this.permissions[1].id)
+                assertEquals(permissionString2, this.permissions[1].permissionString)
+                assertEquals(PermissionType.ALLOW, this.permissions[1].permissionType)
+            }
         }
-        with(adminTestHelper.getPermissionSummary(newUser2)) {
-            assertEquals(2, this.permissions.size)
-            assertEquals(permissionId1, this.permissions[0].id)
-            assertEquals(permissionString1, this.permissions[0].permissionString)
-            assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
-            assertEquals(permissionId2, this.permissions[1].id)
-            assertEquals(permissionString2, this.permissions[1].permissionString)
-            assertEquals(PermissionType.ALLOW, this.permissions[1].permissionType)
+        eventually {
+            with(adminTestHelper.getPermissionSummary(newUser2)) {
+                assertEquals(2, this.permissions.size)
+                assertEquals(permissionId1, this.permissions[0].id)
+                assertEquals(permissionString1, this.permissions[0].permissionString)
+                assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
+                assertEquals(permissionId2, this.permissions[1].id)
+                assertEquals(permissionString2, this.permissions[1].permissionString)
+                assertEquals(PermissionType.ALLOW, this.permissions[1].permissionType)
+            }
         }
     }
 
@@ -129,8 +140,10 @@ class PermissionSummaryE2eTest {
 
         adminTestHelper.createUser(newUser1, newUserPassword, passwordExpiry)
 
-        with(adminTestHelper.getPermissionSummary(newUser1)) {
-            assertEquals(0, this.permissions.size, "New user should have permission summary with empty list")
+        eventually {
+            with(adminTestHelper.getPermissionSummary(newUser1)) {
+                assertEquals(0, this.permissions.size, "New user should have permission summary with empty list")
+            }
         }
 
         val permissionString1: String = "aa" + cordaCluster.uniqueName
@@ -149,30 +162,34 @@ class PermissionSummaryE2eTest {
 
         adminTestHelper.addRoleToUser(newUser1, roleId1)
 
-        with(adminTestHelper.getPermissionSummary(newUser1)) {
-            assertEquals(2, this.permissions.size)
-            assertEquals(permissionId1, this.permissions[0].id)
-            assertEquals(permissionString1, this.permissions[0].permissionString)
-            assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
-            assertEquals(permissionId2, this.permissions[1].id)
-            assertEquals(permissionString2, this.permissions[1].permissionString)
-            assertEquals(PermissionType.ALLOW, this.permissions[1].permissionType)
+        eventually {
+            with(adminTestHelper.getPermissionSummary(newUser1)) {
+                assertEquals(2, this.permissions.size)
+                assertEquals(permissionId1, this.permissions[0].id)
+                assertEquals(permissionString1, this.permissions[0].permissionString)
+                assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
+                assertEquals(permissionId2, this.permissions[1].id)
+                assertEquals(permissionString2, this.permissions[1].permissionString)
+                assertEquals(PermissionType.ALLOW, this.permissions[1].permissionType)
+            }
         }
 
         adminTestHelper.addRoleToUser(newUser1, roleId2)
 
-        with(adminTestHelper.getPermissionSummary(newUser1)) {
-            assertEquals(3, this.permissions.size)
-            // order guaranteed to be DENY permissions first, alphabetically ordered by permission string
-            assertEquals(permissionId1, this.permissions[0].id)
-            assertEquals(permissionString1, this.permissions[0].permissionString)
-            assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
-            assertEquals(permissionId3, this.permissions[1].id)
-            assertEquals(permissionString3, this.permissions[1].permissionString)
-            assertEquals(PermissionType.DENY, this.permissions[1].permissionType)
-            assertEquals(permissionId2, this.permissions[2].id)
-            assertEquals(permissionString2, this.permissions[2].permissionString)
-            assertEquals(PermissionType.ALLOW, this.permissions[2].permissionType)
+        eventually {
+            with(adminTestHelper.getPermissionSummary(newUser1)) {
+                assertEquals(3, this.permissions.size)
+                // order guaranteed to be DENY permissions first, alphabetically ordered by permission string
+                assertEquals(permissionId1, this.permissions[0].id)
+                assertEquals(permissionString1, this.permissions[0].permissionString)
+                assertEquals(PermissionType.DENY, this.permissions[0].permissionType)
+                assertEquals(permissionId3, this.permissions[1].id)
+                assertEquals(permissionString3, this.permissions[1].permissionString)
+                assertEquals(PermissionType.DENY, this.permissions[1].permissionType)
+                assertEquals(permissionId2, this.permissions[2].id)
+                assertEquals(permissionString2, this.permissions[2].permissionString)
+                assertEquals(PermissionType.ALLOW, this.permissions[2].permissionType)
+            }
         }
     }
 

--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/http/TestToolkitProperty.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/http/TestToolkitProperty.kt
@@ -1,5 +1,6 @@
 package net.corda.applications.workers.rest.http
 
+import net.corda.rest.annotations.RestApiVersion
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
@@ -14,14 +15,17 @@ import kotlin.reflect.KProperty
  * Rather than using this class, please consider using [net.corda.applications.workers.rest.utils.E2eCluster] to gain
  * access to multi-cluster deployment as well as other functions available.
  */
-class TestToolkitProperty(private val host: String, private val port: Int) :
-    ReadOnlyProperty<Any, TestToolkit> {
+class TestToolkitProperty(private val host: String, private val port: Int) : ReadOnlyProperty<Any, TestToolkit> {
+
+    private companion object {
+        val REST_API_VERSION_PATH = RestApiVersion.C5_1.versionPath
+    }
 
     private lateinit var impl: TestToolkit
 
     override fun getValue(thisRef: Any, property: KProperty<*>): TestToolkit {
         if (!this::impl.isInitialized) {
-            impl = TestToolkitImpl(thisRef.javaClass, "https://$host:$port/api/v1/")
+            impl = TestToolkitImpl(thisRef.javaClass, "https://$host:$port/api/$REST_API_VERSION_PATH/")
         }
 
         return impl

--- a/components/permissions/permission-rest-resource-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
+++ b/components/permissions/permission-rest-resource-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
@@ -82,7 +82,19 @@ class UserEndpointImpl @Activate constructor(
         return ResponseEntity.created(createUserResult.convertToEndpointType())
     }
 
-    override fun getUser(loginName: String): UserResponseType {
+    @Deprecated("Deprecated in favour of `getUserPath()`")
+    override fun getUserQuery(loginName: String): ResponseEntity<UserResponseType> {
+        "Deprecated, please use next version where loginName is passed as a path parameter.".let { msg ->
+            logger.warn(msg)
+            return ResponseEntity.okButDeprecated(doGetUser(loginName), msg)
+        }
+    }
+
+    override fun getUserPath(loginName: String): UserResponseType {
+        return doGetUser(loginName)
+    }
+
+    private fun doGetUser(loginName: String): UserResponseType {
         val principal = getRestThreadLocalContext()
 
         val userResponseDto = withPermissionManager(permissionManagementService.permissionManager, logger) {

--- a/components/permissions/permission-rest-resource-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImplTest.kt
+++ b/components/permissions/permission-rest-resource-impl/src/test/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImplTest.kt
@@ -123,7 +123,7 @@ internal class UserEndpointImplTest {
         whenever(permissionManager.getUser(getUserRequestDtoCapture.capture())).thenReturn(userResponseDto)
 
         endpoint.start()
-        val responseType = endpoint.getUser("loginName1")
+        val responseType = endpoint.getUserPath("loginName1")
 
         assertNotNull(responseType)
         assertEquals("uuid", responseType.id)
@@ -144,7 +144,7 @@ internal class UserEndpointImplTest {
         whenever(permissionService.isRunning).thenReturn(true)
 
         val e = assertThrows<ResourceNotFoundException> {
-            endpoint.getUser("abc")
+            endpoint.getUserPath("abc")
         }
         assertEquals(ResponseCode.RESOURCE_NOT_FOUND, e.responseCode, "Resource not found exception should have correct response code.")
         assertEquals("User 'abc' not found.", e.message)

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
@@ -13,6 +13,7 @@ import net.corda.rest.response.ResponseEntity
 import net.corda.libs.permissions.endpoints.v1.user.types.CreateUserType
 import net.corda.libs.permissions.endpoints.v1.user.types.UserPermissionSummaryResponseType
 import net.corda.libs.permissions.endpoints.v1.user.types.UserResponseType
+import net.corda.rest.annotations.RestApiVersion
 
 /**
  * User endpoint exposes HTTP endpoints for management of Users in the RBAC permission system.
@@ -81,9 +82,35 @@ interface UserEndpoint : RestResource {
             parentGroup: An optional identifier of the user group for the new user to be included;
                     value of null means that the user will belong to the root group
             properties: An optional set of key/value properties associated with a user account
-            roleAssociations: A set of roles associated with the user account""")
-    fun getUser(
+            roleAssociations: A set of roles associated with the user account""",
+        maxVersion = RestApiVersion.C5_0)
+    @Deprecated("Deprecated in favour of `getUserPath()`")
+    fun getUserQuery(
         @RestQueryParameter(description = "The login name of the user to be returned")
+        loginName: String
+    ): ResponseEntity<UserResponseType>
+
+    @HttpGET(path = "{loginName}", description = "This method returns a user based on the specified login name.",
+        responseDescription = """
+            A user with the following attributes:
+            id: Unique server generated identifier for the user
+            version: The version of the user; version 0 is assigned to a newly created user
+            updateTimestamp: The date and time when the user was last updated
+            fullName: The full name for the new user
+            loginName: The login name for the new user
+            enabled: If true, the user account is enabled; false, the account is disabled
+            ssoAuth: If true, the user account is enabled for SSO authentication; 
+                false, the account is enabled for password authentication
+            passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;
+                    value of null means that the password does not expire
+            parentGroup: An optional identifier of the user group for the new user to be included;
+                    value of null means that the user will belong to the root group
+            properties: An optional set of key/value properties associated with a user account
+            roleAssociations: A set of roles associated with the user account""",
+        minVersion = RestApiVersion.C5_1
+        )
+    fun getUserPath(
+        @RestPathParameter(description = "The login name of the user to be returned")
         loginName: String
     ): UserResponseType
 

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/JsonResultBuilder.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/JsonResultBuilder.kt
@@ -11,6 +11,11 @@ fun Context.buildJsonResult(result: Any?, returnType: Class<*>) {
             // if the responseBody is null, we return null in json
             ctx.json(result.responseBody ?: "null")
                 .status(result.responseCode.statusCode)
+
+            // Add optional headers
+            result.headers.forEach {
+                ctx.header(it.key, it.value)
+            }
         }
         (result as? String) != null ->
             ctx.contentType(ContextUtils.contentTypeApplicationJson).result(result).status(ResponseCode.OK.statusCode)

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/response/ResponseEntity.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/response/ResponseEntity.kt
@@ -29,6 +29,7 @@ import net.corda.rest.RestResource
 class ResponseEntity<T : Any?>(
     val responseCode: ResponseCode,
     val responseBody: T,
+    val headers: Map<String, String> = emptyMap()
 ) {
     companion object {
         fun <T : Any?> ok(responseBody: T): ResponseEntity<T> {
@@ -48,6 +49,10 @@ class ResponseEntity<T : Any?>(
         }
         fun <T : Any?> seeOther(responseBody: T): ResponseEntity<T> {
             return ResponseEntity(ResponseCode.SEE_OTHER, responseBody)
+        }
+        // See: https://www.rfc-editor.org/rfc/rfc7234#section-5.5
+        fun <T : Any?> okButDeprecated(responseBody: T, msg: String): ResponseEntity<T> {
+            return ResponseEntity(ResponseCode.OK, responseBody, mapOf("Warning" to "299 - $msg"))
         }
     }
 }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
@@ -3485,41 +3485,6 @@
       }
     },
     "/user" : {
-      "get" : {
-        "tags" : [ "RBAC User API" ],
-        "description" : "This method returns a user based on the specified login name.",
-        "operationId" : "get_user",
-        "parameters" : [ {
-          "name" : "loginname",
-          "in" : "query",
-          "description" : "The login name of the user to be returned",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The login name of the user to be returned",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "\n            A newly created user with the following attributes:\n            id: Unique server generated identifier for the user\n            version: The version of the user; version 0 is assigned to a newly created user\n            updateTimestamp: The date and time when the user was last updated\n            fullName: The full name for the new user\n            loginName: The login name for the new user\n            enabled: If true, the user account is enabled; false, the account is disabled\n            ssoAuth: If true, the user account is enabled for SSO authentication; \n                false, the account is enabled for password authentication\n            passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire\n            parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n            properties: An optional set of key/value properties associated with a user account\n            roleAssociations: A set of roles associated with the user account",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserResponseType"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      },
       "post" : {
         "tags" : [ "RBAC User API" ],
         "description" : "This method creates a new user.",
@@ -3572,6 +3537,43 @@
                   "format" : "int32",
                   "nullable" : false,
                   "example" : 0
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
+    "/user/{loginname}" : {
+      "get" : {
+        "tags" : [ "RBAC User API" ],
+        "description" : "This method returns a user based on the specified login name.",
+        "operationId" : "get_user__loginname_",
+        "parameters" : [ {
+          "name" : "loginname",
+          "in" : "path",
+          "description" : "The login name of the user to be returned",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The login name of the user to be returned",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "\n            A user with the following attributes:\n            id: Unique server generated identifier for the user\n            version: The version of the user; version 0 is assigned to a newly created user\n            updateTimestamp: The date and time when the user was last updated\n            fullName: The full name for the new user\n            loginName: The login name for the new user\n            enabled: If true, the user account is enabled; false, the account is disabled\n            ssoAuth: If true, the user account is enabled for SSO authentication; \n                false, the account is enabled for password authentication\n            passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire\n            parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n            properties: An optional set of key/value properties associated with a user account\n            roleAssociations: A set of roles associated with the user account",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserResponseType"
                 }
               }
             }


### PR DESCRIPTION
I would recommend to start review with `UserEndpoint.kt` file to get an idea what sort of change we are making to REST resource.

With Smoke/E2E tests passing, I have also done a round of Dev testing locally with Combined Worker.
It is still possible to use `v1` version of the API, however request serviced will contain a `Warning` header like so:
![image](https://github.com/corda/corda-runtime-os/assets/31008341/43f3b00c-0693-4b83-a3f1-d144061d0e90)

Newer version of API will not contain such a warning:
![image](https://github.com/corda/corda-runtime-os/assets/31008341/2f9623f7-d7e1-41f1-b1b8-491e4e3f3c0e)

But in both cases requests serviced successfully.