### PR TITLE
CORE-16310 - Make name a mandatory parameter in plugin onboarding commands

### DIFF
--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -43,7 +43,7 @@ import org.bouncycastle.crypto.util.PrivateKeyFactory
 import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder
 import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder
 import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder
-import picocli.CommandLine
+import picocli.CommandLine.Parameters
 import picocli.CommandLine.Option
 import java.io.File
 import java.io.InputStream
@@ -104,7 +104,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
         }
     }
 
-    @CommandLine.Parameters(
+    @Parameters(
         description = ["The X500 name of the virtual node."],
         arity = "1",
         index = "0"

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -43,6 +43,7 @@ import org.bouncycastle.crypto.util.PrivateKeyFactory
 import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder
 import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder
 import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder
+import picocli.CommandLine
 import picocli.CommandLine.Option
 import java.io.File
 import java.io.InputStream
@@ -102,6 +103,13 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             }
         }
     }
+
+    @CommandLine.Parameters(
+        description = ["The X500 name of the virtual node."],
+        arity = "1",
+        index = "0"
+    )
+    lateinit var x500Name: String
 
     @Option(
         names = ["--ca"],
@@ -173,8 +181,6 @@ abstract class BaseOnboard : Runnable, RestCommand() {
     }
 
     protected abstract val cpiFileChecksum: String
-
-    abstract var x500Name: String
 
     protected abstract val registrationContext: Map<String, Any?>
 

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -109,7 +109,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
         arity = "1",
         index = "0"
     )
