### PR TITLE
CORE-15806 Revert EMFs caching at reconciliations

### DIFF
--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
@@ -4,6 +4,7 @@ import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.orm.JpaEntitiesSet
 import net.corda.virtualnode.VirtualNodeInfo
 import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
 
 /**
  * Additional context to be included during reconciliation.
@@ -44,10 +45,12 @@ class VirtualNodeReconciliationContext(
     val virtualNodeInfo: VirtualNodeInfo
 ) : ReconciliationContext {
 
+    private var entityManagerFactory: EntityManagerFactory? = null
     private var entityManager: EntityManager? = null
 
-    private fun getOrCreateEntityManagerFactory() =
-        dbConnectionManager.getOrCreateEntityManagerFactory(virtualNodeInfo.vaultDmlConnectionId, jpaEntitiesSet)
+    private fun getOrCreateEntityManagerFactory() = entityManagerFactory
+        ?: dbConnectionManager.createEntityManagerFactory(virtualNodeInfo.vaultDmlConnectionId, jpaEntitiesSet)
+            .also { entityManagerFactory = it }
 
     override fun getOrCreateEntityManager(): EntityManager = entityManager
         ?: getOrCreateEntityManagerFactory().createEntityManager()
@@ -55,6 +58,8 @@ class VirtualNodeReconciliationContext(
 
     override fun close() {
         entityManager?.close()
+        entityManagerFactory?.close()
         entityManager = null
+        entityManagerFactory = null
     }
 }

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
@@ -105,9 +105,9 @@ class GroupParametersReconcilerTest {
         on { createCoordinator(any(), any()) } doReturn coordinator
     }
     private val dbConnectionManager: DbConnectionManager = mock {
-        on { getOrCreateEntityManagerFactory(eq(vnode1.vaultDmlConnectionId), any()) } doReturn emf1
-        on { getOrCreateEntityManagerFactory(eq(vnode2.vaultDmlConnectionId), any()) } doReturn emf2
-        on { getOrCreateEntityManagerFactory(eq(vnode3.vaultDmlConnectionId), any()) } doReturn emf3
+        on { createEntityManagerFactory(eq(vnode1.vaultDmlConnectionId), any()) } doReturn emf1
+        on { createEntityManagerFactory(eq(vnode2.vaultDmlConnectionId), any()) } doReturn emf2
+        on { createEntityManagerFactory(eq(vnode3.vaultDmlConnectionId), any()) } doReturn emf3
     }
 
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService = mock {
@@ -226,7 +226,7 @@ class GroupParametersReconcilerTest {
             // call terminal operation to process stream
             groupParametersReconciler.dbReconcilerReader?.getAllVersionedRecords()?.count()
 
-            verify(dbConnectionManager, times(2)).getOrCreateEntityManagerFactory(any<UUID>(), any())
+            verify(dbConnectionManager, times(2)).createEntityManagerFactory(any(), any())
             verify(em1).criteriaBuilder
             verify(em1).createQuery(any<CriteriaQuery<GroupParametersEntity>>())
             verify(em2).criteriaBuilder
@@ -249,6 +249,8 @@ class GroupParametersReconcilerTest {
 
             stream?.collect(Collectors.toList())
 
+            verify(emf1).close()
+            verify(emf2).close()
             verify(em1).close()
             verify(em2).close()
             verify(tx1).rollback()

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
@@ -70,7 +70,7 @@ class MgmAllowedCertificateSubjectsReconcilerTest {
         on { createEntityManager() } doReturn entityManager
     }
     private val dbConnectionManager = mock<DbConnectionManager> {
-        on { getOrCreateEntityManagerFactory(connectionId, entitySet) } doReturn entityManagerFactory
+        on { createEntityManagerFactory(connectionId, entitySet) } doReturn entityManagerFactory
     }
     private val reconcilerFactory = mock<ReconcilerFactory> {
         on {

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContextTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContextTest.kt
@@ -46,7 +46,7 @@ class ReconciliationContextTest {
     private val dbConnectionManager: DbConnectionManager = mock {
         on { getClusterEntityManagerFactory() } doReturn clusterEmf
         on {
-            getOrCreateEntityManagerFactory(eq(virtualNodeInfo.vaultDmlConnectionId), eq(jpaEntitiesSet))
+            createEntityManagerFactory(eq(virtualNodeInfo.vaultDmlConnectionId), eq(jpaEntitiesSet))
         } doReturn vnodeEmf
     }
 
@@ -123,9 +123,9 @@ class ReconciliationContextTest {
         }
 
         @Test
-        fun `Context entity manager factory and entity manager are acquired when called`() {
+        fun `Context entity manager factory and entity manager are created when called`() {
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager).getOrCreateEntityManagerFactory(
+            verify(dbConnectionManager).createEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -133,10 +133,10 @@ class ReconciliationContextTest {
         }
 
         @Test
-        fun `Context entity manager is not recreated if it hasn't been closed`() {
+        fun `Context entity manager factory and entity manager are not recreated if they haven't been closed`() {
             context.getOrCreateEntityManager()
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager).getOrCreateEntityManagerFactory(
+            verify(dbConnectionManager).createEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -144,11 +144,11 @@ class ReconciliationContextTest {
         }
 
         @Test
-        fun `Context entity manager is recreated if it has been closed`() {
+        fun `Context entity manager factory and entity manager are recreated if they have been closed`() {
             context.getOrCreateEntityManager()
             context.close()
             context.getOrCreateEntityManager()
-            verify(dbConnectionManager, times(2)).getOrCreateEntityManagerFactory(
+            verify(dbConnectionManager, times(2)).createEntityManagerFactory(
                 eq(virtualNodeInfo.vaultDmlConnectionId),
                 eq(jpaEntitiesSet)
             )
@@ -166,6 +166,14 @@ class ReconciliationContextTest {
             verify(vnodeEm, never()).close()
             context.close()
             verify(vnodeEm).close()
+        }
+
+        @Test
+        fun `Closing the context closes the entity manager factory`() {
+            context.getOrCreateEntityManager()
+            verify(vnodeEmf, never()).close()
+            context.close()
+            verify(vnodeEmf).close()
         }
     }
 }


### PR DESCRIPTION
Revert EMFs caching at reconciliations because it caused:

```
com.zaxxer.hikari.pool.HikariPool$PoolInitializationException: Failed to initialize pool: FATAL: remaining connection slots are reserved for non-replication superuser connections
```