### PR TITLE
CORE-11201 Custom metadata documentation

### DIFF
--- a/wiki/Group-Parameters-Update.md
+++ b/wiki/Group-Parameters-Update.md
@@ -1,0 +1,49 @@
+The MGM can update the current group parameters using the MGM API. This update may only include changes to the minimum platform version and custom properties. To update the group parameters, the MGM must submit an updated version of the group parameters to the REST endpoint, which will overwrite any previous properties submitted using the endpoint.
+
+To view current group parameters:
+
+<details>
+<summary>Bash</summary>
+
+```bash
+curl --insecure -u admin:admin -X GET $API_URL/members/$HOLDING_ID/group-parameters
+```
+</details>
+
+<details>
+<summary>PowerShell</summary>
+
+```PowerShell
+ Invoke-RestMethod -SkipCertificateCheck  -Headers @{Authorization=("Basic {0}" -f $AUTH_INFO)} -Uri "$API_URL/membership/$HOLDING_ID/group-parameters" | ConvertTo-Json -Depth 4
+```
+</details>
+
+To submit a group parameters update, use the MGM API endpoint shown below. Keys of custom properties must have the prefix "ext.". For minimum platform version, use key "corda.minimum.platform.version". For example:
+
+<details>
+<summary>Bash</summary>
+
+```bash
+export GROUP_PARAMS_UPDATE='{"newGroupParameters":{"corda.minimum.platform.version": "50000", "ext.group.key.0": "value0", "ext.group.key.1": "value1"}}'
+curl --insecure -u admin:admin -d "GROUP_PARAMS_UPDATE" $API_URL/mgm/$HOLDING_ID/group-parameters
+```
+</details>
+<details>
+<summary>PowerShell</summary>
+
+```PowerShell
+GROUP_PARAMS_UPDATE = @{
+  'corda.minimum.platform.version' = "50000"
+  'ext.group.key.0' = "value0"
+  'ext.group.key.1' = "value1"
+}
+$GROUP_PARAMS_UPDATE_RESPONSE = Invoke-RestMethod -SkipCertificateCheck  -Headers @{Authorization=("Basic {0}" -f $AUTH_INFO)} -Method Post -Uri "$API_URL/mgm/$HOLDING_ID/group-parameters" -Body (ConvertTo-Json -Depth 4 @{
+    newGroupParameters = $GROUP_PARAMS_UPDATE
+})
+$GROUP_PARAMS_UPDATE_RESPONSE.parameters
+```
+</details>
+
+These submitted parameters are combined with notary information from the platform to construct the new group parameters, which are then signed by the MGM and distributed within the network.
+
+> Note: Custom properties have a character limit of 128 for keys and 800 for values. A maximum of 100 such key-value pairs may be defined.

--- a/wiki/Member-Onboarding-(Dynamic-Networks).md
+++ b/wiki/Member-Onboarding-(Dynamic-Networks).md
@@ -532,9 +532,14 @@ $REGISTRATION_CONTEXT = @{
 ```
 </details>
 
-It is possible to add custom key value pairs to the registration context JSON. Both the key and the value must be a 
-string and the key must be prefixed with `ext.`. The custom key value pairs can be viewed by other members of the group 
-by doing a member lookup.
+A member may specify custom properties at the time of registration, which will be included in its MemberInfo. These must be included in the registration context of the member's request to join. Keys of custom properties must have the prefix "ext.". For example:
+```bash
+"context": {
+  "ext.member.key.0": "value0",
+  "ext.member.key.1": "value1"
+}
+```
+> Note: Custom properties have a character limit of 128 for keys and 800 for values. A maximum of 100 such key-value pairs may be defined in the registration context.
 
 ## Register members
 

--- a/wiki/Member-Onboarding-(Static-Networks).md
+++ b/wiki/Member-Onboarding-(Static-Networks).md
@@ -33,6 +33,19 @@ To the `corda-cli-plugin-host` repo's `build/plugins` directory. Run the followi
 
 For more options to generate `GroupPolicy` file follow [this](https://github.com/corda/corda-runtime-os/blob/release/os/5.0/tools/plugins/mgm/README.md) readme.
 
+## Custom Group Parameters (Optional)
+Certain properties may be defined in the group policy to be included in the group parameters of a static network. These include the minimum platform version and custom properties containing the prefix "ext.".
+
+To define such group parameters, include them in a `"groupParameters"` block under `"staticNetwork"`. For example:
+```bash
+"groupParameters": {
+  "corda.minimum.platform.version": "50000",
+  "ext.group.key.0": "value0",
+  "ext.group.key.1": "value1"
+}
+```
+> Note: Custom group parameters defined in the group policy cannot be altered or removed. They have a character limit of 128 for keys and 800 for values. A maximum of 100 such key-value pairs may be defined.
+
 ## Create a CPI
 
 Create a CPI by following the steps outlined here: [CorDapp Packaging](../wiki/CorDapp-Packaging)
@@ -83,3 +96,15 @@ To register a member that is acting as a notary service representative, follow t
     "corda.notary.service.flow.protocol.version.0": "1"
 }
 ```
+
+### Registering a member with custom metadata
+A member may specify custom properties at the time of registration, which will be included in its MemberInfo. These must be included in the registration context of the member's request to join. Keys of custom properties must have the prefix "ext.". For example:
+
+```bash
+"context": {
+  "corda.key.scheme": "CORDA.ECDSA.SECP256R1",
+  "ext.member.key.0": "value0",
+  "ext.member.key.1": "value1"
+}
+```
+> Note: Custom properties have a character limit of 128 for keys and 800 for values. A maximum of 100 such key-value pairs may be defined in the registration context.

--- a/wiki/Member-Onboarding-(Static-Networks).md
+++ b/wiki/Member-Onboarding-(Static-Networks).md
@@ -36,7 +36,7 @@ For more options to generate `GroupPolicy` file follow [this](https://github.com
 ## Custom Group Parameters (Optional)
 Certain properties may be defined in the group policy to be included in the group parameters of a static network. These include the minimum platform version and custom properties containing the prefix "ext.".
 
-To define such group parameters, include them in a `"groupParameters"` block under `"staticNetwork"`. For example:
+To define such group parameters, include them in a `groupParameters` block under `staticNetwork`. For example:
 ```bash
 "groupParameters": {
   "corda.minimum.platform.version": "50000",


### PR DESCRIPTION
Adds documentation for custom metadata functionality. Updates the existing dynamic and static registration pages to include information on adding custom metadata to MemberInfo and static group parameters. Introduces a new page to describe how an MGM can update group parameters using the MGM API.