### PR TITLE
CORE-15817 Add `getOrCreateEntityManagerFactory` API by connection ID

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/TestSigningRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/TestSigningRepositoryImpl.kt
@@ -26,7 +26,7 @@ class TestSigningRepositoryImpl {
         // Arguably this is really tessting getEntityManagerFactory so should be moved to a new test class
         val entityManagerFactory = mock<EntityManagerFactory>()
         val dbConnectionManager = mock<DbConnectionManager> {
-            on { getOrCreateEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+            on { getOrCreateEntityManagerFactory(any<CordaDb>(), any()) } doReturn entityManagerFactory
         }
         val tenant = CryptoTenants.CRYPTO
         makeMockSigningRepository(tenant, dbConnectionManager).use { repo ->
@@ -62,7 +62,7 @@ class TestSigningRepositoryImpl {
             on { cryptoDmlConnectionId } doReturn mock()
         }
         val dbConnectionManager = mock<DbConnectionManager> {
-            on { getOrCreateEntityManagerFactory(any(), any()) } doReturn mock()
+            on { getOrCreateEntityManagerFactory(any<CordaDb>(), any()) } doReturn mock()
             on { createEntityManagerFactory(any(), any()) } doReturn ownedEntityManagerFactory
         }
         val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsCachedImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsCachedImpl.kt
@@ -19,7 +19,7 @@ class DbConnectionOpsCachedImpl(
 
     // We should try merging the below two caches into one to, like so, make sure each connection gets one EMF only,
     //  otherwise (i.e. if we get duplicate EMFs for same connection) we end up leaking memory with
-    //  duplicate entity proxies loaded in the class loader as identified in https://r3-cev.atlassian.net/browse/CORE-15806.
+    //  duplicate entity proxies loaded in the class loader as identified in CORE-15806.
     private val cache = ConcurrentHashMap<Pair<String,DbPrivilege>, EntityManagerFactory>()
 
     private val cacheByConnectionId = ConcurrentHashMap<UUID, EntityManagerFactory>()

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsCachedImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsCachedImpl.kt
@@ -20,9 +20,9 @@ class DbConnectionOpsCachedImpl(
     // TODO - replace with caffeine cache
     private val cache = ConcurrentHashMap<Pair<String,DbPrivilege>, EntityManagerFactory>()
 
-    // TODO Maybe we could consider replacing the above cache with the one below. All `db_connection`s have/ get an ID
-    //  Currently the below cache is not cleared on overwriting a connection. In theory I think that should be OK for now
-    //  since we don't allow "re-creating" a vnode (I believe).
+    // TODO Maybe we could consider replacing the above cache with the one below. All `db_connection`s have/ get an ID.
+    //  Currently the below cache is not cleared on overwriting a connection (`putConnection`).
+    //  In theory I think that should be OK for now since we don't allow "re-creating" a vnode (I believe).
     private val cacheByConnectionId = ConcurrentHashMap<UUID, EntityManagerFactory>()
 
     private fun removeFromCache(name: String, privilege: DbPrivilege) {

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsImpl.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/DbConnectionOpsImpl.kt
@@ -92,6 +92,13 @@ class DbConnectionOpsImpl(
         )
     }
 
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory {
+        throw UnsupportedOperationException("You should be using ${DbConnectionOpsImpl::createEntityManagerFactory} instead")
+    }
+
     private fun createManagerFactory(name: String, dataSource: CloseableDataSource): EntityManagerFactory {
         return entityManagerFactoryFactory.create(
             name,

--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/LateInitDbConnectionOps.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/LateInitDbConnectionOps.kt
@@ -64,4 +64,10 @@ class LateInitDbConnectionOps: DbConnectionOps {
 
     override fun createEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet):
             EntityManagerFactory = delegate.createEntityManagerFactory(connectionId, entitiesSet)
+
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory =
+        delegate.getOrCreateEntityManagerFactory(connectionId, entitiesSet)
 }

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionOps.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionOps.kt
@@ -140,4 +140,6 @@ interface DbConnectionOps {
      * @return
      */
     fun createEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet): EntityManagerFactory
+
+    fun getOrCreateEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet): EntityManagerFactory
 }

--- a/components/membership/certificates-service-impl/build.gradle
+++ b/components/membership/certificates-service-impl/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:messaging:messaging')
     implementation project(':libs:membership:certificates-common')
+    implementation project(':components:virtual-node:virtual-node-info-read-service')
     implementation project(':components:membership:certificates-service')
 
     testImplementation project(':libs:db:db-admin')

--- a/components/membership/certificates-service-impl/src/integrationTest/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImplTest.kt
+++ b/components/membership/certificates-service-impl/src/integrationTest/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImplTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.UUID
 import javax.persistence.EntityManagerFactory
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -71,7 +72,7 @@ internal class CertificatesServiceImplTest {
         }
         val dbConnectionManagerMock = mock<DbConnectionManager>().apply {
             whenever(getClusterEntityManagerFactory()) doReturn entityManagerFactory
-            whenever(createEntityManagerFactory(any(), any())) doAnswer {
+            whenever(getOrCreateEntityManagerFactory(any<UUID>(), any())) doAnswer {
                 EntityManagerFactoryFactoryImpl().create(
                     "test_vnode_unit",
                     CertificateEntities.vnodeClasses.toList(),

--- a/components/membership/certificates-service-impl/src/integrationTest/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImplTest.kt
+++ b/components/membership/certificates-service-impl/src/integrationTest/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImplTest.kt
@@ -86,7 +86,8 @@ internal class CertificatesServiceImplTest {
             dbConnectionManagerMock,
             jpaEntitiesRegistryMock,
             mock(),
-            virtualNodeInfoReadServiceMock)
+            virtualNodeInfoReadServiceMock,
+        )
     }
 
     @Suppress("Unused")

--- a/components/membership/certificates-service-impl/src/integrationTest/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImplTest.kt
+++ b/components/membership/certificates-service-impl/src/integrationTest/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImplTest.kt
@@ -5,7 +5,6 @@ import net.corda.data.certificates.CertificateUsage
 import net.corda.db.admin.impl.ClassloaderChangeLog
 import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.connection.manager.DbConnectionManager
-import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
 import net.corda.membership.certificate.service.CertificatesService
@@ -16,6 +15,8 @@ import net.corda.membership.certificates.datamodel.ClusterCertificate
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
@@ -23,7 +24,6 @@ import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import javax.persistence.EntityManagerFactory
@@ -63,9 +63,15 @@ internal class CertificatesServiceImplTest {
         val jpaEntitiesRegistryMock = mock<JpaEntitiesRegistry>().apply {
             whenever(get(any())) doReturn mock()
         }
+        val virtualNodeInfoMock = mock<VirtualNodeInfo>().apply {
+            whenever(vaultDmlConnectionId) doReturn mock()
+        }
+        val virtualNodeInfoReadServiceMock = mock<VirtualNodeInfoReadService>().apply {
+            whenever(getByHoldingIdentityShortHash(any())) doReturn virtualNodeInfoMock
+        }
         val dbConnectionManagerMock = mock<DbConnectionManager>().apply {
             whenever(getClusterEntityManagerFactory()) doReturn entityManagerFactory
-            whenever(getOrCreateEntityManagerFactory(any<String>(), eq(DbPrivilege.DML), any())) doAnswer {
+            whenever(createEntityManagerFactory(any(), any())) doAnswer {
                 EntityManagerFactoryFactoryImpl().create(
                     "test_vnode_unit",
                     CertificateEntities.vnodeClasses.toList(),
@@ -79,7 +85,7 @@ internal class CertificatesServiceImplTest {
             dbConnectionManagerMock,
             jpaEntitiesRegistryMock,
             mock(),
-        )
+            virtualNodeInfoReadServiceMock)
     }
 
     @Suppress("Unused")

--- a/components/membership/certificates-service-impl/src/main/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImpl.kt
+++ b/components/membership/certificates-service-impl/src/main/kotlin/net/corda/membership/certificate/service/impl/CertificatesServiceImpl.kt
@@ -23,6 +23,7 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.ConfigKeys
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -49,6 +50,8 @@ class CertificatesServiceImpl internal constructor(
         jpaEntitiesRegistry: JpaEntitiesRegistry,
         @Reference(service = ConfigurationReadService::class)
         configurationReadService: ConfigurationReadService,
+        @Reference(service = VirtualNodeInfoReadService::class)
+        virtualNodeInfoReadService: VirtualNodeInfoReadService,
     ) : this(
         coordinatorFactory,
         subscriptionFactory,
@@ -56,6 +59,7 @@ class CertificatesServiceImpl internal constructor(
         DbClientImpl(
             dbConnectionManager,
             jpaEntitiesRegistry,
+            virtualNodeInfoReadService,
         )
     )
 

--- a/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/DbClientImplTest.kt
+++ b/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/DbClientImplTest.kt
@@ -50,7 +50,7 @@ class DbClientImplTest {
     private val dbConnectionManager = mock<DbConnectionManager> {
         on { getClusterEntityManagerFactory() } doReturn clusterFactory
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 eq(dmlConnectionId),
                 eq(registry)
             )
@@ -153,17 +153,6 @@ class DbClientImplTest {
             Certificate::class.java,
             "alias"
         )
-    }
-
-    @Test
-    fun `retrieveCertificates will close the node factory`() {
-        client.retrieveCertificates(
-            nodeTenantId,
-            CertificateUsage.P2P_TLS,
-            "alias"
-        )
-
-        verify(nodeFactory).close()
     }
 
     @Test

--- a/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/DbClientImplTest.kt
+++ b/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/DbClientImplTest.kt
@@ -3,24 +3,26 @@ package net.corda.membership.certificate.service.impl
 import net.corda.crypto.core.ShortHash
 import net.corda.data.certificates.CertificateUsage
 import net.corda.db.connection.manager.DbConnectionManager
-import net.corda.db.connection.manager.VirtualNodeDbType
-import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.membership.certificates.CertificateUsageUtils.publicName
 import net.corda.membership.certificates.datamodel.Certificate
 import net.corda.membership.certificates.datamodel.ClusterCertificate
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -44,20 +46,27 @@ class DbClientImplTest {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn registry
     }
     private val nodeTenantId = ShortHash.of("1234567890ab")
+    private val dmlConnectionId = UUID(10, 30)
     private val dbConnectionManager = mock<DbConnectionManager> {
         on { getClusterEntityManagerFactory() } doReturn clusterFactory
         on {
-            getOrCreateEntityManagerFactory(
-                name = VirtualNodeDbType.VAULT.getConnectionName(nodeTenantId),
-                privilege = DbPrivilege.DML,
-                entitiesSet = registry,
+            createEntityManagerFactory(
+                eq(dmlConnectionId),
+                eq(registry)
             )
         } doReturn nodeFactory
+    }
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { vaultDmlConnectionId } doReturn dmlConnectionId
+    }
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(nodeTenantId) } doReturn nodeInfo
     }
 
     private val client = DbClientImpl(
         dbConnectionManager,
         jpaEntitiesRegistry,
+        virtualNodeInfoReadService
     )
 
     @Test
@@ -90,6 +99,18 @@ class DbClientImplTest {
                 "certificate"
             )
         )
+    }
+
+    @Test
+    fun `importCertificates with invalid node throw an exception`() {
+        assertThrows<NoSuchNode> {
+            client.importCertificates(
+                CertificateUsage.REST_TLS,
+                ShortHash.Companion.of("123456789011"),
+                "alias",
+                "certificate"
+            )
+        }
     }
 
     @Test
@@ -135,18 +156,18 @@ class DbClientImplTest {
     }
 
     @Test
-    fun `retrieveCertificates will not close the node factory`() {
+    fun `retrieveCertificates will close the node factory`() {
         client.retrieveCertificates(
             nodeTenantId,
             CertificateUsage.P2P_TLS,
             "alias"
         )
 
-        verify(nodeFactory, never()).close()
+        verify(nodeFactory).close()
     }
 
     @Test
-    fun `retrieveCertificates will not close the cluster factory`() {
+    fun `retrieveCertificates will not close the node factory`() {
         client.retrieveCertificates(
             null,
             CertificateUsage.P2P_TLS,

--- a/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/DbClientImplTest.kt
+++ b/components/membership/certificates-service-impl/src/test/kotlin/net/corda/membership/certificate/service/impl/DbClientImplTest.kt
@@ -156,7 +156,7 @@ class DbClientImplTest {
     }
 
     @Test
-    fun `retrieveCertificates will not close the node factory`() {
+    fun `retrieveCertificates will not close the cluster factory`() {
         client.retrieveCertificates(
             null,
             CertificateUsage.P2P_TLS,

--- a/components/membership/membership-persistence-service-impl/build.gradle
+++ b/components/membership/membership-persistence-service-impl/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation project(':components:configuration:configuration-read-service')
     implementation project(':components:db:db-connection-manager')
     implementation project(':components:membership:membership-persistence-service')
+    implementation project(':components:virtual-node:virtual-node-info-read-service')
     implementation project(':components:membership:mtls-mgm-allowed-list-reader-writer')
     implementation project(':components:membership:group-params-writer-service')
 

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -33,6 +33,7 @@ import net.corda.layeredpropertymap.LayeredPropertyMapFactory
 import net.corda.layeredpropertymap.create
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.datamodel.ConfigurationEntities
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.hash
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -50,6 +51,7 @@ import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
 import net.corda.membership.datamodel.MembershipEntities
 import net.corda.membership.datamodel.RegistrationRequestEntity
 import net.corda.membership.datamodel.StaticNetworkInfoEntity
+import net.corda.membership.impl.persistence.service.dummy.TestVirtualNodeInfoReadService
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.EPOCH_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MODIFIED_TIME_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MPV_KEY
@@ -104,6 +106,7 @@ import net.corda.schema.configuration.BootConfig.BOOT_MAX_ALLOWED_MSG_SIZE
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
+import net.corda.test.util.TestRandom
 import net.corda.test.util.eventually
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
@@ -115,6 +118,7 @@ import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.MemberInfo
 import net.corda.v5.membership.NotaryInfo
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -213,6 +217,9 @@ class MembershipPersistenceTest {
 
         @InjectService(timeout = 5000)
         lateinit var cordaAvroSerializationFactory: CordaAvroSerializationFactory
+
+        @InjectService(timeout = 5000)
+        lateinit var virtualNodeReadService: TestVirtualNodeInfoReadService
 
         @InjectService(timeout = 5000)
         lateinit var layeredPropertyMapFactory: LayeredPropertyMapFactory
@@ -464,6 +471,7 @@ class MembershipPersistenceTest {
             setupConfig()
             dbConnectionManager.startAndWait()
             dbConnectionManager.bootstrap(dbConfig)
+            virtualNodeReadService.startAndWait()
 
             membershipPersistenceService.startAndWait()
             membershipPersistenceClientWrapper.startAndWait()
@@ -474,13 +482,22 @@ class MembershipPersistenceTest {
                 assertEquals(LifecycleStatus.UP, coordinator.status)
                 logger.info("Required services started.")
             }
-            dbConnectionManager.putConnection(
+            val connectionID = dbConnectionManager.putConnection(
                 name = vnodeDbInfo.name,
                 privilege = DbPrivilege.DML,
                 config = vnodeDbInfo.config,
                 description = null,
                 updateActor = "sa"
             )
+            val vnodeInfo = VirtualNodeInfo(
+                viewOwningHoldingIdentity,
+                CpiIdentifier("PLACEHOLDER", "PLACEHOLDER", TestRandom.secureHash()),
+                vaultDmlConnectionId = connectionID,
+                cryptoDmlConnectionId = connectionID,
+                uniquenessDmlConnectionId = connectionID,
+                timestamp = clock.instant()
+            )
+            virtualNodeReadService.putVNodeInfo(vnodeInfo)
         }
 
         @AfterAll
@@ -493,6 +510,7 @@ class MembershipPersistenceTest {
             dbConnectionManager.stop()
             membershipPersistenceService.stop()
             membershipPersistenceClientWrapper.stop()
+            virtualNodeReadService.stop()
         }
 
         private fun setupConfig() {

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/dummy/TestVirtualNodeInfoReadService.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/dummy/TestVirtualNodeInfoReadService.kt
@@ -1,0 +1,84 @@
+package net.corda.membership.impl.persistence.service.dummy
+
+import net.corda.crypto.core.ShortHash
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.StartEvent
+import net.corda.reconciliation.VersionedRecord
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoListener
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.propertytypes.ServiceRanking
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.stream.Stream
+
+interface TestVirtualNodeInfoReadService : VirtualNodeInfoReadService {
+    fun putVNodeInfo(vnodeInfo: VirtualNodeInfo)
+}
+
+@ServiceRanking(Int.MAX_VALUE)
+@Component(service = [VirtualNodeInfoReadService::class, TestVirtualNodeInfoReadService::class])
+class TestVirtualNodeInfoReadServiceImpl @Activate constructor(
+    @Reference(service = LifecycleCoordinatorFactory::class)
+    private val coordinatorFactory: LifecycleCoordinatorFactory,
+) : TestVirtualNodeInfoReadService {
+
+    companion object {
+        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+
+        private const val UNIMPLEMENTED_FUNCTION = "Called unimplemented function for test service"
+    }
+
+    private val coordinator = coordinatorFactory.createCoordinator(lifecycleCoordinatorName) { event, coordinator ->
+        if (event is StartEvent) {
+            coordinator.updateStatus(LifecycleStatus.UP)
+        }
+    }
+    override val isRunning: Boolean
+        get() = coordinator.status == LifecycleStatus.UP
+
+    private val vnodes: ConcurrentHashMap<HoldingIdentity, VirtualNodeInfo> = ConcurrentHashMap()
+
+    override fun putVNodeInfo(vnodeInfo: VirtualNodeInfo) {
+        vnodes[vnodeInfo.holdingIdentity] = vnodeInfo
+    }
+
+    override fun getAll() = vnodes.entries.map { it.value }
+
+    override fun get(holdingIdentity: HoldingIdentity) = vnodes[holdingIdentity]
+
+    override fun getByHoldingIdentityShortHash(holdingIdentityShortHash: ShortHash) = vnodes.entries.firstOrNull {
+        it.key.shortHash == holdingIdentityShortHash
+    }?.value
+
+    override fun registerCallback(listener: VirtualNodeInfoListener): AutoCloseable {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override fun getAllVersionedRecords(): Stream<VersionedRecord<HoldingIdentity, VirtualNodeInfo>>? {
+        with(UNIMPLEMENTED_FUNCTION) {
+            logger.warn(this)
+            throw UnsupportedOperationException(this)
+        }
+    }
+
+    override val lifecycleCoordinatorName: LifecycleCoordinatorName
+        get() = LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>()
+
+    override fun start() {
+        coordinator.start()
+    }
+
+    override fun stop() {
+        coordinator.stop()
+    }
+}

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImpl.kt
@@ -40,6 +40,7 @@ import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.utilities.time.Clock
 import net.corda.utilities.time.UTCClock
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -64,6 +65,8 @@ class MembershipPersistenceServiceImpl @Activate constructor(
     memberInfoFactory: MemberInfoFactory,
     @Reference(service = CordaAvroSerializationFactory::class)
     cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    @Reference(service = VirtualNodeInfoReadService::class)
+    virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = KeyEncodingService::class)
     keyEncodingService: KeyEncodingService,
     @Reference(service = PlatformInfoProvider::class)
@@ -129,6 +132,7 @@ class MembershipPersistenceServiceImpl @Activate constructor(
             setOf(
                 LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
                 LifecycleCoordinatorName.forComponent<DbConnectionManager>(),
+                LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
                 LifecycleCoordinatorName.forComponent<AllowedCertificatesReaderWriterService>(),
             )
         )
@@ -174,6 +178,7 @@ class MembershipPersistenceServiceImpl @Activate constructor(
             jpaEntitiesRegistry,
             memberInfoFactory,
             cordaAvroSerializationFactory,
+            virtualNodeInfoReadService,
             keyEncodingService,
             platformInfoProvider,
             groupParametersWriterService,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/HandlerFactories.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/HandlerFactories.kt
@@ -42,6 +42,7 @@ import net.corda.membership.lib.metrics.getTimerMetric
 import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderWriterService
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.utilities.time.Clock
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 
 @Suppress("LongParameterList")
 internal class HandlerFactories(
@@ -50,6 +51,7 @@ internal class HandlerFactories(
     jpaEntitiesRegistry: JpaEntitiesRegistry,
     memberInfoFactory: MemberInfoFactory,
     cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    virtualNodeInfoReadService: VirtualNodeInfoReadService,
     keyEncodingService: KeyEncodingService,
     platformInfoProvider: PlatformInfoProvider,
     groupParametersWriterService: GroupParametersWriterService,
@@ -62,6 +64,7 @@ internal class HandlerFactories(
         jpaEntitiesRegistry,
         memberInfoFactory,
         cordaAvroSerializationFactory,
+        virtualNodeInfoReadService,
         keyEncodingService,
         platformInfoProvider,
         allowedCertificatesReaderWriterService,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -7,17 +7,18 @@ import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.data.crypto.wire.CryptoSignatureSpec
 import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.db.connection.manager.DbConnectionManager
-import net.corda.db.connection.manager.VirtualNodeDbType
-import net.corda.db.core.DbPrivilege
 import net.corda.db.schema.CordaDb
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.groupparams.writer.service.GroupParametersWriterService
 import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.MemberInfoFactory
+import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderWriterService
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.utils.transaction
 import net.corda.utilities.time.Clock
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.LoggerFactory
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
@@ -41,6 +42,7 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
 
     private val dbConnectionManager get() = persistenceHandlerServices.dbConnectionManager
     private val jpaEntitiesRegistry get() = persistenceHandlerServices.jpaEntitiesRegistry
+    private val virtualNodeInfoReadService get() = persistenceHandlerServices.virtualNodeInfoReadService
     private val transactionTimer get() = persistenceHandlerServices.transactionTimerFactory(operation.simpleName)
     val clock get() = persistenceHandlerServices.clock
     val cordaAvroSerializationFactory get() = persistenceHandlerServices.cordaAvroSerializationFactory
@@ -53,10 +55,17 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
     val groupParametersFactory get() = persistenceHandlerServices.groupParametersFactory
 
     fun <R> transaction(holdingIdentityShortHash: ShortHash, block: (EntityManager) -> R): R {
-        val factory = getEntityManagerFactory(holdingIdentityShortHash)
-        return transactionTimer.recordCallable {
-            factory.transaction(block)
-        }!!
+        val virtualNodeInfo = virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
+            ?: throw MembershipPersistenceException(
+                "Virtual node info can't be retrieved for " +
+                        "holding identity ID $holdingIdentityShortHash"
+            )
+        val factory = getEntityManagerFactory(virtualNodeInfo)
+        return try {
+            transactionTimer.recordCallable { factory.transaction(block) }!!
+        } finally {
+            factory.close()
+        }
     }
     fun <R> transaction(block: (EntityManager) -> R): R {
         return dbConnectionManager.getClusterEntityManagerFactory().let {
@@ -70,10 +79,9 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
         CryptoSignatureSpec(signatureSpec, null, null)
     }
 
-    private fun getEntityManagerFactory(holdingIdentityShortHash: ShortHash): EntityManagerFactory {
-        return dbConnectionManager.getOrCreateEntityManagerFactory(
-            name = VirtualNodeDbType.VAULT.getConnectionName(holdingIdentityShortHash),
-            privilege = DbPrivilege.DML,
+    private fun getEntityManagerFactory(info: VirtualNodeInfo): EntityManagerFactory {
+        return dbConnectionManager.createEntityManagerFactory(
+            connectionId = info.vaultDmlConnectionId,
             entitiesSet = jpaEntitiesRegistry.get(CordaDb.Vault.persistenceUnitName)
                 ?: throw java.lang.IllegalStateException(
                     "persistenceUnitName ${CordaDb.Vault.persistenceUnitName} is not registered."
@@ -88,6 +96,7 @@ internal data class PersistenceHandlerServices(
     val jpaEntitiesRegistry: JpaEntitiesRegistry,
     val memberInfoFactory: MemberInfoFactory,
     val cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     val keyEncodingService: KeyEncodingService,
     val platformInfoProvider: PlatformInfoProvider,
     val allowedCertificatesReaderWriterService: AllowedCertificatesReaderWriterService,

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/handler/PersistenceHandler.kt
@@ -61,11 +61,7 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
                         "holding identity ID $holdingIdentityShortHash"
             )
         val factory = getEntityManagerFactory(virtualNodeInfo)
-        return try {
-            transactionTimer.recordCallable { factory.transaction(block) }!!
-        } finally {
-            factory.close()
-        }
+        return transactionTimer.recordCallable { factory.transaction(block) }!!
     }
     fun <R> transaction(block: (EntityManager) -> R): R {
         return dbConnectionManager.getClusterEntityManagerFactory().let {
@@ -80,7 +76,7 @@ internal abstract class BasePersistenceHandler<REQUEST, RESPONSE>(
     }
 
     private fun getEntityManagerFactory(info: VirtualNodeInfo): EntityManagerFactory {
-        return dbConnectionManager.createEntityManagerFactory(
+        return dbConnectionManager.getOrCreateEntityManagerFactory(
             connectionId = info.vaultDmlConnectionId,
             entitiesSet = jpaEntitiesRegistry.get(CordaDb.Vault.persistenceUnitName)
                 ?: throw java.lang.IllegalStateException(

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -265,7 +265,7 @@ class MembershipPersistenceRPCProcessorTest {
 
     private val dbConnectionManager: DbConnectionManager = mock {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 eq(vaultDmlConnectionId),
                 any()
             )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceRPCProcessorTest.kt
@@ -50,6 +50,7 @@ import net.corda.data.membership.preauth.PreAuthToken
 import net.corda.data.membership.preauth.PreAuthTokenStatus
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.ApprovalRulesEntity
 import net.corda.membership.datamodel.ApprovalRulesEntityPrimaryKey
@@ -66,11 +67,14 @@ import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.exceptions.InvalidEntityUpdateException
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
+import net.corda.test.util.TestRandom
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
@@ -125,6 +129,16 @@ class MembershipPersistenceRPCProcessorTest {
     private val registrationContext = "registration-context".toByteArray()
     private val registrationSignatureKey = "registration-signatureKey".toByteArray()
     private val registrationSignatureContent = "registration-signatureContent".toByteArray()
+    private val vaultDmlConnectionId = UUID(30, 0)
+
+    private val virtualNodeInfo = VirtualNodeInfo(
+        ourHoldingIdentity,
+        CpiIdentifier("TEST_CPI", "1.0", TestRandom.secureHash()),
+        timestamp = clock.instant(),
+        vaultDmlConnectionId = vaultDmlConnectionId,
+        cryptoDmlConnectionId = UUID(0, 0),
+        uniquenessDmlConnectionId = UUID(0, 0)
+    )
 
     private val registrationRequest = RegistrationRequestEntity(
         ourRegistrationId,
@@ -251,10 +265,9 @@ class MembershipPersistenceRPCProcessorTest {
 
     private val dbConnectionManager: DbConnectionManager = mock {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                any(),
+            createEntityManagerFactory(
+                eq(vaultDmlConnectionId),
+                any()
             )
         } doReturn entityManagerFactory
         on {
@@ -273,6 +286,9 @@ class MembershipPersistenceRPCProcessorTest {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValuePairListSerializer
         on { createAvroDeserializer(any(), eq(KeyValuePairList::class.java)) } doReturn keyValuePairListDeserializer
     }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(eq(ourHoldingIdentity.shortHash)) } doReturn virtualNodeInfo
+    }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
 
@@ -288,6 +304,7 @@ class MembershipPersistenceRPCProcessorTest {
                 jpaEntitiesRegistry,
                 memberInfoFactory,
                 cordaAvroSerializationFactory,
+                virtualNodeInfoReadService,
                 keyEncodingService,
                 platformInfoProvider,
                 mock(),

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImplTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceServiceImplTest.kt
@@ -35,6 +35,7 @@ import net.corda.orm.JpaEntitiesRegistry
 import net.corda.schema.Schemas.Membership.MEMBERSHIP_DB_RPC_TOPIC
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -71,6 +72,7 @@ class MembershipPersistenceServiceImplTest {
     private val dependentComponents = setOf(
         LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
         LifecycleCoordinatorName.forComponent<DbConnectionManager>(),
+        LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
         LifecycleCoordinatorName.forComponent<AllowedCertificatesReaderWriterService>(),
     )
     private val lifecycleHandlerCaptor: KArgumentCaptor<LifecycleEventHandler> = argumentCaptor()
@@ -122,6 +124,7 @@ class MembershipPersistenceServiceImplTest {
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock()
     private val memberInfoFactory: MemberInfoFactory = mock()
     private val cordaAvroSerializationFactory: CordaAvroSerializationFactory = mock()
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock()
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
 
@@ -136,6 +139,7 @@ class MembershipPersistenceServiceImplTest {
             jpaEntitiesRegistry,
             memberInfoFactory,
             cordaAvroSerializationFactory,
+            virtualNodeInfoReadService,
             keyEncodingService,
             platformInfoProvider,
             mock(),
@@ -157,11 +161,11 @@ class MembershipPersistenceServiceImplTest {
         verify(coordinator).stop()
     }
 
-    private fun postStartEvent() {
+    fun postStartEvent() {
         lifecycleHandlerCaptor.firstValue.processEvent(StartEvent(), coordinator)
     }
 
-    private fun postStopEvent() {
+    fun postStopEvent() {
         lifecycleHandlerCaptor.firstValue.processEvent(StopEvent(), coordinator)
     }
 

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandlerTest.kt
@@ -71,7 +71,7 @@ class ActivateMemberHandlerTest {
         on { createEntityManager() } doReturn em
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(any(), any()) } doReturn emf
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn emf
     }
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
         on { getByHoldingIdentityShortHash(holdingIdentity.shortHash) } doReturn ourVirtualNodeInfo

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ActivateMemberHandlerTest.kt
@@ -23,6 +23,8 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.assertThrows
@@ -41,6 +43,7 @@ import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
 import net.corda.data.membership.SignedGroupParameters
+import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import javax.persistence.PessimisticLockException
@@ -55,6 +58,9 @@ class ActivateMemberHandlerTest {
     private val knownGroupId = UUID(0, 1).toString()
     private val knownX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val holdingIdentity = HoldingIdentity(knownX500Name, knownGroupId)
+    private val ourVirtualNodeInfo: VirtualNodeInfo = mock {
+        on { vaultDmlConnectionId } doReturn UUID(0, 1)
+    }
     private val clock: Clock = TestClock(Instant.ofEpochSecond(1))
 
     private val transaction: EntityTransaction = mock()
@@ -65,7 +71,10 @@ class ActivateMemberHandlerTest {
         on { createEntityManager() } doReturn em
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn emf
+        on { createEntityManagerFactory(any(), any()) } doReturn emf
+    }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(holdingIdentity.shortHash) } doReturn ourVirtualNodeInfo
     }
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {
         on { get(any()) } doReturn mock()
@@ -101,7 +110,7 @@ class ActivateMemberHandlerTest {
     private val keyValuePairListSerializer = mock<CordaAvroSerializer<KeyValuePairList>> {
         on { serialize(any()) } doReturn byteArrayOf(0)
     }
-    private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>> {
+    private val keyValuePairListDeserializer = mock<CordaAvroDeserializer<KeyValuePairList>>() {
         on { deserialize(serializedMgmContext) } doReturn mgmContext
     }
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
@@ -123,6 +132,7 @@ class ActivateMemberHandlerTest {
     }
     private val persistenceHandlerServices: PersistenceHandlerServices = mock {
         on { clock } doReturn clock
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { cordaAvroSerializationFactory } doReturn cordaAvroSerializationFactory
@@ -159,7 +169,7 @@ class ActivateMemberHandlerTest {
     fun `invoke returns the correct data when member is a notary`() {
         val mockMemberContext = mock<MemberContext> {
             on { entries } doReturn mapOf(
-                "$ROLES_PREFIX.0" to NOTARY_ROLE
+                "${MemberInfoExtension.ROLES_PREFIX}.0" to MemberInfoExtension.NOTARY_ROLE
             ).entries
         }
         val mockMemberInfo = mock<MemberInfo> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
@@ -166,9 +166,9 @@ class AddNotaryToGroupParametersHandlerTest {
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
     }
-    private val connectionManager = mock<DbConnectionManager> {
+    private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 entitySet
             )
@@ -225,7 +225,7 @@ class AddNotaryToGroupParametersHandlerTest {
         on { cordaAvroSerializationFactory } doReturn serializationFactory
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
-        on { dbConnectionManager } doReturn connectionManager
+        on { dbConnectionManager } doReturn dbConnectionManager
         on { clock } doReturn clock
         on { keyEncodingService } doReturn keyEncodingService
         on { memberInfoFactory } doReturn memberInfoFactory
@@ -272,7 +272,6 @@ class AddNotaryToGroupParametersHandlerTest {
         handler.invoke(requestContext, request)
 
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(registry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(keyValuePairListSerializer).serialize(
@@ -306,7 +305,6 @@ class AddNotaryToGroupParametersHandlerTest {
         handler.invoke(requestContext, request)
 
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(registry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(keyValuePairListSerializer).serialize(
@@ -383,7 +381,6 @@ class AddNotaryToGroupParametersHandlerTest {
         handler.invoke(requestContext, request)
 
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(registry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(entityManager, times(0)).persist(any())

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
@@ -38,6 +38,9 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -52,6 +55,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
 import java.util.SortedMap
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -85,6 +89,15 @@ class AddNotaryToGroupParametersHandlerTest {
     private val serializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValuePairListSerializer
         on { createAvroDeserializer(any(), eq(KeyValuePairList::class.java)) } doReturn keyValuePairListDeserializer
+    }
+    private val identity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group").toCorda()
+    private val vaultDmlConnectionId = UUID(1, 2)
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { holdingIdentity } doReturn identity
+        on { vaultDmlConnectionId } doReturn vaultDmlConnectionId
+    }
+    private val nodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(any()) } doReturn nodeInfo
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val registry = mock<JpaEntitiesRegistry> {
@@ -155,10 +168,9 @@ class AddNotaryToGroupParametersHandlerTest {
     }
     private val connectionManager = mock<DbConnectionManager> {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                eq(entitySet),
+            createEntityManagerFactory(
+                vaultDmlConnectionId,
+                entitySet
             )
         } doReturn entityManagerFactory
     }
@@ -211,6 +223,7 @@ class AddNotaryToGroupParametersHandlerTest {
     private lateinit var otherNotary: MemberInfo
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
         on { cordaAvroSerializationFactory } doReturn serializationFactory
+        on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
         on { clock } doReturn clock
@@ -259,6 +272,7 @@ class AddNotaryToGroupParametersHandlerTest {
         handler.invoke(requestContext, request)
 
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(registry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(keyValuePairListSerializer).serialize(
@@ -292,6 +306,7 @@ class AddNotaryToGroupParametersHandlerTest {
         handler.invoke(requestContext, request)
 
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(registry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(keyValuePairListSerializer).serialize(
@@ -368,6 +383,7 @@ class AddNotaryToGroupParametersHandlerTest {
         handler.invoke(requestContext, request)
 
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(registry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(entityManager, times(0)).persist(any())

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandlerTest.kt
@@ -46,7 +46,7 @@ class AddPreAuthTokenHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddPreAuthTokenHandlerTest.kt
@@ -10,6 +10,9 @@ import net.corda.membership.datamodel.PreAuthTokenEntity
 import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderWriterService
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -19,6 +22,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -28,6 +32,12 @@ class AddPreAuthTokenHandlerTest {
         "CN=Mgm, O=Member ,L=London ,C=GB",
         "Group ID",
     )
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { vaultDmlConnectionId } doReturn UUID(0, 90)
+    }
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(holdingIdentity.toCorda().shortHash) } doReturn nodeInfo
+    }
     private val entityTransaction = mock<EntityTransaction>()
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn entityTransaction
@@ -36,7 +46,7 @@ class AddPreAuthTokenHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn entityManagerFactory
+        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {
@@ -44,6 +54,7 @@ class AddPreAuthTokenHandlerTest {
     }
     private val writerToKafka = mock<AllowedCertificatesReaderWriterService>()
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandlerTest.kt
@@ -60,7 +60,7 @@ class ConsumePreAuthTokenHandlerTest {
         on { createEntityManager() } doReturn em
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(any(), any()) } doReturn emf
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn emf
     }
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
         on { getByHoldingIdentityShortHash(ourHoldingIdentity.shortHash) } doReturn ourVirtualNodeInfo

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/ConsumePreAuthTokenHandlerTest.kt
@@ -15,6 +15,8 @@ import net.corda.test.util.time.TestClock
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -41,6 +43,9 @@ class ConsumePreAuthTokenHandlerTest {
     private val ourGroupId = UUID(0, 1).toString()
     private val ourX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val ourHoldingIdentity = HoldingIdentity(ourX500Name, ourGroupId)
+    private val ourVirtualNodeInfo: VirtualNodeInfo = mock {
+        on { vaultDmlConnectionId } doReturn UUID(0, 1)
+    }
     private val clock: Clock = TestClock(Instant.ofEpochSecond(1))
 
     private val tokenIdentifier = UUID(0, 1)
@@ -55,7 +60,10 @@ class ConsumePreAuthTokenHandlerTest {
         on { createEntityManager() } doReturn em
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn emf
+        on { createEntityManagerFactory(any(), any()) } doReturn emf
+    }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(ourHoldingIdentity.shortHash) } doReturn ourVirtualNodeInfo
     }
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {
         on { get(any()) } doReturn mock()
@@ -63,6 +71,7 @@ class ConsumePreAuthTokenHandlerTest {
 
     private val persistenceHandlerServices: PersistenceHandlerServices = mock {
         on { clock } doReturn clock
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { transactionTimerFactory } doReturn { transactionTimer }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/DeleteApprovalRuleHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/DeleteApprovalRuleHandlerTest.kt
@@ -63,9 +63,9 @@ class DeleteApprovalRuleHandlerTest {
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
     }
-    private val connectionManager = mock<DbConnectionManager> {
+    private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 entitySet
             )
@@ -74,7 +74,7 @@ class DeleteApprovalRuleHandlerTest {
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
-        on { dbConnectionManager } doReturn connectionManager
+        on { dbConnectionManager } doReturn dbConnectionManager
         on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val context = mock<MembershipRequestContext> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandlerTest.kt
@@ -44,7 +44,7 @@ class MutualTlsAddToAllowedCertificatesHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsAddToAllowedCertificatesHandlerTest.kt
@@ -10,12 +10,16 @@ import net.corda.membership.datamodel.MutualTlsAllowedClientCertificateEntity
 import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderWriterService
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -25,6 +29,12 @@ class MutualTlsAddToAllowedCertificatesHandlerTest {
         "CN=Mgm, O=Member ,L=London ,C=GB",
         "Group ID",
     )
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { vaultDmlConnectionId } doReturn UUID(0, 90)
+    }
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(holdingIdentity.toCorda().shortHash) } doReturn nodeInfo
+    }
     private val entityTransaction = mock<EntityTransaction>()
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn entityTransaction
@@ -34,7 +44,7 @@ class MutualTlsAddToAllowedCertificatesHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn entityManagerFactory
+        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {
@@ -42,6 +52,7 @@ class MutualTlsAddToAllowedCertificatesHandlerTest {
     }
     private val writerToKafka = mock<AllowedCertificatesReaderWriterService>()
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandlerTest.kt
@@ -48,7 +48,7 @@ class MutualTlsListAllowedCertificatesHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsListAllowedCertificatesHandlerTest.kt
@@ -8,12 +8,16 @@ import net.corda.db.schema.CordaDb
 import net.corda.membership.datamodel.MutualTlsAllowedClientCertificateEntity
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -30,6 +34,12 @@ class MutualTlsListAllowedCertificatesHandlerTest {
         "CN=Mgm, O=Member ,L=London ,C=GB",
         "Group ID",
     )
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { vaultDmlConnectionId } doReturn UUID(0, 90)
+    }
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(holdingIdentity.toCorda().shortHash) } doReturn nodeInfo
+    }
     private val entityTransaction = mock<EntityTransaction>()
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn entityTransaction
@@ -38,13 +48,14 @@ class MutualTlsListAllowedCertificatesHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn entityManagerFactory
+        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn entitySet
     }
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { transactionTimerFactory } doReturn { transactionTimer }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandlerTest.kt
@@ -44,7 +44,7 @@ class MutualTlsRemoveFromAllowedCertificatesHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/MutualTlsRemoveFromAllowedCertificatesHandlerTest.kt
@@ -10,12 +10,16 @@ import net.corda.membership.datamodel.MutualTlsAllowedClientCertificateEntity
 import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderWriterService
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -25,6 +29,12 @@ class MutualTlsRemoveFromAllowedCertificatesHandlerTest {
         "CN=Mgm, O=Member ,L=London ,C=GB",
         "Group ID",
     )
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { vaultDmlConnectionId } doReturn UUID(0, 90)
+    }
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(holdingIdentity.toCorda().shortHash) } doReturn nodeInfo
+    }
     private val entityTransaction = mock<EntityTransaction>()
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn entityTransaction
@@ -34,7 +44,7 @@ class MutualTlsRemoveFromAllowedCertificatesHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn entityManagerFactory
+        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {
@@ -42,6 +52,7 @@ class MutualTlsRemoveFromAllowedCertificatesHandlerTest {
     }
     private val writerToKafka = mock<AllowedCertificatesReaderWriterService>()
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandlerTest.kt
@@ -88,9 +88,9 @@ class PersistApprovalRuleHandlerTest {
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
     }
-    private val connectionManager = mock<DbConnectionManager> {
+    private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 entitySet
             )
@@ -99,7 +99,7 @@ class PersistApprovalRuleHandlerTest {
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
-        on { dbConnectionManager } doReturn connectionManager
+        on { dbConnectionManager } doReturn dbConnectionManager
         on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private lateinit var handler: PersistApprovalRuleHandler

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistApprovalRuleHandlerTest.kt
@@ -10,6 +10,9 @@ import net.corda.membership.datamodel.ApprovalRulesEntity
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -20,6 +23,7 @@ import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -37,6 +41,15 @@ class PersistApprovalRuleHandlerTest {
         const val DUMMY_LABEL = "label1"
     }
 
+    private val identity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group").toCorda()
+    private val vaultDmlConnectionId = UUID(1, 2)
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { holdingIdentity } doReturn identity
+        on { vaultDmlConnectionId } doReturn vaultDmlConnectionId
+    }
+    private val nodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(any()) } doReturn nodeInfo
+    }
     private val entitySet = mock<JpaEntitiesSet>()
     private val registry = mock<JpaEntitiesRegistry> {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn entitySet
@@ -77,14 +90,14 @@ class PersistApprovalRuleHandlerTest {
     }
     private val connectionManager = mock<DbConnectionManager> {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                any(),
+            createEntityManagerFactory(
+                vaultDmlConnectionId,
+                entitySet
             )
         } doReturn entityManagerFactory
     }
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
         on { transactionTimerFactory } doReturn { transactionTimer }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersHandlerTest.kt
@@ -154,9 +154,9 @@ class PersistGroupParametersHandlerTest {
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
     }
-    private val connectionManager = mock<DbConnectionManager> {
+    private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 entitySet
             )
@@ -172,7 +172,7 @@ class PersistGroupParametersHandlerTest {
         on { cordaAvroSerializationFactory } doReturn serializationFactory
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
-        on { dbConnectionManager } doReturn connectionManager
+        on { dbConnectionManager } doReturn dbConnectionManager
         on { clock } doReturn clock
         on { transactionTimerFactory } doReturn { transactionTimer }
         on { groupParametersFactory } doReturn groupParametersFactory

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupParametersInitialSnapshotHandlerTest.kt
@@ -77,9 +77,9 @@ class PersistGroupParametersInitialSnapshotHandlerTest {
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
     }
-    private val connectionManager = mock<DbConnectionManager> {
+    private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 entitySet
             )
@@ -93,7 +93,7 @@ class PersistGroupParametersInitialSnapshotHandlerTest {
         on { cordaAvroSerializationFactory } doReturn serializationFactory
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
-        on { dbConnectionManager } doReturn connectionManager
+        on { dbConnectionManager } doReturn dbConnectionManager
         on { clock } doReturn clock
         on { keyEncodingService } doReturn keyEncodingService
         on { transactionTimerFactory } doReturn { transactionTimer }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -15,6 +15,9 @@ import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
 import net.corda.test.util.time.TestClock
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -28,6 +31,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -46,6 +50,15 @@ class PersistGroupPolicyHandlerTest {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValuePairListSerializer
         on { createAvroDeserializer<KeyValuePairList>(any(), any())} doReturn keyValuePairListDeserializer
     }
+    private val identity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group").toCorda()
+    private val vaultDmlConnectionId = UUID(1, 2)
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { holdingIdentity } doReturn identity
+        on { vaultDmlConnectionId } doReturn vaultDmlConnectionId
+    }
+    private val nodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(any()) } doReturn nodeInfo
+    }
     private val entitySet = mock<JpaEntitiesSet>()
     private val registry = mock<JpaEntitiesRegistry> {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn entitySet
@@ -61,16 +74,16 @@ class PersistGroupPolicyHandlerTest {
     }
     private val connectionManager = mock<DbConnectionManager> {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                eq(entitySet),
+            createEntityManagerFactory(
+                vaultDmlConnectionId,
+                entitySet
             )
         } doReturn entityManagerFactory
     }
     private val clock = TestClock(Instant.ofEpochMilli(10))
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
         on { cordaAvroSerializationFactory } doReturn serializationFactory
+        on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
         on { clock } doReturn clock

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistGroupPolicyHandlerTest.kt
@@ -72,9 +72,9 @@ class PersistGroupPolicyHandlerTest {
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
     }
-    private val connectionManager = mock<DbConnectionManager> {
+    private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 entitySet
             )
@@ -85,7 +85,7 @@ class PersistGroupPolicyHandlerTest {
         on { cordaAvroSerializationFactory } doReturn serializationFactory
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
-        on { dbConnectionManager } doReturn connectionManager
+        on { dbConnectionManager } doReturn dbConnectionManager
         on { clock } doReturn clock
         on { transactionTimerFactory } doReturn { transactionTimer }
     }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -111,7 +111,7 @@ class PersistMemberInfoHandlerTest {
     }
 
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(
+        on { getOrCreateEntityManagerFactory(
             eq(vaultDmlConnectionId),
             any()) } doReturn entityManagerFactory
     }
@@ -204,7 +204,6 @@ class PersistMemberInfoHandlerTest {
             assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
         }
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(jpaEntitiesRegistry).get(eq(CordaDb.Vault.persistenceUnitName))
         with(argumentCaptor<PersistentMemberInfo>()) {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistMemberInfoHandlerTest.kt
@@ -1,9 +1,10 @@
 package net.corda.membership.impl.persistence.service.handler
 
+import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.ShortHash
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
-import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoSignatureSpec
@@ -14,6 +15,7 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.PersistMemberInfo
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
@@ -27,12 +29,15 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.status
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
+import net.corda.test.util.TestRandom
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -86,6 +91,16 @@ class PersistMemberInfoHandlerTest {
         on { status } doReturn MEMBER_STATUS_ACTIVE
         on { serial } doReturn SERIAL_NUMBER
     }
+    private val vaultDmlConnectionId = UUID(0, 1)
+
+    private val virtualNodeInfo = VirtualNodeInfo(
+        ourHoldingIdentity,
+        CpiIdentifier("TEST_CPI", "1.0", TestRandom.secureHash()),
+        vaultDmlConnectionId = vaultDmlConnectionId,
+        cryptoDmlConnectionId = UUID(0, 0),
+        uniquenessDmlConnectionId = UUID(0, 0),
+        timestamp = clock.instant()
+    )
 
     private val entityTransaction: EntityTransaction = mock()
     private val entityManager: EntityManager = mock {
@@ -96,13 +111,9 @@ class PersistMemberInfoHandlerTest {
     }
 
     private val dbConnectionManager: DbConnectionManager = mock {
-        on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                any(),
-            )
-        } doReturn entityManagerFactory
+        on { createEntityManagerFactory(
+            eq(vaultDmlConnectionId),
+            any()) } doReturn entityManagerFactory
     }
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {
         on { get(eq(CordaDb.Vault.persistenceUnitName)) } doReturn mock()
@@ -118,6 +129,9 @@ class PersistMemberInfoHandlerTest {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn keyValueSerializer
         on { createAvroDeserializer<KeyValuePairList>(any(), any()) } doReturn keyValuePairListDeserializer
     }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(eq(ourHoldingIdentity.shortHash)) } doReturn virtualNodeInfo
+    }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
     private val transactionTimerFactory = { _: String -> transactionTimer }
@@ -127,6 +141,7 @@ class PersistMemberInfoHandlerTest {
         jpaEntitiesRegistry,
         memberInfoFactory,
         cordaAvroSerializationFactory,
+        virtualNodeInfoReadService,
         keyEncodingService,
         platformInfoProvider,
         mock(),
@@ -170,6 +185,7 @@ class PersistMemberInfoHandlerTest {
 
         assertThat(result).isInstanceOf(Unit::class.java)
         verify(memberInfoFactory, never()).create(any())
+        verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
         verify(dbConnectionManager, never()).getOrCreateEntityManagerFactory(any(), any(), any())
         verify(jpaEntitiesRegistry, never()).get(any())
     }
@@ -183,7 +199,12 @@ class PersistMemberInfoHandlerTest {
         )
 
         assertThat(result).isInstanceOf(Unit::class.java)
+        with(argumentCaptor<ShortHash>()) {
+            verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
+            assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
+        }
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(jpaEntitiesRegistry).get(eq(CordaDb.Vault.persistenceUnitName))
         with(argumentCaptor<PersistentMemberInfo>()) {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
@@ -84,7 +84,7 @@ class PersistRegistrationRequestHandlerTest {
 
     private val dbConnectionManager: DbConnectionManager = mock {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 eq(vaultDmlConnectionId),
                 any()
             )
@@ -178,7 +178,6 @@ class PersistRegistrationRequestHandlerTest {
             assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
         }
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(jpaEntitiesRegistry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(memberInfoFactory, never()).create(any())

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/PersistRegistrationRequestHandlerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.persistence.service.handler
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.ShortHash
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.KeyValuePairList
@@ -13,13 +14,17 @@ import net.corda.data.membership.db.request.command.PersistRegistrationRequest
 import net.corda.data.membership.p2p.MembershipRegistrationRequest
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.RegistrationRequestEntity
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.orm.JpaEntitiesRegistry
+import net.corda.test.util.TestRandom
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -50,6 +55,7 @@ class PersistRegistrationRequestHandlerTest {
     )
     private val ourRegistrationId = UUID.randomUUID().toString()
     private val clock = TestClock(Instant.ofEpochSecond(0))
+    private val vaultDmlConnectionId = UUID(12, 0)
     private val memberContext = "89".toByteArray()
     private val memberContextSignatureKey = "123".toByteArray()
     private val memberContextSignatureContent = "456".toByteArray()
@@ -58,6 +64,15 @@ class PersistRegistrationRequestHandlerTest {
     private val registrationContextSignatureKey = "registrationContextSignatureKey".toByteArray()
     private val registrationContextSignatureContent = "registrationContextSignatureContent".toByteArray()
     private val registrationContextSignatureSpec = "registrationContextSignatureSpec"
+
+    private val virtualNodeInfo = VirtualNodeInfo(
+        ourHoldingIdentity,
+        CpiIdentifier("TEST_CPI", "1.0", TestRandom.secureHash()),
+        vaultDmlConnectionId = vaultDmlConnectionId,
+        cryptoDmlConnectionId = UUID(0, 0),
+        uniquenessDmlConnectionId = UUID(0, 0),
+        timestamp = clock.instant()
+    )
 
     private val entityTransaction: EntityTransaction = mock()
     private val entityManager: EntityManager = mock {
@@ -69,10 +84,9 @@ class PersistRegistrationRequestHandlerTest {
 
     private val dbConnectionManager: DbConnectionManager = mock {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                any(),
+            createEntityManagerFactory(
+                eq(vaultDmlConnectionId),
+                any()
             )
         } doReturn entityManagerFactory
     }
@@ -86,6 +100,9 @@ class PersistRegistrationRequestHandlerTest {
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn serializer
     }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(eq(ourHoldingIdentity.shortHash)) } doReturn virtualNodeInfo
+    }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
     private val transactionTimerFactory = { _: String -> transactionTimer }
@@ -95,6 +112,7 @@ class PersistRegistrationRequestHandlerTest {
         jpaEntitiesRegistry,
         memberInfoFactory,
         cordaAvroSerializationFactory,
+        virtualNodeInfoReadService,
         keyEncodingService,
         platformInfoProvider,
         mock(),
@@ -155,7 +173,12 @@ class PersistRegistrationRequestHandlerTest {
         )
 
         assertThat(result).isInstanceOf(Unit::class.java)
+        with(argumentCaptor<ShortHash>()) {
+            verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
+            assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
+        }
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityManager).transaction
         verify(jpaEntitiesRegistry).get(eq(CordaDb.Vault.persistenceUnitName))
         verify(memberInfoFactory, never()).create(any())

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandlerTest.kt
@@ -82,9 +82,9 @@ class QueryApprovalRulesHandlerTest {
     private val entityManagerFactory = mock<EntityManagerFactory> {
         on { createEntityManager() } doReturn entityManager
     }
-    private val connectionManager = mock<DbConnectionManager> {
+    private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 entitySet
             )
@@ -93,7 +93,7 @@ class QueryApprovalRulesHandlerTest {
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
         on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
-        on { dbConnectionManager } doReturn connectionManager
+        on { dbConnectionManager } doReturn dbConnectionManager
         on { transactionTimerFactory } doReturn { transactionTimer }
     }
     private val context = mock<MembershipRequestContext> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryApprovalRulesHandlerTest.kt
@@ -10,14 +10,17 @@ import net.corda.db.schema.CordaDb
 import net.corda.membership.datamodel.ApprovalRulesEntity
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -35,6 +38,15 @@ class QueryApprovalRulesHandlerTest {
         const val DUMMY_LABEL = "label1"
     }
 
+    private val identity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group").toCorda()
+    private val vaultDmlConnectionId = UUID(1, 2)
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { holdingIdentity } doReturn identity
+        on { vaultDmlConnectionId } doReturn vaultDmlConnectionId
+    }
+    private val nodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(any()) } doReturn nodeInfo
+    }
     private val entitySet = mock<JpaEntitiesSet>()
     private val registry = mock<JpaEntitiesRegistry> {
         on { get(CordaDb.Vault.persistenceUnitName) } doReturn entitySet
@@ -72,14 +84,14 @@ class QueryApprovalRulesHandlerTest {
     }
     private val connectionManager = mock<DbConnectionManager> {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                eq(entitySet),
+            createEntityManagerFactory(
+                vaultDmlConnectionId,
+                entitySet
             )
         } doReturn entityManagerFactory
     }
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn nodeInfoReadService
         on { jpaEntitiesRegistry } doReturn registry
         on { dbConnectionManager } doReturn connectionManager
         on { transactionTimerFactory } doReturn { transactionTimer }

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
@@ -53,11 +53,13 @@ class QueryGroupPolicyHandlerTest {
     }
 
     private val vaultDmlConnectionId = UUID(0, 33)
-    private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(
-            eq(vaultDmlConnectionId),
-            any()
-        ) } doReturn entityManagerFactory
+    private val dbConnectionManager = mock<DbConnectionManager> {
+        on {
+            getOrCreateEntityManagerFactory(
+                eq(vaultDmlConnectionId),
+                any()
+            )
+        } doReturn entityManagerFactory
     }
 
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryGroupPolicyHandlerTest.kt
@@ -8,13 +8,17 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.query.QueryGroupPolicy
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.GroupPolicyEntity
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.orm.JpaEntitiesRegistry
+import net.corda.test.util.TestRandom
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -48,11 +52,11 @@ class QueryGroupPolicyHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
 
+    private val vaultDmlConnectionId = UUID(0, 33)
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { getOrCreateEntityManagerFactory(
-            any(),
-            any(),
-            any(),
+        on { createEntityManagerFactory(
+            eq(vaultDmlConnectionId),
+            any()
         ) } doReturn entityManagerFactory
     }
 
@@ -73,6 +77,17 @@ class QueryGroupPolicyHandlerTest {
         } doReturn keyValuePairListDeserializer
     }
 
+    private val virtualNodeInfo = VirtualNodeInfo(
+        holdingIdentity,
+        CpiIdentifier("TEST_CPI", "1.0", TestRandom.secureHash()),
+        vaultDmlConnectionId = vaultDmlConnectionId,
+        cryptoDmlConnectionId = UUID(0, 0),
+        uniquenessDmlConnectionId = UUID(0, 0),
+        timestamp = clock.instant()
+    )
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(eq(holdingIdentity.shortHash)) } doReturn virtualNodeInfo
+    }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
 
@@ -83,6 +98,7 @@ class QueryGroupPolicyHandlerTest {
         jpaEntitiesRegistry,
         memberInfoFactory,
         cordaAvroSerializationFactory,
+        virtualNodeInfoReadService,
         keyEncodingService,
         platformInfoProvider,
         mock(),

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
@@ -81,9 +81,9 @@ class QueryMemberInfoHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
 
-    private val dbConnectionManager: DbConnectionManager = mock {
+    private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 eq(vaultDmlConnectionId),
                 any(),
             )
@@ -191,7 +191,6 @@ class QueryMemberInfoHandlerTest {
         }
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityTransaction).begin()
         verify(entityTransaction).commit()
         verify(entityManager).close()
@@ -219,7 +218,6 @@ class QueryMemberInfoHandlerTest {
         }
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityTransaction).begin()
         verify(entityTransaction).commit()
         verify(entityManager).close()
@@ -258,7 +256,6 @@ class QueryMemberInfoHandlerTest {
         }
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityTransaction).begin()
         verify(entityTransaction).commit()
         verify(entityManager).close()
@@ -287,7 +284,6 @@ class QueryMemberInfoHandlerTest {
         }
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
-        verify(entityManagerFactory).close()
         verify(entityTransaction).begin()
         verify(entityTransaction).commit()
         verify(entityManager).close()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberInfoHandlerTest.kt
@@ -1,6 +1,7 @@
 package net.corda.membership.impl.persistence.service.handler
 
 import net.corda.crypto.cipher.suite.KeyEncodingService
+import net.corda.crypto.core.ShortHash
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.data.KeyValuePair
@@ -9,13 +10,17 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.query.QueryMemberInfo
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.orm.JpaEntitiesRegistry
+import net.corda.test.util.TestRandom
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -51,6 +56,16 @@ class QueryMemberInfoHandlerTest {
     )
     private val ourRegistrationId = UUID.randomUUID().toString()
     private val clock = TestClock(Instant.ofEpochSecond(0))
+    private val vaultDmlConnectionId = UUID(44, 0)
+
+    private val virtualNodeInfo = VirtualNodeInfo(
+        ourHoldingIdentity,
+        CpiIdentifier("TEST_CPI", "1.0", TestRandom.secureHash()),
+        vaultDmlConnectionId = vaultDmlConnectionId,
+        cryptoDmlConnectionId = UUID(0, 0),
+        uniquenessDmlConnectionId = UUID(0, 0),
+        timestamp = clock.instant()
+    )
 
     private val memberContextBytes = "123".toByteArray()
     private val mgmContextBytes = "456".toByteArray()
@@ -68,9 +83,8 @@ class QueryMemberInfoHandlerTest {
 
     private val dbConnectionManager: DbConnectionManager = mock {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
+            createEntityManagerFactory(
+                eq(vaultDmlConnectionId),
                 any(),
             )
         } doReturn entityManagerFactory
@@ -93,6 +107,9 @@ class QueryMemberInfoHandlerTest {
     private val cordaAvroSerializationFactory: CordaAvroSerializationFactory = mock {
         on { createAvroDeserializer<KeyValuePairList>(any(), any()) } doReturn keyValueDeserializer
     }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(eq(ourHoldingIdentity.shortHash)) } doReturn virtualNodeInfo
+    }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
     private val transactionTimerFactory = { _: String -> transactionTimer }
@@ -102,6 +119,7 @@ class QueryMemberInfoHandlerTest {
         jpaEntitiesRegistry,
         memberInfoFactory,
         cordaAvroSerializationFactory,
+        virtualNodeInfoReadService,
         keyEncodingService,
         platformInfoProvider,
         mock(),
@@ -167,8 +185,13 @@ class QueryMemberInfoHandlerTest {
             assertThat(firstValue).isEqualTo(memberContextBytes)
             assertThat(secondValue).isEqualTo(mgmContextBytes)
         }
+        with(argumentCaptor<ShortHash>()) {
+            verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
+            assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
+        }
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityTransaction).begin()
         verify(entityTransaction).commit()
         verify(entityManager).close()
@@ -190,8 +213,13 @@ class QueryMemberInfoHandlerTest {
         verify(entityManager).createQuery(any(), eq(MemberInfoEntity::class.java))
         verify(cordaAvroSerializationFactory, never()).createAvroDeserializer<KeyValuePairList>(any(), any())
         verify(keyValueDeserializer, never()).deserialize(any())
+        with(argumentCaptor<ShortHash>()) {
+            verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
+            assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
+        }
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityTransaction).begin()
         verify(entityTransaction).commit()
         verify(entityManager).close()
@@ -224,8 +252,13 @@ class QueryMemberInfoHandlerTest {
             assertThat(firstValue).isEqualTo(memberContextBytes)
             assertThat(secondValue).isEqualTo(mgmContextBytes)
         }
+        with(argumentCaptor<ShortHash>()) {
+            verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
+            assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
+        }
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityTransaction).begin()
         verify(entityTransaction).commit()
         verify(entityManager).close()
@@ -248,8 +281,13 @@ class QueryMemberInfoHandlerTest {
         verify(entityManager).createQuery(any(), eq(MemberInfoEntity::class.java))
         verify(cordaAvroSerializationFactory, never()).createAvroDeserializer<KeyValuePairList>(any(), any())
         verify(keyValueDeserializer, never()).deserialize(any())
+        with(argumentCaptor<ShortHash>()) {
+            verify(virtualNodeInfoReadService).getByHoldingIdentityShortHash(capture())
+            assertThat(firstValue).isEqualTo(ourHoldingIdentity.shortHash)
+        }
         verify(jpaEntitiesRegistry).get(any())
         verify(entityManagerFactory).createEntityManager()
+        verify(entityManagerFactory).close()
         verify(entityTransaction).begin()
         verify(entityTransaction).commit()
         verify(entityManager).close()

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
@@ -79,7 +79,7 @@ class QueryMemberSignatureHandlerTest {
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 jpaEntitiesSet
             )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryMemberSignatureHandlerTest.kt
@@ -13,6 +13,7 @@ import net.corda.data.membership.db.request.query.QueryMemberSignature
 import net.corda.data.membership.db.response.query.MemberSignature
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
@@ -20,7 +21,11 @@ import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.test.util.TestRandom
 import net.corda.test.util.time.TestClock
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -32,6 +37,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 
@@ -51,6 +57,20 @@ class QueryMemberSignatureHandlerTest {
             )
         } doReturn keyValuePairListDeserializer
     }
+    private val vaultDmlConnectionId = UUID(0, 0)
+    private val virtualNodeInfo = VirtualNodeInfo(
+        vaultDmlConnectionId = vaultDmlConnectionId,
+        cpiIdentifier = CpiIdentifier(
+            "", "", TestRandom.secureHash()
+        ),
+        cryptoDmlConnectionId = UUID(0, 0),
+        uniquenessDmlConnectionId = UUID(0, 0),
+        holdingIdentity = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "").toCorda(),
+        timestamp = clock.instant(),
+    )
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(any()) } doReturn virtualNodeInfo
+    }
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn mock()
     }
@@ -59,10 +79,9 @@ class QueryMemberSignatureHandlerTest {
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                eq(jpaEntitiesSet),
+            createEntityManagerFactory(
+                vaultDmlConnectionId,
+                jpaEntitiesSet
             )
         } doReturn factory
     }
@@ -75,6 +94,7 @@ class QueryMemberSignatureHandlerTest {
         jpaEntitiesRegistry,
         memberInfoFactory,
         cordaAvroSerializationFactory,
+        virtualNodeInfoReadService,
         keyEncodingService,
         platformInfoProvider,
         mock(),

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryPreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryPreAuthTokenHandlerTest.kt
@@ -88,7 +88,7 @@ class QueryPreAuthTokenHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandlerTest.kt
@@ -87,7 +87,7 @@ class QueryRegistrationRequestHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn entityManagerFactory
     }
     private val nodeInfo = mock<VirtualNodeInfo> {
         on { vaultDmlConnectionId } doReturn UUID(0, 0)

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestHandlerTest.kt
@@ -13,6 +13,8 @@ import net.corda.db.schema.CordaDb
 import net.corda.membership.datamodel.RegistrationRequestEntity
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -23,6 +25,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -84,9 +87,16 @@ class QueryRegistrationRequestHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn entityManagerFactory
+        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+    }
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { vaultDmlConnectionId } doReturn UUID(0, 0)
+    }
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(holdingIdentity.toCorda().shortHash) } doReturn nodeInfo
     }
     private val service = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { cordaAvroSerializationFactory } doReturn serializationFactory

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
@@ -90,7 +90,7 @@ class QueryRegistrationRequestsHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn entityManagerFactory
     }
     private val nodeInfo = mock<VirtualNodeInfo> {
         on { vaultDmlConnectionId } doReturn UUID(0, 0)

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/QueryRegistrationRequestsHandlerTest.kt
@@ -12,6 +12,8 @@ import net.corda.db.schema.CordaDb
 import net.corda.membership.datamodel.RegistrationRequestEntity
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -24,6 +26,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -87,9 +90,16 @@ class QueryRegistrationRequestsHandlerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn entityManagerFactory
+        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+    }
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { vaultDmlConnectionId } doReturn UUID(0, 0)
+    }
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(holdingIdentity.toCorda().shortHash) } doReturn nodeInfo
     }
     private val service = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { cordaAvroSerializationFactory } doReturn serializationFactory

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandlerTest.kt
@@ -55,7 +55,7 @@ class RevokePreAuthTokenHandlerTest  {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/RevokePreAuthTokenHandlerTest.kt
@@ -11,6 +11,9 @@ import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.membership.mtls.allowed.list.service.AllowedCertificatesReaderWriterService
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -20,6 +23,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -37,6 +41,12 @@ class RevokePreAuthTokenHandlerTest  {
         "CN=Mgm, O=Member ,L=London ,C=GB",
         "Group ID",
     )
+    private val nodeInfo = mock<VirtualNodeInfo> {
+        on { vaultDmlConnectionId } doReturn UUID(0, 90)
+    }
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(holdingIdentity.toCorda().shortHash) } doReturn nodeInfo
+    }
     private val entityTransaction = mock<EntityTransaction>()
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn entityTransaction
@@ -45,7 +55,7 @@ class RevokePreAuthTokenHandlerTest  {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn entityManagerFactory
+        on { createEntityManagerFactory(any(), any()) } doReturn entityManagerFactory
     }
     private val entitySet = mock<JpaEntitiesSet>()
     private val jpaEntitiesRegistry = mock<JpaEntitiesRegistry> {
@@ -53,6 +63,7 @@ class RevokePreAuthTokenHandlerTest  {
     }
     private val writerToKafka = mock<AllowedCertificatesReaderWriterService>()
     private val persistenceHandlerServices = mock<PersistenceHandlerServices> {
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { allowedCertificatesReaderWriterService } doReturn writerToKafka

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandlerTest.kt
@@ -137,7 +137,7 @@ class SuspendMemberHandlerTest {
         on { createEntityManager() } doReturn em
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(any(), any()) } doReturn emf
+        on { getOrCreateEntityManagerFactory(any<UUID>(), any()) } doReturn emf
     }
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
         on { getByHoldingIdentityShortHash(holdingIdentity.shortHash) } doReturn ourVirtualNodeInfo

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/SuspendMemberHandlerTest.kt
@@ -20,6 +20,8 @@ import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -69,6 +71,9 @@ class SuspendMemberHandlerTest {
     private val knownGroupId = UUID(0, 1).toString()
     private val knownX500Name = MemberX500Name.parse("O=Alice,L=London,C=GB")
     private val holdingIdentity = HoldingIdentity(knownX500Name, knownGroupId)
+    private val ourVirtualNodeInfo: VirtualNodeInfo = mock {
+        on { vaultDmlConnectionId } doReturn UUID(0, 1)
+    }
     private val clock: Clock = TestClock(Instant.ofEpochSecond(1))
 
     private val transaction: EntityTransaction = mock()
@@ -132,7 +137,10 @@ class SuspendMemberHandlerTest {
         on { createEntityManager() } doReturn em
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { getOrCreateEntityManagerFactory(any(), any(), any()) } doReturn emf
+        on { createEntityManagerFactory(any(), any()) } doReturn emf
+    }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(holdingIdentity.shortHash) } doReturn ourVirtualNodeInfo
     }
     private val jpaEntitiesRegistry: JpaEntitiesRegistry = mock {
         on { get(any()) } doReturn mock()
@@ -198,6 +206,7 @@ class SuspendMemberHandlerTest {
     }
     private val persistenceHandlerServices: PersistenceHandlerServices = mock {
         on { clock } doReturn clock
+        on { virtualNodeInfoReadService } doReturn virtualNodeInfoReadService
         on { dbConnectionManager } doReturn dbConnectionManager
         on { jpaEntitiesRegistry } doReturn jpaEntitiesRegistry
         on { cordaAvroSerializationFactory } doReturn cordaAvroSerializationFactory

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateGroupParametersHandlerTest.kt
@@ -165,7 +165,7 @@ class UpdateGroupParametersHandlerTest {
 
     private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 eq(vaultDmlConnectionId),
                 any()
             )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
@@ -92,7 +92,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 vaultDmlConnectionId,
                 jpaEntitiesSet
             )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateMemberAndRegistrationRequestToApprovedHandlerTest.kt
@@ -13,6 +13,7 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToApproved
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.datamodel.MemberInfoEntityPrimaryKey
@@ -25,8 +26,12 @@ import net.corda.membership.lib.MemberInfoFactory
 import net.corda.membership.lib.exceptions.MembershipPersistenceException
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
+import net.corda.test.util.TestRandom
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -38,6 +43,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.LockModeType
@@ -64,6 +70,20 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
             createAvroSerializer<KeyValuePairList>(any())
         } doReturn keyValuePairListSerializer
     }
+    private val vaultDmlConnectionId = UUID(0, 0)
+    private val virtualNodeInfo = VirtualNodeInfo(
+        vaultDmlConnectionId = vaultDmlConnectionId,
+        cpiIdentifier = CpiIdentifier(
+            "", "", TestRandom.secureHash()
+        ),
+        cryptoDmlConnectionId = UUID(0, 0),
+        uniquenessDmlConnectionId = UUID(0, 0),
+        holdingIdentity = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "").toCorda(),
+        timestamp = clock.instant(),
+    )
+    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
+        on { getByHoldingIdentityShortHash(any()) } doReturn virtualNodeInfo
+    }
     private val entityManager = mock<EntityManager> {
         on { transaction } doReturn mock()
     }
@@ -72,10 +92,9 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                eq(jpaEntitiesSet),
+            createEntityManagerFactory(
+                vaultDmlConnectionId,
+                jpaEntitiesSet
             )
         } doReturn factory
     }
@@ -91,6 +110,7 @@ class UpdateMemberAndRegistrationRequestToApprovedHandlerTest {
         jpaEntitiesRegistry,
         memberInfoFactory,
         cordaAvroSerializationFactory,
+        virtualNodeInfoReadService,
         keyEncodingService,
         platformInfoProvider,
         mock(),

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
@@ -9,14 +9,18 @@ import net.corda.data.membership.db.request.MembershipRequestContext
 import net.corda.data.membership.db.request.command.UpdateRegistrationRequestStatus
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
+import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.membership.datamodel.RegistrationRequestEntity
 import net.corda.membership.impl.persistence.service.RecoverableException
 import net.corda.membership.lib.MemberInfoFactory
 import net.corda.orm.JpaEntitiesRegistry
+import net.corda.test.util.TestRandom
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -31,6 +35,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
+import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
@@ -49,6 +54,16 @@ class UpdateRegistrationRequestStatusHandlerTest {
         ourGroupId
     )
 
+    private val vaultDmlConnectionId = UUID(0, 11)
+    private val virtualNodeInfo = VirtualNodeInfo(
+        ourHoldingIdentity,
+        CpiIdentifier("TEST_CPI", "1.0", TestRandom.secureHash()),
+        vaultDmlConnectionId = vaultDmlConnectionId,
+        cryptoDmlConnectionId = UUID(0, 0),
+        uniquenessDmlConnectionId = UUID(0, 0),
+        timestamp = clock.instant()
+    )
+
     private val entityTransaction: EntityTransaction = mock()
     private val entityManager: EntityManager = mock {
         on { transaction } doReturn entityTransaction
@@ -60,10 +75,9 @@ class UpdateRegistrationRequestStatusHandlerTest {
 
     private val dbConnectionManager: DbConnectionManager = mock {
         on {
-            getOrCreateEntityManagerFactory(
-                any(),
-                any(),
-                any(),
+            createEntityManagerFactory(
+                eq(vaultDmlConnectionId),
+                any()
             )
         } doReturn entityManagerFactory
     }
@@ -77,6 +91,9 @@ class UpdateRegistrationRequestStatusHandlerTest {
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroSerializer<KeyValuePairList>(any()) } doReturn serializer
     }
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
+        on { getByHoldingIdentityShortHash(eq(ourHoldingIdentity.shortHash)) } doReturn virtualNodeInfo
+    }
     private val keyEncodingService: KeyEncodingService = mock()
     private val platformInfoProvider: PlatformInfoProvider = mock()
     private val transactionTimerFactory = { _: String -> transactionTimer }
@@ -86,6 +103,7 @@ class UpdateRegistrationRequestStatusHandlerTest {
         jpaEntitiesRegistry,
         memberInfoFactory,
         cordaAvroSerializationFactory,
+        virtualNodeInfoReadService,
         keyEncodingService,
         platformInfoProvider,
         mock(),

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/UpdateRegistrationRequestStatusHandlerTest.kt
@@ -75,7 +75,7 @@ class UpdateRegistrationRequestStatusHandlerTest {
 
     private val dbConnectionManager: DbConnectionManager = mock {
         on {
-            createEntityManagerFactory(
+            getOrCreateEntityManagerFactory(
                 eq(vaultDmlConnectionId),
                 any()
             )

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
@@ -148,6 +148,13 @@ class DbConnectionManagerImpl @Activate constructor(
         )
     }
 
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory {
+        TODO("Not yet implemented")
+    }
+
     override fun create(
         driverClass: String,
         jdbcUrl: String,

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -53,6 +53,13 @@ class FakeDbConnectionManager(
         )
     }
 
+    override fun getOrCreateEntityManagerFactory(
+        connectionId: UUID,
+        entitiesSet: JpaEntitiesSet
+    ): EntityManagerFactory {
+        TODO("Not yet implemented")
+    }
+
     fun getDataSource(id: UUID): CloseableDataSource {
         return dbSources.single { it.id ==  id}.dataSource
     }


### PR DESCRIPTION
We used to acquire vnode EMFs by connection name and DB privilege, because that API is also caching the EMF to be re-used across different request for the same vnode (whereas the existing API to acquire a vnode EMF by connection ID is not caching the EMF). Both connection name and DB privilege, however, are esoteric and shouldn't be used for vnode EMFs creations.

- undo [previous work](https://github.com/corda/corda-runtime-os/pull/3916) which was using `getOrCreateEntityManagerFactory` by connection name and DB privilege
- introduce new `getOrCreateEntityManagerFactory` API by connection ID, which also caches the EMF
-  use the new `getOrCreateEntityManagerFactory` API in vnode EMFs creation call sites