### PR TITLE
CORE-15260: Handle RestApiVersions in ResourceNameConflictValidator when resource path conflicts occur

### DIFF
--- a/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/ResourceNameConflictValidator.kt
+++ b/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/ResourceNameConflictValidator.kt
@@ -2,25 +2,52 @@ package net.corda.rest.tools.annotations.validation
 
 import net.corda.rest.RestResource
 import net.corda.rest.annotations.HttpRestResource
-import net.corda.rest.tools.annotations.extensions.path
+import net.corda.rest.annotations.RestApiVersion
+import net.corda.rest.annotations.retrieveApiVersionsSet
 
 /**
  * Validates that multiple classes do not have the same resource path.
  */
 internal class ResourceNameConflictValidator(private val classes: List<Class<out RestResource>>) : RestValidator {
+    companion object {
+        fun error(path: String?,
+                  clazz: Class<out RestResource>,
+                  conflictingClass: Class<out RestResource>): String {
+            val resource = clazz.getAnnotation(HttpRestResource::class.java)
+            val conflictingResource = conflictingClass.getAnnotation(HttpRestResource::class.java)
+            return "Duplicate resource with path '$path' in '${clazz.simpleName}' " +
+                    "for version range (${resource.minVersion} -> ${resource.maxVersion}). " +
+                    "Conflicting resource: '${conflictingClass.simpleName}' " +
+                    "with versions (${conflictingResource.minVersion} -> ${conflictingResource.maxVersion})."
+        }
+    }
     override fun validate(): RestValidationResult {
-        val resourceNames = mutableSetOf<String>()
+        val pathsToTypesAndVersions = mutableMapOf<Pair<String?, RestApiVersion>, Class<out RestResource>>()
         return classes.filter {
             it.annotations.any { annotation -> annotation is HttpRestResource }
-        }.map {
-            it.getAnnotation(HttpRestResource::class.java).path(it).lowercase()
         }.fold(RestValidationResult()) { total, next ->
-            total + if (next in resourceNames) {
-                RestValidationResult(listOf("Duplicate resource name: $next"))
+            total + total + pathsToTypesAndVersions.validateNoDuplicatePath(next)
+        }
+    }
+
+    private fun MutableMap<Pair<String?, RestApiVersion>, Class<out RestResource>>.validateNoDuplicatePath(
+        resourceClass: Class<out RestResource>,
+    ): RestValidationResult {
+        val resource = resourceClass.getAnnotation(HttpRestResource::class.java)
+        val path = resource.path.lowercase()
+        val newVersions = retrieveApiVersionsSet(resource.minVersion, resource.maxVersion)
+
+        val conflicts = mutableSetOf<String>()
+        newVersions.forEach {
+            val version = Pair(path, it)
+            if (this.keys.contains(version)) {
+                val existingClass = this.getValue(version)
+                conflicts.add(error(path, resourceClass, existingClass))
             } else {
-                resourceNames.add(next)
-                RestValidationResult()
+                this[version] = resourceClass
             }
         }
+
+        return RestValidationResult(conflicts.toList())
     }
 }

--- a/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/ResourceNameConflictValidator.kt
+++ b/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/annotations/validation/ResourceNameConflictValidator.kt
@@ -4,6 +4,7 @@ import net.corda.rest.RestResource
 import net.corda.rest.annotations.HttpRestResource
 import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.annotations.retrieveApiVersionsSet
+import net.corda.rest.tools.annotations.extensions.path
 
 /**
  * Validates that multiple classes do not have the same resource path.
@@ -34,7 +35,7 @@ internal class ResourceNameConflictValidator(private val classes: List<Class<out
         resourceClass: Class<out RestResource>,
     ): RestValidationResult {
         val resource = resourceClass.getAnnotation(HttpRestResource::class.java)
-        val path = resource.path.lowercase()
+        val path = resource.path(resourceClass).lowercase()
         val newVersions = retrieveApiVersionsSet(resource.minVersion, resource.maxVersion)
 
         val conflicts = mutableSetOf<String>()

--- a/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/ResourceNameConflictValidatorTest.kt
+++ b/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/ResourceNameConflictValidatorTest.kt
@@ -2,6 +2,8 @@ package net.corda.rest.tools.annotations.validation
 
 import net.corda.rest.RestResource
 import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestApiVersion
+import net.corda.rest.tools.annotations.validation.ResourceNameConflictValidator.Companion.error
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -27,7 +29,117 @@ class ResourceNameConflictValidatorTest {
             )
         ).validate()
 
-        assertEquals(1, result.errors.size)
+        val expectedErrors = listOf(error("test", TestInterface2::class.java, TestInterface::class.java))
+        assertEquals(expectedErrors, result.errors)
+    }
+
+    @Test
+    fun `validate withResourceDuplicateNamesDifferentVersions errorListIsEmpty`() {
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_0, maxVersion = RestApiVersion.C5_1)
+        class TestInterface : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_2, maxVersion = RestApiVersion.C5_2)
+        class TestInterface2 : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        val result = ResourceNameConflictValidator(
+            listOf(
+                TestInterface::class.java,
+                TestInterface2::class.java
+            )
+        ).validate()
+
+        assertEquals(emptyList<String>(), result.errors)
+    }
+
+    @Test
+    fun `validate withResourceDuplicateNamesOverlappingVersions errorListContainsMessage`() {
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_0, maxVersion = RestApiVersion.C5_1)
+        class TestInterface : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_1, maxVersion = RestApiVersion.C5_2)
+        class TestInterface2 : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        val result = ResourceNameConflictValidator(
+            listOf(
+                TestInterface::class.java,
+                TestInterface2::class.java
+            )
+        ).validate()
+
+        val expectedErrors = listOf(error("test", TestInterface2::class.java, TestInterface::class.java))
+        assertEquals(expectedErrors, result.errors)
+    }
+
+    @Test
+    fun `validate withResourceDuplicateNamesContainedVersions errorListContainsMessage`() {
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_0, maxVersion = RestApiVersion.C5_2)
+        class TestInterface : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_1, maxVersion = RestApiVersion.C5_1)
+        class TestInterface2 : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        val result = ResourceNameConflictValidator(
+            listOf(
+                TestInterface::class.java,
+                TestInterface2::class.java
+            )
+        ).validate()
+
+        val expectedErrors = listOf(error("test", TestInterface2::class.java, TestInterface::class.java))
+        assertEquals(expectedErrors, result.errors)
+    }
+
+    @Test
+    fun `validate withResourceDuplicateNamesMultipleConflicts errorListContainsMessages`() {
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_0, maxVersion = RestApiVersion.C5_0)
+        class TestInterface : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_2, maxVersion = RestApiVersion.C5_2)
+        class TestInterface2 : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        @HttpRestResource(path = "test", minVersion = RestApiVersion.C5_0, maxVersion = RestApiVersion.C5_2)
+        class TestInterface3 : RestResource {
+            override val protocolVersion: Int
+                get() = 1
+        }
+
+        val result = ResourceNameConflictValidator(
+            listOf(
+                TestInterface::class.java,
+                TestInterface2::class.java,
+                TestInterface3::class.java
+            )
+        ).validate()
+
+        val expectedErrors = listOf(
+            error("test", TestInterface3::class.java, TestInterface::class.java),
+            error("test", TestInterface3::class.java, TestInterface2::class.java),
+        )
+        assertEquals(expectedErrors, result.errors)
     }
 
     @Test
@@ -51,7 +163,8 @@ class ResourceNameConflictValidatorTest {
             )
         ).validate()
 
-        assertEquals(1, result.errors.size)
+        val expectedErrors = listOf(error("test", TestInterface2::class.java, TestInterface::class.java))
+        assertEquals(expectedErrors, result.errors)
     }
 
     @Test

--- a/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/ResourceNameConflictValidatorTest.kt
+++ b/libs/rest/rest-tools/src/test/kotlin/net/corda/rest/tools/annotations/validation/ResourceNameConflictValidatorTest.kt
@@ -163,7 +163,7 @@ class ResourceNameConflictValidatorTest {
             )
         ).validate()
 
-        val expectedErrors = listOf(error("test", TestInterface2::class.java, TestInterface::class.java))
+        val expectedErrors = listOf(error("testinterface", TestInterface2::class.java, TestInterface::class.java))
         assertEquals(expectedErrors, result.errors)
     }
 


### PR DESCRIPTION
This relaxes the requirements in ResourceNameConflictValidator to allow resources with the same path if they have different, non overlapping versions.