### PR TITLE
ES-618: Add Gradle version catalog implementation for corda-runtime-os

### DIFF
--- a/applications/examples/sandbox-app/build.gradle
+++ b/applications/examples/sandbox-app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
 
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     runtimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    runtimeOnly libs.aries.dynamic.framework
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
 
@@ -68,7 +68,7 @@ dependencies {
 
     // Add OSGi security support.
     implementation project(':components:security-manager')
-    runtimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    runtimeOnly(libs.felix.security) {
         exclude group: 'org.apache.felix'
         exclude group: 'org.osgi'
     }

--- a/applications/examples/sandbox-app/example-cpi/build.gradle
+++ b/applications/examples/sandbox-app/example-cpi/build.gradle
@@ -25,5 +25,5 @@ dependencies {
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-crypto-extensions'
     cordaProvided 'org.slf4j:slf4j-api'
-    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation libs.jackson.annotations
 }

--- a/applications/tools/p2p-test/app-simulator/build.gradle
+++ b/applications/tools/p2p-test/app-simulator/build.gradle
@@ -26,9 +26,9 @@ dependencies {
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:utilities")
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.datatype
+    implementation libs.jackson.dataformat
+    implementation libs.jackson.module
     implementation "org.postgresql:postgresql:$postgresDriverVersion"
 
     implementation project(":osgi-framework-api")

--- a/applications/tools/p2p-test/dump-topic/build.gradle
+++ b/applications/tools/p2p-test/dump-topic/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "info.picocli:picocli:$picocliVersion"
-    implementation "org.apache.avro:avro:$avroVersion"
+    implementation libs.apache.avro
     implementation project(":libs:configuration:configuration-core")
     implementation project(":libs:configuration:configuration-merger")
     implementation project(":libs:messaging:messaging")

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -88,18 +88,18 @@ dependencies {
 
     implementation 'net.corda:corda-config-schema'
 
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    runtimeOnly libs.aries.dynamic.framework
     runtimeOnly "net.corda:corda-application"
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     runtimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-    runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
+    runtimeOnly libs.felix.configadmin
 
     runtimeOnly project(":libs:messaging:${busImplementation}")
 
-    runtimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    runtimeOnly(libs.felix.security) {
         exclude group: 'org.apache.felix'
         exclude group: 'org.osgi'
     }

--- a/applications/workers/release/db-worker/build.gradle
+++ b/applications/workers/release/db-worker/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     testImplementation project(':libs:application:addon')
     testImplementation project(':libs:application:banner')
 
-    runtimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    runtimeOnly(libs.felix.security) {
         exclude group: 'org.apache.felix'
         exclude group: 'org.osgi'
     }

--- a/applications/workers/release/flow-worker/build.gradle
+++ b/applications/workers/release/flow-worker/build.gradle
@@ -34,18 +34,18 @@ dependencies {
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
 
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    runtimeOnly libs.aries.dynamic.framework
     runtimeOnly "net.corda:corda-application"
     runtimeOnly "com.typesafe:config:$typeSafeConfigVersion"
     runtimeOnly "org.apache.felix:org.apache.felix.scr:$felixScrVersion"
     runtimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-    runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
+    runtimeOnly libs.felix.configadmin
 
     runtimeOnly project(":libs:messaging:kafka-message-bus-impl")
 
-    runtimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    runtimeOnly(libs.felix.security) {
         exclude group: 'org.apache.felix'
         exclude group: 'org.osgi'
     }

--- a/applications/workers/release/member-worker/build.gradle
+++ b/applications/workers/release/member-worker/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     runtimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     runtimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     runtimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
-    runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
+    runtimeOnly libs.felix.configadmin
     runtimeOnly project(":libs:messaging:kafka-message-bus-impl")
 }

--- a/applications/workers/release/rest-worker/build.gradle
+++ b/applications/workers/release/rest-worker/build.gradle
@@ -74,8 +74,8 @@ dependencies {
     e2eTestImplementation project(':components:membership:membership-rest')
     e2eTestImplementation project(':testing:packaging-test-utilities')
     e2eTestImplementation project(':tools:plugins:package')
-    e2eTestImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    e2eTestImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    e2eTestImplementation libs.jackson.datatype
+    e2eTestImplementation libs.jackson.module
     e2eTestImplementation "net.corda:corda-avro-schema"
     e2eTestImplementation "net.corda:corda-topic-schema"
     e2eTestRuntimeOnly 'org.osgi:osgi.core'

--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -38,12 +38,12 @@ dependencies {
         }
     }
     implementation libs.jackson.databind
-    implementation ("net.corda.micrometer:micrometer-core:$micrometerVersion") {
+    implementation (libs.micrometer.core) {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
         exclude group: 'org.latencyutils', module: 'LatencyUtils'
     }
-    implementation "net.corda.micrometer:micrometer-registry-prometheus:$micrometerVersion"
+    implementation libs.micrometer.registry.prometheus
 
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly libs.commons.lang3

--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -37,7 +37,7 @@ dependencies {
                     'This might be resolved in the future versions of Javalin.'
         }
     }
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
     implementation ("net.corda.micrometer:micrometer-core:$micrometerVersion") {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
@@ -54,7 +54,7 @@ dependencies {
     testRuntimeOnly 'org.osgi:osgi.core'
 
     // Required for enterprise addons, so must appear in all worker JARs even if they don't use them
-    runtimeOnly "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    runtimeOnly libs.jackson.module
     runtimeOnly libs.caffeine
     runtimeOnly project(":libs:cache:cache-caffeine")
 }

--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "net.corda.micrometer:micrometer-registry-prometheus:$micrometerVersion"
 
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
-    runtimeOnly "org.apache.commons:commons-lang3:$commonsLangVersion"
+    runtimeOnly libs.commons.lang3
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
@@ -55,6 +55,6 @@ dependencies {
 
     // Required for enterprise addons, so must appear in all worker JARs even if they don't use them
     runtimeOnly "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    runtimeOnly "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    runtimeOnly libs.caffeine
     runtimeOnly project(":libs:cache:cache-caffeine")
 }

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -54,7 +54,7 @@ kotlin {
 dependencies {
     // NO CORDA DEPENDENCIES!!
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$kotlinCoroutinesVersion"
+    implementation libs.kotlinx.coroutines
 
     // Avoid having the schema names and keys scattered across projects
     smokeTestImplementation "net.corda:corda-config-schema:$cordaApiVersion"
@@ -67,7 +67,7 @@ dependencies {
     upgradeTestingCpiV1 project(path: ':testing:cpbs:test-cordapp-for-vnode-upgrade-testing-v1', configuration: 'cordaCPB')
     upgradeTestingCpiV2 project(path: ':testing:cpbs:test-cordapp-for-vnode-upgrade-testing-v2', configuration: 'cordaCPB')
 
-    smokeTestImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    smokeTestImplementation libs.jackson.module
     smokeTestImplementation project(':testing:test-utilities')
     smokeTestImplementation project(':testing:e2e-test-utilities')
 

--- a/build.gradle
+++ b/build.gradle
@@ -365,7 +365,7 @@ subprojects {
         dependencies {
         detekt "io.gitlab.arturbosch.detekt:detekt-cli:$detektPluginVersion"
             constraints {
-                detekt("org.yaml:snakeyaml:$snakeyamlVersion") {
+                detekt(libs.snakeyaml) {
                     because "required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21"
                 }
             }
@@ -420,7 +420,7 @@ subprojects {
             cacheChangingModulesFor 0, 'seconds'
 
             dependencySubstitution {
-                substitute module("antlr:antlr") using module("antlr:antlr.osgi:$antlrVersion")
+                substitute module("antlr:antlr") using module("antlr:antlr.osgi:${libs.versions.antlrVersion.get()}")
                 substitute module("org.dom4j:dom4j") using module("org.apache.servicemix.bundles:org.apache.servicemix.bundles.dom4j:$dom4jOsgiVersion")
             }
         }

--- a/components/chunking/chunk-db-write-impl/build.gradle
+++ b/components/chunking/chunk-db-write-impl/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     implementation project(':components:membership:certificates-service')
     integrationTestImplementation project(":libs:serialization:serialization-avro")
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.databind
+    implementation libs.jackson.module
 
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":components:reconciliation:reconciliation")

--- a/components/configuration/configuration-read-service-impl/build.gradle
+++ b/components/configuration/configuration-read-service-impl/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(":libs:messaging:db-topic-admin-impl")
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"

--- a/components/crypto/crypto-persistence-impl/build.gradle
+++ b/components/crypto/crypto-persistence-impl/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    implementation libs.caffeine
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"
     implementation 'net.corda:corda-db-schema'

--- a/components/crypto/crypto-service-impl/build.gradle
+++ b/components/crypto/crypto-service-impl/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    implementation libs.caffeine
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-topic-schema"

--- a/components/crypto/crypto-service-impl/build.gradle
+++ b/components/crypto/crypto-service-impl/build.gradle
@@ -13,9 +13,9 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.databind
+    implementation libs.jackson.datatype
+    implementation libs.jackson.module
     implementation libs.caffeine
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"

--- a/components/crypto/crypto-softhsm-impl/build.gradle
+++ b/components/crypto/crypto-softhsm-impl/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    implementation libs.caffeine
     implementation "net.corda:corda-config-schema"
     implementation 'net.corda:corda-db-schema'
 

--- a/components/flow/flow-mapper-service/build.gradle
+++ b/components/flow/flow-mapper-service/build.gradle
@@ -45,9 +45,9 @@ dependencies {
     integrationTestRuntimeOnly project(":libs:messaging:db-message-bus-impl")
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"

--- a/components/flow/flow-p2p-filter-service/build.gradle
+++ b/components/flow/flow-p2p-filter-service/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"

--- a/components/flow/flow-rest-resource-service-impl/build.gradle
+++ b/components/flow/flow-rest-resource-service-impl/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     implementation 'net.corda:corda-rbac-schema'
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    implementation "com.google.guava:guava:$guavaVersion"
-    implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
+    implementation libs.guava
+    implementation libs.commons.lang3
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -90,5 +90,5 @@ dependencies {
     integrationTestRuntimeOnly project(":components:membership:membership-group-read-impl")
     integrationTestRuntimeOnly project(":components:virtual-node:cpk-read-service-impl")
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 }

--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -59,13 +59,13 @@ dependencies {
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
-    implementation "com.esotericsoftware:kryo:$kryoVersion"
+    implementation libs.kryo
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
-    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    testImplementation libs.jackson.module
 
     testImplementation project(":libs:flows:session-manager-impl")
     testImplementation project(":libs:lifecycle:lifecycle-test-impl")

--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation project(":libs:utilities")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "io.netty:netty-codec-http:$nettyVersion"
+    implementation libs.netty
     implementation libs.commons.validator
     implementation libs.caffeine
     implementation project(':libs:schema-registry:schema-registry')

--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "io.netty:netty-codec-http:$nettyVersion"
-    implementation "commons-validator:commons-validator:$commonsVersion"
-    implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    implementation libs.commons.validator
+    implementation libs.caffeine
     implementation project(':libs:schema-registry:schema-registry')
     implementation project(":libs:metrics")
 
@@ -43,7 +43,7 @@ dependencies {
     integrationTestImplementation "net.corda:corda-avro-schema"
 
     // For async logging
-    integrationTestRuntimeOnly "com.lmax:disruptor:$disruptorVersion"
+    integrationTestRuntimeOnly libs.lmax.disruptor
     integrationTestRuntimeOnly 'org.osgi:osgi.core'
 
     integrationTestImplementation project(':libs:crypto:certificate-generation')

--- a/components/ledger/ledger-common-flow/build.gradle
+++ b/components/ledger/ledger-common-flow/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
     integrationTestRuntimeOnly project(':libs:flows:session-manager-impl')
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 
     cpis project(path: ':testing:ledger:ledger-common-empty-app', configuration: 'cordaCPB')
 }

--- a/components/ledger/ledger-consensual-flow/build.gradle
+++ b/components/ledger/ledger-consensual-flow/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation project(':libs:serialization:serialization-kryo')
     testImplementation project(':testing:test-serialization')
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')

--- a/components/ledger/ledger-persistence/build.gradle
+++ b/components/ledger/ledger-persistence/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     // It's not an OSGi bundle, so you will get errors (despite Intellij appearing to allow you to use it).
 
     integrationTestImplementation("org.mockito:mockito-core:$mockitoVersion")
-    integrationTestImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    integrationTestImplementation(libs.jackson.module)
 
     integrationTestImplementation project(':libs:db:db-admin-impl')
     integrationTestImplementation project(':libs:db:db-orm-impl')

--- a/components/ledger/ledger-persistence/build.gradle
+++ b/components/ledger/ledger-persistence/build.gradle
@@ -96,7 +96,7 @@ dependencies {
     integrationTestImplementation project(':testing:test-utilities')
 
     // needed to import serialization libs
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 
     integrationTestRuntimeOnly project(':components:db:db-connection-manager-impl')
     integrationTestRuntimeOnly project(':libs:flows:external-event-responses-impl')
@@ -104,7 +104,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
 
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 }

--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')

--- a/components/ledger/ledger-utxo-token-cache/build.gradle
+++ b/components/ledger/ledger-utxo-token-cache/build.gradle
@@ -48,5 +48,5 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 }

--- a/components/ledger/ledger-utxo-token-cache/build.gradle
+++ b/components/ledger/ledger-utxo-token-cache/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
-    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    testImplementation libs.jackson.module
 
     testImplementation project(":libs:lifecycle:lifecycle-test-impl")
     testImplementation project(":libs:lifecycle:lifecycle-impl")

--- a/components/ledger/ledger-verification/build.gradle
+++ b/components/ledger/ledger-verification/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     // It's not an OSGi bundle, so you will get errors (despite Intellij appearing to allow you to use it).
 
     integrationTestImplementation("org.mockito:mockito-core:$mockitoVersion")
-    integrationTestImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    integrationTestImplementation(libs.jackson.module)
 
     integrationTestImplementation project(':components:virtual-node:cpi-info-read-service')
     integrationTestImplementation project(':components:virtual-node:virtual-node-info-read-service')

--- a/components/ledger/ledger-verification/build.gradle
+++ b/components/ledger/ledger-verification/build.gradle
@@ -83,13 +83,13 @@ dependencies {
     integrationTestImplementation project(':testing:test-utilities')
 
     // needed to import serialization libs
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 
     integrationTestRuntimeOnly project(':libs:flows:external-event-responses-impl')
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
 
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
 }
 
 //  Copy the cpi builds declared in the cpis configuration into our resources so we find and load them

--- a/components/link-manager/build.gradle
+++ b/components/link-manager/build.gradle
@@ -101,9 +101,9 @@ dependencies {
     integrationTestRuntimeOnly project(":components:membership:membership-group-read-impl")
     integrationTestRuntimeOnly project(":components:membership:membership-persistence-client-impl")
 
-    testRuntimeOnly "com.lmax:disruptor:$disruptorVersion"
-    testRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    testRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    testRuntimeOnly libs.lmax.disruptor
+    testRuntimeOnly libs.javax.activation
+    testRuntimeOnly libs.aries.dynamic.framework
     testRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     testRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     testRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"

--- a/components/membership/membership-group-read-impl/build.gradle
+++ b/components/membership/membership-group-read-impl/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
     integrationTestRuntimeOnly project(':libs:crypto:cipher-suite-impl')
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"

--- a/components/membership/membership-persistence-service-impl/build.gradle
+++ b/components/membership/membership-persistence-service-impl/build.gradle
@@ -56,8 +56,8 @@ dependencies {
     integrationTestImplementation project(':testing:message-patterns')
     integrationTestImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
 
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.javax.activation
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly("org.hibernate:hibernate-core:$hibernateVersion")
 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"

--- a/components/membership/membership-persistence-service-impl/build.gradle
+++ b/components/membership/membership-persistence-service-impl/build.gradle
@@ -54,11 +54,11 @@ dependencies {
     integrationTestImplementation project(':libs:layered-property-map')
     integrationTestImplementation project(':libs:messaging:topic-admin')
     integrationTestImplementation project(':testing:message-patterns')
-    integrationTestImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    integrationTestImplementation libs.kafka.clients
 
     integrationTestRuntimeOnly libs.javax.activation
     integrationTestRuntimeOnly libs.aries.dynamic.framework
-    integrationTestRuntimeOnly("org.hibernate:hibernate-core:$hibernateVersion")
+    integrationTestRuntimeOnly(libs.hibernate.core )
 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"

--- a/components/membership/membership-rest-impl/build.gradle
+++ b/components/membership/membership-rest-impl/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "net.corda:corda-membership"
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
-    implementation "commons-validator:commons-validator:$commonsVersion"
+    implementation libs.commons.validator
 
     testImplementation project(":libs:crypto:crypto-impl")
     testImplementation project(":testing:layered-property-map-testkit")

--- a/components/membership/registration-impl/build.gradle
+++ b/components/membership/registration-impl/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
 
@@ -69,7 +69,7 @@ dependencies {
     testImplementation project(":testing:layered-property-map-testkit")
     testImplementation project(":testing:test-utilities")
 
-    testImplementation "org.apache.commons:commons-text:$commonsTextVersion"
+    testImplementation libs.commons.text
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/components/membership/synchronisation-impl/build.gradle
+++ b/components/membership/synchronisation-impl/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation project(':libs:utilities')
     implementation project(':libs:serialization:serialization-avro')
 
-    testImplementation "org.apache.commons:commons-text:$commonsTextVersion"
+    testImplementation libs.commons.text
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
@@ -59,7 +59,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
     integrationTestRuntimeOnly project(':libs:crypto:merkle-impl')
     integrationTestRuntimeOnly project(':libs:crypto:cipher-suite-impl')
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
 }

--- a/components/persistence/entity-processor-service-impl/build.gradle
+++ b/components/persistence/entity-processor-service-impl/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     integrationTestImplementation project(':testing:test-utilities')
 
     // needed to import serialization libs
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 
     integrationTestRuntimeOnly project(':components:db:db-connection-manager-impl')
     integrationTestRuntimeOnly project(':libs:flows:external-event-responses-impl')
@@ -82,7 +82,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
 
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 }

--- a/components/security-manager/build.gradle
+++ b/components/security-manager/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation 'net.corda:corda-config-schema'
 
-    testRuntimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    testRuntimeOnly(libs.felix.security) {
         exclude group: 'org.osgi'
     }
 
@@ -38,7 +38,7 @@ dependencies {
     integrationTestImplementation project(':testing:security-manager-utilities')
     integrationTestImplementation "net.corda:corda-application"
     integrationTestImplementation 'org.slf4j:slf4j-api'
-    integrationTestRuntimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    integrationTestRuntimeOnly(libs.felix.security) {
         exclude group: 'org.osgi'
     }
 

--- a/components/uniqueness/backing-store-impl/build.gradle
+++ b/components/uniqueness/backing-store-impl/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "net.corda:corda-crypto"
     implementation "net.corda:corda-db-schema"
     implementation "net.corda:corda-ledger-utxo"
-    implementation "org.hibernate:hibernate-core:$hibernateVersion"
+    implementation libs.hibernate.core 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(":components:uniqueness:backing-store")
     implementation project(":components:db:db-connection-manager")
@@ -56,7 +56,7 @@ dependencies {
     implementation project(":libs:uniqueness:common")
     implementation project(":libs:utilities")
 
-    testImplementation "org.hibernate:hibernate-core:$hibernateVersion"
+    testImplementation libs.hibernate.core 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
@@ -82,8 +82,8 @@ dependencies {
     backingStoreBenchmarkRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 
     // For JSON serialization to DB
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.module
+    implementation libs.jackson.datatype
 }
 
 tasks.named('jar', Jar) {

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/build.gradle
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/build.gradle
@@ -42,12 +42,12 @@ dependencies {
     integrationTestImplementation project(':testing:uniqueness:uniqueness-utilities')
 
     // Needed to import serialization libs
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
 
     integrationTestRuntimeOnly project(':components:configuration:configuration-read-service-impl')
     integrationTestRuntimeOnly project(':libs:crypto:cipher-suite-impl')

--- a/components/virtual-node/sandbox-group-context-service/build.gradle
+++ b/components/virtual-node/sandbox-group-context-service/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation project(":components:virtual-node:cpk-read-service")
     implementation project(":components:configuration:configuration-read-service")
 
-    implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    implementation libs.caffeine
 
     runtimeOnly project(':components:virtual-node:sandbox-crypto')
     runtimeOnly project(':libs:sandbox-hooks')
@@ -83,8 +83,8 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:lifecycle:lifecycle-impl')
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
-    integrationTestRuntimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
+    integrationTestRuntimeOnly(libs.felix.security) {
         exclude group: 'org.osgi'
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@ artifactoryContextUrl=https://software.r3.com/artifactory
 kotlin.code.style=official
 kotlinVersion=1.8.21
 kotlin.stdlib.default.dependency=false
-kotlinMetadataVersion = 0.6.0
 
 org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
@@ -26,32 +25,15 @@ bndVersion=6.4.0
 cordaGradlePluginsVersion=7.0.3
 detektPluginVersion=1.22.+
 internalPublishVersion=1.+
-internalDockerVersion=1.+
 dependencyCheckVersion=0.46.+
-snakeyamlVersion=2.0
 dokkaVersion=1.8.+
-# Implementation dependency versions
-activationVersion=1.2.0
-ariesDynamicFrameworkExtensionVersion=1.3.6
-antlrVersion=2.7.7
-asmVersion=9.4
-avroVersion=1.11.1
-commonsVersion = 1.7
-caffeineVersion = 3.1.6
-commonsLangVersion = 3.12.0
-commonsTextVersion = 1.10.0
-bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.0.0.xxx-SNAPSHOT
 cordaApiVersion=5.0.0.765-beta+
 
-disruptorVersion=3.4.4
-felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5
 felixScrVersion=2.2.6
-felixSecurityVersion=2.8.4
-guavaVersion=32.1.1-jre
 # Hibernate cannot be upgraded to 6.x due to missing OSGi support
 hibernateVersion=5.6.15.Final
 hikariCpVersion=5.0.1
@@ -170,3 +152,7 @@ snykVersion = 0.4
 # License
 licenseName = The Apache License, Version 2.0
 licenseUrl = http://www.apache.org/licenses/LICENSE-2.0.txt
+
+# Gradle Version Catalog
+cordaVersionCatalog=1.0.0-beta-+
+releaseVersionCatalog=release-5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,18 +35,11 @@ cordaApiVersion=5.0.0.765-beta+
 felixVersion=7.0.5
 felixScrVersion=2.2.6
 # Hibernate cannot be upgraded to 6.x due to missing OSGi support
-hibernateVersion=5.6.15.Final
-hikariCpVersion=5.0.1
-jacksonVersion=2.15.0
-jaxbVersion = 2.3.1
 jbossTransactionApiSpecVersion=1.1.1.Final
 jetbrainsAnnotationsVersion=24.0.1
-kafkaClientVersion=3.4.0_1
 # NOTE: Kryo cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.
-kryoVersion = 5.5.0
 kryoSerializersVersion = 0.45
-kotlinCoroutinesVersion=1.6.4
 # Liquibase upgrade to 4.20 and 4.21 failed - see CORE-12612 for more details
 liquibaseVersion = 4.19.0
 # Needed by Liquibase:

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,18 +39,10 @@ jbossTransactionApiSpecVersion=1.1.1.Final
 jetbrainsAnnotationsVersion=24.0.1
 # NOTE: Kryo cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.
-kryoSerializersVersion = 0.45
 # Liquibase upgrade to 4.20 and 4.21 failed - see CORE-12612 for more details
-liquibaseVersion = 4.19.0
 # Needed by Liquibase:
-beanutilsVersion=1.9.4
 log4jVersion = 2.20.0
-micrometerVersion=1.11.0
-nettyVersion = 4.1.94.Final
 # com.networknt:json-schema-validator cannot be upgraded beyond 1.0.66 because it becomes dependent on com.ethlo.time which is not OSGi compatible.
-networkntJsonSchemaVersion = 1.0.66
-osgiCmVersion = 1.6.1
-osgiNamespaceServiceVersion = 1.0.0
 osgiServiceComponentVersion = 1.5.1
 osgiUtilFunctionVersion = 1.2.0
 osgiUtilPromiseVersion = 1.3.0

--- a/libs/application/application-impl/build.gradle
+++ b/libs/application/application-impl/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     api project(":libs:serialization:json-serializers")
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module
     implementation 'org.slf4j:slf4j-api'
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/libs/cache/cache-caffeine/build.gradle
+++ b/libs/cache/cache-caffeine/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation project(":libs:metrics")
     implementation project(":libs:utilities")
     implementation 'net.corda:corda-base'
-    api "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+    api libs.caffeine
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 

--- a/libs/configuration/configuration-validation/build.gradle
+++ b/libs/configuration/configuration-validation/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     implementation libs.jackson.databind
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
+    implementation libs.networknt.json.schema.validator
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/libs/configuration/configuration-validation/build.gradle
+++ b/libs/configuration/configuration-validation/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation project(":libs:configuration:configuration-core")
     implementation project(':libs:utilities')
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
 

--- a/libs/crypto/cipher-suite/build.gradle
+++ b/libs/crypto/cipher-suite/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     api 'net.corda:corda-crypto'
     api 'net.corda:corda-crypto-extensions'
 
-    api "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
-    api "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
+    api libs.bouncycastle.bcprov
+    api libs.bouncycastle.bcpkix
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"

--- a/libs/crypto/crypto-core/build.gradle
+++ b/libs/crypto/crypto-core/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     testImplementation "javax.persistence:javax.persistence-api"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-    testImplementation "org.hibernate:hibernate-core:$hibernateVersion"
+    testImplementation libs.hibernate.core 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/libs/crypto/crypto-impl/build.gradle
+++ b/libs/crypto/crypto-impl/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation project(":testing:layered-property-map-testkit")
     testImplementation "javax.persistence:javax.persistence-api"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-    testImplementation "org.hibernate:hibernate-core:$hibernateVersion"
+    testImplementation libs.hibernate.core 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/libs/crypto/crypto-impl/build.gradle
+++ b/libs/crypto/crypto-impl/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation "net.corda:corda-config-schema"
     implementation "net.corda:corda-serialization"
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
+    implementation libs.commons.lang3
 
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 

--- a/libs/crypto/crypto-serialization-impl/build.gradle
+++ b/libs/crypto/crypto-serialization-impl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     api project(':libs:crypto:cipher-suite')
     api 'net.corda:corda-serialization'
-    implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
+    implementation libs.commons.lang3
 
     implementation project(":libs:crypto:crypto-core")
     implementation project(':libs:serialization:serialization-internal')

--- a/libs/crypto/crypto-utils/build.gradle
+++ b/libs/crypto/crypto-utils/build.gradle
@@ -14,6 +14,6 @@ dependencies {
     implementation "net.corda:corda-base"
 
     api "org.slf4j:slf4j-api:$slf4jVersion"
-    api "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
-    api "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
+    api libs.bouncycastle.bcprov
+    api libs.bouncycastle.bcpkix
 }

--- a/libs/crypto/merkle-impl/build.gradle
+++ b/libs/crypto/merkle-impl/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     testImplementation project(":libs:crypto:cipher-suite-impl")
     testImplementation project(":testing:test-utilities")
 
-    integrationTestRuntimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    integrationTestRuntimeOnly(libs.felix.security) {
         exclude group: 'org.osgi'
     }
 }

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     implementation "org.liquibase:liquibase-core:$liquibaseVersion"
     constraints {
-        implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
+        implementation(libs.snakeyaml) {
             because "required until liquibase-core updates it's internal version of snakeYaml, currently using 1.33 which has CVE-2022-1471"
         }
     }

--- a/libs/db/db-admin-impl/build.gradle
+++ b/libs/db/db-admin-impl/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "org.slf4j:slf4j-api"
     compileOnly "org.osgi:org.osgi.service.component.annotations"
 
-    implementation "org.liquibase:liquibase-core:$liquibaseVersion"
+    implementation libs.liquidbase.core
     constraints {
         implementation(libs.snakeyaml) {
             because "required until liquibase-core updates it's internal version of snakeYaml, currently using 1.33 which has CVE-2022-1471"

--- a/libs/db/db-core/build.gradle
+++ b/libs/db/db-core/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "org.osgi:org.osgi.service.jdbc:$osgiJdbcServiceVersion"
     implementation project(':libs:metrics')
 
-    api "com.zaxxer:HikariCP:$hikariCpVersion"
+    api libs.hikaricp
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/libs/db/db-orm-impl/build.gradle
+++ b/libs/db/db-orm-impl/build.gradle
@@ -13,15 +13,15 @@ dependencies {
     implementation "org.slf4j:slf4j-api"
     api "javax.persistence:javax.persistence-api"
 
-    runtimeOnly("org.hibernate:hibernate-core:$hibernateVersion")
+    runtimeOnly(libs.hibernate.core )
     // TODO - statistics integration isn't working in OSGi.
     // https://r3-cev.atlassian.net/browse/CORE-7168
     //
-    // runtimeOnly("org.hibernate:hibernate-micrometer:$hibernateVersion") {
+    // runtimeOnly(libs.hibernate.micrometer) {
     //  // TODO - this can probably be removed once we have a table version of micrometer with OSGi support.
     //  exclude group: 'io.micrometer', module: 'micrometer-core'
     // }
-    implementation("org.hibernate:hibernate-osgi:$hibernateVersion") {
+    implementation(libs.hibernate.osgi) {
         // Need to exclude the org.osgi package as will use the BND ones at runtime
         //  org.osgi ones are added above as compileOnly
         exclude group: 'org.osgi'

--- a/libs/db/osgi-integration-tests/build.gradle
+++ b/libs/db/osgi-integration-tests/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     integrationTestImplementation project(":testing:test-utilities")
     integrationTestImplementation project(":testing:db-testkit")
 
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
@@ -33,5 +33,5 @@ dependencies {
 
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 }

--- a/libs/external-messaging/build.gradle
+++ b/libs/external-messaging/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation "net.corda:corda-config-schema"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.databind
+    implementation libs.jackson.module
     
     implementation project(":libs:crypto:crypto-core")
     implementation project(":libs:packaging:packaging-core")

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -21,16 +21,16 @@ configurations {
 dependencies {
     api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinMetadataVersion"
-    compileOnly "org.ow2.asm:asm:$asmVersion"
+    compileOnly libs.kotlinx.metadata
+    compileOnly libs.ow2.asm
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
     testCompileOnly 'org.jetbrains:annotations'
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5Version"
-    testRuntimeOnly "org.jetbrains.kotlinx:kotlinx-metadata-jvm:$kotlinMetadataVersion"
-    testRuntimeOnly "org.ow2.asm:asm:$asmVersion"
+    testRuntimeOnly libs.kotlinx.metadata
+    testRuntimeOnly libs.ow2.asm
 
     integrationTestImplementation project(':libs:kotlin-reflection:kotlin-reflection-test-example')
     integrationTestImplementation 'org.slf4j:slf4j-api'
@@ -48,7 +48,7 @@ def jar = tasks.named('jar', Jar) {
 Bundle-Name: Corda Kotlin Reflection
 Bundle-SymbolicName: \${project.group}.kotlin-reflection
 Sealed: true
--includeresource: @kotlinx-metadata-jvm-${kotlinMetadataVersion}.jar
+-includeresource: @kotlinx-metadata-jvm-${libs.versions.kotlinMetadataVersion.get()}.jar
 -conditionalpackage: org.objectweb.asm
 """
     }

--- a/libs/ledger/ledger-common-data/build.gradle
+++ b/libs/ledger/ledger-common-data/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation 'net.corda:corda-ledger-common'
 
-    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation libs.jackson.annotations
 
     api project(':libs:base-internal')
     implementation project(':libs:crypto:crypto-core')

--- a/libs/lifecycle/lifecycle-impl/build.gradle
+++ b/libs/lifecycle/lifecycle-impl/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':libs:utilities')
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
-    implementation "com.google.guava:guava:$guavaVersion"
+    implementation libs.guava
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation 'org.slf4j:slf4j-api'

--- a/libs/membership/schema-validation/build.gradle
+++ b/libs/membership/schema-validation/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation "net.corda:corda-base"
     api "net.corda:corda-membership-schema"
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
     implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
     implementation project(':libs:membership:membership-common')
 

--- a/libs/membership/schema-validation/build.gradle
+++ b/libs/membership/schema-validation/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api "net.corda:corda-membership-schema"
 
     implementation libs.jackson.databind
-    implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
+    implementation libs.networknt.json.schema.validator
     implementation project(':libs:membership:membership-common')
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/libs/messaging/db-message-bus-impl/build.gradle
+++ b/libs/messaging/db-message-bus-impl/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     runtimeOnly project(':libs:db:db-orm-impl')
     runtimeOnly project(':libs:schema-registry:schema-registry-impl')
-    runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    runtimeOnly libs.javax.activation
 
     testImplementation project(":testing:test-utilities")
     testImplementation "org.assertj:assertj-core:$assertjVersion"
@@ -46,7 +46,7 @@ dependencies {
     integrationTestImplementation project(":libs:utilities")
     integrationTestImplementation project(":testing:db-testkit")
 
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"

--- a/libs/messaging/db-topic-admin-impl/build.gradle
+++ b/libs/messaging/db-topic-admin-impl/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     integrationTestImplementation project(":libs:db:db-orm-impl")
     integrationTestImplementation project(":testing:db-testkit")
 
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"

--- a/libs/messaging/db-topic-admin-impl/build.gradle
+++ b/libs/messaging/db-topic-admin-impl/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    implementation libs.kafka.clients
     constraints {
         implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
             because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +

--- a/libs/messaging/kafka-message-bus-impl/build.gradle
+++ b/libs/messaging/kafka-message-bus-impl/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-config-schema"
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    implementation libs.kafka.clients
     constraints {
         implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
             because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +

--- a/libs/messaging/kafka-topic-admin-impl/build.gradle
+++ b/libs/messaging/kafka-topic-admin-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    implementation libs.kafka.clients
     constraints {
         implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
             because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +

--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
-    api ("net.corda.micrometer:micrometer-core:$micrometerVersion") {
+    api (libs.micrometer.core) {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.latencyutils', module: 'LatencyUtils'
     }

--- a/libs/p2p-crypto/build.gradle
+++ b/libs/p2p-crypto/build.gradle
@@ -15,8 +15,8 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:crypto:crypto-utils")
 
-    api "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
-    api "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
+    api libs.bouncycastle.bcprov
+    api libs.bouncycastle.bcpkix
 
     testImplementation project(':libs:crypto:cipher-suite')
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/libs/packaging/packaging-verify/build.gradle
+++ b/libs/packaging/packaging-verify/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:packaging:packaging')
     implementation project(':libs:packaging:packaging-core')
-    implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
+    implementation libs.networknt.json.schema.validator
 
     testImplementation project(':testing:test-utilities')
     testImplementation project(':testing:packaging-test-utilities')

--- a/libs/packaging/packaging/build.gradle
+++ b/libs/packaging/packaging/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:utilities')
     implementation project(":libs:packaging:packaging-core")
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module
 
     testImplementation 'org.osgi:osgi.core'
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/libs/permissions/permission-datamodel/build.gradle
+++ b/libs/permissions/permission-datamodel/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     implementation 'net.corda:corda-db-schema'
 
     integrationTestRuntimeOnly project(":libs:db:db-orm-impl")
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.javax.activation
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"

--- a/libs/permissions/permission-datamodel/build.gradle
+++ b/libs/permissions/permission-datamodel/build.gradle
@@ -33,8 +33,8 @@ dependencies {
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 
-    integrationTestRuntimeOnly("org.hibernate:hibernate-core:$hibernateVersion")
-    integrationTestImplementation("org.hibernate:hibernate-osgi:$hibernateVersion") {
+    integrationTestRuntimeOnly(libs.hibernate.core )
+    integrationTestImplementation(libs.hibernate.osgi) {
         // Need to exclude the org.osgi package as will use the BND ones at runtime
         //  org.osgi ones are added above as compileOnly
         exclude group: 'org.osgi'

--- a/libs/permissions/permission-password/build.gradle
+++ b/libs/permissions/permission-password/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     implementation project(":libs:crypto:crypto-core")
-    implementation "org.apache.commons:commons-text:$commonsTextVersion"
+    implementation libs.commons.text
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation project(":libs:crypto:cipher-suite-impl")

--- a/libs/rest/json-serialization/build.gradle
+++ b/libs/rest/json-serialization/build.gradle
@@ -12,8 +12,8 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-application"
 
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.datatype
+    implementation libs.jackson.module
 
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
     implementation project(":libs:serialization:json-serializers")

--- a/libs/rest/rest-client/build.gradle
+++ b/libs/rest/rest-client/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation "net.corda:corda-application"
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "org.apache.commons:commons-lang3:$commonsLangVersion"
+    implementation libs.commons.lang3
     implementation "net.corda:corda-crypto"
 
     api project(":libs:rest:rest")

--- a/libs/rest/rest-client/build.gradle
+++ b/libs/rest/rest-client/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     implementation "com.konghq:unirest-java:$unirestVersion"
     implementation "com.konghq:unirest-objectmapper-jackson:$unirestVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -39,10 +39,10 @@ dependencies {
     implementation "org.eclipse.jetty.http2:http2-server:$jettyVersion"
     implementation "io.swagger.core.v3:swagger-core:$swaggerVersion"
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module
     implementation project(":libs:rest:rest-common")
 
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.datatype
 
     testImplementation project(":libs:rest:rest-test-common")
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
@@ -52,8 +52,8 @@ dependencies {
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
 
     runtimeOnly "org.webjars:swagger-ui:$swaggeruiVersion"
-    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    runtimeOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    runtimeOnly libs.jackson.databind
+    runtimeOnly libs.jackson.datatype
     runtimeOnly libs.javax.activation
 
     integrationTestImplementation "com.konghq:unirest-java:$unirestVersion"

--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     runtimeOnly "org.webjars:swagger-ui:$swaggeruiVersion"
     runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     runtimeOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    runtimeOnly libs.javax.activation
 
     integrationTestImplementation "com.konghq:unirest-java:$unirestVersion"
 

--- a/libs/rest/rest-test-common/build.gradle
+++ b/libs/rest/rest-test-common/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-serialization"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module
     implementation "com.nimbusds:oauth2-oidc-sdk:$nimbusVersion"
     implementation "com.konghq:unirest-java:$unirestVersion"
 

--- a/libs/rest/ssl-cert-read-impl/build.gradle
+++ b/libs/rest/ssl-cert-read-impl/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'net.corda:corda-base'
     implementation 'net.corda:corda-config-schema'
-    implementation "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
-    implementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
+    implementation libs.bouncycastle.bcprov
+    implementation libs.bouncycastle.bcpkix
 
     api project(':libs:rest:ssl-cert-read')
 

--- a/libs/sandbox-internal/sandbox-irresolvable-cpk/build.gradle
+++ b/libs/sandbox-internal/sandbox-irresolvable-cpk/build.gradle
@@ -20,5 +20,5 @@ dependencies {
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     // Corda does not actually provide this dependency, so an error will be thrown at sandbox creation time.
-    cordaProvided "org.osgi:org.osgi.service.cm:$osgiCmVersion"
+    cordaProvided libs.osgi.service.cm
 }

--- a/libs/sandbox-internal/sandbox-irresolvable-cpk/readme.md
+++ b/libs/sandbox-internal/sandbox-irresolvable-cpk/readme.md
@@ -1,3 +1,3 @@
-This CPK requires Corda to provide "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion" as a 
+This CPK requires Corda to provide libs.felix.configadmin as a 
 dependency. Corda has a matching bundle installed, but it's a private bundle in a public sandbox, so should not be 
 available to resolve against. We test for this resolution failure in the tests.

--- a/libs/schema-registry/schema-registry-impl/build.gradle
+++ b/libs/schema-registry/schema-registry-impl/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
 
-    implementation "org.apache.avro:avro:$avroVersion"
+    implementation libs.apache.avro
 
     implementation "net.corda:corda-avro-schema"
     implementation project(":libs:schema-registry:schema-registry")

--- a/libs/schema-registry/schema-registry/build.gradle
+++ b/libs/schema-registry/schema-registry/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
-    api "org.apache.avro:avro:$avroVersion"
+    api libs.apache.avro
     api "net.corda:corda-avro-schema"
 }
 

--- a/libs/serialization/json-serializers/build.gradle
+++ b/libs/serialization/json-serializers/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-application"
     implementation 'net.corda:corda-base'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 }

--- a/libs/serialization/json-validator/build.gradle
+++ b/libs/serialization/json-validator/build.gradle
@@ -27,7 +27,7 @@ dependencies {
         // Exclude transitive dependency on vulnerable version of jackson
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
 }

--- a/libs/serialization/json-validator/build.gradle
+++ b/libs/serialization/json-validator/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'net.corda:corda-serialization'
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "io.github.erdtman:java-json-canonicalization:$jsonCanonicalizerVersion"
-    implementation("com.networknt:json-schema-validator:$networkntJsonSchemaVersion"){
+    implementation(libs.networknt.json.schema.validator){
         // Exclude transitive dependency on vulnerable version of jackson
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }

--- a/libs/serialization/kryo-serializers/build.gradle
+++ b/libs/serialization/kryo-serializers/build.gradle
@@ -14,7 +14,7 @@ ext {
     kryoProtobufVersion = '3.6.1'
     kryoWicketVersion = '1.4.17'
     guavaOsgiVersion = provider {
-        parseMavenString(ibs.versions.guavaVersion.get()).getOSGiVersion()
+        parseMavenString(libs.versions.guavaVersion.get()).getOSGiVersion()
     }
 }
 
@@ -33,7 +33,7 @@ dependencies {
     compileOnly "org.apache.wicket:wicket:$kryoWicketVersion"
     compileOnly "joda-time:joda-time:$kryoJodaTimeVersion"
     compileOnly "cglib:cglib:$kryoCglibVersion"
-    api "com.esotericsoftware:kryo:$kryoVersion"
+    api libs.kryo
 }
 
 def jar = tasks.named('jar', Jar) {

--- a/libs/serialization/kryo-serializers/build.gradle
+++ b/libs/serialization/kryo-serializers/build.gradle
@@ -14,7 +14,7 @@ ext {
     kryoProtobufVersion = '3.6.1'
     kryoWicketVersion = '1.4.17'
     guavaOsgiVersion = provider {
-        parseMavenString(guavaVersion).getOSGiVersion()
+        parseMavenString(ibs.versions.guavaVersion.get()).getOSGiVersion()
     }
 }
 

--- a/libs/serialization/kryo-serializers/build.gradle
+++ b/libs/serialization/kryo-serializers/build.gradle
@@ -27,7 +27,7 @@ configurations {
 
 dependencies {
     // This information has been read from kryo-serializers' original POM.
-    compileOnly "de.javakaffee:kryo-serializers:$kryoSerializersVersion"
+    compileOnly libs.kryo.serializers
     compileOnly "com.github.andrewoma.dexx:collection:$kryoDexxCollectionVersion"
     compileOnly "com.google.protobuf:protobuf-java:$kryoProtobufVersion"
     compileOnly "org.apache.wicket:wicket:$kryoWicketVersion"
@@ -44,7 +44,7 @@ def jar = tasks.named('jar', Jar) {
 Automatic-Module-Name: de.javakaffee.kryoserializers
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.kryo-serializers
-Bundle-Version: ${kryoSerializersVersion}
+Bundle-Version: ${libs.versions.kryoSerializersVersion.get()}
 Export-Package: \
     de.javakaffee.kryoserializers.*
 Import-Package: \
@@ -56,7 +56,7 @@ Import-Package: \
     net.sf.cglib.*;resolution:=optional,\
     sun.reflect;resolution:=optional,\
     *
--includeresource: @kryo-serializers-${kryoSerializersVersion}.jar
+-includeresource: @kryo-serializers-${libs.versions.kryoSerializersVersion.get()}.jar
 """
     }
 }

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation project(":libs:utilities")
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "com.google.guava:guava:$guavaVersion"
+    implementation libs.guava
     implementation "org.apache.qpid:proton-j:$protonjVersion"
     implementation 'org.slf4j:slf4j-api'
 
@@ -67,13 +67,13 @@ dependencies {
     integrationTestImplementation project(':components:security-manager')
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation "net.corda:corda-application"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly project(':libs:crypto:crypto-core')
     integrationTestRuntimeOnly project(':libs:crypto:cipher-suite-impl')
     integrationTestRuntimeOnly project(":libs:lifecycle:lifecycle-impl")
     integrationTestRuntimeOnly project(':libs:messaging:db-message-bus-impl')
     integrationTestRuntimeOnly project(':libs:messaging:messaging-impl')
-    integrationTestRuntimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
+    integrationTestRuntimeOnly(libs.felix.security) {
         exclude group: 'org.osgi'
     }
 }

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
     testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    testImplementation libs.jackson.databind
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"

--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation "net.corda:corda-serialization"
 
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
-    implementation "com.esotericsoftware:kryo:$kryoVersion"
+    implementation libs.kryo
     implementation project(path: ':libs:serialization:kryo-serializers', configuration: 'bundle')
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "org.slf4j:slf4j-api"

--- a/libs/utilities/build.gradle
+++ b/libs/utilities/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     // Concluded this is the one acceptable dependency in addition to kotlin.
     implementation 'org.slf4j:slf4j-api'
-    implementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
+    implementation libs.bouncycastle.bcpkix
 
     implementation project(":libs:configuration:configuration-core")
 

--- a/osgi-framework-bootstrap/build.gradle
+++ b/osgi-framework-bootstrap/build.gradle
@@ -25,9 +25,9 @@ dependencies {
     runtimeOnly "org.apache.logging.log4j:log4j-layout-template-json:$log4jVersion"
 
     // Jackson dependencies for JSON formatted logs
-    runtimeOnly "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    runtimeOnly "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    runtimeOnly libs.jackson.core
+    runtimeOnly libs.jackson.databind
+    runtimeOnly libs.jackson.annotations
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.apache.sling:org.apache.sling.testing.osgi-mock.junit5:$slingVersion"

--- a/processors/crypto-processor/build.gradle
+++ b/processors/crypto-processor/build.gradle
@@ -72,8 +72,8 @@ dependencies {
     runtimeOnly project(":libs:messaging:messaging-impl")
     runtimeOnly project(":libs:schema-registry:schema-registry-impl")
 
-    runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    runtimeOnly libs.javax.activation
+    runtimeOnly libs.aries.dynamic.framework
 
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 
@@ -84,7 +84,7 @@ dependencies {
     integrationTestRuntimeOnly project(":components:crypto:crypto-hes-core-impl")
     integrationTestRuntimeOnly project(":components:crypto:crypto-hes-impl")
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    integrationTestRuntimeOnly libs.javax.activation
 
     integrationTestRuntimeOnly "org.hibernate:hibernate-core:$hibernateVersion"
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"

--- a/processors/crypto-processor/build.gradle
+++ b/processors/crypto-processor/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     integrationTestImplementation project(":testing:db-testkit")
     integrationTestImplementation project(":testing:test-utilities")
 
-    integrationTestImplementation("org.hibernate:hibernate-osgi:$hibernateVersion") {
+    integrationTestImplementation(libs.hibernate.osgi) {
         // Need to exclude the org.osgi package as will use the BND ones at runtime
         //  org.osgi ones are added above as compileOnly
         exclude group: 'org.osgi'
@@ -86,7 +86,7 @@ dependencies {
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
     integrationTestRuntimeOnly libs.javax.activation
 
-    integrationTestRuntimeOnly "org.hibernate:hibernate-core:$hibernateVersion"
+    integrationTestRuntimeOnly libs.hibernate.core 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
 

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -96,9 +96,9 @@ dependencies {
 
     runtimeOnly libs.javax.activation
     runtimeOnly libs.aries.dynamic.framework
-    runtimeOnly "org.liquibase:liquibase-core:$liquibaseVersion"
+    runtimeOnly libs.liquidbase.core
     // NOTE: this is needed by Liquibase but for some reason not picked up automatically.
-    runtimeOnly "commons-beanutils:commons-beanutils:$beanutilsVersion"
+    runtimeOnly libs.commons.beanutils
 
     testRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"
 

--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -94,8 +94,8 @@ dependencies {
     runtimeOnly project(":libs:sandbox-internal")
     runtimeOnly project(':libs:schema-registry:schema-registry-impl')
 
-    runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    runtimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    runtimeOnly libs.javax.activation
+    runtimeOnly libs.aries.dynamic.framework
     runtimeOnly "org.liquibase:liquibase-core:$liquibaseVersion"
     // NOTE: this is needed by Liquibase but for some reason not picked up automatically.
     runtimeOnly "commons-beanutils:commons-beanutils:$beanutilsVersion"

--- a/processors/member-processor/build.gradle
+++ b/processors/member-processor/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     integrationTestImplementation project(":testing:db-testkit")
     integrationTestImplementation project(":testing:test-utilities")
 
-    integrationTestImplementation("org.hibernate:hibernate-osgi:$hibernateVersion") {
+    integrationTestImplementation(libs.hibernate.osgi) {
         // Need to exclude the org.osgi package as will use the BND ones at runtime
         //  org.osgi ones are added above as compileOnly
         exclude group: 'org.osgi'
@@ -109,7 +109,7 @@ dependencies {
     integrationTestRuntimeOnly project(':libs:crypto:merkle-impl')
 
     integrationTestRuntimeOnly libs.aries.dynamic.framework
-    integrationTestRuntimeOnly "org.hibernate:hibernate-core:$hibernateVersion"
+    integrationTestRuntimeOnly libs.hibernate.core 
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"
     integrationTestRuntimeOnly "org.postgresql:postgresql:$postgresDriverVersion"

--- a/processors/member-processor/build.gradle
+++ b/processors/member-processor/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
     implementation project(':libs:configuration:configuration-core')
 
-    runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    runtimeOnly libs.javax.activation
 
     runtimeOnly project(':components:crypto:crypto-hes-impl')
     runtimeOnly project(':components:membership:group-params-writer-service-impl')
@@ -108,7 +108,7 @@ dependencies {
     integrationTestRuntimeOnly project(":libs:schema-registry:schema-registry-impl")
     integrationTestRuntimeOnly project(':libs:crypto:merkle-impl')
 
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly "org.hibernate:hibernate-core:$hibernateVersion"
     integrationTestRuntimeOnly "org.ops4j.pax.jdbc:pax-jdbc-hsqldb:$paxJdbcVersion"
     integrationTestRuntimeOnly "org.hsqldb:hsqldb:$hsqldbVersion"

--- a/processors/uniqueness-processor/build.gradle
+++ b/processors/uniqueness-processor/build.gradle
@@ -19,5 +19,5 @@ dependencies {
     runtimeOnly project(':libs:lifecycle:lifecycle-impl')
     runtimeOnly project(':libs:messaging:messaging-impl')
 
-    runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
+    runtimeOnly libs.javax.activation
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -90,7 +90,7 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         libs {
-            from("net.corda:corda-version-catalog:$cordaVersionCatalog")
+            from("net.corda:$releaseVersionCatalog:$cordaVersionCatalog")
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -58,6 +58,43 @@ plugins {
     id 'com.gradle.enterprise'
 }
 
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        def cordaUseCache = System.getenv("CORDA_USE_CACHE")
+        if (cordaUseCache != null) {
+            maven {
+                url = "$artifactoryContextUrl/$cordaUseCache"
+                name = "R3 Maven remote repositories"
+                authentication {
+                    basic(BasicAuthentication)
+                }
+                credentials {
+                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+                }
+            }
+        } else {
+            maven {
+                url = "$artifactoryContextUrl/corda-os-maven"
+                authentication {
+                    basic(BasicAuthentication)
+                }
+                credentials {
+                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+                }
+            }
+        }
+    }
+    versionCatalogs {
+        libs {
+            from("net.corda:corda-version-catalog:$cordaVersionCatalog")
+        }
+    }
+}
+
 rootProject.name = 'corda-runtime-os'
 include 'applications:examples:sandbox-app'
 include 'applications:examples:sandbox-app:example-cpi'

--- a/simulator/runtime/build.gradle
+++ b/simulator/runtime/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     implementation "org.hibernate:hibernate-core:$hibernateVersion"
     implementation "org.hsqldb:hsqldb:$hsqldbVersion"
 
-    api "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
-    api "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
+    api libs.bouncycastle.bcprov
+    api libs.bouncycastle.bcpkix
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-application:$cordaApiVersion"

--- a/simulator/runtime/build.gradle
+++ b/simulator/runtime/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 dependencies {
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.databind
+    implementation libs.jackson.module
+    implementation libs.jackson.datatype
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    implementation "org.hibernate:hibernate-core:$hibernateVersion"
+    implementation libs.hibernate.core 
     implementation "org.hsqldb:hsqldb:$hsqldbVersion"
 
     api libs.bouncycastle.bcprov

--- a/testing/cpbs/sandbox-security-manager-one/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-one/build.gradle
@@ -17,7 +17,7 @@ cordapp {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion") {
+    implementation(libs.jackson.module) {
         // this transitive dependency is not needed as it is shaded in the jackson module, but there is a bug in
         //  the metadata: https://github.com/FasterXML/jackson-core/issues/999
         exclude group: "ch.randelshofer"

--- a/testing/cpbs/sandbox-security-manager-two/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-two/build.gradle
@@ -18,7 +18,7 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion") {
+    implementation(libs.jackson.module) {
         // this transitive dependency is not needed as it is shaded in the jackson module, but there is a bug in
         //  the metadata: https://github.com/FasterXML/jackson-core/issues/999
         exclude group: "ch.randelshofer"

--- a/testing/cpi-info-read-service-fake/build.gradle
+++ b/testing/cpi-info-read-service-fake/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     implementation project(":libs:packaging:packaging-core")
     implementation project(':libs:lifecycle:lifecycle')
 
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.dataformat
+    implementation libs.jackson.module
 
     testImplementation project(':libs:crypto:crypto-core')
     testImplementation project(":libs:lifecycle:lifecycle-impl")

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     implementation "net.corda:corda-config-schema:$cordaApiVersion"
 
     implementation "com.konghq:unirest-java:$unirestVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.module
+    implementation libs.jackson.datatype
     implementation project(':testing:test-utilities')
 
     implementation libs.commons.text

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     implementation project(':testing:test-utilities')
 
-    implementation "org.apache.commons:commons-text:$commonsTextVersion"
+    implementation libs.commons.text
     implementation "org.assertj:assertj-core:$assertjVersion"
     implementation "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     implementation project(':components:flow:flow-rest-resource-service')

--- a/testing/kryo-serialization-testkit/build.gradle
+++ b/testing/kryo-serialization-testkit/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     runtimeOnly 'org.osgi:osgi.core'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "com.esotericsoftware:kryo:$kryoVersion"
+    implementation libs.kryo
     implementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
 
     implementation project(":libs:serialization:serialization-kryo")

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -68,8 +68,8 @@ dependencies {
     integrationTestRuntimeOnly "org.osgi:org.osgi.util.promise:$osgiUtilPromiseVersion"
     integrationTestRuntimeOnly "org.osgi:org.osgi.util.function:$osgiUtilFunctionVersion"
     integrationTestRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
-    integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
-    integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"
+    integrationTestRuntimeOnly libs.javax.activation
+    integrationTestRuntimeOnly libs.aries.dynamic.framework
     integrationTestRuntimeOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
 
     kafkaIntegrationTestRuntimeOnly project(":libs:messaging:kafka-topic-admin-impl")

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     integrationTestImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     integrationTestImplementation "org.osgi:org.osgi.test.junit5:$osgiTestJunit5Version"
     integrationTestImplementation "javax.persistence:javax.persistence-api"
-    integrationTestImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    integrationTestImplementation libs.kafka.clients
 
     integrationTestImplementation project(":components:kafka-topic-admin")
     integrationTestImplementation 'net.corda:corda-db-schema'

--- a/testing/sandboxes/build.gradle
+++ b/testing/sandboxes/build.gradle
@@ -28,7 +28,7 @@ dependencies {
         exclude group: 'org.mockito'
     }
 
-    runtimeOnly "org.apache.felix:org.apache.felix.configadmin:$felixConfigAdminVersion"
+    runtimeOnly libs.felix.configadmin
     runtimeOnly project(':libs:sandbox-internal')
 }
 

--- a/testing/sandboxes/build.gradle
+++ b/testing/sandboxes/build.gradle
@@ -7,7 +7,7 @@ description 'Creates sandboxes for testing purposes'
 dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
-    compileOnly "org.osgi:org.osgi.service.cm:$osgiCmVersion"
+    compileOnly libs.osgi.service.cm
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"

--- a/testing/virtual-node-info-read-service-fake/build.gradle
+++ b/testing/virtual-node-info-read-service-fake/build.gradle
@@ -17,9 +17,9 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(":components:reconciliation:reconciliation")
 
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.dataformat
+    implementation libs.jackson.module
+    implementation libs.jackson.datatype
 
     testImplementation project(":libs:lifecycle:lifecycle-impl")
     testImplementation project(":libs:lifecycle:registry")

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'javax.persistence:javax.persistence-api'
     implementation "org.liquibase:liquibase-core:$liquibaseVersion"
     constraints {
-        implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
+        implementation(libs.snakeyaml) {
             because "required until liquibase-core updates it's internal version of snakeYaml, currently using 1.33 which has CVE-2022-1471"
         }
     }

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-db-schema'
     implementation 'javax.persistence:javax.persistence-api'
-    implementation "org.liquibase:liquibase-core:$liquibaseVersion"
+    implementation libs.liquidbase.core
     constraints {
         implementation(libs.snakeyaml) {
             because "required until liquibase-core updates it's internal version of snakeYaml, currently using 1.33 which has CVE-2022-1471"

--- a/tools/plugins/mgm/build.gradle
+++ b/tools/plugins/mgm/build.gradle
@@ -15,7 +15,7 @@ group 'net.corda.cli.deployment'
 dependencies {
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module
     implementation libs.snakeyaml
     implementation "com.konghq:unirest-java:$unirestVersion"
     implementation project(":libs:crypto:certificate-generation")

--- a/tools/plugins/mgm/build.gradle
+++ b/tools/plugins/mgm/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
 
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
+    implementation libs.snakeyaml
     implementation "com.konghq:unirest-java:$unirestVersion"
     implementation project(":libs:crypto:certificate-generation")
     implementation project(':libs:crypto:cipher-suite')

--- a/tools/plugins/network/build.gradle
+++ b/tools/plugins/network/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation project(":components:membership:membership-rest")
 
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
+    implementation libs.snakeyaml
     implementation "org.pf4j:pf4j:${pf4jVersion}"
     kapt "org.pf4j:pf4j:${pf4jVersion}"
 

--- a/tools/plugins/network/build.gradle
+++ b/tools/plugins/network/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation project(":tools:plugins:plugins-rest")
     implementation project(":components:membership:membership-rest")
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module
     implementation libs.snakeyaml
     implementation "org.pf4j:pf4j:${pf4jVersion}"
     kapt "org.pf4j:pf4j:${pf4jVersion}"

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -13,8 +13,8 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib'
-    compileOnly "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    compileOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    compileOnly libs.jackson.module
+    compileOnly libs.jackson.dataformat
 
     compileOnly "org.pf4j:pf4j:$pf4jVersion"
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
@@ -23,7 +23,7 @@ dependencies {
 
     compileOnly platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-topic-schema:$cordaApiVersion"
-    compileOnly "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    compileOnly libs.kafka.clients
     constraints {
         implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
             because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +
@@ -36,9 +36,9 @@ dependencies {
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
     testImplementation "org.pf4j:pf4j:$pf4jVersion"
     testImplementation "net.corda.cli.host:api:$pluginHostVersion"
-    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    testImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    testImplementation libs.jackson.module
+    testImplementation libs.jackson.dataformat
+    testImplementation libs.kafka.clients
 }
 
 cliPlugin {

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     kapt "org.pf4j:pf4j:$pf4jVersion"
     kapt "info.picocli:picocli:$picocliVersion"
 
-    implementation "org.liquibase:liquibase-core:$liquibaseVersion"
+    implementation libs.liquidbase.core
     constraints {
         implementation(libs.snakeyaml) {
             because "required until liquibase-core updates it's internal version of snakeYaml, currently using 1.33 which has CVE-2022-1471"

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     implementation "org.liquibase:liquibase-core:$liquibaseVersion"
     constraints {
-        implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
+        implementation(libs.snakeyaml) {
             because "required until liquibase-core updates it's internal version of snakeYaml, currently using 1.33 which has CVE-2022-1471"
         }
     }


### PR DESCRIPTION
**Description:**
As part improving version dependencies within Corda we have added [Gradle Version Catalog](https://docs.gradle.org/current/userguide/platforms.html) for corda-runtime-os. This will allow us to use the newly created central repository [corda-version-catalog](https://github.com/corda/corda-version-catalog) for maintaining and managing 3rd parties dependency that is use within corda-runtime-os.

**Changes:**
Added implementation of using Gradle Version Catalog for corda-runtime-os repo in build.gradle file
Replace all version reference occurrences which use gradle.properties to version catalog in build.gradle files.