### PR TITLE
CORE-15660: Use fewer database connections, and close them afterwards.

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/utility/MigrationUtilityImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/utility/MigrationUtilityImpl.kt
@@ -71,7 +71,9 @@ internal class MigrationUtilityImpl(
         logger.info("Preparing to run ${changeLogs.size} migrations for CPK '$cpkFileChecksum'.")
         val allChangeLogsForCpk = VirtualNodeDbChangeLog(changeLogs)
         try {
-            liquibaseSchemaMigrator.updateDb(dataSource.connection, allChangeLogsForCpk, tag = cpkFileChecksum.toString())
+            dataSource.connection.use { connection ->
+                liquibaseSchemaMigrator.updateDb(connection, allChangeLogsForCpk, tag = cpkFileChecksum.toString())
+            }
         } catch (e: Exception) {
             val msg =
                 "CPI migrations failed for virtual node '$virtualNodeShortHash`. Failure occurred running CPI migrations on " +

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
@@ -57,7 +57,9 @@ class VirtualNodeService @Activate constructor(
         ))
 
         val dataSource = dataSourceAdmin.getOrCreateDataSource(dbConnectionId, "connection-${connectionCounter.incrementAndGet()}")
-        liquibaseSchemaMigrator.updateDb(dataSource.connection, vaultSchema)
+        dataSource.connection.use { connection ->
+            liquibaseSchemaMigrator.updateDb(connection, vaultSchema)
+        }
         return virtualNodeInfo
     }
 }


### PR DESCRIPTION
Reuse some database connections while installing the database, and close them when we've finished with them.

This should mostly affect the tests running on Jenkins.