### PR TITLE
CORE-9470: Remove nullable from parameter that is never null

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowMessageFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowMessageFactory.kt
@@ -51,5 +51,5 @@ interface FlowMessageFactory {
      * @param details about flow termination
      * @return a new instance of a [FlowStatus] record.
      */
-    fun createFlowKilledStatusMessage(checkpoint: FlowCheckpoint, message: String?): FlowStatus
+    fun createFlowKilledStatusMessage(checkpoint: FlowCheckpoint, message: String): FlowStatus
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowMessageFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowMessageFactoryImpl.kt
@@ -42,10 +42,10 @@ class FlowMessageFactoryImpl(private val currentTimeProvider: () -> Instant) : F
         }
     }
 
-    override fun createFlowKilledStatusMessage(checkpoint: FlowCheckpoint, message: String?): FlowStatus {
+    override fun createFlowKilledStatusMessage(checkpoint: FlowCheckpoint, message: String): FlowStatus {
         return getCommonFlowStatus(checkpoint).apply {
             flowStatus = FlowStates.KILLED
-            message?.let { processingTerminatedReason = it }
+            processingTerminatedReason = message
         }
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -290,7 +290,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             }
     }
 
-    private fun createFlowKilledStatusRecord(checkpoint: FlowCheckpoint, message: String?): List<Record<*, *>> {
+    private fun createFlowKilledStatusRecord(checkpoint: FlowCheckpoint, message: String): List<Record<*, *>> {
         return createStatusRecord(checkpoint.flowId) {
             flowMessageFactory.createFlowKilledStatusMessage(checkpoint, message)
         }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -22,6 +22,7 @@ import net.corda.rest.server.impl.internal.ParameterRetrieverFactory
 import net.corda.rest.server.impl.internal.ParametersRetrieverContext
 import net.corda.rest.server.impl.security.RestAuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.CredentialResolver
+import net.corda.tracing.currentTraceId
 import net.corda.utilities.debug
 import net.corda.utilities.trace
 import net.corda.utilities.withMDC
@@ -127,6 +128,7 @@ internal object ContextUtils {
                     ctx.buildJsonResult(result, this.method.method.returnType)
 
                     ctx.header(Header.CACHE_CONTROL, "no-cache")
+                    ctx.header("X-B3-TraceId", currentTraceId())
                     methodLogger.debug { "Invoke method \"${this.method.method.name}\" for route info completed." }
                 } catch (e: Exception) {
                     "Error invoking path '${this.fullPath}' - ${e.message}".let {

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/TraceThis.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/TraceThis.kt
@@ -71,6 +71,8 @@ fun addTraceContextToRecord(it: CordaProducerRecord<*, *>): CordaProducerRecord<
     return it.copy(headers = TracingState.currentTraceService.addTraceHeaders(it.headers))
 }
 
+fun currentTraceId() = TracingState.currentTraceService.getCurrentTraceId()
+
 fun traceSend(
     headers: List<Pair<String,String>>,
     operationName: String

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/TracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/TracingService.kt
@@ -26,5 +26,7 @@ interface TracingService : AutoCloseable {
     fun getTracedServletFilter(): Filter
 
     fun traceBatch(operationName: String): BatchRecordTracer
+
+    fun getCurrentTraceId(): String
 }
 

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/impl/BraveTracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/impl/BraveTracingService.kt
@@ -129,6 +129,8 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
         tracing.tracer()
     }
 
+    override fun getCurrentTraceId(): String = tracer.currentSpan().context().traceIdString()
+
     private val recordInjector by lazy {
         tracing.propagation().injector { param: MutableList<Pair<String, String>>, key: String, value: String ->
             param.removeAll { it.first == key }

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/impl/NoopTracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/impl/NoopTracingService.kt
@@ -119,6 +119,10 @@ class NoopTracingService : TracingService {
         return NoopBatchRecordTracer()
     }
 
+    override fun getCurrentTraceId(): String {
+        return ""
+    }
+
     override fun close() {
     }
 }

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/testflows/TestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/testflows/TestFlow.kt
@@ -1,5 +1,7 @@
 package com.r3.corda.testing.testflows
 
+import com.r3.corda.testing.testflows.messages.TestFlowInput
+import com.r3.corda.testing.testflows.messages.TestFlowOutput
 import net.corda.v5.application.flows.ClientRequestBody
 import net.corda.v5.application.flows.ClientStartableFlow
 import net.corda.v5.application.flows.CordaInject
@@ -8,8 +10,6 @@ import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import com.r3.corda.testing.testflows.messages.TestFlowInput
-import com.r3.corda.testing.testflows.messages.TestFlowOutput
 import org.slf4j.LoggerFactory
 
 /**

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/testflows/WaitAMinuteFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/testflows/WaitAMinuteFlow.kt
@@ -1,0 +1,15 @@
+package com.r3.corda.testing.testflows
+
+import net.corda.v5.application.flows.ClientRequestBody
+import net.corda.v5.application.flows.ClientStartableFlow
+import net.corda.v5.base.annotations.Suspendable
+import kotlin.time.Duration.Companion.seconds
+
+class WaitAMinuteFlow : ClientStartableFlow {
+    @Suspendable
+    override fun call(requestBody: ClientRequestBody): String {
+        // Sleep for 1 minute but wake often to give flow worker a chance to stop the flow
+        repeat(60) { Thread.sleep(1.seconds.inWholeMilliseconds) }
+        return "Minute"
+    }
+}


### PR DESCRIPTION
The `message` parameter of `createFlowKilledStatusMessage` is always set.