### PR TITLE
CORE-13501: update parent key on key rotation

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -585,7 +585,7 @@ open class SoftCryptoService(
                 logger.trace { "Should decrypt key material in row $id with alias $targetAlias using " +
                         "${wrappingKeyInfo.parentKeyAlias} and encrypt key material using $newParentKeyAlias" }
                 val wrappedWithNewKey = newParentKey.wrap(wrappingKey)
-                wrappingRepo.saveKeyWithId(targetAlias, wrappingKeyInfo.copy(keyMaterial = wrappedWithNewKey), id)
+                wrappingRepo.saveKeyWithId(targetAlias, wrappingKeyInfo.copy(keyMaterial = wrappedWithNewKey, parentKeyAlias = newParentKeyAlias), id)
             }
         }
     }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -585,7 +585,10 @@ open class SoftCryptoService(
                 logger.trace { "Should decrypt key material in row $id with alias $targetAlias using " +
                         "${wrappingKeyInfo.parentKeyAlias} and encrypt key material using $newParentKeyAlias" }
                 val wrappedWithNewKey = newParentKey.wrap(wrappingKey)
-                wrappingRepo.saveKeyWithId(targetAlias, wrappingKeyInfo.copy(keyMaterial = wrappedWithNewKey, parentKeyAlias = newParentKeyAlias), id)
+                wrappingRepo.saveKeyWithId(
+                    targetAlias,
+                    wrappingKeyInfo.copy(keyMaterial = wrappedWithNewKey, parentKeyAlias = newParentKeyAlias),
+                    id)
             }
         }
     }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
@@ -856,7 +856,7 @@ class SoftCryptoServiceGeneralTests {
         assertThat(clearKey2).isEqualTo(clearKey1)
         assertThat(wrappedWithRoot1).isNotEqualTo(wrappedWithRoot2)
         
-        // now let's rotate back to parent key root, and the encrypted and clear material should be the same
+        // now let's rotate back to parent key root, and the clear material should be the same
         myCryptoService.rewrapWrappingKey(CryptoTenants.CRYPTO, "alpha", "root")
         val wrappedWithRoot1Again = checkNotNull(cryptoRepositoryWrapping.keys.get("alpha")).keyMaterial
         val clearKey3 = rootWrappingKey.unwrapWrappingKey(wrappedWithRoot1Again)

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
@@ -73,6 +73,7 @@ import java.security.PublicKey
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.TimeUnit
+import javax.crypto.AEADBadTagException
 import javax.persistence.QueryTimeoutException
 import kotlin.test.assertTrue
 
@@ -832,12 +833,36 @@ class SoftCryptoServiceGeneralTests {
     fun `can rewrap a managed wrapping key`() {
         cryptoRepositoryWrapping.keys["root"] = sampleWrappingKeyInfo
         // service has a mock root wrapping key, so we have to make one with a real wrapping key
+        val rootWrappingKey = WrappingKeyImpl.generateWrappingKey(schemeMetadata)
+        val rootWrappingKey2 = WrappingKeyImpl.generateWrappingKey(schemeMetadata)
         val myCryptoService = makeSoftCryptoService(
             wrappingRepository = cryptoRepositoryWrapping,
             schemeMetadata = schemeMetadata,
-            rootWrappingKey = WrappingKeyImpl.generateWrappingKey(schemeMetadata)
+            rootWrappingKey = rootWrappingKey,
+            rootWrappingKey2 = rootWrappingKey2
         )
+        assertThat(cryptoRepositoryWrapping.keys.contains("alpha")).isFalse()
         myCryptoService.createWrappingKey("alpha", false, emptyMap())
+        val wrappedWithRoot1 = checkNotNull(cryptoRepositoryWrapping.keys.get("alpha")).keyMaterial
+        val clearKey1 = rootWrappingKey.unwrapWrappingKey(wrappedWithRoot1)
+        
+        // try rotating to parent key root2
         myCryptoService.rewrapWrappingKey(CryptoTenants.CRYPTO, "alpha", "root2")
+        val wrappedWithRoot2 = checkNotNull(cryptoRepositoryWrapping.keys.get("alpha")).keyMaterial
+        val clearKey2 = rootWrappingKey2.unwrapWrappingKey(wrappedWithRoot2)
+        assertThrows<AEADBadTagException> {
+            rootWrappingKey.unwrapWrappingKey(wrappedWithRoot2)
+        }
+        assertThat(clearKey2).isEqualTo(clearKey1)
+        assertThat(wrappedWithRoot1).isNotEqualTo(wrappedWithRoot2)
+        
+        // now let's rotate back to parent key root, and the encrypted and clear material should be the same
+        myCryptoService.rewrapWrappingKey(CryptoTenants.CRYPTO, "alpha", "root")
+        val wrappedWithRoot1Again = checkNotNull(cryptoRepositoryWrapping.keys.get("alpha")).keyMaterial
+        val clearKey3 = rootWrappingKey.unwrapWrappingKey(wrappedWithRoot1Again)
+        assertThat(clearKey3).isEqualTo(clearKey1)
+        
+        // AES may have a different initialisation vector so wrappedWithRoot1Again will usually not equal
+        // wrappedWithRoot1
     }
 }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/MakeCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/MakeCryptoService.kt
@@ -27,6 +27,7 @@ fun makeSoftCryptoService(
     shortHashCache: Cache<ShortHashCacheKey, SigningKeyInfo>? = null,
     schemeMetadata: CipherSchemeMetadataImpl = CipherSchemeMetadataImpl(),
     rootWrappingKey: WrappingKey = WrappingKeyImpl.generateWrappingKey(schemeMetadata),
+    rootWrappingKey2: WrappingKey? = null,
     wrappingKeyFactory: (schemeMetadata: CipherSchemeMetadata) -> WrappingKey = { it ->
         WrappingKeyImpl.generateWrappingKey(it)
     },
@@ -39,7 +40,8 @@ fun makeSoftCryptoService(
         signingRepositoryFactory = { signingRepository },
         schemeMetadata = schemeMetadata,
         defaultUnmanagedWrappingKeyName = "root",
-        unmanagedWrappingKeys = mapOf("root" to rootWrappingKey, "root2" to WrappingKeyImpl.generateWrappingKey(schemeMetadata)),
+        unmanagedWrappingKeys = mapOf("root" to rootWrappingKey)
+                + (if (rootWrappingKey2 != null) mapOf("root2" to rootWrappingKey2) else emptyMap()),
         digestService = PlatformDigestServiceImpl(schemeMetadata),
         wrappingKeyCache = wrappingKeyCache,
         privateKeyCache = privateKeyCache,


### PR DESCRIPTION
Improve test case, allow a second root wrapping key to be optionally specified in test fixture for `SoftCryptoService`.