### PR TITLE
CORE-15806 Re-creating entity manager factories causing memory leak of non-heap

### DIFF
--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
@@ -4,7 +4,6 @@ import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.orm.JpaEntitiesSet
 import net.corda.virtualnode.VirtualNodeInfo
 import javax.persistence.EntityManager
-import javax.persistence.EntityManagerFactory
 
 /**
  * Additional context to be included during reconciliation.
@@ -45,12 +44,10 @@ class VirtualNodeReconciliationContext(
     val virtualNodeInfo: VirtualNodeInfo
 ) : ReconciliationContext {
 
-    private var entityManagerFactory: EntityManagerFactory? = null
     private var entityManager: EntityManager? = null
 
-    private fun getOrCreateEntityManagerFactory() = entityManagerFactory
-        ?: dbConnectionManager.createEntityManagerFactory(virtualNodeInfo.vaultDmlConnectionId, jpaEntitiesSet)
-            .also { entityManagerFactory = it }
+    private fun getOrCreateEntityManagerFactory() =
+        dbConnectionManager.getOrCreateEntityManagerFactory(virtualNodeInfo.vaultDmlConnectionId, jpaEntitiesSet)
 
     override fun getOrCreateEntityManager(): EntityManager = entityManager
         ?: getOrCreateEntityManagerFactory().createEntityManager()
@@ -58,8 +55,6 @@ class VirtualNodeReconciliationContext(
 
     override fun close() {
         entityManager?.close()
-        entityManagerFactory?.close()
         entityManager = null
-        entityManagerFactory = null
     }
 }

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
@@ -105,9 +105,9 @@ class GroupParametersReconcilerTest {
         on { createCoordinator(any(), any()) } doReturn coordinator
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { createEntityManagerFactory(eq(vnode1.vaultDmlConnectionId), any()) } doReturn emf1
-        on { createEntityManagerFactory(eq(vnode2.vaultDmlConnectionId), any()) } doReturn emf2
-        on { createEntityManagerFactory(eq(vnode3.vaultDmlConnectionId), any()) } doReturn emf3
+        on { getOrCreateEntityManagerFactory(eq(vnode1.vaultDmlConnectionId), any()) } doReturn emf1
+        on { getOrCreateEntityManagerFactory(eq(vnode2.vaultDmlConnectionId), any()) } doReturn emf2
+        on { getOrCreateEntityManagerFactory(eq(vnode3.vaultDmlConnectionId), any()) } doReturn emf3
     }
 
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
@@ -226,7 +226,7 @@ class GroupParametersReconcilerTest {
             // call terminal operation to process stream
             groupParametersReconciler.dbReconcilerReader?.getAllVersionedRecords()?.count()
 
-            verify(dbConnectionManager, times(2)).createEntityManagerFactory(any(), any())
+            verify(dbConnectionManager, times(2)).getOrCreateEntityManagerFactory(any<UUID>(), any())
             verify(em1).criteriaBuilder
             verify(em1).createQuery(any<CriteriaQuery<GroupParametersEntity>>())
             verify(em2).criteriaBuilder
@@ -249,8 +249,6 @@ class GroupParametersReconcilerTest {
 
             stream?.collect(Collectors.toList())
 
-            verify(emf1).close()
-            verify(emf2).close()
             verify(em1).close()
             verify(em2).close()
             verify(tx1).rollback()

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
@@ -70,7 +70,7 @@ class MgmAllowedCertificateSubjectsReconcilerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { createEntityManagerFactory(connectionId, entitySet) } doReturn entityManagerFactory
+        on { getOrCreateEntityManagerFactory(connectionId, entitySet) } doReturn entityManagerFactory
     }
     private val reconcilerFactory = mock<ReconcilerFactory> {
         on {

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContextTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContextTest.kt
@@ -46,7 +46,7 @@ class ReconciliationContextTest {
     private val dbConnectionManager: DbConnectionManager = mock {
         on { getClusterEntityManagerFactory() } doReturn clusterEmf
         on {
-            createEntityManagerFactory(eq(virtualNodeInfo.vaultDmlConnectionId), eq(jpaEntitiesSet))
+            getOrCreateEntityManagerFactory(eq(virtualNodeInfo.vaultDmlConnectionId), eq(jpaEntitiesSet))
         } doReturn vnodeEmf
     }
 
@@ -123,9 +123,9 @@ class ReconciliationContextTest {
         }
 
         @Test
-        fun `Context entity manager factory and entity manager are created when called`() {
+        fun `Context entity manager factory and entity manager are acquired when called`() {
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager).createEntityManagerFactory(
+            verify(dbConnectionManager).getOrCreateEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -133,10 +133,10 @@ class ReconciliationContextTest {
         }
 
         @Test
-        fun `Context entity manager factory and entity manager are not recreated if they haven't been closed`() {
+        fun `Context entity manager is not recreated if it hasn't been closed`() {
             context.getOrCreateEntityManager()
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager).createEntityManagerFactory(
+            verify(dbConnectionManager).getOrCreateEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -144,11 +144,11 @@ class ReconciliationContextTest {
         }
 
         @Test
-        fun `Context entity manager factory and entity manager are recreated if they have been closed`() {
+        fun `Context entity manager is recreated if it has been closed`() {
             context.getOrCreateEntityManager()
             context.close()
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager, times(2)).createEntityManagerFactory(
+            verify(dbConnectionManager, times(2)).getOrCreateEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -166,14 +166,6 @@ class ReconciliationContextTest {
             verify(vnodeEm, never()).close()
             context.close()
             verify(vnodeEm).close()
-        }
-
-        @Test
-        fun `Closing the context closes the entity manager factory`() {
-            context.getOrCreateEntityManager()
-            verify(vnodeEmf, never()).close()
-            context.close()
-            verify(vnodeEmf).close()
         }
     }
 }


### PR DESCRIPTION
## Problem

On every VNode reconciliation run we create a new EMF per VNode DB connection (i.e. 1 EMF per VNode DB connection for all VNodes). The problem is, on new EMF creation, Hibernate creates and loads new proxy classes for the entities, even for the same entities, and these proxies accumulate in the class loader (memory leak). 

## Fix

Caches EMFs across VNode reconciliations to like so re-use existing EMFs and stop creating new ones every time which means entity proxies are now being created once per VNode and are re-used across reconciliations.

##

After this "fix" it means we should still have "duplicate" entities proxies across VNodes EMFs but the "duplicate" entities proxies across reconciliation runs are now resolved.

The effect of this "fix" was tested to be fixing the above memory leak as shown [here](https://github.com/corda/corda-runtime-os/pull/4364#discussion_r1277361956).