### PR TITLE
CORE-15641 Revise character limit on custom metadata values

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/verifiers/RegistrationContextCustomFieldsVerifier.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/verifiers/RegistrationContextCustomFieldsVerifier.kt
@@ -5,13 +5,13 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
 internal class RegistrationContextCustomFieldsVerifier {
 
     private companion object {
-        const val MAX_VALUE_LENGTH = 256
+        const val MAX_VALUE_LENGTH = 800
         const val MAX_KEY_LENGTH = 128
         const val MAX_CUSTOM_FIELDS = 100
     }
 
     fun verify(context: Map<String, String>): Result {
-        val customFields = context.filter { it.key.startsWith(CUSTOM_KEY_PREFIX) }
+        val customFields = context.filter { it.key.startsWith("$CUSTOM_KEY_PREFIX.") }
         if (customFields.size > MAX_CUSTOM_FIELDS ) {
             return Result.Failure(
                 "The number of custom fields (${customFields.size}) in the registration context is larger than " +

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/verifiers/RegistrationContextCustomFieldsVerifierTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/verifiers/RegistrationContextCustomFieldsVerifierTest.kt
@@ -10,7 +10,7 @@ class RegistrationContextCustomFieldsVerifierTest {
         const val CUSTOM_VALUE = "customValue"
     }
     private val fieldsVerifier = RegistrationContextCustomFieldsVerifier()
-    private val longString = StringBuilder().apply { for(i in 0..256){ this.append("a") } }.toString()
+    private val longString = StringBuilder().apply { for(i in 0..800){ this.append("a") } }.toString()
 
     @Test
     fun `adding a custom field verifies successfully`() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.10-beta+
+cordaApiVersion=5.1.0.11-alpha-1690812156735
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.11-alpha-1690812156735
+cordaApiVersion=5.1.0.11-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/verifiers/GroupParametersUpdateVerifier.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/verifiers/GroupParametersUpdateVerifier.kt
@@ -1,17 +1,18 @@
 package net.corda.membership.lib.verifiers
 
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MPV_KEY
+import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
 
 class GroupParametersUpdateVerifier {
 
     private companion object {
-        const val CUSTOM_KEY_PREFIX = "ext."
         const val MAX_KEY_LENGTH = 128
+        const val MAX_VALUE_LENGTH = 800
         const val MAX_CUSTOM_FIELDS = 100
     }
 
     fun verify(parameters: Map<String, String>): Result {
-        val customFields = parameters.filter { it.key.startsWith(CUSTOM_KEY_PREFIX) }
+        val customFields = parameters.filter { it.key.startsWith("$CUSTOM_KEY_PREFIX.") }
         if (customFields.size > MAX_CUSTOM_FIELDS ) {
             return Result.Failure("The number of custom fields (${customFields.size}) in the group parameters " +
                     "update is larger than the maximum allowed ($MAX_CUSTOM_FIELDS).")
@@ -22,6 +23,10 @@ class GroupParametersUpdateVerifier {
             if (it.key.length > MAX_KEY_LENGTH) {
                 errorMessages += "The key: ${it.key} has too many characters (${it.key.length}). Maximum of $MAX_KEY_LENGTH characters " +
                         "allowed.\n"
+            }
+            if (it.value.length > MAX_VALUE_LENGTH) {
+                errorMessages += "The key: ${it.key} has a value which has too many characters (${it.value.length}). Maximum of" +
+                        " $MAX_VALUE_LENGTH characters allowed.\n"
             }
         }
         parameters[MPV_KEY]?.let {

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/verifiers/GroupParametersUpdateVerifierTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/verifiers/GroupParametersUpdateVerifierTest.kt
@@ -11,7 +11,7 @@ class GroupParametersUpdateVerifierTest {
         const val CUSTOM_KEY = "ext.customKey"
         const val CUSTOM_VALUE = "customValue"
     }
-    private val longString = StringBuilder().apply { for(i in 0..256){ this.append("a") } }.toString()
+    private val longString = StringBuilder().apply { for(i in 0..800){ this.append("a") } }.toString()
 
     private val verifier = GroupParametersUpdateVerifier()
 
@@ -34,6 +34,13 @@ class GroupParametersUpdateVerifierTest {
         val result = verifier.verify(mapOf("ext.$longString" to CUSTOM_VALUE))
         assertThat(result).isInstanceOf(GroupParametersUpdateVerifier.Result.Failure::class.java)
         assertThat((result as GroupParametersUpdateVerifier.Result.Failure).reason).contains(longString)
+    }
+
+    @Test
+    fun `adding a long value causes verification to fail`() {
+        val result = verifier.verify(mapOf(CUSTOM_KEY to longString))
+        assertThat(result).isInstanceOf(GroupParametersUpdateVerifier.Result.Failure::class.java)
+        assertThat((result as GroupParametersUpdateVerifier.Result.Failure).reason).contains(CUSTOM_KEY)
     }
 
     @Test


### PR DESCRIPTION
Updates custom metadata verifiers for registration context and group parameters to apply revised character limit on custom metadata values.

The character limit is raised to 800 to allow for PEM values. Public key lengths of the following key schemes were used for reference: CORDA.RSA(BC,RSA), CORDA.ECDSA.SECP256K1(BC,EC), CORDA.ECDSA.SECP256R1(BC,EC), CORDA.EDDSA.ED25519(BC,Ed25519), CORDA.X25519(BC,X25519), CORDA.SM2(BC,EC), CORDA.GOST3410.GOST3411(BC,GOST3410).

https://github.com/corda/corda-api/pull/1195