### PR TITLE
CORE-13376: remove unnecessary wrapping types for collections

### DIFF
--- a/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/ClusterTestUtils.kt
+++ b/applications/workers/release/rest-worker/src/e2eTest/kotlin/net/corda/applications/workers/rest/utils/ClusterTestUtils.kt
@@ -94,7 +94,7 @@ fun E2eCluster.uploadCpi(
         with(client.start().proxy) {
             // Check if MGM CPI was already uploaded in previous run. Current validation only allows one MGM CPI.
             if (isMgm) {
-                getAllCpis().cpis.firstOrNull {
+                getAllCpisList().firstOrNull {
                     it.groupPolicy?.contains("CREATE_ID") ?: false
                 }?.let {
                     return it.cpiFileChecksum

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
@@ -120,7 +120,7 @@ class VirtualNodeRestTest {
                 condition { it.code == 200 }
             }.toJson()
 
-            assertThat(json["cpis"].size()).isGreaterThan(0)
+            assertThat(json.size()).isGreaterThan(0)
         }
     }
 
@@ -142,7 +142,7 @@ class VirtualNodeRestTest {
                 interval(retryInterval)
                 command { vNodeList() }
                 condition { response ->
-                    val nodes = vNodeList().toJson()["virtualNodes"].map {
+                    val nodes = vNodeList().toJson().map {
                         it["holdingIdentity"]["x500Name"].textValue()
                     }
                     response.code == 200 && nodes.contains(aliceX500)
@@ -182,7 +182,7 @@ class VirtualNodeRestTest {
         val cpis = assertWithRetryIgnoringExceptions {
             command { cpiList() }
             condition { it.code == ResponseCode.OK.statusCode }
-        }.body.toJson()["cpis"]
+        }.body.toJson()
 
         val cpiJson = cpis.toList().find { it["id"]["cpiName"].textValue() == cpiName }
         assertNotNull(cpiJson, "Cpi with name $cpiName not yet found in cpi list.")

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImpl.kt
@@ -82,7 +82,6 @@ class FlowClassRestResourceImpl @Activate constructor(
     }
 
     @Deprecated("Deprecated in favour of getAllStartableFlowsList")
-
     override fun getStartableFlows(holdingIdentityShortHash: String): ResponseEntity<StartableFlowsResponse> {
         "Deprecated, please use next version at ${RestApiVersion.C5_1} or above.".let { msg ->
             log.warn(msg)

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImpl.kt
@@ -81,7 +81,7 @@ class FlowClassRestResourceImpl @Activate constructor(
         }
     }
 
-    @Deprecated("Deprecated in favour of getAllStartableFlowsList")
+    @Deprecated("Deprecated in favour of getStartableFlowsList")
     override fun getStartableFlows(holdingIdentityShortHash: String): ResponseEntity<StartableFlowsResponse> {
         "Deprecated, please use next version at ${RestApiVersion.C5_1} or above.".let { msg ->
             log.warn(msg)

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package net.corda.flow.rest.impl.v1
 
 import net.corda.cpiinfo.read.CpiInfoReadService

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
@@ -13,7 +13,6 @@ import net.corda.flow.rest.v1.types.request.StartFlowParameters
 import net.corda.flow.rest.v1.types.response.FlowResultResponse
 import net.corda.flow.rest.v1.types.response.FlowStatusResponse
 import net.corda.flow.rest.v1.types.response.FlowStatusResponses
-import net.corda.flow.rest.v1.types.response.StartableFlowsResponse
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.platform.PlatformInfoProvider
@@ -59,7 +58,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.TimeUnit
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 @Component(service = [FlowRestResource::class, PluggableRestResource::class])
 class FlowRestResourceImpl @Activate constructor(
     @Reference(service = VirtualNodeInfoReadService::class)

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
@@ -263,7 +263,7 @@ class FlowRestResourceImpl @Activate constructor(
     @Deprecated("Deprecated in favour of getMultipleFlowStatusList")
     override fun getMultipleFlowStatus(holdingIdentityShortHash: String): ResponseEntity<FlowStatusResponses> {
         "Deprecated, please use next version at ${RestApiVersion.C5_1} or above.".let { msg ->
-            FlowClassRestResourceImpl.log.warn(msg)
+            log.warn(msg)
             val flowStatusList = doGetMultipleFlowStatusList(holdingIdentityShortHash)
             return ResponseEntity.okButDeprecated(
                 FlowStatusResponses(flowStatusList),

--- a/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImplTest.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/v1/FlowClassRestResourceImplTest.kt
@@ -85,7 +85,7 @@ class FlowClassRestResourceImplTest {
             mock()
         )
         assertThrows<ResourceNotFoundException> {
-            flowClassRestResource.getStartableFlows("1234567890ab")
+            flowClassRestResource.getStartableFlowsList("1234567890ab")
         }
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(cpiInfoReadService, times(0)).get(any())
@@ -102,7 +102,7 @@ class FlowClassRestResourceImplTest {
             mock()
         )
         assertThrows<ResourceNotFoundException> {
-            flowClassRestResource.getStartableFlows("1234567890ab")
+            flowClassRestResource.getStartableFlowsList("1234567890ab")
         }
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(cpiInfoReadService, times(1)).get(any())
@@ -116,7 +116,7 @@ class FlowClassRestResourceImplTest {
             cpiInfoReadService,
             mock()
         )
-        flowClassRestResource.getStartableFlows("1234567890ab")
+        flowClassRestResource.getStartableFlowsList("1234567890ab")
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(cpiInfoReadService, times(1)).get(any())
     }

--- a/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImplTest.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImplTest.kt
@@ -222,7 +222,7 @@ class FlowRestResourceImplTest {
     fun `get multiple flow status`() {
         whenever(flowStatusCacheService.getStatusesPerIdentity(any())).thenReturn(listOf(FlowStatus(), FlowStatus()))
         val flowRestResource = createFlowRestResource()
-        flowRestResource.getMultipleFlowStatus(VALID_SHORT_HASH)
+        flowRestResource.getMultipleFlowStatusList(VALID_SHORT_HASH)
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusCacheService, times(1)).getStatusesPerIdentity(any())
@@ -237,7 +237,7 @@ class FlowRestResourceImplTest {
         val flowRestResource = createFlowRestResource()
 
         assertThrows<ResourceNotFoundException> {
-            flowRestResource.getMultipleFlowStatus(VALID_SHORT_HASH)
+            flowRestResource.getMultipleFlowStatusList(VALID_SHORT_HASH)
         }
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
@@ -252,7 +252,7 @@ class FlowRestResourceImplTest {
         val flowRestResource = createFlowRestResource()
 
         assertThrows<BadRequestException> {
-            flowRestResource.getMultipleFlowStatus(invalidShortHash)
+            flowRestResource.getMultipleFlowStatusList(invalidShortHash)
         }
 
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowClassRestResource.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowClassRestResource.kt
@@ -5,6 +5,8 @@ import net.corda.rest.RestResource
 import net.corda.rest.annotations.HttpGET
 import net.corda.rest.annotations.RestPathParameter
 import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestApiVersion
+import net.corda.rest.response.ResponseEntity
 
 /** Rest operations for getting flow information from a vNode. */
 @HttpRestResource(
@@ -15,15 +17,31 @@ import net.corda.rest.annotations.HttpRestResource
 )
 interface FlowClassRestResource : RestResource {
 
+    @Deprecated("Deprecated in favour of getStartableFlowsList")
     @HttpGET(
         path = "{holdingIdentityShortHash}",
         title = "Get Startable Flows",
         description = "This method gets all flows that can be used by the specified holding identity.",
-        responseDescription = "The class names of all flows that can be run"
+        responseDescription = "The class names of all flows that can be run",
+        minVersion = RestApiVersion.C5_0,
+        maxVersion = RestApiVersion.C5_0
     )
     fun getStartableFlows(
         @RestPathParameter(description = "The short hash of the holding identity; " +
                 "this is obtained during node registration")
         holdingIdentityShortHash: String
-    ): StartableFlowsResponse
+    ): ResponseEntity<StartableFlowsResponse>
+
+    @HttpGET(
+        path = "{holdingIdentityShortHash}",
+        title = "Get Startable Flows",
+        description = "This method gets all flows that can be used by the specified holding identity.",
+        responseDescription = "The class names of all flows that can be run",
+        minVersion = RestApiVersion.C5_1
+    )
+    fun getStartableFlowsList(
+        @RestPathParameter(description = "The short hash of the holding identity; " +
+                "this is obtained during node registration")
+        holdingIdentityShortHash: String
+    ): List<String>
 }

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowClassRestResource.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowClassRestResource.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package net.corda.flow.rest.v1
 
 import net.corda.flow.rest.v1.types.response.StartableFlowsResponse

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowRestResource.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowRestResource.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package net.corda.flow.rest.v1
 
 import net.corda.flow.rest.v1.types.request.StartFlowParameters
@@ -14,6 +15,7 @@ import net.corda.rest.annotations.HttpWS
 import net.corda.rest.response.ResponseEntity
 import net.corda.rest.ws.DuplexChannel
 import net.corda.libs.configuration.SmartConfig
+import net.corda.rest.annotations.RestApiVersion
 
 /** Rest operations for flow management. */
 @HttpRestResource(
@@ -88,6 +90,7 @@ interface FlowRestResource : RestResource {
         clientRequestId: String
     ): FlowStatusResponse
 
+    @Deprecated("Deprecated in favour of getMultipleFlowStatusList")
     @HttpGET(
         path = "{holdingIdentityShortHash}",
         title = "Get Multiple Flow Status",
@@ -103,12 +106,37 @@ interface FlowRestResource : RestResource {
             flowResult: The result returned from a completed flow, only set when the flow status is 'COMPLETED' otherwise null
             flowError: The details of the error that caused a flow to fail, only set when the flow status is 'FAILED' otherwise null
             timestamp: The timestamp of when the status was last updated (in UTC)
-            """
+            """,
+        minVersion = RestApiVersion.C5_0,
+        maxVersion = RestApiVersion.C5_0
     )
     fun getMultipleFlowStatus(
         @RestPathParameter(description = "The short hash of the holding identity; obtained during node registration")
         holdingIdentityShortHash: String
-    ): FlowStatusResponses
+    ): ResponseEntity<FlowStatusResponses>
+
+    @HttpGET(
+        path = "{holdingIdentityShortHash}",
+        title = "Get Multiple Flow Status",
+        description = "This method returns an array containing the statuses of all flows running for a specified " +
+                "holding identity. An empty array is returned if there are no flows running.",
+        responseDescription = """
+            A collection of statuses for the flow instances, including:
+            
+            holdingIdentityShortHash: The short form hash of the Holding Identity
+            clientRequestId: The unique ID supplied by the client when the flow was created.
+            flowId: The internal unique ID for the flow.
+            flowStatus: The current state of the executing flow.
+            flowResult: The result returned from a completed flow, only set when the flow status is 'COMPLETED' otherwise null
+            flowError: The details of the error that caused a flow to fail, only set when the flow status is 'FAILED' otherwise null
+            timestamp: The timestamp of when the status was last updated (in UTC)
+            """,
+        minVersion = RestApiVersion.C5_1
+    )
+    fun getMultipleFlowStatusList(
+        @RestPathParameter(description = "The short hash of the holding identity; obtained during node registration")
+        holdingIdentityShortHash: String
+    ): List<FlowStatusResponse>
 
     @HttpGET(
         path = "{holdingIdentityShortHash}/{clientRequestId}/result",

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/types/response/FlowStatusResponses.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/types/response/FlowStatusResponses.kt
@@ -5,6 +5,7 @@ package net.corda.flow.rest.v1.types.response
  *
  * @param flowStatusResponses List of [FlowStatusResponse]. Empty if there are no flows for this holding id.
  */
+@Deprecated("Deprecated, unused in newer endpoint getAllStartableFlowsList, remove once out of LTS")
 data class FlowStatusResponses(
     val flowStatusResponses: List<FlowStatusResponse>
 )

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/types/response/FlowStatusResponses.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/types/response/FlowStatusResponses.kt
@@ -5,7 +5,7 @@ package net.corda.flow.rest.v1.types.response
  *
  * @param flowStatusResponses List of [FlowStatusResponse]. Empty if there are no flows for this holding id.
  */
-@Deprecated("Deprecated, unused in newer endpoint getAllStartableFlowsList, remove once out of LTS")
+@Deprecated("Deprecated, unused in newer endpoint getMultipleFlowStatusList, remove once out of LTS")
 data class FlowStatusResponses(
     val flowStatusResponses: List<FlowStatusResponse>
 )

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/types/response/StartableFlowsResponse.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/types/response/StartableFlowsResponse.kt
@@ -5,6 +5,7 @@ package net.corda.flow.rest.v1.types.response
  *
  * @param flowClassNames List of flow class names.
  */
+@Deprecated("Deprecated, unused in newer endpoint getAllStartableFlowsList, remove once out of LTS")
 data class StartableFlowsResponse(
     val flowClassNames: List<String>
 )

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/types/response/StartableFlowsResponse.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/types/response/StartableFlowsResponse.kt
@@ -5,7 +5,7 @@ package net.corda.flow.rest.v1.types.response
  *
  * @param flowClassNames List of flow class names.
  */
-@Deprecated("Deprecated, unused in newer endpoint getAllStartableFlowsList, remove once out of LTS")
+@Deprecated("Deprecated, unused in newer endpoint getStartableFlowsList, remove once out of LTS")
 data class StartableFlowsResponse(
     val flowClassNames: List<String>
 )

--- a/components/virtual-node/cpi-upload-rest-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
+++ b/components/virtual-node/cpi-upload-rest-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
@@ -111,6 +111,7 @@ class CpiUploadRestResourceImpl @Activate constructor(
         }
     }
 
+    @Deprecated("Deprecated in favour of getAllCpisList")
     override fun getAllCpis(): ResponseEntity<GetCPIsResponse> {
         "Deprecated, please use next version at ${RestApiVersion.C5_1} or above.".let { msg ->
             logger.warn(msg)

--- a/components/virtual-node/cpi-upload-rest-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
+++ b/components/virtual-node/cpi-upload-rest-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
@@ -16,12 +16,15 @@ import net.corda.rest.exception.ResourceAlreadyExistsException
 import net.corda.rest.messagebus.MessageBusUtils.tryWithExceptionHandling
 import net.corda.libs.cpiupload.DuplicateCpiUploadException
 import net.corda.libs.cpiupload.ValidationException
+import net.corda.libs.cpiupload.endpoints.v1.CpiMetadata
 import net.corda.libs.cpiupload.endpoints.v1.CpiUploadRestResource
 import net.corda.libs.cpiupload.endpoints.v1.GetCPIsResponse
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.createCoordinator
+import net.corda.rest.annotations.RestApiVersion
+import net.corda.rest.response.ResponseEntity
 import net.corda.utilities.trace
 import net.corda.v5.crypto.SecureHash
 import org.osgi.service.component.annotations.Activate
@@ -108,11 +111,21 @@ class CpiUploadRestResourceImpl @Activate constructor(
         }
     }
 
-    override fun getAllCpis(): GetCPIsResponse {
+    override fun getAllCpis(): ResponseEntity<GetCPIsResponse> {
+        "Deprecated, please use next version at ${RestApiVersion.C5_1} or above.".let { msg ->
+            logger.warn(msg)
+            return ResponseEntity.okButDeprecated(GetCPIsResponse(doGetAllCpis()), msg)
+        }
+    }
+
+    override fun getAllCpisList(): List<CpiMetadata> {
+        return doGetAllCpis()
+    }
+
+    private fun doGetAllCpis(): List<CpiMetadata> {
         logger.trace { "Get all CPIs request" }
         requireRunning()
-        val cpis = cpiInfoReadService.getAll().map { it.toEndpointType() }
-        return GetCPIsResponse(cpis)
+        return cpiInfoReadService.getAll().map { it.toEndpointType() }
     }
 
     /**

--- a/components/virtual-node/cpi-upload-rest-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
+++ b/components/virtual-node/cpi-upload-rest-service/src/main/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package net.corda.cpi.upload.endpoints.v1
 
 import net.corda.chunking.Constants.Companion.CHUNK_FILENAME_KEY

--- a/components/virtual-node/cpi-upload-rest-service/src/test/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImplTest.kt
+++ b/components/virtual-node/cpi-upload-rest-service/src/test/kotlin/net/corda/cpi/upload/endpoints/v1/CpiUploadRestResourceImplTest.kt
@@ -75,8 +75,8 @@ class CpiUploadRestResourceImplTest {
     }
 
     @Test
-    fun `getAllCpis calls CpiInfoReadService to retrieve all CPIs`() {
-        cpiUploadRestResourceImpl.getAllCpis()
+    fun `getAllCpisList calls CpiInfoReadService to retrieve all CPIs`() {
+        cpiUploadRestResourceImpl.getAllCpisList()
         verify(cpiInfoReadService).getAll()
     }
 

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package net.corda.virtualnode.rest.impl.v1
 
 import net.corda.configuration.read.ConfigChangedEvent
@@ -42,6 +43,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.rest.PluggableRestResource
+import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.asynchronous.v1.AsyncOperationState
 import net.corda.rest.asynchronous.v1.AsyncOperationStatus
 import net.corda.rest.asynchronous.v1.AsyncResponse
@@ -240,8 +242,34 @@ internal class VirtualNodeRestResourceImpl(
      * @see VirtualNodes
      * @see VirtualNodeInfo
      */
-    override fun getAllVirtualNodes(): VirtualNodes {
-        return VirtualNodes(virtualNodeInfoReadService.getAll().map(messageConverter::convert))
+    @Deprecated("Deprecated in favour of getAllVirtualNodesList")
+
+    override fun getAllVirtualNodes(): ResponseEntity<VirtualNodes> {
+        "Deprecated, please use next version at ${RestApiVersion.C5_1} or above.".let { msg ->
+            logger.warn(msg)
+            val virtualNodes = doGetAllVirtualNodes()
+            return ResponseEntity.okButDeprecated(
+                VirtualNodes(virtualNodes),
+                msg
+            )
+        }
+    }
+
+    /**
+     * Retrieves the list of virtual nodes stored on the message bus
+     *
+     * @throws IllegalStateException is thrown if the component isn't running and therefore able to service requests.
+     * @return [VirtualNodes] which is a list of [VirtualNodeInfo]
+     *
+     * @see VirtualNodes
+     * @see VirtualNodeInfo
+     */
+    override fun getAllVirtualNodesList(): List<VirtualNodeInfo> {
+        return doGetAllVirtualNodes()
+    }
+
+    private fun doGetAllVirtualNodes(): List<VirtualNodeInfo> {
+        return virtualNodeInfoReadService.getAll().map(messageConverter::convert)
     }
 
     /**

--- a/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiUploadRestResource.kt
+++ b/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiUploadRestResource.kt
@@ -7,6 +7,8 @@ import net.corda.rest.annotations.RestPathParameter
 import net.corda.rest.annotations.HttpPOST
 import net.corda.rest.annotations.ClientRequestBodyParameter
 import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestApiVersion
+import net.corda.rest.response.ResponseEntity
 
 @HttpRestResource(
     name = "CPI API",
@@ -71,10 +73,26 @@ interface CpiUploadRestResource : RestResource {
      *
      * @throws `HttpApiException` If the request returns an exceptional response.
      */
+    @Deprecated("Deprecated in favour of getAllCpisList")
     @HttpGET(
         title = "CPI info",
         description = "The GET method returns a list of all CPIs uploaded to the cluster.",
-        responseDescription = "Details of all of the CPIs uploaded to the cluster."
+        responseDescription = "Details of all of the CPIs uploaded to the cluster.",
+        minVersion = RestApiVersion.C5_0,
+        maxVersion = RestApiVersion.C5_0
     )
-    fun getAllCpis(): GetCPIsResponse
+    fun getAllCpis(): ResponseEntity<GetCPIsResponse>
+
+    /**
+     * Lists all CPIs uploaded to the cluster.
+     *
+     * @throws `HttpApiException` If the request returns an exceptional response.
+     */
+    @HttpGET(
+        title = "CPI info",
+        description = "The GET method returns a list of all CPIs uploaded to the cluster.",
+        responseDescription = "Details of all of the CPIs uploaded to the cluster.",
+        minVersion = RestApiVersion.C5_1,
+    )
+    fun getAllCpisList(): List<CpiMetadata>
 }

--- a/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiUploadRestResource.kt
+++ b/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiUploadRestResource.kt
@@ -73,6 +73,7 @@ interface CpiUploadRestResource : RestResource {
      *
      * @throws `HttpApiException` If the request returns an exceptional response.
      */
+    @Suppress("DEPRECATION")
     @Deprecated("Deprecated in favour of getAllCpisList")
     @HttpGET(
         title = "CPI info",

--- a/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/GetCPIsResponse.kt
+++ b/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/GetCPIsResponse.kt
@@ -5,4 +5,5 @@ package net.corda.libs.cpiupload.endpoints.v1
  *
  * @param cpis List of CPIs.
  */
+@Deprecated("Deprecated, unused in newer endpoint getAllCpisList, remove once out of LTS")
 data class GetCPIsResponse(val cpis: List<CpiMetadata>)

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package net.corda.libs.virtualnode.endpoints.v1
 
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
@@ -11,6 +12,7 @@ import net.corda.rest.annotations.HttpGET
 import net.corda.rest.annotations.HttpPOST
 import net.corda.rest.annotations.HttpPUT
 import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.annotations.RestPathParameter
 import net.corda.rest.asynchronous.v1.AsyncOperationStatus
 import net.corda.rest.asynchronous.v1.AsyncResponse
@@ -44,12 +46,28 @@ interface VirtualNodeRestResource : RestResource {
      *
      * @throws `HttpApiException` If the request returns an exceptional response.
      */
+    @Deprecated("Deprecated in favour of getAllVirtualNodesList")
     @HttpGET(
         title = "Lists all virtual nodes",
         description = "This method lists all virtual nodes in the cluster.",
-        responseDescription = "List of virtual node details."
+        responseDescription = "List of virtual node details.",
+        minVersion = RestApiVersion.C5_0,
+        maxVersion = RestApiVersion.C5_0
     )
-    fun getAllVirtualNodes(): VirtualNodes
+    fun getAllVirtualNodes(): ResponseEntity<VirtualNodes>
+
+    /**
+     * Lists all virtual nodes onboarded to the cluster.
+     *
+     * @throws `HttpApiException` If the request returns an exceptional response.
+     */
+    @HttpGET(
+        title = "Lists all virtual nodes",
+        description = "This method lists all virtual nodes in the cluster.",
+        responseDescription = "List of virtual node details.",
+        minVersion = RestApiVersion.C5_1
+    )
+    fun getAllVirtualNodesList(): List<VirtualNodeInfo>
 
     /**
      * Updates a virtual nodes state.

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodes.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodes.kt
@@ -10,6 +10,7 @@ package net.corda.libs.virtualnode.endpoints.v1.types
  *
  * @param virtualNodes List of [VirtualNodeInfo].
  */
+@Deprecated("Deprecated, unused in newer endpoint getAllStartableFlowsList, remove once out of LTS")
 data class VirtualNodes(
     val virtualNodes: List<VirtualNodeInfo>
 )

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodes.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/VirtualNodes.kt
@@ -10,7 +10,7 @@ package net.corda.libs.virtualnode.endpoints.v1.types
  *
  * @param virtualNodes List of [VirtualNodeInfo].
  */
-@Deprecated("Deprecated, unused in newer endpoint getAllStartableFlowsList, remove once out of LTS")
+@Deprecated("Deprecated, unused in newer endpoint getAllVirtualNodesList, remove once out of LTS")
 data class VirtualNodes(
     val virtualNodes: List<VirtualNodeInfo>
 )

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
@@ -3788,7 +3788,12 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/VirtualNodes"
+                  "uniqueItems" : false,
+                  "type" : "array",
+                  "nullable" : false,
+                  "items" : {
+                    "$ref" : "#/components/schemas/VirtualNodeInfo"
+                  }
                 }
               }
             }
@@ -5592,20 +5597,6 @@
             "type" : "string",
             "nullable" : false,
             "example" : "string"
-          }
-        }
-      },
-      "VirtualNodes" : {
-        "required" : [ "virtualNodes" ],
-        "type" : "object",
-        "properties" : {
-          "virtualNodes" : {
-            "uniqueItems" : false,
-            "type" : "array",
-            "nullable" : false,
-            "items" : {
-              "$ref" : "#/components/schemas/VirtualNodeInfo"
-            }
           }
         }
       }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
@@ -607,7 +607,12 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/GetCPIsResponse"
+                  "uniqueItems" : false,
+                  "type" : "array",
+                  "nullable" : false,
+                  "items" : {
+                    "$ref" : "#/components/schemas/CpiMetadata"
+                  }
                 }
               }
             }
@@ -783,7 +788,12 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/FlowStatusResponses"
+                  "uniqueItems" : false,
+                  "type" : "array",
+                  "nullable" : false,
+                  "items" : {
+                    "$ref" : "#/components/schemas/FlowStatusResponse"
+                  }
                 }
               }
             }
@@ -991,7 +1001,13 @@
             "content" : {
               "application/json" : {
                 "schema" : {
-                  "$ref" : "#/components/schemas/StartableFlowsResponse"
+                  "uniqueItems" : false,
+                  "type" : "array",
+                  "nullable" : false,
+                  "items" : {
+                    "type" : "string",
+                    "example" : "string"
+                  }
                 }
               }
             }
@@ -4601,20 +4617,6 @@
           }
         }
       },
-      "FlowStatusResponses" : {
-        "required" : [ "flowStatusResponses" ],
-        "type" : "object",
-        "properties" : {
-          "flowStatusResponses" : {
-            "uniqueItems" : false,
-            "type" : "array",
-            "nullable" : false,
-            "items" : {
-              "$ref" : "#/components/schemas/FlowStatusResponse"
-            }
-          }
-        }
-      },
       "GenerateCsrWrapperRequest" : {
         "required" : [ "x500Name" ],
         "type" : "object",
@@ -4647,20 +4649,6 @@
         },
         "description" : "GenerateCsrWrapperRequest",
         "nullable" : false
-      },
-      "GetCPIsResponse" : {
-        "required" : [ "cpis" ],
-        "type" : "object",
-        "properties" : {
-          "cpis" : {
-            "uniqueItems" : false,
-            "type" : "array",
-            "nullable" : false,
-            "items" : {
-              "$ref" : "#/components/schemas/CpiMetadata"
-            }
-          }
-        }
       },
       "GetConfigResponse" : {
         "required" : [ "configWithDefaults", "schemaVersion", "section", "sourceConfig", "version" ],
@@ -5339,21 +5327,6 @@
           }
         },
         "description" : "\n                Information required to start a flow for this holdingId, including:\n                clientRequestId: a client provided flow identifier\n                flowClassName: fully qualified class name of the flow to start\n                requestBody: optional start arguments string passed to the flow; defaults to an empty string\n            "
-      },
-      "StartableFlowsResponse" : {
-        "required" : [ "flowClassNames" ],
-        "type" : "object",
-        "properties" : {
-          "flowClassNames" : {
-            "uniqueItems" : false,
-            "type" : "array",
-            "nullable" : false,
-            "items" : {
-              "type" : "string",
-              "example" : "string"
-            }
-          }
-        }
       },
       "SuspensionActivationParameters" : {
         "required" : [ "x500Name" ],

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -166,6 +166,9 @@ class ClusterBuilder {
     /** List all CPIs in the system */
     fun cpiList() = client!!.get("/api/$REST_API_VERSION_PATH/cpi")
 
+    /** Used to test RestApiVersion.C5_0 getAllCpis, remove after LTS */
+    fun deprecatedCpiList() = client!!.get("/api/${RestApiVersion.C5_0.versionPath}/cpi")
+
     private fun vNodeBody(cpiHash: String, x500Name: String) =
         """{ "cpiFileChecksum" : "$cpiHash", "x500Name" : "$x500Name"}"""
 
@@ -461,6 +464,10 @@ class ClusterBuilder {
         """{ "clientRequestId" : "$clientRequestId", "flowClassName" : "$flowClassName", "requestBody" : 
             |"$requestData" }
         """.trimMargin()
+
+    /** Used to test RestApiVersion.C5_0 getStartableFlows, remove after LTS */
+    fun deprecatedGetStartableFlows(holdingIdentityShortHash: String) =
+        get("/api/${RestApiVersion.C5_0}/flowclass/$holdingIdentityShortHash")
 
     /** Get cluster configuration for the specified section */
     fun getConfig(section: String) = get("/api/$REST_API_VERSION_PATH/config/$section")

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -363,7 +363,6 @@ class ClusterBuilder {
     fun deprecatedMultipleFlowStatus(holdingIdentityShortHash: String) =
         get("/api/${RestApiVersion.C5_0.versionPath}/flow/$holdingIdentityShortHash")
 
-
     /** Get result of a flow execution */
     fun flowResult(holdingIdentityShortHash: String, clientRequestId: String) =
         get("/api/$REST_API_VERSION_PATH/flow/$holdingIdentityShortHash/$clientRequestId/result")

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -277,6 +277,9 @@ class ClusterBuilder {
     /** List all virtual nodes */
     fun vNodeList() = client!!.get("/api/$REST_API_VERSION_PATH/virtualnode")
 
+    /** Used to test RestApiVersion.C5_0 getAllVirtualNodes, remove after LTS */
+    fun deprecatedVNodeList() = client!!.get("/api/${RestApiVersion.C5_0.versionPath}/virtualnode")
+
     /** List all virtual nodes */
     fun getVNode(holdingIdentityShortHash: String) = client!!.get("/api/$REST_API_VERSION_PATH/virtualnode/$holdingIdentityShortHash")
 
@@ -356,6 +359,11 @@ class ClusterBuilder {
     fun multipleFlowStatus(holdingIdentityShortHash: String) =
         get("/api/$REST_API_VERSION_PATH/flow/$holdingIdentityShortHash")
 
+    /** Used to test RestApiVersion.C5_0 getMultipleFlowStatus, remove after LTS */
+    fun deprecatedMultipleFlowStatus(holdingIdentityShortHash: String) =
+        get("/api/${RestApiVersion.C5_0.versionPath}/flow/$holdingIdentityShortHash")
+
+
     /** Get result of a flow execution */
     fun flowResult(holdingIdentityShortHash: String, clientRequestId: String) =
         get("/api/$REST_API_VERSION_PATH/flow/$holdingIdentityShortHash/$clientRequestId/result")
@@ -363,6 +371,10 @@ class ClusterBuilder {
     /** Get status of multiple flows */
     fun runnableFlowClasses(holdingIdentityShortHash: String) =
         get("/api/$REST_API_VERSION_PATH/flowclass/$holdingIdentityShortHash")
+
+    /** Used to test RestApiVersion.C5_0 getStartableFlows, remove after LTS */
+    fun deprecatedRunnableFlowClasses(holdingIdentityShortHash: String) =
+        get("/api/${RestApiVersion.C5_0.versionPath}/flowclass/$holdingIdentityShortHash")
 
     /** Create a new RBAC role */
     fun createRbacRole(roleName: String, groupVisibility: String? = null) =
@@ -464,10 +476,6 @@ class ClusterBuilder {
         """{ "clientRequestId" : "$clientRequestId", "flowClassName" : "$flowClassName", "requestBody" : 
             |"$requestData" }
         """.trimMargin()
-
-    /** Used to test RestApiVersion.C5_0 getStartableFlows, remove after LTS */
-    fun deprecatedGetStartableFlows(holdingIdentityShortHash: String) =
-        get("/api/${RestApiVersion.C5_0}/flowclass/$holdingIdentityShortHash")
 
     /** Get cluster configuration for the specified section */
     fun getConfig(section: String) = get("/api/$REST_API_VERSION_PATH/config/$section")

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -115,7 +115,7 @@ fun ClusterInfo.getOrCreateVirtualNodeFor(
     val normalizedX500 = MemberX500Name.parse(x500).toString()
 
     if (vNodesJson.findValuesAsText("x500Name").contains(normalizedX500)) {
-        vNodeList().toJson()["virtualNodes"].toList().first {
+        vNodeList().toJson().toList().first {
             it["holdingIdentity"]["x500Name"].textValue() == normalizedX500
         }["holdingIdentity"]["shortHash"].textValue()
     } else {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -137,11 +137,7 @@ fun ClusterInfo.getExistingCpi(
         command { cpiList() }
         condition { it.code == ResponseCode.OK.statusCode }
         failMessage("Failed to list CPIs")
-    }.toJson().apply {
-            assertThat(contains("cpis")).isTrue
-        }["cpis"]
-        .toList()
-        .firstOrNull {
+    }.toJson().firstOrNull {
             it["id"]["cpiName"].textValue() == cpiName
         }
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -151,12 +151,11 @@ fun awaitMultipleRpcFlowFinished(holdingId: String, expectedFlowCount: Int) {
             timeout(Duration.ofSeconds(20))
             condition {
                 val json = it.toJson()
-                val flowStatuses = json["flowStatusResponses"]
-                val allStatusComplete = flowStatuses.map { flowStatus ->
+                val allStatusComplete = json.map { flowStatus ->
                     flowStatus["flowStatus"].textValue() == RPC_FLOW_STATUS_SUCCESS ||
                             flowStatus["flowStatus"].textValue() == RPC_FLOW_STATUS_FAILED
                 }.all { true }
-                it.code == 200 && flowStatuses.size() == expectedFlowCount && allStatusComplete
+                it.code == 200 && json.size() == expectedFlowCount && allStatusComplete
             }
         }
     }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -173,7 +173,7 @@ fun ClusterInfo.getFlowClasses(holdingId: String): List<String> {
             failMessage("Failed to get flows for holdingId '$holdingId'")
         }.toJson()
 
-        vNodeJson["flowClassNames"].map { it.textValue() }
+        vNodeJson.map { it.textValue() }
     }
 }
 

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnBoardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnBoardMember.kt
@@ -101,7 +101,7 @@ class OnBoardMember : Runnable, BaseOnboard() {
     private fun checkIfCpiWasUploaded(cpiFileChecksum: String): Boolean {
         val currentCpis = createRestClient(CpiUploadRestResource::class)
             .use { client ->
-                client.start().proxy.getAllCpis().cpis
+                client.start().proxy.getAllCpis().responseBody.cpis
             }
 
         return currentCpis.any { it.cpiFileChecksum == cpiFileChecksum }
@@ -133,7 +133,7 @@ class OnBoardMember : Runnable, BaseOnboard() {
         if (cpiHashesFile.canRead()) {
             val cpiFileChecksum = cpiHashesFile.readText()
             val currentCpis = createRestClient(CpiUploadRestResource::class).use { client ->
-                client.start().proxy.getAllCpis().cpis
+                client.start().proxy.getAllCpis().responseBody.cpis
             }
             if (currentCpis.any { it.cpiFileChecksum == cpiFileChecksum }) {
                 println("CPI was already uploaded in $cpiFile. CPI hash checksum is $cpiFileChecksum")

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnBoardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnBoardMember.kt
@@ -98,9 +98,11 @@ class OnBoardMember : Runnable, BaseOnboard() {
         )
     }
 
+    @Suppress("DEPRECATION")
     private fun checkIfCpiWasUploaded(cpiFileChecksum: String): Boolean {
         val currentCpis = createRestClient(CpiUploadRestResource::class)
             .use { client ->
+                // using deprecated getAllCpis to support CLI compatibility with Corda 5.0
                 client.start().proxy.getAllCpis().responseBody.cpis
             }
 
@@ -125,6 +127,7 @@ class OnBoardMember : Runnable, BaseOnboard() {
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun uploadCpb(cpbFile: File): String {
         val hash = listOf(cpbFile, groupPolicyFile).hash()
         val cpiRoot = File(cpisRoot, hash)
@@ -133,6 +136,7 @@ class OnBoardMember : Runnable, BaseOnboard() {
         if (cpiHashesFile.canRead()) {
             val cpiFileChecksum = cpiHashesFile.readText()
             val currentCpis = createRestClient(CpiUploadRestResource::class).use { client ->
+                // using deprecated getAllCpis to support CLI compatibility with Corda 5.0
                 client.start().proxy.getAllCpis().responseBody.cpis
             }
             if (currentCpis.any { it.cpiFileChecksum == cpiFileChecksum }) {

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
@@ -168,6 +168,8 @@ class OnboardMgm : Runnable, BaseOnboard() {
         }
     }
 
+    @Suppress("DEPRECATION")
+    // using deprecated getAllCpis to support CLI compatibility with Corda 5.0
     private fun getExistingCpiHash(hash: String? = null): String? {
         return createRestClient(CpiUploadRestResource::class).use { client ->
             val response = client.start().proxy.getAllCpis().responseBody

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
@@ -170,7 +170,7 @@ class OnboardMgm : Runnable, BaseOnboard() {
 
     private fun getExistingCpiHash(hash: String? = null): String? {
         return createRestClient(CpiUploadRestResource::class).use { client ->
-            val response = client.start().proxy.getAllCpis()
+            val response = client.start().proxy.getAllCpis().responseBody
             response.cpis
                 .filter { it.cpiFileChecksum == hash || (hash == null && it.groupPolicy?.contains("CREATE_ID") ?: false) }
                 .map { it.cpiFileChecksum }


### PR DESCRIPTION
Some endpoints which return a list of objects had wrapping Objects to contain the lists. This PR removes these wrapping objects and directly returns the list in order to have consistency across our endpoints. This was done using the guidelines here: [Versioning of Rest API](https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4472635529/Versioning+of+REST+API)


| Endpoint | Class | Method | Wrapper |  Wrapper contents | 
| ------------- | ------------- | ------------- | ------------- | ------------- |
| /flowclass/{holdingIdentityShortHash  | FlowClassRestResource | getStartableFlows | StartableFlowsResponse | flowClassNames: `List<String>` | 
| /flow/{holdingIdentityShortHash}  | FlowRestResource  | getMultipleFlowStatus | FlowStatusResponses | flowStatusResponses: `List<FlowStatusResponse>` | 
 | /virtualnode | VirtualNodeRestResource | getAllVirtualNodes | VirtualNodes | virtualNodes: `List<VirtualNodeInfo>` | 
 | /cpi | CpiUploadRestResource | getAllCpis | GetCPIsResponse | cpis: `List<CpiMetadata>` | 


Corresponding tests have been added to cover the deprecated endpoints here: https://github.com/corda/corda-e2e-tests/pull/186

Non-functional tests are being updated here: https://github.com/corda/corda-non-functional-test/pull/223














