### PR TITLE
CORE-13900 Throw more meaningful exception in toSignedTransaction() if the creator is not a signatory

### DIFF
--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/FakeTransactionSignatureService.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/FakeTransactionSignatureService.kt
@@ -4,11 +4,12 @@ import net.corda.crypto.core.SecureHashImpl
 import net.corda.ledger.common.flow.transaction.TransactionSignatureServiceInternal
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 import net.corda.v5.ledger.common.transaction.TransactionWithMetadata
 import java.security.MessageDigest
 import java.security.PublicKey
 
-private class FakeTransactionSignatureService: TransactionSignatureServiceInternal {
+private open class FakeTransactionSignatureService: TransactionSignatureServiceInternal {
     override fun sign(
         transaction: TransactionWithMetadata,
         publicKeys: Iterable<PublicKey>
@@ -32,7 +33,20 @@ private class FakeTransactionSignatureService: TransactionSignatureServiceIntern
         MessageDigest.getInstance(digestAlgorithmName).digest(publicKey.encoded)
     )
 }
+private class FakeTransactionSignatureServiceNoKeysAvailable: FakeTransactionSignatureService() {
+    override fun sign(
+        transaction: TransactionWithMetadata,
+        publicKeys: Iterable<PublicKey>
+    ): List<DigitalSignatureAndMetadata> =
+        throw TransactionNoAvailableKeysException(
+            "The publicKeys do not have any private counterparts available.",
+            null
+        )
+}
 
 fun fakeTransactionSignatureService(): TransactionSignatureServiceInternal {
     return FakeTransactionSignatureService()
+}
+fun fakeTransactionSignatureServiceNoKeysAvailable(): TransactionSignatureServiceInternal {
+    return FakeTransactionSignatureServiceNoKeysAvailable()
 }

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -31,10 +31,10 @@ import org.mockito.kotlin.whenever
 
 abstract class UtxoLedgerTest : CommonLedgerTest() {
     private val mockUtxoLedgerPersistenceService = mock<UtxoLedgerPersistenceService>()
-    private val mockUtxoLedgerTransactionVerificationService = mock<UtxoLedgerTransactionVerificationService>()
-    private val mockUtxoLedgerGroupParametersPersistenceService = mock<UtxoLedgerGroupParametersPersistenceService>()
-    private val mockCurrentGroupParametersService = mockCurrentGroupParametersService()
-    private val mockSignedGroupParametersVerifier = mock<SignedGroupParametersVerifier>()
+    val mockUtxoLedgerTransactionVerificationService = mock<UtxoLedgerTransactionVerificationService>()
+    val mockUtxoLedgerGroupParametersPersistenceService = mock<UtxoLedgerGroupParametersPersistenceService>()
+    val mockCurrentGroupParametersService = mockCurrentGroupParametersService()
+    val mockSignedGroupParametersVerifier = mock<SignedGroupParametersVerifier>()
 
     val mockUtxoLedgerStateQueryService = mock<UtxoLedgerStateQueryService>()
     val mockCurrentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
@@ -64,7 +64,7 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
             serializationServiceWithWireTx
         ), serializationServiceWithWireTx
     )
-    private val utxoLedgerTransactionFactory = UtxoLedgerTransactionFactoryImpl(
+    val utxoLedgerTransactionFactory = UtxoLedgerTransactionFactoryImpl(
         serializationServiceWithWireTx,
         mockUtxoLedgerStateQueryService
     )


### PR DESCRIPTION
Throw `CordaRuntimeException("Creator of the transaction does not own any signatory keys.")` instead of `TransactionNoAvailableKeysException` when TransactionBuilder's toSignedTransaction() gets called and the caller is not a signatory.