-    lateinit var x500Name: String
+    lateinit var name: String
 
     @Option(
         names = ["--ca"],
@@ -204,7 +204,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
 
     protected val holdingId: String by lazy {
         val request = CreateVirtualNodeRequest(
-            x500Name = x500Name,
+            x500Name = name,
             cpiFileChecksum = cpiFileChecksum,
             vaultDdlConnection = null,
             vaultDmlConnection = null,
@@ -375,7 +375,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             throw OnboardException("Could not submit MGM registration: ${response.memberInfoSubmitted}")
         }
 
-        println("Registration ID of $x500Name is $registrationId")
+        println("Registration ID of $name is $registrationId")
 
         if (waitForFinalStatus) {
             waitForFinalStatus(registrationId)

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnBoardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnBoardMember.kt
@@ -246,8 +246,7 @@ class OnBoardMember : Runnable, BaseOnboard() {
 
     override fun run() {
         verifyAndPrintError {
-            println("This sub command should only be used in for internal development")
-            println("On-boarding member $x500Name")
+            println("On-boarding member $name")
 
             configureGateway()
 
@@ -269,7 +268,7 @@ class OnBoardMember : Runnable, BaseOnboard() {
             register(waitForFinalStatus)
 
             if (waitForFinalStatus) {
-                println("Member $x500Name was onboarded.")
+                println("Member $name was onboarded.")
             } else {
                 println(
                     "Registration request has been submitted. Wait for MGM approval to finalize registration. " +

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnBoardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnBoardMember.kt
@@ -8,7 +8,6 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.File
 import java.security.MessageDigest
-import java.util.UUID
 import net.corda.cli.plugins.network.enums.MemberRole
 import net.corda.cli.plugins.network.utils.PrintUtils.Companion.verifyAndPrintError
 import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
@@ -70,12 +69,6 @@ class OnBoardMember : Runnable, BaseOnboard() {
         description = ["The CPI hash (Use either cpb-file or cpi-hash)."]
     )
     var cpiHash: String? = null
-
-    @Option(
-        names = ["--x500-name", "-x"],
-        description = ["The X500 name of the member. Default to a random member name"]
-    )
-    override var x500Name: String = "O=${UUID.randomUUID()}, L=London, C=GB"
 
     @Option(
         names = ["--pre-auth-token"],

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
@@ -6,7 +6,6 @@ import net.corda.cli.plugins.common.RestClientUtils.createRestClient
 import net.corda.cli.plugins.network.utils.InvariantUtils.checkInvariant
 import net.corda.crypto.test.certificates.generation.toPem
 import net.corda.membership.rest.v1.MGMRestResource
-import picocli.CommandLine.Parameters
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.ByteArrayOutputStream
@@ -21,13 +20,6 @@ import java.util.UUID
     ]
 )
 class OnboardMgm : Runnable, BaseOnboard() {
-    @Parameters(
-        description = ["The X500 name of the MGM. Default to a random name"],
-        paramLabel = "--x500-name",
-        arity = "0..1",
-    )
-    override var x500Name: String = "O=Mgm, L=London, C=GB, OU=${UUID.randomUUID()}"
-
     @Option(
         names = ["--cpi-hash"],
         description = ["The CPI hash of a previously uploaded CPI. " +

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
@@ -172,7 +172,7 @@ class OnboardMgm : Runnable, BaseOnboard() {
 
     override fun run() {
         println("This sub command should only be used in for internal development")
-        println("On-boarding MGM member $x500Name")
+        println("On-boarding MGM member $name")
 
         configureGateway()
 
@@ -182,7 +182,7 @@ class OnboardMgm : Runnable, BaseOnboard() {
 
         setupNetwork()
 
-        println("MGM Member $x500Name was onboarded")
+        println("MGM Member $name was onboarded")
 
         saveGroupPolicy()
 

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/README.md
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/README.md
@@ -115,11 +115,11 @@ Examples of on-boarding an MGM can be:
 ```shell
 ./corda-cli.sh network dynamic onboard-mgm 'O=MGM, L=London, C=GB' --user=admin --password=admin --target=https://localhost:8888 --insecure
 
-./corda-cli.sh network dynamic onboard-mgm --cpi-hash=D8AF6080C7B4 --user=admin --password=admin --target=https://localhost:8888 --insecure
+./corda-cli.sh network dynamic onboard-mgm 'O=MGM, L=London, C=GB' --cpi-hash=D8AF6080C7B4 --user=admin --password=admin --target=https://localhost:8888 --insecure
 
-./corda-cli.sh network dynamic onboard-mgm --save-group-policy-as /tmp/groupPolicy.json --user=admin --password=admin --target=https://localhost:8888 --insecure
+./corda-cli.sh network dynamic onboard-mgm 'O=MGM, L=London, C=GB' --save-group-policy-as /tmp/groupPolicy.json --user=admin --password=admin --target=https://localhost:8888 --insecure
 
-./corda-cli.sh network dynamic onboard-mgm --user=admin --password=admin --target=https://localhost:8888 --p2p-gateway-url=https://localhost:8888 --p2p-gateway-url=https://localhost:8886 --insecure
+./corda-cli.sh network dynamic onboard-mgm 'O=MGM, L=London, C=GB' --user=admin --password=admin --target=https://localhost:8888 --p2p-gateway-url=https://localhost:8888 --p2p-gateway-url=https://localhost:8886 --insecure
 ```
 
 Use the `--help` to view all the other options and defaults.
@@ -147,8 +147,8 @@ Few examples of on-boarding a member can be:
 ```shell
 ./corda-cli.sh network dynamic onboard-member 'O=Alice, L=London, C=GB' --cpb-file ~/corda-runtime-os/testing/cpbs/chat/build/libs/*.cpb --user=admin --password=admin --target=https://localhost:8888 --insecure
 ./corda-cli.sh network dynamic onboard-member 'O=Alice, L=London, C=GB' --cpb-file ~/corda-runtime-os/testing/cpbs/chat/build/libs/*.cpb --wait --user=admin --password=admin --target=https://localhost:8888 --insecure
-./corda-cli.sh network dynamic onboard-member --cpi-hash 8CBD8A9C6318 --wait --user=admin --password=admin --target=https://localhost:8888 --insecure -r "notary" -s "corda.notary.service.name"="C=GB, L=London, O=Arish"
-./corda-cli.sh network dynamic onboard-member --cpi-hash 200E86176EF2 --user=admin --password=admin --target=https://localhost:8888 --insecure
+./corda-cli.sh network dynamic onboard-member 'O=Alice, L=London, C=GB' --cpi-hash 8CBD8A9C6318 --wait --user=admin --password=admin --target=https://localhost:8888 --insecure -r "notary" -s "corda.notary.service.name"="C=GB, L=London, O=Arish"
+./corda-cli.sh network dynamic onboard-member 'O=Alice, L=London, C=GB' --cpi-hash 200E86176EF2 --user=admin --password=admin --target=https://localhost:8888 --insecure
 ```
 Use the `--help` to view all the other options and defaults.
 

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/README.md
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/README.md
@@ -105,9 +105,6 @@ To run the network either use the app simulator `deploy.sh` script ([see here](.
 ## Onboard an MGM member to an existing Corda cluster
 This command should only be used for internal development. See the [wiki](https://github.com/corda/corda-runtime-os/wiki/MGM-Onboarding) for more details.
 
-This command should only be used for internal development. See
-the [wiki](https://github.com/corda/corda-runtime-os/wiki/MGM-Onboarding) for more details.
-
 This is a sub-command under the `dynamic` sub-command to onboard a new MGM member (and create a new group). By default, the command will save the group policy file into `~/.corda/gp/groupPolicy.json` (and will overwrite any
 existing group policy file there).
 Use the `--save-group-policy-as` to indicate another location to save the MGM group policy file (that can be used to
@@ -116,7 +113,7 @@ create CPIs - [see here](../../../../../../../../../package/README.md))
 Examples of on-boarding an MGM can be:
 
 ```shell
-./corda-cli.sh network dynamic onboard-mgm --x500-name='O=MGM, L=London, C=GB' --user=admin --password=admin --target=https://localhost:8888 --insecure
+./corda-cli.sh network dynamic onboard-mgm 'O=MGM, L=London, C=GB' --user=admin --password=admin --target=https://localhost:8888 --insecure
 
 ./corda-cli.sh network dynamic onboard-mgm --cpi-hash=D8AF6080C7B4 --user=admin --password=admin --target=https://localhost:8888 --insecure
 
@@ -148,8 +145,8 @@ need to manually approve (or decline) your submitted registration to be fully on
 
 Few examples of on-boarding a member can be:
 ```shell
-./corda-cli.sh network dynamic onboard-member --x500-name='O=Alice, L=London, C=GB' --cpb-file ~/corda-runtime-os/testing/cpbs/chat/build/libs/*.cpb --user=admin --password=admin --target=https://localhost:8888 --insecure
-./corda-cli.sh network dynamic onboard-member --x500-name='O=Alice, L=London, C=GB' --cpb-file ~/corda-runtime-os/testing/cpbs/chat/build/libs/*.cpb --wait --user=admin --password=admin --target=https://localhost:8888 --insecure
+./corda-cli.sh network dynamic onboard-member 'O=Alice, L=London, C=GB' --cpb-file ~/corda-runtime-os/testing/cpbs/chat/build/libs/*.cpb --user=admin --password=admin --target=https://localhost:8888 --insecure
+./corda-cli.sh network dynamic onboard-member 'O=Alice, L=London, C=GB' --cpb-file ~/corda-runtime-os/testing/cpbs/chat/build/libs/*.cpb --wait --user=admin --password=admin --target=https://localhost:8888 --insecure
 ./corda-cli.sh network dynamic onboard-member --cpi-hash 8CBD8A9C6318 --wait --user=admin --password=admin --target=https://localhost:8888 --insecure -r "notary" -s "corda.notary.service.name"="C=GB, L=London, O=Arish"
 ./corda-cli.sh network dynamic onboard-member --cpi-hash 200E86176EF2 --user=admin --password=admin --target=https://localhost:8888 --insecure
 ```
@@ -204,17 +201,17 @@ Use either `--holding-identity-short-hash` or `--name` (optionally with `--group
 To look up group parameters visible to member `3B8DECDDD6E2`:
 
 ```shell
-./corda-cli.sh network lookup group-parameters -h "3B8DECDDD6E2"
+./corda-cli.sh network lookup group-parameters -h "3B8DECDDD6E2" --user=admin --password=admin --target=https://localhost:8888 --insecure
 ```
 
 To look up group parameters visible to `C=GB, L=London, O=Member1` from the default (last created) group:
 
 ```shell
-./corda-cli.sh network lookup group-parameters -n "C=GB, L=London, O=Member1"
+./corda-cli.sh network lookup group-parameters -n "C=GB, L=London, O=Member1" --user=admin --password=admin --target=https://localhost:8888 --insecure
 ```
 
 To look up group parameters visible to `C=GB, L=London, O=Member1` from group `b0a0f381-e0d6-49d2-abba-6094992cef02`:
 
 ```shell
-./corda-cli.sh network lookup group-parameters -n "C=GB, L=London, O=Member1" -g "b0a0f381-e0d6-49d2-abba-6094992cef02"
+./corda-cli.sh network lookup group-parameters -n "C=GB, L=London, O=Member1" -g "b0a0f381-e0d6-49d2-abba-6094992cef02" --user=admin --password=admin --target=https://localhost:8888 --insecure
 ```


### PR DESCRIPTION
This PR introduces changes in the `BaseOnboard`, `OnboardMgm` and `OnboardMember` classes. The change is done on changing the `x500Name` to a Parameter instead of an Option. Also, the `name` variable is shifted to `BaseOnboard` and removed from both `OnboardMgm` and `OnboardMember` classes for clean code purposes.

Moreover, the docs are also addressed to reflect the above mentioned changes in the commands.

## Results
<img width="1291" alt="Screenshot 2023-08-15 at 15 24 10" src="https://github.com/corda/corda-runtime-os/assets/137182748/ddab34b7-ab34-42d0-ab76-1eff62a2e162">
<img width="1302" alt="Screenshot 2023-08-17 at 10 44 27" src="https://github.com/corda/corda-runtime-os/assets/137182748/a37fbf9e-815f-4769-836d-18840a25ec4d">
<img width="1302" alt="Screenshot 2023-08-17 at 10 46 33" src="https://github.com/corda/corda-runtime-os/assets/137182748/50d52a71-2b5a-4b0e-b4d1-cfc58225d2b8">


