### PR TITLE
CORE-14685: Support for UTXO token cache.

### DIFF
--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/InMemoryEntityManagerConfiguration.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/InMemoryEntityManagerConfiguration.kt
@@ -48,6 +48,7 @@ open class InMemoryEntityManagerConfiguration(dbName: String) : EntityManagerCon
                 .applySqlFunction("JsonFieldAsObject", StandardSQLFunction("JsonFieldAsObject", STRING))
                 .applySqlFunction("JsonFieldAsText", StandardSQLFunction("JsonFieldAsText", STRING))
                 .applySqlFunction("HasJsonKey", StandardSQLFunction("HasJsonKey", BOOLEAN))
+                .applySqlFunction("REGEXP_MATCHES",  StandardSQLFunction("REGEXP_LIKE", BOOLEAN))
         }
     }
 }

--- a/testing/driver/driver-engine/build.gradle
+++ b/testing/driver/driver-engine/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':components:flow:flow-p2p-filter-service')
     implementation project(':components:flow:flow-service')
     implementation project(':components:ledger:ledger-persistence')
+    implementation project(':components:ledger:ledger-utxo-token-cache')
     implementation project(':components:ledger:ledger-verification')
     implementation project(':components:membership:group-policy')
     implementation project(':components:membership:membership-group-read')

--- a/testing/driver/driver-engine/src/main/java/net/corda/testing/driver/db/HsqldbJsonMetadataContributor.java
+++ b/testing/driver/driver-engine/src/main/java/net/corda/testing/driver/db/HsqldbJsonMetadataContributor.java
@@ -14,6 +14,7 @@ final class HsqldbJsonMetadataContributor implements MetadataBuilderContributor 
         metadataBuilder
             .applySqlFunction("JsonFieldAsObject", new StandardSQLFunction("JsonFieldAsObject", STRING))
             .applySqlFunction("JsonFieldAsText", new StandardSQLFunction("JsonFieldAsText", STRING))
-            .applySqlFunction("HasJsonKey", new StandardSQLFunction("HasJsonKey", BOOLEAN));
+            .applySqlFunction("HasJsonKey", new StandardSQLFunction("HasJsonKey", BOOLEAN))
+            .applySqlFunction("REGEXP_MATCHES", new StandardSQLFunction("REGEXP_LIKE", BOOLEAN));
     }
 }

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/db/DbConnectionManagerImpl.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/db/DbConnectionManagerImpl.kt
@@ -70,6 +70,10 @@ class DbConnectionManagerImpl private constructor(
         dataSourceFactory = HikariDataSourceFactory()
     )
 
