### PR TITLE
CORE-9521 E2E test utility for group parameters update

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -346,3 +346,23 @@ fun ClusterInfo.activateMember(
         condition { it.code == ResponseCode.NO_CONTENT.statusCode || it.code == ResponseCode.CONFLICT.statusCode }
     }
 }
+
+/**
+ * Update the group parameters as the MGM identified by [mgmHoldingId], and return the newly updated group parameters.
+ */
+fun ClusterInfo.updateGroupParameters(
+    mgmHoldingId: String,
+    update: Map<String, String>
+) = cluster {
+    val payload = mapOf(
+        "parameters" to update
+    )
+    assertWithRetry {
+        timeout(15.seconds)
+        interval(1.seconds)
+        command {
+            post("/api/v1/mgm/$mgmHoldingId/group-parameters", ObjectMapper().writeValueAsString(payload))
+        }
+        condition { it.code == ResponseCode.OK.statusCode }
+    }.toJson()
+}


### PR DESCRIPTION
Adds an E2E test utility to support group parameters update testing.
https://github.com/corda/corda-e2e-tests/pull/166