### PR TITLE
CORE-15498: Parse group parameters correctly

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/types/GroupParameters.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/types/GroupParameters.kt
@@ -46,4 +46,9 @@ data class GroupParameters(val context: Map<String, String>) {
  * Creates [GroupParameters] from a [SimpleResponse].
  * Only works if the [SimpleResponse] is the response of a group parameters lookup.
  */
-fun SimpleResponse.jsonToGroupParameters(): GroupParameters = GroupParameters(toJson().parseContextMap())
+fun SimpleResponse.jsonToGroupParameters(): GroupParameters =
+    GroupParameters(
+        toJson()
+            .get("parameters")
+            .parseContextMap()
+    )


### PR DESCRIPTION
Fix an issue with the e2e tests caused by https://github.com/corda/corda-runtime-os/pull/4284

The tests are passing in https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda5-e2e-tests/detail/PR-154/6/tests