### PR TITLE
CORE-15574 - Add replays for exceptions on REST calls for e2e-tests

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/utils/ClusterUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/utils/ClusterUtils.kt
@@ -55,7 +55,7 @@ fun ClusterBuilder.eventuallyUploadCpi(
 }
 
 fun ClusterBuilder.eventuallyCreateVirtualNode(cpiFileChecksum: String, x500Name: String): String {
-    val vNodeJson = assertWithRetryIgnoringExceptions {
+    val vNodeJson = assertWithRetry {
         timeout(retryTimeout)
         interval(retryInterval)
         command { vNodeCreate(cpiFileChecksum, x500Name) }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/utils/ClusterUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/utils/ClusterUtils.kt
@@ -2,6 +2,7 @@ package net.corda.applications.workers.smoketest.utils
 
 import net.corda.e2etest.utilities.ClusterBuilder
 import net.corda.e2etest.utilities.assertWithRetry
+import net.corda.e2etest.utilities.assertWithRetryIgnoringExceptions
 import net.corda.e2etest.utilities.awaitVirtualNodeOperationStatusCheck
 import net.corda.rest.ResponseCode
 import org.assertj.core.api.Assertions
@@ -26,7 +27,7 @@ fun ClusterBuilder.eventuallyUploadCpi(
     Assertions.assertThat(requestId).withFailMessage(ERROR_IS_CLUSTER_RUNNING).isNotEmpty
 
     // BUG:  returning "OK" feels 'weakly' typed
-    val json = assertWithRetry {
+    val json = assertWithRetryIgnoringExceptions {
         timeout(retryTimeout)
         interval(retryInterval)
         command { cpiStatus(requestId) }
@@ -54,7 +55,7 @@ fun ClusterBuilder.eventuallyUploadCpi(
 }
 
 fun ClusterBuilder.eventuallyCreateVirtualNode(cpiFileChecksum: String, x500Name: String): String {
-    val vNodeJson = assertWithRetry {
+    val vNodeJson = assertWithRetryIgnoringExceptions {
         timeout(retryTimeout)
         interval(retryInterval)
         command { vNodeCreate(cpiFileChecksum, x500Name) }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -11,6 +11,7 @@ import net.corda.e2etest.utilities.CODE_SIGNER_CERT_USAGE
 import net.corda.e2etest.utilities.RpcSmokeTestInput
 import net.corda.e2etest.utilities.SMOKE_TEST_CLASS_NAME
 import net.corda.e2etest.utilities.assertWithRetry
+import net.corda.e2etest.utilities.assertWithRetryIgnoringExceptions
 import net.corda.e2etest.utilities.awaitRpcFlowFinished
 import net.corda.e2etest.utilities.cluster
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
@@ -48,7 +49,7 @@ class FlowStatusFeedSmokeTest {
         fun beforeAll() {
             // Certificate upload can be slow in the combined worker, especially after it has just started up.
             cluster {
-                assertWithRetry {
+                assertWithRetryIgnoringExceptions {
                     timeout(Duration.ofSeconds(100))
                     interval(Duration.ofSeconds(1))
                     command { importCertificate(CODE_SIGNER_CERT, CODE_SIGNER_CERT_USAGE, CODE_SIGNER_CERT_ALIAS) }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -57,7 +57,7 @@ fun ClusterInfo.generateCsr(
         }
     }
 
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         interval(1.seconds)
         command { post("/api/${RestApiVersion.C5_1.versionPath}/certificate/$tenantId/$keyId", ObjectMapper().writeValueAsString(payload)) }
         condition { it.code == ResponseCode.OK.statusCode }
@@ -73,7 +73,7 @@ fun ClusterInfo.importCertificate(
     alias: String
 ) {
     cluster {
-        assertWithRetry {
+        assertWithRetryIgnoringExceptions {
             interval(1.seconds)
             command { importCertificate(file, usage, alias) }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -32,7 +32,7 @@ fun ClusterInfo.conditionallyUploadCpiSigningCertificate() = cluster {
         it.code != ResponseCode.RESOURCE_NOT_FOUND.statusCode
     }
     if (!hasCertificateChain) {
-        assertWithRetryIgnoringExceptions {
+        assertWithRetry {
             // Certificate upload can be slow in the combined worker, especially after it has just started up.
             timeout(30.seconds)
             interval(2.seconds)
@@ -145,7 +145,7 @@ fun ClusterInfo.addSoftHsmFor(
     holdingId: String,
     category: String
 ) = cluster {
-    assertWithRetryIgnoringExceptions {
+    assertWithRetry {
         timeout(Duration.ofSeconds(5))
         command { addSoftHsmToVNode(holdingId, category) }
         condition { it.code == 200 }
@@ -159,7 +159,7 @@ fun ClusterInfo.createKeyFor(
     category: String,
     scheme: String
 ): String = cluster {
-    val keyId = assertWithRetryIgnoringExceptions {
+    val keyId = assertWithRetry {
         interval(1.seconds)
         command { createKey(tenantId, alias, category, scheme) }
         condition {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -32,7 +32,7 @@ fun ClusterInfo.conditionallyUploadCpiSigningCertificate() = cluster {
         it.code != ResponseCode.RESOURCE_NOT_FOUND.statusCode
     }
     if (!hasCertificateChain) {
-        assertWithRetry {
+        assertWithRetryIgnoringExceptions {
             // Certificate upload can be slow in the combined worker, especially after it has just started up.
             timeout(30.seconds)
             interval(2.seconds)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ConfigTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ConfigTestUtils.kt
@@ -36,7 +36,10 @@ fun updateConfig(config: String, section: String) = DEFAULT_CLUSTER.updateConfig
 
 fun ClusterInfo.updateConfig(config: String, section: String) {
     return cluster {
-        val currentConfig = getConfig(section).body.toJson()
+        val currentConfig = assertWithRetryIgnoringExceptions {
+            command { getConfig(section) }
+            condition { it.code == OK.statusCode }
+        }.body.toJson()
         val currentSchemaVersion = currentConfig["schemaVersion"]
 
         try {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -71,7 +71,7 @@ fun awaitRpcFlowFinished(
 fun ClusterInfo.awaitRpcFlowFinished(holdingId: String, requestId: String): FlowStatus {
     return cluster {
         ObjectMapper().readValue(
-            assertWithRetry {
+            assertWithRetryIgnoringExceptions {
                 command { flowStatus(holdingId, requestId) }
                 //CORE-6118 - tmp increase this timeout to a large number to allow tests to pass while slow flow sessions are investigated
                 timeout(Duration.ofMinutes(6))
@@ -92,7 +92,7 @@ fun awaitRestFlowResult(
 fun ClusterInfo.awaitRestFlowResult(holdingId: String, requestId: String): FlowResult {
     return cluster {
         val jsonNode = ObjectMapper().readTree(
-            assertWithRetry {
+            assertWithRetryIgnoringExceptions {
                 command { flowResult(holdingId, requestId) }
                 timeout(Duration.ofMinutes(6))
                 condition {
@@ -126,7 +126,7 @@ fun getFlowStatus(
 fun ClusterInfo.getFlowStatus(holdingId: String, requestId: String, expectedCode: Int): FlowStatus {
     return cluster {
         ObjectMapper().readValue(
-            assertWithRetry {
+            assertWithRetryIgnoringExceptions {
                 command { flowStatus(holdingId, requestId) }
                 timeout(Duration.ofMinutes(6))
                 condition {
@@ -146,7 +146,7 @@ private fun JsonNode.asFlowError(): FlowError {
 
 fun awaitMultipleRpcFlowFinished(holdingId: String, expectedFlowCount: Int) {
     return DEFAULT_CLUSTER.cluster {
-        assertWithRetry {
+        assertWithRetryIgnoringExceptions {
             command { multipleFlowStatus(holdingId) }
             timeout(Duration.ofSeconds(20))
             condition {
@@ -168,7 +168,7 @@ fun getFlowClasses(
 
 fun ClusterInfo.getFlowClasses(holdingId: String): List<String> {
     return cluster {
-        val vNodeJson = assertWithRetry {
+        val vNodeJson = assertWithRetryIgnoringExceptions {
             command { runnableFlowClasses(holdingId) }
             condition { it.code == 200 }
             failMessage("Failed to get flows for holdingId '$holdingId'")

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -64,7 +64,7 @@ fun ClusterInfo.onboardMgm(
 fun ClusterInfo.exportGroupPolicy(
     mgmHoldingId: String
 ) = cluster {
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         interval(2.seconds)
         timeout(30.seconds)
         command { get("/api/v1/mgm/$mgmHoldingId/info") }
@@ -103,7 +103,7 @@ private fun ClusterInfo.createApprovalRuleCommon(
         "ruleRegex" to regex
     )
 
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         interval(1.seconds)
         command { post(url, ObjectMapper().writeValueAsString(payload)) }
         condition { it.code == ResponseCode.OK.statusCode }
@@ -155,7 +155,7 @@ fun ClusterInfo.createPreAuthToken(
         ttl?.let { put("ttl", it.toString()) }
     }
 
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         interval(1.seconds)
         command { post("/api/v1/mgm/$mgmHoldingId/preauthtoken", ObjectMapper().writeValueAsString(payload)) }
         condition { it.code == ResponseCode.OK.statusCode }
@@ -195,7 +195,7 @@ fun ClusterInfo.getPreAuthTokens(
         ownerX500name?.let { add("ownerx500name=${encode(it, defaultCharset())}") }
     }
     val query = queries.joinToString(prefix = "?", separator = "&")
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         interval(1.seconds)
         command { get("/api/v1/mgm/$mgmHoldingId/preauthtoken$query") }
         condition { it.code == ResponseCode.OK.statusCode }
@@ -215,7 +215,7 @@ fun ClusterInfo.waitForPendingRegistrationReviews(
         val query = memberX500Name?.let {
             "?requestsubjectx500name=${encode(memberX500Name.toString(), defaultCharset())}"
         } ?: ""
-        assertWithRetry {
+        assertWithRetryIgnoringExceptions {
             timeout(2.minutes)
             interval(3.seconds)
             command { get("/api/v1/mgm/$mgmHoldingId/registrations$query") }
@@ -237,7 +237,7 @@ fun ClusterInfo.approveRegistration(
     registrationId: String
 ) {
     cluster {
-        assertWithRetry {
+        assertWithRetryIgnoringExceptions {
             interval(1.seconds)
             command { post("/api/v1/mgm/$mgmHoldingId/approve/$registrationId", "") }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
@@ -253,7 +253,7 @@ fun ClusterInfo.declineRegistration(
     registrationId: String
 ) {
     cluster {
-        assertWithRetry {
+        assertWithRetryIgnoringExceptions {
             interval(1.seconds)
             command { post(
                 "/api/v1/mgm/$mgmHoldingId/decline/$registrationId",
@@ -312,7 +312,7 @@ fun ClusterInfo.suspendMember(
     x500Name: String,
     serialNumber: Int? = null,
 ) = cluster {
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         timeout(15.seconds)
         interval(1.seconds)
         command {
@@ -334,7 +334,7 @@ fun ClusterInfo.activateMember(
     x500Name: String,
     serialNumber: Int? = null,
 ) = cluster {
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         timeout(15.seconds)
         interval(1.seconds)
         command {
@@ -357,7 +357,7 @@ fun ClusterInfo.updateGroupParameters(
     val payload = mapOf(
         "parameters" to update
     )
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         timeout(15.seconds)
         interval(1.seconds)
         command {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -103,7 +103,7 @@ private fun ClusterInfo.createApprovalRuleCommon(
         "ruleRegex" to regex
     )
 
-    assertWithRetryIgnoringExceptions {
+    assertWithRetry {
         interval(1.seconds)
         command { post(url, ObjectMapper().writeValueAsString(payload)) }
         condition { it.code == ResponseCode.OK.statusCode }
@@ -237,7 +237,7 @@ fun ClusterInfo.approveRegistration(
     registrationId: String
 ) {
     cluster {
-        assertWithRetryIgnoringExceptions {
+        assertWithRetry {
             interval(1.seconds)
             command { post("/api/v1/mgm/$mgmHoldingId/approve/$registrationId", "") }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
@@ -253,7 +253,7 @@ fun ClusterInfo.declineRegistration(
     registrationId: String
 ) {
     cluster {
-        assertWithRetryIgnoringExceptions {
+        assertWithRetry {
             interval(1.seconds)
             command { post(
                 "/api/v1/mgm/$mgmHoldingId/decline/$registrationId",
@@ -312,7 +312,7 @@ fun ClusterInfo.suspendMember(
     x500Name: String,
     serialNumber: Int? = null,
 ) = cluster {
-    assertWithRetryIgnoringExceptions {
+    assertWithRetry {
         timeout(15.seconds)
         interval(1.seconds)
         command {
@@ -334,7 +334,7 @@ fun ClusterInfo.activateMember(
     x500Name: String,
     serialNumber: Int? = null,
 ) = cluster {
-    assertWithRetryIgnoringExceptions {
+    assertWithRetry {
         timeout(15.seconds)
         interval(1.seconds)
         command {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -148,7 +148,7 @@ fun ClusterInfo.configureNetworkParticipant(
     sessionKeyId: String
 ) {
     return cluster {
-        assertWithRetry {
+        assertWithRetryIgnoringExceptions {
             interval(1.seconds)
             command { configureNetworkParticipant(holdingId, sessionKeyId) }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
@@ -208,7 +208,7 @@ fun ClusterInfo.waitForRegistrationStatus(
     registrationStatus: String
 ) {
     cluster {
-        assertWithRetry {
+        assertWithRetryIgnoringExceptions {
             // Use a fairly long timeout here to give plenty of time for the other side to respond. Longer
             // term this should be changed to not use the RPC message pattern and have the information available in a
             // cache on the REST worker, but for now this will have to suffice.
@@ -304,7 +304,7 @@ fun ClusterInfo.lookup(
     holdingId: String,
     statuses: List<String> = emptyList()
 ) = cluster {
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         timeout(15.seconds)
         interval(1.seconds)
         command {
@@ -321,7 +321,7 @@ fun ClusterInfo.lookup(
 fun ClusterInfo.lookupGroupParameters(
     holdingId: String
 ) = cluster {
-    assertWithRetry {
+    assertWithRetryIgnoringExceptions {
         timeout(15.seconds)
         interval(1.seconds)
         command {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/RbacTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/RbacTestUtils.kt
@@ -8,7 +8,7 @@ object RbacTestUtils {
 
     fun getAllRbacRoles(): List<RbacRole> {
         return DEFAULT_CLUSTER.cluster {
-            val bodyAsString = assertWithRetry {
+            val bodyAsString = assertWithRetryIgnoringExceptions {
                 command { getRbacRoles() }
                 condition { it.code == 200 }
                 failMessage("Failed to get all the RBAC roles in the cluster")

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/VirtualNodeUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/VirtualNodeUtils.kt
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 
 fun ClusterBuilder.awaitVirtualNodeOperationStatusCheck(requestId: String): String {
-    val statusResponse = assertWithRetry {
+    val statusResponse = assertWithRetryIgnoringExceptions {
         timeout(1.minutes)
         command { getVNodeStatus(requestId) }
         condition {


### PR DESCRIPTION
Adding retries for exceptions, so that tests can recover from transient failures, such as `HttpHostConnectException` or `SSLHandshakeException`. I scanned all the usages of `assertWithRetry` and converted to `assertWithRetryIgnoringExceptions` with the exceptions of cases where the operation might have side-effects if applied under transient network conditions that could later lead to test failures (e.g. initiation of registrations, flows etc.).

I also did a run of the e2e tests job integrated with the changes in this PR, available [here](https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda5-e2e-tests/detail/PR-178/3/pipeline/). 