### PR TITLE
CORE-13641 Adds tests exposing error on duplicate persistence request

### DIFF
--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -298,7 +298,7 @@ class PersistenceExceptionTests {
     @Disabled("This test is disabled for now because currently we do execute duplicate persistence requests." +
             "It should be re-enabled after deduplication work is done in epic CORE-5909")
     @Test
-    fun `on duplicate persistence request don't execute it - statically updatable field isn't getting updated in DB`() {
+    fun `on duplicate persistence request don't execute it - statically updated field isn't getting updated in DB`() {
         createVersionedDogDb()
         val persistEntitiesRequest = createVersionedDogPersistRequest()
 

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -314,7 +314,6 @@ class PersistenceExceptionTests {
                     }
                 }
             }
-
         // There shouldn't be a dog duplicate entry in the DB, i.e. dogs count in the DB should still be 1
         assertEquals(1, dogCount)
     }

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -319,8 +319,6 @@ class PersistenceExceptionTests {
 
     private fun noOpPayloadCheck(bytes: ByteBuffer) = bytes
 
-    private var dogClass: Class<*>? = null
-
     /**
      * Create a simple request and return it.
      */
@@ -338,8 +336,6 @@ class PersistenceExceptionTests {
                         dbConnectionManager.getDataSource(virtualNodeInfo.vaultDmlConnectionId),
                         liquibaseScript
                     )
-                }.also {
-                    dogClass = it::class.java
                 }
         val serialisedDog = sandbox.getSerializationService().serialize(dog).bytes
 

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -399,38 +399,25 @@ class PersistenceExceptionTests {
     private fun createDogDb(liquibaseScript: String = DOGS_TABLE) {
         val cpkFileHashes = cpiInfoReadService.getCpkFileHashes(virtualNodeInfo)
         val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
-
         val dog = sandbox.createDog("Stray", owner = "Not Known").instance
-
-        val dogClass = dog::class.java
-        val cl = ClassloaderChangeLog(
-            linkedSetOf(
-                ClassloaderChangeLog.ChangeLogResourceFiles(
-                    dogClass.packageName,
-                    listOf(liquibaseScript),
-                    dogClass.classLoader
-                )
-            )
-        )
-        val ds = dbConnectionManager.getDataSource(virtualNodeInfo.vaultDmlConnectionId)
-        ds.connection.use {
-            lbm.updateDb(it, cl)
-        }
+        createDb(liquibaseScript, dog)
     }
 
     private fun createVersionedDogDb() {
         val cpkFileHashes = cpiInfoReadService.getCpkFileHashes(virtualNodeInfo)
         val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
+        val versionedDog = sandbox.createVersionedDog("Stray", owner = "Not Known")
+        createDb(VERSIONED_DOGS_TABLE, versionedDog)
+    }
 
-        val dog = sandbox.createVersionedDog("Stray", owner = "Not Known")
-
-        val dogClass = dog::class.java
+    private fun createDb(liquibaseScript: String, entity: Any) {
+        val entityClass = entity::class.java
         val cl = ClassloaderChangeLog(
             linkedSetOf(
                 ClassloaderChangeLog.ChangeLogResourceFiles(
-                    dogClass.packageName,
-                    listOf(VERSIONED_DOGS_TABLE),
-                    dogClass.classLoader
+                    entityClass.packageName,
+                    listOf(liquibaseScript),
+                    entityClass.classLoader
                 )
             )
         )

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -290,7 +290,7 @@ class PersistenceExceptionTests {
         val record2 = processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), persistEntitiesRequest)))
         assertNull(((record2.single().value as FlowEvent).payload as ExternalEventResponse).error)
 
-        val dogDbCount = dogDbCount(virtualNodeInfo.vaultDmlConnectionId)
+        val dogDbCount = getDogDbCount(virtualNodeInfo.vaultDmlConnectionId)
         // There shouldn't be a dog duplicate entry in the DB, i.e. dogs count in the DB should still be 1
         assertEquals(1, dogDbCount)
     }
@@ -332,18 +332,18 @@ class PersistenceExceptionTests {
         // first update request
         processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), mergeEntityRequest)))
         // check we update same dog
