### PR TITLE
CORE-13893: Register sandbox eviction listener for StateAndRefCache.

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImpl.kt
@@ -42,6 +42,12 @@ class StateAndRefCacheImpl @Activate constructor(
         Caffeine.newBuilder().maximumSize(maximumSize)
     )
 
+    init {
+        if (!cacheEviction.addEvictionListener(SandboxGroupType.FLOW, ::onEviction)) {
+            log.error("FAILED TO ADD EVICTION LISTENER")
+        }
+    }
+
     override fun get(stateRefs: Set<StateRef>): Map<StateRef, StateAndRef<*>> {
         return if (stateRefs.isNotEmpty()) {
             val virtualNodeContext = currentSandboxGroupContext.get().virtualNodeContext


### PR DESCRIPTION
Register `onEviction` as a `FLOW` sandbox eviction listener, as otherwise it will never be invoked.