### PR TITLE
CORE-15451 Snyk waivers for kubernetes-client

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -21,4 +21,20 @@ ignore:
           configuring Jetty programmatically.
         expires: 2023-12-13T12:08:30.514Z
         created: 2023-07-13T12:08:30.517Z
+
+  SNYK-JAVA-COMSQUAREUPOKIO-5773320:
+    - '*':
+        reason: >-
+          Corda 5 is not vulnerable to a DoS attack as the exploitable library is used by
+          an HTTP client, not server.
+        expires: 2023-12-20T08:26:30.514Z
+        created: 2023-07-20T08:26:30.517Z
+
+  SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044:
+    - '*':
+        reason: >-
+          Corda 5 is not vulnerable to this attack as users do not have control over the
+          HTTP headers used with the client.
+        expires: 2023-12-20T08:30:30.514Z
+        created: 2023-07-20T08:30:30.517Z
 patch: {}


### PR DESCRIPTION
Adds waivers for two vulnerabilities introduced via `kubernetes-client` that do not impact Corda as they only apply to the use of the dependent libraries on the server side, not as a client.