-        val dogDbCount = dogDbCount(virtualNodeInfo.vaultDmlConnectionId, dogDBTable = "versionedDog")
+        val dogDbCount = getDogDbCount(virtualNodeInfo.vaultDmlConnectionId, dogDBTable = "versionedDog")
         assertEquals(1, dogDbCount)
         // check timestamp 1
-        val dogVersion1 = getDogVersionFromDb(virtualNodeInfo.vaultDmlConnectionId)
+        val dogVersion1 = getDogDbVersion(virtualNodeInfo.vaultDmlConnectionId)
 
         // duplicate update request
         processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), mergeEntityRequest)))
         // check we update same dog
-        val dogDbCount2 = dogDbCount(virtualNodeInfo.vaultDmlConnectionId, dogDBTable = "versionedDog")
+        val dogDbCount2 = getDogDbCount(virtualNodeInfo.vaultDmlConnectionId, dogDBTable = "versionedDog")
         assertEquals(1, dogDbCount2)
         // check timestamp 2
-        val dogVersion2 = getDogVersionFromDb(virtualNodeInfo.vaultDmlConnectionId)
+        val dogVersion2 = getDogDbVersion(virtualNodeInfo.vaultDmlConnectionId)
         assertEquals(dogVersion1, dogVersion2)
     }
 
@@ -440,7 +440,7 @@ class PersistenceExceptionTests {
         }
     }
 
