### PR TITLE
CORE-14685: Stub handler for Token Cache events.

### DIFF
--- a/testing/driver/driver-engine/build.gradle
+++ b/testing/driver/driver-engine/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     }
     runtimeOnly "commons-beanutils:commons-beanutils:$beanutilsVersion"
     runtimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
+    runtimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
 
     testRuntimeOnly project(':testing:driver')
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/processor/token/TokenCacheProcessor.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/processor/token/TokenCacheProcessor.kt
@@ -1,0 +1,26 @@
+package net.corda.testing.driver.processor.token
+
+import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
+import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
+import net.corda.messaging.api.records.Record
+import net.corda.testing.driver.processor.ExternalProcessor
+import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
+
+@Component(service = [ TokenCacheProcessor::class ])
+class TokenCacheProcessor : ExternalProcessor {
+    private val logger = LoggerFactory.getLogger(TokenCacheProcessor::class.java)
+
+    override fun processEvent(record: Record<*, *>): List<Record<*, *>> {
+        val tokenPoolCacheKey = requireNotNull(record.key as? TokenPoolCacheKey) {
+            "Invalid or missing TokenPoolCacheKey"
+        }
+        val tokenPoolCacheEvent = requireNotNull(record.value as? TokenPoolCacheEvent) {
+            "Invalid or missing TokenPoolCacheEvent"
+        }
+
+        // Currently logging these only for information purposes.
+        logger.info("Key={}, Event={}", tokenPoolCacheKey, tokenPoolCacheEvent)
+        return emptyList()
+    }
+}

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/MembershipGroupControllerProviderImpl.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/MembershipGroupControllerProviderImpl.kt
@@ -2,6 +2,7 @@ package net.corda.testing.driver.sandbox
 
 import java.nio.ByteBuffer
 import java.security.PublicKey
+import java.util.LinkedList
 import java.util.SortedMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
@@ -313,8 +314,8 @@ class MembershipGroupControllerProviderImpl @Activate constructor(
         }
 
         private fun Collection<MemberInfo>.filterBy(filter: MembershipStatusFilter): Collection<MemberInfo> {
-            val candidates = filterTo(mutableListOf()) { it.filterBy(filter) }
-            val pending = candidates.extractAllTo(mutableListOf()) { it.status == MEMBER_STATUS_PENDING }
+            val candidates = filterTo(LinkedList()) { it.filterBy(filter) }
+            val pending = candidates.extractAllTo(LinkedList()) { it.status == MEMBER_STATUS_PENDING }
             return when(filter) {
                 MembershipStatusFilter.ACTIVE,
                 MembershipStatusFilter.ACTIVE_OR_SUSPENDED ->

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/Tools.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/Tools.kt
@@ -1,10 +1,10 @@
 @file:JvmName("Tools")
 package net.corda.testing.driver.sandbox
 
-inline fun <T> MutableCollection<T>.extractAllTo(
-    destination: MutableCollection<T>,
+inline fun <T, C: MutableCollection<T>> MutableCollection<T>.extractAllTo(
+    destination: C,
     predicate: (T) -> Boolean
-): MutableCollection<T> {
+): C {
     val iterator = iterator()
     while (iterator.hasNext()) {
         val item = iterator.next()


### PR DESCRIPTION
UTXO flows also generate `service.token.event` events. The driver doesn't currently have a use for these, so intercept them and dispatch them to a "logging only" handler.

Also tidy up the flow event loop slightly, using `pollFirst()` instead of `removeFirst()`, and with a single response queue.