### PR TITLE
CORE-14685: Add some Kotlin-friendly extensions to DriverDSL.

### DIFF
--- a/testing/driver/README.md
+++ b/testing/driver/README.md
@@ -134,7 +134,7 @@ public interface DriverDSL {
     @Nullable
     String runFlow(
         @NotNull VirtualNodeInfo virtualNodeInfo,
-        @NotNull Class<?> flowClass,
+        @NotNull Class<? extends ClientStartableFlow> flowClass,
         @NotNull ThrowingSupplier<String> flowArgMapper
     );
 
@@ -204,7 +204,7 @@ classes exist both inside and outside our framework. These classes must therefor
 belong to the framework's system bundle.
 
 We define our system bundle also to include these bundles:
-- All Corda API bundles, which we identify by a `Corda-Api` tag in their manifest.
+- Corda API bundles `net.corda.base`, `net.corda.crypto`, `net.corda.crypto-extensions` and `net.corda.avro-schema`.
 - Avro
 - Bouncy Castle
 - `slf4j.api`
@@ -215,6 +215,11 @@ We define our system bundle also to include these bundles:
 - `org.osgi.service.log`
 - `org.osgi.util.function`
 - `org.osgi.util.promise`
+
+Some Corda API bundles contain interfaces with `@Suspendable` default methods, which
+Quasar _must_ instrument using its OSGi `WeavingHook`. We therefore _deliberately_
+restrict the Corda API bundles to just the basic ones, because Quasar _cannot_
+instrument anything inside the system bundle.
 
 Our system bundle also needs to contain the `net.corda.testing.driver.node` and
 `net.corda.testing.driver.function` packages, which are defined by the Driver's

--- a/testing/driver/build.gradle
+++ b/testing/driver/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
     api platform("net.corda:corda-api:$cordaApiVersion")
     api 'net.corda:corda-base'
+    api 'net.corda:corda-application'
     api project(':libs:virtual-node:virtual-node-info')
     api "org.junit.jupiter:junit-jupiter-api:$junit5Version"
     implementation 'net.corda:corda-avro-schema'

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/Tools.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/Tools.kt
@@ -1,6 +1,9 @@
 @file:JvmName("Tools")
 package net.corda.testing.driver.sandbox
 
+import org.osgi.framework.Bundle
+import org.osgi.framework.wiring.BundleRevision
+
 inline fun <T, C: MutableCollection<T>> MutableCollection<T>.extractAllTo(
     destination: C,
     predicate: (T) -> Boolean
@@ -15,3 +18,6 @@ inline fun <T, C: MutableCollection<T>> MutableCollection<T>.extractAllTo(
     }
     return destination
 }
+
+val Bundle.isFragment: Boolean
+    get() = (adapt(BundleRevision::class.java).types and BundleRevision.TYPE_FRAGMENT) != 0

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/AMQPSerializationTests.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/AMQPSerializationTests.kt
@@ -3,6 +3,7 @@ package net.corda.testing.driver.tests
 import com.r3.corda.testing.smoketests.flow.AmqpSerializationTestFlow
 import java.util.concurrent.TimeUnit.MINUTES
 import net.corda.testing.driver.DriverNodes
+import net.corda.testing.driver.runFlow
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.VirtualNodeInfo
 import org.assertj.core.api.Assertions.assertThat
@@ -44,7 +45,7 @@ class AMQPSerializationTests {
         }
 
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(testCorDapp, AmqpSerializationTestFlow::class.java) { "" }
+            dsl.runFlow<AmqpSerializationTestFlow>(testCorDapp) { "" }
         } ?: fail("flowResult must not be null")
         logger.info("AMQPSerializationTest result={}", flowResult)
 

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/FlowDriverTest.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/FlowDriverTest.kt
@@ -6,6 +6,7 @@ import com.r3.corda.demo.mandelbrot.RequestMessage
 import java.util.concurrent.TimeUnit.MINUTES
 import java.util.stream.Stream
 import net.corda.testing.driver.DriverNodes