-    private fun dogDbCount(connectionId: UUID, dogDBTable: String = "dog"): Int =
+    private fun getDogDbCount(connectionId: UUID, dogDBTable: String = "dog"): Int =
         dbConnectionManager
             .getDataSource(connectionId).connection.use { connection ->
                 connection.prepareStatement("SELECT count(*) FROM $dogDBTable").use {
@@ -453,7 +453,7 @@ class PersistenceExceptionTests {
                 }
             }
 
-    private fun getDogVersionFromDb(connectionId: UUID): Int =
+    private fun getDogDbVersion(connectionId: UUID): Int =
         dbConnectionManager
             .getDataSource(connectionId).connection.use { connection ->
                 connection.prepareStatement("SELECT version FROM versionedDog").use {

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -332,14 +332,12 @@ class PersistenceExceptionTests {
         val serialisedDog = sandbox.getSerializationService().serialize(dog).bytes
 
         // create persist request for the sandbox that isn't dog-aware
-        val requestId = UUID.randomUUID().toString()
-        val flowId = UUID.randomUUID().toString()
         return EntityRequest(
             virtualNodeInfo.holdingIdentity.toAvro(),
             PersistEntities(listOf(ByteBuffer.wrap(serialisedDog))),
             ExternalEventContext(
-                requestId,
-                flowId,
+                UUID.randomUUID().toString(),
+                UUID.randomUUID().toString(),
                 KeyValuePairList(
                     cpkFileHashes.map { KeyValuePair(CPK_FILE_CHECKSUM, it.toString()) }
                 )

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -252,14 +252,6 @@ class PersistenceExceptionTests {
         createDogDb()
         val persistEntitiesRequest = createEntityRequest()
 
-        val entitySandboxService =
-            EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
-                cpkReadService,
-                virtualNodeInfoReadService,
-                dbConnectionManager
-            )
-
         val processor = EntityMessageProcessor(
             currentSandboxGroupContext,
             entitySandboxService,
@@ -282,14 +274,6 @@ class PersistenceExceptionTests {
     fun `on duplicate persistence request don't execute it - without PK constraint does not add duplicate DB entry`() {
         createDogDb(DOGS_TABLE_WITHOUT_PK)
         val persistEntitiesRequest = createEntityRequest()
-
-        val entitySandboxService =
-            EntitySandboxServiceFactory().create(
-                virtualNode.sandboxGroupContextComponent,
-                cpkReadService,
-                virtualNodeInfoReadService,
-                dbConnectionManager
-            )
 
         val processor = EntityMessageProcessor(
             currentSandboxGroupContext,

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -302,21 +302,21 @@ class PersistenceExceptionTests {
         // duplicate request
         val record2 = processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), persistEntitiesRequest)))
         assertNull(((record2.single().value as FlowEvent).payload as ExternalEventResponse).error)
-        // There shouldn't be a dog duplicate entry in the DB, i.e. dogs count in the DB should still be 1
-        assertEquals(1,
-            dbConnectionManager
-                .getDataSource(animalDbConnection!!.first).connection.use {
-                    it.prepareStatement("SELECT count(*) FROM dog").use {
-                        it.executeQuery().use { rs ->
-                            if (!rs.next()) {
-                                throw IllegalStateException("Should be able to find at least 1 dog entry")
-                            }
-                            val dogCount = rs.getInt(1)
-                            dogCount
+
+        val dogCount = dbConnectionManager
+            .getDataSource(animalDbConnection!!.first).connection.use {
+                it.prepareStatement("SELECT count(*) FROM dog").use {
+                    it.executeQuery().use { rs ->
+                        if (!rs.next()) {
+                            throw IllegalStateException("Should be able to find at least 1 dog entry")
                         }
+                        rs.getInt(1)
                     }
                 }
-        )
+            }
+
+        // There shouldn't be a dog duplicate entry in the DB, i.e. dogs count in the DB should still be 1
+        assertEquals(1, dogCount)
     }
 
     private fun noOpPayloadCheck(bytes: ByteBuffer) = bytes

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -139,7 +139,7 @@ class PersistenceExceptionTests {
 
     @Test
     fun `exception raised when cpks not present`() {
-        val ignoredRequest = createEntityRequest()
+        val ignoredRequest = createDogPersistRequest()
 
         val processor = EntityMessageProcessor(
             currentSandboxGroupContext,
@@ -170,7 +170,7 @@ class PersistenceExceptionTests {
 
     @Test
     fun `exception raised when vnode cannot be found`() {
-        val ignoredRequest = createEntityRequest()
+        val ignoredRequest = createDogPersistRequest()
 
         val brokenVirtualNodeInfoReadService = object :
             VirtualNodeInfoReadService by virtualNodeInfoReadService {
@@ -209,7 +209,7 @@ class PersistenceExceptionTests {
 
     @Test
     fun `exception raised when sent a missing command`() {
-        val oldRequest = createEntityRequest()
+        val oldRequest = createDogPersistRequest()
         val unknownCommand = ExceptionEnvelope("", "") // Any Avro object, or null works here.
 
         val vNodeInfo = virtualNodeInfoReadService.get(oldRequest.holdingIdentity.toCorda())!!
@@ -252,7 +252,7 @@ class PersistenceExceptionTests {
     @Test
     fun `on duplicate persistence request don't execute it - with PK constraint does not throw PK violation`() {
         createDogDb()
-        val persistEntitiesRequest = createEntityRequest()
+        val persistEntitiesRequest = createDogPersistRequest()
 
         val processor = EntityMessageProcessor(
             currentSandboxGroupContext,
@@ -275,7 +275,7 @@ class PersistenceExceptionTests {
     @Test
     fun `on duplicate persistence request don't execute it - without PK constraint does not add duplicate DB entry`() {
         createDogDb(DOGS_TABLE_WITHOUT_PK)
-        val persistEntitiesRequest = createEntityRequest()
+        val persistEntitiesRequest = createDogPersistRequest()
 
         val processor = EntityMessageProcessor(
             currentSandboxGroupContext,
@@ -374,7 +374,7 @@ class PersistenceExceptionTests {
     /**
      * Create a simple request and return it.
      */
-    private fun createEntityRequest(): EntityRequest {
+    private fun createDogPersistRequest(): EntityRequest {
         val cpkFileHashes = cpiInfoReadService.getCpkFileHashes(virtualNodeInfo)
         val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
         // create dog using dog-aware sandbox

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -20,6 +20,8 @@ import net.corda.db.persistence.testkit.fake.FakeDbConnectionManager
 import net.corda.db.persistence.testkit.helpers.Resources
 import net.corda.db.persistence.testkit.helpers.SandboxHelper.createDog
 import net.corda.db.persistence.testkit.helpers.SandboxHelper.createVersionedDog
+import net.corda.db.persistence.testkit.helpers.SandboxHelper.getDogClass
+import net.corda.db.persistence.testkit.helpers.SandboxHelper.getVersionedDogClass
 import net.corda.entityprocessor.impl.internal.EntityMessageProcessor
 import net.corda.flow.external.events.responses.exceptions.CpkNotAvailableException
 import net.corda.flow.external.events.responses.exceptions.VirtualNodeException
@@ -378,19 +380,18 @@ class PersistenceExceptionTests {
     }
 
     private fun createDogDb(liquibaseScript: String = DOGS_TABLE) {
-        val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
-        val dog = sandbox.createDog("Stray", owner = "Not Known").instance
-        createDb(liquibaseScript, dog)
+        val sandboxGroupContext = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
+        val dogClass = sandboxGroupContext.sandboxGroup.getDogClass()
+        createDb(liquibaseScript, dogClass)
     }
 
     private fun createVersionedDogDb() {
-        val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
-        val versionedDog = sandbox.createVersionedDog("Stray", owner = "Not Known")
+        val sandboxGroupContext = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
+        val versionedDog = sandboxGroupContext.sandboxGroup.getVersionedDogClass()
         createDb(VERSIONED_DOGS_TABLE, versionedDog)
     }
 
-    private fun createDb(liquibaseScript: String, entity: Any) {
-        val entityClass = entity::class.java
+    private fun createDb(liquibaseScript: String, entityClass: Class<*>) {
         val cl = ClassloaderChangeLog(
             linkedSetOf(
                 ClassloaderChangeLog.ChangeLogResourceFiles(

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -351,24 +351,14 @@ class PersistenceExceptionTests {
 
         val dog = sandbox.createDog("Stray", owner = "Not Known").instance
 
-        createDBTables(
-            dog::class.java,
-            dbConnectionManager.getDataSource(virtualNodeInfo.vaultDmlConnectionId),
-            liquibaseScript
-        )
-    }
-
-    private fun createDBTables(
-        clazz: Class<*>,
-        ds: DataSource,
-        liquibaseScript: String
-    ) {
+        val dogClass = dog::class.java
+        val ds = dbConnectionManager.getDataSource(virtualNodeInfo.vaultDmlConnectionId)
         val cl = ClassloaderChangeLog(
             linkedSetOf(
                 ClassloaderChangeLog.ChangeLogResourceFiles(
-                    clazz.packageName,
+                    dogClass.packageName,
                     listOf(liquibaseScript),
-                    clazz.classLoader
+                    dogClass.classLoader
                 )
             )
         )

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -258,14 +258,11 @@ class PersistenceExceptionTests {
 
         val record1 = processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), persistEntitiesRequest)))
         assertNull(((record1.single().value as FlowEvent).payload as ExternalEventResponse).error)
-        println(record1)
-
         // duplicate request
         val record2 = processor.onNext(listOf(Record(TOPIC, UUID.randomUUID().toString(), persistEntitiesRequest)))
         // The below should not contain a PK violation error as it should be identified it is the same persistence request
         // and therefore not executed
         assertNull(((record2.single().value as FlowEvent).payload as ExternalEventResponse).error)
-        println(record2)
     }
 
     private fun noOpPayloadCheck(bytes: ByteBuffer) = bytes

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -73,7 +73,7 @@ class PersistenceExceptionTests {
         const val TOPIC = "pretend-topic"
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
-        const val DOGS_TABLE_WITH_PK = "migration/db.changelog-master.xml"
+        const val DOGS_TABLE = "migration/db.changelog-master.xml"
         const val DOGS_TABLE_WITHOUT_PK = "dogs-without-pk.xml"
     }
 
@@ -347,7 +347,7 @@ class PersistenceExceptionTests {
         )
     }
 
-    private fun createDogDb(liquibaseScript: String = DOGS_TABLE_WITH_PK) {
+    private fun createDogDb(liquibaseScript: String = DOGS_TABLE) {
         val cpkFileHashes = cpiInfoReadService.getCpkFileHashes(virtualNodeInfo)
         val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
 

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -350,36 +350,23 @@ class PersistenceExceptionTests {
         // create dog using dog-aware sandbox
         val dog = sandbox.createVersionedDog("Stray", owner = "Not Known")
         val serialisedDog = sandbox.getSerializationService().serialize(dog).bytes
-
-        // create persist request for the sandbox that isn't dog-aware
-        val requestId = UUID.randomUUID().toString()
-        return EntityRequest(
-            virtualNodeInfo.holdingIdentity.toAvro(),
-            PersistEntities(listOf(ByteBuffer.wrap(serialisedDog))),
-            ExternalEventContext(
-                requestId,
-                "flow id",
-                KeyValuePairList(
-                    cpkFileHashes.map { KeyValuePair(CPK_FILE_CHECKSUM, it.toString()) }
-                )
-            )
-        )
+        return createPersistEntitiesRequest(listOf(ByteBuffer.wrap(serialisedDog)))
     }
 
-    /**
-     * Create a simple request and return it.
-     */
     private fun createDogPersistRequest(): EntityRequest {
         val sandbox = entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
         // create dog using dog-aware sandbox
         val dog = sandbox.createDog("Stray", owner = "Not Known").instance
         val serialisedDog = sandbox.getSerializationService().serialize(dog).bytes
+        return createPersistEntitiesRequest(listOf(ByteBuffer.wrap(serialisedDog)))
+    }
 
+    private fun createPersistEntitiesRequest(serializedEntities: List<ByteBuffer>): EntityRequest {
         // create persist request for the sandbox that isn't dog-aware
         val requestId = UUID.randomUUID().toString()
         return EntityRequest(
             virtualNodeInfo.holdingIdentity.toAvro(),
-            PersistEntities(listOf(ByteBuffer.wrap(serialisedDog))),
+            PersistEntities(serializedEntities),
             ExternalEventContext(
                 requestId,
                 "flow id",

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -303,7 +303,7 @@ class PersistenceExceptionTests {
         assertNull(((record2.single().value as FlowEvent).payload as ExternalEventResponse).error)
 
         val dogCount = dbConnectionManager
-            .getDataSource(animalDbConnection!!.first).connection.use {
+            .getDataSource(virtualNodeInfo.vaultDmlConnectionId).connection.use {
                 it.prepareStatement("SELECT count(*) FROM dog").use {
                     it.executeQuery().use { rs ->
                         if (!rs.next()) {
@@ -318,8 +318,6 @@ class PersistenceExceptionTests {
     }
 
     private fun noOpPayloadCheck(bytes: ByteBuffer) = bytes
-
-    private var animalDbConnection: Pair<UUID, String>? = null
 
     private var dogClass: Class<*>? = null
 

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -318,7 +318,8 @@ class PersistenceExceptionTests {
                 )
             )
         )
-
-        lbm.updateDb(ds.connection, cl)
+        ds.connection.use {
+            lbm.updateDb(it, cl)
+        }
     }
 }

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -303,8 +303,8 @@ class PersistenceExceptionTests {
         assertNull(((record2.single().value as FlowEvent).payload as ExternalEventResponse).error)
 
         val dogCount = dbConnectionManager
-            .getDataSource(virtualNodeInfo.vaultDmlConnectionId).connection.use {
-                it.prepareStatement("SELECT count(*) FROM dog").use {
+            .getDataSource(virtualNodeInfo.vaultDmlConnectionId).connection.use { connection ->
+                connection.prepareStatement("SELECT count(*) FROM dog").use {
                     it.executeQuery().use { rs ->
                         if (!rs.next()) {
                             throw IllegalStateException("Should be able to find at least 1 dog entry")

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -352,7 +352,6 @@ class PersistenceExceptionTests {
         val dog = sandbox.createDog("Stray", owner = "Not Known").instance
 
         val dogClass = dog::class.java
-        val ds = dbConnectionManager.getDataSource(virtualNodeInfo.vaultDmlConnectionId)
         val cl = ClassloaderChangeLog(
             linkedSetOf(
                 ClassloaderChangeLog.ChangeLogResourceFiles(
@@ -362,6 +361,7 @@ class PersistenceExceptionTests {
                 )
             )
         )
+        val ds = dbConnectionManager.getDataSource(virtualNodeInfo.vaultDmlConnectionId)
         ds.connection.use {
             lbm.updateDb(it, cl)
         }

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -249,7 +249,7 @@ class PersistenceExceptionTests {
             "It should be re-enabled after deduplication work is done in epic CORE-5909")
     @Test
     fun `on duplicate persistence request don't execute it - with PK constraint does not throw PK violation`() {
-        val (dbConnectionManager, persistEntitiesRequest) = setupExceptionHandlingTests()
+        val persistEntitiesRequest = createEntityRequest()
 
         val entitySandboxService =
             EntitySandboxServiceFactory().create(
@@ -279,8 +279,7 @@ class PersistenceExceptionTests {
             "It should be re-enabled after deduplication work is done in epic CORE-5909")
     @Test
     fun `on duplicate persistence request don't execute it - without PK constraint does not add duplicate DB entry`() {
-        val (dbConnectionManager, persistEntitiesRequest) =
-            setupExceptionHandlingTests(DOGS_TABLE_WITHOUT_PK)
+        val persistEntitiesRequest = createEntityRequest(DOGS_TABLE_WITHOUT_PK)
 
         val entitySandboxService =
             EntitySandboxServiceFactory().create(

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -295,8 +295,8 @@ class PersistenceExceptionTests {
         assertEquals(1, dogDbCount)
     }
 
-//    @Disabled("This test is disabled for now because currently we do execute duplicate persistence requests." +
-//            "It should be re-enabled after deduplication work is done in epic CORE-5909")
+    @Disabled("This test is disabled for now because currently we do execute duplicate persistence requests." +
+            "It should be re-enabled after deduplication work is done in epic CORE-5909")
     @Test
     fun `on duplicate persistence request don't execute it - statically updatable field isn't getting updated in DB`() {
         createVersionedDogDb()

--- a/testing/bundles/testing-dogs/src/main/kotlin/com/r3/corda/testing/bundles/dogs/VersionedDog.kt
+++ b/testing/bundles/testing-dogs/src/main/kotlin/com/r3/corda/testing/bundles/dogs/VersionedDog.kt
@@ -1,0 +1,35 @@
+package com.r3.corda.testing.bundles.dogs
+
+import net.corda.v5.base.annotations.CordaSerializable
+import java.time.Instant
+import java.util.UUID
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+
+@CordaSerializable
+@Entity
+data class VersionedDog(
+    @get:Id
+    @get:Column
+    var id: UUID,
+
+    @Column
+    var name: String,
+
+    @Column
+    var birthdate: Instant,
+
+    @Column
+    var owner: String?
+) {
+    constructor() : this(id = UUID.randomUUID(), name = "", birthdate = Instant.now(), owner = "")
+
+    // The below doesn't make sense because it is per process only. It is only added in an attempt to
+    // trigger an `entityManager.merge` to emit an UPDATE sql statement when no other state of the entity has changed
+    // compared to its mapped DB state.
+    @Column
+    var version: Int = globalVersion++
+}
+
+var globalVersion = 0

--- a/testing/bundles/testing-dogs/src/main/resources/dogs-without-pk.xml
+++ b/testing/bundles/testing-dogs/src/main/resources/dogs-without-pk.xml
@@ -1,0 +1,16 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="R3.Corda" id="dogs-without-pk">
+        <createTable tableName="dog">
+            <column name="id" type="uuid">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="birthdate" type="DATETIME"/>
+            <column name="owner" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/testing/bundles/testing-dogs/src/main/resources/versioned-dogs.xml
+++ b/testing/bundles/testing-dogs/src/main/resources/versioned-dogs.xml
@@ -1,0 +1,18 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="R3.Corda" id="versioned-dogs">
+        <createTable tableName="versionedDog">
+            <column name="id" type="uuid">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="birthdate" type="DATETIME"/>
+            <column name="owner" type="VARCHAR(255)"/>
+            <column name="version" type="BIGINT"/>
+        </createTable>
+        <addPrimaryKey columnNames="id" constraintName="dog_id" tableName="versionedDog"/>
+    </changeSet>
+</databaseChangeLog>

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -9,6 +9,7 @@ import net.corda.db.schema.CordaDb
 import net.corda.db.testkit.DbUtils
 import net.corda.libs.configuration.SmartConfig
 import net.corda.orm.DbEntityManagerConfiguration
+import net.corda.orm.DdlManage
 import net.corda.orm.EntityManagerFactoryFactory
 import net.corda.orm.JpaEntitiesSet
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
@@ -49,7 +50,10 @@ class FakeDbConnectionManager(
         return emff.create(
             source.name,
             entitiesSet.classes.toList(),
-            DbEntityManagerConfiguration(source.dataSource),
+            DbEntityManagerConfiguration(
+                source.dataSource,
+                ddlManage = DdlManage.CREATE
+            ),
         )
     }
 

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -9,7 +9,6 @@ import net.corda.db.schema.CordaDb
 import net.corda.db.testkit.DbUtils
 import net.corda.libs.configuration.SmartConfig
 import net.corda.orm.DbEntityManagerConfiguration
-import net.corda.orm.DdlManage
 import net.corda.orm.EntityManagerFactoryFactory
 import net.corda.orm.JpaEntitiesSet
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -50,10 +50,7 @@ class FakeDbConnectionManager(
         return emff.create(
             source.name,
             entitiesSet.classes.toList(),
-            DbEntityManagerConfiguration(
-                source.dataSource,
-                ddlManage = DdlManage.CREATE
-            ),
+            DbEntityManagerConfiguration(source.dataSource),
         )
     }
 

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/helpers/SandboxHelper.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/helpers/SandboxHelper.kt
@@ -14,6 +14,7 @@ import java.util.UUID
  */
 object SandboxHelper {
     const val DOG_CLASS_NAME = "com.r3.corda.testing.bundles.dogs.Dog"
+    const val VERSIONED_DOG_CLASS_NAME = "com.r3.corda.testing.bundles.dogs.VersionedDog"
     const val CAT_CLASS_NAME = "com.r3.corda.testing.bundles.cats.Cat"
     const val CAT_KEY_CLASS_NAME = "com.r3.corda.testing.bundles.cats.CatKey"
 
@@ -46,6 +47,17 @@ object SandboxHelper {
             .getDeclaredConstructor(UUID::class.java, String::class.java, Instant::class.java, String::class.java)
         val instance = dogCtor.newInstance(id, name, date, owner)
         return Box(instance, id)
+    }
+
+    fun SandboxGroupContext.createVersionedDog(
+        name: String = "Lassie",
+        id: UUID = UUID.randomUUID(),
+        date: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+        owner: String? = "me"
+    ): Any {
+        val dogCtor = this.sandboxGroup.loadClassFromMainBundles(VERSIONED_DOG_CLASS_NAME)
+            .getDeclaredConstructor(UUID::class.java, String::class.java, Instant::class.java, String::class.java)
+        return dogCtor.newInstance(id, name, date, owner)
     }
 
     fun SandboxGroupContext.createCatKeyInstance(id: UUID, name: String): Any {

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/helpers/SandboxHelper.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/helpers/SandboxHelper.kt
@@ -23,6 +23,10 @@ object SandboxHelper {
         return this.loadClassFromMainBundles(DOG_CLASS_NAME)
     }
 
+    fun SandboxGroup.getVersionedDogClass(): Class<*> {
+        return this.loadClassFromMainBundles(VERSIONED_DOG_CLASS_NAME)
+    }
+
     fun SandboxGroup.getCatKeyClass(): Class<*> {
         return this.loadClassFromMainBundles(CAT_KEY_CLASS_NAME)
     }
@@ -55,7 +59,7 @@ object SandboxHelper {
         date: Instant = Instant.now().truncatedTo(ChronoUnit.MILLIS),
         owner: String? = "me"
     ): Any {
-        val dogCtor = this.sandboxGroup.loadClassFromMainBundles(VERSIONED_DOG_CLASS_NAME)
+        val dogCtor = this.sandboxGroup.getVersionedDogClass()
             .getDeclaredConstructor(UUID::class.java, String::class.java, Instant::class.java, String::class.java)
         return dogCtor.newInstance(id, name, date, owner)
     }


### PR DESCRIPTION
Adds tests around `EntityMessageProcessor` (it's responsible for processing Cordapp persistence requests) re-producing the following issues caused from retrying persistence requests (i.e. from processing duplicate persistence requests):

- duplicate `PersistEntities` request against table having PK (unique constraint) leading to PK violation.
- duplicate `PersistEntities` request against table not having unique constraint leading to duplicate entry(ies) in the DB.
- duplicate `MergeEntities` request leading to field updated statically being updated to the DB as well.