### PR TITLE
CORE-15702 Resolve memory leak when repeatedly trying to establish a session

### DIFF
--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -149,6 +149,10 @@ class P2PLayerEndToEndTest {
         }
     }
 
+    init {
+        Security.addProvider(BouncyCastleProvider())
+    }
+
     private val bootstrapConfig = SmartConfigFactory.createWithoutSecurityServices()
         .create(ConfigFactory.empty().withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(1)))
         .withValue(MessagingConfig.MAX_ALLOWED_MSG_SIZE, ConfigValueFactory.fromAnyRef(10000000))
@@ -480,9 +484,6 @@ class P2PLayerEndToEndTest {
         checkRevocation: Boolean,
         keyTemplate: KeySchemeTemplate,
     ) : AutoCloseable {
-        init {
-            Security.addProvider(BouncyCastleProvider())
-        }
         private val p2pPort by lazy {
             ServerSocket(0).use {
                 it.localPort

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -114,6 +114,7 @@ import java.security.KeyFactory
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.PublicKey
+import java.security.Security
 import java.security.Signature
 import java.security.spec.PKCS8EncodedKeySpec
 import java.time.Duration
@@ -479,6 +480,9 @@ class P2PLayerEndToEndTest {
         checkRevocation: Boolean,
         keyTemplate: KeySchemeTemplate,
     ) : AutoCloseable {
+        init {
+            Security.addProvider(BouncyCastleProvider())
+        }
         private val p2pPort by lazy {
             ServerSocket(0).use {
                 it.localPort
@@ -597,7 +601,8 @@ class P2PLayerEndToEndTest {
                 val providerName = when (publicKey.algorithm) {
                     "RSA" -> "SunRsaSign"
                     "EC" -> "SunEC"
-                    else -> throw SecurityException("Unsupported Algorithm")
+                    "ECDSA" -> "BC"
+                    else -> throw SecurityException("Unsupported Algorithm: ${publicKey.algorithm}")
                 }
                 val signature = Signature.getInstance(
                     signatureSpec.signatureName,

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
@@ -40,6 +40,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.security.KeyPairGenerator
+import java.security.Security
 import java.util.UUID
 
 class InMemorySessionReplayerTest {
@@ -62,6 +63,7 @@ class InMemorySessionReplayerTest {
         @JvmStatic
         fun setup() {
             loggingInterceptor = LoggingInterceptor.setupLogging()
+            Security.addProvider(BouncyCastleProvider())
         }
     }
 

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSession.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSession.kt
@@ -33,7 +33,7 @@ class AuthenticatedEncryptionSession(override val sessionId: String,
                                      private val inboundNonce: ByteArray,
                                      val maxMessageSize: Int): Session {
 
-    private val provider = BouncyCastleProvider()
+    private val provider = BouncyCastleProvider.PROVIDER_NAME
     private val encryptionCipher = Cipher.getInstance(CIPHER_ALGO, provider)
     private val decryptionCipher = Cipher.getInstance(CIPHER_ALGO, provider)
     private val sequenceNo = AtomicLong(nextSequenceNo)

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSession.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSession.kt
@@ -24,7 +24,7 @@ class AuthenticatedSession(override val sessionId: String,
                            private val inboundSecretKey: SecretKey,
                            val maxMessageSize: Int): Session {
 
-    private val provider = BouncyCastleProvider()
+    private val provider = BouncyCastleProvider.PROVIDER_NAME
     private val generationHMac = Mac.getInstance(HMAC_ALGO, provider).apply {
         this.init(outboundSecretKey)
     }

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocol.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocol.kt
@@ -71,7 +71,7 @@ abstract class AuthenticationProtocol(private val certificateValidatorFactory: (
     protected var agreedMaxMessageSize: Int? = null
 
     protected val secureRandom = SecureRandom()
-    protected val provider = BouncyCastleProvider()
+    protected val provider = BouncyCastleProvider.PROVIDER_NAME
     protected val ephemeralKeyFactory = KeyFactory.getInstance(ELLIPTIC_CURVE_ALGO, provider)
     protected val keyPairGenerator = KeyPairGenerator.getInstance(ELLIPTIC_CURVE_ALGO, provider).apply {
         this.initialize(ELLIPTIC_CURVE_KEY_SIZE_BITS, secureRandom)

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
@@ -8,15 +8,17 @@ import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
+import java.security.Security
 import java.security.Signature
 import java.util.UUID
 
 class AuthenticatedEncryptionSessionTest {
 
-    private val provider = BouncyCastleProvider()
+    private val provider = BouncyCastleProvider.PROVIDER_NAME
     private val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
     private val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
 
@@ -40,6 +42,14 @@ class AuthenticatedEncryptionSessionTest {
     private val partyBMaxMessageSize = 1_500_000
     private val partyBSessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
+
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
 
     @Test
     fun `session can be established between two parties and used for transmission of authenticated and encrypted data successfully`() {

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
@@ -8,16 +8,18 @@ import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
+import java.security.Security
 import java.security.Signature
 import java.time.Instant
 import java.util.UUID
 
 class AuthenticatedSessionTest {
 
-    private val provider = BouncyCastleProvider()
+    private val provider = BouncyCastleProvider.PROVIDER_NAME
     private val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
     private val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
 
@@ -41,6 +43,14 @@ class AuthenticatedSessionTest {
     private val partyBMaxMessageSize = 1_500_000
     private val partyBSessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
+
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
 
     @Test
     fun `session can be established between two parties and used for transmission of authenticated data successfully`() {

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolFailureTest.kt
@@ -6,6 +6,7 @@ import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -13,6 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
+import java.security.Security
 import java.security.Signature
 import java.util.UUID
 
@@ -21,7 +23,7 @@ import java.util.UUID
  */
 class AuthenticationProtocolFailureTest {
 
-    private val provider = BouncyCastleProvider()
+    private val provider = BouncyCastleProvider.PROVIDER_NAME
     private val keyPairGenerator = KeyPairGenerator.getInstance("EC", provider)
     private val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName, provider)
     private val aliceX500Name = MemberX500Name.parse("CN=alice, OU=MyUnit, O=MyOrg, L=London, S=London, C=GB")
@@ -46,6 +48,14 @@ class AuthenticationProtocolFailureTest {
     private val partyBSessionKey = keyPairGenerator.generateKeyPair()
     private val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
     private val certificateValidator = mock<CertificateValidator>()
+
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
 
     @Test
     fun `session authentication fails if malicious actor changes initiator's handshake message`() {

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolTest.kt
@@ -8,17 +8,19 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.security.Security
 import java.security.Signature
 import java.util.UUID
 
 class AuthenticationProtocolTest {
 
-    private val provider = BouncyCastleProvider()
+    private val provider = BouncyCastleProvider.PROVIDER_NAME
     private val sessionId = UUID.randomUUID().toString()
     private val groupId = "some-group-id"
 
@@ -28,6 +30,14 @@ class AuthenticationProtocolTest {
     // party B
     private val partyBMaxMessageSize = 1_500_000
     private val aliceX500Name = MemberX500Name.parse("CN=alice, OU=MyUnit, O=MyOrg, L=London, S=London, C=GB")
+
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
 
     @Test
     fun `no handshake message crosses the minimum value allowed for max message size`() {

--- a/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/internal/LinkManagerProcessorImpl.kt
+++ b/processors/link-manager-processor/src/main/kotlin/net/corda/processors/p2p/linkmanager/internal/LinkManagerProcessorImpl.kt
@@ -26,11 +26,13 @@ import net.corda.processors.p2p.linkmanager.LinkManagerProcessor
 import net.corda.schema.configuration.MessagingConfig.Subscription.POLL_TIMEOUT
 import net.corda.utilities.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.security.Security
 
 @Suppress("LongParameterList", "Unused")
 @Component(service = [LinkManagerProcessor::class])
@@ -94,6 +96,8 @@ class LinkManagerProcessorImpl @Activate constructor(
             }
             is BootConfigEvent -> {
                 configurationReadService.bootstrapConfig(event.config)
+
+                Security.addProvider(BouncyCastleProvider())
 
                 val linkManager = LinkManager(
                     subscriptionFactory,


### PR DESCRIPTION
e2e test `MembershipSuspensionMultiCluster` `onboard, suspend, fail to communicate, activate member and communicate` is currently failing after suspending a member and attempting to send a flow between and active member and a suspended member. The test never reactivates the member because the test failed before it tried. After this, the link manager's heap space fills up and it eventually crashes due to an OOM error and restarts. 

On inspection of the heap dumps it became clear that instances of `BouncyCastleProvider` were taking the majority of the heap space. This PR remove initialisation of new instances of `BouncyCastleProvider` in favour of referencing by name during session creation so that in this particular scenario, when session establishment is repeated, the heap space isn't filled up.

Before:
![Screenshot 2023-07-21 at 11 00 30](https://github.com/corda/corda-runtime-os/assets/69511999/ddc7d649-bddc-45da-aaf7-6c8b9c01971e)
![Screenshot 2023-07-21 at 11 33 09](https://github.com/corda/corda-runtime-os/assets/69511999/26809f35-2a44-4635-bd08-1a9c40b3378f)
![Screenshot 2023-07-21 at 11 34 25](https://github.com/corda/corda-runtime-os/assets/69511999/dac01065-269b-41e8-b666-0f376647dbef)


After:
![Screenshot 2023-07-21 at 13 02 32](https://github.com/corda/corda-runtime-os/assets/69511999/acef9de5-5961-4569-a50b-8dd3b7f43dfc)
![Screenshot 2023-07-21 at 13 03 17](https://github.com/corda/corda-runtime-os/assets/69511999/036a65fb-f61c-47da-8012-2239b8a0249c)