+import net.corda.testing.driver.runFlow
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.VirtualNodeInfo
 import org.assertj.core.api.Assertions.assertThat
@@ -57,14 +58,14 @@ class FlowDriverTest {
         }
 
         val aliceResult = driver.let { dsl ->
-            dsl.runFlow(mandelbrot.single { it.holdingIdentity.x500Name == alice }, CalculateBlockFlow::class.java) {
+            dsl.runFlow<CalculateBlockFlow>(mandelbrot.single { it.holdingIdentity.x500Name == alice }) {
                 jsonMapper.writeValueAsString(request)
             }
         } ?: fail("aliceResult must not be null")
         logger.info("Alice Mandelbrot Block={}", aliceResult)
 
         val bobResult = driver.let { dsl ->
-            dsl.runFlow(mandelbrot.single { it.holdingIdentity.x500Name == bob }, CalculateBlockFlow::class.java) {
+            dsl.runFlow<CalculateBlockFlow>(mandelbrot.single { it.holdingIdentity.x500Name == bob }) {
                 jsonMapper.writeValueAsString(request)
             }
         } ?: fail("bobResult must not be null")

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/FlowTests.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/FlowTests.kt
@@ -6,6 +6,7 @@ import com.r3.corda.testing.smoketests.flow.messages.RpcSmokeTestInput
 import java.util.UUID
 import java.util.concurrent.TimeUnit.MINUTES
 import net.corda.testing.driver.DriverNodes
+import net.corda.testing.driver.runFlow
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.VirtualNodeInfo
 import org.assertj.core.api.Assertions.assertThat
@@ -49,7 +50,7 @@ class FlowTests {
     @Test
     fun `create an initiated session in an initiating flow and pass it to a inline subflow`() {
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "subflow_passed_in_initiated_session"
                     data = mapOf(
@@ -70,7 +71,7 @@ class FlowTests {
     @Test
     fun `create an uninitiated session in an initiating flow and pass it to a inline subflow`() {
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "subflow_passed_in_non_initiated_session"
                     data = mapOf(
@@ -91,7 +92,7 @@ class FlowTests {
     @Test
     fun `initiate multiple sessions and exercise the flow messaging apis`() {
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "flow_messaging_apis"
                     data = mapOf("sessions" to bob.toString())
@@ -109,7 +110,7 @@ class FlowTests {
     @Test
     fun `crypto - sign and verify bytes`() {
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "crypto_sign_and_verify"
                     data = mapOf("memberX500" to alice.toString())
@@ -127,7 +128,7 @@ class FlowTests {
     @Test
     fun `crypto - verify invalid signature`() {
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "crypto_verify_invalid_signature"
                     data = mapOf("memberX500" to alice.toString())
@@ -146,7 +147,7 @@ class FlowTests {
     fun `serialize and deserialize an object`() {
         val dataToSerialize = "serialize this"
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "serialization"
                     data = mapOf("data" to dataToSerialize)
@@ -164,7 +165,7 @@ class FlowTests {
     @Test
     fun `json serialization`() {
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "json_serialization"
                     data = mapOf("vnode" to bob.toString())
@@ -208,7 +209,7 @@ class FlowTests {
         val id2 = UUID.randomUUID()
 
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_persist_bulk"
                     data = mapOf("ids" to "$id1;$id2")
@@ -244,7 +245,7 @@ class FlowTests {
         persistDog(id2)
 
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_merge_bulk"
                     data = mapOf(
@@ -268,7 +269,7 @@ class FlowTests {
         persistDog(id)
 
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_delete"
                     data = mapOf("id" to id.toString())
@@ -291,7 +292,7 @@ class FlowTests {
         persistDog(id2)
 
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_delete_bulk"
                     data = mapOf("ids" to "$id1;$id2")
@@ -314,7 +315,7 @@ class FlowTests {
         mergeDog(id, newName)
 
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_find"
                     data = mapOf("id" to id.toString())
@@ -341,7 +342,7 @@ class FlowTests {
         mergeDog(id2, newName2)
 
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_find_bulk"
                     data = mapOf("ids" to "$id1;$id2")
@@ -367,7 +368,7 @@ class FlowTests {
         persistDog(UUID.randomUUID())
 
         val flowResult = driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_findall"
                 }
@@ -383,7 +384,7 @@ class FlowTests {
 
     private fun persistDog(id: UUID): String {
         return driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_persist"
                     data = mapOf("id" to id.toString())
@@ -395,7 +396,7 @@ class FlowTests {
 
     private fun mergeDog(id: UUID, name: String): String {
         return driver.let { dsl ->
-            dsl.runFlow(aliceCorDapp, RpcSmokeTestFlow::class.java) {
+            dsl.runFlow<RpcSmokeTestFlow>(aliceCorDapp) {
                 val request = RpcSmokeTestInput().apply {
                     command = "persistence_merge"
                     data = mapOf(

--- a/testing/driver/src/main/java/net/corda/testing/driver/DriverDSL.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/DriverDSL.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import net.corda.testing.driver.function.ThrowingConsumer;
 import net.corda.testing.driver.function.ThrowingSupplier;
 import net.corda.testing.driver.node.Member;
+import net.corda.v5.application.flows.ClientStartableFlow;
 import net.corda.v5.base.annotations.DoNotImplement;
 import net.corda.v5.base.types.MemberX500Name;
 import net.corda.virtualnode.VirtualNodeInfo;
@@ -22,7 +23,7 @@ public interface DriverDSL {
     @Nullable
     String runFlow(
         @NotNull VirtualNodeInfo virtualNodeInfo,
-        @NotNull Class<?> flowClass,
+        @NotNull Class<? extends ClientStartableFlow> flowClass,
         @NotNull ThrowingSupplier<String> flowArgMapper
     );
 

--- a/testing/driver/src/main/kotlin/net/corda/testing/driver/KotlinHelpers.kt
+++ b/testing/driver/src/main/kotlin/net/corda/testing/driver/KotlinHelpers.kt
@@ -1,0 +1,13 @@
+@file:JvmName("DriverHelpers")
+package net.corda.testing.driver
+
+import net.corda.testing.driver.function.ThrowingSupplier
+import net.corda.v5.application.flows.ClientStartableFlow
+import net.corda.virtualnode.VirtualNodeInfo
+
+inline fun <reified T: ClientStartableFlow> DriverDSL.runFlow(
+    vNode: VirtualNodeInfo,
+    flowArgMapper: ThrowingSupplier<String>
+): String? {
+    return runFlow(vNode, T::class.java, flowArgMapper)
+}

--- a/testing/driver/src/main/kotlin/net/corda/testing/driver/impl/DriverDSLImpl.kt
+++ b/testing/driver/src/main/kotlin/net/corda/testing/driver/impl/DriverDSLImpl.kt
@@ -27,6 +27,7 @@ import net.corda.testing.driver.function.ThrowingConsumer
 import net.corda.testing.driver.function.ThrowingSupplier
 import net.corda.testing.driver.node.EmbeddedNodeService
 import net.corda.testing.driver.node.Member
+import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
@@ -389,7 +390,7 @@ internal class DriverDSLImpl(
 
     override fun runFlow(
         virtualNodeInfo: VirtualNodeInfo,
-        flowClass: Class<*>,
+        flowClass: Class<out ClientStartableFlow>,
         flowArgMapper: ThrowingSupplier<String>
     ): String? {
         return FlowRunner(this).runFlow(virtualNodeInfo, flowClass, flowArgMapper, TIMEOUT)


### PR DESCRIPTION
Add some `inline` Kotlin extension functions so that the  Java `DriverDSL` is nicer to use from Kotlin.

Also compute the Corda API bundles to map into each sandbox rather than relying on a hard-coded list, which too easily becomes out-of-date. The selection criteria are:
- It is not a fragment bundle.
- It has the `Corda-Api` attribute in its manifest.
- It exports package matching `net.corda.v5.*`.