### PR TITLE
CORE-15774: Update JPA entities used for testing to be Java 17 compatible.

### DIFF
--- a/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/test/entities/Cat.kt
+++ b/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/test/entities/Cat.kt
@@ -15,19 +15,21 @@ import javax.persistence.NamedQuery
 )
 @Entity
 data class Cat(
-    @Id
-    @Column
-    val id: UUID,
-    @Column
-    val name: String,
-    @Column
-    val colour: String,
+    @get:Id
+    @get:Column
+    var id: UUID,
 
-    @ManyToOne
-    @JoinColumns(
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var colour: String,
+
+    @get:ManyToOne
+    @get:JoinColumns(
         JoinColumn(name = "owner_id", referencedColumnName = "id")
     )
-    val owner: Owner?
+    var owner: Owner?
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "", colour = "sort-of-spotty", owner = null)
 }

--- a/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/test/entities/MutableEntity.kt
+++ b/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/test/entities/MutableEntity.kt
@@ -7,9 +7,10 @@ import javax.persistence.Id
 
 @Entity
 data class MutableEntity(
-    @Id
-    @Column
-    val id: UUID,
-    @Column
+    @get:Id
+    @get:Column
+    var id: UUID,
+
+    @get:Column
     var tag: String,
 )

--- a/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/test/entities/Owner.kt
+++ b/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/test/entities/Owner.kt
@@ -7,13 +7,15 @@ import javax.persistence.Id
 
 @Entity
 data class Owner(
-    @Id
-    @Column
-    val id: UUID,
-    @Column
-    val name: String,
-    @Column
-    val age: Int
+    @get:Id
+    @get:Column
+    var id: UUID,
+
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var age: Int
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "anonymous", age = Int.MAX_VALUE)
 }

