### PR TITLE
CORE-15497: make use of notary passed from request body

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -68,6 +68,7 @@ class FlowTests {
             davidX500,
             notaryX500
         )
+        private val notaryServiceX500 = "O=MyNotaryService-${notaryHoldingId}, L=London, C=GB"
 
         val invalidConstructorFlowNames = listOf(
             "com.r3.corda.testing.smoketests.flow.errors.PrivateConstructorFlow",
@@ -126,7 +127,7 @@ class FlowTests {
 
             registerStaticMember(bobHoldingId)
             registerStaticMember(charlieHoldingId)
-            registerStaticMember(notaryHoldingId, isNotary = true)
+            registerStaticMember(notaryHoldingId, notaryServiceX500)
         }
 
         private val JsonNode?.command: String

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -68,7 +68,7 @@ class FlowTests {
             davidX500,
             notaryX500
         )
-        private val notaryServiceX500 = "O=MyNotaryService-${notaryHoldingId}, L=London, C=GB"
+        private const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val invalidConstructorFlowNames = listOf(
             "com.r3.corda.testing.smoketests.flow.errors.PrivateConstructorFlow",
@@ -127,7 +127,7 @@ class FlowTests {
 
             registerStaticMember(bobHoldingId)
             registerStaticMember(charlieHoldingId)
-            registerStaticMember(notaryHoldingId, notaryServiceX500)
+            registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
         }
 
         private val JsonNode?.command: String

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
@@ -52,7 +52,7 @@ class UtxoLedgerTests {
     private val charlieHoldingId: String = getHoldingIdShortHash(charlieX500, groupId)
     private val notaryHoldingId: String = getHoldingIdShortHash(notaryX500, groupId)
 
-    private val notaryServiceX500 = "O=NotaryService-${notaryHoldingId}, L=London, C=GB"
+    private val notaryServiceX500 = "O=MyNotaryService-${notaryHoldingId}, L=London, C=GB"
 
     private val staticMemberList = listOf(
         aliceX500,
@@ -90,7 +90,7 @@ class UtxoLedgerTests {
         registerStaticMember(bobHoldingId)
         registerStaticMember(charlieHoldingId)
 
-        registerStaticMember(notaryHoldingId, true, notaryServiceX500)
+        registerStaticMember(notaryHoldingId, notaryServiceX500)
     }
 
     @Test

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
@@ -52,6 +52,8 @@ class UtxoLedgerTests {
     private val charlieHoldingId: String = getHoldingIdShortHash(charlieX500, groupId)
     private val notaryHoldingId: String = getHoldingIdShortHash(notaryX500, groupId)
 
+    private val notaryServiceX500 = "O=NotaryService-${notaryHoldingId}, L=London, C=GB"
+
     private val staticMemberList = listOf(
         aliceX500,
         bobX500,
@@ -88,7 +90,7 @@ class UtxoLedgerTests {
         registerStaticMember(bobHoldingId)
         registerStaticMember(charlieHoldingId)
 
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, true, notaryServiceX500)
     }
 
     @Test
@@ -101,7 +103,7 @@ class UtxoLedgerTests {
             // Issue state
             val flowId = startRpcFlow(
                 aliceHoldingId,
-                mapOf("input" to input, "members" to listOf(bobX500, charlieX500), "notary" to notaryX500),
+                mapOf("input" to input, "members" to listOf(bobX500, charlieX500), "notary" to notaryServiceX500),
                 "com.r3.corda.demo.utxo.UtxoDemoFlow"
             )
 
@@ -139,7 +141,7 @@ class UtxoLedgerTests {
         val input = "test input"
         val utxoFlowRequestId = startRpcFlow(
             aliceHoldingId,
-            mapOf("input" to input, "members" to listOf(bobX500, charlieX500), "notary" to notaryX500),
+            mapOf("input" to input, "members" to listOf(bobX500, charlieX500), "notary" to notaryServiceX500),
             "com.r3.corda.demo.utxo.UtxoDemoFlow"
         )
         val utxoFlowResult = awaitRpcFlowFinished(aliceHoldingId, utxoFlowRequestId)
@@ -206,7 +208,7 @@ class UtxoLedgerTests {
     fun `Utxo Ledger - creating a transaction that fails custom validation causes finality to fail`() {
         val utxoFlowRequestId = startRpcFlow(
             aliceHoldingId,
-            mapOf("input" to "fail", "members" to listOf(bobX500, charlieX500), "notary" to notaryX500),
+            mapOf("input" to "fail", "members" to listOf(bobX500, charlieX500), "notary" to notaryServiceX500),
             "com.r3.corda.demo.utxo.UtxoDemoFlow"
         )
         val utxoFlowResult = awaitRpcFlowFinished(aliceHoldingId, utxoFlowRequestId)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
@@ -27,6 +27,7 @@ class UtxoLedgerTests {
     private companion object {
         const val TEST_CPI_NAME = "ledger-utxo-demo-app"
         const val TEST_CPB_LOCATION = "/META-INF/ledger-utxo-demo-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
@@ -51,8 +52,6 @@ class UtxoLedgerTests {
     private val bobHoldingId: String = getHoldingIdShortHash(bobX500, groupId)
     private val charlieHoldingId: String = getHoldingIdShortHash(charlieX500, groupId)
     private val notaryHoldingId: String = getHoldingIdShortHash(notaryX500, groupId)
-
-    private val notaryServiceX500 = "O=MyNotaryService, L=London, C=GB"
 
     private val staticMemberList = listOf(
         aliceX500,
@@ -90,7 +89,7 @@ class UtxoLedgerTests {
         registerStaticMember(bobHoldingId)
         registerStaticMember(charlieHoldingId)
 
-        registerStaticMember(notaryHoldingId, notaryServiceX500)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test
@@ -103,7 +102,7 @@ class UtxoLedgerTests {
             // Issue state
             val flowId = startRpcFlow(
                 aliceHoldingId,
-                mapOf("input" to input, "members" to listOf(bobX500, charlieX500), "notary" to notaryServiceX500),
+                mapOf("input" to input, "members" to listOf(bobX500, charlieX500), "notary" to NOTARY_SERVICE_X500),
                 "com.r3.corda.demo.utxo.UtxoDemoFlow"
             )
 
@@ -141,7 +140,7 @@ class UtxoLedgerTests {
         val input = "test input"
         val utxoFlowRequestId = startRpcFlow(
             aliceHoldingId,
-            mapOf("input" to input, "members" to listOf(bobX500, charlieX500), "notary" to notaryServiceX500),
+            mapOf("input" to input, "members" to listOf(bobX500, charlieX500), "notary" to NOTARY_SERVICE_X500),
             "com.r3.corda.demo.utxo.UtxoDemoFlow"
         )
         val utxoFlowResult = awaitRpcFlowFinished(aliceHoldingId, utxoFlowRequestId)
@@ -208,7 +207,7 @@ class UtxoLedgerTests {
     fun `Utxo Ledger - creating a transaction that fails custom validation causes finality to fail`() {
         val utxoFlowRequestId = startRpcFlow(
             aliceHoldingId,
-            mapOf("input" to "fail", "members" to listOf(bobX500, charlieX500), "notary" to notaryServiceX500),
+            mapOf("input" to "fail", "members" to listOf(bobX500, charlieX500), "notary" to NOTARY_SERVICE_X500),
             "com.r3.corda.demo.utxo.UtxoDemoFlow"
         )
         val utxoFlowResult = awaitRpcFlowFinished(aliceHoldingId, utxoFlowRequestId)

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
@@ -52,7 +52,7 @@ class UtxoLedgerTests {
     private val charlieHoldingId: String = getHoldingIdShortHash(charlieX500, groupId)
     private val notaryHoldingId: String = getHoldingIdShortHash(notaryX500, groupId)
 
-    private val notaryServiceX500 = "O=MyNotaryService-${notaryHoldingId}, L=London, C=GB"
+    private val notaryServiceX500 = "O=MyNotaryService, L=London, C=GB"
 
     private val staticMemberList = listOf(
         aliceX500,

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/TokenBalanceQueryTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/TokenBalanceQueryTests.kt
@@ -48,6 +48,7 @@ class TokenBalanceQueryTests {
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
         }
+        private val notaryServiceX500 = "O=MyNotaryService-${notaryHoldingId}, L=London, C=GB"
     }
 
     private fun convertToTokenBalanceQueryResponseMsg(tokenBalanceQueryResponseMsgStr: String) =
@@ -100,7 +101,7 @@ class TokenBalanceQueryTests {
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
 
-        registerStaticMember(notaryHoldingId, true)
+        registerStaticMember(notaryHoldingId, notaryServiceX500)
     }
 
     @Test

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/TokenBalanceQueryTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/TokenBalanceQueryTests.kt
@@ -25,6 +25,7 @@ class TokenBalanceQueryTests {
     private companion object {
         const val TEST_CPI_NAME = "ledger-utxo-demo-app"
         const val TEST_CPB_LOCATION = "/META-INF/ledger-utxo-demo-app.cpb"
+        const val NOTARY_SERVICE_X500 = "O=MyNotaryService, L=London, C=GB"
 
         val testRunUniqueId = UUID.randomUUID().toString()
         val groupId = UUID.randomUUID().toString()
@@ -48,7 +49,6 @@ class TokenBalanceQueryTests {
         val objectMapper = ObjectMapper().apply {
             registerModule(KotlinModule.Builder().build())
         }
-        private val notaryServiceX500 = "O=MyNotaryService-${notaryHoldingId}, L=London, C=GB"
     }
 
     private fun convertToTokenBalanceQueryResponseMsg(tokenBalanceQueryResponseMsgStr: String) =
@@ -101,7 +101,7 @@ class TokenBalanceQueryTests {
         registerStaticMember(aliceHoldingId)
         registerStaticMember(bobHoldingId)
 
-        registerStaticMember(notaryHoldingId, notaryServiceX500)
+        registerStaticMember(notaryHoldingId, NOTARY_SERVICE_X500)
     }
 
     @Test

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/UtxoDemoFlow.kt
@@ -65,9 +65,7 @@ class UtxoDemoFlow : ClientStartableFlow {
                 request.members + listOf(myInfo.name.toString())
             )
 
-            val notary = requireNotNull(notaryLookup.lookup(MemberX500Name.parse(request.notary))) {
-                "notary ${request.notary} is null"
-            }
+            val notary = notaryLookup.lookup(MemberX500Name.parse(request.notary))?: notaryLookup.notaryServices.single()
 
             val txBuilder = utxoLedgerService.createTransactionBuilder()
 

--- a/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/UtxoDemoFlow.kt
+++ b/testing/cpbs/ledger-utxo-demo-app/src/main/kotlin/com/r3/corda/demo/utxo/UtxoDemoFlow.kt
@@ -53,7 +53,6 @@ class UtxoDemoFlow : ClientStartableFlow {
         log.info("Utxo flow demo starting...")
         try {
             val request = requestBody.getRequestBodyAs(jsonMarshallingService, InputMessage::class.java)
-
             val myInfo = memberLookup.myInfo()
             val members = request.members.map { x500 ->
                 requireNotNull(memberLookup.lookup(MemberX500Name.parse(x500))) {
@@ -66,7 +65,10 @@ class UtxoDemoFlow : ClientStartableFlow {
                 request.members + listOf(myInfo.name.toString())
             )
 
-            val notary = notaryLookup.notaryServices.single()
+            val notary = requireNotNull(notaryLookup.lookup(MemberX500Name.parse(request.notary))) {
+                "notary ${request.notary} is null"
+            }
+
             val txBuilder = utxoLedgerService.createTransactionBuilder()
 
             val signedTransaction = txBuilder

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -258,10 +258,10 @@ class ClusterBuilder {
      * notary service. This is fine for now as we only support a 1-1 mapping from notary service to
      * notary vnode. It will need revisiting when 1-* is supported.
      */
-    fun registerStaticMember(holdingIdShortHash: String, isNotary:Boolean = false, notaryServiceName: String) =
+    fun registerStaticMember(holdingIdShortHash: String, notaryServiceName: String? = null) =
         register(
             holdingIdShortHash,
-            if (isNotary) registerNotaryBody(notaryServiceName) else registerMemberBody()
+            if (notaryServiceName != null) registerNotaryBody(notaryServiceName) else registerMemberBody()
         )
 
     fun register(holdingIdShortHash: String, registrationContext: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -155,12 +155,12 @@ class ClusterBuilder {
     private fun registerMemberBody() =
         """{ "context": { "corda.key.scheme" : "CORDA.ECDSA.SECP256R1" } }""".trimMargin()
 
-    private fun registerNotaryBody(holdingIdShortHash: String) =
+    private fun registerNotaryBody(notaryServiceName: String) =
         """{ 
             |  "context": { 
             |    "corda.key.scheme" : "CORDA.ECDSA.SECP256R1", 
             |    "corda.roles.0" : "notary",
-            |    "corda.notary.service.name" : "O=MyNotaryService-${holdingIdShortHash}, L=London, C=GB",
+            |    "corda.notary.service.name" : "$notaryServiceName",
             |    "corda.notary.service.flow.protocol.name" : "com.r3.corda.notary.plugin.nonvalidating",
             |    "corda.notary.service.flow.protocol.version.0" : "1"
             |   } 
@@ -258,10 +258,10 @@ class ClusterBuilder {
      * notary service. This is fine for now as we only support a 1-1 mapping from notary service to
      * notary vnode. It will need revisiting when 1-* is supported.
      */
-    fun registerStaticMember(holdingIdShortHash: String, isNotary: Boolean = false) =
+    fun registerStaticMember(holdingIdShortHash: String, isNotary:Boolean = false, notaryServiceName: String) =
         register(
             holdingIdShortHash,
-            if (isNotary) registerNotaryBody(holdingIdShortHash) else registerMemberBody()
+            if (isNotary) registerNotaryBody(notaryServiceName) else registerMemberBody()
         )
 
     fun register(holdingIdShortHash: String, registrationContext: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -232,18 +232,20 @@ fun ClusterInfo.waitForRegistrationStatus(
  */
 fun registerStaticMember(
     holdingIdentityShortHash: String,
-    isNotary: Boolean = false
-) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, isNotary)
+    isNotary: Boolean = false,
+    notaryServiceName: String = "O=MyNotaryService-${holdingIdentityShortHash}, L=London, C=GB"
+) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, isNotary, notaryServiceName)
 
 fun ClusterInfo.registerStaticMember(
     holdingIdentityShortHash: String,
-    isNotary: Boolean = false
+    isNotary: Boolean = false,
+    notaryServiceName: String
 ) {
     cluster {
         assertWithRetry {
             interval(1.seconds)
             timeout(10.seconds)
-            command { registerStaticMember(holdingIdentityShortHash, isNotary) }
+            command { registerStaticMember(holdingIdentityShortHash, isNotary, notaryServiceName) }
             condition {
                 it.code == ResponseCode.OK.statusCode
                         && it.toJson()["registrationStatus"].textValue() == REGISTRATION_SUBMITTED

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -232,20 +232,18 @@ fun ClusterInfo.waitForRegistrationStatus(
  */
 fun registerStaticMember(
     holdingIdentityShortHash: String,
-    isNotary: Boolean = false,
-    notaryServiceName: String = "O=MyNotaryService-${holdingIdentityShortHash}, L=London, C=GB"
-) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, isNotary, notaryServiceName)
+    notaryServiceName: String? = null
+) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, notaryServiceName)
 
 fun ClusterInfo.registerStaticMember(
     holdingIdentityShortHash: String,
-    isNotary: Boolean = false,
-    notaryServiceName: String
+    notaryServiceName: String? = null
 ) {
     cluster {
         assertWithRetry {
             interval(1.seconds)
             timeout(10.seconds)
-            command { registerStaticMember(holdingIdentityShortHash, isNotary, notaryServiceName) }
+            command { registerStaticMember(holdingIdentityShortHash, notaryServiceName) }
             condition {
                 it.code == ResponseCode.OK.statusCode
                         && it.toJson()["registrationStatus"].textValue() == REGISTRATION_SUBMITTED


### PR DESCRIPTION
This PR changed api of `registerStaticMember` and context notary body in MGM registration for e2e testing, so that we can make use of notary that has passed to request body of demo flow, as opposed to notary not being used previously. Now the update will use either notary that was specified in call site or whatever notary that was available in network.