### PR TITLE
CORE-11532 - [WIP]: Quick NFT Test

### DIFF
--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -225,7 +225,8 @@ class CryptoProcessorImpl @Activate constructor(
 
         // first make the signing service object, which both processors will consume
         val signingService = SigningServiceImpl(
-            cryptoServiceFactory, SigningRepositoryFactoryImpl(
+            cryptoServiceFactory,
+            SigningRepositoryFactoryImpl(
                 dbConnectionManager,
                 virtualNodeInfoReadService,
                 jpaEntitiesRegistry,

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -182,6 +182,7 @@ class CryptoProcessorImpl @Activate constructor(
                         coordinator.postEvent(AssociateHSM())
                     }
                 } else {
+                    coordinator.closeManagedResources(setOf(FLOW_OPS_SUBSCRIPTION, RPC_OPS_SUBSCRIPTION, HSM_REG_SUBSCRIPTION))
                     dependenciesUp = false
                     setStatus(event.status, coordinator)
                 }

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -172,9 +172,9 @@ class CryptoProcessorImpl @Activate constructor(
             }
             is RegistrationStatusChangeEvent -> {
                 logger.trace("Registering for configuration updates.")
-                configurationReadService.registerComponentForUpdates(coordinator, configKeys)
                 if (event.status == LifecycleStatus.UP) {
                     dependenciesUp = true
+                    configurationReadService.registerComponentForUpdates(coordinator, configKeys)
                     // TODO only do setStatus once the config is in in ConfigChangedEvent
                     if (hsmAssociated) {
                         setStatus(event.status, coordinator)

--- a/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
+++ b/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
@@ -159,6 +159,19 @@ class CryptoProcessorImplTest {
             verify(flowOpsSubscription, times(2)).start()
             verify(rpcOpsSubscription, times(2)).start()
             verify(hsmRegSubscription, times(2)).start()
+
+
+            bringDependencyDown<CryptoServiceFactory>()
+            verify(flowOpsSubscription, times(2)).close()
+            verify(rpcOpsSubscription, times(2)).close()
+            verify(hsmRegSubscription, times(2)).close()
+
+            bringDependencyUp<CryptoServiceFactory>()
+            verifyIsUp<CryptoProcessor>()
+            sendConfigUpdate<CryptoProcessor>(mapOf(CRYPTO_CONFIG to cryptoConfig, MESSAGING_CONFIG to mock()))
+            verify(flowOpsSubscription, times(3)).start()
+            verify(rpcOpsSubscription, times(3)).start()
+            verify(hsmRegSubscription, times(3)).start()
         }
     }
 }


### PR DESCRIPTION
As marked on the ticket the below issue seems to be appearing on every resilience testing run with a frequency of 1 or 2 flows / 400 flows on a flow's request to the crypto worker `sign` operation:

```
-- failure 1 --Flow launched as holdingId '594BEDF2992B' with requestId '594BEDF2992B-flow-144-1685249031877' failed: {"holdingIdentityShortHash":"594BEDF2992B","clientRequestId":"594BEDF2992B-flow-144-1685249031877","flowId":"4eae3a35-11a9-4240-88c2-4188ec564afc","flowStatus":"FAILED","flowResult":null,"flowError":{"type":"FLOW_FAILED","message":"Component net.corda.crypto.service.CryptoServiceFactory is not ready."},"timestamp":"2023-05-28T04:43:52.400Z"} 
```

The interesting part of the above error line is: "_Component net.corda.crypto.service.CryptoServiceFactory is not ready_"

It seems the issue is [SigningServiceImpl](https://github.com/corda/corda-runtime-os/blob/release/os/5.0/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/SigningServiceImpl.kt) which seems to be a non lifecycle service, however it references a lifecycle service: `CryptoServiceFactory`. Now `SigningServiceImpl` is being used by 2 Kafka consumers ("_processors_"):  `CryptoFlowOpsBusProcessor` and `CryptoOpsBusProcessor`. What seems to be happening is it might happen that `CryptoServiceFactory` goes DOWN/ ERROR, however the processors are not being notified of those events and so they "think" they are still UP, however their underlying `CryptoServiceFactory` service is `DOWN`.

This PR takes the processors down (detaches them from Kafka) so we stop processing events targeting those processors when `CryptoServiceFactory` is DOWN/ ERROR, at the `CryptoProcessorImpl` level, and we can do that there, because `CryptoProcessorImpl` lifecycle depends on `CryptoServiceFactory` and therefore it can "see" when `CryptoServiceFactory` has gone DOWN/ ERROR.

