### PR TITLE
CORE-14023 Ledger transaction resolve states

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -32,7 +32,7 @@ import net.corda.ledger.consensual.data.transaction.ConsensualLedgerTransactionI
 import net.corda.ledger.consensual.data.transaction.TRANSACTION_META_DATA_CONSENSUAL_LEDGER_VERSION
 import net.corda.ledger.consensual.data.transaction.consensualComponentGroupStructure
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
-import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
+import net.corda.ledger.persistence.processor.LedgerPersistenceRequestProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.ResponseFactory
 import net.corda.persistence.common.getSerializationService
@@ -147,7 +147,7 @@ class ConsensualLedgerMessageProcessorTests {
         )
 
         // Send request to message processor
-        val processor = PersistenceRequestProcessor(
+        val processor = LedgerPersistenceRequestProcessor(
             currentSandboxGroupContext,
             virtualNode.entitySandboxService,
             delegatedRequestHandlerSelector,

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -26,7 +26,7 @@ import net.corda.ledger.common.testkit.createExample
 import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
 import net.corda.ledger.persistence.consensual.tests.ConsensualLedgerMessageProcessorTests
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
-import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
+import net.corda.ledger.persistence.processor.LedgerPersistenceRequestProcessor
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
 import net.corda.messaging.api.records.Record
@@ -151,7 +151,7 @@ class UtxoLedgerMessageProcessorTests {
             })
 
         // Send request to message processor
-        val processor = PersistenceRequestProcessor(
+        val processor = LedgerPersistenceRequestProcessor(
             currentSandboxGroupContext,
             virtualNode.entitySandboxService,
             delegatedRequestHandlerSelector,

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -31,7 +31,7 @@ import net.corda.ledger.persistence.utxo.UtxoTransactionReader
 import net.corda.ledger.persistence.utxo.impl.UtxoPersistenceServiceImpl
 import net.corda.ledger.persistence.utxo.tests.datamodel.UtxoEntityFactory
 import net.corda.ledger.utxo.data.state.StateAndRefImpl
-import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
+import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
@@ -231,7 +231,7 @@ class UtxoPersistenceServiceImplTest {
         val retval = persistenceService.findSignedLedgerTransaction(transaction.id.toString(), UNVERIFIED)
 
         assertThat(retval).isEqualTo(
-            LedgerTransactionContainer(
+            SignedLedgerTransactionContainer(
                 transaction.wireTransaction,
                 resolvedInputStateRefs,
                 resolvedReferenceStateRefs,

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -10,11 +10,15 @@ import net.corda.db.persistence.testkit.components.VirtualNodeService
 import net.corda.db.testkit.DbUtils
 import net.corda.ledger.common.data.transaction.PrivacySalt
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
+import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.common.data.transaction.TransactionStatus.VERIFIED
+import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
+import net.corda.ledger.common.testkit.cpiPackageSummaryExample
+import net.corda.ledger.common.testkit.cpkPackageSummaryListExample
 import net.corda.ledger.common.testkit.getPrivacySalt
 import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
 import net.corda.ledger.common.testkit.transactionMetadataExample
@@ -28,8 +32,12 @@ import net.corda.ledger.persistence.utxo.UtxoTransactionReader
 import net.corda.ledger.persistence.utxo.impl.UtxoPersistenceServiceImpl
 import net.corda.ledger.persistence.utxo.tests.datamodel.UtxoEntityFactory
 import net.corda.ledger.utxo.data.state.StateAndRefImpl
+import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
+import net.corda.ledger.utxo.data.transaction.UtxoTransactionMetadata
+import net.corda.ledger.utxo.data.transaction.utxoComponentGroupStructure
 import net.corda.libs.packaging.hash
 import net.corda.orm.utils.transaction
 import net.corda.persistence.common.getEntityManagerFactory
@@ -124,8 +132,9 @@ class UtxoPersistenceServiceImplTest {
             }.genKeyPair().public
         private val notaryExampleName = notaryX500Name
         private val notaryExampleKey = publicKeyExample
-        private val transactionInputs = listOf(StateRef(SecureHashImpl("SHA-256", ByteArray(12)), 1))
-        private val transactionOutputs = listOf(TestContractState1(), TestContractState2())
+        private val defaultInputStateRefs = listOf(StateRef(SecureHashImpl("SHA-256", ByteArray(12)), 1))
+        private val defaultReferenceStateRefs = listOf(StateRef(SecureHashImpl("SHA-256", ByteArray(34)), 2))
+        private val defaultTransactionOutputs = listOf(TestContractState1(), TestContractState2())
     }
 
     @BeforeAll
@@ -195,6 +204,49 @@ class UtxoPersistenceServiceImplTest {
         val transaction = persistTransactionViaEntity(entityFactory)
 
         val retval = persistenceService.findSignedTransaction(transaction.id.toString(), VERIFIED)
+
+        assertThat(retval).isEqualTo(null to "U")
+    }
+
+    @Test
+    fun `find ledger transaction that matches input status`() {
+        val entityFactory = UtxoEntityFactory(entityManagerFactory)
+
+        val transactions = listOf(
+            persistTransactionViaEntity(entityFactory, VERIFIED),
+            persistTransactionViaEntity(entityFactory, VERIFIED)
+        )
+
+        val inputStateRefs = listOf(StateRef(transactions[0].id, 0))
+        val referenceStateRefs = listOf(StateRef(transactions[1].id, 1))
+
+        val transaction = persistTransactionViaEntity(
+            entityFactory,
+            inputStateRefs = inputStateRefs,
+            referenceStateRefs = referenceStateRefs
+        )
+
+        val resolvedInputStateRefs = persistenceService.resolveStateRefs(inputStateRefs)
+        val resolvedReferenceStateRefs = persistenceService.resolveStateRefs(referenceStateRefs)
+
+        val retval = persistenceService.findLedgerTransaction(transaction.id.toString(), UNVERIFIED)
+
+        assertThat(retval).isEqualTo(
+            LedgerTransactionContainer(
+                transaction.wireTransaction,
+                resolvedInputStateRefs,
+                resolvedReferenceStateRefs,
+                transaction.signatures
+            ) to "U"
+        )
+    }
+
+    @Test
+    fun `find ledger transaction with different status returns null to Status`() {
+        val entityFactory = UtxoEntityFactory(entityManagerFactory)
+        val transaction = persistTransactionViaEntity(entityFactory)
+
+        val retval = persistenceService.findLedgerTransaction(transaction.id.toString(), VERIFIED)
 
         assertThat(retval).isEqualTo(null to "U")
     }
@@ -398,10 +450,10 @@ class UtxoPersistenceServiceImplTest {
                 .setParameter("transactionId", signedTransaction.id.toString())
                 .resultList
             assertThat(dbTransactionSources).isNotNull
-                .hasSameSizeAs(transactionInputs)
+                .hasSameSizeAs(defaultInputStateRefs)
             dbTransactionSources
                 .sortedWith(compareBy<Any> { it.field<Int>("groupIndex") }.thenBy { it.field<Int>("leafIndex") })
-                .zip(transactionInputs)
+                .zip(defaultInputStateRefs)
                 .forEachIndexed { leafIndex, (dbInput, transactionInput) ->
                     assertThat(dbInput.field<Int>("groupIndex")).isEqualTo(UtxoComponentGroup.INPUTS.ordinal)
                     assertThat(dbInput.field<Int>("leafIndex")).isEqualTo(leafIndex)
@@ -420,7 +472,7 @@ class UtxoPersistenceServiceImplTest {
                 .hasSameSizeAs(componentGroupLists.get(UtxoComponentGroup.OUTPUTS.ordinal))
             dbTransactionOutputs
                 .sortedWith(compareBy<Any> { it.field<Int>("groupIndex") }.thenBy { it.field<Int>("leafIndex") })
-                .zip(transactionOutputs)
+                .zip(defaultTransactionOutputs)
                 .forEachIndexed { leafIndex, (dbInput, transactionOutput) ->
                     assertThat(dbInput.field<Int>("groupIndex")).isEqualTo(UtxoComponentGroup.OUTPUTS.ordinal)
                     assertThat(dbInput.field<Int>("leafIndex")).isEqualTo(leafIndex)
@@ -531,9 +583,12 @@ class UtxoPersistenceServiceImplTest {
 
     private fun persistTransactionViaEntity(
         entityFactory: UtxoEntityFactory,
-        status: TransactionStatus = UNVERIFIED
+        status: TransactionStatus = UNVERIFIED,
+        inputStateRefs: List<StateRef> = defaultInputStateRefs,
+        referenceStateRefs: List<StateRef> = defaultReferenceStateRefs
+
     ): SignedTransactionContainer {
-        val signedTransaction = createSignedTransaction()
+        val signedTransaction = createSignedTransaction(inputStateRefs = inputStateRefs, referenceStateRefs = referenceStateRefs)
         entityManagerFactory.transaction { em ->
             em.persist(createTransactionEntity(entityFactory, signedTransaction, status = status))
         }
@@ -613,11 +668,11 @@ class UtxoPersistenceServiceImplTest {
 
     private fun createSignedTransaction(
         createdTs: Instant = testClock.instant(),
-        seed: String = seedSequence.incrementAndGet().toString()
+        seed: String = seedSequence.incrementAndGet().toString(),
+        inputStateRefs: List<StateRef> = defaultInputStateRefs,
+        referenceStateRefs: List<StateRef> = defaultReferenceStateRefs
     ): SignedTransactionContainer {
-        val transactionMetadata = transactionMetadataExample(
-            cpkPackageSeed = seed
-        )
+        val transactionMetadata = utxoTransactionMetadataExample(cpkPackageSeed = seed,)
         val componentGroupLists: List<List<ByteArray>> = listOf(
             listOf(jsonValidator.canonicalize(jsonMarshallingService.format(transactionMetadata)).toByteArray()),
             listOf("group1_component1".toByteArray()),
@@ -632,9 +687,9 @@ class UtxoPersistenceServiceImplTest {
             ),
             listOf("group4_component1".toByteArray()),
             listOf("group5_component1".toByteArray()),
-            transactionInputs.map { it.toBytes() },
-            listOf("group7_component1".toByteArray()),
-            transactionOutputs.map { it.toBytes() },
+            inputStateRefs.map { it.toBytes() },
+            referenceStateRefs.map { it.toBytes() },
+            defaultTransactionOutputs.map { it.toBytes() },
             listOf("group9_component1".toByteArray())
 
         )
@@ -749,4 +804,17 @@ class UtxoPersistenceServiceImplTest {
         val random = Random()
         return SecureHashImpl(DigestAlgorithmName.SHA2_256.name, ByteArray(32).also(random::nextBytes))
     }
+
+    private fun utxoTransactionMetadataExample(cpkPackageSeed: String? = null) = TransactionMetadataImpl(mapOf(
+        TransactionMetadataImpl.LEDGER_MODEL_KEY to UtxoLedgerTransactionImpl::class.java.name,
+        TransactionMetadataImpl.LEDGER_VERSION_KEY to UtxoTransactionMetadata.LEDGER_VERSION,
+        TransactionMetadataImpl.TRANSACTION_SUBTYPE_KEY to UtxoTransactionMetadata.TransactionSubtype.GENERAL,
+        TransactionMetadataImpl.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues,
+        TransactionMetadataImpl.PLATFORM_VERSION_KEY to 123,
+        TransactionMetadataImpl.CPI_METADATA_KEY to cpiPackageSummaryExample,
+        TransactionMetadataImpl.CPK_METADATA_KEY to cpkPackageSummaryListExample(cpkPackageSeed),
+        TransactionMetadataImpl.SCHEMA_VERSION_KEY to TransactionMetadataImpl.SCHEMA_VERSION,
+        TransactionMetadataImpl.COMPONENT_GROUPS_KEY to utxoComponentGroupStructure,
+        TransactionMetadataImpl.MEMBERSHIP_GROUP_PARAMETERS_HASH_KEY to "MEMBERSHIP_GROUP_PARAMETERS_HASH"
+    ))
 }

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -21,7 +21,6 @@ import net.corda.ledger.common.testkit.cpiPackageSummaryExample
 import net.corda.ledger.common.testkit.cpkPackageSummaryListExample
 import net.corda.ledger.common.testkit.getPrivacySalt
 import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
-import net.corda.ledger.common.testkit.transactionMetadataExample
 import net.corda.ledger.persistence.consensual.tests.datamodel.field
 import net.corda.ledger.persistence.json.ContractStateVaultJsonFactoryRegistry
 import net.corda.ledger.persistence.json.impl.DefaultContractStateVaultJsonFactoryImpl
@@ -229,7 +228,7 @@ class UtxoPersistenceServiceImplTest {
         val resolvedInputStateRefs = persistenceService.resolveStateRefs(inputStateRefs)
         val resolvedReferenceStateRefs = persistenceService.resolveStateRefs(referenceStateRefs)
 
-        val retval = persistenceService.findLedgerTransaction(transaction.id.toString(), UNVERIFIED)
+        val retval = persistenceService.findSignedLedgerTransaction(transaction.id.toString(), UNVERIFIED)
 
         assertThat(retval).isEqualTo(
             LedgerTransactionContainer(
@@ -246,7 +245,7 @@ class UtxoPersistenceServiceImplTest {
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
         val transaction = persistTransactionViaEntity(entityFactory)
 
-        val retval = persistenceService.findLedgerTransaction(transaction.id.toString(), VERIFIED)
+        val retval = persistenceService.findSignedLedgerTransaction(transaction.id.toString(), VERIFIED)
 
         assertThat(retval).isEqualTo(null to "U")
     }

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -184,7 +184,7 @@ class UtxoPersistenceServiceImplTest {
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
         val transaction = persistTransactionViaEntity(entityFactory)
 
-        val retval = persistenceService.findTransaction(transaction.id.toString(), UNVERIFIED)
+        val retval = persistenceService.findSignedTransaction(transaction.id.toString(), UNVERIFIED)
 
         assertThat(retval).isEqualTo(transaction to "U")
     }
@@ -194,7 +194,7 @@ class UtxoPersistenceServiceImplTest {
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
         val transaction = persistTransactionViaEntity(entityFactory)
 
-        val retval = persistenceService.findTransaction(transaction.id.toString(), VERIFIED)
+        val retval = persistenceService.findSignedTransaction(transaction.id.toString(), VERIFIED)
 
         assertThat(retval).isEqualTo(null to "U")
     }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/LedgerPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/LedgerPersistenceService.kt
@@ -4,7 +4,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
-import net.corda.ledger.persistence.processor.PersistenceRequestSubscriptionFactory
+import net.corda.ledger.persistence.processor.LedgerPersistenceRequestSubscriptionFactory
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.Lifecycle
@@ -41,8 +41,8 @@ class LedgerPersistenceService @Activate constructor(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CpiInfoReadService::class)
     private val cpiInfoReadService: CpiInfoReadService,
-    @Reference(service = PersistenceRequestSubscriptionFactory::class)
-    private val persistenceRequestSubscriptionFactory: PersistenceRequestSubscriptionFactory
+    @Reference(service = LedgerPersistenceRequestSubscriptionFactory::class)
+    private val ledgerPersistenceRequestSubscriptionFactory: LedgerPersistenceRequestSubscriptionFactory
 ) : Lifecycle {
     private var configHandle: Resource? = null
     private var ledgerProcessorSubscription: Subscription<String, LedgerPersistenceRequest>? = null
@@ -79,7 +79,7 @@ class LedgerPersistenceService @Activate constructor(
             }
             is ConfigChangedEvent -> {
                 ledgerProcessorSubscription?.close()
-                val newLedgerProcessorSubscription = persistenceRequestSubscriptionFactory.create(
+                val newLedgerProcessorSubscription = ledgerPersistenceRequestSubscriptionFactory.create(
                     event.config.getConfig(MESSAGING_CONFIG)
                 )
                 logger.debug("Starting LedgerPersistenceService.")

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualRequestHandlerSelectorImpl.kt
@@ -8,6 +8,8 @@ import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.common.UnsupportedRequestTypeException
 import net.corda.ledger.persistence.consensual.ConsensualRepository
 import net.corda.ledger.persistence.consensual.ConsensualRequestHandlerSelector
+import net.corda.ledger.persistence.consensual.impl.request.handlers.ConsensualFindTransactionRequestHandler
+import net.corda.ledger.persistence.consensual.impl.request.handlers.ConsensualPersistTransactionRequestHandler
 import net.corda.persistence.common.ResponseFactory
 import net.corda.persistence.common.getEntityManagerFactory
 import net.corda.persistence.common.getSerializationService

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/request/handlers/ConsensualFindTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/request/handlers/ConsensualFindTransactionRequestHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.persistence.consensual.impl
+package net.corda.ledger.persistence.consensual.impl.request.handlers
 
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/request/handlers/ConsensualPersistTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/request/handlers/ConsensualPersistTransactionRequestHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.persistence.consensual.impl
+package net.corda.ledger.persistence.consensual.impl.request.handlers
 
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext
@@ -6,6 +6,7 @@ import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.data.persistence.EntityResponse
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.consensual.ConsensualPersistenceService
+import net.corda.ledger.persistence.consensual.impl.ConsensualTransactionReaderImpl
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.ResponseFactory
 import net.corda.v5.application.serialization.SerializationService

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/LedgerPersistenceRequestProcessor.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/LedgerPersistenceRequestProcessor.kt
@@ -20,6 +20,7 @@ import net.corda.utilities.translateFlowContextToMDC
 import net.corda.utilities.withMDC
 import net.corda.v5.application.flows.FlowContextPropertyKeys.CPK_FILE_CHECKSUM
 import net.corda.virtualnode.toCorda
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
 
@@ -27,7 +28,7 @@ import java.time.Duration
  * Handles incoming requests, typically from the flow worker, and sends responses.
  */
 @Suppress("LongParameterList")
-class PersistenceRequestProcessor(
+class LedgerPersistenceRequestProcessor(
     private val currentSandboxGroupContext: CurrentSandboxGroupContext,
     private val entitySandboxService: EntitySandboxService,
     private val delegatedRequestHandlerSelector: DelegatedRequestHandlerSelector,
@@ -35,7 +36,7 @@ class PersistenceRequestProcessor(
 ) : DurableProcessor<String, LedgerPersistenceRequest> {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        val log: Logger = LoggerFactory.getLogger(LedgerPersistenceRequestProcessor::class.java)
     }
 
     override val keyClass = String::class.java

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/LedgerPersistenceRequestSubscriptionFactory.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/LedgerPersistenceRequestSubscriptionFactory.kt
@@ -5,10 +5,10 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.subscription.Subscription
 
 /**
- * The [PersistenceRequestSubscriptionFactory] creates a new subscription to the durable topic used to receive
+ * The [LedgerPersistenceRequestSubscriptionFactory] creates a new subscription to the durable topic used to receive
  * [LedgerPersistenceRequest] messages.
  */
-interface PersistenceRequestSubscriptionFactory {
+interface LedgerPersistenceRequestSubscriptionFactory {
     /**
      * Create a new subscription
      *

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestSubscriptionFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestSubscriptionFactoryImpl.kt
@@ -2,8 +2,8 @@ package net.corda.ledger.persistence.processor.impl
 
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
-import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
-import net.corda.ledger.persistence.processor.PersistenceRequestSubscriptionFactory
+import net.corda.ledger.persistence.processor.LedgerPersistenceRequestProcessor
+import net.corda.ledger.persistence.processor.LedgerPersistenceRequestSubscriptionFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
@@ -16,9 +16,9 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 
-@Component(service = [PersistenceRequestSubscriptionFactory::class])
+@Component(service = [LedgerPersistenceRequestSubscriptionFactory::class])
 @Suppress("LongParameterList")
-class PersistenceRequestSubscriptionFactoryImpl @Activate constructor(
+class LedgerPersistenceRequestSubscriptionFactoryImpl @Activate constructor(
     @Reference(service = CurrentSandboxGroupContext::class)
     private val currentSandboxGroupContext: CurrentSandboxGroupContext,
     @Reference(service = SubscriptionFactory::class)
@@ -29,7 +29,7 @@ class PersistenceRequestSubscriptionFactoryImpl @Activate constructor(
     private val delegatedRequestHandlerSelector: DelegatedRequestHandlerSelector,
     @Reference(service = ResponseFactory::class)
     private val responseFactory: ResponseFactory
-) : PersistenceRequestSubscriptionFactory {
+) : LedgerPersistenceRequestSubscriptionFactory {
     companion object {
         internal const val GROUP_NAME = "persistence.ledger.processor"
     }
@@ -37,7 +37,7 @@ class PersistenceRequestSubscriptionFactoryImpl @Activate constructor(
     override fun create(config: SmartConfig): Subscription<String, LedgerPersistenceRequest> {
         val subscriptionConfig = SubscriptionConfig(GROUP_NAME, Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC)
 
-        val processor = PersistenceRequestProcessor(
+        val processor = LedgerPersistenceRequestProcessor(
             currentSandboxGroupContext ,
             entitySandboxService,
             delegatedRequestHandlerSelector,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
@@ -8,7 +8,6 @@ import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.messaging.api.records.Record
-import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.virtualnode.HoldingIdentity
@@ -26,7 +25,7 @@ interface UtxoOutputRecordFactory {
         externalEventContext: ExternalEventContext,
     ): Record<String, FlowEvent>
 
-    fun getFindLedgerTransactionSuccessRecord(
+    fun getFindSignedLedgerTransactionSuccessRecord(
         transactionContainer: LedgerTransactionContainer?,
         status: String?,
         externalEventContext: ExternalEventContext,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
@@ -5,6 +5,7 @@ import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
+import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.messaging.api.records.Record
 import net.corda.v5.application.serialization.SerializationService
@@ -23,13 +24,17 @@ interface UtxoOutputRecordFactory {
         transactionContainer: SignedTransactionContainer?,
         status: String?,
         externalEventContext: ExternalEventContext,
-        serializationService: SerializationService
+    ): Record<String, FlowEvent>
+
+    fun getFindLedgerTransactionSuccessRecord(
+        transactionContainer: LedgerTransactionContainer?,
+        status: String?,
+        externalEventContext: ExternalEventContext,
     ): Record<String, FlowEvent>
 
     fun getStatesSuccessRecord(
         states: List<UtxoTransactionOutputDto>,
         externalEventContext: ExternalEventContext,
-        serializationService: SerializationService
     ): Record<String, FlowEvent>
 
     fun getPersistTransactionSuccessRecord(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
@@ -5,7 +5,7 @@ import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
-import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
+import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.messaging.api.records.Record
 import net.corda.v5.ledger.utxo.StateAndRef
@@ -26,7 +26,7 @@ interface UtxoOutputRecordFactory {
     ): Record<String, FlowEvent>
 
     fun getFindSignedLedgerTransactionSuccessRecord(
-        transactionContainer: LedgerTransactionContainer?,
+        transactionContainer: SignedLedgerTransactionContainer?,
         status: String?,
         externalEventContext: ExternalEventContext,
     ): Record<String, FlowEvent>

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -4,7 +4,7 @@ import net.corda.data.membership.SignedGroupParameters
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.persistence.common.InconsistentLedgerStateException
-import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
+import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.utxo.ContractState
@@ -14,7 +14,7 @@ import net.corda.v5.ledger.utxo.observer.UtxoToken
 interface UtxoPersistenceService {
 
     /**
-     * Find a verified signed transaction in the persistence context given it's [id].
+     * Find a signed transaction in the persistence context given it's [id].
      *
      * @param id transaction ID.
      * @param transactionStatus filter for this status.
@@ -26,8 +26,8 @@ interface UtxoPersistenceService {
     fun findSignedTransaction(id: String, transactionStatus: TransactionStatus): Pair<SignedTransactionContainer?, String?>
 
     /**
-     * Find a verified signed ledger transaction in the persistence context given it's [id] and return it with the status it is stored with.
-     * This involves resolving its input and reference state and fetching the transaction's signatures.
+     * Find a signed ledger transaction in the persistence context given it's [id] and return it with the status it is stored with. This
+     * involves resolving its input and reference state and fetching the transaction's signatures.
      *
      * @param id transaction ID.
      * @param transactionStatus filter for this status.
@@ -37,7 +37,7 @@ interface UtxoPersistenceService {
      * @throws InconsistentLedgerStateException If the ledger tables are inconsistent.
      * @throws CordaRuntimeException If any state refs fail to resolve.
      */
-    fun findSignedLedgerTransaction(id: String, transactionStatus: TransactionStatus): Pair<LedgerTransactionContainer?, String?>
+    fun findSignedLedgerTransaction(id: String, transactionStatus: TransactionStatus): Pair<SignedLedgerTransactionContainer?, String?>
 
     fun <T: ContractState> findUnconsumedVisibleStatesByType(stateClass: Class<out T>): List<UtxoTransactionOutputDto>
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.persistence.utxo
 import net.corda.data.membership.SignedGroupParameters
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
+import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.utxo.ContractState
@@ -10,7 +11,9 @@ import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 
 interface UtxoPersistenceService {
-    fun findTransaction(id: String, transactionStatus: TransactionStatus): Pair<SignedTransactionContainer?, String?>
+    fun findSignedTransaction(id: String, transactionStatus: TransactionStatus): Pair<SignedTransactionContainer?, String?>
+
+    fun findLedgerTransaction(id: String, transactionStatus: TransactionStatus): Pair<LedgerTransactionContainer?, String?>
 
     fun <T: ContractState> findUnconsumedVisibleStatesByType(stateClass: Class<out T>): List<UtxoTransactionOutputDto>
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.persistence.utxo
 import net.corda.data.membership.SignedGroupParameters
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
+import net.corda.ledger.persistence.common.InconsistentLedgerStateException
 import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
@@ -11,9 +12,32 @@ import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 
 interface UtxoPersistenceService {
+
+    /**
+     * Find a verified signed transaction in the persistence context given it's [id].
+     *
+     * @param id transaction ID.
+     * @param transactionStatus filter for this status.
+     *
+     * @return The found signed transaction and its status, null if it could not be found in the persistence context.
+     *
+     * @throws InconsistentLedgerStateException If the ledger tables are inconsistent.
+     */
     fun findSignedTransaction(id: String, transactionStatus: TransactionStatus): Pair<SignedTransactionContainer?, String?>
 
-    fun findLedgerTransaction(id: String, transactionStatus: TransactionStatus): Pair<LedgerTransactionContainer?, String?>
+    /**
+     * Find a verified signed ledger transaction in the persistence context given it's [id] and return it with the status it is stored with.
+     * This involves resolving its input and reference state and fetching the transaction's signatures.
+     *
+     * @param id transaction ID.
+     * @param transactionStatus filter for this status.
+     *
+     * @return The found signed ledger transaction and its status, null if it could not be found in the persistence context.
+     *
+     * @throws InconsistentLedgerStateException If the ledger tables are inconsistent.
+     * @throws CordaRuntimeException If any state refs fail to resolve.
+     */
+    fun findSignedLedgerTransaction(id: String, transactionStatus: TransactionStatus): Pair<LedgerTransactionContainer?, String?>
 
     fun <T: ContractState> findUnconsumedVisibleStatesByType(stateClass: Class<out T>): List<UtxoTransactionOutputDto>
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoOutputRecordFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoOutputRecordFactoryImpl.kt
@@ -13,7 +13,7 @@ import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 import net.corda.data.persistence.EntityResponse
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
-import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
+import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.ResponseFactory
@@ -75,7 +75,7 @@ class UtxoOutputRecordFactoryImpl(
     }
 
     override fun getFindSignedLedgerTransactionSuccessRecord(
-        transactionContainer: LedgerTransactionContainer?,
+        transactionContainer: SignedLedgerTransactionContainer?,
         status: String?,
         externalEventContext: ExternalEventContext,
     ): Record<String, FlowEvent> {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoOutputRecordFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoOutputRecordFactoryImpl.kt
@@ -74,7 +74,7 @@ class UtxoOutputRecordFactoryImpl(
         )
     }
 
-    override fun getFindLedgerTransactionSuccessRecord(
+    override fun getFindSignedLedgerTransactionSuccessRecord(
         transactionContainer: LedgerTransactionContainer?,
         status: String?,
         externalEventContext: ExternalEventContext,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -75,8 +75,8 @@ class UtxoPersistenceServiceImpl(
         return entityManagerFactory.transaction { em ->
             val status = repository.findTransactionStatus(em, id)
             if (status == transactionStatus.value) {
-                val (transaction, signatures) = repository.findTransaction(em, id)
-                    ?.let { WrappedUtxoWireTransaction(it.wireTransaction, serializationService) to it.signatures }
+                val transaction = repository.findTransaction(em, id)
+                    ?.let { WrappedUtxoWireTransaction(it.wireTransaction, serializationService) }
                     ?: throw InconsistentLedgerStateException("Transaction $id in status $status has disappeared from the database")
 
                 val allStateRefs = (transaction.inputStateRefs + transaction.referenceStateRefs).distinct()
@@ -93,7 +93,7 @@ class UtxoPersistenceServiceImpl(
                         ?: throw CordaRuntimeException("Could not find reference StateRef $it when finding transaction $id")
                 }
 
-                LedgerTransactionContainer(transaction.wireTransaction, inputStateAndRefs, referenceStateAndRefs, signatures)
+                LedgerTransactionContainer(transaction.wireTransaction, inputStateAndRefs, referenceStateAndRefs)
             } else {
                 null
             } to status

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -67,7 +67,7 @@ class UtxoPersistenceServiceImpl(
         }
     }
 
-    override fun findLedgerTransaction(
+    override fun findSignedLedgerTransaction(
         id: String,
         transactionStatus: TransactionStatus
     ): Pair<LedgerTransactionContainer?, String?> {
@@ -82,11 +82,11 @@ class UtxoPersistenceServiceImpl(
 
                 val stateRefsToStateAndRefs = resolveStateRefs(allStateRefs)
                     .associateBy { StateRef(parseSecureHash(it.transactionId), it.leafIndex) }
+
                 val inputStateAndRefs = transaction.inputStateRefs.map {
                     stateRefsToStateAndRefs[it]
                         ?: throw CordaRuntimeException("Could not find input StateRef $it when finding transaction $id")
                 }
-
                 val referenceStateAndRefs = transaction.referenceStateRefs.map {
                     stateRefsToStateAndRefs[it]
                         ?: throw CordaRuntimeException("Could not find reference StateRef $it when finding transaction $id")

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -12,7 +12,7 @@ import net.corda.ledger.persistence.utxo.CustomRepresentation
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.ledger.persistence.utxo.UtxoRepository
 import net.corda.ledger.persistence.utxo.UtxoTransactionReader
-import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
+import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
@@ -70,7 +70,7 @@ class UtxoPersistenceServiceImpl(
     override fun findSignedLedgerTransaction(
         id: String,
         transactionStatus: TransactionStatus
-    ): Pair<LedgerTransactionContainer?, String?> {
+    ): Pair<SignedLedgerTransactionContainer?, String?> {
         return entityManagerFactory.transaction { em ->
             val status = repository.findTransactionStatus(em, id)
             if (status == transactionStatus.value) {
@@ -92,7 +92,7 @@ class UtxoPersistenceServiceImpl(
                         ?: throw CordaRuntimeException("Could not find reference StateRef $it when finding transaction $id")
                 }
 
-                LedgerTransactionContainer(transaction.wireTransaction, inputStateAndRefs, referenceStateAndRefs, signatures)
+                SignedLedgerTransactionContainer(transaction.wireTransaction, inputStateAndRefs, referenceStateAndRefs, signatures)
             } else {
                 null
             } to status

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.persistence.utxo.impl
 
 import net.corda.data.ledger.persistence.FindSignedGroupParameters
+import net.corda.data.ledger.persistence.FindSignedLedgerTransaction
 import net.corda.data.ledger.persistence.FindTransaction
 import net.corda.data.ledger.persistence.FindUnconsumedStatesByType
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
@@ -10,7 +11,6 @@ import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.data.ledger.persistence.PersistTransactionIfDoesNotExist
 import net.corda.data.ledger.persistence.ResolveStateRefs
 import net.corda.data.ledger.persistence.UpdateTransactionStatus
-import net.corda.data.ledger.persistence.v2.FindLedgerTransaction
 import net.corda.data.persistence.FindWithNamedQuery
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.persistence.common.RequestHandler
@@ -19,8 +19,8 @@ import net.corda.ledger.persistence.json.impl.DefaultContractStateVaultJsonFacto
 import net.corda.ledger.persistence.query.execution.impl.VaultNamedQueryExecutorImpl
 import net.corda.ledger.persistence.utxo.UtxoRequestHandlerSelector
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoExecuteNamedQueryHandler
-import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedLedgerTransactionRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedGroupParametersRequestHandler
+import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedLedgerTransactionRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindTransactionRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindUnconsumedStatesByTypeRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoPersistSignedGroupParametersIfDoNotExistRequestHandler
@@ -78,7 +78,7 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
                     outputRecordFactory
                 )
             }
-            is FindLedgerTransaction -> {
+            is FindSignedLedgerTransaction -> {
                 UtxoFindSignedLedgerTransactionRequestHandler(
                     req,
                     externalEventContext,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -19,7 +19,7 @@ import net.corda.ledger.persistence.json.impl.DefaultContractStateVaultJsonFacto
 import net.corda.ledger.persistence.query.execution.impl.VaultNamedQueryExecutorImpl
 import net.corda.ledger.persistence.utxo.UtxoRequestHandlerSelector
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoExecuteNamedQueryHandler
-import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindLedgerTransactionRequestHandler
+import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedLedgerTransactionRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedGroupParametersRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindTransactionRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindUnconsumedStatesByTypeRequestHandler
@@ -79,7 +79,7 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
                 )
             }
             is FindLedgerTransaction -> {
-                UtxoFindLedgerTransactionRequestHandler(
+                UtxoFindSignedLedgerTransactionRequestHandler(
                     req,
                     externalEventContext,
                     persistenceService,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
@@ -102,7 +102,7 @@ class UtxoTransactionReaderImpl(
 
         return inputsGroupedByTransactionId.flatMap { inputsByTransactionId ->
 
-            val (transaction, _) = persistenceService.findTransaction(
+            val (transaction, _) = persistenceService.findSignedTransaction(
                 id = inputsByTransactionId.key.toString(),
                 transactionStatus = TransactionStatus.VERIFIED
             )

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoExecuteNamedQueryHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoExecuteNamedQueryHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.persistence.FindWithNamedQuery

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindLedgerTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindLedgerTransactionRequestHandler.kt
@@ -1,7 +1,8 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.FindTransaction
+import net.corda.data.ledger.persistence.v2.FindLedgerTransaction
 import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
@@ -9,9 +10,8 @@ import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.messaging.api.records.Record
 import net.corda.v5.application.serialization.SerializationService
 
-class UtxoFindTransactionRequestHandler(
-    private val findTransaction: FindTransaction,
-    private val serializationService: SerializationService,
+class UtxoFindLedgerTransactionRequestHandler(
+    private val findTransaction: FindLedgerTransaction,
     private val externalEventContext: ExternalEventContext,
     private val persistenceService: UtxoPersistenceService,
     private val utxoOutputRecordFactory: UtxoOutputRecordFactory
@@ -19,18 +19,17 @@ class UtxoFindTransactionRequestHandler(
 
     override fun execute(): List<Record<*, *>> {
         // Find the transaction
-        val (transactionContainer, status) = persistenceService.findTransaction(
+        val (transactionContainer, status) = persistenceService.findLedgerTransaction(
             findTransaction.id,
             findTransaction.transactionStatus.toTransactionStatus()
         )
 
         // return output records
         return listOf(
-            utxoOutputRecordFactory.getFindTransactionSuccessRecord(
+            utxoOutputRecordFactory.getFindLedgerTransactionSuccessRecord(
                 transactionContainer,
                 status,
                 externalEventContext,
-                serializationService
             )
         )
     }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindSignedGroupParametersRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindSignedGroupParametersRequestHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.external.ExternalEventContext

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindSignedLedgerTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindSignedLedgerTransactionRequestHandler.kt
@@ -21,7 +21,7 @@ class UtxoFindSignedLedgerTransactionRequestHandler(
             findTransaction.transactionStatus.toTransactionStatus()
         )
         return listOf(
-            utxoOutputRecordFactory.getFindLedgerTransactionSuccessRecord(
+            utxoOutputRecordFactory.getFindSignedLedgerTransactionSuccessRecord(
                 transactionContainer,
                 status,
                 externalEventContext,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindSignedLedgerTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindSignedLedgerTransactionRequestHandler.kt
@@ -1,30 +1,25 @@
 package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.flow.event.external.ExternalEventContext
-import net.corda.data.ledger.persistence.FindTransaction
-import net.corda.data.ledger.persistence.v2.FindLedgerTransaction
+import net.corda.data.ledger.persistence.FindSignedLedgerTransaction
 import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.messaging.api.records.Record
-import net.corda.v5.application.serialization.SerializationService
 
-class UtxoFindLedgerTransactionRequestHandler(
-    private val findTransaction: FindLedgerTransaction,
+class UtxoFindSignedLedgerTransactionRequestHandler(
+    private val findTransaction: FindSignedLedgerTransaction,
     private val externalEventContext: ExternalEventContext,
     private val persistenceService: UtxoPersistenceService,
     private val utxoOutputRecordFactory: UtxoOutputRecordFactory
 ) : RequestHandler {
 
     override fun execute(): List<Record<*, *>> {
-        // Find the transaction
-        val (transactionContainer, status) = persistenceService.findLedgerTransaction(
+        val (transactionContainer, status) = persistenceService.findSignedLedgerTransaction(
             findTransaction.id,
             findTransaction.transactionStatus.toTransactionStatus()
         )
-
-        // return output records
         return listOf(
             utxoOutputRecordFactory.getFindLedgerTransactionSuccessRecord(
                 transactionContainer,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindTransactionRequestHandler.kt
@@ -1,0 +1,32 @@
+package net.corda.ledger.persistence.utxo.impl.request.handlers
+
+import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.data.ledger.persistence.FindTransaction
+import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
+import net.corda.ledger.persistence.common.RequestHandler
+import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
+import net.corda.ledger.persistence.utxo.UtxoPersistenceService
+import net.corda.messaging.api.records.Record
+
+class UtxoFindTransactionRequestHandler(
+    private val findTransaction: FindTransaction,
+    private val externalEventContext: ExternalEventContext,
+    private val persistenceService: UtxoPersistenceService,
+    private val utxoOutputRecordFactory: UtxoOutputRecordFactory
+) : RequestHandler {
+
+    override fun execute(): List<Record<*, *>> {
+        val (transactionContainer, status) = persistenceService.findSignedTransaction(
+            findTransaction.id,
+            findTransaction.transactionStatus.toTransactionStatus()
+        )
+
+        return listOf(
+            utxoOutputRecordFactory.getFindTransactionSuccessRecord(
+                transactionContainer,
+                status,
+                externalEventContext,
+            )
+        )
+    }
+}

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindUnconsumedStatesByTypeRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindUnconsumedStatesByTypeRequestHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.FindUnconsumedStatesByType
@@ -7,14 +7,12 @@ import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.messaging.api.records.Record
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.ledger.utxo.ContractState
 
 @Suppress("LongParameterList")
 class UtxoFindUnconsumedStatesByTypeRequestHandler(
     private val findUnconsumedStatesByType: FindUnconsumedStatesByType,
     private val sandbox: SandboxGroupContext,
-    private val serializationService: SerializationService,
     private val externalEventContext: ExternalEventContext,
     private val persistenceService: UtxoPersistenceService,
     private val utxoOutputRecordFactory: UtxoOutputRecordFactory
@@ -27,18 +25,10 @@ class UtxoFindUnconsumedStatesByTypeRequestHandler(
             "Provided ${findUnconsumedStatesByType.stateClassName} is not type of ContractState"
         }
 
-        // Find the visible states of transaction
         val visibleStates = persistenceService.findUnconsumedVisibleStatesByType(
             stateType as Class<out ContractState>
         )
 
-        // Return output records
-        return listOf(
-            utxoOutputRecordFactory.getStatesSuccessRecord(
-                visibleStates,
-                externalEventContext,
-                serializationService
-            )
-        )
+        return listOf(utxoOutputRecordFactory.getStatesSuccessRecord(visibleStates, externalEventContext))
     }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistSignedGroupParametersIfDoNotExistRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistSignedGroupParametersIfDoNotExistRequestHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionIfDoesNotExistRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionIfDoesNotExistRequestHandler.kt
@@ -1,28 +1,33 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext
-import net.corda.data.ledger.persistence.UpdateTransactionStatus
 import net.corda.data.persistence.EntityResponse
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
-import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
+import net.corda.ledger.persistence.utxo.UtxoTransactionReader
 import net.corda.messaging.api.records.Record
+import net.corda.v5.application.serialization.SerializationService
+import java.nio.ByteBuffer
 
-class UtxoUpdateTransactionStatusRequestHandler(
-    private val request: UpdateTransactionStatus,
+class UtxoPersistTransactionIfDoesNotExistRequestHandler(
+    private val transaction: UtxoTransactionReader,
     private val externalEventContext: ExternalEventContext,
     private val externalEventResponseFactory: ExternalEventResponseFactory,
+    private val serializationService: SerializationService,
     private val persistenceService: UtxoPersistenceService
 ) : RequestHandler {
 
     override fun execute(): List<Record<*, *>> {
-        persistenceService.updateStatus(request.id, request.transactionStatus.toTransactionStatus())
+        // persist the transaction if it doesn't exist
+        val result = persistenceService.persistTransactionIfDoesNotExist(transaction)
+
+        // should this do token related side effect things?
         return listOf(
             externalEventResponseFactory.success(
                 externalEventContext,
-                EntityResponse(emptyList(), KeyValuePairList(emptyList()))
+                EntityResponse(listOf(ByteBuffer.wrap(serializationService.serialize(result).bytes)), KeyValuePairList(emptyList()))
             )
         )
     }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionRequestHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.ledger.common.data.transaction.TransactionStatus

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoResolveStateRefsRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoResolveStateRefsRequestHandler.kt
@@ -7,7 +7,6 @@ import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.messaging.api.records.Record
-import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.ledger.utxo.StateRef
 
 @Suppress("LongParameterList")

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoResolveStateRefsRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoResolveStateRefsRequestHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.flow.event.external.ExternalEventContext
@@ -13,14 +13,12 @@ import net.corda.v5.ledger.utxo.StateRef
 @Suppress("LongParameterList")
 class UtxoResolveStateRefsRequestHandler(
     private val resolveStateRefs: ResolveStateRefs,
-    private val serializationService: SerializationService,
     private val externalEventContext: ExternalEventContext,
     private val persistenceService: UtxoPersistenceService,
     private val utxoOutputRecordFactory: UtxoOutputRecordFactory
 ) : RequestHandler {
 
     override fun execute(): List<Record<*, *>> {
-        // Find the states
         val stateAndRefs = persistenceService.resolveStateRefs(
             resolveStateRefs.stateRefs.map {
                 StateRef(
@@ -29,14 +27,6 @@ class UtxoResolveStateRefsRequestHandler(
                 )
             }
         )
-
-        // Return output records
-        return listOf(
-            utxoOutputRecordFactory.getStatesSuccessRecord(
-                stateAndRefs,
-                externalEventContext,
-                serializationService
-            )
-        )
+        return listOf(utxoOutputRecordFactory.getStatesSuccessRecord(stateAndRefs, externalEventContext))
     }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoUpdateTransactionStatusRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoUpdateTransactionStatusRequestHandler.kt
@@ -1,33 +1,28 @@
-package net.corda.ledger.persistence.utxo.impl
+package net.corda.ledger.persistence.utxo.impl.request.handlers
 
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.data.ledger.persistence.UpdateTransactionStatus
 import net.corda.data.persistence.EntityResponse
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
+import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
-import net.corda.ledger.persistence.utxo.UtxoTransactionReader
 import net.corda.messaging.api.records.Record
-import net.corda.v5.application.serialization.SerializationService
-import java.nio.ByteBuffer
 
-class UtxoPersistTransactionIfDoesNotExistRequestHandler(
-    private val transaction: UtxoTransactionReader,
+class UtxoUpdateTransactionStatusRequestHandler(
+    private val request: UpdateTransactionStatus,
     private val externalEventContext: ExternalEventContext,
     private val externalEventResponseFactory: ExternalEventResponseFactory,
-    private val serializationService: SerializationService,
     private val persistenceService: UtxoPersistenceService
 ) : RequestHandler {
 
     override fun execute(): List<Record<*, *>> {
-        // persist the transaction if it doesn't exist
-        val result = persistenceService.persistTransactionIfDoesNotExist(transaction)
-
-        // should this do token related side effect things?
+        persistenceService.updateStatus(request.id, request.transactionStatus.toTransactionStatus())
         return listOf(
             externalEventResponseFactory.success(
                 externalEventContext,
-                EntityResponse(listOf(ByteBuffer.wrap(serializationService.serialize(result).bytes)), KeyValuePairList(emptyList()))
+                EntityResponse(emptyList(), KeyValuePairList(emptyList()))
             )
         )
     }

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/LedgerPersistenceServiceTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/LedgerPersistenceServiceTest.kt
@@ -3,7 +3,7 @@ package net.corda.ledger.persistence
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
-import net.corda.ledger.persistence.processor.PersistenceRequestSubscriptionFactory
+import net.corda.ledger.persistence.processor.LedgerPersistenceRequestSubscriptionFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.test.impl.LifecycleTest
 import net.corda.messaging.api.subscription.Subscription
@@ -38,7 +38,7 @@ class LedgerPersistenceServiceTest {
 
     private val subscription1 = mock<Subscription<String, LedgerPersistenceRequest>>()
     private val subscription2 = mock<Subscription<String, LedgerPersistenceRequest>>()
-    private val persistenceRequestSubscriptionFactory = mock<PersistenceRequestSubscriptionFactory>().apply {
+    private val ledgerPersistenceRequestSubscriptionFactory = mock<LedgerPersistenceRequestSubscriptionFactory>().apply {
         whenever(this.create(MINIMUM_SMART_CONFIG)).thenReturn(subscription1, subscription2)
     }
 
@@ -50,7 +50,7 @@ class LedgerPersistenceServiceTest {
     @Test
     fun `on configuration event creates and starts subscription`() {
         val subscription = mock<Subscription<String, LedgerPersistenceRequest>>()
-        whenever(persistenceRequestSubscriptionFactory.create(MINIMUM_SMART_CONFIG)).thenReturn(subscription)
+        whenever(ledgerPersistenceRequestSubscriptionFactory.create(MINIMUM_SMART_CONFIG)).thenReturn(subscription)
 
         getTokenCacheComponentTestContext().run {
             testClass.start()
@@ -58,7 +58,7 @@ class LedgerPersistenceServiceTest {
 
             sendConfigUpdate<LedgerPersistenceService>(exampleConfig)
 
-            verify(persistenceRequestSubscriptionFactory).create(MINIMUM_SMART_CONFIG)
+            verify(ledgerPersistenceRequestSubscriptionFactory).create(MINIMUM_SMART_CONFIG)
             verify(subscription).start()
         }
     }
@@ -71,7 +71,7 @@ class LedgerPersistenceServiceTest {
 
             sendConfigUpdate<LedgerPersistenceService>(exampleConfig)
 
-            verify(persistenceRequestSubscriptionFactory).create(MINIMUM_SMART_CONFIG)
+            verify(ledgerPersistenceRequestSubscriptionFactory).create(MINIMUM_SMART_CONFIG)
             verify(subscription1).start()
 
             sendConfigUpdate<LedgerPersistenceService>(exampleConfig)
@@ -137,7 +137,7 @@ class LedgerPersistenceServiceTest {
                 sandboxGroupContextComponent,
                 virtualNodeInfoReadService,
                 cpiInfoReadService,
-                persistenceRequestSubscriptionFactory
+                ledgerPersistenceRequestSubscriptionFactory
             )
         }
     }

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestProcessorTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestProcessorTest.kt
@@ -10,7 +10,7 @@ import net.corda.data.ledger.persistence.LedgerTypes
 import net.corda.ledger.persistence.ALICE_X500_HOLDING_ID
 import net.corda.ledger.persistence.common.RequestHandler
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
-import net.corda.ledger.persistence.processor.PersistenceRequestProcessor
+import net.corda.ledger.persistence.processor.LedgerPersistenceRequestProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.EntitySandboxService
 import net.corda.persistence.common.ResponseFactory
@@ -26,7 +26,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.Instant
 
-class PersistenceRequestProcessorTest {
+class LedgerPersistenceRequestProcessorTest {
 
     private val entitySandboxService = mock<EntitySandboxService>()
     private val delegatedRequestHandlerSelector = mock<DelegatedRequestHandlerSelector>()
@@ -37,7 +37,7 @@ class PersistenceRequestProcessorTest {
     private val virtualNodeContext = mock<VirtualNodeContext>()
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
 
-    private val target = PersistenceRequestProcessor(
+    private val target = LedgerPersistenceRequestProcessor(
         currentSandboxGroupContext,
         entitySandboxService,
         delegatedRequestHandlerSelector,

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestSubscriptionFactoryImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestSubscriptionFactoryImplTest.kt
@@ -14,7 +14,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
-internal class PersistenceRequestSubscriptionFactoryImplTest {
+internal class LedgerPersistenceRequestSubscriptionFactoryImplTest {
     @Test
     fun `factory creates subscription`() {
         val subscriptionFactory = mock<SubscriptionFactory>()
@@ -35,7 +35,7 @@ internal class PersistenceRequestSubscriptionFactoryImplTest {
             )
         ).thenReturn(expectedSubscription)
 
-        val target = PersistenceRequestSubscriptionFactoryImpl(mock(), subscriptionFactory, mock(), mock(), mock())
+        val target = LedgerPersistenceRequestSubscriptionFactoryImpl(mock(), subscriptionFactory, mock(), mock(), mock())
 
         val result = target.create(config)
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -85,12 +85,12 @@ class UtxoLedgerServiceImpl @Activate constructor(
 
     @Suspendable
     override fun findSignedTransaction(id: SecureHash): UtxoSignedTransaction? {
-        return utxoLedgerPersistenceService.find(id, TransactionStatus.VERIFIED)
+        return utxoLedgerPersistenceService.findSignedTransaction(id, TransactionStatus.VERIFIED)
     }
 
     @Suspendable
     override fun findLedgerTransaction(id: SecureHash): UtxoLedgerTransaction? {
-        return utxoLedgerPersistenceService.find(id)?.toLedgerTransaction()
+        return utxoLedgerPersistenceService.findLedgerTransaction(id)
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -90,7 +90,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
 
     @Suspendable
     override fun findLedgerTransaction(id: SecureHash): UtxoLedgerTransaction? {
-        return utxoLedgerPersistenceService.findLedgerTransaction(id)
+        return utxoLedgerPersistenceService.findSignedLedgerTransaction(id)?.ledgerTransaction
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
@@ -43,7 +43,6 @@ class TransactionBackchainVerifierImpl @Activate constructor(
         val sortedTransactions = topologicalSort.complete().iterator()
 
         for (transactionId in sortedTransactions) {
-            // can call find ledger transaction here because we find a signed tx and then resolve states later on
             val (transaction, status) = utxoLedgerPersistenceService.findSignedLedgerTransactionWithStatus(
                 transactionId,
                 UNVERIFIED

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImpl.kt
@@ -44,7 +44,8 @@ class TransactionBackchainVerifierImpl @Activate constructor(
         val sortedTransactions = topologicalSort.complete().iterator()
 
         for (transactionId in sortedTransactions) {
-            val (transaction, status) = utxoLedgerPersistenceService.findTransactionWithStatus(
+            // can call find ledger transaction here because we find a signed tx and then resolve states later on
+            val (transaction, status) = utxoLedgerPersistenceService.findLedgerTransactionWithStatus(
                 transactionId,
                 UNVERIFIED
             ) ?: throw CordaRuntimeException("Transaction does not exist locally")

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainResolutionFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainResolutionFlowV1.kt
@@ -46,7 +46,7 @@ class TransactionBackchainResolutionFlowV1(
     @Suspendable
     override fun call() {
         val alreadyVerifiedTransactions =
-            initialTransactionIds.filter { utxoLedgerPersistenceService.find(it, VERIFIED) != null }.toSet()
+            initialTransactionIds.filter { utxoLedgerPersistenceService.findSignedTransaction(it, VERIFIED) != null }.toSet()
         val originalTransactionsToRetrieve = initialTransactionIds - alreadyVerifiedTransactions
         if (originalTransactionsToRetrieve.isNotEmpty()) {
             log.debug {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainSenderFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainSenderFlowV1.kt
@@ -53,7 +53,7 @@ class TransactionBackchainSenderFlowV1(
             when (val request = session.receive(TransactionBackchainRequestV1::class.java)) {
                 is TransactionBackchainRequestV1.Get -> {
                     val transactions = request.transactionIds.map { id ->
-                        utxoLedgerPersistenceService.find(id)
+                        utxoLedgerPersistenceService.findSignedTransaction(id)
                             ?: throw CordaRuntimeException("Requested transaction does not exist locally")
                     }
                     // sending in batches of 1

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
@@ -3,7 +3,7 @@ package net.corda.ledger.utxo.flow.impl.persistence
 enum class LedgerPersistenceMetricOperationName {
 
     FindGroupParameters,
-    FindLedgerTransactionWithStatus,
+    FindSignedLedgerTransactionWithStatus,
     FindTransactionWithStatus,
     FindUnconsumedStatesByType,
     FindWithNamedQuery,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.utxo.flow.impl.persistence
 enum class LedgerPersistenceMetricOperationName {
 
     FindGroupParameters,
+    FindLedgerTransactionWithStatus,
     FindTransactionWithStatus,
     FindUnconsumedStatesByType,
     FindWithNamedQuery,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -1,11 +1,11 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
 import net.corda.ledger.common.data.transaction.TransactionStatus
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedLedgerTransaction
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
-import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 
 /**
@@ -38,7 +38,7 @@ interface UtxoLedgerPersistenceService {
      * @throws CordaPersistenceException if an error happens during find operation.
      */
     @Suspendable
-    fun findLedgerTransaction(id: SecureHash): UtxoLedgerTransaction?
+    fun findSignedLedgerTransaction(id: SecureHash): UtxoSignedLedgerTransaction?
 
     /**
      * Find a UTXO signed transaction in the persistence context given it's [id], resolve its state refs and convert it to a ledger
@@ -52,7 +52,7 @@ interface UtxoLedgerPersistenceService {
      * @throws CordaPersistenceException if an error happens during find operation.
      */
     @Suspendable
-    fun findLedgerTransactionWithStatus(id: SecureHash, transactionStatus: TransactionStatus): Pair<UtxoLedgerTransaction?, TransactionStatus>?
+    fun findSignedLedgerTransactionWithStatus(id: SecureHash, transactionStatus: TransactionStatus): Pair<UtxoSignedLedgerTransaction?, TransactionStatus>?
 
     /**
      * Persist a [UtxoSignedTransaction] to the store.

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -54,25 +54,6 @@ interface UtxoLedgerPersistenceService {
     @Suspendable
     fun findLedgerTransactionWithStatus(id: SecureHash, transactionStatus: TransactionStatus): Pair<UtxoLedgerTransaction?, TransactionStatus>?
 
-    // NOT NEEDED NOW, WAS ONLY USED BY BACKCHAIN VERIFIED
-    /**
-     * Find a UTXO signed transaction in the persistence context given it's [id] and return it with its status.
-     *
-     * @param id UTXO signed transaction ID.
-     * @param transactionStatus filter for this status.
-     *
-     * @return The found UTXO signed transaction and its status
-     *      null if it could not be found in the persistence context.
-     *      null to real status if the transaction exists, but its status is not the expected.
-     *
-     * @throws CordaPersistenceException if an error happens during find operation.
-     */
-    @Suspendable
-    fun findSignedTransactionWithStatus(
-        id: SecureHash,
-        transactionStatus: TransactionStatus = TransactionStatus.VERIFIED
-    ): Pair<UtxoSignedTransaction?, TransactionStatus>?
-
     /**
      * Persist a [UtxoSignedTransaction] to the store.
      *

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -5,6 +5,7 @@ import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 
 /**
@@ -24,8 +25,36 @@ interface UtxoLedgerPersistenceService {
      * @throws CordaPersistenceException if an error happens during find operation.
      */
     @Suspendable
-    fun find(id: SecureHash, transactionStatus: TransactionStatus = TransactionStatus.VERIFIED): UtxoSignedTransaction?
+    fun findSignedTransaction(id: SecureHash, transactionStatus: TransactionStatus = TransactionStatus.VERIFIED): UtxoSignedTransaction?
 
+    /**
+     * Find a verified UTXO signed transaction in the persistence context given it's [id], resolve its state refs and convert it to a ledger
+     * transaction.
+     *
+     * @param id UTXO signed transaction ID.
+     *
+     * @return The found UTXO ledger transaction, null if it could not be found in the persistence context.
+     *
+     * @throws CordaPersistenceException if an error happens during find operation.
+     */
+    @Suspendable
+    fun findLedgerTransaction(id: SecureHash): UtxoLedgerTransaction?
+
+    /**
+     * Find a UTXO signed transaction in the persistence context given it's [id], resolve its state refs and convert it to a ledger
+     * transaction.
+     *
+     * @param id UTXO signed transaction ID.
+     * @param transactionStatus filter for this status.
+     *
+     * @return The found UTXO ledger transaction, null if it could not be found in the persistence context.
+     *
+     * @throws CordaPersistenceException if an error happens during find operation.
+     */
+    @Suspendable
+    fun findLedgerTransactionWithStatus(id: SecureHash, transactionStatus: TransactionStatus): Pair<UtxoLedgerTransaction?, TransactionStatus>?
+
+    // NOT NEEDED NOW, WAS ONLY USED BY BACKCHAIN VERIFIED
     /**
      * Find a UTXO signed transaction in the persistence context given it's [id] and return it with its status.
      *
@@ -39,7 +68,7 @@ interface UtxoLedgerPersistenceService {
      * @throws CordaPersistenceException if an error happens during find operation.
      */
     @Suspendable
-    fun findTransactionWithStatus(
+    fun findSignedTransactionWithStatus(
         id: SecureHash,
         transactionStatus: TransactionStatus = TransactionStatus.VERIFIED
     ): Pair<UtxoSignedTransaction?, TransactionStatus>?

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -28,12 +28,12 @@ interface UtxoLedgerPersistenceService {
     fun findSignedTransaction(id: SecureHash, transactionStatus: TransactionStatus = TransactionStatus.VERIFIED): UtxoSignedTransaction?
 
     /**
-     * Find a verified UTXO signed transaction in the persistence context given it's [id], resolve its state refs and convert it to a ledger
-     * transaction.
+     * Find a verified [UtxoSignedLedgerTransaction] in the persistence context given it's [id]. This involves resolving its input and
+     * reference state and fetching the transaction's signatures.
      *
-     * @param id UTXO signed transaction ID.
+     * @param id transaction ID.
      *
-     * @return The found UTXO ledger transaction, null if it could not be found in the persistence context.
+     * @return The found [UtxoSignedLedgerTransaction], null if it could not be found in the persistence context.
      *
      * @throws CordaPersistenceException if an error happens during find operation.
      */
@@ -41,18 +41,21 @@ interface UtxoLedgerPersistenceService {
     fun findSignedLedgerTransaction(id: SecureHash): UtxoSignedLedgerTransaction?
 
     /**
-     * Find a UTXO signed transaction in the persistence context given it's [id], resolve its state refs and convert it to a ledger
-     * transaction.
+     * Find a [UtxoSignedLedgerTransaction] in the persistence context given it's [id] and return it with the status it is stored with.
+     * This involves resolving its input and reference state and fetching the transaction's signatures.
      *
-     * @param id UTXO signed transaction ID.
+     * @param id transaction ID.
      * @param transactionStatus filter for this status.
      *
-     * @return The found UTXO ledger transaction, null if it could not be found in the persistence context.
+     * @return The found [UtxoSignedLedgerTransaction] and its status, null if it could not be found in the persistence context.
      *
      * @throws CordaPersistenceException if an error happens during find operation.
      */
     @Suspendable
-    fun findSignedLedgerTransactionWithStatus(id: SecureHash, transactionStatus: TransactionStatus): Pair<UtxoSignedLedgerTransaction?, TransactionStatus>?
+    fun findSignedLedgerTransactionWithStatus(
+        id: SecureHash,
+        transactionStatus: TransactionStatus
+    ): Pair<UtxoSignedLedgerTransaction?, TransactionStatus>?
 
     /**
      * Persist a [UtxoSignedTransaction] to the store.

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -6,10 +6,14 @@ import net.corda.flow.fiber.metrics.recordSuspendable
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
+import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
+import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.FindLedgerTransactionWithStatus
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.FindTransactionWithStatus
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.PersistTransaction
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.PersistTransactionIfDoesNotExist
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.UpdateTransactionStatus
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindLedgerTransactionExternalEventFactory
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindLedgerTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionExternalEventFactory
@@ -19,6 +23,7 @@ import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransa
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.UpdateTransactionStatusExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.UpdateTransactionStatusParameters
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
 import net.corda.metrics.CordaMetrics
 import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
@@ -29,6 +34,8 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
+import net.corda.v5.ledger.utxo.ContractState
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
@@ -49,17 +56,42 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
     private val externalEventExecutor: ExternalEventExecutor,
     @Reference(service = SerializationService::class)
     private val serializationService: SerializationService,
+    @Reference(service = UtxoLedgerTransactionFactory::class)
+    private val utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory,
     @Reference(service = UtxoSignedTransactionFactory::class)
     private val utxoSignedTransactionFactory: UtxoSignedTransactionFactory
 ) : UtxoLedgerPersistenceService, UsedByFlow, SingletonSerializeAsToken {
 
     @Suspendable
-    override fun find(id: SecureHash, transactionStatus: TransactionStatus): UtxoSignedTransaction? {
-        return findTransactionWithStatus(id, transactionStatus)?.first
+    override fun findSignedTransaction(id: SecureHash, transactionStatus: TransactionStatus): UtxoSignedTransaction? {
+        return findSignedTransactionWithStatus(id, transactionStatus)?.first
     }
 
     @Suspendable
-    override fun findTransactionWithStatus(
+    override fun findLedgerTransaction(id: SecureHash): UtxoLedgerTransaction? {
+        return findLedgerTransactionWithStatus(id, TransactionStatus.VERIFIED)?.first
+    }
+
+    @Suspendable
+    override fun findLedgerTransactionWithStatus(id: SecureHash, transactionStatus: TransactionStatus): Pair<UtxoLedgerTransaction?, TransactionStatus>? {
+        return recordSuspendable({ ledgerPersistenceFlowTimer(FindLedgerTransactionWithStatus) }) @Suspendable {
+            wrapWithPersistenceException {
+                externalEventExecutor.execute(
+                    FindLedgerTransactionExternalEventFactory::class.java,
+                    FindLedgerTransactionParameters(id.toString(), transactionStatus)
+                )
+            }.firstOrNull().let {
+                if (it == null) return@let null
+                val (transaction, status) = serializationService.deserialize<Pair<LedgerTransactionContainer?, String?>>(it.array())
+                if (status == null)
+                    return@let null
+                transaction?.toLedgerTransaction() to status.toTransactionStatus()
+            }
+        }
+    }
+
+    @Suspendable
+    override fun findSignedTransactionWithStatus(
         id: SecureHash,
         transactionStatus: TransactionStatus
     ): Pair<UtxoSignedTransaction?, TransactionStatus>? {
@@ -130,15 +162,23 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
         }
     }
 
-    private fun SignedTransactionContainer.toSignedTransaction()
-            : UtxoSignedTransaction { 
+    private fun SignedTransactionContainer.toSignedTransaction(): UtxoSignedTransaction {
         return utxoSignedTransactionFactory.create(wireTransaction, signatures)
     }
 
-    private fun UtxoSignedTransaction.toContainer() =
-        (this as UtxoSignedTransactionInternal).run {
+    private fun UtxoSignedTransaction.toContainer(): SignedTransactionContainer {
+        return (this as UtxoSignedTransactionInternal).run {
             SignedTransactionContainer(wireTransaction, signatures)
         }
+    }
+
+    private fun LedgerTransactionContainer.toLedgerTransaction(): UtxoLedgerTransaction {
+        return utxoLedgerTransactionFactory.create(
+            this.wireTransaction,
+            this.serializedInputStateAndRefs.map { it.toStateAndRef<ContractState>(serializationService) },
+            this.serializedReferenceStateAndRefs.map { it.toStateAndRef<ContractState>(serializationService) }
+        )
+    }
 
     private fun serialize(payload: Any) = ByteBuffer.wrap(serializationService.serialize(payload).bytes)
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -7,7 +7,7 @@ import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
-import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.FindLedgerTransactionWithStatus
+import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.FindSignedLedgerTransactionWithStatus
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.FindTransactionWithStatus
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.PersistTransaction
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.PersistTransactionIfDoesNotExist
@@ -86,7 +86,7 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun findSignedLedgerTransactionWithStatus(id: SecureHash, transactionStatus: TransactionStatus): Pair<UtxoSignedLedgerTransaction?, TransactionStatus>? {
-        return recordSuspendable({ ledgerPersistenceFlowTimer(FindLedgerTransactionWithStatus) }) @Suspendable {
+        return recordSuspendable({ ledgerPersistenceFlowTimer(FindSignedLedgerTransactionWithStatus) }) @Suspendable {
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     FindSignedLedgerTransactionExternalEventFactory::class.java,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -12,8 +12,8 @@ import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperat
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.PersistTransaction
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.PersistTransactionIfDoesNotExist
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.UpdateTransactionStatus
-import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindLedgerTransactionExternalEventFactory
-import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindLedgerTransactionParameters
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionExternalEventFactory
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionExternalEventFactory
@@ -89,8 +89,8 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
         return recordSuspendable({ ledgerPersistenceFlowTimer(FindLedgerTransactionWithStatus) }) @Suspendable {
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
-                    FindLedgerTransactionExternalEventFactory::class.java,
-                    FindLedgerTransactionParameters(id.toString(), transactionStatus)
+                    FindSignedLedgerTransactionExternalEventFactory::class.java,
+                    FindSignedLedgerTransactionParameters(id.toString(), transactionStatus)
                 )
             }.firstOrNull().let {
                 if (it == null) return@let null

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindLedgerTransactionExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindLedgerTransactionExternalEventFactory.kt
@@ -1,0 +1,22 @@
+package net.corda.ledger.utxo.flow.impl.persistence.external.events
+
+import net.corda.data.ledger.persistence.FindTransaction
+import net.corda.data.ledger.persistence.v2.FindLedgerTransaction
+import net.corda.flow.external.events.factory.ExternalEventFactory
+import net.corda.ledger.common.data.transaction.TransactionStatus
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import java.time.Clock
+
+@Component(service = [ExternalEventFactory::class])
+class FindLedgerTransactionExternalEventFactory : AbstractUtxoLedgerExternalEventFactory<FindLedgerTransactionParameters> {
+    @Activate
+    constructor() : super()
+    constructor(clock: Clock) : super(clock)
+
+    override fun createRequest(parameters: FindLedgerTransactionParameters): Any {
+        return FindLedgerTransaction(parameters.id, parameters.transactionStatus.value)
+    }
+}
+
+data class FindLedgerTransactionParameters(val id: String, val transactionStatus: TransactionStatus)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindSignedLedgerTransactionExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindSignedLedgerTransactionExternalEventFactory.kt
@@ -1,6 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.persistence.external.events
 
-import net.corda.data.ledger.persistence.v2.FindLedgerTransaction
+import net.corda.data.ledger.persistence.FindSignedLedgerTransaction
 import net.corda.flow.external.events.factory.ExternalEventFactory
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import org.osgi.service.component.annotations.Activate
@@ -14,7 +14,7 @@ class FindSignedLedgerTransactionExternalEventFactory : AbstractUtxoLedgerExtern
     constructor(clock: Clock) : super(clock)
 
     override fun createRequest(parameters: FindSignedLedgerTransactionParameters): Any {
-        return FindLedgerTransaction(parameters.id, parameters.transactionStatus.value)
+        return FindSignedLedgerTransaction(parameters.id, parameters.transactionStatus.value)
     }
 }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindSignedLedgerTransactionExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindSignedLedgerTransactionExternalEventFactory.kt
@@ -1,6 +1,5 @@
 package net.corda.ledger.utxo.flow.impl.persistence.external.events
 
-import net.corda.data.ledger.persistence.FindTransaction
 import net.corda.data.ledger.persistence.v2.FindLedgerTransaction
 import net.corda.flow.external.events.factory.ExternalEventFactory
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -9,14 +8,14 @@ import org.osgi.service.component.annotations.Component
 import java.time.Clock
 
 @Component(service = [ExternalEventFactory::class])
-class FindLedgerTransactionExternalEventFactory : AbstractUtxoLedgerExternalEventFactory<FindLedgerTransactionParameters> {
+class FindSignedLedgerTransactionExternalEventFactory : AbstractUtxoLedgerExternalEventFactory<FindSignedLedgerTransactionParameters> {
     @Activate
     constructor() : super()
     constructor(clock: Clock) : super(clock)
 
-    override fun createRequest(parameters: FindLedgerTransactionParameters): Any {
+    override fun createRequest(parameters: FindSignedLedgerTransactionParameters): Any {
         return FindLedgerTransaction(parameters.id, parameters.transactionStatus.value)
     }
 }
 
-data class FindLedgerTransactionParameters(val id: String, val transactionStatus: TransactionStatus)
+data class FindSignedLedgerTransactionParameters(val id: String, val transactionStatus: TransactionStatus)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransaction.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransaction.kt
@@ -1,8 +1,16 @@
 package net.corda.ledger.utxo.flow.impl.transaction
 
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 
-interface UtxoSignedLedgerTransaction : UtxoSignedTransactionInternal, UtxoLedgerTransactionInternal {
+/**
+ * [UtxoSignedLedgerTransaction] is a wrapper that combines the functionality of [UtxoLedgerTransactionInternal] and
+ * [UtxoSignedTransactionInternal] for convenience.
+ */
+interface UtxoSignedLedgerTransaction : UtxoLedgerTransactionInternal, UtxoSignedTransactionInternal {
 
-    val ledgerTransaction: UtxoLedgerTransactionInternal
+    /**
+     * Gets the delegate [UtxoLedgerTransaction] from the [UtxoSignedLedgerTransaction] instance.
+     */
+    val ledgerTransaction: UtxoLedgerTransaction
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransaction.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransaction.kt
@@ -1,0 +1,8 @@
+package net.corda.ledger.utxo.flow.impl.transaction
+
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
+
+interface UtxoSignedLedgerTransaction : UtxoSignedTransactionInternal, UtxoLedgerTransactionInternal {
+
+    val ledgerTransaction: UtxoLedgerTransactionInternal
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransactionImpl.kt
@@ -11,6 +11,14 @@ import net.corda.v5.ledger.utxo.TimeWindow
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import java.security.PublicKey
 
+/**
+ * [UtxoSignedLedgerTransactionImpl] delegates to [UtxoLedgerTransactionInternal] and [UtxoSignedTransactionInternal] instances to provide
+ * the behaviour of the two interfaces.
+ *
+ * All the overridden methods in this class are methods that appear on both [UtxoLedgerTransactionInternal] and
+ * [UtxoSignedTransactionInternal]. The implementation from the [signedTransaction] is used; however, using the [ledgerTransaction]
+ * instead will lead to the same behaviour.
+ */
 data class UtxoSignedLedgerTransactionImpl(
     override val ledgerTransaction: UtxoLedgerTransactionInternal,
     private val signedTransaction: UtxoSignedTransactionInternal

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransactionImpl.kt
@@ -1,0 +1,58 @@
+package net.corda.ledger.utxo.flow.impl.transaction
+
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.common.transaction.TransactionMetadata
+import net.corda.v5.ledger.utxo.Command
+import net.corda.v5.ledger.utxo.StateAndRef
+import net.corda.v5.ledger.utxo.StateRef
+import net.corda.v5.ledger.utxo.TimeWindow
+import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
+import java.security.PublicKey
+
+data class UtxoSignedLedgerTransactionImpl(
+    override val ledgerTransaction: UtxoLedgerTransactionInternal,
+    private val signedTransaction: UtxoSignedTransactionInternal
+) : UtxoSignedLedgerTransaction, UtxoLedgerTransaction by ledgerTransaction, UtxoSignedTransactionInternal by signedTransaction {
+
+    override fun getId(): SecureHash {
+        return signedTransaction.id
+    }
+
+    override fun getMetadata(): TransactionMetadata {
+        return signedTransaction.metadata
+    }
+
+    override fun getInputStateRefs(): MutableList<StateRef> {
+        return signedTransaction.inputStateRefs
+    }
+
+    override fun getReferenceStateRefs(): MutableList<StateRef> {
+        return signedTransaction.referenceStateRefs
+    }
+
+    override fun getOutputStateAndRefs(): MutableList<StateAndRef<*>> {
+        return signedTransaction.outputStateAndRefs
+    }
+
+    override fun getNotaryName(): MemberX500Name {
+        return signedTransaction.notaryName
+    }
+
+    override fun getNotaryKey(): PublicKey {
+        return signedTransaction.notaryKey
+    }
+
+    override fun getTimeWindow(): TimeWindow {
+        return signedTransaction.timeWindow
+    }
+
+    override fun getCommands(): MutableList<Command> {
+        return signedTransaction.commands
+    }
+
+    override fun getSignatories(): MutableList<PublicKey> {
+        return signedTransaction.signatories
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.utxo.flow.impl.transaction.factory
 
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 
 /**
@@ -24,7 +24,7 @@ interface UtxoLedgerTransactionFactory {
     @Suspendable
     fun create(
         wireTransaction: WireTransaction,
-        inputStateAndRefs: List<StateAndRef<*>>,
-        referenceStateAndRefs: List<StateAndRef<*>>
+        inputStateAndRefs: List<UtxoTransactionOutputDto>,
+        referenceStateAndRefs: List<UtxoTransactionOutputDto>
     ): UtxoLedgerTransaction
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.transaction.factory
 
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
@@ -21,10 +22,9 @@ interface UtxoLedgerTransactionFactory {
         wireTransaction: WireTransaction
     ): UtxoLedgerTransaction
 
-    @Suspendable
     fun create(
         wireTransaction: WireTransaction,
         inputStateAndRefs: List<UtxoTransactionOutputDto>,
         referenceStateAndRefs: List<UtxoTransactionOutputDto>
-    ): UtxoLedgerTransaction
+    ): UtxoLedgerTransactionInternal
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.transaction.factory
 
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 
 /**
@@ -18,5 +19,12 @@ interface UtxoLedgerTransactionFactory {
     @Suspendable
     fun create(
         wireTransaction: WireTransaction
+    ): UtxoLedgerTransaction
+
+    @Suspendable
+    fun create(
+        wireTransaction: WireTransaction,
+        inputStateAndRefs: List<StateAndRef<*>>,
+        referenceStateAndRefs: List<StateAndRef<*>>
     ): UtxoLedgerTransaction
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoSignedTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoSignedTransactionFactory.kt
@@ -1,10 +1,10 @@
 package net.corda.ledger.utxo.flow.impl.transaction.factory
 
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import java.security.PublicKey
 
 interface UtxoSignedTransactionFactory {
@@ -12,10 +12,10 @@ interface UtxoSignedTransactionFactory {
     fun create(
         utxoTransactionBuilder: UtxoTransactionBuilderInternal,
         signatories: Iterable<PublicKey>
-    ): UtxoSignedTransaction
+    ): UtxoSignedTransactionInternal
 
     fun create(
         wireTransaction: WireTransaction,
         signaturesWithMetaData: List<DigitalSignatureAndMetadata>
-    ): UtxoSignedTransaction
+    ): UtxoSignedTransactionInternal
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.transaction.factory.impl
 
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerStateQueryService
@@ -11,7 +12,6 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.utxo.ContractState
-import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
@@ -64,12 +64,11 @@ class UtxoLedgerTransactionFactoryImpl @Activate constructor(
         )
     }
 
-    @Suspendable
     override fun create(
         wireTransaction: WireTransaction,
         inputStateAndRefs: List<UtxoTransactionOutputDto>,
         referenceStateAndRefs: List<UtxoTransactionOutputDto>
-    ): UtxoLedgerTransaction {
+    ): UtxoLedgerTransactionInternal {
         return UtxoLedgerTransactionImpl(
             WrappedUtxoWireTransaction(wireTransaction, serializationService),
             inputStateAndRefs.map { it.toStateAndRef<ContractState>(serializationService) },

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
@@ -19,9 +19,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope
 
-@Component(
-    service = [UtxoLedgerTransactionFactory::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE
-)
+@Component(service = [UtxoLedgerTransactionFactory::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE)
 class UtxoLedgerTransactionFactoryImpl @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serializationService: SerializationService,
@@ -29,11 +27,6 @@ class UtxoLedgerTransactionFactoryImpl @Activate constructor(
     private val utxoLedgerStateQueryService: UtxoLedgerStateQueryService
 ) : UtxoLedgerTransactionFactory, UsedByFlow, SingletonSerializeAsToken {
 
-    // fetch whole ledger tx as part of the find in the ledger service
-    // put states into the cache
-    // if all the states exist in the cache then no need to retrieve them from the database, need to hold in the checkpoint though or they
-    // could get evicted by the time we come back from the database (this is an optimisation though so need to decide if it is worth
-    // doing it).
     @Suspendable
     override fun create(
         wireTransaction: WireTransaction

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.transaction.factory.impl
 
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
+import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerStateQueryService
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
@@ -9,6 +10,7 @@ import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.serialization.SingletonSerializeAsToken
@@ -62,18 +64,16 @@ class UtxoLedgerTransactionFactoryImpl @Activate constructor(
         )
     }
 
-    // if any of the state refs are missing return a platform exception from the database worker
-    // no point returning part of the data and then discarding it
     @Suspendable
     override fun create(
         wireTransaction: WireTransaction,
-        inputStateAndRefs: List<StateAndRef<*>>, // or transaction output dtos
-        referenceStateAndRefs: List<StateAndRef<*>> // or transaction output dtos
+        inputStateAndRefs: List<UtxoTransactionOutputDto>,
+        referenceStateAndRefs: List<UtxoTransactionOutputDto>
     ): UtxoLedgerTransaction {
         return UtxoLedgerTransactionImpl(
             WrappedUtxoWireTransaction(wireTransaction, serializationService),
-            inputStateAndRefs,
-            referenceStateAndRefs
+            inputStateAndRefs.map { it.toStateAndRef<ContractState>(serializationService) },
+            referenceStateAndRefs.map { it.toStateAndRef<ContractState>(serializationService) }
         )
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -13,13 +13,14 @@ import net.corda.ledger.utxo.data.transaction.UtxoTransactionMetadata
 import net.corda.ledger.utxo.data.transaction.utxoComponentGroupStructure
 import net.corda.ledger.utxo.data.transaction.verifier.verifyMetadata
 import net.corda.ledger.utxo.flow.impl.groupparameters.CurrentGroupParametersService
+import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.verifier.UtxoLedgerTransactionVerificationService
-import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
 import net.corda.membership.lib.SignedGroupParameters
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
@@ -28,7 +29,6 @@ import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -72,7 +72,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
     override fun create(
         utxoTransactionBuilder: UtxoTransactionBuilderInternal,
         signatories: Iterable<PublicKey>
-    ): UtxoSignedTransaction {
+    ): UtxoSignedTransactionInternal {
         val utxoMetadata = utxoMetadata()
         val metadata = transactionMetadataFactory.create(utxoMetadata)
 
@@ -101,7 +101,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
     override fun create(
         wireTransaction: WireTransaction,
         signaturesWithMetaData: List<DigitalSignatureAndMetadata>
-    ): UtxoSignedTransaction = UtxoSignedTransactionImpl(
+    ): UtxoSignedTransactionInternal = UtxoSignedTransactionImpl(
         serializationService,
         transactionSignatureService,
         utxoLedgerTransactionFactory,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImplTest.kt
@@ -60,7 +60,7 @@ class TransactionBackchainVerifierImplTest {
     @BeforeEach
     fun beforeEach() {
         whenever(
-            utxoLedgerPersistenceService.findSignedTransactionWithStatus(
+            utxoLedgerPersistenceService.find(
                 TX_ID_1,
                 UNVERIFIED
             )

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/TransactionBackchainVerifierImplTest.kt
@@ -60,19 +60,19 @@ class TransactionBackchainVerifierImplTest {
     @BeforeEach
     fun beforeEach() {
         whenever(
-            utxoLedgerPersistenceService.findTransactionWithStatus(
+            utxoLedgerPersistenceService.findSignedTransactionWithStatus(
                 TX_ID_1,
                 UNVERIFIED
             )
         ).thenReturn(transaction1 to UNVERIFIED)
         whenever(
-            utxoLedgerPersistenceService.findTransactionWithStatus(
+            utxoLedgerPersistenceService.findSignedTransactionWithStatus(
                 TX_ID_2,
                 UNVERIFIED
             )
         ).thenReturn(transaction2 to UNVERIFIED)
         whenever(
-            utxoLedgerPersistenceService.findTransactionWithStatus(
+            utxoLedgerPersistenceService.findSignedTransactionWithStatus(
                 TX_ID_3,
                 UNVERIFIED
             )
@@ -154,21 +154,21 @@ class TransactionBackchainVerifierImplTest {
 
     @Test
     fun `throws an exception if a transaction cannot be retrieved from the database`() {
-        whenever(utxoLedgerPersistenceService.findTransactionWithStatus(TX_ID_1, UNVERIFIED)).thenReturn(null )
+        whenever(utxoLedgerPersistenceService.findSignedTransactionWithStatus(TX_ID_1, UNVERIFIED)).thenReturn(null )
         assertThrows<CordaRuntimeException>{transactionBackchainVerifier.verify(setOf(RESOLVING_TX_ID), topologicalSort())}
         verify(utxoLedgerPersistenceService, never()).persist(any(), eq(VERIFIED), any())
     }
 
     @Test
     fun `returns false if a transaction comes as invalid from the database`() {
-        whenever(utxoLedgerPersistenceService.findTransactionWithStatus(TX_ID_1, UNVERIFIED)).thenReturn(null to TransactionStatus.INVALID)
+        whenever(utxoLedgerPersistenceService.findSignedTransactionWithStatus(TX_ID_1, UNVERIFIED)).thenReturn(null to TransactionStatus.INVALID)
         assertThat(transactionBackchainVerifier.verify(setOf(RESOLVING_TX_ID), topologicalSort())).isFalse
         verify(utxoLedgerPersistenceService, never()).persist(any(), eq(VERIFIED), any())
     }
 
     @Test
     fun `updates the statuses of transactions that pass verification even when a later transaction cannot be retrieved from the database`() {
-        whenever(utxoLedgerPersistenceService.findTransactionWithStatus(TX_ID_3, UNVERIFIED)).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransactionWithStatus(TX_ID_3, UNVERIFIED)).thenReturn(null)
         assertThrows<CordaRuntimeException>{transactionBackchainVerifier.verify(setOf(RESOLVING_TX_ID), topologicalSort())}
 
         verify(utxoLedgerPersistenceService).persist(transaction1, VERIFIED, emptyList())
@@ -178,7 +178,7 @@ class TransactionBackchainVerifierImplTest {
 
     @Test
     fun `returns true if a transaction comes as already verified from the database`() {
-        whenever(utxoLedgerPersistenceService.findTransactionWithStatus(TX_ID_1, UNVERIFIED)).thenReturn(null to VERIFIED)
+        whenever(utxoLedgerPersistenceService.findSignedTransactionWithStatus(TX_ID_1, UNVERIFIED)).thenReturn(null to VERIFIED)
         assertThat(transactionBackchainVerifier.verify(setOf(RESOLVING_TX_ID), topologicalSort())).isTrue
     }
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
@@ -57,7 +57,7 @@ class TransactionBackchainReceiverFlowV1Test {
 
     @Test
     fun `a resolved transaction has its dependencies retrieved from its peer and persisted`() {
-        whenever(utxoLedgerPersistenceService.find(any(), any())).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(any(), any())).thenReturn(null)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -110,7 +110,7 @@ class TransactionBackchainReceiverFlowV1Test {
 
     @Test
     fun `receiving a transaction that is stored locally as UNVERIFIED has its dependencies added to the transactions to retrieve`() {
-        whenever(utxoLedgerPersistenceService.find(any(), any())).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(any(), any())).thenReturn(null)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -149,7 +149,7 @@ class TransactionBackchainReceiverFlowV1Test {
 
     @Test
     fun `receiving a transaction that is stored locally as VERIFIED does not have its dependencies added to the transactions to retrieve`() {
-        whenever(utxoLedgerPersistenceService.find(TX_ID_1)).thenReturn(retrievedTransaction1)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(retrievedTransaction1)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -186,7 +186,7 @@ class TransactionBackchainReceiverFlowV1Test {
 
     @Test
     fun `receiving a transaction that was not included in the requested batch of transactions throws an exception`() {
-        whenever(utxoLedgerPersistenceService.find(TX_ID_1)).thenReturn(retrievedTransaction1)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(retrievedTransaction1)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -263,7 +263,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(transaction1.id).thenReturn(transactionId1)
         whenever(transaction1.inputStateRefs).thenReturn(emptyList())
 
-        whenever(utxoLedgerPersistenceService.find(any(), any())).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(any(), any())).thenReturn(null)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(transaction3),

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v2/TransactionBackchainReceiverFlowV2Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v2/TransactionBackchainReceiverFlowV2Test.kt
@@ -71,7 +71,7 @@ class TransactionBackchainReceiverFlowV2Test {
 
     @Test
     fun `a resolved transaction has its dependencies retrieved from its peer and persisted`() {
-        whenever(utxoLedgerPersistenceService.find(any(), any())).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(any(), any())).thenReturn(null)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -127,7 +127,7 @@ class TransactionBackchainReceiverFlowV2Test {
 
     @Test
     fun `receiving a transaction that is stored locally as UNVERIFIED has its dependencies added to the transactions to retrieve`() {
-        whenever(utxoLedgerPersistenceService.find(any(), any())).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(any(), any())).thenReturn(null)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -174,7 +174,7 @@ class TransactionBackchainReceiverFlowV2Test {
 
     @Test
     fun `receiving a transaction that is stored locally as VERIFIED does not have its dependencies added to the transactions to retrieve`() {
-        whenever(utxoLedgerPersistenceService.find(TX_ID_1)).thenReturn(retrievedTransaction1)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(retrievedTransaction1)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -217,7 +217,7 @@ class TransactionBackchainReceiverFlowV2Test {
 
     @Test
     fun `receiving a transaction that was not included in the requested batch of transactions throws an exception`() {
-        whenever(utxoLedgerPersistenceService.find(TX_ID_1)).thenReturn(retrievedTransaction1)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(retrievedTransaction1)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -250,7 +250,7 @@ class TransactionBackchainReceiverFlowV2Test {
 
     @Test
     fun `receiving signed group parameters that was not requested  throws an exception`() {
-        whenever(utxoLedgerPersistenceService.find(TX_ID_1)).thenReturn(retrievedTransaction1)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(retrievedTransaction1)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -280,7 +280,7 @@ class TransactionBackchainReceiverFlowV2Test {
 
     @Test
     fun `receiving signed group parameters with invalid signature throws an exception`() {
-        whenever(utxoLedgerPersistenceService.find(TX_ID_1)).thenReturn(retrievedTransaction1)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(retrievedTransaction1)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -313,7 +313,7 @@ class TransactionBackchainReceiverFlowV2Test {
 
     @Test
     fun `receiving a transaction without signed group parameters hash in its metadata throws an exception`() {
-        whenever(utxoLedgerPersistenceService.find(TX_ID_1)).thenReturn(retrievedTransaction1)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(retrievedTransaction1)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(retrievedTransaction1),
@@ -410,7 +410,7 @@ class TransactionBackchainReceiverFlowV2Test {
         whenever(tx2Metadata.getMembershipGroupParametersHash()).thenReturn(groupParametersHash2.toString())
         whenever(tx1Metadata.getMembershipGroupParametersHash()).thenReturn(groupParametersHash1.toString())
 
-        whenever(utxoLedgerPersistenceService.find(any(), any())).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(any(), any())).thenReturn(null)
 
         whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
             listOf(transaction3),

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v2/TransactionBackchainResolutionFlowV2Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v2/TransactionBackchainResolutionFlowV2Test.kt
@@ -80,7 +80,7 @@ class TransactionBackchainResolutionFlowV2Test {
             )
         )
 
-        whenever(utxoLedgerPersistenceService.find(any(), eq(TransactionStatus.VERIFIED))).thenReturn(mock())
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(any(), eq(TransactionStatus.VERIFIED))).thenReturn(mock())
 
         callTransactionBackchainResolutionFlow()
 
@@ -104,8 +104,8 @@ class TransactionBackchainResolutionFlowV2Test {
             )
         )
 
-        whenever(utxoLedgerPersistenceService.find(TX_ID_2, TransactionStatus.VERIFIED)).thenReturn(mock())
-        whenever(utxoLedgerPersistenceService.find(TX_ID_3, TransactionStatus.VERIFIED)).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_2, TransactionStatus.VERIFIED)).thenReturn(mock())
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_3, TransactionStatus.VERIFIED)).thenReturn(null)
 
         whenever(flowEngine.subFlow(any<TransactionBackchainReceiverFlowV1>())).thenReturn(TopologicalSort())
 
@@ -140,8 +140,8 @@ class TransactionBackchainResolutionFlowV2Test {
             )
         )
 
-        whenever(utxoLedgerPersistenceService.find(TX_ID_2, TransactionStatus.VERIFIED)).thenReturn(mock())
-        whenever(utxoLedgerPersistenceService.find(TX_ID_3, TransactionStatus.VERIFIED)).thenReturn(null)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_2, TransactionStatus.VERIFIED)).thenReturn(mock())
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_3, TransactionStatus.VERIFIED)).thenReturn(null)
         whenever(transactionBackchainVerifier.verify(eq(setOf(TX_ID_3)), any())).thenReturn(false)
 
         whenever(flowEngine.subFlow(any<TransactionBackchainReceiverFlowV1>())).thenReturn(TopologicalSort())

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v2/TransactionBackchainSenderFlowV2Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v2/TransactionBackchainSenderFlowV2Test.kt
@@ -44,9 +44,9 @@ class TransactionBackchainSenderFlowV2Test {
 
         whenever(transactionBackchainIsRequestedFor.id).thenReturn(TX_ID_0)
 
-        whenever(utxoLedgerPersistenceService.find(TX_ID_1)).thenReturn(transaction1)
-        whenever(utxoLedgerPersistenceService.find(TX_ID_2)).thenReturn(transaction2)
-        whenever(utxoLedgerPersistenceService.find(TX_ID_3)).thenReturn(transaction3)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(transaction1)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_2)).thenReturn(transaction2)
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_3)).thenReturn(transaction3)
 
         whenever(transaction1.toLedgerTransaction()).thenReturn(ledgerTransaction1)
         whenever(transaction2.toLedgerTransaction()).thenReturn(ledgerTransaction2)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -9,7 +9,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.common.data.transaction.TransactionStatus.VERIFIED
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureServiceInternal
-import net.corda.ledger.utxo.data.transaction.LedgerTransactionContainer
+import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
@@ -187,7 +187,7 @@ class UtxoLedgerPersistenceServiceImplTest {
     }
 
     @Test
-    fun `findLedgerTransaction executes successfully`() {
+    fun `findSignedLedgerTransaction executes successfully`() {
         val metadata = mock<TransactionMetadata>()
         val signedTransaction = mock<UtxoSignedTransactionInternal>()
         val ledgerTransaction = mock<UtxoLedgerTransactionInternal>()
@@ -202,9 +202,9 @@ class UtxoLedgerPersistenceServiceImplTest {
         val inputUtxoTransactionOutputDtos = listOf(UtxoTransactionOutputDto("tx1", 1, byteArrayOf(0), byteArrayOf(1)))
         val referenceUtxoTransactionOutputDtos = listOf(UtxoTransactionOutputDto("tx2", 1, byteArrayOf(0), byteArrayOf(1)))
 
-        whenever(serializationService.deserialize<Pair<LedgerTransactionContainer, String>>(any<ByteArray>(), any()))
+        whenever(serializationService.deserialize<Pair<SignedLedgerTransactionContainer, String>>(any<ByteArray>(), any()))
             .thenReturn(
-                LedgerTransactionContainer(
+                SignedLedgerTransactionContainer(
                     wireTransaction,
                     inputUtxoTransactionOutputDtos,
                     referenceUtxoTransactionOutputDtos,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -16,7 +16,7 @@ import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.ALICE_X500_HOLDING_IDENTITY
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.AbstractUtxoLedgerExternalEventFactory
-import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindLedgerTransactionExternalEventFactory
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionIfDoesNotExistExternalEventFactory
@@ -225,7 +225,7 @@ class UtxoLedgerPersistenceServiceImplTest {
         assertThat(utxoLedgerPersistenceService.findSignedLedgerTransaction(parseSecureHash("SHA256:1234567890123456")))
             .isEqualTo(UtxoSignedLedgerTransactionImpl(ledgerTransaction, signedTransaction))
 
-        assertThat(argumentCaptor.firstValue).isEqualTo(FindLedgerTransactionExternalEventFactory::class.java)
+        assertThat(argumentCaptor.firstValue).isEqualTo(FindSignedLedgerTransactionExternalEventFactory::class.java)
     }
 
     private fun persistIfDoesNotExist(

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -173,7 +173,7 @@ class UtxoLedgerPersistenceServiceImplTest {
 
         whenever(utxoSignedTransactionFactory.create(any<WireTransaction>(), any())).thenReturn(expectedObj)
 
-        assertThat(utxoLedgerPersistenceService.find(testId)).isEqualTo(expectedObj)
+        assertThat(utxoLedgerPersistenceService.findSignedTransaction(testId)).isEqualTo(expectedObj)
 
         verify(serializationService).deserialize<UtxoSignedTransactionInternal>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(FindTransactionExternalEventFactory::class.java)
@@ -203,7 +203,7 @@ class UtxoLedgerPersistenceServiceImplTest {
 
         whenever(utxoSignedTransactionFactory.create(any<WireTransaction>(), any())).thenReturn(expectedObj)
 
-        assertThat(utxoLedgerPersistenceService.findTransactionWithStatus(testId)).isEqualTo(expectedObj to VERIFIED)
+        assertThat(utxoLedgerPersistenceService.findSignedTransactionWithStatus(testId)).isEqualTo(expectedObj to VERIFIED)
 
         verify(serializationService).deserialize<UtxoSignedTransactionInternal>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(FindTransactionExternalEventFactory::class.java)

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.11-beta+
+cordaApiVersion=5.1.0.12-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/LedgerTransactionContainer.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/LedgerTransactionContainer.kt
@@ -1,0 +1,17 @@
+package net.corda.ledger.utxo.data.transaction
+
+import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.crypto.SecureHash
+
+@CordaSerializable
+data class LedgerTransactionContainer(
+    val wireTransaction: WireTransaction,
+    val serializedInputStateAndRefs: List<UtxoTransactionOutputDto>,
+    val serializedReferenceStateAndRefs: List<UtxoTransactionOutputDto>,
+    val signatures: List<DigitalSignatureAndMetadata>
+) {
+    val id: SecureHash
+        get() = wireTransaction.id
+}

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/LedgerTransactionContainer.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/LedgerTransactionContainer.kt
@@ -1,7 +1,6 @@
 package net.corda.ledger.utxo.data.transaction
 
 import net.corda.ledger.common.data.transaction.WireTransaction
-import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.SecureHash
 
@@ -9,8 +8,7 @@ import net.corda.v5.crypto.SecureHash
 data class LedgerTransactionContainer(
     val wireTransaction: WireTransaction,
     val serializedInputStateAndRefs: List<UtxoTransactionOutputDto>,
-    val serializedReferenceStateAndRefs: List<UtxoTransactionOutputDto>,
-    val signatures: List<DigitalSignatureAndMetadata>
+    val serializedReferenceStateAndRefs: List<UtxoTransactionOutputDto>
 ) {
     val id: SecureHash
         get() = wireTransaction.id

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/LedgerTransactionContainer.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/LedgerTransactionContainer.kt
@@ -1,6 +1,7 @@
 package net.corda.ledger.utxo.data.transaction
 
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.SecureHash
 
@@ -8,7 +9,8 @@ import net.corda.v5.crypto.SecureHash
 data class LedgerTransactionContainer(
     val wireTransaction: WireTransaction,
     val serializedInputStateAndRefs: List<UtxoTransactionOutputDto>,
-    val serializedReferenceStateAndRefs: List<UtxoTransactionOutputDto>
+    val serializedReferenceStateAndRefs: List<UtxoTransactionOutputDto>,
+    val signatures: List<DigitalSignatureAndMetadata>
 ) {
     val id: SecureHash
         get() = wireTransaction.id

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/SignedLedgerTransactionContainer.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/SignedLedgerTransactionContainer.kt
@@ -6,7 +6,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.SecureHash
 
 @CordaSerializable
-data class LedgerTransactionContainer(
+data class SignedLedgerTransactionContainer(
     val wireTransaction: WireTransaction,
     val serializedInputStateAndRefs: List<UtxoTransactionOutputDto>,
     val serializedReferenceStateAndRefs: List<UtxoTransactionOutputDto>,

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/builder/KafkaCordaProducerBuilderImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/builder/KafkaCordaProducerBuilderImpl.kt
@@ -57,6 +57,7 @@ class KafkaCordaProducerBuilderImpl @Activate constructor(
                 val producer = createKafkaProducer(kafkaProperties, onSerializationError)
                 val maxAllowedMessageSize = messageBusConfig.getLong(MessagingConfig.MAX_ALLOWED_MSG_SIZE)
                 val producerChunkService = messagingChunkFactory.createChunkSerializerService(maxAllowedMessageSize)
+//                val producerChunkService = messagingChunkFactory.createChunkSerializerService(12000)
                 CordaKafkaProducerImpl(
                     resolvedConfig,
                     producer,

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/builder/KafkaCordaProducerBuilderImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/producer/builder/KafkaCordaProducerBuilderImpl.kt
@@ -57,7 +57,6 @@ class KafkaCordaProducerBuilderImpl @Activate constructor(
                 val producer = createKafkaProducer(kafkaProperties, onSerializationError)
                 val maxAllowedMessageSize = messageBusConfig.getLong(MessagingConfig.MAX_ALLOWED_MSG_SIZE)
                 val producerChunkService = messagingChunkFactory.createChunkSerializerService(maxAllowedMessageSize)
-//                val producerChunkService = messagingChunkFactory.createChunkSerializerService(12000)
                 CordaKafkaProducerImpl(
                     resolvedConfig,
                     producer,


### PR DESCRIPTION
Retrieve ledger transactions in one step, including resolving the input and reference states of the transaction and retrieving the transaction's signatures.

Add `UtxoLedgerPersistenceService.findSignedLedgerTransaction` to retrieve the transaction, resolve its states and the transaction's signatures.

`UtxoSignedLedgerTransaction` was created to wrap behaviour of `UtxoLedgerTransaction` and `UtxoSignedTransaction` into a single interface which assists in our internal code where we need both behaviours.

This change also tidied up and renamed a few classes in the ledger persistence code.