### PR TITLE
CORE-15833: Fix parsing of (:parameter) and (**::int) for custom queries.

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/parsing/expressions/PostgresVaultNamedQueryExpressionParser.kt
@@ -49,9 +49,9 @@ class PostgresVaultNamedQueryExpressionParser : VaultNamedQueryExpressionParser 
         """(?<op>(->>)|(->)|[+-/*=?]|<(=)?|>(=)?|==|!(=)?|(?i)\bas\b|(?i)\bfrom\b|(?i)\bselect\b|(?i)\bwhere\b|(?i)\band\b|(?i)\bor\b|(?i)\bis null\b|(?i)\bis not null\b|(?i)\bin\b|(?i)\blike\b)"""
     )
 
-    private val jsonCastPattern = Regex("""::(?<cast>.*?)((->>)|[+*=]|&&|\|\||<(=)?|>(=)?|==|!(=)?|\s|$)""")
+    private val jsonCastPattern = Regex("""::(?<cast>.*?)((->>)|[+*=()\s]|&&|\|\||<(=)?|>(=)?|==|!(=)?|$)""")
 
-    private val parameterPattern = Regex("""(?<parameter>:[^:]\S+)""")
+    private val parameterPattern = Regex("""(?<parameter>:[\w-]+)""")
 
     @Suppress("NestedBlockDepth")
     override fun parse(query: String): List<Token> {

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParserTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/query/impl/parsing/expressions/PostgresVaultNamedQueryExpressionParserTest.kt
@@ -110,7 +110,15 @@ class PostgresVaultNamedQueryExpressionParserTest {
             .contains(Parameter(":parameter"), Index.atIndex(0))
             .contains(Parameter(":another_one"), Index.atIndex(3))
             .contains(Parameter(":with-dashes"), Index.atIndex(6))
+    }
 
+    @Test
+    fun `parameter name in brackets is parsed as Parameter`() {
+        assertThat(expressionParser.parse("(:parameter)")).containsExactly(
+            LeftParentheses(),
+            Parameter(":parameter"),
+            RightParentheses()
+        )
     }
 
     @Test
@@ -346,6 +354,15 @@ class PostgresVaultNamedQueryExpressionParserTest {
             .contains(JsonCast("int"), Index.atIndex(4))
             .contains(JsonCast("int"), Index.atIndex(7))
             .contains(JsonCast("intz"), Index.atIndex(11))
+    }
+
+    @Test
+    fun `json cast in brackets is parsed as JsonCast`() {
+        assertThat(expressionParser.parse("(::int)")).containsExactly(
+            LeftParentheses(),
+            JsonCast("int"),
+            RightParentheses()
+        )
     }
 
     @Test


### PR DESCRIPTION
Prevent parentheses from being included in either `Parameter` or `JsonCast` tokens, because `LeftParentheses` and `RightParentheses` are tokens in their own right and need to be parsed as such.