### PR TITLE
CORE-11805 - Upgrade json schema validator library

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -75,7 +75,7 @@ log4jVersion = 2.20.0
 micrometerVersion=1.11.0
 nettyVersion = 4.1.94.Final
 # com.networknt:json-schema-validator cannot be upgraded beyond 1.0.66 because it becomes dependent on com.ethlo.time which is not OSGi compatible.
-networkntJsonSchemaVersion = 1.0.66
+networkntJsonSchemaVersion = 1.0.86
 osgiCmVersion = 1.6.1
 osgiNamespaceServiceVersion = 1.0.0
 osgiServiceComponentVersion = 1.5.1


### PR DESCRIPTION
Upgrade json schema validator library to remove spurious warnings in the logs.