### PR TITLE
CORE-15919: Deduce Corda API bundles instead of using hard-coded lists.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,6 @@ allprojects {
 
             doFirst {
                 systemProperty 'java.io.tmpdir', buildDir.absolutePath
-                jvmArgs '--illegal-access=deny'
             }
         }
     }

--- a/components/configuration/configuration-read-service-impl/test.bndrun
+++ b/components/configuration/configuration-read-service-impl/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\
     javax.xml.stream.events;version=1.0.0,\

--- a/components/flow/flow-p2p-filter-service/test.bndrun
+++ b/components/flow/flow-p2p-filter-service/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 #uncomment to remote debug
 #-runjdb: 5005
 

--- a/components/flow/flow-service/test.bndrun
+++ b/components/flow/flow-service/test.bndrun
@@ -10,7 +10,6 @@
 -runvm: \
     -Djava.util.logging.config.file=${.}/logging.properties,\
     -Djava.io.tmpdir=${task.temporaryDir},\
-    --illegal-access=deny,\
     --add-opens, 'java.base/java.lang=ALL-UNNAMED'
 
 -runsystempackages: \

--- a/components/ledger/ledger-common-flow/test.bndrun
+++ b/components/ledger/ledger-common-flow/test.bndrun
@@ -6,8 +6,7 @@
 
 -runvm: \
     --add-opens, 'java.base/java.lang.invoke=ALL-UNNAMED',\
-    --add-opens, 'java.base/java.util=ALL-UNNAMED',\
-    --illegal-access=deny
+    --add-opens, 'java.base/java.util=ALL-UNNAMED'
 
 -runrequires: \
     bnd.identity;id='net.corda.ledger-common-flow',\

--- a/components/ledger/ledger-consensual-flow/test.bndrun
+++ b/components/ledger/ledger-consensual-flow/test.bndrun
@@ -10,8 +10,7 @@
     --add-opens, 'java.base/java.security=ALL-UNNAMED',\
     --add-opens, 'java.base/java.time=ALL-UNNAMED',\
     --add-opens, 'java.base/java.util=ALL-UNNAMED',\
-    --add-opens, 'jdk.crypto.ec/sun.security.ec=ALL-UNNAMED',\
-    --illegal-access=deny
+    --add-opens, 'jdk.crypto.ec/sun.security.ec=ALL-UNNAMED'
 
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\

--- a/components/ledger/ledger-persistence/test.bndrun
+++ b/components/ledger/ledger-persistence/test.bndrun
@@ -9,8 +9,7 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword},\
-    --illegal-access=deny
+    -DpostgresPassword=${project.postgresPassword}
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/components/ledger/ledger-utxo-flow/test.bndrun
+++ b/components/ledger/ledger-utxo-flow/test.bndrun
@@ -10,8 +10,7 @@
     --add-opens, 'java.base/java.security=ALL-UNNAMED',\
     --add-opens, 'java.base/java.time=ALL-UNNAMED',\
     --add-opens, 'java.base/java.util=ALL-UNNAMED',\
-    --add-opens, 'jdk.crypto.ec/sun.security.ec=ALL-UNNAMED',\
-    --illegal-access=deny
+    --add-opens, 'jdk.crypto.ec/sun.security.ec=ALL-UNNAMED'
 
 # Enable debugging.
 # -runjdb: 1044

--- a/components/ledger/ledger-verification/test.bndrun
+++ b/components/ledger/ledger-verification/test.bndrun
@@ -9,8 +9,7 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword},\
-    --illegal-access=deny
+    -DpostgresPassword=${project.postgresPassword}
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/components/link-manager/test.bndrun
+++ b/components/link-manager/test.bndrun
@@ -5,8 +5,7 @@
 -runtrace: true
 
 -runvm: \
-    -Djava.io.tmpdir=${task.temporaryDir},\
-    --illegal-access=deny
+    -Djava.io.tmpdir=${task.temporaryDir}
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/components/membership/membership-group-read-impl/test.bndrun
+++ b/components/membership/membership-group-read-impl/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 -runproperties: \
     org.slf4j.simpleLogger.defaultLogLevel=info,\
     org.slf4j.simpleLogger.showShortLogName=true,\

--- a/components/membership/membership-persistence-service-impl/test.bndrun
+++ b/components/membership/membership-persistence-service-impl/test.bndrun
@@ -10,8 +10,7 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword},\
-    --illegal-access=deny
+    -DpostgresPassword=${project.postgresPassword}
 
 -runsystempackages: \
     sun.security.x509