+    init {
+        jpaEntitiesRegistry.register(CordaDb.Vault.persistenceUnitName, emptySet())
+    }
+
     @Deactivate
     fun done() {
         entityManagerFactories.clear()

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/processor/token/TokenCacheProcessor.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/processor/token/TokenCacheProcessor.kt
@@ -1,26 +1,83 @@
 package net.corda.testing.driver.processor.token
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
+import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
+import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.messaging.api.records.Record
+import net.corda.ledger.utxo.token.cache.converters.EntityConverterImpl
+import net.corda.ledger.utxo.token.cache.converters.EventConverterImpl
+import net.corda.ledger.utxo.token.cache.entities.TokenEvent
+import net.corda.ledger.utxo.token.cache.factories.RecordFactoryImpl
+import net.corda.ledger.utxo.token.cache.handlers.TokenBalanceQueryEventHandler
+import net.corda.ledger.utxo.token.cache.handlers.TokenClaimQueryEventHandler
+import net.corda.ledger.utxo.token.cache.handlers.TokenClaimReleaseEventHandler
+import net.corda.ledger.utxo.token.cache.handlers.TokenEventHandler
+import net.corda.ledger.utxo.token.cache.handlers.TokenLedgerChangeEventHandler
+import net.corda.ledger.utxo.token.cache.services.AvailableTokenService
+import net.corda.ledger.utxo.token.cache.services.SimpleTokenFilterStrategy
+import net.corda.ledger.utxo.token.cache.services.TokenCacheEventProcessor
 import net.corda.testing.driver.processor.ExternalProcessor
+import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
-import org.slf4j.LoggerFactory
+import org.osgi.service.component.annotations.Reference
 
 @Component(service = [ TokenCacheProcessor::class ])
-class TokenCacheProcessor : ExternalProcessor {
-    private val logger = LoggerFactory.getLogger(TokenCacheProcessor::class.java)
+class TokenCacheProcessor @Activate constructor(
+    @Reference
+    availableTokenService: AvailableTokenService,
+    @Reference
+    externalEventResponseFactory: ExternalEventResponseFactory,
+    @Reference
+    cordaAvroSerializationFactory: CordaAvroSerializationFactory
+) : ExternalProcessor {
+    private val anyDeserializer = cordaAvroSerializationFactory.createAvroDeserializer({}, Any::class.java)
+    private var states = mutableMapOf<TokenPoolCacheKey, TokenPoolCacheState>()
+    private val processor: TokenCacheEventProcessor
+
+    init {
+        val entityConverter = EntityConverterImpl()
+        val eventConverter = EventConverterImpl(entityConverter)
+        val recordFactory = RecordFactoryImpl(externalEventResponseFactory)
+        val tokenFilterStrategy = SimpleTokenFilterStrategy()
+
+        val eventHandlerMap = mapOf<Class<*>, TokenEventHandler<TokenEvent>>(
+            createHandler(TokenClaimQueryEventHandler(tokenFilterStrategy, recordFactory, availableTokenService)),
+            createHandler(TokenClaimReleaseEventHandler(recordFactory)),
+            createHandler(TokenLedgerChangeEventHandler()),
+            createHandler(TokenBalanceQueryEventHandler(recordFactory, availableTokenService)),
+        )
+
+        processor = TokenCacheEventProcessor(eventConverter, entityConverter, eventHandlerMap)
+    }
 
     override fun processEvent(record: Record<*, *>): List<Record<*, *>> {
-        val tokenPoolCacheKey = requireNotNull(record.key as? TokenPoolCacheKey) {
+        val cacheKey = requireNotNull(unpack<TokenPoolCacheKey>(record.key)) {
             "Invalid or missing TokenPoolCacheKey"
         }
-        val tokenPoolCacheEvent = requireNotNull(record.value as? TokenPoolCacheEvent) {
+        val cacheEvent = requireNotNull(unpack<TokenPoolCacheEvent>(record.value)) {
             "Invalid or missing TokenPoolCacheEvent"
         }
 
-        // Currently logging these only for information purposes.
-        logger.info("Key={}, Event={}", tokenPoolCacheKey, tokenPoolCacheEvent)
-        return emptyList()
+        val response = processor.onNext(states[cacheKey], Record(record.topic, cacheKey, cacheEvent))
+        val state = response.updatedState
+        if (state != null) {
+            states[cacheKey] = state
+        } else {
+            states.remove(cacheKey)
+        }
+        return response.responseEvents
+    }
+
+    private inline fun <reified T : Any> unpack(obj: Any?): T? {
+        return (((obj as? ByteArray)?.let(anyDeserializer::deserialize)) ?: obj) as? T
+    }
+
+    private inline fun <reified T : TokenEvent> createHandler(
+        handler: TokenEventHandler<T>
+    ): Pair<Class<T>, TokenEventHandler<TokenEvent>> {
+        @Suppress("unchecked_cast")
+        return Pair(T::class.java, handler as TokenEventHandler<TokenEvent>)
     }
 }

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/TokenBalanceQueryTests.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/TokenBalanceQueryTests.kt
@@ -1,0 +1,99 @@
+package net.corda.testing.driver.tests
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.r3.corda.demo.utxo.token.selection.TokenBalanceQueryFlow
+import java.math.BigDecimal
+import java.util.concurrent.TimeUnit.MINUTES
+import net.corda.testing.driver.DriverNodes
+import net.corda.testing.driver.runFlow
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.crypto.SecureHash
+import net.corda.virtualnode.VirtualNodeInfo
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.slf4j.LoggerFactory
+
+@Suppress("FunctionName")
+@Timeout(5, unit = MINUTES)
+@TestInstance(PER_CLASS)
+class TokenBalanceQueryTests {
+    private companion object {
+        private const val ISSUER_CURRENCY = "USD"
+    }
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val alice = MemberX500Name.parse("CN=Alice, OU=Testing, O=R3, L=London, C=GB")
+    private val bob = MemberX500Name.parse("CN=Bob, OU=Testing, O=R3, L=San Francisco, C=US")
+    private val notary = MemberX500Name.parse("CN=Notary, OU=Testing, O=R3, L=Rome, C=IT")
+    private val utxoLedger = mutableMapOf<MemberX500Name, VirtualNodeInfo>()
+    private val jsonMapper = ObjectMapper().apply {
+        registerModule(KotlinModule.Builder().build())
+
+        val module = SimpleModule().apply {
+            addSerializer(SecureHash::class.java, SecureHashSerializer)
+            addDeserializer(SecureHash::class.java, SecureHashDeserializer)
+        }
+        registerModule(module)
+    }
+
+    @Suppress("JUnitMalformedDeclaration")
+    @RegisterExtension
+    private val driver = DriverNodes(alice, bob).withNotary(notary, 1).forAllTests()
+
+    @BeforeAll
+    fun start() {
+        driver.run { dsl ->
+            dsl.startNodes(setOf(alice, bob)).onEach { vNode ->
+                logger.info("VirtualNode({}): {}", vNode.holdingIdentity.x500Name, vNode)
+            }.filter { vNode ->
+                vNode.cpiIdentifier.name == "ledger-utxo-demo-app"
+            }.associateByTo(utxoLedger) { vNode ->
+                vNode.holdingIdentity.x500Name
+            }
+            assertThat(utxoLedger).hasSize(2)
+        }
+        logger.info("{} and {} started successfully", alice.commonName, bob.commonName)
+    }
+
+    @Test
+    fun `ensure it is possible to send a balance query request and receive a response`() {
+         val tokenBalanceQueryResult = driver.let { dsl ->
+            dsl.runFlow<TokenBalanceQueryFlow>(utxoLedger[alice] ?: fail("Missing vNode for Alice")) {
+                val request = TokenBalanceQueryRequest(
+                    tokenType = "com.r3.corda.demo.utxo.contract.CoinState",
+                    issuerBankX500 = bob.toString(),
+                    currency = ISSUER_CURRENCY
+                )
+                jsonMapper.writeValueAsString(request)
+            }
+        } ?: fail("tokenBalanceQueryResult must not be null")
+        logger.info("tokenBalanceQueryResult: {}", tokenBalanceQueryResult)
+
+        val tokenBalanceQueryResponse = jsonMapper.readValue<TokenBalanceQueryResponse?>(tokenBalanceQueryResult)
+            ?: fail("TokenBalanceQueryResponse is null")
+
+        // Check that the balance of the token cache is zero since no token has been created
+        assertAll(
+            { assertThat(tokenBalanceQueryResponse.availableBalance).isEqualTo(BigDecimal.ZERO) },
+            { assertThat(tokenBalanceQueryResponse.totalBalance).isEqualTo(BigDecimal.ZERO) }
+        )
+    }
+
+    data class TokenBalanceQueryRequest(val tokenType: String, val issuerBankX500: String, val currency: String)
+
+    data class TokenBalanceQueryResponse(
+        val availableBalance: BigDecimal,
+        val totalBalance: BigDecimal
+    )
+}


### PR DESCRIPTION
Add `TokenCacheProcessor` to handle flows that issue and consume UTXO tokens.

The token cache uses Postgres-specific `REGEXP_LIKE` in its SQL query, which Hibernate must map to `REGEXP_MATCHES` when using HSQLDB.

Ultimately, Corda will need to decide whether it should continue to use regular expressions here, or switch to something more compatible with ANSI SQL `LIKE`.