### PR TITLE
CORE-15770: Update remaining JPA entities to use var properties with property access

### DIFF
--- a/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/HSMAssociationEntity.kt
+++ b/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/HSMAssociationEntity.kt
@@ -19,7 +19,7 @@ class HSMAssociationEntity(
      */
     @Id
     @Column(name = "id", nullable = false, updatable = false, length = 36)
-    val id: String,
+    var id: String,
 
     /**
      * Tenant which the configuration belongs to.

--- a/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/HSMCategoryAssociationEntity.kt
+++ b/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/HSMCategoryAssociationEntity.kt
@@ -22,7 +22,7 @@ class HSMCategoryAssociationEntity(
      */
     @Id
     @Column(name = "id", nullable = false, updatable = false, length = 36)
-    val id: String,
+    var id: String,
 
     /**
      * Tenant which the association belongs to, added as the means to keep uniqueness for tenant/category/deprecation

--- a/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/SigningKeyEntity.kt
+++ b/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/SigningKeyEntity.kt
@@ -27,7 +27,7 @@ class SigningKeyEntity(
      */
     @Id
     @Column(name = "id", nullable = false)
-    val id: UUID,
+    var id: UUID,
 
     /**
      * Tenant which the key belongs to.

--- a/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/SigningKeyMaterialEntity.kt
+++ b/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/SigningKeyMaterialEntity.kt
@@ -50,8 +50,9 @@ class SigningKeyMaterialEntity(
                 other.wrappingKeyId.equals(this.wrappingKeyId) &&
                 other.signingKeyId.equals(this.signingKeyId)
 }
+
 @Embeddable
 data class SigningKeyMaterialEntityId(
-    val wrappingKeyId: UUID,
-    val signingKeyId: UUID,
+    var wrappingKeyId: UUID,
+    var signingKeyId: UUID,
 ) : Serializable

--- a/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/WrappingKeyEntity.kt
+++ b/components/crypto/crypto-persistence-model/src/main/kotlin/net/corda/crypto/persistence/db/model/WrappingKeyEntity.kt
@@ -20,13 +20,13 @@ import javax.persistence.Table
 class WrappingKeyEntity(
     @Id
     @Column(name = "id", nullable = false)
-    val id: UUID,
+    var id: UUID,
 
     /**
      * Key alias must be unique across all tenants. The key can be reused by different tenants.
      */
     @Column(name = "alias", nullable = false, updatable = false, length = 64)
-    val alias: String,
+    var alias: String,
 
     @Column(name = "generation", nullable = false, updatable = false)
     var generation: Int,

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntities.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntities.kt
@@ -26,9 +26,9 @@ internal object JPABackingStoreEntities {
 }
 
 internal class UniquenessTxAlgoStateRefKey(
-    val issueTxIdAlgo: String = "",
-    val issueTxId: ByteArray = ByteArray(0),
-    val issueTxOutputIndex: Int = 0
+    var issueTxIdAlgo: String = "",
+    var issueTxId: ByteArray = ByteArray(0),
+    var issueTxOutputIndex: Int = 0
 ) : Serializable {
 
     override fun equals(other: Any?): Boolean {
@@ -57,8 +57,8 @@ internal class UniquenessTxAlgoStateRefKey(
 }
 
 internal class UniquenessTxAlgoIdKey(
-    val txIdAlgo: String = "",
-    val txId: ByteArray = ByteArray(0),
+    var txIdAlgo: String = "",
+    var txId: ByteArray = ByteArray(0),
 ) : Serializable {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -104,21 +104,21 @@ internal class UniquenessTxAlgoIdKey(
 internal class UniquenessStateDetailEntity(
     @Id
     @Column(name = "issue_tx_id_algo", length = TRANSACTION_ID_ALGO_LENGTH, nullable = false)
-    val issueTxIdAlgo: String,
+    var issueTxIdAlgo: String,
 
     @Id
     @Column(name = "issue_tx_id", length = TRANSACTION_ID_LENGTH, nullable = false)
-    val issueTxId: ByteArray,
+    var issueTxId: ByteArray,
 
     @Id
     @Column(name = "issue_tx_output_idx", nullable = false)
-    val issueTxOutputIndex: Int,
+    var issueTxOutputIndex: Int,
 
     @Column(name = "consuming_tx_id_algo", nullable = true, length = TRANSACTION_ID_ALGO_LENGTH)
-    val consumingTxIdAlgo: String?,
+    var consumingTxIdAlgo: String?,
 
     @Column(name = "consuming_tx_id", nullable = true, length = TRANSACTION_ID_LENGTH)
-    val consumingTxId: ByteArray?
+    var consumingTxId: ByteArray?
 ) {
     @Suppress("ComplexMethod")
     override fun equals(other: Any?): Boolean {
@@ -161,23 +161,23 @@ internal class UniquenessStateDetailEntity(
 internal class UniquenessTransactionDetailEntity(
     @Id
     @Column(name = "tx_id_algo", length = TRANSACTION_ID_ALGO_LENGTH, nullable = false)
-    val txIdAlgo: String,
+    var txIdAlgo: String,
 
     @Id
     @Column(name = "tx_id", length = TRANSACTION_ID_LENGTH, nullable = false)
-    val txId: ByteArray,
+    var txId: ByteArray,
 
     @Column(name = "originator_x500_name", length = ORIGINATOR_X500_NAME_LENGTH, nullable = false)
-    val originatorX500Name: String,
+    var originatorX500Name: String,
 
     @Column(name = "expiry_datetime", nullable = false)
-    val expiryDateTime: Instant,
+    var expiryDateTime: Instant,
 
     @Column(name = "commit_timestamp", nullable = false)
-    val commitTimestamp: Instant,
+    var commitTimestamp: Instant,
 
     @Column(name = "result", nullable = false)
-    val result: Char
+    var result: Char
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -211,14 +211,15 @@ internal class UniquenessTransactionDetailEntity(
 internal class UniquenessRejectedTransactionEntity(
     @Id
     @Column(name = "tx_id_algo", length = TRANSACTION_ID_ALGO_LENGTH, nullable = false)
-    val txIdAlgo: String,
+    var txIdAlgo: String,
 
     @Id
     // NOTE: In case of a ByteArray length is probably ignored but we keep it here just in case
     @Column(name = "tx_id", length = TRANSACTION_ID_LENGTH, nullable = false)
-    val txId: ByteArray,
+    var txId: ByteArray,
 
-    @Column(name = "error_details", nullable = false) val errorDetails: ByteArray
+    @Column(name = "error_details", nullable = false)
+    var errorDetails: ByteArray
 ) {
     init {
         if (errorDetails.size > REJECTED_TRANSACTION_ERROR_DETAILS_LENGTH) {

--- a/libs/application/application-db-setup/src/main/kotlin/net/corda/application/dbsetup/SqlFormatters.kt
+++ b/libs/application/application-db-setup/src/main/kotlin/net/corda/application/dbsetup/SqlFormatters.kt
@@ -5,10 +5,12 @@ import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.Table
 import javax.persistence.Version
+import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.jvm.isAccessible
 import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.javaGetter
 
 // TODO This file is copy of file
 // tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/SqlFormatters.kt
@@ -17,13 +19,13 @@ import kotlin.reflect.jvm.javaField
 /**
  * Create the SQL insert statement to persist an object annotated as javax.persistence.Entity
  * into a database. It assumes that the table name is annotated on the object
- * and that all columns are either annotated as @Column, @JoinColumn @Version or @Id.
+ * and that all columns are either annotated as @Column, @JoinColumn, @Version or @Id.
  */
 fun Any.toInsertStatement(): String {
-    val values = this::class.declaredMemberProperties.mapNotNull { field ->
-        val columnInfo = getColumnInfo(field) ?: return@mapNotNull null
-        field.isAccessible = true
-        val value = formatValue(extractValue(field, this, columnInfo.joinColumn)) ?: return@mapNotNull null
+    val values = this::class.declaredMemberProperties.mapNotNull { property ->
+        val columnInfo = getColumnInfo(property) ?: return@mapNotNull null
+        property.isAccessible = true
+        val value = formatValue(extractValue(property, this, columnInfo.joinColumn)) ?: return@mapNotNull null
         columnInfo.name to value
     }
 
@@ -43,26 +45,35 @@ private fun formatValue(value: Any?): String? {
 
 private data class ColumnInfo(val name: String, val joinColumn: Boolean)
 
-private fun getColumnInfo(field: KProperty1<out Any, *>): ColumnInfo? {
-    field.javaField?.getAnnotation<Column>(Column::class.java)?.name?.let { name ->
+private fun getColumnInfo(property: KProperty1<out Any, *>): ColumnInfo? {
+    property.getVarAnnotation(Column::class.java)?.name?.let { name ->
         return if (name.isBlank()) {
-            ColumnInfo(field.name, false)
-        } else
+            ColumnInfo(property.name, false)
+        } else {
             ColumnInfo(name, false)
+        }
     }
-    field.javaField?.getAnnotation<JoinColumn>(JoinColumn::class.java)?.name?.let { name ->
+    property.getVarAnnotation(JoinColumn::class.java)?.name?.let { name ->
         return if (name.isBlank()) {
-            ColumnInfo(field.name, true)
-        } else
+            ColumnInfo(property.name, true)
+        } else {
             ColumnInfo(name, true)
+        }
     }
-    field.javaField?.getAnnotation<Id>(Id::class.java)?.let {
-        return ColumnInfo(field.name, false)
+    property.getVarAnnotation(Id::class.java)?.let {
+        return ColumnInfo(property.name, false)
     }
-    field.javaField?.getAnnotation<Version>(Version::class.java)?.let {
-        return ColumnInfo("version", false)
+    return property.getVarAnnotation(Version::class.java)?.let {
+        ColumnInfo("version", false)
     }
-    return null
+}
+
+private fun <T : Annotation> KProperty1<*, *>.getVarAnnotation(type: Class<T>): T? {
+    return (javaField?.getAnnotation(type) ?: javaGetter?.getAnnotation(type))?.also {
+        if (this !is KMutableProperty1<*, *>) {
+            throw IllegalArgumentException("Property '$this' must be var for JPA annotations.")
+        }
+    }
 }
 
 private fun String.simpleSqlEscaping(): String {
@@ -84,7 +95,7 @@ private fun extractValue(field: KProperty1<out Any?, *>, obj: Any, getId: Boolea
     if (!getId || value == null)
         return value
     value::class.declaredMemberProperties.forEach { property ->
-        if (property.javaField?.getAnnotation<Id>(Id::class.java) != null) {
+        if (property.getVarAnnotation(Id::class.java) != null) {
             property.isAccessible = true
             return property.getter.call(value)
         }

--- a/libs/chunking/chunking-datamodel/src/main/kotlin/net/corda/chunking/datamodel/ChunkEntity.kt
+++ b/libs/chunking/chunking-datamodel/src/main/kotlin/net/corda/chunking/datamodel/ChunkEntity.kt
@@ -15,14 +15,18 @@ import javax.persistence.Table
 data class ChunkEntity(
     @Id
     @Column(name = "request_id", nullable = false)
-    val requestId: String,
+    var requestId: String,
+
     @Column(name = "checksum", nullable = true)
     var checksum: String?,
+
     @Id
     @Column(name = "part_nr", nullable = false)
     var partNumber: Int,
+
     @Column(name = "data_offset", nullable = false)
     var offset: Long,
+
     @Column(name = "data", nullable = true)
     var data: ByteArray?
 ) {

--- a/libs/chunking/chunking-datamodel/src/main/kotlin/net/corda/chunking/datamodel/ChunkPropertyEntity.kt
+++ b/libs/chunking/chunking-datamodel/src/main/kotlin/net/corda/chunking/datamodel/ChunkPropertyEntity.kt
@@ -19,14 +19,14 @@ data class ChunkPropertyEntity(
 
     @Id
     @Column(name = "request_id", nullable = false)
-    val requestId: String,
+    var requestId: String,
 
     @Id
     @Column(name = "key", nullable = false)
-    val key: String,
+    var key: String,
 
     @Column(name = "value", nullable = true)
-    val value: String?,
+    var value: String?,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigAuditEntity.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigAuditEntity.kt
@@ -34,18 +34,18 @@ data class ConfigAuditEntity(
     )
     @GeneratedValue(strategy = SEQUENCE, generator = CONFIG_AUDIT_GENERATOR)
     @Column(name = "change_number", nullable = false)
-    val changeNumber: Int,
+    var changeNumber: Int,
 
     @Column(name = "section", nullable = false)
-    val section: String,
+    var section: String,
     @Column(name = "config", nullable = false)
-    val config: String,
+    var config: String,
     @Column(name = "config_version", nullable = false)
-    val configVersion: Int,
+    var configVersion: Int,
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,
     @Column(name = "update_actor", nullable = false)
-    val updateActor: String
+    var updateActor: String
 ) {
     constructor(configEntity: ConfigEntity) : this(
         0,

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigEntity.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/ConfigEntity.kt
@@ -26,7 +26,7 @@ import net.corda.db.schema.DbSchema.CONFIG_TABLE
 data class ConfigEntity(
     @Id
     @Column(name = "section", nullable = false)
-    val section: String,
+    var section: String,
     @Column(name = "config", nullable = false)
     var config: String,
     @Column(name = "schema_version_major", nullable = false)
@@ -38,7 +38,7 @@ data class ConfigEntity(
     @Column(name = "update_actor", nullable = false)
     var updateActor: String,
     @Column(name = "is_deleted", nullable = false)
-    val isDeleted: Boolean = false
+    var isDeleted: Boolean = false
 ) {
     @Version
     @Column(name = "version", nullable = false)

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/DbConnectionAudit.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/DbConnectionAudit.kt
@@ -38,15 +38,15 @@ data class DbConnectionAudit (
     )
     @GeneratedValue(strategy = SEQUENCE, generator = DB_CONNECTION_AUDIT_GENERATOR)
     @Column(name = "change_number", nullable = false)
-    val changeNumber: Int,
+    var changeNumber: Int,
 
     @Column(name = "connection_id", nullable = false)
-    val id: UUID,
+    var id: UUID,
     @Column(name = "connection_name", nullable = false)
-    val name: String,
+    var name: String,
     @Enumerated(EnumType.STRING)
     @Column(name = "privilege", nullable = false)
-    val privilege: DbPrivilege,
+    var privilege: DbPrivilege,
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,
     @Column(name = "update_actor", nullable = false)

--- a/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/DbConnectionConfig.kt
+++ b/libs/configuration/configuration-datamodel/src/main/kotlin/net/corda/libs/configuration/datamodel/DbConnectionConfig.kt
@@ -39,12 +39,12 @@ internal const val QUERY_PARAM_PRIVILEGE = "privilege"
 data class DbConnectionConfig (
     @Id
     @Column(name = "connection_id", nullable = false)
-    val id: UUID,
+    var id: UUID,
     @Column(name = "connection_name", nullable = false)
-    val name: String,
+    var name: String,
     @Enumerated(EnumType.STRING)
     @Column(name = "privilege", nullable = false)
-    val privilege: DbPrivilege,
+    var privilege: DbPrivilege,
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,
     @Column(name = "update_actor", nullable = false)

--- a/libs/membership/certificates-datamodel/src/main/kotlin/net/corda/membership/certificates/datamodel/Certificate.kt
+++ b/libs/membership/certificates-datamodel/src/main/kotlin/net/corda/membership/certificates/datamodel/Certificate.kt
@@ -14,11 +14,11 @@ import javax.persistence.Table
 data class Certificate(
     @Id
     @Column(name = "alias", nullable = false, updatable = false)
-    override val alias: String,
+    override var alias: String,
 
     @Column(name = "usage", nullable = false, updatable = false)
-    override val usage: String,
+    override var usage: String,
 
     @Column(name = "raw_certificate", nullable = false, updatable = true)
-    override val rawCertificate: String,
+    override var rawCertificate: String,
 ) : CertificateEntity

--- a/libs/membership/certificates-datamodel/src/main/kotlin/net/corda/membership/certificates/datamodel/ClusterCertificate.kt
+++ b/libs/membership/certificates-datamodel/src/main/kotlin/net/corda/membership/certificates/datamodel/ClusterCertificate.kt
@@ -14,11 +14,11 @@ import javax.persistence.Table
 data class ClusterCertificate(
     @Id
     @Column(name = "alias", nullable = false, updatable = false)
-    override val alias: String,
+    override var alias: String,
 
     @Column(name = "usage", nullable = false, updatable = false)
-    override val usage: String,
+    override var usage: String,
 
     @Column(name = "raw_certificate", nullable = false, updatable = true)
-    override val rawCertificate: String,
+    override var rawCertificate: String,
 ) : CertificateEntity

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/ApprovalRulesEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/ApprovalRulesEntity.kt
@@ -20,17 +20,17 @@ import javax.persistence.Table
 class ApprovalRulesEntity(
     @Id
     @Column(name = "rule_id", nullable = false, updatable = false)
-    val ruleId: String,
+    var ruleId: String,
 
     @Id
     @Column(name = "rule_type", nullable = false, updatable = false)
-    val ruleType: String,
+    var ruleType: String,
 
     @Column(name = "rule_regex", nullable = false, updatable = false)
-    val ruleRegex: String,
+    var ruleRegex: String,
 
     @Column(name = "rule_label", nullable = true, updatable = false)
-    val ruleLabel: String? = null
+    var ruleLabel: String? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (other === this) return true
@@ -47,6 +47,6 @@ class ApprovalRulesEntity(
 
 @Embeddable
 data class ApprovalRulesEntityPrimaryKey(
-    val ruleId: String,
-    val ruleType: String
+    var ruleId: String,
+    var ruleType: String
 ) : Serializable

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/GroupParametersEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/GroupParametersEntity.kt
@@ -32,19 +32,19 @@ fun EntityManager.getCurrentGroupParameters(): GroupParametersEntity? {
 class GroupParametersEntity(
     @Id
     @Column(name = "epoch", nullable = false, updatable = false)
-    val epoch: Int,
+    var epoch: Int,
 
     @Column(name = "parameters", nullable = false, updatable = false)
-    val parameters: ByteArray,
+    var parameters: ByteArray,
 
     @Column(name = "signature_public_key", nullable = true, updatable = false)
-    val signaturePublicKey: ByteArray?,
+    var signaturePublicKey: ByteArray?,
 
     @Column(name = "signature_content", nullable = true, updatable = false)
-    val signatureContent: ByteArray?,
+    var signatureContent: ByteArray?,
 
     @Column(name = "signature_spec", nullable = true, updatable = false)
-    val signatureSpec: String?,
+    var signatureSpec: String?,
 ) {
     fun isSigned(): Boolean {
         return signatureSpec != null

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/GroupPolicyEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/GroupPolicyEntity.kt
@@ -20,10 +20,10 @@ class GroupPolicyEntity(
     var version: Long,
 
     @Column(name = "created_at", nullable = false, updatable = false)
-    val createdAt: Instant,
+    var createdAt: Instant,
 
     @Column(name = "properties", nullable = false, updatable = false)
-    val properties: ByteArray,
+    var properties: ByteArray,
 ) {
 
     override fun equals(other: Any?): Boolean {

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MemberInfoEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MemberInfoEntity.kt
@@ -21,15 +21,15 @@ import javax.persistence.Table
 class MemberInfoEntity(
     @Id
     @Column(name = "group_id", nullable = false, updatable = false)
-    val groupId: String,
+    var groupId: String,
 
     @Id
     @Column(name = "member_name", nullable = false, updatable = false)
-    val memberX500Name: String,
+    var memberX500Name: String,
 
     @Id
     @Column(name = "is_pending", nullable = false, updatable = false)
-    val isPending: Boolean,
+    var isPending: Boolean,
 
     @Column(nullable = false)
     var status: String,
@@ -38,24 +38,24 @@ class MemberInfoEntity(
     var modifiedTime: Instant,
 
     @Column(name = "member_context", nullable = false)
-    val memberContext: ByteArray,
+    var memberContext: ByteArray,
 
     @Column(name = "member_signature_key", nullable = false, columnDefinition = "BLOB")
-    val memberSignatureKey: ByteArray,
+    var memberSignatureKey: ByteArray,
 
     @Column(name = "member_signature_content", nullable = false, columnDefinition = "BLOB")
-    val memberSignatureContent: ByteArray,
+    var memberSignatureContent: ByteArray,
 
     // TODO Are we going to be storing `ParameterizedSignatureSpec` here?
     //  If so need to consider saving extra signature spec parameters as recorded in https://r3-cev.atlassian.net/browse/CORE-11685
     @Column(name = "member_signature_spec", nullable = false)
-    val memberSignatureSpec: String,
+    var memberSignatureSpec: String,
 
     @Column(name = "mgm_context", nullable = false)
     var mgmContext: ByteArray,
 
     @Column(name = "serial_number", nullable = false)
-    val serialNumber: Long,
+    var serialNumber: Long,
 ) {
     override fun equals(other: Any?): Boolean {
         if (other === this) return true
@@ -77,7 +77,7 @@ class MemberInfoEntity(
 
 @Embeddable
 data class MemberInfoEntityPrimaryKey(
-    val groupId: String,
-    val memberX500Name: String,
-    val isPending: Boolean,
+    var groupId: String,
+    var memberX500Name: String,
+    var isPending: Boolean,
 ) : Serializable

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MutualTlsAllowedClientCertificateEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/MutualTlsAllowedClientCertificateEntity.kt
@@ -15,9 +15,10 @@ import javax.persistence.Table
 class MutualTlsAllowedClientCertificateEntity(
     @Id
     @Column(name = "subject", nullable = false, updatable = false)
-    val subject: String,
+    var subject: String,
+
     @Column(name = "is_deleted", nullable = false, updatable = true)
-    val isDeleted: Boolean,
+    var isDeleted: Boolean,
 ) {
     override fun equals(other: Any?): Boolean {
         if (other === this) return true

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/PreAuthTokenEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/PreAuthTokenEntity.kt
@@ -16,19 +16,19 @@ class PreAuthTokenEntity (
      */
     @Id
     @Column(name = "token_id", nullable = false, updatable = false)
-    val tokenId: String,
+    var tokenId: String,
 
     @Column(name = "owner_x500_name", nullable = false, updatable = false)
-    val ownerX500Name: String,
+    var ownerX500Name: String,
 
     @Column(name = "ttl", updatable = false)
-    val ttl: Instant?,
+    var ttl: Instant?,
 
     @Column(name = "status", nullable = false)
     var status: String,
 
     @Column(name = "creation_remark", updatable = false)
-    val creationRemark: String?,
+    var creationRemark: String?,
 
     @Column(name = "removal_remark")
     var removalRemark: String?

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/RegistrationRequestEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/RegistrationRequestEntity.kt
@@ -19,13 +19,13 @@ class RegistrationRequestEntity(
      */
     @Id
     @Column(name = "registration_id", nullable = false, updatable = false)
-    val registrationId: String,
+    var registrationId: String,
 
     /**
      * The holding identity ID of the registering member.
      */
     @Column(name = "holding_identity_id", nullable = false, updatable = false)
-    val holdingIdentityShortHash: String,
+    var holdingIdentityShortHash: String,
 
     /**
      * The last status of the registration request.
@@ -37,7 +37,7 @@ class RegistrationRequestEntity(
      * The instant representing when this registration request was received or created.
      */
     @Column(nullable = false, updatable = false)
-    val created: Instant,
+    var created: Instant,
 
     /**
      * The instant representing the last time this registration request was updated.
@@ -50,56 +50,56 @@ class RegistrationRequestEntity(
      * The serialized member context provided during registration. Serialized as [KeyValuePairList].
      */
     @Column(name = "member_context", nullable = false, updatable = false, columnDefinition = "BLOB")
-    val memberContext: ByteArray,
+    var memberContext: ByteArray,
 
     /**
      * Signature key of member signature, can be sued to verify the signature.
      */
     @Column(name = "member_context_signature_key", nullable = false, updatable = false, columnDefinition = "BLOB")
-    val memberContextSignatureKey: ByteArray,
+    var memberContextSignatureKey: ByteArray,
 
     /**
      * Byte array of the member signature, exactly as returned by crypto signing operations.
      */
     @Column(name = "member_context_signature_content", nullable = false, updatable = false, columnDefinition = "BLOB")
-    val memberContextSignatureContent: ByteArray,
+    var memberContextSignatureContent: ByteArray,
 
     /**
      * Signature spec of member signature.
      */
     @Column(name = "member_context_signature_spec", nullable = false, updatable = false)
-    val memberContextSignatureSpec: String,
+    var memberContextSignatureSpec: String,
 
     /**
      * The serialized registration context provided during registration. Serialized as [KeyValuePairList].
      */
     @Column(name = "registration_context", nullable = false, updatable = false, columnDefinition = "BLOB")
-    val registrationContext: ByteArray,
+    var registrationContext: ByteArray,
 
     /**
      * Signature key of member signature over the registration context, can be used to verify the signature.
      */
     @Column(name = "registration_context_signature_key", nullable = false, updatable = false, columnDefinition = "BLOB")
-    val registrationContextSignatureKey: ByteArray,
+    var registrationContextSignatureKey: ByteArray,
 
     /**
      * Byte array of the member signature over the registration context,
      * exactly as returned by crypto signing operations.
      */
     @Column(name = "registration_context_signature_content", nullable = false, updatable = false, columnDefinition = "BLOB")
-    val registrationContextSignatureContent: ByteArray,
+    var registrationContextSignatureContent: ByteArray,
 
     /**
      * Signature spec of member signature over the registration context.
      */
     @Column(name = "registration_context_signature_spec", nullable = false, updatable = false)
-    val registrationContextSignatureSpec: String,
+    var registrationContextSignatureSpec: String,
 
     /**
      * Latest serial seen by the member when calling registration.
      */
     @Column(name = "serial", nullable = true)
-    val serial: Long?,
+    var serial: Long?,
 
     /**
      * Reason why the request is in the status specified by [status].

--- a/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/StaticNetworkInfoEntity.kt
+++ b/libs/membership/membership-datamodel/src/main/kotlin/net/corda/membership/datamodel/StaticNetworkInfoEntity.kt
@@ -15,13 +15,13 @@ class StaticNetworkInfoEntity(
      */
     @Id
     @Column(name = "group_id", nullable = false, updatable = false)
-    val groupId: String,
+    var groupId: String,
 
     /**
      * The static network's "virtual" MGM's public signing key.
      */
     @Column(name = "mgm_public_signing_key", nullable = false, updatable = false)
-    val mgmPublicKey: ByteArray,
+    var mgmPublicKey: ByteArray,
 
     /**
      * The static network's "virtual" MGM's private signing key.
@@ -29,7 +29,7 @@ class StaticNetworkInfoEntity(
      * for production usage.
      */
     @Column(name = "mgm_private_signing_key", nullable = false, updatable = false)
-    val mgmPrivateKey: ByteArray,
+    var mgmPrivateKey: ByteArray,
 
     /**
      * Group parameters serialized as a [KeyValuePairList] using AVRO serialization

--- a/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/CommittedPositionEntry.kt
+++ b/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/CommittedPositionEntry.kt
@@ -24,25 +24,25 @@ import javax.persistence.Table
 @IdClass(CommittedOffsetEntryKey::class)
 class CommittedPositionEntry(
     @Id
-    val topic: String,
+    var topic: String,
 
     @Id
     @Column(name = "consumer_group")
-    val consumerGroup: String,
+    var consumerGroup: String,
 
     @Id
-    val partition: Int,
+    var partition: Int,
 
     @Id
     @Column(name = "record_offset")
-    val recordPosition: Long,
+    var recordPosition: Long,
 
     @ManyToOne
     @JoinColumn(name = "transaction_id")
-    val transactionId: TransactionRecordEntry,
+    var transactionId: TransactionRecordEntry,
 
     @Column
-    val timestamp: Instant = Instant.now(),
+    var timestamp: Instant = Instant.now(),
 ) {
     override fun toString(): String {
         return "CommittedPositionEntry(" +
@@ -56,8 +56,8 @@ class CommittedPositionEntry(
 
 @Embeddable
 data class CommittedOffsetEntryKey(
-    val topic: String,
-    val consumerGroup: String,
-    val partition: Int,
-    val recordPosition: Long
+    var topic: String,
+    var consumerGroup: String,
+    var partition: Int,
+    var recordPosition: Long
 ) : Serializable

--- a/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/TopicEntry.kt
+++ b/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/TopicEntry.kt
@@ -14,10 +14,10 @@ import javax.persistence.Table
 @Table(name = "topic")
 class TopicEntry(
     @Id
-    val topic: String,
+    var topic: String,
 
     @Column(name = "num_partitions")
-    val numPartitions: Int
+    var numPartitions: Int
 ) {
     override fun toString(): String {
         return "TopicEntry(topic='$topic', numPartitions=$numPartitions)"

--- a/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/TopicRecordEntry.kt
+++ b/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/TopicRecordEntry.kt
@@ -25,32 +25,39 @@ import javax.persistence.Table
 class TopicRecordEntry(
     @Id
     @Column
-    val topic: String,
+    var topic: String,
+
     @Id
     @Column
-    val partition: Int,
+    var partition: Int,
+
     @Id
     @Column(name = "record_offset")
-    val recordOffset: Long,
+    var recordOffset: Long,
+
     /**
      * NOTE: All keys must end up on the same partition
      */
     @Column(name = "record_key")
-    val key: ByteArray,
+    var key: ByteArray,
+
     @Column(name = "record_value")
-    val value: ByteArray?,
+    var value: ByteArray?,
+
     @Column(name = "record_headers")
-    val headers: String?,
+    var headers: String?,
+
     @ManyToOne
     @JoinColumn(name = "transaction_id")
-    val transactionId: TransactionRecordEntry,
+    var transactionId: TransactionRecordEntry,
+
     @Column
-    val timestamp: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+    var timestamp: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
 )
 
 @Embeddable
 data class TopicRecordEntryKey(
-    val topic: String,
-    val partition: Int,
-    val recordOffset: Long,
+    var topic: String,
+    var partition: Int,
+    var recordOffset: Long,
 ): Serializable

--- a/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/TransactionRecordEntry.kt
+++ b/libs/messaging/db-message-bus-datamodel/src/main/kotlin/net/corda/messagebus/db/datamodel/TransactionRecordEntry.kt
@@ -19,7 +19,7 @@ enum class TransactionState {
 class TransactionRecordEntry(
     @Id
     @Column(name = "transaction_id")
-    val transactionId: String,
+    var transactionId: String,
 
     @Column
     var state: TransactionState = TransactionState.PENDING,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/ChangeAudit.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/ChangeAudit.kt
@@ -13,20 +13,20 @@ import javax.persistence.Table
 class ChangeAudit(
     @Id
     @Column(name = "id", nullable = false)
-    val id: String,
+    var id: String,
 
     @Column(name = "update_ts", nullable = false)
-    val updateTimestamp: Instant,
+    var updateTimestamp: Instant,
 
     @Column(name = "actor_user", nullable = false)
-    val actorUser: String,
+    var actorUser: String,
 
     @Enumerated(value = EnumType.STRING)
     @Column(name = "change_type", nullable = false)
-    val changeType: RestPermissionOperation,
+    var changeType: RestPermissionOperation,
 
     @Column(name = "details", nullable = false)
-    val details: String,
+    var details: String,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/Group.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/Group.kt
@@ -17,7 +17,7 @@ import javax.persistence.Version
 class Group(
     @Id
     @Column(name = "id", nullable = false)
-    val id: String,
+    var id: String,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/GroupProperty.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/GroupProperty.kt
@@ -15,7 +15,7 @@ import javax.persistence.Version
 class GroupProperty(
     @Id
     @Column(name = "id", nullable = false)
-    val id: String,
+    var id: String,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/Permission.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/Permission.kt
@@ -21,7 +21,7 @@ import javax.persistence.Version
 class Permission(
     @Id
     @Column(name = "id", nullable = false)
-    val id: String,
+    var id: String,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/Role.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/Role.kt
@@ -20,7 +20,7 @@ import javax.persistence.Version
 class Role(
     @Id
     @Column(name = "id", nullable = false, updatable = false)
-    val id: String,
+    var id: String,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/RoleGroupAssociation.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/RoleGroupAssociation.kt
@@ -18,15 +18,15 @@ import javax.persistence.Table
 class RoleGroupAssociation(
     @Id
     @Column(name = "id", nullable = false, updatable = false)
-    val id: String,
+    var id: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id")
-    val role: Role,
+    var role: Role,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
-    val group: Group,
+    var group: Group,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/RolePermissionAssociation.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/RolePermissionAssociation.kt
@@ -18,15 +18,15 @@ import javax.persistence.Table
 class RolePermissionAssociation(
     @Id
     @Column(name = "id", nullable = false, updatable = false)
-    val id: String,
+    var id: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id")
-    val role: Role,
+    var role: Role,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "perm_id")
-    val permission: Permission,
+    var permission: Permission,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/RoleUserAssociation.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/RoleUserAssociation.kt
@@ -18,15 +18,15 @@ import javax.persistence.Table
 class RoleUserAssociation(
     @Id
     @Column(name = "id", nullable = false, updatable = false)
-    val id: String,
+    var id: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "role_id")
-    val role: Role,
+    var role: Role,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
-    val user: User,
+    var user: User,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/User.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/User.kt
@@ -18,7 +18,7 @@ import javax.persistence.Version
 class User(
     @Id
     @Column(name = "id", nullable = false, updatable = false)
-    val id: String,
+    var id: String,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/UserProperty.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/model/UserProperty.kt
@@ -15,7 +15,7 @@ import javax.persistence.Version
 class UserProperty(
     @Id
     @Column(name = "id", nullable = false)
-    val id: String,
+    var id: String,
 
     @Column(name = "update_ts", nullable = false)
     var updateTimestamp: Instant,
@@ -25,13 +25,13 @@ class UserProperty(
      */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_ref", nullable = false)
-    val userRef: User,
+    var userRef: User,
 
     @Column(name = "key", nullable = false)
-    val key: String,
+    var key: String,
 
     @Column(name = "value", nullable = false)
-    val value: String
+    var value: String
 ) {
     /**
      * Version column for optimistic locking.

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpiCpkEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpiCpkEntity.kt
@@ -21,13 +21,22 @@ import javax.persistence.Version
 @Table(name = "cpi_cpk")
 internal class CpiCpkEntity(
     @EmbeddedId
-    val id: CpiCpkKey,
+    var id: CpiCpkKey,
+
     @Column(name = "cpk_file_name", nullable = false)
     var cpkFileName: String,
+
     // note - orphanRemoval = false because a CPK could be associated with a different CPI.
     @OneToOne(cascade = [CascadeType.MERGE, CascadeType.PERSIST])
-    @JoinColumn(name = "cpk_file_checksum", referencedColumnName = "file_checksum", insertable = false, updatable = false)
+    @JoinColumn(
+        name = "cpk_file_checksum",
+        referencedColumnName = "file_checksum",
+        insertable = false,
+        updatable = false,
+        nullable = false
+    )
     var metadata: CpkMetadataEntity,
+
     @Version
     @Column(name = "entity_version", nullable = false)
     var entityVersion: Int = 0
@@ -35,6 +44,7 @@ internal class CpiCpkEntity(
     // Initial population of this TS is managed on the DB itself
     @Column(name = "insert_ts", insertable = false, updatable = true)
     var insertTimestamp: Instant? = null
+
     @Column(name = "is_deleted", nullable = false)
     var isDeleted: Boolean = false
 
@@ -42,6 +52,7 @@ internal class CpiCpkEntity(
     fun onUpdate() {
         insertTimestamp = Instant.now()
     }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -60,14 +71,17 @@ internal class CpiCpkEntity(
 
 @Embeddable
 internal class CpiCpkKey(
-    @Column(name = "cpi_name")
-    val cpiName: String,
-    @Column(name = "cpi_version")
-    val cpiVersion: String,
-    @Column(name = "cpi_signer_summary_hash")
-    val cpiSignerSummaryHash: String,
-    @Column(name = "cpk_file_checksum")
-    val cpkFileChecksum: String,
+    @Column(name = "cpi_name", nullable = false)
+    var cpiName: String,
+
+    @Column(name = "cpi_version", nullable = false)
+    var cpiVersion: String,
+
+    @Column(name = "cpi_signer_summary_hash", nullable = false)
+    var cpiSignerSummaryHash: String,
+
+    @Column(name = "cpk_file_checksum", nullable = false)
+    var cpkFileChecksum: String,
 ): Serializable {
 
     override fun equals(other: Any?): Boolean {

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpiMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpiMetadataEntity.kt
@@ -39,44 +39,57 @@ import net.corda.v5.crypto.SecureHash
 internal class CpiMetadataEntity(
     @Id
     @Column(name = "name", nullable = false)
-    val name: String,
+    var name: String,
+
     @Id
     @Column(name = "version", nullable = false)
-    val version: String,
+    var version: String,
+
     @Id
     @Column(name = "signer_summary_hash", nullable = false)
-    val signerSummaryHash: String,
+    var signerSummaryHash: String,
+
     @Column(name = "file_name", nullable = false)
     var fileName: String,
+
     @Column(name = "file_checksum", nullable = false)
     var fileChecksum: String,
+
     @Column(name = "group_policy", nullable = false)
     var groupPolicy: String,
+
     @Column(name = "group_id", nullable = false)
     var groupId: String,
+
     @Column(name = "file_upload_request_id", nullable = false)
     var fileUploadRequestId: String,
+
     @OneToMany(
+        targetEntity = CpiCpkEntity::class,
         fetch = FetchType.EAGER,
         cascade = [CascadeType.PERSIST, CascadeType.MERGE],
         orphanRemoval = true
     )
     @JoinColumns(
-        JoinColumn(name = "cpi_name", referencedColumnName = "name", insertable = false, updatable = false),
-        JoinColumn(name = "cpi_version", referencedColumnName = "version", insertable = false, updatable = false),
+        JoinColumn(name = "cpi_name", referencedColumnName = "name", insertable = false, updatable = false, nullable = false),
+        JoinColumn(name = "cpi_version", referencedColumnName = "version", insertable = false, updatable = false, nullable = false),
         JoinColumn(
             name = "cpi_signer_summary_hash",
             referencedColumnName = "signer_summary_hash",
             insertable = false,
-            updatable = false
+            updatable = false,
+            nullable = false
         ),
     )
-    val cpks: Set<CpiCpkEntity>,
+    var cpks: Set<CpiCpkEntity>,
+
     // Initial population of this TS is managed on the DB itself
     @Column(name = "insert_ts", insertable = false, updatable = true)
     var insertTimestamp: Instant? = null,
+
     @Column(name = "is_deleted", nullable = false)
     var isDeleted: Boolean = false,
+
     @Version
     @Column(name = "entity_version", nullable = false)
     var entityVersion: Int = 0,
@@ -182,9 +195,9 @@ internal class CpiMetadataEntity(
 /** The composite primary key for a CpiEntity. */
 @Embeddable
 internal class CpiMetadataEntityKey(
-    private val name: String,
-    private val version: String,
-    private val signerSummaryHash: String,
+    private var name: String,
+    private var version: String,
+    private var signerSummaryHash: String,
 ) : Serializable {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkDbChangeLogAuditEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkDbChangeLogAuditEntity.kt
@@ -14,18 +14,23 @@ import javax.persistence.Table
 @Table(name = "cpk_db_change_log_audit")
 internal class CpkDbChangeLogAuditEntity(
     @Id
-    val id: String,
+    var id: String,
+
     @Column(name = "cpk_file_checksum", nullable = false, updatable = false)
-    val cpkFileChecksum: String,
+    var cpkFileChecksum: String,
+
     @Column(name = "file_path", nullable = false, updatable = false)
-    val filePath: String,
+    var filePath: String,
+
     @Column(name = "content", nullable = false, updatable = false)
-    val content: String,
+    var content: String,
+
     @Column(name = "is_deleted", nullable = false, updatable = false)
     var isDeleted: Boolean = false,
+
     // this TS is managed on the DB itself
     @Column(name = "insert_ts", insertable = false, updatable = false)
-    val insertTimestamp: Instant? = null
+    var insertTimestamp: Instant? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkDbChangeLogEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkDbChangeLogEntity.kt
@@ -17,8 +17,10 @@ import javax.persistence.Version
 internal class CpkDbChangeLogEntity(
     @EmbeddedId
     var id: CpkDbChangeLogKey,
+
     @Column(name = "content", nullable = false)
-    val content: String,
+    var content: String,
+
     // This structure does not distinguish the root changelogs from changelog include files
     // (or CSVs, which we do not need to support). So, to find the root, you need to look for a filename
     // convention. See the comment in the companion object of VirtualNodeDbChangeLog.
@@ -32,7 +34,7 @@ internal class CpkDbChangeLogEntity(
 
     // this TS is managed on the DB itself
     @Column(name = "insert_ts", insertable = false, updatable = false)
-    val insertTimestamp: Instant? = null
+    var insertTimestamp: Instant? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -58,7 +60,7 @@ internal class CpkDbChangeLogKey(
     @Column(name = "cpk_file_checksum", nullable = false)
     var cpkFileChecksum: String,
     @Column(name = "file_path", nullable = false)
-    val filePath: String
+    var filePath: String
 ) : Serializable {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkFileEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkFileEntity.kt
@@ -42,9 +42,11 @@ internal class CpkFileEntity(
     @Id
     @Column(name = "file_checksum", nullable = false, unique = true)
     var fileChecksum: String,
+
     @Lob
     @Column(name = "data", nullable = false)
     var data: ByteArray,
+
     @Column(name = "is_deleted", nullable = false)
     var isDeleted: Boolean = false
 ) {

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkMetadataEntity.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/entities/internal/CpkMetadataEntity.kt
@@ -16,18 +16,25 @@ internal class CpkMetadataEntity(
     @Id
     @Column(name = "file_checksum", nullable = false, unique = true)
     var cpkFileChecksum: String,
-    @Column(name = "cpk_name")
+
+    @Column(name = "cpk_name", nullable = false)
     var cpkName: String,
-    @Column(name = "cpk_version")
+
+    @Column(name = "cpk_version", nullable = false)
     var cpkVersion: String,
-    @Column(name = "cpk_signer_summary_hash")
+
+    @Column(name = "cpk_signer_summary_hash", nullable = false)
     var cpkSignerSummaryHash: String,
+
     @Column(name = "format_version", nullable = false)
     var formatVersion: String,
+
     @Column(name = "metadata", nullable = false)
     var serializedMetadata: String,
+
     @Column(name = "is_deleted", nullable = false)
     var isDeleted: Boolean = false,
+
     @Version
     @Column(name = "entity_version", nullable = false)
     var entityVersion: Int = 0

--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/impl/CpiMetadataRepositoryImpl.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/impl/CpiMetadataRepositoryImpl.kt
@@ -146,7 +146,7 @@ internal class CpiMetadataRepositoryImpl: CpiMetadataRepository {
         CpiMetadata(
             CpiIdentifier(name, version, parseSecureHash(signerSummaryHash)),
             parseSecureHash(fileChecksum),
-            cpks.map { it.metadata.toDto() }.toSet(),
+            cpks.mapTo(linkedSetOf()) { it.metadata.toDto() },
             groupPolicy,
             version = entityVersion,
             timestamp = insertTimestamp ?: Instant.now()

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/HoldingIdentityEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/HoldingIdentityEntity.kt
@@ -3,7 +3,8 @@ package net.corda.libs.virtualnode.datamodel.entities
 import net.corda.db.schema.DbSchema.HOLDING_IDENTITY_DB_TABLE
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
-import java.util.*
+import java.util.Objects
+import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.Id
@@ -24,13 +25,17 @@ import javax.persistence.Table
 internal class HoldingIdentityEntity(
     @Id
     @Column(name = "holding_identity_id", nullable = false)
-    val holdingIdentityShortHash: String,
+    var holdingIdentityShortHash: String,
+
     @Column(name = "holding_identity_full_hash", nullable = false)
     var holdingIdentityFullHash: String,
+
     @Column(name = "x500_name", nullable = false)
     var x500Name: String,
+
     @Column(name = "mgm_group_id", nullable = false)
     var mgmGroupId: String,
+
     @Column(name = "hsm_connection_id", nullable = true)
     var hsmConnectionId: UUID?
 ) {

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/entities/VirtualNodeEntity.kt
@@ -45,13 +45,13 @@ import javax.persistence.Version
 @Suppress("LongParameterList")
 internal class VirtualNodeEntity(
     @Id
-    @Column(name = "holding_identity_id")
-    val holdingIdentityId: String,
+    @Column(name = "holding_identity_id", nullable = false)
+    var holdingIdentityId: String,
 
     @MapsId
     @OneToOne(cascade = [CascadeType.ALL])
-    @JoinColumn(name = "holding_identity_id")
-    val holdingIdentity: HoldingIdentityEntity,
+    @JoinColumn(name = "holding_identity_id", nullable = false)
+    var holdingIdentity: HoldingIdentityEntity,
 
     @Column(name = "cpi_name", nullable = false)
     var cpiName: String,

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForFieldAccess.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForFieldAccess.kt
@@ -10,7 +10,6 @@ import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.Table
 import javax.persistence.Version
-import org.junit.jupiter.api.Disabled
 
 class TestSqlFormattersForFieldAccess {
 
@@ -189,7 +188,6 @@ class TestSqlFormattersForFieldAccess {
         assertEquals("insert into UnnamedColumn (testFace) values ('test')", statement)
     }
 
-    @Disabled
     @Test
     fun testEntityWithValProperty() {
         val ent = EntityWithValProperty("test")

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForPropertyAccess.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForPropertyAccess.kt
@@ -10,7 +10,6 @@ import javax.persistence.Id
 import javax.persistence.JoinColumn
 import javax.persistence.Table
 import javax.persistence.Version
-import org.junit.jupiter.api.Disabled
 
 class TestSqlFormattersForPropertyAccess {
 
@@ -189,7 +188,6 @@ class TestSqlFormattersForPropertyAccess {
         assertEquals("insert into UnnamedColumn (testFace) values ('test')", statement)
     }
 
-    @Disabled
     @Test
     fun testEntityWithValProperty() {
         val ent = EntityWithValProperty("test")


### PR DESCRIPTION
Java 17 forbids Java reflection from updating non-static `final` fields, which means we can no longer declare JPA-annotated properties as `val`. Change them to `var` so that the underlying field cannot be `final`.

~Also move annotations to the "getter" methods so that Hibernate no longer needs to use reflection to update them either.~
Hibernate's "property access" is not very compatible with Kotlin's "null safety", since Hibernate seems to want to set properties to `null` occasionally, but Kotlin "setter" methods prevent it unconditionally. So I'll revert back to using "field access" here for now.

However, I'll leave the _capability_ for our entities to use Hibernate "property access" in place, since theoretically it's still a valid option.