### PR TITLE
CORE-15539: Extend RbacEntitiesTest to check ChangeAudit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.8-alpha-1689678186012
+cordaApiVersion=5.1.0.7-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.7-beta+
+cordaApiVersion=5.1.0.8-alpha-1689678186012
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/permissions/permission-datamodel/src/integrationTest/kotlin/net/corda/permissions/model/test/RbacEntitiesTest.kt
+++ b/libs/permissions/permission-datamodel/src/integrationTest/kotlin/net/corda/permissions/model/test/RbacEntitiesTest.kt
@@ -99,21 +99,24 @@ class RbacEntitiesTest {
             null
         )
         emf.transaction { em -> em.persist(user) }
+        emf.createEntityManager().use { em ->
+            val retrievedUser = em.createQuery("from User where id = '$id'", user.javaClass).singleResult
+            assertThat(retrievedUser).isEqualTo(user)
+        }
+    }
 
+    @Test
+    fun `test change audit`() {
         val actorUserLongId = "RbacEntitiesTest" + UUID.randomUUID().toString()
         val auditLog = ChangeAudit(
             id = UUID.randomUUID().toString(),
             updateTimestamp = Instant.now(),
             actorUser = actorUserLongId,
             changeType = RestPermissionOperation.USER_INSERT,
-            details = "User '${user.loginName}' created by '$actorUserLongId'."
+            details = "User created by '$actorUserLongId'."
         )
         emf.transaction { em -> em.persist(auditLog) }
-
         emf.createEntityManager().use { em ->
-            val retrievedUser = em.createQuery("from User where id = '$id'", user.javaClass).singleResult
-            assertThat(retrievedUser).isEqualTo(user)
-
             val retrievedAudit = em.createQuery("from ChangeAudit where actorUser = '$actorUserLongId'", auditLog.javaClass).singleResult
             assertThat(retrievedAudit).isEqualTo(auditLog)
         }


### PR DESCRIPTION
- Extended RbacEntitiesTest to check ChangeAudit is working with long `actorUser`

Relevant fix in `corda-api` repo: [CORE-15539: Increase actor user column character length #1179](https://github.com/corda/corda-api/pull/1179)
Relevant E2E test change: [CORE-15539: Revert loginName truncation #158](https://github.com/corda/corda-e2e-tests/pull/158)