### PR TITLE
CORE-15770: Update CLI plugin's SqlFormatter to understand Hibernate property access.

### DIFF
--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/SqlFormatters.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/SqlFormatters.kt
@@ -5,10 +5,13 @@ import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.Table
 import javax.persistence.Version
+import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.javaGetter
+import org.slf4j.LoggerFactory
 
 /**
  * Create the SQL insert statement to persist an object annotated as javax.persistence.Entity
@@ -16,10 +19,10 @@ import kotlin.reflect.jvm.javaField
  * and that all columns are either annotated as @Column, @JoinColumn or @Version.
  */
 fun Any.toInsertStatement(): String {
-    val values = this::class.declaredMemberProperties.mapNotNull { field ->
-        val columnInfo = getColumnInfo(field) ?: return@mapNotNull null
-        field.isAccessible = true
-        val value = formatValue(extractValue(field, this, columnInfo.joinColumn)) ?: return@mapNotNull null
+    val values = this::class.declaredMemberProperties.mapNotNull { property ->
+        val columnInfo = getColumnInfo(property) ?: return@mapNotNull null
+        property.isAccessible = true
+        val value = formatValue(extractValue(property, this, columnInfo.joinColumn)) ?: return@mapNotNull null
         columnInfo.name to value
     }
 
@@ -39,23 +42,33 @@ private fun formatValue(value: Any?): String? {
 
 private data class ColumnInfo(val name: String, val joinColumn: Boolean)
 
-private fun getColumnInfo(field: KProperty1<out Any, *>): ColumnInfo? {
-    field.javaField?.getAnnotation<Column>(Column::class.java)?.name?.let { name ->
+private fun getColumnInfo(property: KProperty1<out Any, *>): ColumnInfo? {
+    property.getVarAnnotation(Column::class.java)?.name?.let { name ->
         return if (name.isBlank()) {
-            ColumnInfo(field.name, false)
-        } else
+            ColumnInfo(property.name, false)
+        } else {
             ColumnInfo(name, false)
+        }
     }
-    field.javaField?.getAnnotation<JoinColumn>(JoinColumn::class.java)?.name?.let { name ->
+    property.getVarAnnotation(JoinColumn::class.java)?.name?.let { name ->
         return if (name.isBlank()) {
-            ColumnInfo(field.name, true)
-        } else
+            ColumnInfo(property.name, true)
+        } else {
             ColumnInfo(name, true)
+        }
     }
-    field.javaField?.getAnnotation<Version>(Version::class.java)?.let {
-        return ColumnInfo("version", false)
+    return property.getVarAnnotation(Version::class.java)?.let {
+        ColumnInfo("version", false)
     }
-    return null
+}
+
+private fun <T : Annotation> KProperty1<*, *>.getVarAnnotation(type: Class<T>): T? {
+    return (javaField?.getAnnotation(type) ?: javaGetter?.getAnnotation(type))?.also {
+        if (this !is KMutableProperty1<*, *>) {
+            //throw IllegalArgumentException("Property '$this' must be var for JPA annotations.")
+            LoggerFactory.getLogger(this::class.java.name).warn("Property '$this' must be var for JPA annotations.")
+        }
+    }
 }
 
 private fun String.simpleSqlEscaping(): String {
@@ -77,7 +90,7 @@ private fun extractValue(field: KProperty1<out Any?, *>, obj: Any, getId: Boolea
     if (!getId || value == null)
         return value
     value::class.declaredMemberProperties.forEach { property ->
-        if (property.javaField?.getAnnotation<Id>(Id::class.java) != null) {
+        if (property.getVarAnnotation(Id::class.java) != null) {
             property.isAccessible = true
             return property.getter.call(value)
         }

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForFieldAccess.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForFieldAccess.kt
@@ -1,0 +1,202 @@
+package net.corda.cli.plugin.initialconfig
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.Table
+import javax.persistence.Version
+import org.junit.jupiter.api.Disabled
+
+class TestSqlFormattersForFieldAccess {
+
+    @Entity
+    @Table(name = "testtable", schema = "testschema")
+    private class TestEntity(
+        @Suppress("Unused")
+        @Column(name = "testyMcTestFace", nullable = false)
+        var testFace: String,
+
+        @Suppress("Unused")
+        @Column(name = "testNumber")
+        var testNum: Int,
+
+        @Suppress("Unused")
+        @Column(name = "testDate")
+        var testDate: Instant? = null,
+
+        @Suppress("Unused")
+        @JoinColumn(name = "crossRef")
+        var reference: ReferencedEntity? = null
+    )
+
+    @Entity
+    @Table(name = "testtable", schema = "testschema")
+    private class VersionedTestEntity(
+        @Suppress("Unused")
+        @Column(name = "testyMcTestFace", nullable = false)
+        var testFace: String
+    ) {
+        @Suppress("Unused")
+        @Version
+        var version: Int = 0
+    }
+
+    @Entity
+    @Table(name = "testRefTable", schema = "testschema")
+    private class ReferencedEntity(
+        @Suppress("Unused")
+        @Id
+        @Column(name = "name", nullable = false)
+        var name: String
+    )
+
+    @Entity
+    @Table(name = "testRefTable", schema = "testschema")
+    private class InvalidReferencedEntity(
+        @Suppress("Unused")
+        @JoinColumn(name = "reference")
+        var reference: VersionedTestEntity
+    )
+
+    @Entity
+    @Table(name = "NoSchemaTable")
+    private class NoSchemaEntity(
+        @Suppress("Unused")
+        @Column(name = "testface")
+        var testface: String
+    )
+
+    @Entity
+    @Table
+    private class NoNameEntity(
+        @Suppress("Unused")
+        @Column(name = "testface")
+        var testFace: String
+    )
+
+    @Entity
+    @Table(name = "UnnamedColumn")
+    private class UnnamedColumnEntity(
+        @Suppress("Unused")
+        @Column
+        var testFace: String
+    )
+
+    @Entity
+    @Table(name = "HasValProperty")
+    private class EntityWithValProperty(
+        @Suppress("Unused")
+        @Column
+        val testFace: String
+    )
+
+    @Test
+    fun testToInsertStatementNullValueGetsIgnored() {
+        val ent = TestEntity("face", 42)
+        val statement = ent.toInsertStatement()
+
+        assertEquals(
+            "insert into testschema.testtable (testyMcTestFace, testNumber) " +
+                "values ('face', 42)",
+            statement
+        )
+    }
+
+    @Test
+    fun testToInsertStatementTimeStamp() {
+        val ent = TestEntity("face", 42, Instant.ofEpochSecond(123456))
+        val statement = ent.toInsertStatement()
+
+        assertEquals(
+            "insert into testschema.testtable (testDate, testyMcTestFace, testNumber) " +
+                "values ('1970-01-02T10:17:36Z', 'face', 42)",
+            statement
+        )
+    }
+
+    @Test
+    fun testToInsertStatementJoinColumn() {
+        val ent = TestEntity("face", 42, reference = ReferencedEntity("ref#1"))
+        val statement = ent.toInsertStatement()
+
+        assertEquals(
+            "insert into testschema.testtable (crossRef, testyMcTestFace, testNumber) " +
+                "values ('ref#1', 'face', 42)",
+            statement
+        )
+    }
+
+    @Test
+    fun testToInsertStatementVersioned() {
+        val ent = VersionedTestEntity("face")
+        val statement = ent.toInsertStatement()
+
+        assertEquals(
+            "insert into testschema.testtable (testyMcTestFace, version) " +
+                "values ('face', 0)",
+            statement
+        )
+    }
+
+    @Test
+    fun testToInsertStatementBobbyTables() {
+        val testEntity = TestEntity("Robert'); DROP TABLE Students;--", 34)
+        val statement = testEntity.toInsertStatement()
+
+        assertEquals(
+            "insert into testschema.testtable (testyMcTestFace, testNumber) " +
+                "values ('Robert\\'); DROP TABLE Students;--', 34)",
+            statement
+        )
+    }
+
+    @Test
+    fun joinColumnWithMissingIdBlowsUp() {
+        val ent = InvalidReferencedEntity(VersionedTestEntity("foo"))
+
+        val ex = assertThrows<java.lang.IllegalArgumentException> { ent.toInsertStatement() }
+        assertEquals(
+            "Value " +
+                "net.corda.cli.plugin.initialconfig.TestSqlFormattersForFieldAccess.VersionedTestEntity for join " +
+                "column does not have a primary key/id column",
+            ex.message
+        )
+    }
+
+    @Test
+    fun testToInsertStatementNoSchema() {
+        val ent = NoSchemaEntity("test")
+        val statement = ent.toInsertStatement()
+        assertEquals("insert into NoSchemaTable (testface) values ('test')", statement)
+    }
+
+    @Test
+    fun testMissingTableName() {
+        val ent = NoNameEntity("test")
+        val statement = ent.toInsertStatement()
+        assertEquals("insert into NoNameEntity (testface) values ('test')", statement)
+    }
+
+    @Test
+    fun testMissingColumnName() {
+        val ent = UnnamedColumnEntity("test")
+        val statement = ent.toInsertStatement()
+        assertEquals("insert into UnnamedColumn (testFace) values ('test')", statement)
+    }
+
+    @Disabled
+    @Test
+    fun testEntityWithValProperty() {
+        val ent = EntityWithValProperty("test")
+        val ex = assertThrows<IllegalArgumentException> { ent.toInsertStatement() }
+        assertEquals(
+            "Property 'val ${EntityWithValProperty::class.java.canonicalName}.testFace: kotlin.String' must be var for JPA annotations.",
+            ex.message
+        )
+    }
+}


### PR DESCRIPTION
Update `SqlFormatter` to check for JPA property annotations on both the underlying field and the getter method.

Log a warning for each `val` property that has JPA annotations. This will become an error once all JPA entities have been updated.