### PR TITLE
CORE-15182 - Added a check that ensures no contract state type has more than one UTXO token observer

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTokenObserverMapImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTokenObserverMapImpl.kt
@@ -11,6 +11,6 @@ class UtxoTokenObserverMapImpl(private val sandboxGroupContext: SandboxGroupCont
     UtxoTokenObserverMap {
 
     override fun getObserverFor(contactStateType: Class<*>): UtxoLedgerTokenStateObserver<ContractState>? {
-        return sandboxGroupContext.getTokenStateObservers()[contactStateType]?.firstOrNull()
+        return sandboxGroupContext.getTokenStateObservers()[contactStateType]
     }
 }

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxContextTypes.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxContextTypes.kt
@@ -32,7 +32,7 @@ fun SandboxGroupContext.getEntityManagerFactory(): EntityManagerFactory =
         )
 
 fun SandboxGroupContext.getTokenStateObservers()
-        : Map<Class<out ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>> = getObjectByKey(
+        : Map<Class<out ContractState>, UtxoLedgerTokenStateObserver<ContractState>> = getObjectByKey(
     EntitySandboxContextTypes.SANDBOX_TOKEN_STATE_OBSERVERS
 ) ?: throw CordaRuntimeException(
     "Token State Observers not found within the sandbox for identity: ${virtualNodeContext.holdingIdentity}"

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxContextTypes.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxContextTypes.kt
@@ -32,7 +32,7 @@ fun SandboxGroupContext.getEntityManagerFactory(): EntityManagerFactory =
         )
 
 fun SandboxGroupContext.getTokenStateObservers()
-        : Map<Class<out ContractState>, UtxoLedgerTokenStateObserver<ContractState>> = getObjectByKey(
+        : Map<Class<out ContractState>, UtxoLedgerTokenStateObserver<ContractState>?> = getObjectByKey(
     EntitySandboxContextTypes.SANDBOX_TOKEN_STATE_OBSERVERS
 ) ?: throw CordaRuntimeException(
     "Token State Observers not found within the sandbox for identity: ${virtualNodeContext.holdingIdentity}"

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -194,16 +194,16 @@ class EntitySandboxServiceImpl @Activate constructor(
     ): Map<Class<ContractState>, UtxoLedgerTokenStateObserver<ContractState>?> {
 
         return tokenStateObserverMap.entries.associate { contractStateTypeToObserver  ->
-            val numberOfObservers = entry.value.size
+            val numberOfObservers = contractStateTypeToObserver.value.size
 
             if (numberOfObservers > 1) {
-                val observerTypes = contractStateTypeToObserver.value.map { it.stateType.name }
+                val observerTypes = contractStateTypeToObserver.value.map { observer -> observer.stateType.name }
                 throw IllegalStateException(
                     "More than one observer found for the contract state. " +
-                            "Contract state: ${entry.key}, observers: $observerTypes"
+                            "Contract state: ${contractStateTypeToObserver.key}, observers: $observerTypes"
                 )
             }
-            contractStateTypeToObserver.key to entry.value.singleOrNull()
+            contractStateTypeToObserver.key to contractStateTypeToObserver.value.singleOrNull()
         }
     }
 

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -174,26 +174,26 @@ class EntitySandboxServiceImpl @Activate constructor(
         ctx: MutableSandboxGroupContext,
         cpks: Collection<CpkMetadata>
     ) {
-        val tokenStateObserverMap = cpks
+        val contractStateTypeToObserver = cpks
             .flatMap { it.cordappManifest.tokenStateObservers }
             .toSet()
             .mapNotNull { getObserverFromClassName(it, ctx) }
             .groupBy { it.stateType }
 
-        ctx.putObjectByKey(SANDBOX_TOKEN_STATE_OBSERVERS, requireSingleObserverToState(tokenStateObserverMap))
+        ctx.putObjectByKey(SANDBOX_TOKEN_STATE_OBSERVERS, requireSingleObserverToState(contractStateTypeToObserver))
 
         logger.debug {
-            "Registered token observers: ${tokenStateObserverMap.mapValues { (_, observers) ->
+            "Registered token observers: ${contractStateTypeToObserver.mapValues { (_, observers) ->
                 observers.map { it::class.java.name }}
             }"
         }
     }
 
     private fun requireSingleObserverToState(
-        tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>
+        contractStateTypeToObserver: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>
     ): Map<Class<ContractState>, UtxoLedgerTokenStateObserver<ContractState>?> {
 
-        return tokenStateObserverMap.entries.associate { entry  ->
+        return contractStateTypeToObserver.entries.associate { entry  ->
             val numberOfObservers = entry.value.size
 
             if (numberOfObservers > 1) {

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -180,8 +180,6 @@ class EntitySandboxServiceImpl @Activate constructor(
             .mapNotNull { getObserverFromClassName(it, ctx) }
             .groupBy { it.stateType }
 
-        validateTokenStateObservers(tokenStateObserverMap)
-
         ctx.putObjectByKey(SANDBOX_TOKEN_STATE_OBSERVERS, requireSingleObserverToState(tokenStateObserverMap))
 
         logger.debug {
@@ -193,12 +191,7 @@ class EntitySandboxServiceImpl @Activate constructor(
 
     private fun requireSingleObserverToState(
         tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>
-    ) =
-        tokenStateObserverMap.entries.associate { it.key to it.value.singleOrNull() }
-
-    private fun validateTokenStateObservers(
-        tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>
-    ) {
+    ): Map<Class<ContractState>, UtxoLedgerTokenStateObserver<ContractState>?> {
 
         tokenStateObserverMap.forEach { contractStateTypeToObservers ->
             val numberOfObservers = contractStateTypeToObservers.value.size
@@ -211,6 +204,8 @@ class EntitySandboxServiceImpl @Activate constructor(
                 )
             }
         }
+
+        return tokenStateObserverMap.entries.associate { it.key to it.value.singleOrNull() }
     }
 
     private fun getObserverFromClassName(

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -180,7 +180,7 @@ class EntitySandboxServiceImpl @Activate constructor(
             .mapNotNull { getObserverFromClassName(it, ctx) }
             .groupBy { it.stateType }
 
-        validateObservers(tokenStateObserverMap)
+        validateTokenStateObservers(tokenStateObserverMap)
 
         ctx.putObjectByKey(SANDBOX_TOKEN_STATE_OBSERVERS, tokenStateObserverMap)
         logger.debug {
@@ -190,7 +190,7 @@ class EntitySandboxServiceImpl @Activate constructor(
         }
     }
 
-    private fun validateObservers(tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>) {
+    private fun validateTokenStateObservers(tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>) {
 
         tokenStateObserverMap.forEach { contractStateTypeToObservers ->
             val numberOfObservers = contractStateTypeToObservers.value.size

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -193,19 +193,18 @@ class EntitySandboxServiceImpl @Activate constructor(
         tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>
     ): Map<Class<ContractState>, UtxoLedgerTokenStateObserver<ContractState>?> {
 
-        tokenStateObserverMap.forEach { contractStateTypeToObservers ->
-            val numberOfObservers = contractStateTypeToObservers.value.size
+        return tokenStateObserverMap.entries.associate { entry  ->
+            val numberOfObservers = entry.value.size
 
             if (numberOfObservers > 1) {
-                val observerTypes = contractStateTypeToObservers.value.map { it.stateType.name }
+                val observerTypes = entry.value.map { it.stateType.name }
                 throw IllegalStateException(
                     "More than one observer found for the contract state. " +
-                            "Contract state: ${contractStateTypeToObservers.key}, observers: $observerTypes"
+                            "Contract state: ${entry.key}, observers: $observerTypes"
                 )
             }
+            entry.key to entry.value.singleOrNull()
         }
-
-        return tokenStateObserverMap.entries.associate { it.key to it.value.singleOrNull() }
     }
 
     private fun getObserverFromClassName(

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -190,14 +190,19 @@ class EntitySandboxServiceImpl @Activate constructor(
         }
     }
 
-    private fun validateTokenStateObservers(tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>) {
+    private fun validateTokenStateObservers(
+        tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>
+    ) {
 
         tokenStateObserverMap.forEach { contractStateTypeToObservers ->
             val numberOfObservers = contractStateTypeToObservers.value.size
 
             if (numberOfObservers > 1) {
                 val observerTypes = contractStateTypeToObservers.value.map { it.stateType.toString() }
-                throw SandboxException("More than one observer found for the contract state. Contract state: ${contractStateTypeToObservers.key}, observers: $observerTypes")
+                throw SandboxException(
+                    "More than one observer found for the contract state. " +
+                            "Contract state: ${contractStateTypeToObservers.key}, observers: $observerTypes"
+                )
             }
         }
     }

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -193,17 +193,17 @@ class EntitySandboxServiceImpl @Activate constructor(
         tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>
     ): Map<Class<ContractState>, UtxoLedgerTokenStateObserver<ContractState>?> {
 
-        return tokenStateObserverMap.entries.associate { contractStateTypeToObserver  ->
-            val numberOfObservers = contractStateTypeToObserver.value.size
+        return tokenStateObserverMap.entries.associate { contractStateTypeToObservers  ->
+            val numberOfObservers = contractStateTypeToObservers.value.size
 
             if (numberOfObservers > 1) {
-                val observerTypes = contractStateTypeToObserver.value.map { observer -> observer.stateType.name }
+                val observerTypes = contractStateTypeToObservers.value.map { observer -> observer.stateType.name }
                 throw IllegalStateException(
                     "More than one observer found for the contract state. " +
-                            "Contract state: ${contractStateTypeToObserver.key}, observers: $observerTypes"
+                            "Contract state: ${contractStateTypeToObservers.key}, observers: $observerTypes"
                 )
             }
-            contractStateTypeToObserver.key to contractStateTypeToObserver.value.singleOrNull()
+            contractStateTypeToObservers.key to contractStateTypeToObservers.value.singleOrNull()
         }
     }
 

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -182,7 +182,11 @@ class EntitySandboxServiceImpl @Activate constructor(
 
         validateTokenStateObservers(tokenStateObserverMap)
 
-        ctx.putObjectByKey(SANDBOX_TOKEN_STATE_OBSERVERS, tokenStateObserverMap)
+        // Create a map that contains a single UTXO token observer for each token state
+        // This away, people know that the there will never be more than one UTXO token observer
+        val validatedTokenStateObserverMap = tokenStateObserverMap.map { it.key to it.value.singleOrNull() }
+
+        ctx.putObjectByKey(SANDBOX_TOKEN_STATE_OBSERVERS, validatedTokenStateObserverMap)
         logger.debug {
             "Registered token observers: ${tokenStateObserverMap.mapValues { (_, observers) ->
                 observers.map { it::class.java.name }}

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -184,7 +184,7 @@ class EntitySandboxServiceImpl @Activate constructor(
 
         // Create a map that contains a single UTXO token observer for each token state
         // This away, people know that the there will never be more than one UTXO token observer
-        val validatedTokenStateObserverMap = tokenStateObserverMap.map { it.key to it.value.singleOrNull() }
+        val validatedTokenStateObserverMap = tokenStateObserverMap.entries.associate { it.key to it.value.singleOrNull() }
 
         ctx.putObjectByKey(SANDBOX_TOKEN_STATE_OBSERVERS, validatedTokenStateObserverMap)
         logger.debug {


### PR DESCRIPTION
The verification is performed when the sandbox is created. This means the verification is only done during runtime and a flow can failed because more than one UTXO token observer was found. This is not ideal but can be improved in the future.

Refactored the code so the values of the container that maps a `token state` to `UTXO token observer` is a single instance and not a list.