--- a/components/membership/registration-impl/test.bndrun
+++ b/components/membership/registration-impl/test.bndrun
@@ -7,9 +7,6 @@
 # Enable debugging.
 #-runjdb: 5006
 
--runvm: \
-    --illegal-access=deny
-
 -runsystemcapabilities: \
     osgi.service;objectClass:List<String>='net.corda.membership.groupparams.writer.service.GroupParametersWriterService';effective:=active
 

--- a/components/membership/synchronisation-impl/test.bndrun
+++ b/components/membership/synchronisation-impl/test.bndrun
@@ -7,9 +7,6 @@
 # Enable debugging.
 #-runjdb: 5006
 
--runvm: \
-    --illegal-access=deny
-
 -runsystempackages: \
     sun.security.x509
 

--- a/components/security-manager/test.bndrun
+++ b/components/security-manager/test.bndrun
@@ -6,8 +6,7 @@
 
 # Canonicalise the permissions paths
 -runvm: \
-    -Djdk.io.permissionsUseCanonicalPath=true,\
-    --illegal-access=deny
+    -Djdk.io.permissionsUseCanonicalPath=true
 
 -runsystemcapabilities: \
     osgi.service;objectClass:List<String>='net.corda.lifecycle.LifecycleCoordinatorFactory';effective:=active,\

--- a/components/uniqueness/uniqueness-checker-impl-osgi-tests/test.bndrun
+++ b/components/uniqueness/uniqueness-checker-impl-osgi-tests/test.bndrun
@@ -9,8 +9,7 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword},\
-    --illegal-access=deny
+    -DpostgresPassword=${project.postgresPassword}
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextComponentImpl.kt
@@ -25,6 +25,10 @@ import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.debug
 import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
