### PR TITLE
CORE-16216 - Member is able to re-register when MGM is on 5.0 platform

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -108,7 +108,6 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.base.versioning.Version
 import net.corda.v5.crypto.SignatureSpec
-import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toAvro
@@ -474,6 +473,7 @@ class DynamicMemberRegistrationService @Activate constructor(
          * If submitted serial or member's current serial suggests re-registration attempt,
          * we will mark their request as INVALID.
          */
+        @Suppress("ComplexCondition")
         private fun verifyReRegistrationIsEnabled(
             submittedSerial: Long,
             currentSerial: Long?,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -480,8 +480,8 @@ class DynamicMemberRegistrationService @Activate constructor(
             mgmPlatformVersion: Int,
         ) {
             if ((submittedSerial > 0 || (currentSerial != null && currentSerial > 0)) && mgmPlatformVersion < 50100) {
-                throw InvalidMembershipRegistrationException("MGM is on 5.0 platform. " +
-                        "Re-registration is not supported.")
+                throw InvalidMembershipRegistrationException("MGM is on a lower version where re-registration " +
+                        "is not supported.")
             }
         }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -1140,7 +1140,7 @@ class DynamicMemberRegistrationServiceTest {
         }
 
         @Test
-        fun `re-registration fails when MGM is on 50000 platform - serial from request is incorrect and would let re-registration happen`() {
+        fun `re-registration fails when MGM is on 50000 platform - serial in request is incorrect and would let re-registration`() {
             val mgmInfo = mock<MemberInfo> {
                 on { mgmProvidedContext } doReturn mock()
                 on { memberProvidedContext } doReturn mock()

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -171,6 +171,7 @@ class DynamicMemberRegistrationServiceTest {
         on { name } doReturn mgmName
         on { groupId } doReturn GROUP_NAME
         on { isMgm } doReturn true
+        on { platformVersion } doReturn 50100
     }
     private val memberName = MemberX500Name("Alice", "London", "GB")
     private val member = HoldingIdentity(memberName, GROUP_NAME)
@@ -1085,6 +1086,89 @@ class DynamicMemberRegistrationServiceTest {
                 registrationService.register(registrationResultId, member, newContext.toMap())
             }
             assertThat(exception).hasMessageContaining("cannot be added, removed or updated")
+        }
+
+        @Test
+        fun `re-registration fails when MGM is on 50000 platform - request contains serial`() {
+            val mgmInfo = mock<MemberInfo> {
+                on { mgmProvidedContext } doReturn mock()
+                on { memberProvidedContext } doReturn mock()
+                on { isMgm } doReturn true
+                on { platformVersion } doReturn 50000
+            }
+            whenever(groupReader.lookup()).doReturn(listOf(mgmInfo))
+
+            postConfigChangedEvent()
+            registrationService.start()
+
+            val contextWithInvalidSerial = context + mapOf(SERIAL to "2")
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, contextWithInvalidSerial)
+            }
+            assertThat(exception).hasMessageContaining("Re-registration is not supported.")
+        }
+
+        @Test
+        fun `re-registration fails when MGM is on 50000 platform - serial is from existing info`() {
+            val mgmInfo = mock<MemberInfo> {
+                on { mgmProvidedContext } doReturn mock()
+                on { memberProvidedContext } doReturn mock()
+                on { isMgm } doReturn true
+                on { platformVersion } doReturn 50000
+            }
+            whenever(groupReader.lookup()).doReturn(listOf(mgmInfo))
+
+            val previous = mock<MemberContext> {
+                on { entries } doReturn previousRegistrationContext.entries
+            }
+            val memberInfo = mock<MemberInfo> {
+                on { memberProvidedContext } doReturn previous
+                on { mgmProvidedContext } doReturn mock()
+                on { name } doReturn memberName
+                on { groupId } doReturn GROUP_NAME
+                on { serial } doReturn 1
+            }
+            whenever(groupReader.lookup(eq(memberName), any())).doReturn(memberInfo)
+
+            postConfigChangedEvent()
+            registrationService.start()
+
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, context)
+            }
+            assertThat(exception).hasMessageContaining("Re-registration is not supported.")
+        }
+
+        @Test
+        fun `re-registration fails when MGM is on 50000 platform - serial from request is incorrect and would let re-registration happen`() {
+            val mgmInfo = mock<MemberInfo> {
+                on { mgmProvidedContext } doReturn mock()
+                on { memberProvidedContext } doReturn mock()
+                on { isMgm } doReturn true
+                on { platformVersion } doReturn 50000
+            }
+            whenever(groupReader.lookup()).doReturn(listOf(mgmInfo))
+
+            val previous = mock<MemberContext> {
+                on { entries } doReturn previousRegistrationContext.entries
+            }
+            val memberInfo = mock<MemberInfo> {
+                on { memberProvidedContext } doReturn previous
+                on { mgmProvidedContext } doReturn mock()
+                on { name } doReturn memberName
+                on { groupId } doReturn GROUP_NAME
+                on { serial } doReturn 1
+            }
+            whenever(groupReader.lookup(eq(memberName), any())).doReturn(memberInfo)
+
+            postConfigChangedEvent()
+            registrationService.start()
+
+            val contextSuggestingInitialRegistration = context + mapOf(SERIAL to "0")
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, contextSuggestingInitialRegistration)
+            }
+            assertThat(exception).hasMessageContaining("Re-registration is not supported.")
         }
     }
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -1105,7 +1105,7 @@ class DynamicMemberRegistrationServiceTest {
             val exception = assertThrows<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, contextWithInvalidSerial)
             }
