### PR TITLE
CORE-8434: Disable services which sandbox testing needs to override.

### DIFF
--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/SandboxGroupContextComponentImpl.kt
@@ -16,7 +16,10 @@ import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
 @Suppress("unused")
-@Component(service = [ SandboxGroupContextComponent::class ])
+@Component(
+    service = [ SandboxGroupContextComponent::class ],
+    property = [ SandboxSetup.SANDBOX_SERVICE ]
+)
 @ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class SandboxGroupContextComponentImpl @Activate constructor(
     @Reference

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
@@ -3,6 +3,7 @@ package net.corda.testing.sandboxes.testkit.impl
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.testing.sandboxes.CpiLoader
+import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.testing.sandboxes.testkit.VirtualNodeService
 import net.corda.v5.base.types.MemberX500Name
@@ -24,7 +25,7 @@ class VirtualNodeServiceImpl @Activate constructor(
     @Reference
     private val virtualNodeLoader: VirtualNodeLoader,
 
-    @Reference
+    @Reference(target = SandboxSetup.SANDBOX_SERVICE_FILTER)
     private val sandboxGroupContextComponent: SandboxGroupContextComponent
 ) : VirtualNodeService {
     private companion object {

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/SandboxSetup.kt
@@ -6,6 +6,8 @@ import org.osgi.framework.BundleContext
 interface SandboxSetup {
     companion object {
         const val SANDBOX_SERVICE_RANKING = Int.MAX_VALUE / 2
+        const val SANDBOX_SERVICE = "corda.testing.sandbox:Boolean=true"
+        const val SANDBOX_SERVICE_FILTER = "(corda.testing.sandbox=*)"
     }
 
     fun configure(bundleContext: BundleContext, baseDirectory: Path)

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpiInfoServiceImpl.kt
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory
 import java.util.stream.Stream
 
 @Suppress("unused")
-@Component
+@Component(property = [ SandboxSetup.SANDBOX_SERVICE ])
 @ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class CpiInfoServiceImpl @Activate constructor(
     @Reference

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpkReadServiceImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/CpkReadServiceImpl.kt
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Component(
     name = CpiLoader.COMPONENT_NAME,
     service = [ CpkReadService::class, CpiLoader::class ],
+    property = [ SandboxSetup.SANDBOX_SERVICE ],
     configurationPolicy = REQUIRE
 )
 @ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
@@ -50,10 +51,6 @@ class CpkReadServiceImpl @Activate constructor(
         get() = cpks.map(Cpk::metadata)
 
     override val isRunning: Boolean get() = true
-
-    init {
-        logger.info("Activated")
-    }
 
     private fun getInputStream(resourceName: String): InputStream {
         return testBundle.getResource(resourceName)?.openStream()

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/MembershipGroupReaderProviderImpl.kt
@@ -16,7 +16,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking
 import org.slf4j.LoggerFactory
 
 @Suppress("unused")
-@Component
+@Component(property = [ SandboxSetup.SANDBOX_SERVICE ])
 @ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -29,11 +29,11 @@ class MembershipGroupReaderProviderImpl : MembershipGroupReaderProvider {
         get() = true
 
     override fun start() {
-        logger.info("Starting")
+        logger.info("Started")
     }
 
     override fun stop() {
-        logger.info("Stopping")
+        logger.info("Stopped")
     }
 
     private class MembershipGroupReaderImpl(holdingIdentity: HoldingIdentity) : MembershipGroupReader {

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -1,12 +1,17 @@
 package net.corda.testing.sandboxes.impl
 
+import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.cpk.read.CpkReadService
+import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.sandbox.SandboxCreationService
 import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.SandboxSetup
+import net.corda.testing.sandboxes.SandboxSetup.Companion.SANDBOX_SERVICE_FILTER
 import net.corda.testing.sandboxes.impl.SandboxSetupImpl.Companion.INSTALLER_NAME
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.framework.BundleContext
 import org.osgi.service.cm.ConfigurationAdmin
+import org.osgi.service.component.ComponentConstants.COMPONENT_NAME
 import org.osgi.service.component.ComponentContext
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -14,6 +19,7 @@ import org.osgi.service.component.annotations.Deactivate
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL
 import org.osgi.service.component.annotations.ReferencePolicy.DYNAMIC
+import org.osgi.service.component.runtime.ServiceComponentRuntime
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import java.util.Collections.unmodifiableSet
@@ -27,6 +33,7 @@ import java.util.concurrent.TimeoutException
     reference = [ Reference(
         name = INSTALLER_NAME,
         service = CpkReadService::class,
+        target = SANDBOX_SERVICE_FILTER,
         cardinality = OPTIONAL,
         policy = DYNAMIC
     )]
@@ -35,11 +42,14 @@ class SandboxSetupImpl @Activate constructor(
     @Reference
     private val configAdmin: ConfigurationAdmin,
     @Reference
+    private val scr: ServiceComponentRuntime,
+    @Reference
     private val sandboxCreator: SandboxCreationService,
     private val componentContext: ComponentContext
 ) : SandboxSetup {
     companion object {
         const val INSTALLER_NAME = "installer"
+        private const val NON_SANDBOX_COMPONENT_FILTER = "(&($COMPONENT_NAME=*)(!$SANDBOX_SERVICE_FILTER))"
         private const val WAIT_MILLIS = 100L
 
         // The names of the bundles to place as public bundles in the sandbox service's platform sandbox.
@@ -66,6 +76,14 @@ class SandboxSetupImpl @Activate constructor(
             "slf4j.api"
         ))
 
+        private val REPLACEMENT_SERVICES = unmodifiableSet(setOf(
+            CpiInfoReadService::class.java,
+            CpkReadService::class.java,
+            MembershipGroupReaderProvider::class.java,
+            VirtualNodeInfoReadService::class.java
+        ).mapTo(linkedSetOf(), Class<*>::getName) + setOf(
+            "net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent"
+        ))
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
@@ -78,6 +96,9 @@ class SandboxSetupImpl @Activate constructor(
         val testBundle = bundleContext.bundle
         logger.info("Configuring sandboxes for [{}]", testBundle.symbolicName)
 
+        // We are replacing these Corda services with our own versions.
+        REPLACEMENT_SERVICES.forEach(::disableNonSandboxServices)
+
         configAdmin.getConfiguration(CpiLoader.COMPONENT_NAME)?.also { config ->
             val properties = Hashtable<String, Any?>()
             properties[CpiLoader.BASE_DIRECTORY_KEY] = baseDirectory.toString()
@@ -89,6 +110,18 @@ class SandboxSetupImpl @Activate constructor(
             bundle.symbolicName in PLATFORM_PUBLIC_BUNDLE_NAMES
         }
         sandboxCreator.createPublicSandbox(publicBundles, privateBundles)
+    }
+
+    private fun disableNonSandboxServices(serviceType: String) {
+        with(componentContext) {
+            bundleContext.getAllServiceReferences(serviceType, NON_SANDBOX_COMPONENT_FILTER)?.forEach { svcRef ->
+                val componentName = svcRef.properties[COMPONENT_NAME] ?: return@forEach
+                scr.getComponentDescriptionDTO(svcRef.bundle, componentName.toString())?.also { dto ->
+                    logger.info("Found and disabling service: {}", componentName)
+                    scr.disableComponent(dto)
+                }
+            }
+        }
     }
 
     /**

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
@@ -23,7 +23,10 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 
 @Suppress("unused")
-@Component(service = [ VirtualNodeLoader::class, VirtualNodeInfoReadService::class ])
+@Component(
+    service = [ VirtualNodeLoader::class, VirtualNodeInfoReadService::class ],
+    property = [ SandboxSetup.SANDBOX_SERVICE ]
+)
 @ServiceRanking(SandboxSetup.SANDBOX_SERVICE_RANKING)
 class VirtualNodeLoaderImpl @Activate constructor(
     @Reference


### PR DESCRIPTION
The `:testing:sandboxes` library works by replacing key Corda sandboxing services with its own versions. The testing versions are ranked higher than Corda's and so the OSGi framework chooses the testing ones by default. However, there is obviously a race condition in the initialisation code for the ledger tests that can still allow the flow services to use Corda's `VirtualNodeInfoReadService` instead of the testing one.

Fix this by deactivating all Corda services which the sandbox testing needs to replace.

To do this, assign each sandbox service a `corda.testing.sandbox=true` property. Then we can use the SCR to deactivate all instances of these services that lack this property.

---
This change now results in this extra logging line from the `TestOSGi` tasks:
```
[main] INFO net.corda.testing.sandboxes.impl.SandboxSetupImpl - Found and disabling service: net.corda.virtualnode.read.impl.VirtualNodeInfoReadServiceImpl
```