### PR TITLE
CORE-15815: Reduce the number of open connections in mutual TLS

### DIFF
--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/TestBase.kt
@@ -76,16 +76,16 @@ open class TestBase {
     private val c4TruststoreCertificatePem by lazy {
         Certificates.c4TruststoreCertificatePem.readText()
     }
-    protected val truststoreKeyStore by lazy {
-        TrustStoresMap.TrustedCertificates(listOf(truststoreCertificatePem)).trustStore!!
+    internal val truststoreKeyStore by lazy {
+        TrustStoresMap.TrustedCertificates(listOf(truststoreCertificatePem))
     }
 
-    protected val truststoreKeyStoreWithRevocation by lazy {
-        TrustStoresMap.TrustedCertificates(listOf(truststoreWithRevocationCertificatePem)).trustStore!!
+    internal val truststoreKeyStoreWithRevocation by lazy {
+        TrustStoresMap.TrustedCertificates(listOf(truststoreWithRevocationCertificatePem))
     }
 
-    protected val c4TruststoreKeyStore by lazy {
-        TrustStoresMap.TrustedCertificates(listOf(c4TruststoreCertificatePem)).trustStore!!
+    internal val c4TruststoreKeyStore by lazy {
+        TrustStoresMap.TrustedCertificates(listOf(c4TruststoreCertificatePem))
     }
 
     protected fun getOpenPort(): Int {

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
@@ -58,7 +58,7 @@ class TrustStoresMapIntegrationTests : TestBase() {
             assertThat(map.isRunning).isTrue
 
             val store = assertDoesNotThrow {
-                map.getTrustStore(MemberX500Name.parse(ALICE_NAME), GROUP_ID)
+                map.getTrustStore(MemberX500Name.parse(ALICE_NAME), GROUP_ID).trustStore
             }
 
             val certificate = store.aliases().toList().map {

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManager.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManager.kt
@@ -131,6 +131,6 @@ internal class DynamicX509ExtendedTrustManager(
     private fun getAllX509TrustManagers(): List<X509ExtendedTrustManager> =
         trustStoresMap
             .getTrustStores()
-            .mapNotNull { it.trustStore }
+            .map { it.trustStore }
             .flatMap { it.x509ExtendedTrustManager() }
 }

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManager.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManager.kt
@@ -129,5 +129,8 @@ internal class DynamicX509ExtendedTrustManager(
     }
 
     private fun getAllX509TrustManagers(): List<X509ExtendedTrustManager> =
-        trustStoresMap.getTrustStores().flatMap { it.x509ExtendedTrustManager() }
+        trustStoresMap
+            .getTrustStores()
+            .mapNotNull { it.trustStore }
+            .flatMap { it.x509ExtendedTrustManager() }
 }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/ConnectionManagerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/ConnectionManagerTest.kt
@@ -4,6 +4,7 @@ import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.util.concurrent.Future
 import net.corda.p2p.gateway.messaging.http.DestinationInfo
 import net.corda.p2p.gateway.messaging.http.HttpClient
+import net.corda.p2p.gateway.messaging.http.TrustStoresMap
 import net.corda.utilities.seconds
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -16,7 +17,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import java.net.URI
-import java.security.KeyStore
 import java.util.concurrent.TimeUnit
 
 class ConnectionManagerTest {
@@ -25,7 +25,7 @@ class ConnectionManagerTest {
 
     private val connectionManager = ConnectionManager(sslConfiguration, connectionConfiguration)
     private val mockedClient = mockConstruction(HttpClient::class.java)
-    private val trustStore = mock<KeyStore>()
+    private val trustStore = mock<TrustStoresMap.TrustedCertificates>()
 
     @AfterEach
     fun cleanUp() {

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
@@ -41,6 +41,7 @@ import java.security.InvalidKeyException
 import java.security.PublicKey
 import java.security.cert.Certificate
 import java.security.cert.CertificateFactory
+import java.util.Objects
 import java.util.concurrent.CompletableFuture
 
 class DynamicKeyStoreTest {
@@ -356,7 +357,7 @@ class DynamicKeyStoreTest {
             assertThat(
                 dynamicKeyStore.getClientKeyStore(
                     id,
-                )
+                )?.keyStore
             ).isSameAs(keyStoreWithPassword)
         }
 
@@ -364,7 +365,7 @@ class DynamicKeyStoreTest {
         fun `getClientKeyStore uses the correct aliasToCertificates`() {
             dynamicKeyStore.getClientKeyStore(
                 id
-            )
+            )?.keyStore
 
             assertThat(keyStoreCreationCertificatesStore?.aliasToCertificates)
                 .hasSize(1)
@@ -378,7 +379,7 @@ class DynamicKeyStoreTest {
         fun `getClientKeyStore throw exception when wrong public key is used`() {
             dynamicKeyStore.getClientKeyStore(
                 id
-            )
+            )?.keyStore
 
             assertThrows<InvalidKeyException> {
                 keyStoreCreationSigner?.sign(
@@ -408,7 +409,7 @@ class DynamicKeyStoreTest {
 
             dynamicKeyStore.getClientKeyStore(
                 id
-            )
+            )?.keyStore
 
             assertThat(
                 keyStoreCreationSigner?.sign(
@@ -436,6 +437,70 @@ class DynamicKeyStoreTest {
                     id,
                 )
             ).isNull()
+        }
+
+        @Test
+        fun `hashCode comes from the certificates and tenant id hash codes`() {
+            val certificateOne = mock<Certificate>()
+            val certificateTwo = mock<Certificate>()
+            val certificateThree = mock<Certificate>()
+            val id = "id"
+            val store = dynamicKeyStore.ClientKeyStore(
+                listOf(certificateOne, certificateTwo, certificateThree), id
+            )
+
+            assertThat(store.hashCode()).isEqualTo(
+                Objects.hash(
+                    listOf(certificateOne, certificateTwo, certificateThree),
+                    id,
+                )
+            )
+        }
+
+        @Test
+        fun `equals return false for different certificates`() {
+            val certificateOne = mock<Certificate>()
+            val certificateTwo = mock<Certificate>()
+            val certificateThree = mock<Certificate>()
+            val id = "id"
+            val storeOne = dynamicKeyStore.ClientKeyStore(
+                listOf(certificateOne, certificateThree), id
+            )
+            val storeTwo = dynamicKeyStore.ClientKeyStore(
+                listOf(certificateOne, certificateTwo), id
+            )
+
+            assertThat(storeOne).isNotEqualTo(storeTwo)
+        }
+
+        @Test
+        fun `equals return false for different ids`() {
+            val certificateOne = mock<Certificate>()
+            val certificateTwo = mock<Certificate>()
+            val certificateThree = mock<Certificate>()
+            val storeOne = dynamicKeyStore.ClientKeyStore(
+                listOf(certificateOne, certificateTwo, certificateThree), "id1"
+            )
+            val storeTwo = dynamicKeyStore.ClientKeyStore(
+                listOf(certificateOne, certificateTwo, certificateThree), "id2"
+            )
+
+            assertThat(storeOne).isNotEqualTo(storeTwo)
+        }
+
+        @Test
+        fun `equals return true when ids and certifiactes are the same`() {
+            val certificateOne = mock<Certificate>()
+            val certificateTwo = mock<Certificate>()
+            val certificateThree = mock<Certificate>()
+            val storeOne = dynamicKeyStore.ClientKeyStore(
+                listOf(certificateOne, certificateTwo, certificateThree), "id"
+            )
+            val storeTwo = dynamicKeyStore.ClientKeyStore(
+                listOf(certificateOne, certificateTwo, certificateThree), "id"
+            )
+
+            assertThat(storeOne).isEqualTo(storeTwo)
         }
     }
 }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
@@ -489,7 +489,7 @@ class DynamicKeyStoreTest {
         }
 
         @Test
-        fun `equals return true when ids and certifiactes are the same`() {
+        fun `equals return true when ids and certificates are the same`() {
             val certificateOne = mock<Certificate>()
             val certificateTwo = mock<Certificate>()
             val certificateThree = mock<Certificate>()

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManagerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/DynamicX509ExtendedTrustManagerTest.kt
@@ -18,7 +18,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.net.Socket
-import java.security.KeyStore
 import java.security.cert.CertificateException
 import java.security.cert.PKIXBuilderParameters
 import java.security.cert.X509Certificate
@@ -49,7 +48,9 @@ class DynamicX509ExtendedTrustManagerTest {
     private val mockTrustManagerFactory = mock<TrustManagerFactory> {
         on { trustManagers } doReturn arrayOf(mockX509ExtendedTrustManager, secondMockX509ExtendedTrustManager)
     }
-    private val mockTrustStore = mock<KeyStore>()
+    private val mockTrustStore = mock<TrustStoresMap.TrustedCertificates> {
+        on { trustStore } doReturn mock()
+    }
     private val trustStoresMap = mock<TrustStoresMap> {
         on { getTrustStores() } doReturn setOf(mockTrustStore)
     }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/HttpClientTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/HttpClientTest.kt
@@ -39,14 +39,15 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.io.IOException
 import java.net.URI
-import java.security.KeyStore
 import java.security.cert.PKIXBuilderParameters
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.TrustManagerFactory
 
 class HttpClientTest {
-    private val trustStore = mock<KeyStore>()
+    private val trustStore = mock<TrustStoresMap.TrustedCertificates> {
+        on { trustStore } doReturn mock()
+    }
     private val destinationInfo = DestinationInfo(
         uri = URI("http://www.r3.com:3023"),
         sni = "sni",

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandlerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandlerTest.kt
@@ -29,7 +29,6 @@ import net.corda.p2p.gateway.messaging.TlsType
 import net.corda.p2p.gateway.messaging.http.DestinationInfo
 import net.corda.p2p.gateway.messaging.http.HttpClient
 import net.corda.p2p.gateway.messaging.http.HttpResponse
-import net.corda.p2p.gateway.messaging.http.KeyStoreWithPassword
 import net.corda.p2p.gateway.messaging.http.TrustStoresMap
 import net.corda.test.util.time.MockTimeFacilitiesProvider
 import net.corda.utilities.millis
@@ -52,7 +51,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.net.URI
 import java.nio.ByteBuffer
-import java.security.KeyStore
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ScheduledExecutorService
@@ -94,7 +92,7 @@ class OutboundMessageHandlerTest {
         }
         whenever(mock.dominoTile).doReturn(mockDominoTile)
     }
-    private val truststore = mock<KeyStore>()
+    private val truststore = mock<TrustStoresMap.TrustedCertificates>()
     private val trustStoresMap = mock<TrustStoresMap> {
         on { getTrustStore(any(), eq(GROUP_ID)) } doReturn truststore
     }
@@ -271,7 +269,7 @@ class OutboundMessageHandlerTest {
         val sslConfig = mock<SslConfiguration> {
             on { tlsType } doReturn TlsType.MUTUAL
         }
-        val keyStore = mock<KeyStoreWithPassword>()
+        val keyStore = mock<DynamicKeyStore.ClientKeyStore>()
         val dynamicKeyStore = mock<DynamicKeyStore> {
             on {
                 getClientKeyStore(

--- a/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/CertificateAuthorityUtilities.kt
+++ b/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/CertificateAuthorityUtilities.kt
@@ -3,7 +3,6 @@ package net.corda.crypto.test.certificates.generation
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import java.io.StringWriter
 import java.security.Key
-import java.security.KeyStore
 import java.security.cert.Certificate
 
 /**
@@ -27,15 +26,5 @@ fun Key.toPem(): String {
             writer.writeObject(this)
         }
         str.toString()
-    }
-}
-
-/**
- * Convert a certificate to a key store object (with alias "alias")
- */
-fun Certificate.toKeystore(): KeyStore {
-    return KeyStore.getInstance("PKCS12").also { keyStore ->
-        keyStore.load(null)
-        keyStore.setCertificateEntry("alias", this)
     }
 }


### PR DESCRIPTION
This pull request changes the destination info key to a valid hash map key so the number of connections will stay minimal.