### PR TITLE
CORE-3920 Sessions Should Not hang indefinitely if both parties are waiting to receive data DRAFT

### DIFF
--- a/components/flow/flow-p2p-filter-service/src/integrationTest/kotlin/net/corda/flow/p2p/filter/integration/FlowFilterServiceIntegrationTest.kt
+++ b/components/flow/flow-p2p-filter-service/src/integrationTest/kotlin/net/corda/flow/p2p/filter/integration/FlowFilterServiceIntegrationTest.kt
@@ -111,7 +111,7 @@ class FlowFilterServiceIntegrationTest {
                 emptyKeyValuePairList(),
                 emptyKeyValuePairList(),
                 ByteBuffer.wrap("".toByteArray())
-            )
+            ), false
         )
 
         val sessionRecord = Record(

--- a/components/flow/flow-p2p-filter-service/src/test/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterProcessorTest.kt
+++ b/components/flow/flow-p2p-filter-service/src/test/kotlin/net/corda/flow/p2p/filter/FlowP2PFilterProcessorTest.kt
@@ -60,7 +60,8 @@ class FlowP2PFilterProcessorTest {
                 emptyKeyValuePairList(),
                 emptyKeyValuePairList(),
                 ByteBuffer.wrap("".toByteArray())
-            )
+            ),
+            false
         )
 
         val flowEventMockData: ByteArray = "flowEvent".toByteArray()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -54,6 +54,7 @@ class SessionEventHandler @Activate constructor(
     override fun preProcess(context: FlowEventContext<SessionEvent>): FlowEventContext<SessionEvent> {
         val checkpoint = context.checkpoint
         val sessionEvent = context.inputEventPayload
+        val waitingForData = context.inputEventPayload.waitingForDataFlag
 
         log.trace { "Session event in handler: ${sessionEvent.payload}" }
 
@@ -63,7 +64,7 @@ class SessionEventHandler @Activate constructor(
             sessionId,
             if (checkpoint.doesExist) checkpoint.getSessionState(sessionId) else null,
             sessionEvent,
-            now
+            now, waitingForData
         )
 
         // Null is returned if duplicate [SessionInit]s are received

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -214,7 +214,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             val exceptionHandlingStartTime = Instant.now()
             val checkpoint = context.checkpoint
 
-                if (!checkpoint.doesExist) {
+            if (!checkpoint.doesExist) {
                 val statusRecord = createFlowKilledStatusRecordWithoutCheckpoint(
                     checkpoint.flowId,
                     context,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -214,7 +214,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             val exceptionHandlingStartTime = Instant.now()
             val checkpoint = context.checkpoint
 
-            if (!checkpoint.doesExist) {
+                if (!checkpoint.doesExist) {
                 val statusRecord = createFlowKilledStatusRecordWithoutCheckpoint(
                     checkpoint.flowId,
                     context,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/FlowSessionManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/FlowSessionManager.kt
@@ -28,7 +28,7 @@ interface FlowSessionManager {
      * @param flowConfig The config containing the flow session config values such as the resend time window
      * @param instant The [Instant] used within the created error events.
      */
-    fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant): List<Record<*, FlowMapperEvent>>
+    fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant, waitingForData: Boolean): List<Record<*, FlowMapperEvent>>
 
     /**
      * Create a new [SessionState] and queue a [SessionInit] message to send.

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/FlowSessionManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/FlowSessionManager.kt
@@ -28,7 +28,7 @@ interface FlowSessionManager {
      * @param flowConfig The config containing the flow session config values such as the resend time window
      * @param instant The [Instant] used within the created error events.
      */
-    fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant, waitingForData: Boolean): List<Record<*, FlowMapperEvent>>
+    fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant): List<Record<*, FlowMapperEvent>>
 
     /**
      * Create a new [SessionState] and queue a [SessionInit] message to send.

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
@@ -38,7 +38,7 @@ class FlowSessionManagerImpl @Activate constructor(
     private val flowRecordFactory: FlowRecordFactory,
 ) : FlowSessionManager {
 
-    override fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant, waitingForData: Boolean):
+    override fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant):
             List<Record<*, FlowMapperEvent>> {
         val waitingForData = false // In the case of session error, it is irrelevant if the session is waiting to receive or not.
         return checkpoint.sessions
@@ -82,6 +82,7 @@ class FlowSessionManagerImpl @Activate constructor(
             .setReceivedSequenceNum(0)
             .setOutOfOrderSequenceNums(listOf(0))
             .setPayload(payload)
+            .setWaitingForDataFlag(false)
             .build()
 
         return sessionManager.processMessageToSend(
@@ -284,6 +285,7 @@ class FlowSessionManagerImpl @Activate constructor(
                 .setReceivedSequenceNum(0)
                 .setOutOfOrderSequenceNums(listOf(0))
                 .setPayload(payload)
+                .setWaitingForDataFlag(false)
                 .build(),
             instant = instant,
             maxMsgSize = checkpoint.maxMessageSize

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
@@ -38,7 +38,7 @@ class FlowSessionManagerImpl @Activate constructor(
     private val flowRecordFactory: FlowRecordFactory,
 ) : FlowSessionManager {
 
-    override fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant):
+    override fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant, waitingForData: Boolean):
             List<Record<*, FlowMapperEvent>> {
         val waitingForData = false // In the case of session error, it is irrelevant if the session is waiting to receive or not.
         return checkpoint.sessions

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
@@ -38,7 +38,7 @@ class FlowSessionManagerImpl @Activate constructor(
     private val flowRecordFactory: FlowRecordFactory,
 ) : FlowSessionManager {
 
-    override fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant):
+    override fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant, waitingForData: Boolean):
             List<Record<*, FlowMapperEvent>> {
         return checkpoint.sessions
             .filter { it.status == SessionStateType.ERROR }
@@ -47,7 +47,7 @@ class FlowSessionManagerImpl @Activate constructor(
                     sessionState,
                     instant,
                     flowConfig,
-                    checkpoint.flowKey.identity
+                    checkpoint.flowKey.identity, waitingForData
                 )
             }
             .flatMap { (_, events) -> events }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
@@ -38,8 +38,9 @@ class FlowSessionManagerImpl @Activate constructor(
     private val flowRecordFactory: FlowRecordFactory,
 ) : FlowSessionManager {
 
-    override fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant, waitingForData: Boolean):
+    override fun getSessionErrorEventRecords(checkpoint: FlowCheckpoint, flowConfig: SmartConfig, instant: Instant):
             List<Record<*, FlowMapperEvent>> {
+        val waitingForData = false // In the case of session error, it is irrelevant if the session is waiting to receive or not.
         return checkpoint.sessions
             .filter { it.status == SessionStateType.ERROR }
             .map { sessionState ->

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
@@ -108,6 +108,7 @@ class SessionEventHandlerTest {
                 any(),
                 anyOrNull(),
                 any(),
+                any(),
                 any()
             )
         ).thenReturn(updatedSessionState)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
@@ -208,6 +208,7 @@ class SessionEventHandlerTest {
             .setPayload(payload)
             .setInitiatedIdentity(ALICE_X500_HOLDING_IDENTITY)
             .setInitiatingIdentity(BOB_X500_HOLDING_IDENTITY)
+            .setWaitingForDataFlag(false)
             .build()
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
@@ -78,6 +78,7 @@ class FlowEventProcessorImplTest {
             .setSequenceNum(1)
             .setReceivedSequenceNum(0)
             .setOutOfOrderSequenceNums(emptyList())
+            .setWaitingForDataFlag(false)
             .build()
 
     private val flowKey = "flow id"

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -131,7 +131,8 @@ class FlowGlobalPostProcessorImplTest {
                 eq(sessionState1),
                 any(),
                 eq(testContext.config),
-                eq(ALICE_X500_HOLDING_IDENTITY)
+                eq(ALICE_X500_HOLDING_IDENTITY),
+                false
             )
         ).thenReturn(sessionState1 to listOf(sessionEvent1, sessionEvent2))
         whenever(
@@ -139,7 +140,8 @@ class FlowGlobalPostProcessorImplTest {
                 eq(sessionState2),
                 any(),
                 eq(testContext.config),
-                eq(ALICE_X500_HOLDING_IDENTITY)
+                eq(ALICE_X500_HOLDING_IDENTITY),
+                false
             )
         ).thenReturn(sessionState2 to listOf(sessionEvent3))
 
@@ -148,7 +150,8 @@ class FlowGlobalPostProcessorImplTest {
                 eq(sessionState3),
                 any(),
                 eq(testContext.config),
-                eq(ALICE_X500_HOLDING_IDENTITY)
+                eq(ALICE_X500_HOLDING_IDENTITY),
+                false
             )
         ).thenReturn(sessionState3 to listOf(sessionEvent4))
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -132,7 +132,7 @@ class FlowGlobalPostProcessorImplTest {
                 any(),
                 eq(testContext.config),
                 eq(ALICE_X500_HOLDING_IDENTITY),
-                false
+                eq(false)
             )
         ).thenReturn(sessionState1 to listOf(sessionEvent1, sessionEvent2))
         whenever(
@@ -141,7 +141,7 @@ class FlowGlobalPostProcessorImplTest {
                 any(),
                 eq(testContext.config),
                 eq(ALICE_X500_HOLDING_IDENTITY),
-                false
+                eq(false)
             )
         ).thenReturn(sessionState2 to listOf(sessionEvent3))
 
@@ -151,7 +151,7 @@ class FlowGlobalPostProcessorImplTest {
                 any(),
                 eq(testContext.config),
                 eq(ALICE_X500_HOLDING_IDENTITY),
-                false
+                eq(false)
             )
         ).thenReturn(sessionState3 to listOf(sessionEvent4))
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
@@ -149,8 +149,8 @@ class FlowSessionManagerImplTest {
     fun `get session error event records`() {
         whenever(checkpoint.sessions).thenReturn(sessionsWithErrors)
 
-        whenever(sessionManager.getMessagesToSend(eq(errorSessionState1), any(), any(), any())).thenReturn(errorPairing1)
-        whenever(sessionManager.getMessagesToSend(eq(errorSessionState2), any(), any(), any())).thenReturn(errorPairing2)
+        whenever(sessionManager.getMessagesToSend(eq(errorSessionState1), any(), any(), any(), false)).thenReturn(errorPairing1)
+        whenever(sessionManager.getMessagesToSend(eq(errorSessionState2), any(), any(), any(), false)).thenReturn(errorPairing2)
 
         whenever(flowRecordFactory.createFlowMapperEventRecord(eq("s1"), eq(errorEvent1))).thenReturn(record1)
         whenever(flowRecordFactory.createFlowMapperEventRecord(eq("s2"), eq(errorEvent2))).thenReturn(record2)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImplTest.kt
@@ -149,8 +149,8 @@ class FlowSessionManagerImplTest {
     fun `get session error event records`() {
         whenever(checkpoint.sessions).thenReturn(sessionsWithErrors)
 
-        whenever(sessionManager.getMessagesToSend(eq(errorSessionState1), any(), any(), any(), false)).thenReturn(errorPairing1)
-        whenever(sessionManager.getMessagesToSend(eq(errorSessionState2), any(), any(), any(), false)).thenReturn(errorPairing2)
+        whenever(sessionManager.getMessagesToSend(eq(errorSessionState1), any(), any(), any(), eq(false))).thenReturn(errorPairing1)
+        whenever(sessionManager.getMessagesToSend(eq(errorSessionState2), any(), any(), any(), eq(false))).thenReturn(errorPairing2)
 
         whenever(flowRecordFactory.createFlowMapperEventRecord(eq("s1"), eq(errorEvent1))).thenReturn(record1)
         whenever(flowRecordFactory.createFlowMapperEventRecord(eq("s2"), eq(errorEvent2))).thenReturn(record2)

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.9-SNAPSHOT
+cordaApiVersion=5.1.0.11-alpha-1690821589916
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,8 +45,8 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-#cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.8-beta+
+#cordaApiVersion=5.0.0.xxx-SNAPSHOT
+cordaApiVersion=5.1.0.9-SNAPSHOT
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,8 +45,8 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-#cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.10-beta+
+#cordaApiVersion=5.0.0.xxx-SNAPSHOT
+cordaApiVersion=5.0.0.758-SNAPSHOT
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,8 +45,8 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-#cordaApiVersion=5.0.0.xxx-SNAPSHOT
-cordaApiVersion=5.0.0.758-SNAPSHOT
+#cordaApiVersion=5.1.0.xxx-SNAPSHOT
+cordaApiVersion=5.1.0.8-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/FlowMapperHelper.kt
+++ b/libs/flows/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/FlowMapperHelper.kt
@@ -109,7 +109,8 @@ fun createP2PRecord(
                 sessionEvent.initiatedIdentity,
                 receivedSequenceNumber,
                 emptyList(),
-                payload
+                payload,
+                sessionEvent.waitingForDataFlag
             ),
             sessionEventSerializer,
             flowConfig

--- a/libs/flows/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/FlowMapperEventExecutorFactoryImplTest.kt
+++ b/libs/flows/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/FlowMapperEventExecutorFactoryImplTest.kt
@@ -46,7 +46,7 @@ class FlowMapperEventExecutorFactoryImplTest {
         val executor = executorFactoryImpl.create(
             "",
             FlowMapperEvent(SessionEvent(MessageDirection.INBOUND, Instant.now(), "", 1,
-                HoldingIdentity(), HoldingIdentity(), 0, listOf(), null)),
+                HoldingIdentity(), HoldingIdentity(), 0, listOf(), null, false)),
             null,
             SmartConfigImpl.empty(),
             Instant.now()
@@ -70,7 +70,7 @@ class FlowMapperEventExecutorFactoryImplTest {
                         "FlowMapper-SessionError",
                         "Received SessionError with sessionId 1"
                     )
-                ))),
+                ), false)),
             null,
             SmartConfigImpl.empty(),
             Instant.now()

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/SessionParty.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/SessionParty.kt
@@ -40,7 +40,7 @@ class SessionParty (
     }
 
     override fun sendMessages(instant: Instant) {
-        val (updatedState, outputMessages) = sessionManager.getMessagesToSend(sessionState!!, instant, testConfig, testIdentity)
+        val (updatedState, outputMessages) = sessionManager.getMessagesToSend(sessionState!!, instant, testConfig, testIdentity, waitingForData = true)
         sessionState = updatedState
         outboundMessages.addMessages(outputMessages)
     }
@@ -67,7 +67,7 @@ class SessionParty (
 
     private fun processAndAcknowledgeEventsInSequence(nextMessage: SessionEvent?) {
         if (nextMessage != null) {
-            sessionState = sessionManager.processMessageReceived("key", sessionState, nextMessage, Instant.now())
+            sessionState = sessionManager.processMessageReceived("key", sessionState, nextMessage, Instant.now(), nextMessage.waitingForDataFlag)
 
             var message = sessionManager.getNextReceivedEvent(sessionState!!)
             while (message != null) {

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateClosedTransitionTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateClosedTransitionTest.kt
@@ -58,7 +58,7 @@ class SessionStateClosedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.INIT, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSED)
     }
 
@@ -68,7 +68,7 @@ class SessionStateClosedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.DATA, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 2
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.ERROR)
     }
 
@@ -78,7 +78,7 @@ class SessionStateClosedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.DATA, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSED)
     }
 
@@ -88,7 +88,7 @@ class SessionStateClosedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.CLOSE, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSED)
     }
 
@@ -99,7 +99,7 @@ class SessionStateClosedTransitionTest {
         val sessionEvent = generateMessage(SessionMessageType.ACK, instant, MessageDirection.INBOUND)
         sessionEvent.receivedSequenceNum = 2
 
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSED)
     }
 

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateClosingTransitionTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateClosingTransitionTest.kt
@@ -78,7 +78,7 @@ class SessionStateClosingTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.INIT, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSING)
     }
 
@@ -88,7 +88,7 @@ class SessionStateClosingTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.DATA, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 2
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.ERROR)
     }
 
@@ -98,7 +98,7 @@ class SessionStateClosingTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.CLOSE, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.WAIT_FOR_FINAL_ACK)
     }
 
@@ -109,7 +109,7 @@ class SessionStateClosingTransitionTest {
         val sessionEvent = generateMessage(SessionMessageType.ACK, instant, MessageDirection.INBOUND)
         sessionEvent.receivedSequenceNum = 2
 
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSING)
     }
 

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateConfirmedTransitionTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateConfirmedTransitionTest.kt
@@ -60,7 +60,7 @@ class SessionStateConfirmedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.INIT, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CONFIRMED)
     }
 
@@ -70,7 +70,7 @@ class SessionStateConfirmedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.DATA, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CONFIRMED)
     }
 
@@ -80,7 +80,7 @@ class SessionStateConfirmedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.CLOSE, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSING)
     }
 
@@ -90,7 +90,7 @@ class SessionStateConfirmedTransitionTest {
         val sessionEvent = generateMessage(SessionMessageType.ACK, instant, MessageDirection.INBOUND)
         sessionEvent.receivedSequenceNum = 1
 
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CONFIRMED)
     }
 

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateCreatedTransitionTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateCreatedTransitionTest.kt
@@ -59,7 +59,7 @@ class SessionStateCreatedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.INIT, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.ERROR)
     }
 
@@ -69,7 +69,7 @@ class SessionStateCreatedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.DATA, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CREATED)
     }
 
@@ -79,7 +79,7 @@ class SessionStateCreatedTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.CLOSE, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSING)
     }
 
@@ -89,7 +89,7 @@ class SessionStateCreatedTransitionTest {
         val sessionEvent = generateMessage(SessionMessageType.ACK, instant, MessageDirection.INBOUND)
         sessionEvent.receivedSequenceNum = 1
 
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant)
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, instant, false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CONFIRMED)
     }
 

--- a/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateWaitFinalAckTransitionTest.kt
+++ b/libs/flows/session-manager-impl/src/integrationTest/kotlin/net/corda/session/manager/integration/transition/SessionStateWaitFinalAckTransitionTest.kt
@@ -59,7 +59,7 @@ class SessionStateWaitFinalAckTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.INIT, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, Instant.now())
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, Instant.now(), false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.WAIT_FOR_FINAL_ACK)
     }
 
@@ -69,7 +69,7 @@ class SessionStateWaitFinalAckTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.DATA, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 2
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, Instant.now())
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, Instant.now(), false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.ERROR)
     }
 
@@ -79,7 +79,7 @@ class SessionStateWaitFinalAckTransitionTest {
 
         val sessionEvent = generateMessage(SessionMessageType.CLOSE, instant, MessageDirection.INBOUND)
         sessionEvent.sequenceNum = 1
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, Instant.now())
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, Instant.now(), false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.WAIT_FOR_FINAL_ACK)
     }
 
@@ -90,7 +90,7 @@ class SessionStateWaitFinalAckTransitionTest {
         val sessionEvent = generateMessage(SessionMessageType.ACK, instant, MessageDirection.INBOUND)
         sessionEvent.receivedSequenceNum = 2
 
-        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, Instant.now())
+        val outputState = sessionManager.processMessageReceived(sessionState, sessionState, sessionEvent, Instant.now(), false)
         Assertions.assertThat(outputState.status).isEqualTo(SessionStateType.CLOSED)
     }
 

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/SessionManagerImpl.kt
@@ -179,6 +179,7 @@ class SessionManagerImpl @Activate constructor(
      * @param identity identity of the party sending messages
      * @return Messages to send to the counterparty
      */
+    @Suppress("LongParameterList")
     private fun handleHeartbeatAndAcknowledgements(
         sessionState: SessionState,
         config: SmartConfig,

--- a/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/helper/SessionProcessorHelper.kt
+++ b/libs/flows/session-manager-impl/src/main/kotlin/net/corda/session/manager/impl/processor/helper/SessionProcessorHelper.kt
@@ -68,6 +68,7 @@ fun generateErrorEvent(
         .setReceivedSequenceNum(0)
         .setOutOfOrderSequenceNums(emptyList())
         .setPayload(sessionError)
+        .setWaitingForDataFlag(false)
         .build()
 }
 

--- a/libs/flows/session-manager-impl/src/test/kotlin/net/corda/session/manager/impl/SessionManagerImplTest.kt
+++ b/libs/flows/session-manager-impl/src/test/kotlin/net/corda/session/manager/impl/SessionManagerImplTest.kt
@@ -123,7 +123,7 @@ class SessionManagerImplTest {
             ),
         )
         //validate only messages with a timestamp in the past are returned.
-        val (outputState, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity)
+        val (outputState, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity, false)
         assertThat(messagesToSend.size).isEqualTo(2)
         //validate all acks removed
         assertThat(outputState.sendEventsState.undeliveredMessages.size).isEqualTo(3)
@@ -133,7 +133,8 @@ class SessionManagerImplTest {
         val (secondOutputState, secondMessagesToSend) = sessionManager.getMessagesToSend(
             sessionState, instant.plusMillis(testResendWindow + 100),
             testSmartConfig,
-            testIdentity
+            testIdentity,
+            false
         )
         assertThat(secondMessagesToSend.size).isEqualTo(3)
         assertThat(secondOutputState.sendEventsState.undeliveredMessages.size).isEqualTo(3)
@@ -155,14 +156,15 @@ class SessionManagerImplTest {
         )
 
         //validate no heartbeat
-        val (_, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity)
+        val (_, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity, false)
         assertThat(messagesToSend.size).isEqualTo(0)
 
         //Validate heartbeat
         val (_, secondMessagesToSend) = sessionManager.getMessagesToSend(
             sessionState, instant.plusMillis(testResendWindow  + 1),
             testSmartConfig,
-            testIdentity
+            testIdentity,
+            false
         )
 
         assertThat(secondMessagesToSend.size).isEqualTo(1)
@@ -185,7 +187,7 @@ class SessionManagerImplTest {
         )
 
         //validate no heartbeat
-        val (_, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity)
+        val (_, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity, false)
         assertThat(messagesToSend.size).isEqualTo(1)
         val messageToSend = messagesToSend.first()
         assertThat(messageToSend.payload::class.java).isEqualTo(SessionAck::class.java)
@@ -206,7 +208,7 @@ class SessionManagerImplTest {
         )
 
         //validate no heartbeat
-        val (_, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity)
+        val (_, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity, false)
         assertThat(messagesToSend).isEmpty()
     }
 
@@ -223,7 +225,7 @@ class SessionManagerImplTest {
         )
 
         //validate no heartbeat
-        val (firstUpdatedState, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity)
+        val (firstUpdatedState, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity, false)
         assertThat(messagesToSend.size).isEqualTo(0)
         assertThat(firstUpdatedState.status).isEqualTo(SessionStateType.CONFIRMED)
 
@@ -231,7 +233,8 @@ class SessionManagerImplTest {
         val (secondUpdatedState, secondMessagesToSend) = sessionManager.getMessagesToSend(
             sessionState, instant.plusMillis(testHeartbeatTimeout  + 1),
             testSmartConfig,
-            testIdentity
+            testIdentity,
+            false
         )
 
         assertThat(secondMessagesToSend.size).isEqualTo(1)
@@ -256,7 +259,7 @@ class SessionManagerImplTest {
         )
 
         // Ensure that only the SessionInit event is returned
-        val (_, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity)
+        val (_, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity, false)
         assertThat(messagesToSend.size).isEqualTo(1)
         assertThat(messagesToSend.first().payload is SessionInit).isTrue
     }
@@ -270,7 +273,7 @@ class SessionManagerImplTest {
         )
 
         val sessionEvent = buildSessionEvent(MessageDirection.INBOUND, "sessionId", null, SessionAck(), 1)
-        val updatedState = sessionManager.processMessageReceived("key", sessionState, sessionEvent, Instant.now())
+        val updatedState = sessionManager.processMessageReceived("key", sessionState, sessionEvent, Instant.now(), false)
 
         assertThat(updatedState.status).isEqualTo(SessionStateType.CONFIRMED)
         assertThat(updatedState.sendEventsState?.undeliveredMessages).isEmpty()
@@ -287,7 +290,7 @@ class SessionManagerImplTest {
 
         val sessionEvent = buildSessionEvent(MessageDirection.INBOUND, "sessionId", null, SessionAck(), 2)
 
-        val updatedState = sessionManager.processMessageReceived("key", sessionState, sessionEvent, Instant.now())
+        val updatedState = sessionManager.processMessageReceived("key", sessionState, sessionEvent, Instant.now(), false)
 
         assertThat(updatedState.status).isEqualTo(SessionStateType.CONFIRMED)
         assertThat(updatedState.sendEventsState?.undeliveredMessages?.size).isEqualTo(1)
@@ -302,7 +305,7 @@ class SessionManagerImplTest {
         )
 
         val sessionEvent = buildSessionEvent(MessageDirection.INBOUND, "sessionId", null, SessionAck(), 0, listOf(3))
-        val updatedState = sessionManager.processMessageReceived("key", sessionState, sessionEvent, Instant.now())
+        val updatedState = sessionManager.processMessageReceived("key", sessionState, sessionEvent, Instant.now(), false)
 
         assertThat(updatedState.status).isEqualTo(SessionStateType.CLOSED)
         assertThat(updatedState.sendEventsState?.undeliveredMessages).isEmpty()

--- a/libs/flows/session-manager-impl/src/test/kotlin/net/corda/session/manager/impl/SessionManagerImplTest.kt
+++ b/libs/flows/session-manager-impl/src/test/kotlin/net/corda/session/manager/impl/SessionManagerImplTest.kt
@@ -225,7 +225,8 @@ class SessionManagerImplTest {
         )
 
         //validate no heartbeat
-        val (firstUpdatedState, messagesToSend) = sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity, false)
+        val (firstUpdatedState, messagesToSend) =
+            sessionManager.getMessagesToSend(sessionState, instant, testSmartConfig, testIdentity, false)
         assertThat(messagesToSend.size).isEqualTo(0)
         assertThat(firstUpdatedState.status).isEqualTo(SessionStateType.CONFIRMED)
 

--- a/libs/flows/session-manager/src/main/kotlin/net/corda/session/manager/SessionManager.kt
+++ b/libs/flows/session-manager/src/main/kotlin/net/corda/session/manager/SessionManager.kt
@@ -36,7 +36,13 @@ interface SessionManager {
      * @return Updated session state with any output messages added to the undelivered sent events queue
      * and any valid received messages added to the undelivered received events queue
      */
-    fun processMessageReceived(key: Any, sessionState: SessionState?, event: SessionEvent, instant: Instant, waitingForData: Boolean): SessionState
+    fun processMessageReceived(
+        key: Any,
+        sessionState: SessionState?,
+        event: SessionEvent,
+        instant: Instant,
+        waitingForData: Boolean
+    ): SessionState
 
     /**
      * Process a session [event] to be sent to a counterparty, and output the updated session state.
@@ -85,8 +91,13 @@ interface SessionManager {
      * @param waitingForData List of session IDs that the party is waiting to receive data from.
      * @return The updated [SessionState] with SessionAcks removed as well as any messages to send to the counterparty.
      */
-    fun getMessagesToSend(sessionState: SessionState, instant: Instant, config: SmartConfig, identity: HoldingIdentity, waitingForData: Boolean): Pair<SessionState,
-            List<SessionEvent>>
+    fun getMessagesToSend(
+        sessionState: SessionState,
+        instant: Instant,
+        config: SmartConfig,
+        identity: HoldingIdentity,
+        waitingForData: Boolean
+    ): Pair<SessionState, List<SessionEvent>>
 
     /**
      * Errors the passed [SessionState], returning the updated state.

--- a/libs/flows/session-manager/src/main/kotlin/net/corda/session/manager/SessionManager.kt
+++ b/libs/flows/session-manager/src/main/kotlin/net/corda/session/manager/SessionManager.kt
@@ -32,10 +32,11 @@ interface SessionManager {
      * @param sessionState The session state. This should be null in the case of [SessionInit]
      * @param event Session event to process.
      * @param instant Timestamp to be applied for any output messages.
+     * @param waitingForData List of session IDs that the party is waiting to receive data from.
      * @return Updated session state with any output messages added to the undelivered sent events queue
      * and any valid received messages added to the undelivered received events queue
      */
-    fun processMessageReceived(key: Any, sessionState: SessionState?, event: SessionEvent, instant: Instant): SessionState
+    fun processMessageReceived(key: Any, sessionState: SessionState?, event: SessionEvent, instant: Instant, waitingForData: Boolean): SessionState
 
     /**
      * Process a session [event] to be sent to a counterparty, and output the updated session state.
@@ -81,9 +82,10 @@ interface SessionManager {
      * @param instant The time to check session events against when determining which messages need to be sent
      * @param config The config containing the flow session config values such as the resend time window
      * @param identity Identity of the calling party who owns the session state
+     * @param waitingForData List of session IDs that the party is waiting to receive data from.
      * @return The updated [SessionState] with SessionAcks removed as well as any messages to send to the counterparty.
      */
-    fun getMessagesToSend(sessionState: SessionState, instant: Instant, config: SmartConfig, identity: HoldingIdentity): Pair<SessionState,
+    fun getMessagesToSend(sessionState: SessionState, instant: Instant, config: SmartConfig, identity: HoldingIdentity, waitingForData: Boolean): Pair<SessionState,
             List<SessionEvent>>
 
     /**

--- a/testing/flow/flow-utilities/src/main/kotlin/net/corda/test/flow/util/SessionHelper.kt
+++ b/testing/flow/flow-utilities/src/main/kotlin/net/corda/test/flow/util/SessionHelper.kt
@@ -58,5 +58,6 @@ fun buildSessionEvent(
         .setTimestamp(timestamp)
         .setReceivedSequenceNum(receivedSequenceNum)
         .setOutOfOrderSequenceNums(outOfOrderSeqNums)
+        .setWaitingForDataFlag(false)
         .build()
 }


### PR DESCRIPTION
**DRAFT** ***********************************
TODO:
1. Add unit and integration tests
2. Run this branch through the sample flow written to replicate this issue and ensure that changes prevent it.

**Issue**
Sessions are sometimes found to be waiting for data indefinitely. This may occur due to error in writing flows, where there might be excess receive functions being called. 

**Solution**
Added `waitingForDataFlag` to SessionEvent message. Added check in `processMessageReceived` to check if sessions are waiting for data from user and if user is also waiting for data from session. Generates session error if both are true.