### PR TITLE
CORE-8434: Create an OSGi requirement for sandboxes-testkit.

### DIFF
--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/VirtualNodeService.kt
@@ -7,6 +7,7 @@ import net.corda.persistence.common.EntitySandboxService
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.testing.sandboxes.VirtualNodeLoader
+import net.corda.testing.sandboxes.testkit.RequireSandboxTestkit
 import net.corda.virtualnode.VirtualNodeInfo
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -14,6 +15,7 @@ import org.osgi.service.component.annotations.Reference
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
+@RequireSandboxTestkit
 @Component(service = [ VirtualNodeService::class ])
 class VirtualNodeService @Activate constructor(
     @Reference

--- a/testing/sandboxes-testkit/src/main/java/net/corda/testing/sandboxes/testkit/RequireSandboxTestkit.java
+++ b/testing/sandboxes-testkit/src/main/java/net/corda/testing/sandboxes/testkit/RequireSandboxTestkit.java
@@ -1,0 +1,22 @@
+package net.corda.testing.sandboxes.testkit;
+
+import org.osgi.annotation.bundle.Requirement;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+@Requirement(
+    namespace = RequireSandboxTestkit.SANDBOX_TESTING_NAMESPACE,
+    name = RequireSandboxTestkit.SANDBOX_TESTKIT,
+    version = RequireSandboxTestkit.SANDBOX_TESTKIT_VERSION
+)
+@Target({ PACKAGE, TYPE })
+@Retention(CLASS)
+public @interface RequireSandboxTestkit {
+    String SANDBOX_TESTING_NAMESPACE = "corda.testing.sandbox";
+    String SANDBOX_TESTKIT = "sandbox.testkit";
+    String SANDBOX_TESTKIT_VERSION = "1.0.0";
+}

--- a/testing/sandboxes-testkit/src/main/java/net/corda/testing/sandboxes/testkit/package-info.java
+++ b/testing/sandboxes-testkit/src/main/java/net/corda/testing/sandboxes/testkit/package-info.java
@@ -1,4 +1,10 @@
+@Capability(
+    namespace = RequireSandboxTestkit.SANDBOX_TESTING_NAMESPACE,
+    name = RequireSandboxTestkit.SANDBOX_TESTKIT,
+    version = RequireSandboxTestkit.SANDBOX_TESTKIT_VERSION
+)
 @Export
 package net.corda.testing.sandboxes.testkit;
 
+import org.osgi.annotation.bundle.Capability;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Define a `@RequireSandboxTestkit` annotation so that clients of `:testing:sandboxes-testkit` can declare an explicit OSGi dependency. Otherwise Bnd's resolver may not decide to include the testkit in the bundles passed to the `TestOSGi` task.

The point is that the new `@RequireSandboxTestkit` annotation creates a new OSGi requirement that only `:testing:sandboxes-testkit` can satisfy. Hence annotating anything as `@RequireSandboxTestkit` _forces_ the Bnd resolver to include the testkit bundle.

This is all caused by a limitation of Bnd's `effective:=active` resolution: it can only notice that an instance of a particular service _exists_, and not whether that instance will be enabled at runtime.