+import org.osgi.framework.wiring.BundleRevision
+import org.osgi.framework.wiring.BundleRevision.PACKAGE_NAMESPACE
+import org.osgi.framework.wiring.BundleRevision.TYPE_FRAGMENT
+import org.osgi.framework.wiring.BundleWiring
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
@@ -55,6 +59,9 @@ class SandboxGroupContextComponentImpl @Activate constructor(
     private val bundleContext: BundleContext
 ) : SandboxGroupContextComponent, SandboxGroupContextService by sandboxGroupContextService {
     companion object {
+        private const val CORDA_API_PACKAGES = "net.corda.v5."
+        private const val CORDA_API_HEADER = "Corda-Api"
+
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private val PLATFORM_PUBLIC_BUNDLE_NAMES: List<String> = unmodifiableList(
@@ -63,17 +70,6 @@ class SandboxGroupContextComponentImpl @Activate constructor(
                 "com.esotericsoftware.reflectasm",
                 "javax.persistence-api",
                 "jcl.over.slf4j",
-                "net.corda.application",
-                "net.corda.base",
-                "net.corda.crypto",
-                "net.corda.crypto-extensions",
-                "net.corda.ledger-common",
-                "net.corda.ledger-consensual",
-                "net.corda.ledger-utxo",
-                "net.corda.membership",
-                "net.corda.notary-plugin",
-                "net.corda.persistence",
-                "net.corda.serialization",
                 "org.apache.aries.spifly.dynamic.framework.extension",
                 "org.apache.felix.framework",
                 "org.hibernate.orm.core",
@@ -166,10 +162,21 @@ class SandboxGroupContextComponentImpl @Activate constructor(
 
     private fun initialiseSandboxContext(allBundles: Array<Bundle>) {
         val (publicBundles, privateBundles) = allBundles.partition { bundle ->
-            bundle.symbolicName in PLATFORM_PUBLIC_BUNDLE_NAMES
+            bundle.symbolicName in PLATFORM_PUBLIC_BUNDLE_NAMES || bundle.isCordaApi
         }
         sandboxCreationService.createPublicSandbox(publicBundles, privateBundles)
     }
+
+    private val Bundle.isFragment: Boolean
+        get() = (adapt(BundleRevision::class.java).types and TYPE_FRAGMENT) != 0
+
+    private val Bundle.hasCordaApiPackage: Boolean
+        get() = adapt(BundleWiring::class.java).getCapabilities(PACKAGE_NAMESPACE).any { capability ->
+            capability.attributes[PACKAGE_NAMESPACE].let { it != null && it.toString().startsWith(CORDA_API_PACKAGES) }
+        }
+
+    private val Bundle.isCordaApi: Boolean
+        get() = !isFragment && headers[CORDA_API_HEADER] != null && hasCordaApiPackage
 
     override fun flushCache(): CompletableFuture<*> {
         return (sandboxGroupContextService as? CacheControl

--- a/components/virtual-node/sandbox-group-context-service/test.bndrun
+++ b/components/virtual-node/sandbox-group-context-service/test.bndrun
@@ -9,8 +9,7 @@
 
 -runvm: \
     -Djdk.io.permissionsUseCanonicalPath=true, \
-    --add-opens, 'java.base/java.lang=ALL-UNNAMED',\
-    --illegal-access=deny
+    --add-opens, 'java.base/java.lang=ALL-UNNAMED'
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/libs/application/addon-osgi-test/test.bndrun
+++ b/libs/application/addon-osgi-test/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='junit-jupiter-engine',\

--- a/libs/configuration/configuration-osgi-test/test.bndrun
+++ b/libs/configuration/configuration-osgi-test/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='junit-jupiter-engine',\

--- a/libs/configuration/configuration-validation/test.bndrun
+++ b/libs/configuration/configuration-validation/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\
     javax.xml.stream.events;version=1.0.0,\

--- a/libs/crypto/merkle-impl/test.bndrun
+++ b/libs/crypto/merkle-impl/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 -runsystempackages: \
     javax.annotation;version=3.0.0,\
     javax.annotation.meta;version=3.0.0

--- a/libs/db/osgi-integration-tests/test.bndrun
+++ b/libs/db/osgi-integration-tests/test.bndrun
@@ -9,8 +9,7 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword},\
-    --illegal-access=deny
+    -DpostgresPassword=${project.postgresPassword}
 
 -runsystempackages: \
     sun.security.x509

--- a/libs/flows/flow-mapper-impl/test.bndrun
+++ b/libs/flows/flow-mapper-impl/test.bndrun
@@ -7,9 +7,6 @@
 # Enable debugging.
 # -runjdb: 1044
 
--runvm: \
-    --illegal-access=deny
-
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\
     javax.xml.stream.events;version=1.0.0,\

--- a/libs/kotlin-reflection/test.bndrun
+++ b/libs/kotlin-reflection/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 # Enable debugging.
 # -runjdb: 1044
 

--- a/libs/layered-property-map/test.bndrun
+++ b/libs/layered-property-map/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 -runproperties: \
     org.slf4j.simpleLogger.defaultLogLevel=info,\
     org.slf4j.simpleLogger.showShortLogName=true,\

--- a/libs/permissions/permission-datamodel/test.bndrun
+++ b/libs/permissions/permission-datamodel/test.bndrun
@@ -9,8 +9,7 @@
     -DpostgresPort=${project.postgresPort},\
     -DpostgresDb=${project.postgresDb},\
     -DpostgresUser=${project.postgresUser},\
-    -DpostgresPassword=${project.postgresPassword},\
-    --illegal-access=deny
+    -DpostgresPassword=${project.postgresPassword}
 
 -runsystempackages: \
     sun.security.x509

--- a/libs/platform-info/test.bndrun
+++ b/libs/platform-info/test.bndrun
@@ -4,9 +4,6 @@
 -runee: JavaSE-17
 -runtrace: true
 
--runvm: \
-    --illegal-access=deny
-
 -runrequires: \
     bnd.identity;id='${project.archivesBaseName}-tests',\
     bnd.identity;id='junit-jupiter-engine',\

--- a/libs/sandbox-internal/test.bndrun
+++ b/libs/sandbox-internal/test.bndrun
@@ -5,8 +5,7 @@
 -runtrace: true
 
 -runvm: \
-    -Djava.io.tmpdir=${task.temporaryDir},\
-    --illegal-access=deny
+    -Djava.io.tmpdir=${task.temporaryDir}
 
 -runsystempackages: \
     javax.xml.stream;version=1.0.0,\

--- a/libs/serialization/serialization-amqp/test.bndrun
+++ b/libs/serialization/serialization-amqp/test.bndrun
@@ -6,8 +6,7 @@
 
 -runvm: \
     -Djava.io.tmpdir=${task.temporaryDir},\
-    --add-opens, 'java.base/java.lang=ALL-UNNAMED',\
-    --illegal-access=deny
+    --add-opens, 'java.base/java.lang=ALL-UNNAMED'
 
 # Enable debugging.
 # -runjdb: 5005

--- a/libs/serialization/serialization-kryo/test.bndrun
+++ b/libs/serialization/serialization-kryo/test.bndrun
@@ -7,8 +7,7 @@
 -runvm: \
     -Djava.io.tmpdir=${task.temporaryDir},\
     --add-opens, 'java.base/java.lang.invoke=ALL-UNNAMED',\
-    --add-opens, 'java.base/java.util=ALL-UNNAMED',\
-    --illegal-access=deny
+    --add-opens, 'java.base/java.util=ALL-UNNAMED'
 
 # Enable debugging.
 # -runjdb: 5005

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -9,7 +9,12 @@ import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.SandboxSetup.Companion.SANDBOX_SERVICE_FILTER
 import net.corda.testing.sandboxes.impl.SandboxSetupImpl.Companion.INSTALLER_NAME
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.osgi.framework.Bundle
 import org.osgi.framework.BundleContext
+import org.osgi.framework.wiring.BundleRevision
+import org.osgi.framework.wiring.BundleRevision.PACKAGE_NAMESPACE
+import org.osgi.framework.wiring.BundleRevision.TYPE_FRAGMENT
+import org.osgi.framework.wiring.BundleWiring
 import org.osgi.service.cm.ConfigurationAdmin
 import org.osgi.service.component.ComponentConstants.COMPONENT_NAME
 import org.osgi.service.component.ComponentContext
@@ -50,6 +55,8 @@ class SandboxSetupImpl @Activate constructor(
     companion object {
         const val INSTALLER_NAME = "installer"
         private const val NON_SANDBOX_COMPONENT_FILTER = "(&($COMPONENT_NAME=*)(!$SANDBOX_SERVICE_FILTER))"
+        private const val CORDA_API_PACKAGES = "net.corda.v5."
+        private const val CORDA_API_HEADER = "Corda-Api"
         private const val WAIT_MILLIS = 100L
 
         // The names of the bundles to place as public bundles in the sandbox service's platform sandbox.
@@ -58,16 +65,6 @@ class SandboxSetupImpl @Activate constructor(
             "com.esotericsoftware.reflectasm",
             "javax.persistence-api",
             "jcl.over.slf4j",
-            "net.corda.application",
-            "net.corda.base",
-            "net.corda.crypto",
-            "net.corda.crypto-extensions",
-            "net.corda.ledger-consensual",
-            "net.corda.ledger-utxo",
-            "net.corda.membership",
-            "net.corda.persistence",
-            "net.corda.serialization",
-            "net.corda.test-api",
             "org.apache.aries.spifly.dynamic.framework.extension",
             "org.apache.felix.framework",
             "org.apache.felix.scr",
@@ -107,10 +104,21 @@ class SandboxSetupImpl @Activate constructor(
         }
 
         val (publicBundles, privateBundles) = bundleContext.bundles.partition { bundle ->
-            bundle.symbolicName in PLATFORM_PUBLIC_BUNDLE_NAMES
+            bundle.symbolicName in PLATFORM_PUBLIC_BUNDLE_NAMES || bundle.isCordaApi
         }
         sandboxCreator.createPublicSandbox(publicBundles, privateBundles)
     }
+
+    private val Bundle.isFragment: Boolean
+        get() = (adapt(BundleRevision::class.java).types and TYPE_FRAGMENT) != 0
+
+    private val Bundle.hasCordaApiPackage: Boolean
+        get() = adapt(BundleWiring::class.java).getCapabilities(PACKAGE_NAMESPACE).any { capability ->
+            capability.attributes[PACKAGE_NAMESPACE].let { it != null && it.toString().startsWith(CORDA_API_PACKAGES) }
+        }
+
+    private val Bundle.isCordaApi: Boolean
+        get() = !isFragment && headers[CORDA_API_HEADER] != null && hasCordaApiPackage
 
     private fun disableNonSandboxServices(serviceType: String) {
         with(componentContext) {

--- a/testing/sandboxes/test-api/build.gradle
+++ b/testing/sandboxes/test-api/build.gradle
@@ -8,3 +8,11 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 }
+
+tasks.named('jar', Jar) {
+    bundle {
+        bnd """\
+Corda-Api: $cordaApiVersion
+"""
+    }
+}


### PR DESCRIPTION
Remove the Corda API bundles from the sandboxes' lists of public "platform" bundles, because these lists are too difficult to maintain. Deduce which are Corda API bundles instead, according to these criteria:
- It is not a fragment bundle.
- It has the `Corda-Api` attribute in its manifest (which has already been implemented).
- It exports a package matching `net.corda.v5.*`.

Also remove all uses of the JVM `--illegal-access=warn` argument, because this is obsolete in Java 17.