### PR TITLE
ES-651: Fix Composite Build for 5.1 stream

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -234,7 +234,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         if (useDaemon.get()) {
             logger.info("Daemon available")
             def imageName = "${baseImageTag.get().empty ? baseImageName.get() : "${baseImageName.get()}:${baseImageTag.get()}"}"
-            if (imageName.endsWith("latest-local-${cordaProductVersion }") {
+            if (imageName.endsWith("latest-local-${cordaProductVersion}")) {
                 logger.info("Resolving base image ${baseImageName.get()}:${baseImageTag.get()} from local Docker daemon")
                 builder = Jib.from(DockerDaemonImage.named(imageName))
             } else if (imageName.contains("software.r3.com")) {

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -234,7 +234,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
         if (useDaemon.get()) {
             logger.info("Daemon available")
             def imageName = "${baseImageTag.get().empty ? baseImageName.get() : "${baseImageName.get()}:${baseImageTag.get()}"}"
-            if (imageName.endsWith("-local")) {
+            if (imageName.endsWith("latest-local-${cordaProductVersion }") {
                 logger.info("Resolving base image ${baseImageName.get()}:${baseImageTag.get()} from local Docker daemon")
                 builder = Jib.from(DockerDaemonImage.named(imageName))
             } else if (imageName.contains("software.r3.com")) {


### PR DESCRIPTION
As part of enabling composite build for release 5.1, we made changes to the DeployableContainerBuilder.groovy file to be able to read Docker images correctly. This will fix a image naming issue as previous implementation wasn't able to identifier the correct path for the image.

**Tested**
https://ci02.dev.r3.com/job/Corda5/job/Open-Sourcing/job/Release_Branch/job/Corda_Composite_Build_5.1/45/