### PR TITLE
CORE-15771: Update Ledger JPA entities for testing datamodel.

### DIFF
--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualCpkEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualCpkEntity.kt
@@ -12,25 +12,25 @@ import net.corda.v5.base.annotations.CordaSerializable
 @Entity
 @Table(name = "consensual_cpk")
 data class ConsensualCpkEntity(
-    @Id
-    @Column(name = "file_checksum", nullable = false)
-    val fileChecksum: String,
+    @get:Id
+    @get:Column(name = "file_checksum", nullable = false)
+    var fileChecksum: String,
 
-    @Column(name = "name", nullable = false)
-    val name: String,
+    @get:Column(name = "name", nullable = false)
+    var name: String,
 
-    @Column(name = "signer_summary_hash", nullable = false)
-    val signerSummaryHash: String,
+    @get:Column(name = "signer_summary_hash", nullable = false)
+    var signerSummaryHash: String,
 
-    @Column(name = "version", nullable = false)
-    val version: String,
+    @get:Column(name = "version", nullable = false)
+    var version: String,
 
-    @Column(name = "data", nullable = false)
-    @Lob
-    val data: ByteArray,
+    @get:Column(name = "data", nullable = false)
+    @get:Lob
+    var data: ByteArray,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant
+    @get:Column(name = "created", nullable = false)
+    var created: Instant
 
 ) {
     override fun equals(other: Any?): Boolean {

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualTransactionComponentEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualTransactionComponentEntity.kt
@@ -17,27 +17,27 @@ import net.corda.v5.base.annotations.CordaSerializable
 @Table(name = "consensual_transaction_component")
 @IdClass(ConsensualTransactionComponentEntityId::class)
 data class ConsensualTransactionComponentEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: ConsensualTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: ConsensualTransactionEntity,
 
-    @Id
-    @Column(name = "group_idx", nullable = false)
-    val groupIndex: Int,
+    @get:Id
+    @get:Column(name = "group_idx", nullable = false)
+    var groupIndex: Int,
 
-    @Id
-    @Column(name = "leaf_idx", nullable = false)
-    val leafIndex: Int,
+    @get:Id
+    @get:Column(name = "leaf_idx", nullable = false)
+    var leafIndex: Int,
 
-    @Column(name = "data", nullable = false)
-    val data: ByteArray,
+    @get:Column(name = "data", nullable = false)
+    var data: ByteArray,
 
-    @Column(name = "hash", nullable = false)
-    val hash: String,
+    @get:Column(name = "hash", nullable = false)
+    var hash: String,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant
+    @get:Column(name = "created", nullable = false)
+    var created: Instant
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -68,7 +68,7 @@ data class ConsensualTransactionComponentEntity(
 
 @Embeddable
 data class ConsensualTransactionComponentEntityId(
-    val transaction: ConsensualTransactionEntity,
-    val groupIndex: Int,
-    val leafIndex: Int
+    var transaction: ConsensualTransactionEntity,
+    var groupIndex: Int,
+    var leafIndex: Int
 ) : Serializable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualTransactionEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualTransactionEntity.kt
@@ -16,34 +16,34 @@ import net.corda.v5.base.annotations.CordaSerializable
 @Entity
 @Table(name = "consensual_transaction")
 data class ConsensualTransactionEntity(
-    @Id
-    @Column(name = "id", nullable = false, updatable = false)
-    val id: String,
+    @get:Id
+    @get:Column(name = "id", nullable = false, updatable = false)
+    var id: String,
 
-    @Column(name = "privacy_salt", nullable = false)
-    val privacySalt: ByteArray,
+    @get:Column(name = "privacy_salt", nullable = false)
+    var privacySalt: ByteArray,
 
-    @Column(name = "account_id", nullable = false)
-    val accountId: String,
+    @get:Column(name = "account_id", nullable = false)
+    var accountId: String,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant,
+    @get:Column(name = "created", nullable = false)
+    var created: Instant,
 ) {
-    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val components: MutableList<ConsensualTransactionComponentEntity> = mutableListOf()
+    @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var components: MutableList<ConsensualTransactionComponentEntity> = mutableListOf()
 
-    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val statuses: MutableList<ConsensualTransactionStatusEntity> = mutableListOf()
+    @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var statuses: MutableList<ConsensualTransactionStatusEntity> = mutableListOf()
 
-    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val signatures: MutableList<ConsensualTransactionSignatureEntity> = mutableListOf()
+    @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var signatures: MutableList<ConsensualTransactionSignatureEntity> = mutableListOf()
 
-    @ManyToMany(cascade = [CascadeType.PERSIST, CascadeType.MERGE])
-    @JoinTable(name = "consensual_transaction_cpk",
+    @get:ManyToMany(cascade = [CascadeType.PERSIST, CascadeType.MERGE])
+    @get:JoinTable(name = "consensual_transaction_cpk",
         joinColumns = [JoinColumn(name = "transaction_id")],
         inverseJoinColumns = [JoinColumn(name = "file_checksum")]
     )
-    val cpks: MutableSet<ConsensualCpkEntity> = mutableSetOf()
+    var cpks: MutableSet<ConsensualCpkEntity> = mutableSetOf()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualTransactionSignatureEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualTransactionSignatureEntity.kt
@@ -17,23 +17,23 @@ import net.corda.v5.base.annotations.CordaSerializable
 @Table(name = "consensual_transaction_signature")
 @IdClass(ConsensualTransactionSignatureEntityId::class)
 data class ConsensualTransactionSignatureEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: ConsensualTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: ConsensualTransactionEntity,
 
-    @Id
-    @Column(name = "signature_idx", nullable = false)
-    val index: Int,
+    @get:Id
+    @get:Column(name = "signature_idx", nullable = false)
+    var index: Int,
 
-    @Column(name = "signature", nullable = false)
-    val signature: ByteArray,
+    @get:Column(name = "signature", nullable = false)
+    var signature: ByteArray,
 
-    @Column(name = "pub_key_hash", nullable = false)
-    val publicKeyHash: String,
+    @get:Column(name = "pub_key_hash", nullable = false)
+    var publicKeyHash: String,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant
+    @get:Column(name = "created", nullable = false)
+    var created: Instant
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -62,6 +62,6 @@ data class ConsensualTransactionSignatureEntity(
 
 @Embeddable
 data class ConsensualTransactionSignatureEntityId(
-    val transaction: ConsensualTransactionEntity,
-    val index: Int
+    var transaction: ConsensualTransactionEntity,
+    var index: Int
 ) : Serializable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualTransactionStatusEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/consensual/ConsensualTransactionStatusEntity.kt
@@ -17,21 +17,21 @@ import net.corda.v5.base.annotations.CordaSerializable
 @Table(name = "consensual_transaction_status")
 @IdClass(ConsensualTransactionStatusEntityId::class)
 data class ConsensualTransactionStatusEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: ConsensualTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: ConsensualTransactionEntity,
 
-    @Id
-    @Column(name = "status", nullable = false)
-    val status: String,
+    @get:Id
+    @get:Column(name = "status", nullable = false)
+    var status: String,
 
-    @Column(name = "updated", nullable = false)
-    val updated: Instant
+    @get:Column(name = "updated", nullable = false)
+    var updated: Instant
 )
 
 @Embeddable
 data class ConsensualTransactionStatusEntityId(
-    val transaction: ConsensualTransactionEntity,
-    val status: String
+    var transaction: ConsensualTransactionEntity,
+    var status: String
 ) : Serializable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionComponentEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionComponentEntity.kt
@@ -12,32 +12,33 @@ import javax.persistence.ManyToOne
 import javax.persistence.Table
 import net.corda.v5.base.annotations.CordaSerializable
 
+@Suppress("LongParameterList")
 @CordaSerializable
 @Entity
 @Table(name = "utxo_transaction_component")
 @IdClass(UtxoTransactionComponentEntityId::class)
 data class UtxoTransactionComponentEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: UtxoTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: UtxoTransactionEntity,
 
-    @Id
-    @Column(name = "group_idx", nullable = false)
-    val groupIndex: Int,
+    @get:Id
+    @get:Column(name = "group_idx", nullable = false)
+    var groupIndex: Int,
 
-    @Id
-    @Column(name = "leaf_idx", nullable = false)
-    val leafIndex: Int,
+    @get:Id
+    @get:Column(name = "leaf_idx", nullable = false)
+    var leafIndex: Int,
 
-    @Column(name = "data", nullable = false)
-    val data: ByteArray,
+    @get:Column(name = "data", nullable = false)
+    var data: ByteArray,
 
-    @Column(name = "hash", nullable = false)
-    val hash: String,
+    @get:Column(name = "hash", nullable = false)
+    var hash: String,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant
+    @get:Column(name = "created", nullable = false)
+    var created: Instant
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -68,7 +69,7 @@ data class UtxoTransactionComponentEntity(
 
 @Embeddable
 data class UtxoTransactionComponentEntityId(
-    val transaction: UtxoTransactionEntity,
-    val groupIndex: Int,
-    val leafIndex: Int
+    var transaction: UtxoTransactionEntity,
+    var groupIndex: Int,
+    var leafIndex: Int
 ) : Serializable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionEntity.kt
@@ -16,27 +16,27 @@ import net.corda.v5.base.annotations.CordaSerializable
 @Entity
 @Table(name = "utxo_transaction")
 data class UtxoTransactionEntity(
-    @Id
-    @Column(name = "id", nullable = false, updatable = false)
-    val id: String,
+    @get:Id
+    @get:Column(name = "id", nullable = false, updatable = false)
+    var id: String,
 
-    @Column(name = "privacy_salt", nullable = false)
-    val privacySalt: ByteArray,
+    @get:Column(name = "privacy_salt", nullable = false)
+    var privacySalt: ByteArray,
 
-    @Column(name = "account_id", nullable = false)
-    val accountId: String,
+    @get:Column(name = "account_id", nullable = false)
+    var accountId: String,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant,
+    @get:Column(name = "created", nullable = false)
+    var created: Instant,
 ) {
-    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val components: MutableList<UtxoTransactionComponentEntity> = mutableListOf()
+    @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var components: MutableList<UtxoTransactionComponentEntity> = mutableListOf()
 
-    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val statuses: MutableList<UtxoTransactionStatusEntity> = mutableListOf()
+    @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var statuses: MutableList<UtxoTransactionStatusEntity> = mutableListOf()
 
-    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val signatures: MutableList<UtxoTransactionSignatureEntity> = mutableListOf()
+    @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var signatures: MutableList<UtxoTransactionSignatureEntity> = mutableListOf()
 
     @ManyToMany(cascade = [CascadeType.PERSIST, CascadeType.MERGE])
     @JoinTable(name = "utxo_transaction_cpk",

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionOutputEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionOutputEntity.kt
@@ -23,50 +23,50 @@ import javax.persistence.Table
 @Table(name = "utxo_transaction_output")
 @IdClass(UtxoTransactionOutputEntityId::class)
 data class UtxoTransactionOutputEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: UtxoTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: UtxoTransactionEntity,
 
-    @Id
-    @Column(name = "group_idx", nullable = false)
-    val groupIndex: Int,
+    @get:Id
+    @get:Column(name = "group_idx", nullable = false)
+    var groupIndex: Int,
 
-    @Id
-    @Column(name = "leaf_idx", nullable = false)
-    val leafIndex: Int,
+    @get:Id
+    @get:Column(name = "leaf_idx", nullable = false)
+    var leafIndex: Int,
 
-    @Column(name = "type", nullable = true)
-    val type: String?,
+    @get:Column(name = "type", nullable = true)
+    var type: String?,
 
-    @Column(name = "token_type", nullable = true)
-    val tokenType: String?,
+    @get:Column(name = "token_type", nullable = true)
+    var tokenType: String?,
 
-    @Column(name = "token_issuer_hash", nullable = true)
-    val tokenIssuerHash: String?,
+    @get:Column(name = "token_issuer_hash", nullable = true)
+    var tokenIssuerHash: String?,
 
-    @Column(name = "token_notary_x500_name", nullable = true)
-    val tokenNotaryX500Name: String?,
+    @get:Column(name = "token_notary_x500_name", nullable = true)
+    var tokenNotaryX500Name: String?,
 
-    @Column(name = "token_symbol", nullable = true)
-    val tokenSymbol: String?,
+    @get:Column(name = "token_symbol", nullable = true)
+    var tokenSymbol: String?,
 
-    @Column(name = "token_tag", nullable = true)
-    val tokenTag: String?,
+    @get:Column(name = "token_tag", nullable = true)
+    var tokenTag: String?,
 
-    @Column(name = "token_owner_hash", nullable = true)
-    val tokenOwnerHash: String?,
+    @get:Column(name = "token_owner_hash", nullable = true)
+    var tokenOwnerHash: String?,
 
-    @Column(name = "token_amount", nullable = true)
-    val tokenAmount: BigDecimal?,
+    @get:Column(name = "token_amount", nullable = true)
+    var tokenAmount: BigDecimal?,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant
+    @get:Column(name = "created", nullable = false)
+    var created: Instant
 )
 
 @Embeddable
 data class UtxoTransactionOutputEntityId(
-    val transaction: UtxoTransactionEntity,
-    val groupIndex: Int,
-    val leafIndex: Int
+    var transaction: UtxoTransactionEntity,
+    var groupIndex: Int,
+    var leafIndex: Int
 ) : Serializable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionSignatureEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionSignatureEntity.kt
@@ -17,23 +17,23 @@ import net.corda.v5.base.annotations.CordaSerializable
 @Table(name = "utxo_transaction_signature")
 @IdClass(UtxoTransactionSignatureEntityId::class)
 data class UtxoTransactionSignatureEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: UtxoTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: UtxoTransactionEntity,
 
-    @Id
-    @Column(name = "signature_idx", nullable = false)
-    val index: Int,
+    @get:Id
+    @get:Column(name = "signature_idx", nullable = false)
+    var index: Int,
 
-    @Column(name = "signature", nullable = false)
-    val signature: ByteArray,
+    @get:Column(name = "signature", nullable = false)
+    var signature: ByteArray,
 
-    @Column(name = "pub_key_hash", nullable = false)
-    val publicKeyHash: String,
+    @get:Column(name = "pub_key_hash", nullable = false)
+    var publicKeyHash: String,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant
+    @get:Column(name = "created", nullable = false)
+    var created: Instant
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -62,6 +62,6 @@ data class UtxoTransactionSignatureEntity(
 
 @Embeddable
 data class UtxoTransactionSignatureEntityId(
-    val transaction: UtxoTransactionEntity,
-    val index: Int
+    var transaction: UtxoTransactionEntity,
+    var index: Int
 ) : Serializable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionSourceEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionSourceEntity.kt
@@ -22,35 +22,35 @@ import javax.persistence.Table
 @Table(name = "utxo_transaction_sources")
 @IdClass(UtxoTransactionSourceEntityId::class)
 data class UtxoTransactionSourceEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: UtxoTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: UtxoTransactionEntity,
 
-    @Id
-    @Column(name = "group_idx", nullable = false)
-    val groupIndex: Int,
+    @get:Id
+    @get:Column(name = "group_idx", nullable = false)
+    var groupIndex: Int,
 
-    @Id
-    @Column(name = "leaf_idx", nullable = false)
-    val leafIndex: Int,
+    @get:Id
+    @get:Column(name = "leaf_idx", nullable = false)
+    var leafIndex: Int,
 
-    @Column(name = "ref_transaction_id", nullable = false)
-    val refTransactionId: String,
+    @get:Column(name = "ref_transaction_id", nullable = false)
+    var refTransactionId: String,
 
-    @Column(name = "ref_leaf_idx", nullable = false)
-    val refLeafIndex: Int,
+    @get:Column(name = "ref_leaf_idx", nullable = false)
+    var refLeafIndex: Int,
 
-    @Column(name = "is_ref_input", nullable = false)
-    val isRefInput: Boolean,
+    @get:Column(name = "is_ref_input", nullable = false)
+    var isRefInput: Boolean,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant
+    @get:Column(name = "created", nullable = false)
+    var created: Instant
 )
 
 @Embeddable
 data class UtxoTransactionSourceEntityId(
-    val transaction: UtxoTransactionEntity,
-    val groupIndex: Int,
-    val leafIndex: Int
+    var transaction: UtxoTransactionEntity,
+    var groupIndex: Int,
+    var leafIndex: Int
 ) : Serializable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionStatusEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionStatusEntity.kt
@@ -17,21 +17,21 @@ import net.corda.v5.base.annotations.CordaSerializable
 @Table(name = "utxo_transaction_status")
 @IdClass(UtxoTransactionStatusEntityId::class)
 data class UtxoTransactionStatusEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: UtxoTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: UtxoTransactionEntity,
 
-    @Id
-    @Column(name = "status", nullable = false)
-    val status: String,
+    @get:Id
+    @get:Column(name = "status", nullable = false)
+    var status: String,
 
-    @Column(name = "updated", nullable = false)
-    val updated: Instant
+    @get:Column(name = "updated", nullable = false)
+    var updated: Instant
 )
 
 @Embeddable
 data class UtxoTransactionStatusEntityId(
-    val transaction: UtxoTransactionEntity,
-    val status: String
+    var transaction: UtxoTransactionEntity,
+    var status: String
 ) : Serializable

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoVisibleTransactionStateEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoVisibleTransactionStateEntity.kt
@@ -22,32 +22,32 @@ import javax.persistence.Table
 @Table(name = "utxo_visible_transaction_state")
 @IdClass(UtxoVisibleTransactionStateEntityId::class)
 data class UtxoVisibleTransactionStateEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: UtxoTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: UtxoTransactionEntity,
 
-    @Id
-    @Column(name = "group_idx", nullable = false)
-    val groupIndex: Int,
+    @get:Id
+    @get:Column(name = "group_idx", nullable = false)
+    var groupIndex: Int,
 
-    @Id
-    @Column(name = "leaf_idx", nullable = false)
-    val leafIndex: Int,
+    @get:Id
+    @get:Column(name = "leaf_idx", nullable = false)
+    var leafIndex: Int,
 
-    @Column(name = "custom_representation", nullable = false, columnDefinition = "jsonb")
-    val customRepresentation: String,
+    @get:Column(name = "custom_representation", nullable = false, columnDefinition = "jsonb")
+    var customRepresentation: String,
 
-    @Column(name = "created", nullable = false)
-    val created: Instant,
+    @get:Column(name = "created", nullable = false)
+    var created: Instant,
 
-    @Column(name = "consumed", nullable = true)
-    val consumed: Instant?
+    @get:Column(name = "consumed", nullable = true)
+    var consumed: Instant?
 )
 
 @Embeddable
 data class UtxoVisibleTransactionStateEntityId(
-    val transaction: UtxoTransactionEntity,
-    val groupIndex: Int,
-    val leafIndex: Int
+    var transaction: UtxoTransactionEntity,
+    var groupIndex: Int,
+    var leafIndex: Int
 ) : Serializable


### PR DESCRIPTION
Java 17 no longer allows non-`static` `final` fields to be modified via Java reflection. Alter the definitions of these JPA entities so that Hibernate can update them, and no longer needs to use reflection anyway.