### PR TITLE
CORE-15642 - Persist token attributes in the output table

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -405,7 +405,7 @@ class UtxoPersistenceServiceImplTest {
                     assertThat(dbInput.field<String>("type")).isEqualTo(transactionOutput::class.java.canonicalName)
                     assertThat(dbInput.field<String>("tokenType")).isNull()
                     assertThat(dbInput.field<String>("tokenIssuerHash")).isNull()
-                    assertThat(dbInput.field<String>("tokenNotaryX500Name")).isNull()
+                    assertThat(dbInput.field<String>("tokenNotaryX500Name")).isEqualTo(notaryX500Name.toString())
                     assertThat(dbInput.field<String>("tokenSymbol")).isNull()
                     assertThat(dbInput.field<String>("tokenTag")).isNull()
                     assertThat(dbInput.field<String>("tokenOwnerHash")).isNull()

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -405,7 +405,6 @@ class UtxoPersistenceServiceImplTest {
                     assertThat(dbInput.field<String>("type")).isEqualTo(transactionOutput::class.java.canonicalName)
                     assertThat(dbInput.field<String>("tokenType")).isNull()
                     assertThat(dbInput.field<String>("tokenIssuerHash")).isNull()
-                    assertThat(dbInput.field<String>("tokenNotaryX500Name")).isEqualTo(notaryX500Name.toString())
                     assertThat(dbInput.field<String>("tokenSymbol")).isNull()
                     assertThat(dbInput.field<String>("tokenTag")).isNull()
                     assertThat(dbInput.field<String>("tokenOwnerHash")).isNull()

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateRef
+import net.corda.v5.ledger.utxo.observer.UtxoToken
 
 interface UtxoPersistenceService {
     fun findTransaction(id: String, transactionStatus: TransactionStatus): Pair<SignedTransactionContainer?, String?>
@@ -15,7 +16,7 @@ interface UtxoPersistenceService {
 
     fun resolveStateRefs(stateRefs: List<StateRef>): List<UtxoTransactionOutputDto>
 
-    fun persistTransaction(transaction: UtxoTransactionReader): List<CordaPackageSummary>
+    fun persistTransaction(transaction: UtxoTransactionReader, utxoTokenMap: Map<StateRef, UtxoToken> = emptyMap()): List<CordaPackageSummary>
 
     fun persistTransactionIfDoesNotExist(transaction: UtxoTransactionReader): Pair<String?, List<CordaPackageSummary>>
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -16,7 +16,10 @@ interface UtxoPersistenceService {
 
     fun resolveStateRefs(stateRefs: List<StateRef>): List<UtxoTransactionOutputDto>
 
-    fun persistTransaction(transaction: UtxoTransactionReader, utxoTokenMap: Map<StateRef, UtxoToken> = emptyMap()): List<CordaPackageSummary>
+    fun persistTransaction(
+        transaction: UtxoTransactionReader,
+        utxoTokenMap: Map<StateRef, UtxoToken> = emptyMap()
+    ): List<CordaPackageSummary>
 
     fun persistTransactionIfDoesNotExist(transaction: UtxoTransactionReader): Pair<String?, List<CordaPackageSummary>>
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -95,7 +95,6 @@ interface UtxoRepository {
         type: String,
         tokenType: String? = null,
         tokenIssuerHash: String? = null,
-        tokenNotaryX500Name: String? = null,
         tokenSymbol: String? = null,
         tokenTag: String? = null,
         tokenOwnerHash: String? = null,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistTransactionRequestHandler.kt
@@ -45,10 +45,10 @@ class UtxoPersistTransactionRequestHandler @Suppress("LongParameterList") constr
             listOf()
         }
 
-        val unconsumedTokensMap = listOfPairsStateAndUtxoToken.associate { it.first.ref to it.second }
+        val utxoTokenMap = listOfPairsStateAndUtxoToken.associate { it.first.ref to it.second }
 
         // persist the transaction
-        persistenceService.persistTransaction(transaction, unconsumedTokensMap)
+        persistenceService.persistTransaction(transaction, utxoTokenMap)
 
         // return output records
         return outputTokenRecords + utxoOutputRecordFactory.getPersistTransactionSuccessRecord(externalEventContext)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -110,7 +110,11 @@ class UtxoPersistenceServiceImpl(
         }
     }
 
-    private fun persistTransaction(em: EntityManager, transaction: UtxoTransactionReader, utxoTokenMap: Map<StateRef, UtxoToken> = emptyMap()): List<CordaPackageSummary> {
+    private fun persistTransaction(
+        em: EntityManager,
+        transaction: UtxoTransactionReader,
+        utxoTokenMap: Map<StateRef, UtxoToken> = emptyMap()
+    ): List<CordaPackageSummary> {
         val nowUtc = utcClock.instant()
         val transactionIdString = transaction.id.toString()
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -168,7 +168,6 @@ class UtxoPersistenceServiceImpl(
                 stateAndRef.state.contractState::class.java.canonicalName,
                 utxoToken?.poolKey?.tokenType,
                 utxoToken?.poolKey?.issuerHash?.toString(),
-                stateAndRef.state.notaryName.toString(),
                 utxoToken?.poolKey?.symbol,
                 utxoToken?.filterFields?.tag,
                 utxoToken?.filterFields?.ownerHash?.toString(),

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -171,7 +171,7 @@ class UtxoPersistenceServiceImpl(
                 stateAndRef.state.notaryName.toString(),
                 utxoToken?.poolKey?.symbol,
                 utxoToken?.filterFields?.tag,
-                utxoToken?.filterFields?.ownerHash.toString(),
+                utxoToken?.filterFields?.ownerHash?.toString(),
                 utxoToken?.amount,
                 nowUtc
             )

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -29,6 +29,7 @@ import net.corda.v5.ledger.utxo.query.json.ContractStateVaultJsonFactory
 import org.slf4j.LoggerFactory
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
+import net.corda.v5.ledger.utxo.observer.UtxoToken
 
 @Suppress("LongParameterList")
 class UtxoPersistenceServiceImpl(
@@ -103,13 +104,13 @@ class UtxoPersistenceServiceImpl(
         } ?: emptyList()
     }
 
-    override fun persistTransaction(transaction: UtxoTransactionReader): List<CordaPackageSummary> {
+    override fun persistTransaction(transaction: UtxoTransactionReader, utxoTokenMap: Map<StateRef, UtxoToken>): List<CordaPackageSummary> {
         entityManagerFactory.transaction { em ->
-            return persistTransaction(em, transaction)
+            return persistTransaction(em, transaction, utxoTokenMap)
         }
     }
 
-    private fun persistTransaction(em: EntityManager, transaction: UtxoTransactionReader): List<CordaPackageSummary> {
+    private fun persistTransaction(em: EntityManager, transaction: UtxoTransactionReader, utxoTokenMap: Map<StateRef, UtxoToken> = emptyMap()): List<CordaPackageSummary> {
         val nowUtc = utcClock.instant()
         val transactionIdString = transaction.id.toString()
 
@@ -154,13 +155,21 @@ class UtxoPersistenceServiceImpl(
 
         // Insert outputs data
         transaction.getVisibleStates().entries.forEach { (stateIndex, stateAndRef) ->
+            val utxoToken = utxoTokenMap[stateAndRef.ref]
             repository.persistTransactionOutput(
                 em,
                 transactionIdString,
                 UtxoComponentGroup.OUTPUTS.ordinal,
                 stateIndex,
                 stateAndRef.state.contractState::class.java.canonicalName,
-                timestamp = nowUtc
+                utxoToken?.poolKey?.tokenType,
+                utxoToken?.poolKey?.issuerHash?.toString(),
+                stateAndRef.state.notaryName.toString(),
+                utxoToken?.poolKey?.symbol,
+                utxoToken?.filterFields?.tag,
+                utxoToken?.filterFields?.ownerHash.toString(),
+                utxoToken?.amount,
+                nowUtc
             )
         }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -292,7 +292,6 @@ class UtxoRepositoryImpl @Activate constructor(
         type: String,
         tokenType: String?,
         tokenIssuerHash: String?,
-        tokenNotaryX500Name: String?,
         tokenSymbol: String?,
         tokenTag: String?,
         tokenOwnerHash: String?,
@@ -302,10 +301,10 @@ class UtxoRepositoryImpl @Activate constructor(
         entityManager.createNativeQuery(
             """
             INSERT INTO {h-schema}utxo_transaction_output(
-                transaction_id, group_idx, leaf_idx, type, token_type, token_issuer_hash, token_notary_x500_name,
+                transaction_id, group_idx, leaf_idx, type, token_type, token_issuer_hash,
                 token_symbol, token_tag, token_owner_hash, token_amount, created)
             VALUES(
-                :transactionId, :groupIndex, :leafIndex, :type, :tokenType, :tokenIssuerHash, :tokenNotaryX500Name,
+                :transactionId, :groupIndex, :leafIndex, :type, :tokenType, :tokenIssuerHash,
                 :tokenSymbol, :tokenTag, :tokenOwnerHash, :tokenAmount, :createdAt)
             ON CONFLICT DO NOTHING"""
         )
@@ -315,7 +314,6 @@ class UtxoRepositoryImpl @Activate constructor(
             .setParameter("type", type)
             .setParameter("tokenType", tokenType)
             .setParameter("tokenIssuerHash", tokenIssuerHash)
-            .setParameter("tokenNotaryX500Name", tokenNotaryX500Name)
             .setParameter("tokenSymbol", tokenSymbol)
             .setParameter("tokenTag", tokenTag)
             .setParameter("tokenOwnerHash", tokenOwnerHash)

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
@@ -33,6 +33,7 @@ import java.lang.IllegalArgumentException
 import java.security.PublicKey
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
+import net.corda.v5.base.types.MemberX500Name
 
 // FIXME / NOTE: This test only tests custom representation (JSON) string functionality
 class UtxoPersistenceServiceImplTest {
@@ -297,6 +298,7 @@ class UtxoPersistenceServiceImplTest {
     private inline fun <reified T : ContractState> createStateAndRef(returnState: T): StateAndRef<T> {
         val txState = mock<TransactionState<T>> {
             on { contractState } doReturn returnState
+            on { notaryName } doReturn MemberX500Name.parse("O=notary, L=London, C=GB")
         }
         val secureHash = mock<SecureHash> {
             on { toString() } doReturn "hash"

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
@@ -50,7 +50,7 @@ class UtxoPersistenceServiceImplTest {
         on { persistTransaction(any(), any(), any(), any(), any()) } doAnswer {}
         on { persistTransactionComponentLeaf(any(), any(), any(), any(), any(), any(), any()) } doAnswer {}
         on { persistTransactionOutput(any(), any(), any(), any(), any(), any(), any(), any(), any(),
-            any(), any(), any(), any()) } doAnswer {}
+            any(), any(), any()) } doAnswer {}
     }
 
     private val mockPrivacySalt = mock<PrivacySalt> {

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionOutputEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionOutputEntity.kt
@@ -45,9 +45,6 @@ data class UtxoTransactionOutputEntity(
     @get:Column(name = "token_issuer_hash", nullable = true)
     var tokenIssuerHash: String?,
 
-    @get:Column(name = "token_notary_x500_name", nullable = true)
-    var tokenNotaryX500Name: String?,
-
     @get:Column(name = "token_symbol", nullable = true)
     var tokenSymbol: String?,
 


### PR DESCRIPTION
Before this change the columns `tokenType`, `tokenIssuerHash`, `tokenSymbol`, `tokenTag`, `tokenOwnerHash`, and `tokenAmount` were not being populated.

Output table after updating the code:
![image](https://github.com/corda/corda-runtime-os/assets/6329837/5668eb64-9796-4994-9876-200eb2aa0341)
