### PR TITLE
CORE-15915: Change plugins rest client to use v1 endpoints

### DIFF
--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package net.corda.cli.plugins.network
 
 import net.corda.libs.cpiupload.endpoints.v1.CpiUploadRestResource

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -6,7 +6,7 @@ import net.corda.cli.plugins.common.RestCommand
 import net.corda.rest.HttpFileUpload
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
-import net.corda.membership.rest.v1.KeyRestResource
+import net.corda.membership.rest.v1.KeysRestResource
 import net.corda.membership.rest.v1.HsmRestResource
 import net.corda.membership.rest.v1.types.request.HostedIdentitySetupRequest
 import net.corda.membership.rest.v1.NetworkRestResource
@@ -15,7 +15,7 @@ import net.corda.membership.rest.v1.types.request.MemberRegistrationRequest
 import net.corda.libs.configuration.endpoints.v1.ConfigRestResource
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
 import com.fasterxml.jackson.databind.node.ObjectNode
-import net.corda.membership.rest.v1.CertificateRestResource
+import net.corda.membership.rest.v1.CertificatesRestResource
 import net.corda.virtualnode.OperationalStatus
 import org.bouncycastle.openssl.PEMParser
 import org.bouncycastle.pkcs.PKCS10CertificationRequest
@@ -235,7 +235,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             }
         }
 
-        val response = createRestClient(KeyRestResource::class).use { keyClient ->
+        val response = createRestClient(KeysRestResource::class).use { keyClient ->
             keyClient.start().proxy.generateKeyPair(
                 holdingId, "$holdingId-$category", category, "CORDA.ECDSA.SECP256R1"
             )
@@ -273,7 +273,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
     }
 
     protected fun createTlsKeyIdNeeded() {
-        val hasKeys = createRestClient(KeyRestResource::class).use { client ->
+        val hasKeys = createRestClient(KeysRestResource::class).use { client ->
             client.start().proxy.listKeys(
                 tenantId = "p2p",
                 skip = 0,
@@ -291,7 +291,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
 
         if (hasKeys) return
 
-        val tlsKeyId = createRestClient(KeyRestResource::class).use { client ->
+        val tlsKeyId = createRestClient(KeysRestResource::class).use { client ->
             client.start().proxy.generateKeyPair(
                 tenantId = "p2p",
                 alias = P2P_TLS_KEY_ALIAS,
@@ -300,7 +300,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             ).id
         }
 
-        val csr = createRestClient(CertificateRestResource::class).use { client ->
+        val csr = createRestClient(CertificatesRestResource::class).use { client ->
             client.start().proxy.generateCsr(
                 tenantId = "p2p",
                 keyId = tlsKeyId,
@@ -316,7 +316,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             }
         } as? PKCS10CertificationRequest ?: throw OnboardException("CSR is not a valid CSR: $csr")
 
-        createRestClient(CertificateRestResource::class).use { client ->
+        createRestClient(CertificatesRestResource::class).use { client ->
             val certificate = ca.signCsr(csrCertRequest).toPem().byteInputStream()
             client.start().proxy.importCertificateChain(
                 usage = "p2p-tls",
@@ -475,7 +475,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             ?.toPem()
             ?.byteInputStream()
             ?.use { certificate ->
-                createRestClient(CertificateRestResource::class).use { client ->
+                createRestClient(CertificatesRestResource::class).use { client ->
                     client.start().proxy.importCertificateChain(
                         usage = "code-signer",
                         alias = GRADLE_PLUGIN_DEFAULT_KEY_ALIAS,
@@ -492,7 +492,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             ?.toPem()
             ?.byteInputStream()
             ?.use { certificate ->
-                createRestClient(CertificateRestResource::class).use { client ->
+                createRestClient(CertificatesRestResource::class).use { client ->
                     client.start().proxy.importCertificateChain(
                         usage = "code-signer",
                         alias = "signingkey1-2022",

--- a/tools/plugins/plugins-rest/src/main/kotlin/net/corda/cli/plugins/common/RestClientUtils.kt
+++ b/tools/plugins/plugins-rest/src/main/kotlin/net/corda/cli/plugins/common/RestClientUtils.kt
@@ -20,7 +20,7 @@ object RestClientUtils {
 
     fun <I : RestResource> RestCommand.createRestClient(
         restResource: KClass<I>,
-        apiVersion: RestApiVersion = RestApiVersion.C5_1
+        apiVersion: RestApiVersion = RestApiVersion.C5_0
     ): RestClient<I> {
         val localTargetUrl = if(targetUrl.endsWith("/")) {
             targetUrl.dropLast(1)


### PR DESCRIPTION
This allows CLI to work with older versions of Corda Clusters. This will be followed by work to handle CLI endpoints for Corda versions in a more robust way. 