-            assertThat(exception).hasMessageContaining("Re-registration is not supported.")
+            assertThat(exception).hasMessageContaining("re-registration is not supported.")
         }
 
         @Test
@@ -1136,7 +1136,7 @@ class DynamicMemberRegistrationServiceTest {
             val exception = assertThrows<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, context)
             }
-            assertThat(exception).hasMessageContaining("Re-registration is not supported.")
+            assertThat(exception).hasMessageContaining("re-registration is not supported.")
         }
 
         @Test
@@ -1168,7 +1168,7 @@ class DynamicMemberRegistrationServiceTest {
             val exception = assertThrows<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, contextSuggestingInitialRegistration)
             }
-            assertThat(exception).hasMessageContaining("Re-registration is not supported.")
+            assertThat(exception).hasMessageContaining("re-registration is not supported.")
         }
     }
 


### PR DESCRIPTION
When MGM is on 5.0 and member is on 5.1 platform, the member can successfully re-register. Since re-registration is only available starting from 5.1, this scenario should be avoided and the re-registration attempt should be INVALID.

Testing:

1) Register MGM on 5.0 platform
2) Register Alice on 5.1 platform

Alice's view of initial registration request:
<img width="1691" alt="alice-registers" src="https://github.com/corda/corda-runtime-os/assets/61757742/9cfd9d70-a85c-4e96-b049-e802a1e67455">
MGM's view of initial registration request:
<img width="1699" alt="mgms-view-of-alices-request" src="https://github.com/corda/corda-runtime-os/assets/61757742/ef1b01bf-b245-4366-bd6b-14a6e07265b5">

3) Alice tries to re-register

Alice sees request as invalid:
<img width="1696" alt="alice-re-registers" src="https://github.com/corda/corda-runtime-os/assets/61757742/f2fdae35-b5b0-415c-9d29-491e0c242e02">
MGM won't receive the request:
<img width="1438" alt="mgm-wont-see-request" src="https://github.com/corda/corda-runtime-os/assets/61757742/8c3b05d0-4c38-48e6-8992-5e32e944c7c9">

4) Alice tries to pretend initial registration by manually setting the serial

Alice sees request as invalid:
<img width="1679" alt="pretend-initial-registration" src="https://github.com/corda/corda-runtime-os/assets/61757742/8144ab75-d37b-4ce9-9f1d-4dfc72013ec1">

