### PR TITLE
CORE-14775 Preventing DBCordaConsumerImpl from skipping over pending records

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -32,7 +32,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
@@ -565,7 +564,6 @@ class FlowTests {
     }
 
     @Test
-    @Disabled
     fun `Flow Session - Initiate multiple sessions and exercise the flow messaging apis`() {
 
         val requestBody = RpcSmokeTestInput().apply {

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
@@ -76,12 +76,9 @@ internal class DBCordaConsumerImplTest {
     }
 
     private fun getTopicRecords(
-        topic: String = defaultTopic,
         partition: CordaTopicPartition = partition0,
         startOffset: Long = 0L,
-        key: ByteArray = serializedKey,
         value: ByteArray? = serializedValue,
-        header: String = serializedHeader,
         txState: TransactionState = TransactionState.COMMITTED,
         count: Int = 1): List<TopicRecordEntry>
     {
@@ -89,12 +86,12 @@ internal class DBCordaConsumerImplTest {
 
         return (0 until count).mapIndexed { index, _ ->
             TopicRecordEntry(
-                topic,
+                defaultTopic,
                 partition.partition,
                 startOffset + index,
-                key,
+                serializedKey,
                 value,
-                header,
+                serializedHeader,
                 TransactionRecordEntry("id", txState),
                 timestamp
             )


### PR DESCRIPTION
## Overview
After investigation, the root cause of the test flakiness described in CORE-14775 was found to be a bug in `DBCordaConsumerImpl` which allowed for records in `TransactionState.PENDING` to be skipped over if they were followed by records with the state `TransactionState.COMMITTED`. This scenario can occur when one transaction is still in progress but a subsequent transaction has already been completed.

## Fix
To prevent this, the logic in the `DBCordaConsumerImpl` was modified such that:
1. We cannot read beyond the last `PENDING` record.
2. Offsets must be read sequentially.

## Testing
Following the changes, I ran the previously flaky `Flow Session - Initiate multiple sessions and exercise the flow messaging apis()` test locally on the combined worker and verified that it successfully passed 50 times in a row (where previously it had been failing every 2-3 runs, as seen also on Jenkins).

I also added unit tests to cover the previously failing scenario, and refactored the existing unit tests to tighten up their logic against the correct behaviour.