### PR TITLE
CORE-15815: Reduce the number of open connections

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
@@ -57,7 +57,7 @@ internal class TrustStoresMap(
             .expireAfterAccess(KEEP_KEY_STORE)
     )
 
-    private fun TrustedCertificates.cachedKeyStore(): KeyStore? {
+    private fun TrustedCertificates.cachedKeyStore(): KeyStore {
         return keyStorePool.get(pemCertificates) {
             trustStore
         }
@@ -77,7 +77,11 @@ internal class TrustStoresMap(
             ?: throw IllegalArgumentException("Unknown trust store for source X500 name ($sourceX500Name) " +
                     "and group ID ($destinationGroupId)")
 
-    fun getTrustStores() = trustRootsPerHoldingIdentity.values.mapNotNull { it.cachedKeyStore() }
+    fun getTrustStores() = trustRootsPerHoldingIdentity
+        .values
+        .map {
+            it.cachedKeyStore()
+        }.toSet()
 
     private val blockingDominoTile = BlockingDominoTile(
         this::class.java.simpleName,

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManagerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManagerTest.kt
@@ -51,7 +51,7 @@ class DynamicX509ExtendedTrustManagerTest {
     }
     private val mockTrustStore = mock<KeyStore>()
     private val trustStoresMap = mock<TrustStoresMap> {
-        on { getTrustStores() } doReturn listOf(mockTrustStore)
+        on { getTrustStores() } doReturn setOf(mockTrustStore)
     }
     private val dynamicX509ExtendedTrustManager = DynamicX509ExtendedTrustManager(
         trustStoresMap,

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
@@ -246,7 +246,7 @@ class TrustStoresMapTest {
     }
 
     @Test
-    fun `trust store creat the key sore more than once when the certificates are different`() {
+    fun `trust store create the key sore more than once when the certificates are different`() {
         val source1X500Name = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
         val source2X500Name = "CN=Bob, O=Alice Corp, L=LDN, C=GB"
         val groupId = "group id 1"

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
@@ -25,6 +25,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.InputStream
@@ -223,5 +224,43 @@ class TrustStoresMapTest {
 
         assertThat(data.firstValue.reader().readText()).isEqualTo("one")
         assertThat(data.secondValue.reader().readText()).isEqualTo("two")
+    }
+
+    @Test
+    fun `trust store create the key store once when the certificate are the same`() {
+        val source1X500Name = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
+        val source2X500Name = "CN=Bob, O=Alice Corp, L=LDN, C=GB"
+        val groupId = "group id 1"
+        creteResources.get()?.invoke(mock())
+        processor.firstValue.onSnapshot(
+            mapOf(
+                "key1" to GatewayTruststore(HoldingIdentity(source1X500Name, groupId), listOf("one")),
+                "key2" to GatewayTruststore(HoldingIdentity(source2X500Name, groupId), listOf("one"))
+            )
+        )
+
+        testObject.getTrustStore(MemberX500Name.parse(source1X500Name), groupId)
+        testObject.getTrustStore(MemberX500Name.parse(source2X500Name), groupId)
+
+        verify(keyStore, times(1)).setCertificateEntry(any(), any())
+    }
+
+    @Test
+    fun `trust store creat the key sore more than once when the certificates are different`() {
+        val source1X500Name = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
+        val source2X500Name = "CN=Bob, O=Alice Corp, L=LDN, C=GB"
+        val groupId = "group id 1"
+        creteResources.get()?.invoke(mock())
+        processor.firstValue.onSnapshot(
+            mapOf(
+                "key1" to GatewayTruststore(HoldingIdentity(source1X500Name, groupId), listOf("one")),
+                "key2" to GatewayTruststore(HoldingIdentity(source2X500Name, groupId), listOf("two"))
+            )
+        )
+
+        testObject.getTrustStore(MemberX500Name.parse(source1X500Name), groupId)
+        testObject.getTrustStore(MemberX500Name.parse(source2X500Name), groupId)
+
+        verify(keyStore, times(2)).setCertificateEntry(any(), any())
     }
 }


### PR DESCRIPTION
Add a cache of key stores in the `TrustStoresMap` so that two identical sets of certificates will have the same key store, and the same key in the connection manager, which will reduce the number of connections in the connection manager.