### PR TITLE
ES-1152: Update Jenkinsfile to remove cron override and thus build 5.0 once per day not every 6 hours 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
 cordaPipelineKubernetesAgent(
-    dailyBuildCron: 'H H/6 * * *',
     runIntegrationTests: true,
     createPostgresDb: true,
     publishOSGiImage: true,


### PR DESCRIPTION
Now that 5.0 has been released and that branch is locked for all but critical patches, there is no need to build this project every 6 hours.

Removing the `dailyBuildCron` property here allows the project to fall back to the default set in the groovy class backing this file, cordaPipelineKubernetesAgent. Where the job will be executed once a day on a corn schedule at 7 am.

**Note, this change will not be patched forward** 