### PR TITLE
CORE-14784 Add e2e test config manager to update and revert configs per test.

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -42,6 +42,7 @@ class ConfigTests {
             val updatedValue = getReconConfigValue(defaults = false)
             assertThat(updatedValue).isEqualTo(newValue)
         }
+        waitForConfigurationChange(RECONCILIATION_CONFIG, RECONCILIATION_CONFIG_INTERVAL_MS, initialValue.toString(), false)
     }
 
     private fun getReconConfigValue(defaults: Boolean): Int {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ConfigTests.kt
@@ -42,7 +42,6 @@ class ConfigTests {
             val updatedValue = getReconConfigValue(defaults = false)
             assertThat(updatedValue).isEqualTo(newValue)
         }
-        waitForConfigurationChange(RECONCILIATION_CONFIG, RECONCILIATION_CONFIG_INTERVAL_MS, initialValue.toString(), false)
     }
 
     private fun getReconConfigValue(defaults: Boolean): Int {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -15,15 +15,13 @@ import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
 import net.corda.e2etest.utilities.awaitRestFlowResult
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
-import net.corda.e2etest.utilities.configWithDefaultsNode
-import net.corda.e2etest.utilities.getConfig
+import net.corda.e2etest.utilities.config.configWithDefaultsNode
+import net.corda.e2etest.utilities.config.getConfig
+import net.corda.e2etest.utilities.config.managedConfig
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
 import net.corda.e2etest.utilities.startRpcFlow
-import net.corda.e2etest.utilities.toJsonString
-import net.corda.e2etest.utilities.updateConfig
-import net.corda.e2etest.utilities.waitForConfigurationChange
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import net.corda.v5.crypto.DigestAlgorithmName
@@ -874,13 +872,11 @@ class FlowTests {
         val currentConfigValue = getConfig(MESSAGING_CONFIG).configWithDefaultsNode()[MAX_ALLOWED_MSG_SIZE].asInt()
         val newConfigurationValue = (currentConfigValue * 1.5).toInt()
 
-        // Update cluster configuration (ConfigProcessor should kick off on all workers at this point)
-        updateConfig(mapOf(MAX_ALLOWED_MSG_SIZE to newConfigurationValue).toJsonString(), MESSAGING_CONFIG)
+        managedConfig { configManager ->
+            configManager
+                .load(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue)
+                .apply()
 
-        // Wait for the rpc-worker to reload the configuration and come back up
-        waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue.toString())
-
-        try {
             // Execute some flows which require functionality from different workers and make sure they succeed
             val flowIds = mutableListOf(
                 startRpcFlow(
@@ -913,10 +909,6 @@ class FlowTests {
                 assertThat(flowResult.flowError).isNull()
                 assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
             }
-        } finally {
-            // Be a good neighbour and rollback the configuration change back to what it was
-            updateConfig(mapOf(MAX_ALLOWED_MSG_SIZE to currentConfigValue).toJsonString(), MESSAGING_CONFIG)
-            waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, currentConfigValue.toString())
         }
     }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -20,6 +20,7 @@ import net.corda.e2etest.utilities.conditionallyUploadCpiSigningCertificate
 import net.corda.e2etest.utilities.config.configWithDefaultsNode
 import net.corda.e2etest.utilities.config.getConfig
 import net.corda.e2etest.utilities.config.managedConfig
+import net.corda.e2etest.utilities.config.waitForConfigurationChange
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
@@ -880,6 +881,8 @@ class FlowTests {
             configManager
                 .load(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue)
                 .apply()
+            // Wait for the rpc-worker to reload the configuration and come back up
+            waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue.toString())
 
             // Execute some flows which require functionality from different workers and make sure they succeed
             val flowIds = mutableListOf(

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/FlowTests.kt
@@ -882,7 +882,7 @@ class FlowTests {
                 .load(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue)
                 .apply()
             // Wait for the rpc-worker to reload the configuration and come back up
-            waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue.toString())
+            waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue.toString(), false)
 
             // Execute some flows which require functionality from different workers and make sure they succeed
             val flowIds = mutableListOf(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -7,7 +7,6 @@ import net.corda.crypto.test.certificates.generation.FileSystemCertificatesAutho
 import net.corda.crypto.test.certificates.generation.KeysFactoryDefinitions
 import net.corda.crypto.test.certificates.generation.toPem
 import net.corda.e2etest.utilities.config.SingleClusterTestConfigManager
-import net.corda.e2etest.utilities.config.TestConfigManager
 import net.corda.rest.ResponseCode
 import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 import net.corda.utilities.seconds

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -6,6 +6,8 @@ import net.corda.crypto.test.certificates.generation.CertificateAuthorityFactory
 import net.corda.crypto.test.certificates.generation.FileSystemCertificatesAuthority
 import net.corda.crypto.test.certificates.generation.KeysFactoryDefinitions
 import net.corda.crypto.test.certificates.generation.toPem
+import net.corda.e2etest.utilities.config.SingleClusterTestConfigManager
+import net.corda.e2etest.utilities.config.TestConfigManager
 import net.corda.rest.ResponseCode
 import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 import net.corda.utilities.seconds
@@ -82,10 +84,10 @@ fun ClusterInfo.importCertificate(
 
 /**
  * Disable certificate revocation checks.
+ * CRL checks disabled is the default for E2E tests so this doesn't attempt to revert after use.
  */
 fun ClusterInfo.disableCertificateRevocationChecks() {
-    updateConfig(
-        "{ \"sslConfig\": { \"revocationCheck\": { \"mode\": \"OFF\" }  }  }",
-        P2P_GATEWAY_CONFIG
-    )
+    SingleClusterTestConfigManager(this)
+        .load(P2P_GATEWAY_CONFIG, "sslConfig.revocationCheck.mode", "OFF")
+        .apply()
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterInfo.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterInfo.kt
@@ -19,11 +19,12 @@ abstract class ClusterInfo {
         private const val DEFAULT_P2P_PORT = 8080
     }
 
-    private val restHostPropertyName get() = "E2E_CLUSTER_${id}_REST_HOST"
-    private val restPortPropertyName get() = "E2E_CLUSTER_${id}_REST_PORT"
-    private val restPasswordPropertyName get() = "E2E_CLUSTER_${id}_REST_PASSWORD"
-    private val p2pHostPropertyName get() = "E2E_CLUSTER_${id}_P2P_HOST"
-    private val p2pPortPropertyName get() = "E2E_CLUSTER_${id}_P2P_PORT"
+    val name: String get() = "E2E_CLUSTER_${id}"
+    private val restHostPropertyName get() = "${name}_REST_HOST"
+    private val restPortPropertyName get() = "${name}_REST_PORT"
+    private val restPasswordPropertyName get() = "${name}_REST_PASSWORD"
+    private val p2pHostPropertyName get() = "${name}_P2P_HOST"
+    private val p2pPortPropertyName get() = "${name}_P2P_PORT"
 
 
     /**

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MapUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MapUtils.kt
@@ -1,0 +1,36 @@
+package net.corda.e2etest.utilities
+
+fun Map<*, *>.flatten(
+    target: MutableMap<String, Any?> = mutableMapOf(),
+    prefix: String? = null
+): Map<String, Any?> {
+    forEach { (k, v) ->
+        val newPrefix = "${prefix?.let{"$it.$k"} ?: k}"
+        if (v is Map<*, *>) {
+            v.flatten(target, newPrefix)
+        } else {
+            target[newPrefix] = v
+        }
+    }
+    return target
+}
+
+fun Map<String, Any?>.expand(): Map<String, Any?> {
+    return mutableMapOf<String, Any?>().also { output ->
+        forEach { (k, v) ->
+            var targetMap: MutableMap<String, Any?> = output
+            val splitKey = k.split('.')
+            splitKey.dropLast(1).forEach {
+                if (targetMap.contains(it)) {
+                    @Suppress("unchecked_cast")
+                    targetMap = targetMap[it] as MutableMap<String, Any?>
+                } else {
+                    val newMap = mutableMapOf<String, Any?>()
+                    targetMap[it] = newMap
+                    targetMap = newMap
+                }
+            }
+            targetMap[splitKey.last()] = v
+        }
+    }
+}

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
@@ -1,13 +1,31 @@
-package net.corda.e2etest.utilities
+package net.corda.e2etest.utilities.config
 
 import com.fasterxml.jackson.databind.JsonNode
 import kong.unirest.UnirestException
+import net.corda.e2etest.utilities.ClusterInfo
+import net.corda.e2etest.utilities.DEFAULT_CLUSTER
+import net.corda.e2etest.utilities.assertWithRetryIgnoringExceptions
+import net.corda.e2etest.utilities.cluster
+import net.corda.e2etest.utilities.toJson
 import net.corda.rest.ResponseCode.OK
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.fail
 import java.io.IOException
 import java.time.Duration
+
+/**
+ * Runs a function in the scope of a managed configuration which is automatically reverted upon completion.
+ */
+fun managedConfig(vararg clusters: ClusterInfo, func: (TestConfigManager) -> Unit) {
+    if(clusters.isEmpty()) {
+        SingleClusterTestConfigManager(DEFAULT_CLUSTER).use(func)
+    } else if (clusters.size == 1){
+        SingleClusterTestConfigManager(clusters[0]).use(func)
+    } else {
+        MultiClusterTestConfigManager(*clusters).use(func)
+    }
+}
 
 fun JsonNode.sourceConfigNode(): JsonNode =
     this["sourceConfig"].textValue().toJson()
@@ -18,8 +36,10 @@ fun JsonNode.configWithDefaultsNode(): JsonNode =
 /**
  * Get the current configuration (as a [JsonNode]) for the specified [section].
  */
-fun getConfig(section: String): JsonNode {
-    return DEFAULT_CLUSTER.cluster {
+fun getConfig(section: String) = DEFAULT_CLUSTER.getConfig(section)
+
+fun ClusterInfo.getConfig(section: String): JsonNode {
+    return cluster {
         assertWithRetryIgnoringExceptions {
             command { getConfig(section) }
             condition { it.code == OK.statusCode }
@@ -104,21 +124,4 @@ fun ClusterInfo.waitForConfigurationChange(
             }
         }
     }
-}
-
-fun ClusterInfo.updateConfigAndWaitForChange(
-    section: String,
-    key: String,
-    value: Any
-) {
-    updateConfig(
-        mapOf(key to value).toJsonString(),
-        section
-    )
-    waitForConfigurationChange(
-        section,
-        key,
-        value.toString(),
-        expectServiceToBeDown = false
-    )
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
@@ -18,13 +18,12 @@ import java.time.Duration
  * Runs a function in the scope of a managed configuration which is automatically reverted upon completion.
  */
 fun managedConfig(vararg clusters: ClusterInfo, func: (TestConfigManager) -> Unit) {
-    if(clusters.isEmpty()) {
-        SingleClusterTestConfigManager(DEFAULT_CLUSTER).use(func)
-    } else if (clusters.size == 1){
-        SingleClusterTestConfigManager(clusters[0]).use(func)
+    val clusterDedup = clusters.toSet()
+    if(clusterDedup.size > 1) {
+        MultiClusterTestConfigManager(clusterDedup)
     } else {
-        MultiClusterTestConfigManager(*clusters).use(func)
-    }
+        SingleClusterTestConfigManager(clusters.getOrNull(0) ?: DEFAULT_CLUSTER)
+    }.use(func)
 }
 
 fun JsonNode.sourceConfigNode(): JsonNode =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/MultiClusterTestConfigManager.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/MultiClusterTestConfigManager.kt
@@ -1,0 +1,31 @@
+package net.corda.e2etest.utilities.config
+
+import net.corda.e2etest.utilities.ClusterInfo
+
+class MultiClusterTestConfigManager(
+    vararg clusterInfos: ClusterInfo
+): TestConfigManager, AutoCloseable {
+    private val configManagers: MutableSet<TestConfigManager> = mutableSetOf()
+
+    init {
+        configManagers.addAll(clusterInfos.map { SingleClusterTestConfigManager(it) })
+    }
+
+    override fun load(section: String, props: Map<String, Any?>): TestConfigManager {
+        configManagers.forEach { it.load(section, props) }
+        return this
+    }
+    override fun load(section: String, prop: String, value: Any?): TestConfigManager {
+        configManagers.forEach { it.load(section, prop, value) }
+        return this
+    }
+    override fun apply(): TestConfigManager {
+        configManagers.forEach { it.apply() }
+        return this
+    }
+    override fun revert(): TestConfigManager {
+        configManagers.forEach { it.revert() }
+        return this
+    }
+    override fun close() = configManagers.forEach { it.close() }
+}

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/MultiClusterTestConfigManager.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/MultiClusterTestConfigManager.kt
@@ -3,7 +3,7 @@ package net.corda.e2etest.utilities.config
 import net.corda.e2etest.utilities.ClusterInfo
 
 class MultiClusterTestConfigManager(
-    vararg clusterInfos: ClusterInfo
+    clusterInfos: Collection<ClusterInfo>
 ): TestConfigManager, AutoCloseable {
     private val configManagers: MutableSet<TestConfigManager> = mutableSetOf()
 

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/SingleClusterTestConfigManager.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/SingleClusterTestConfigManager.kt
@@ -77,10 +77,10 @@ class SingleClusterTestConfigManager(
     override fun revert(): TestConfigManager {
         originalConfigs.forEach { (section, originalConfig) ->
             val previousVersion = getConfig(section).version
-            val preTestConfig = originalConfig.sourceConfig
+            val preTestConfig = originalConfig.sourceConfig.ifBlank { "{}" }
 
             logger.info("Reverting test config for section $section to $preTestConfig for cluster ${clusterInfo.name}.")
-            updateConfig(preTestConfig.ifBlank { "{}" }, section)
+            updateConfig(preTestConfig, section)
 
             eventually {
                 val newConfig = getConfig(section)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/SingleClusterTestConfigManager.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/SingleClusterTestConfigManager.kt
@@ -27,7 +27,7 @@ class SingleClusterTestConfigManager(
 
     override fun load(section: String, prop: String, value: Any?): TestConfigManager {
         logger.info(
-            "Loading test config $value for property $prop in section $section for cluster ${clusterInfo.name} " +
+            "Loading test config \"$value\" for property \"$prop\" in section \"$section\" for cluster \"${clusterInfo.name}\" " +
                     "into TestConfigManager."
         )
 
@@ -62,8 +62,8 @@ class SingleClusterTestConfigManager(
 
             val newConfig = toJsonString(configOverride)
             logger.info(
-                "Updating from config $previousSourceConfig to $newConfig for section $section on " +
-                        "cluster ${clusterInfo.name}."
+                "Updating from config \"$previousSourceConfig\" to \"$newConfig\" for section \"$section\" on " +
+                        "cluster \"${clusterInfo.name}\"."
             )
 
             if(newConfig != previousSourceConfig) {
@@ -88,8 +88,8 @@ class SingleClusterTestConfigManager(
             val preTestConfig = originalConfig.sourceConfig.ifBlank { "{}" }
 
             logger.info(
-                "Reverting test config for section $section from $previousSourceConfig to $preTestConfig " +
-                    "for cluster ${clusterInfo.name}."
+                "Reverting test config for section \"$section\" from \"$previousSourceConfig\" to \"$preTestConfig\" " +
+                    "for cluster \"${clusterInfo.name}\"."
             )
             updateConfig(preTestConfig, section)
 

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/SingleClusterTestConfigManager.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/SingleClusterTestConfigManager.kt
@@ -1,0 +1,144 @@
+package net.corda.e2etest.utilities.config
+
+import com.fasterxml.jackson.databind.JsonNode
+import net.corda.e2etest.utilities.ClusterInfo
+import net.corda.e2etest.utilities.DEFAULT_CLUSTER
+import net.corda.e2etest.utilities.toJsonString
+import net.corda.test.util.eventually
+import org.assertj.core.api.Assertions
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+
+class SingleClusterTestConfigManager(
+    private val clusterInfo: ClusterInfo = DEFAULT_CLUSTER
+) : TestConfigManager {
+
+    private companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    private val flattenedOverrides: MutableMap<String, Map<String, Any?>> = ConcurrentHashMap()
+    private var originalConfigs: MutableMap<String, JsonNode> = ConcurrentHashMap()
+
+    override fun load(section: String, props: Map<String, Any?>): TestConfigManager {
+        props.forEach { (k, v) -> load(section, k, v) }
+        return this
+    }
+
+    override fun load(section: String, prop: String, value: Any?): TestConfigManager {
+        logger.info("Loading test config $value for property $prop in section $section for cluster ${clusterInfo.name}.")
+
+        // If the input value is a map, flatten it to a standardised form for merging with previously loaded configs.
+        val propsAsFlattenedTree = mutableMapOf<String, Any?>().also {
+            if (value is Map<*, *>) {
+                flatten(value, it, prop)
+            } else {
+                it[prop] = value
+            }
+        }
+
+        // Combine with previously loaded overrides with the new properties taking precedence.
+        flattenedOverrides.compute(section) { _, v ->
+            (v ?: emptyMap()) + propsAsFlattenedTree
+        }
+
+        return this
+    }
+
+    override fun apply(): TestConfigManager {
+        flattenedOverrides.filterValues {
+            it.isNotEmpty()
+        }.forEach { (section, configOverride) ->
+            val currentConfig = getConfig(section)
+            // Store original config for later revert.
+            originalConfigs.computeIfAbsent(section) { currentConfig }
+
+            val (previousVersion, previousSourceConfig) = with(currentConfig) {
+                version to sourceConfig
+            }
+
+            val newConfig = toJsonString(configOverride)
+            logger.info("Applying config $newConfig for section $section on cluster ${clusterInfo.name}.")
+
+            if(newConfig != previousSourceConfig) {
+                updateConfig(newConfig, section)
+
+                eventually {
+                    with(getConfig(section)) {
+                        Assertions.assertThat(version).isNotEqualTo(previousVersion)
+                        Assertions.assertThat(sourceConfig).isNotEqualTo(previousSourceConfig)
+                    }
+                }
+            }
+        }
+        return this
+    }
+
+    override fun revert(): TestConfigManager {
+        originalConfigs.forEach { (section, originalConfig) ->
+            val previousVersion = getConfig(section).version
+            val preTestConfig = originalConfig.sourceConfig
+
+            logger.info("Reverting test config for section $section to $preTestConfig for cluster ${clusterInfo.name}.")
+            updateConfig(preTestConfig.ifBlank { "{}" }, section)
+
+            eventually {
+                val newConfig = getConfig(section)
+                Assertions.assertThat(newConfig.version).isNotEqualTo(previousVersion)
+                Assertions.assertThat(newConfig.sourceConfig).isEqualTo(preTestConfig)
+            }
+        }
+        return this
+    }
+
+    /**
+     * Revert back to the original config on close.
+     */
+    override fun close() {
+        revert()
+    }
+
+    private fun getConfig(section: String) = clusterInfo.getConfig(section)
+
+    private fun updateConfig(config: String, section: String) = clusterInfo.updateConfig(config, section)
+
+    private val JsonNode.version: Int
+        get() = get("version").intValue()
+
+    private val JsonNode.sourceConfig: String
+        get() = get("sourceConfig").textValue()
+
+    private fun flatten(
+        map: Map<*, *>,
+        targetMap: MutableMap<String, Any?>,
+        prefix: String
+    ) {
+        map.forEach { (k, v) ->
+            if (v is Map<*, *>) {
+                flatten(v, targetMap, "$prefix.$k")
+            } else {
+                targetMap["$prefix.$k"] = v
+            }
+        }
+    }
+
+    private fun toJsonString(source: Map<String, Any?>): String {
+        return mutableMapOf<String, Any?>().also { output ->
+            source.forEach { (k, v) ->
+                var targetMap: MutableMap<String, Any?> = output
+                val splitKey = k.split('.')
+                splitKey.dropLast(1).forEach {
+                    if (targetMap.contains(it)) {
+                        @Suppress("unchecked_cast")
+                        targetMap = targetMap[it] as MutableMap<String, Any?>
+                    } else {
+                        val newMap = mutableMapOf<String, Any?>()
+                        targetMap[it] = newMap
+                        targetMap = newMap
+                    }
+                }
+                targetMap[splitKey.last()] = v
+            }
+        }.toJsonString()
+    }
+}

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/TestConfigManager.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/TestConfigManager.kt
@@ -1,0 +1,42 @@
+package net.corda.e2etest.utilities.config
+
+interface TestConfigManager: AutoCloseable {
+    /**
+     * Loads a new configuration into the [TestConfigManager]. Configs are not applied to a cluster until [apply]
+     * is called, so [load] only stages changes.
+     *
+     * `load("corda.flow", {"foo": "bar"})`
+     * `load("corda.flow", {"foo": {"bar": {"hey": "ho"}}})`
+     * `load("corda.flow", {"foo.bar.hey": "ho"})`
+     *
+     * @param section The section of config to update e.g. `corda.flow`
+     * @param props Map of config properties to load. This can be single level (i.e. key-value), property trees
+     *  (i.e. key-map), or property trees through key usage (i.e. using dot notation to reference lower values).
+     */
+    fun load(section: String, props: Map<String, Any?>): TestConfigManager
+
+    /**
+     * Loads a new configuration into the [TestConfigManager]. Configs are not applied to a cluster until [apply]
+     * is called, so [load] only stages changes.
+     *
+     * `load("corda.flow", "foo", "bar")`
+     * `load("corda.flow", "foo", {"bar": {"hey": "ho"}})`
+     * `load("corda.flow", "foo.bar.hey", "ho")`
+     *
+     * @param section The section of config to update e.g. `corda.flow`
+     * @param prop Config property name. Can also be a path to a config property in a config tree.
+     * @param value Property value. Can be a map of values also.
+     */
+    fun load(section: String, prop: String, value: Any?): TestConfigManager
+
+    /**
+     * Using the cluster REST API, push all currently loaded configurations and wait for the new config to become
+     * visible.
+     */
+    fun apply(): TestConfigManager
+
+    /**
+     * Revert any changed configurations back to their original version before applying any changes.
+     */
+    fun revert(): TestConfigManager
+}

--- a/testing/e2e-test-utilities/src/test/kotlin/net/corda/e2etest/utilities/MapUtilsTest.kt
+++ b/testing/e2e-test-utilities/src/test/kotlin/net/corda/e2etest/utilities/MapUtilsTest.kt
@@ -1,0 +1,243 @@
+package net.corda.e2etest.utilities
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class MapUtilsTest {
+
+    @Nested
+    inner class FlattenMap {
+
+        @Test
+        fun `non-nested map is unchanged`() {
+            val input = mapOf(
+                "foo" to "bar",
+                "foo.again" to "bar"
+            )
+
+            assertThat(input.flatten()).isEqualTo(input)
+        }
+
+        @Test
+        fun `nested map is flattened`() {
+            val input = mapOf(
+                "foo" to mapOf("again" to "bar")
+            )
+
+            val expected = mapOf(
+                "foo.again" to "bar"
+            )
+
+            assertThat(input.flatten()).isEqualTo(expected)
+        }
+
+        @Test
+        fun `mix dot notation and nested map is flatten as expected`() {
+            val input = mapOf(
+                "foo.first" to "bar1",
+                "foo" to mapOf("second" to "bar2")
+            )
+
+            val expected = mapOf(
+                "foo.first" to "bar1",
+                "foo.second" to "bar2"
+            )
+
+            assertThat(input.flatten()).isEqualTo(expected)
+        }
+
+        @Test
+        fun `multi layered nesting is flattened as expected`() {
+            val input = mapOf(
+                "foo" to mapOf(
+                    "bar" to mapOf(
+                        "baz" to mapOf(
+                            "qux" to mapOf(
+                                "quux" to "test"
+                            )
+                        )
+                    )
+                ),
+            )
+
+            val expected = mapOf(
+                "foo.bar.baz.qux.quux" to "test"
+            )
+
+            assertThat(input.flatten()).isEqualTo(expected)
+        }
+
+        @Test
+        fun `multi layered nesting is flattened as expected with different data types`() {
+            val input = mapOf(
+                "foo" to mapOf(
+                    0 to mapOf(
+                        true to mapOf(
+                            1L to mapOf(
+                                'c' to 3.14
+                            )
+                        )
+                    )
+                ),
+            )
+
+            val expected = mapOf(
+                "foo.0.true.1.c" to 3.14
+            )
+
+            assertThat(input.flatten()).isEqualTo(expected)
+        }
+
+        @Test
+        fun `nested map is flattened into target map`() {
+            val target = mutableMapOf<String, Any?>()
+            val input = mapOf(
+                "foo" to mapOf("again" to "bar")
+            )
+
+            val expected = mapOf(
+                "foo.again" to "bar"
+            )
+            input.flatten(target)
+            assertThat(target).isEqualTo(expected)
+        }
+
+        @Test
+        fun `prefix is applied to flattened properties if specified`() {
+            val input = mapOf(
+                "foo" to mapOf("again" to "bar")
+            )
+
+            val expected = mapOf(
+                "mytest.foo.again" to "bar"
+            )
+            assertThat(input.flatten(prefix = "mytest")).isEqualTo(expected)
+        }
+
+        @Test
+        fun `map value can be null`() {
+            val input = mapOf(
+                "foo" to mapOf("again" to null)
+            )
+
+            val expected = mapOf(
+                "foo.again" to null
+            )
+            assertThat(input.flatten()).isEqualTo(expected)
+        }
+
+        @Test
+        fun `large map with mix of input is flattened as expected`() {
+            val input = mapOf(
+                "one" to 1,
+                "two" to false,
+                "three" to 'a',
+                "four" to null,
+                "five" to mapOf(
+                    "six.first" to 1,
+                    "six.second.one" to "test1",
+                    "six" to mapOf(
+                        "second.two" to "test2"
+                    )
+                ),
+                "five.six.third" to false
+            )
+
+            val expected = mapOf(
+                "test.one" to 1,
+                "test.two" to false,
+                "test.three" to 'a',
+                "test.four" to null,
+                "test.five.six.first" to 1,
+                "test.five.six.second.one" to "test1",
+                "test.five.six.second.two" to "test2",
+                "test.five.six.third" to false
+            )
+            val target = mutableMapOf<String, Any?>()
+            input.flatten(target, prefix="test")
+            assertThat(target).isEqualTo(expected)
+        }
+
+        @Test
+        fun `flatten empty map`() {
+            val input = emptyMap<String, Any?>()
+
+            assertThat(input.flatten()).isEqualTo(input)
+        }
+    }
+
+    @Nested
+    inner class ExpandTest {
+
+        @Test
+        fun `test expand() with nested keys`() {
+            val input = mapOf(
+                "a.b.c" to 1,
+                "a.b.d" to 2,
+                "x.y.z" to "hello"
+            )
+
+            val result = input.expand()
+
+            val expected = mapOf(
+                "a" to mapOf(
+                    "b" to mapOf(
+                        "c" to 1,
+                        "d" to 2
+                    )
+                ),
+                "x" to mapOf(
+                    "y" to mapOf(
+                        "z" to "hello"
+                    )
+                )
+            )
+            assertThat(result).isEqualTo(expected)
+        }
+
+        @Test
+        fun `test expand() with non-nested keys`() {
+            val input = mapOf(
+                "a" to 1,
+                "b" to 2,
+                "c" to "hello"
+            )
+
+            val result = input.expand()
+
+            val expected = mapOf(
+                "a" to 1,
+                "b" to 2,
+                "c" to "hello"
+            )
+            assertThat(result).isEqualTo(expected)
+        }
+
+        @Test
+        fun `test expand() with empty input map`() {
+            val input = emptyMap<String, Any?>()
+
+            val result = input.expand()
+
+            val expected = emptyMap<String, Any?>()
+            assertThat(result).isEqualTo(expected)
+        }
+
+        @Test
+        fun `test expand() with null values`() {
+            val input = mapOf(
+                "a.b" to null,
+                "x.y.z" to null
+            )
+
+            val result = input.expand()
+
+            val expected = mapOf(
+                "a" to mapOf("b" to null),
+                "x" to mapOf("y" to mapOf("z" to null))
+            )
+            assertThat(result).isEqualTo(expected)
+        }
+    }
+}


### PR DESCRIPTION
Added library to the e2e test utilities for testing with specific configurations. This provides common handling of configurations across e2e tests which includes reverting configuration. `SingleClusterTestConfigManager` can be use to manage the config of a specific or default single cluster, and `MultiClusterTestConfigManager` can be used to manage the same config across multiple clusters. Configuration overrides can be loaded for multiple properties and configuration sections before applying them to the cluster(s). The configuration manager implements AutoCloseable so these can be used with try-with-resources to ensure the configuration is reverted once no longer needed. Configuration will always be reverted back to it's original state before the test run.

A utility method is included called `managedConfig` which allows test writers to pass in a lambda which once complete will revert any test configuration set.

This also provides clear logging in the test output about what configuration values were set during a test run and confirmation that they were reverted. `ClusterInfo` was updated to expose a name property for clearer logging.

Two tests in this repo which were already testing with configuration changes have been updated to use the new library. Here is a sample of the smoke tests logging output after this change: 
```
[2023-07-27T10:07:04.071Z]     10:07:03.470 [Test worker] INFO  net.corda.e2etest.utilities.config.SingleClusterTestConfigManager - Loading test config "60000" for property "configIntervalMs" in section "corda.reconciliation" for cluster "E2E_CLUSTER_B" into TestConfigManager.
[2023-07-27T10:07:04.071Z]     10:07:03.996 [Test worker] INFO  net.corda.e2etest.utilities.config.SingleClusterTestConfigManager - Updating from config "" to "{"configIntervalMs":60000}" for section "corda.reconciliation" on cluster "E2E_CLUSTER_B".
[2023-07-27T10:07:07.346Z]     10:07:07.052 [Test worker] INFO  net.corda.e2etest.utilities.config.SingleClusterTestConfigManager - Reverting test config for section "corda.reconciliation" from "{"configIntervalMs":60000}" to "{}" for cluster "E2E_CLUSTER_B".
[2023-07-27T10:13:20.881Z]     10:13:20.642 [Test worker] INFO  net.corda.e2etest.utilities.config.SingleClusterTestConfigManager - Loading test config "1459200" for property "maxAllowedMessageSize" in section "corda.messaging" for cluster "E2E_CLUSTER_B" into TestConfigManager.
[2023-07-27T10:13:21.452Z]     10:13:21.160 [Test worker] INFO  net.corda.e2etest.utilities.config.SingleClusterTestConfigManager - Updating from config "" to "{"maxAllowedMessageSize":1459200}" for section "corda.messaging" on cluster "E2E_CLUSTER_B".
[2023-07-27T10:13:32.261Z]     10:13:32.109 [Test worker] INFO  net.corda.e2etest.utilities.config.SingleClusterTestConfigManager - Reverting test config for section "corda.messaging" from "{"maxAllowedMessageSize":1459200}" to "{}" for cluster "E2E_CLUSTER_B".
```