### PR TITLE
CORE-8657 - Added check that CPI version is valid

### DIFF
--- a/tools/plugins/package/build.gradle
+++ b/tools/plugins/package/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testImplementation "net.corda.cli.host:api:$pluginHostVersion"
     testImplementation "org.pf4j:pf4j:${pf4jVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter:${junit5Version}"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:${junit5Version}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation project(":testing:test-utilities")
     testImplementation project(":testing:packaging-test-utilities")

--- a/tools/plugins/package/build.gradle
+++ b/tools/plugins/package/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     testImplementation "net.corda.cli.host:api:$pluginHostVersion"
     testImplementation "org.pf4j:pf4j:${pf4jVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter:${junit5Version}"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
     testImplementation project(":testing:test-utilities")
     testImplementation project(":testing:packaging-test-utilities")
 

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
@@ -96,6 +96,8 @@ class CreateCpiV2 : Runnable {
 
         GroupPolicyValidator.validateGroupPolicy(groupPolicyString)
 
+        verifyCpiVersion()
+
         val cpbPath = cpbFileName?.let { requireFileExists(it) }
 
         // Check input Cpb file is indeed a Cpb
@@ -143,6 +145,15 @@ class CreateCpiV2 : Runnable {
             .trustedCerts(readCertificates(signingOptions.keyStoreFileName, signingOptions.keyStorePass))
             .build()
             .verify()
+    }
+
+    /**
+     * @throws IllegalArgumentException if Cpb version is invalid
+     */
+    private fun verifyCpiVersion() {
+        if (!cpiVersion.matches(".*[a-zA-Z0-9].*".toRegex())) {
+            throw IllegalArgumentException("CPI version should include at least one alphanumeric character")
+        }
     }
 
     /**

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
@@ -150,9 +150,11 @@ class CreateCpiV2 : Runnable {
     /**
      * @throws IllegalArgumentException if Cpi version is invalid
      */
+
     public fun verifyCpiVersion(version: String) {
         require(version.matches("[0-9][a-zA-Z0-9\\.-]*".toRegex())) {
-            "CPI version should match the Maven version specification (see https://maven.apache.org/pom.html#version-order-specification for more information)"
+            "CPI version should match the Maven version specification " +
+                    "(see https://maven.apache.org/pom.html#version-order-specification for more information)"
         }
     }
 

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
@@ -96,7 +96,7 @@ class CreateCpiV2 : Runnable {
 
         GroupPolicyValidator.validateGroupPolicy(groupPolicyString)
 
-        verifyCpiVersion()
+        require(cpiVersion.matches(".*[a-zA-Z0-9].*".toRegex())) { "CPI version should include at least one alphanumeric character" }
 
         val cpbPath = cpbFileName?.let { requireFileExists(it) }
 
@@ -145,15 +145,6 @@ class CreateCpiV2 : Runnable {
             .trustedCerts(readCertificates(signingOptions.keyStoreFileName, signingOptions.keyStorePass))
             .build()
             .verify()
-    }
-
-    /**
-     * @throws IllegalArgumentException if Cpb version is invalid
-     */
-    private fun verifyCpiVersion() {
-        if (!cpiVersion.matches(".*[a-zA-Z0-9].*".toRegex())) {
-            throw IllegalArgumentException("CPI version should include at least one alphanumeric character")
-        }
     }
 
     /**

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2.kt
@@ -96,7 +96,7 @@ class CreateCpiV2 : Runnable {
 
         GroupPolicyValidator.validateGroupPolicy(groupPolicyString)
 
-        require(cpiVersion.matches(".*[a-zA-Z0-9].*".toRegex())) { "CPI version should include at least one alphanumeric character" }
+        verifyCpiVersion(cpiVersion)
 
         val cpbPath = cpbFileName?.let { requireFileExists(it) }
 
@@ -145,6 +145,15 @@ class CreateCpiV2 : Runnable {
             .trustedCerts(readCertificates(signingOptions.keyStoreFileName, signingOptions.keyStorePass))
             .build()
             .verify()
+    }
+
+    /**
+     * @throws IllegalArgumentException if Cpi version is invalid
+     */
+    public fun verifyCpiVersion(version: String) {
+        require(version.matches("[0-9][a-zA-Z0-9\\.-]*".toRegex())) {
+            "CPI version should match the Maven version specification (see https://maven.apache.org/pom.html#version-order-specification for more information)"
+        }
     }
 
     /**

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
@@ -20,6 +20,8 @@ import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import picocli.CommandLine
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -275,27 +277,21 @@ class CreateCpiV2Test {
         )
     }
 
-    @Test
-    fun `cpi create tool aborts if cpi version is invalid`() {
+    @ParameterizedTest
+    @ValueSource(strings = arrayOf("1.%", "1.$", "1.#", "1.\\", "", "v1", "first version"))
+    fun `cpi create tool aborts if cpi version is invalid`(input: String) {
         val createTool = CreateCpiV2()
         assertFailsWith<IllegalArgumentException>(
             block = {
-                createTool.verifyCpiVersion("\$%#")
+                createTool.verifyCpiVersion(input)
             }
         )
+    }
 
-        assertFailsWith<IllegalArgumentException>(
-            block = {
-                createTool.verifyCpiVersion("")
-            }
-        )
-
-        createTool.verifyCpiVersion("1")
-        createTool.verifyCpiVersion("1.0-alpha")
-        createTool.verifyCpiVersion("2.5")
-        createTool.verifyCpiVersion("4-beta")
-        createTool.verifyCpiVersion("2.7-gamma")
-        createTool.verifyCpiVersion("21-delta-3")
-        createTool.verifyCpiVersion("0.1-epsilon-7")
+    @ParameterizedTest
+    @ValueSource(strings = arrayOf("1", "1.0-alpha", "2.5", "4-beta", "2.7-gamma", "21-delta-3", "0.1-epsilon-7"))
+    fun `cpi create tool succeeds if cpi version is valid`(input: String) {
+        val createTool = CreateCpiV2()
+        createTool.verifyCpiVersion(input)
     }
 }

--- a/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
+++ b/tools/plugins/package/src/test/kotlin/net/corda/cli/plugins/packaging/CreateCpiV2Test.kt
@@ -273,4 +273,26 @@ class CreateCpiV2Test {
                         "[\$.groupId: does not match the regex pattern")
         )
     }
+
+    @Test
+    fun `cpi create tool aborts if cpi version is invalid`() {
+        val outputFile = Path.of(tempDir.toString(), CPI_FILE_NAME)
+        val errText = TestUtils.captureStdErr {
+            CommandLine(CreateCpiV2()).execute (
+                "--cpb=${cpbPath}",
+                "--group-policy=${testGroupPolicy}",
+                "--cpi-name=testCpi",
+                "--cpi-version=\$%#",
+                "--file=$outputFile",
+                "--keystore=${testKeyStore}",
+                "--storepass=keystore password",
+                "--key=${SIGNING_KEY_1_ALIAS}",
+                "--sig-file=$CPI_SIGNER_NAME"
+            )
+        }
+
+        assertFalse(outputFile.exists())
+        assertTrue(errText.contains("CPI version should include at least one alphanumeric character")
+        )
+    }
 }


### PR DESCRIPTION
Prevents CLI users from creating a CPI where the CPI version contains only special characters.