### PR TITLE
CORE-13641 Try simplify test

### DIFF
--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -38,6 +38,7 @@ import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -117,6 +118,11 @@ class PersistenceExceptionTests {
         }
     }
 
+    @AfterEach
+    fun cleanUp() {
+        dbConnectionManager.stop()
+    }
+
     @Test
     fun `exception raised when cpks not present`() {
         val ignoredRequest = createEntityRequest()
@@ -146,8 +152,6 @@ class PersistenceExceptionTests {
         assertThat(response.error.errorType).isEqualTo(ExternalEventResponseErrorType.TRANSIENT)
         // The failure also captures the exception name.
         assertThat(response.error.exception.errorType).isEqualTo(CpkNotAvailableException::class.java.name)
-
-        dbConnectionManager.stop()
     }
 
     @Test
@@ -187,8 +191,6 @@ class PersistenceExceptionTests {
         assertThat(response.error.errorType).isEqualTo(ExternalEventResponseErrorType.TRANSIENT)
         // The failure also captures the exception name.
         assertThat(response.error.exception.errorType).isEqualTo(VirtualNodeException::class.java.name)
-
-        dbConnectionManager.stop()
     }
 
     @Test
@@ -229,8 +231,6 @@ class PersistenceExceptionTests {
         assertThat(response.error.errorType).isEqualTo(ExternalEventResponseErrorType.FATAL)
         // The failure also captures the exception name.
         assertThat(response.error.exception.errorType).isEqualTo(CordaRuntimeException::class.java.name)
-
-        dbConnectionManager.stop()
     }
 
     private fun noOpPayloadCheck(bytes: ByteBuffer) = bytes

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -102,7 +102,6 @@ class PersistenceExceptionTests {
             responseFactory = setup.fetchService(timeout = 5000)
             currentSandboxGroupContext = setup.fetchService(timeout = 5000)
 
-
             virtualNodeInfo = virtualNode.load(Resources.EXTENDABLE_CPB)
             dbConnectionManager = FakeDbConnectionManager(
                 listOf(Pair(virtualNodeInfo.vaultDmlConnectionId, "animals-node")),

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -119,7 +119,7 @@ class PersistenceExceptionTests {
 
     @Test
     fun `exception raised when cpks not present`() {
-        val ignoredRequest = getEntityRequest()
+        val ignoredRequest = createEntityRequest()
 
         val processor = EntityMessageProcessor(
             currentSandboxGroupContext,
@@ -152,7 +152,7 @@ class PersistenceExceptionTests {
 
     @Test
     fun `exception raised when vnode cannot be found`() {
-        val ignoredRequest = getEntityRequest()
+        val ignoredRequest = createEntityRequest()
 
         val brokenVirtualNodeInfoReadService = object :
             VirtualNodeInfoReadService by virtualNodeInfoReadService {
@@ -193,7 +193,7 @@ class PersistenceExceptionTests {
 
     @Test
     fun `exception raised when sent a missing command`() {
-        val oldRequest = getEntityRequest()
+        val oldRequest = createEntityRequest()
         val unknownCommand = ExceptionEnvelope("", "") // Any Avro object, or null works here.
 
         val vNodeInfo = virtualNodeInfoReadService.get(oldRequest.holdingIdentity.toCorda())!!
@@ -238,7 +238,7 @@ class PersistenceExceptionTests {
     /**
      * Create a simple request and return it.
      */
-    private fun getEntityRequest(): EntityRequest {
+    private fun createEntityRequest(): EntityRequest {
         val cpkFileHashes = cpiInfoReadService.getCpkFileHashes(virtualNodeInfo)
         val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
         // create dog using dog-aware sandbox

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -93,6 +93,7 @@ class PersistenceExceptionTests {
     ) {
         logger.info("Setup test (test Directory: $testDirectory)")
         sandboxSetup.configure(bundleContext, testDirectory)
+        // The below callback runs before each test
         lifecycle.accept(sandboxSetup) { setup ->
             virtualNode = setup.fetchService(timeout = 5000)
             cpiInfoReadService = setup.fetchService(timeout = 5000)


### PR DESCRIPTION
- moves common services & virtual node info to test class property level than having the same local in every test function
- simplifies test helper function to only do one thing (single responsibility principle)