### PR TITLE
ES-1031: Restore CODEOWNERS file for 5.0 branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,103 @@
-# Reduced list for the duration of 5.0 code freeze 
-* @mnesbit @driessamyn @ronanbrowne @rick-r3 @fenryka @yarivus
+# Build scripts should be audited by BLT
 
+Jenkinsfile        @corda/blt
+.ci/**             @corda/blt
+
+*.gradle           @corda/blt
+gradle.properties  @corda/corda5-team-leads
+gradle/*           @corda/blt
+
+.github/**          @corda/blt
+CODEOWNERS         @corda/blt @corda/corda5-team-leads
+
+# Modules to be audited by REST team
+/applications/workers/release/rest-worker/      @corda/rest
+/components/rest-gateway-comp/                  @corda/rest
+/components/permissions/                        @corda/rest
+/components/rbac-security-manager-service/      @corda/rest
+/libs/rest/                                     @corda/rest
+/libs/permissions/                              @corda/rest
+/processors/rest-processor/                     @corda/rest
+
+# Corda Helm chart for cluster management team
+/charts/corda/                                @corda/cluster-management
+
+# Modules to be audited by the Network team
+/applications/workers/release/p2p-gateway-worker/               @corda/corda-platform-network-team
+/applications/workers/release/p2p-link-manager-worker/          @corda/corda-platform-network-team
+/applications/workers/release/member-worker/                    @corda/corda-platform-network-team
+/processors/link-manager-processor/                             @corda/corda-platform-network-team
+/processors/gateway-processor/                                  @corda/corda-platform-network-team
+/processors/member-processor/                                   @corda/corda-platform-network-team
+/components/gateway/                                            @corda/corda-platform-network-team
+/components/link-manager/                                       @corda/corda-platform-network-team
+/components/membership/                                         @corda/corda-platform-network-team
+/libs/membership/                                               @corda/corda-platform-network-team
+/libs/p2p-crypto/                                               @corda/corda-platform-network-team
+/libs/layered-property-map/                                     @corda/corda-platform-network-team
+/tools/plugins/mgm/                                             @corda/corda-platform-network-team
+/tools/plugins/network/                                         @corda/corda-platform-network-team
+/applications/tools/p2p-test/                                   @corda/corda-platform-network-team
+
+# Modules to be audited by Sandboxing SMEs
+/components/security-manager/                                   @corda/sandboxing
+/components/virtual-node/sandbox-*                              @corda/sandboxing
+/components/sandbox*                                            @corda/sandboxing
+/libs/virtual-node/sandbox-*                                    @corda/sandboxing
+/osgi-*                                                         @corda/sandboxing
+/testing/sandboxes/                                             @corda/sandboxing
+/testing/sandboxes-testkit/                                     @corda/sandboxing
+/testing/security-manager-utilities/                            @corda/sandboxing
+
+# Modules to be audited by Crypto SMEs
+/components/crypto/                                             @corda/crypto
+/libs/crypto/                                                   @corda/crypto
+/processors/crypto/                                             @corda/crypto
+
+# Modules to be audited by Packaging SMEs
+/components/chunking/                                           @corda/packaging
+/components/virtual-node/cpi-*                                  @corda/packaging
+/components/virtual-node/cpk-*                                  @corda/packaging
+/libs/chunking/                                                 @corda/packaging
+/libs/packaging/                                                @corda/packaging
+/libs/serialization/                                            @corda/packaging
+/libs/virtual-node/cpi-*                                        @corda/packaging
+/testing/packaging-test-utilities/                              @corda/packaging
+/tools/plugins/package                                          @corda/packaging
+
+# Modules to be audited by DB SMEs
+/components/db/                                                 @corda/db
+/components/persistence/                                        @corda/db
+/components/reconciliation/                                     @corda/db
+/libs/db/                                                       @corda/db
+/processors/db/                                                 @corda/db
+/testing/persistence-testkit/                                   @corda/db
+/tools/plugins/db-config                                        @corda/db
+
+# Modules to be audited by Flow Worker team
+/components/flow/                                               @corda/flow-worker
+/libs/flows/                                                    @corda/flow-worker
+/libs/lifecycle/                                                @corda/flow-worker
+/libs/messaging/                                                @corda/flow-worker
+/libs/application/application-impl/                             @corda/flow-worker
+/processors/flow-processor/                                     @corda/flow-worker
+/testing/flow/                                                  @corda/flow-worker
+/testing/message-patterns/                                      @corda/flow-worker
+/applications/workers/release/flow-worker                       @corda/flow-worker
+
+# Modules to be audited by Ledger SMEs
+/components/ledger/                                             @corda/ledger
+/libs/ledger/                                                   @corda/ledger
+/testing/ledger/                                                @corda/ledger
+
+# Modules to be audited by Notary SMEs
+/components/uniqueness/                                         @corda/notaries
+/libs/uniqueness/                                               @corda/notaries
+/notary-plugins/                                                @corda/notaries
+/processors/uniqueness-processor/                               @corda/notaries
+/testing/uniqueness/                                            @corda/notaries
+
+# Ledger token selection files to be reviewed by the REST team
+# This needs to be after the ledger rules to partially override those
+/components/ledger/ledger-utxo-token-cache                      @corda/rest
+/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/impl/token @corda/rest


### PR DESCRIPTION
Restoring `CODEOWNERS` file to its original format, as part of this the GitHub freeze branch feature will be active on 5.0 streams.

Meaning PR's will still go through the normal review process and need to be approved by relevant groups in the CODEOWNERS file but, Merging will be blocked on that branch at a configuration level, until a repo admin temporarily lifts the freeze

