### PR TITLE
ES-1123: Build the project using k8s pod rather than full EC2 instance

### DIFF
--- a/.ci/nightly/JenkinsfileUnstableTests
+++ b/.ci/nightly/JenkinsfileUnstableTests
@@ -1,7 +1,7 @@
 //catch all job for flaky tests
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
-cordaPipeline(
+cordaPipelineKubernetesAgent(
     runIntegrationTests: true,
     createPostgresDb: true,
     gradleAdditionalArgs: '-PrunUnstableTests',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
-cordaPipeline(
+cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',
     runIntegrationTests: true,
     createPostgresDb: true,


### PR DESCRIPTION
Migrate to use cordaPipelineKubernetesAgent.groovy

- Functionally identical except for the fact we now build in a k8s pod, thus using less cloud resource as each build no longer needs a full EC2 instance
- No application-level change as part of this PR , this only effects infra this project is built on