--- a/simulator/api/src/main/kotlin/net/corda/simulator/entities/ConsensualTransactionEntity.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/entities/ConsensualTransactionEntity.kt
@@ -18,18 +18,18 @@ import javax.persistence.Table
 @Entity
 @Table(name = "consensual_transaction")
 class ConsensualTransactionEntity (
-    @Id
-    @Column(name="id")
-    val id: String,
+    @get:Id
+    @get:Column(name="id")
+    var id: String,
 
-    @Column(name="state_data")
-    val stateData: ByteArray,
+    @get:Column(name="state_data")
+    var stateData: ByteArray,
 
-    @Column(name="timestamp")
-    val timestamp: Instant,
+    @get:Column(name="timestamp")
+    var timestamp: Instant,
 
-    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    val signatures: MutableSet<ConsensualTransactionSignatureEntity> = mutableSetOf()
+    @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var signatures: MutableSet<ConsensualTransactionSignatureEntity> = mutableSetOf()
 ){
     override fun equals(other: Any?): Boolean {
         if(this === other) return true
@@ -59,20 +59,20 @@ class ConsensualTransactionEntity (
 @IdClass(ConsensualTransactionSignatureEntityId::class)
 class ConsensualTransactionSignatureEntity(
 
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "transaction_id", nullable = false, updatable = false)
-    val transaction: ConsensualTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
+    var transaction: ConsensualTransactionEntity,
 
-    @Id
-    @Column(name = "signature_idx", nullable = false)
-    val index: Int,
+    @get:Id
+    @get:Column(name = "signature_idx", nullable = false)
+    var index: Int,
 
-    @Column(name = "key", nullable = false)
-    val signatureWithKey: ByteArray,
+    @get:Column(name = "key", nullable = false)
+    var signatureWithKey: ByteArray,
 
-    @Column(name = "timestamp", nullable = false)
-    val timestamp: Instant
+    @get:Column(name = "timestamp", nullable = false)
+    var timestamp: Instant
 ){
     override fun equals(other: Any?): Boolean {
         if(this === other) return true
@@ -91,8 +91,8 @@ class ConsensualTransactionSignatureEntity(
 
 @Embeddable
 class ConsensualTransactionSignatureEntityId(
-    val transaction: ConsensualTransactionEntity,
-    val index: Int
+    var transaction: ConsensualTransactionEntity,
+    var index: Int
 ) : Serializable {
     override fun equals(other: Any?): Boolean {
         if(this === other) return true

--- a/simulator/api/src/main/kotlin/net/corda/simulator/entities/UtxoTransactionEntity.kt
+++ b/simulator/api/src/main/kotlin/net/corda/simulator/entities/UtxoTransactionEntity.kt
@@ -23,33 +23,33 @@ import javax.persistence.Embeddable
 @Entity
 @Table(name = "utxo_transaction")
 class UtxoTransactionEntity(
-    @Id
-    @Column(name="tx_id")
-    val id: String,
+    @get:Id
+    @get:Column(name="tx_id")
+    var id: String,
 
-    @Column(name="command_data")
-    val commandData: ByteArray,
+    @get:Column(name="command_data")
+    var commandData: ByteArray,
 
-    @Column(name="input_data")
-    val inputData: ByteArray,
+    @get:Column(name="input_data")
+    var inputData: ByteArray,
 
-    @Column(name="reference_state_data")
-    val referenceStateDate: ByteArray,
+    @get:Column(name="reference_state_data")
+    var referenceStateDate: ByteArray,
 
-    @Column(name="signatories_data")
-    val signatoriesData: ByteArray,
+    @get:Column(name="signatories_data")
+    var signatoriesData: ByteArray,
 
-    @Column(name="time_window_data")
-    val timeWindowData: ByteArray,
+    @get:Column(name="time_window_data")
+    var timeWindowData: ByteArray,
 
-    @Column(name="output_data")
-    val outputData: ByteArray,
+    @get:Column(name="output_data")
+    var outputData: ByteArray,
 
-    @Column(name="attachment_data")
-    val attachmentData: ByteArray,
+    @get:Column(name="attachment_data")
+    var attachmentData: ByteArray,
 
-    @OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    val signatures: MutableSet<UtxoTransactionSignatureEntity> = mutableSetOf(),
+    @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    var signatures: MutableSet<UtxoTransactionSignatureEntity> = mutableSetOf(),
 
 ){
     override fun equals(other: Any?): Boolean {
@@ -83,20 +83,20 @@ class UtxoTransactionEntity(
 @Table(name = "utxo_transaction_signature")
 @IdClass(UtxoTransactionEntityId::class)
 class UtxoTransactionSignatureEntity(
-    @Id
-    @ManyToOne
-    @JoinColumn(name = "tx_id", nullable = false, updatable = false)
-    val transaction: UtxoTransactionEntity,
+    @get:Id
+    @get:ManyToOne
+    @get:JoinColumn(name = "tx_id", nullable = false, updatable = false)
+    var transaction: UtxoTransactionEntity,
 
-    @Id
-    @Column(name = "signature_idx", nullable = false)
-    val index: Int,
+    @get:Id
+    @get:Column(name = "signature_idx", nullable = false)
+    var index: Int,
 
-    @Column(name = "key", nullable = false)
-    val signatureWithKey: ByteArray,
+    @get:Column(name = "key", nullable = false)
+    var signatureWithKey: ByteArray,
 
-    @Column(name = "timestamp", nullable = false)
-    val timestamp: Instant
+    @get:Column(name = "timestamp", nullable = false)
+    var timestamp: Instant
 ){
     override fun equals(other: Any?): Boolean {
         if(this === other) return true
@@ -126,24 +126,24 @@ class UtxoTransactionSignatureEntity(
     query = "from UtxoTransactionOutputEntity where consumed = false and type = :type"
 )
 class UtxoTransactionOutputEntity(
-    @Id
-    @Column(name = "tx_id", nullable = false, updatable = false)
-    val transactionId: String,
+    @get:Id
+    @get:Column(name = "tx_id", nullable = false, updatable = false)
+    var transactionId: String,
 
-    @Column(name = "type", nullable = true)
-    val type: String?,
+    @get:Column(name = "type", nullable = true)
+    var type: String?,
 
-    @Column(name="encumbrance_data")
-    val encumbranceData: ByteArray,
+    @get:Column(name="encumbrance_data")
+    var encumbranceData: ByteArray,
 
-    @Column(name="state_data")
-    val stateData: ByteArray,
+    @get:Column(name="state_data")
+    var stateData: ByteArray,
 
-    @Id
-    @Column(name = "index", nullable = false)
-    val index: Int,
+    @get:Id
+    @get:Column(name = "index", nullable = false)
+    var index: Int,
 
-    @Column(name = "consumed", nullable = false)
+    @get:Column(name = "consumed", nullable = false)
     var isConsumed: Boolean,
 
 ): Serializable {
@@ -164,8 +164,8 @@ class UtxoTransactionOutputEntity(
 
 @Embeddable
 data class UtxoTransactionEntityId(
-    val transaction: UtxoTransactionEntity,
-    val index: Int
+    var transaction: UtxoTransactionEntity,
+    var index: Int
 ) : Serializable{
     override fun equals(other: Any?): Boolean {
         if(this === other) return true
@@ -184,8 +184,8 @@ data class UtxoTransactionEntityId(
 
 @Embeddable
 data class UtxoTransactionOutputEntityId(
-    val transactionId: String,
-    val index: Int
+    var transactionId: String,
+    var index: Int
 ) : Serializable{
     override fun equals(other: Any?): Boolean {
         if(this === other) return true

--- a/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
+++ b/simulator/example-app/src/main/kotlin/net/cordacon/example/rollcall/TruancyResponderFlow.kt
@@ -79,11 +79,12 @@ class TruancyResponderFlow : ResponderFlow {
 @Entity
 @Table(name = "truancy_entity")
 data class TruancyEntity(
-    @Id
-    @Column(name = "id")
-    val id: UUID = UUID.randomUUID(),
-    @Column(name = "student_name")
-    val name: String
+    @get:Id
+    @get:Column(name = "id")
+    var id: UUID = UUID.randomUUID(),
+
+    @get:Column(name = "student_name")
+    var name: String
 )
 
 private fun PublicKey.fullIdHash(digestService: DigestService): SecureHash =

--- a/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/persistence/GreetingEntity.kt
+++ b/simulator/runtime/src/test/kotlin/net/corda/simulator/runtime/persistence/GreetingEntity.kt
@@ -14,9 +14,10 @@ import javax.persistence.Table
 @Entity
 @Table(name="greetingentity")
 data class GreetingEntity (
-    @Id
-    @Column(name="id")
-    val id: UUID,
-    @Column(name="greeting")
-    val greeting: String
+    @get:Id
+    @get:Column(name="id")
+    var id: UUID,
+
+    @get:Column(name="greeting")
+    var greeting: String
 )

--- a/testing/bundles/cpk-for-duplicate-changelog-testing/src/main/kotlin/com/r3/corda/testing/bundles/changelog/Cart.kt
+++ b/testing/bundles/cpk-for-duplicate-changelog-testing/src/main/kotlin/com/r3/corda/testing/bundles/changelog/Cart.kt
@@ -9,11 +9,13 @@ import javax.persistence.Id
 @CordaSerializable
 @Entity
 class Cart(
-    @Id
-    @Column
-    val id: String,
-    @Column
-    val name: String,
-    @Column
-    val colour: String,
+    @get:Id
+    @get:Column
+    var id: String,
+
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var colour: String,
 )

--- a/testing/bundles/testing-cats/src/main/kotlin/com/r3/corda/testing/bundles/cats/Cat.kt
+++ b/testing/bundles/testing-cats/src/main/kotlin/com/r3/corda/testing/bundles/cats/Cat.kt
@@ -17,20 +17,22 @@ import javax.persistence.ManyToOne
 @Entity
 @IdClass(CatKey::class)
 data class Cat(
-    @Id
-    @Column
-    val id: UUID,
-    @Id
-    @Column
-    val name: String,
-    @Column
-    val colour: String,
+    @get:Id
+    @get:Column
+    var id: UUID,
 
-    @ManyToOne(fetch= FetchType.EAGER, cascade = [CascadeType.ALL])
-    @JoinColumns(
+    @get:Id
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var colour: String,
+
+    @get:ManyToOne(fetch= FetchType.EAGER, cascade = [CascadeType.ALL])
+    @get:JoinColumns(
         JoinColumn(name = "owner_id", referencedColumnName = "id")
     )
-    val owner: Owner?
+    var owner: Owner?
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "", colour = "sort-of-spotty", owner = null)
 }

--- a/testing/bundles/testing-cats/src/main/kotlin/com/r3/corda/testing/bundles/cats/Owner.kt
+++ b/testing/bundles/testing-cats/src/main/kotlin/com/r3/corda/testing/bundles/cats/Owner.kt
@@ -9,13 +9,15 @@ import javax.persistence.Id
 @CordaSerializable
 @Entity
 data class Owner(
-    @Id
-    @Column
-    val id: UUID,
-    @Column
-    val name: String,
-    @Column
-    val age: Int
+    @get:Id
+    @get:Column
+    var id: UUID,
+
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var age: Int
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "anonymous", age = Int.MAX_VALUE)
 }

--- a/testing/bundles/testing-dogs/src/main/kotlin/com/r3/corda/testing/bundles/dogs/Dog.kt
+++ b/testing/bundles/testing-dogs/src/main/kotlin/com/r3/corda/testing/bundles/dogs/Dog.kt
@@ -20,16 +20,18 @@ import javax.persistence.NamedQuery
     NamedQuery(name = "Dog.count", query = "SELECT COUNT(1) FROM Dog")
 )
 data class Dog(
-    @Id
+    @get:Id
+    @get:Column
+    var id: UUID,
+
     @Column
-    val id: UUID,
+    var name: String,
+
     @Column
-    val name: String,
+    var birthdate: Instant,
+
     @Column
-    val birthdate: Instant,
-    @Column
-    val owner: String?
+    var owner: String?
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "", birthdate = Instant.now(), owner = "")
 }
-

--- a/testing/bundles/testing-fish/src/main/kotlin/com/r3/corda/testing/bundles/fish/Fish.kt
+++ b/testing/bundles/testing-fish/src/main/kotlin/com/r3/corda/testing/bundles/fish/Fish.kt
@@ -17,20 +17,22 @@ import javax.persistence.ManyToOne
 @Entity
 @IdClass(FishKey::class)
 data class Fish(
-    @Id
-    @Column
-    val id: UUID,
-    @Id
-    @Column
-    val name: String,
-    @Column
-    val colour: String,
+    @get:Id
+    @get:Column
+    var id: UUID,
 
-    @ManyToOne(fetch= FetchType.EAGER, cascade = [CascadeType.ALL])
-    @JoinColumns(
+    @get:Id
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var colour: String,
+
+    @get:ManyToOne(fetch= FetchType.EAGER, cascade = [CascadeType.ALL])
+    @get:JoinColumns(
         JoinColumn(name = "owner_id", referencedColumnName = "id")
     )
-    val owner: Owner?
+    var owner: Owner?
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "", colour = "sort-of-spotty", owner = null)
 }

--- a/testing/bundles/testing-fish/src/main/kotlin/com/r3/corda/testing/bundles/fish/Owner.kt
+++ b/testing/bundles/testing-fish/src/main/kotlin/com/r3/corda/testing/bundles/fish/Owner.kt
@@ -9,13 +9,15 @@ import javax.persistence.Id
 @CordaSerializable
 @Entity
 data class Owner(
-    @Id
-    @Column
-    val id: UUID,
-    @Column
-    val name: String,
-    @Column
-    val age: Int
+    @get:Id
+    @get:Column
+    var id: UUID,
+
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var age: Int
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "anonymous", age = Int.MAX_VALUE)
 }

--- a/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v1/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/Fish.kt
+++ b/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v1/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/Fish.kt
@@ -17,20 +17,22 @@ import javax.persistence.ManyToOne
 @Entity
 @IdClass(FishKey::class)
 data class Fish(
-    @Id
-    @Column
-    val id: UUID,
-    @Id
-    @Column
-    val name: String,
-    @Column
-    val colour: String,
+    @get:Id
+    @get:Column
+    var id: UUID,
 
-    @ManyToOne(fetch= FetchType.EAGER, cascade = [CascadeType.ALL])
-    @JoinColumns(
+    @get:Id
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var colour: String,
+
+    @get:ManyToOne(fetch= FetchType.EAGER, cascade = [CascadeType.ALL])
+    @get:JoinColumns(
         JoinColumn(name = "owner_id", referencedColumnName = "id")
     )
-    val owner: Owner?
+    var owner: Owner?
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "", colour = "sort-of-spotty", owner = null)
 }

--- a/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v1/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/Owner.kt
+++ b/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v1/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/Owner.kt
@@ -9,13 +9,15 @@ import javax.persistence.Id
 @CordaSerializable
 @Entity
 data class Owner(
-    @Id
-    @Column
-    val id: UUID,
-    @Column
-    val name: String,
-    @Column
-    val age: Int
+    @get:Id
+    @get:Column
+    var id: UUID,
+
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var age: Int
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "anonymous", age = Int.MAX_VALUE)
 }

--- a/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v2/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/Dog.kt
+++ b/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v2/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/Dog.kt
@@ -20,16 +20,18 @@ import javax.persistence.NamedQuery
     NamedQuery(name = "Dog.count", query = "SELECT COUNT(1) FROM Dog")
 )
 data class Dog(
-    @Id
-    @Column
-    val id: UUID,
-    @Column
-    val name: String,
-    @Column
-    val birthdate: Instant,
-    @Column
-    val owner: String?
+    @get:Id
+    @get:Column
+    var id: UUID,
+
+    @get:Column
+    var name: String,
+
+    @get:Column
+    var birthdate: Instant,
+
+    @get:Column
+    var owner: String?
 ) {
     constructor() : this(id = UUID.randomUUID(), name = "", birthdate = Instant.now(), owner = "")
 }
-


### PR DESCRIPTION
Ensure underlying fields in these JPA entities are not `final` by declaring them as `var` rather than `val`. Also use "property access" rather than "field access" so that Hibernate doesn't need to use Java reflection to modify them in the first place.