### PR TITLE
CORE-4815 Added check if all sessions in subflow are already closed or errored before skipping suspension

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowEngineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowEngineImpl.kt
@@ -115,14 +115,10 @@ class FlowEngineImpl @Activate constructor(
         }
     }
     private fun anyActiveSessions(currentSessionIds: List<String>): Boolean {
-        val checkPoint = getFiberExecutionContext().flowCheckpoint
-        for (sessionId in currentSessionIds){
-            val status = checkPoint.getSessionState(sessionId)?.status
-            if (status != SessionStateType.CLOSED && status != SessionStateType.ERROR){
-                return true
-            }
+        val flowCheckPoint = getFiberExecutionContext().flowCheckpoint
+        return currentSessionIds.any {sessionId ->
+            flowCheckPoint.getSessionState(sessionId)?.status !in listOf(SessionStateType.CLOSED, SessionStateType.ERROR)
         }
-        return false
     }
 
     private fun peekCurrentFlowStackItem(): FlowStackItem {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowEngineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowEngineImpl.kt
@@ -100,25 +100,21 @@ class FlowEngineImpl @Activate constructor(
     @Suspendable
     private fun closeSessionsOnSubFlowFinish() {
         val currentSessionIds = this.currentSessionIds
-        if (currentSessionIds.isNotEmpty()) {
-            if (sessionsAllErrorOrClose()){
-                flowFiberService.getExecutingFiber()
-                    .suspend(FlowIORequest.SubFlowFinished(currentSessionIds))
-            }
+        if (currentSessionIds.isNotEmpty() && anyActiveSessions(currentSessionIds)) {
+            flowFiberService.getExecutingFiber()
+                .suspend(FlowIORequest.SubFlowFinished(currentSessionIds))
         }
     }
 
     @Suspendable
     private fun errorSessionsOnSubFlowFinish(t: Throwable) {
         val currentSessionIds = this.currentSessionIds
-        if (currentSessionIds.isNotEmpty()) {
-           if (sessionsAllErrorOrClose()){
-               flowFiberService.getExecutingFiber()
-                   .suspend(FlowIORequest.SubFlowFailed(t, currentSessionIds))
-           }
+        if (currentSessionIds.isNotEmpty() && anyActiveSessions(currentSessionIds)) {
+           flowFiberService.getExecutingFiber()
+               .suspend(FlowIORequest.SubFlowFailed(t, currentSessionIds))
         }
     }
-    private fun sessionsAllErrorOrClose(): Boolean {
+    private fun anyActiveSessions(currentSessionIds: List<String>): Boolean {
         val checkPoint = getFiberExecutionContext().flowCheckpoint
         for (sessionId in currentSessionIds){
             val status = checkPoint.getSessionState(sessionId)?.status


### PR DESCRIPTION
Check if all the sessions in a subflow are already closed or errored and then skipping suspending. This saves the flow the time of suspending only to do nothing and scheduling a wakeup.