### PR TITLE
CORE-15918 Make the fake ca tool work with Java 17

### DIFF
--- a/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/Ca.kt
+++ b/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/Ca.kt
@@ -98,8 +98,8 @@ class Ca {
                 )
             }
             Algorithm.EC -> {
-                val disabled = Security.getProperty("jdk.disabled.namedCurves")
-                    .split(",").map {
+                val disabledCurves = Security.getProperty("jdk.disabled.namedCurves") ?: ""
+                val disabled = disabledCurves.split(",").map {
                         it.trim()
                     }.contains(curveName)
                 if (disabled) {

--- a/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/Ca.kt
+++ b/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/Ca.kt
@@ -7,7 +7,6 @@ import org.bouncycastle.jce.ECNamedCurveTable
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.File
-import java.security.Security
 import java.time.Duration
 
 @Command(

--- a/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/Ca.kt
+++ b/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/Ca.kt
@@ -98,13 +98,6 @@ class Ca {
                 )
             }
             Algorithm.EC -> {
-                val disabledCurves = Security.getProperty("jdk.disabled.namedCurves") ?: ""
-                val disabled = disabledCurves.split(",").map {
-                        it.trim()
-                    }.contains(curveName)
-                if (disabled) {
-                    throw FakeCaException("Curve name: $curveName disabled")
-                }
                 val spec = ECNamedCurveTable.getParameterSpec(curveName) ?: throw FakeCaException("Unknown curve name: $curveName")
                 if (!ValidCurvedNames().contains(curveName)) {
                     throw FakeCaException("Invalid curve name: $curveName")

--- a/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/ValidCurvedNames.kt
+++ b/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/ValidCurvedNames.kt
@@ -18,10 +18,10 @@ class ValidCurvedNames : Iterable<String> {
         }
     }
     override fun iterator(): Iterator<String> {
-        val disabled = Security.getProperty("jdk.disabled.namedCurves")
-            .split(",").map {
-                it.trim()
-            }.toSet()
+        val disabledCurves = Security.getProperty("jdk.disabled.namedCurves") ?: ""
+        val disabled = disabledCurves.split(",").map {
+            it.trim()
+        }.toSet()
 
         return ECNamedCurveTable.getNames()
             .toList()

--- a/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/ValidCurvedNames.kt
+++ b/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/ValidCurvedNames.kt
@@ -18,17 +18,10 @@ class ValidCurvedNames : Iterable<String> {
         }
     }
     override fun iterator(): Iterator<String> {
-        val disabledCurves = Security.getProperty("jdk.disabled.namedCurves") ?: ""
-        val disabled = disabledCurves.split(",").map {
-            it.trim()
-        }.toSet()
-
         return ECNamedCurveTable.getNames()
             .toList()
             .filterIsInstance<String>()
-            .filter {
-                !disabled.contains(it)
-            }.filter { validName(it) }
+            .filter { validName(it) }
             .iterator()
     }
 }

--- a/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/ValidCurvedNames.kt
+++ b/applications/tools/p2p-test/fake-ca/src/main/kotlin/net/corda/p2p/fake/ca/ValidCurvedNames.kt
@@ -3,7 +3,6 @@ package net.corda.p2p.fake.ca
 import org.bouncycastle.jce.ECNamedCurveTable
 import java.security.InvalidAlgorithmParameterException
 import java.security.KeyPairGenerator
-import java.security.Security
 import java.security.spec.ECGenParameterSpec
 
 class ValidCurvedNames : Iterable<String> {


### PR DESCRIPTION
The fake CA tool checks the secruity property "jdk.disabled.namedCurves" when it starts up, to check for disabled elliptic curves. This property is not set in JDK 17. This caused the fake ca tool to fail with error:
```
java -jar ./applications/tools/p2p-test/fake-ca/build/bin/corda-fake-ca*.jar create-ca
getProperty("jdk.disabled.namedCurves") must not be null
```
So I changed the code to remove this check.

The secruity property "jdk.disabled.namedCurves" was added to Java 11 here:  https://bugs.openjdk.org/browse/JDK-8235540 at the same time as disabling some curves by default. These curves were completely removed from Java 16: https://bugs.openjdk.org/browse/JDK-8251547

Testing
----
You can create a CA:
```
java -jar ./applications/tools/p2p-test/fake-ca/build/bin/corda-fake-ca*.jar  create-ca
Warning: This tool is not safe for production use, and it should only be used for testing purposes.
Wrote CA root certificate to /Users/william.vigor/.fake.ca/ca/root-certificate.pem
william.vigor@LDNM-WHD6VPFHQC corda-runtime-os % openssl x509 -in /Users/william.vigor/.fake.ca/ca/root-certificate.pem -noout -text
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 2 (0x2)
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: C = UK, CN = r3.com
        Validity
            Not Before: Aug  2 15:21:46 2023 GMT
            Not After : Sep  1 15:21:46 2023 GMT
        Subject: C = UK, CN = r3.com
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:4e:fa:1b:f9:47:b7:c1:75:f5:bc:ea:23:59:86:
                    f8:8b:48:07:ba:b2:6f:13:60:11:5d:69:f9:dc:d6:
                    a7:cd:37:75:d9:7c:ca:0f:d3:84:69:e1:79:57:91:
                    ee:c1:9b:3e:73:61:90:52:ca:66:cd:1e:45:94:a6:
                    43:80:2f:4d:3a
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Basic Constraints: critical
                CA:TRUE
            X509v3 Key Usage:
                Digital Signature, Key Encipherment, Key Agreement, Certificate Sign, CRL Sign
    Signature Algorithm: ecdsa-with-SHA256
    Signature Value:
        30:45:02:21:00:c7:22:e3:32:1d:c6:3c:2c:c6:7a:e8:11:90:
        c3:71:5d:36:5c:e4:ba:3e:98:b8:6a:02:e6:71:f2:90:84:11:
        b8:02:20:3f:5b:2c:46:ec:94:c9:ec:ac:86:f5:4d:b3:a4:5c:
        53:8a:79:74:f3:32:67:47:0d:c3:19:18:bb:d1:04:48:4c
```

If you try and create a CA with a disabled curve e.g.:
```
java -jar ./applications/tools/p2p-test/fake-ca/build/bin/corda-fake-ca*.jar -c secp112r1 create-ca
Warning: This tool is not safe for production use, and it should only be used for testing purposes.
Invalid curve name: secp112r1
```
You still get an error because `ECNamedCurveParameterSpec.getParameterSpec(secp112r1)` returns null.