### PR TITLE
CORE-15923: Allow Quasar to instrument our 'net.corda.metrics' bundle.

### DIFF
--- a/buildSrc/src/main/groovy/corda.quasar-app.gradle
+++ b/buildSrc/src/main/groovy/corda.quasar-app.gradle
@@ -18,14 +18,13 @@ quasar {
         'com.typesafe.**',
         'de.javakaffee.kryoserializers**',
         'io.micrometer.**',
+        'io.zipkin.**',
         'javax.**',
         'kotlin**',
         'org.apache.**',
         'org.objectweb.asm',
         'org.objenesis**',
-        'org.osgi.**',
-        'io.zipkin.**',
-        'io.micrometer.**',
+        'org.osgi.**'
     ]
 }
 

--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'

--- a/libs/metrics/src/main/java/net/corda/metrics/package-info.java
+++ b/libs/metrics/src/main/java/net/corda/metrics/package-info.java
@@ -1,6 +1,4 @@
 @Export
-@QuasarIgnorePackage
 package net.corda.metrics;
 
-import co.paralleluniverse.quasar.annotations.QuasarIgnorePackage;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
Remove the `@QuasarIgnorePackage` annotation from the `net.corda.metrics` package in the `net.corda.metrics` bundle.

Also remove duplicate Quasar exclusion from the `corda.quasar-app` convention plugin.