### PR TITLE
CORE-10386 Re-execute named query until result set is filled

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/external/events/FindAllExternalEventFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/external/events/FindAllExternalEventFactory.kt
@@ -37,8 +37,7 @@ class FindAllExternalEventFactory: ExternalEventFactory<FindAllParameters, Entit
 
         return ResultSetExecutor.Results(
             serializedResults = response.results,
-            numberOfRowsFromQuery = numberOfRowsFromQuery,
-            newOffset = numberOfRowsFromQuery
+            numberOfRowsFromQuery = numberOfRowsFromQuery
         )
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/external/events/FindAllExternalEventFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/external/events/FindAllExternalEventFactory.kt
@@ -33,9 +33,12 @@ class FindAllExternalEventFactory: ExternalEventFactory<FindAllParameters, Entit
     }
 
     override fun resumeWith(checkpoint: FlowCheckpoint, response: EntityResponse): ResultSetExecutor.Results {
+        val numberOfRowsFromQuery = response.metadata.items.single { it.key == "numberOfRowsFromQuery" }.value.toInt()
+
         return ResultSetExecutor.Results(
             serializedResults = response.results,
-            numberOfRowsFromQuery = response.metadata.items.single { it.key == "numberOfRowsFromQuery" }.value.toInt()
+            numberOfRowsFromQuery = numberOfRowsFromQuery,
+            newOffset = numberOfRowsFromQuery
         )
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/external/events/NamedQueryExternalEventFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/external/events/NamedQueryExternalEventFactory.kt
@@ -34,9 +34,12 @@ class NamedQueryExternalEventFactory : ExternalEventFactory<NamedQueryParameters
     }
 
     override fun resumeWith(checkpoint: FlowCheckpoint, response: EntityResponse): ResultSetExecutor.Results {
+        val numberOfRowsFromQuery = response.metadata.items.single { it.key == "numberOfRowsFromQuery" }.value.toInt()
+
         return ResultSetExecutor.Results(
             serializedResults = response.results,
-            numberOfRowsFromQuery = response.metadata.items.single { it.key == "numberOfRowsFromQuery" }.value.toInt()
+            numberOfRowsFromQuery = numberOfRowsFromQuery,
+            newOffset = numberOfRowsFromQuery
         )
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/external/events/NamedQueryExternalEventFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/external/events/NamedQueryExternalEventFactory.kt
@@ -38,8 +38,7 @@ class NamedQueryExternalEventFactory : ExternalEventFactory<NamedQueryParameters
 
         return ResultSetExecutor.Results(
             serializedResults = response.results,
-            numberOfRowsFromQuery = numberOfRowsFromQuery,
-            newOffset = numberOfRowsFromQuery
+            numberOfRowsFromQuery = numberOfRowsFromQuery
         )
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetImpl.kt
@@ -31,9 +31,9 @@ data class ResultSetImpl<R> internal constructor(
         if (!hasNext()) {
             throw NoSuchElementException("The result set has no more pages to query")
         }
-        val (serializedResults, numberOfRowsFromQuery) = resultSetExecutor.execute(serializedParameters, offset)
+        val (serializedResults, numberOfRowsFromQuery, newOffset) = resultSetExecutor.execute(serializedParameters, offset)
         hasNext = limit in 1..numberOfRowsFromQuery
-        offset += limit
+        offset = newOffset
         results = serializedResults.map { serializationService.deserialize(it.array(), resultClass) }
         return results
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetImpl.kt
@@ -15,6 +15,16 @@ data class ResultSetImpl<R> internal constructor(
     private val resultSetExecutor: ResultSetExecutor<R>
 ) : PagedQuery.ResultSet<R> {
 
+    init {
+        // Ideally this will never happen, but we keep this check in here for safety
+        require(offset >= 0) {
+            "Offset cannot be negative or zero"
+        }
+        require(limit > 0) {
+            "Limit cannot be negative or zero"
+        }
+    }
+
     private var results: List<R> = emptyList()
     private var hasNext: Boolean = true
 
@@ -44,7 +54,6 @@ data class ResultSetImpl<R> internal constructor(
         // Example:
         // `limit` = 5, `numberOfRowsFromQuery` = 5, `hasNext = 5 % 5 == 0` => `hasNext =  0 == 0` == true
         hasNext = numberOfRowsFromQuery != 0  // If there are no rows left there are no more pages to fetch
-                && limit != 0 // If the limit is 0 it means we fetch everything in one go so there are no pages left
                 && numberOfRowsFromQuery % limit == 0
         offset += numberOfRowsFromQuery
         results = serializedResults.map { serializationService.deserialize(it.array(), resultClass) }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetImpl.kt
@@ -43,7 +43,9 @@ data class ResultSetImpl<R> internal constructor(
         // 2. yield true if we can't know for sure if there's a next page
         // Example:
         // `limit` = 5, `numberOfRowsFromQuery` = 5, `hasNext = 5 % 5 == 0` => `hasNext =  0 == 0` == true
-        hasNext = numberOfRowsFromQuery != 0 && numberOfRowsFromQuery % limit == 0
+        hasNext = numberOfRowsFromQuery != 0  // If there are no rows left there's no more pages to fetch
+                && limit != 0 // If the limit is 0 it means we fetch everything in one go so there are no pages left
+                && numberOfRowsFromQuery % limit == 0
         offset += numberOfRowsFromQuery
         results = serializedResults.map { serializationService.deserialize(it.array(), resultClass) }
         return results

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetImpl.kt
@@ -43,7 +43,7 @@ data class ResultSetImpl<R> internal constructor(
         // 2. yield true if we can't know for sure if there's a next page
         // Example:
         // `limit` = 5, `numberOfRowsFromQuery` = 5, `hasNext = 5 % 5 == 0` => `hasNext =  0 == 0` == true
-        hasNext = numberOfRowsFromQuery != 0  // If there are no rows left there's no more pages to fetch
+        hasNext = numberOfRowsFromQuery != 0  // If there are no rows left there are no more pages to fetch
                 && limit != 0 // If the limit is 0 it means we fetch everything in one go so there are no pages left
                 && numberOfRowsFromQuery % limit == 0
         offset += numberOfRowsFromQuery

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/ResultSetImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/ResultSetImplTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
@@ -60,12 +61,6 @@ class ResultSetImplTest {
     }
 
     @Test
-    fun `hasNext returns true when the limit is 0 and next has not been called yet`() {
-        val resultSet = this.resultSet.copy(limit = 0)
-        assertThat(resultSet.hasNext()).isTrue
-    }
-
-    @Test
     fun `hasNext returns true when the number of rows returned from next is equal to the limit`() {
         whenever(resultSetExecutor.execute(serializedParameters, OFFSET)).thenReturn(resultExecutorResults)
         resultSet.next()
@@ -89,11 +84,17 @@ class ResultSetImplTest {
     }
 
     @Test
-    fun `hasNext returns false when the limit is 0 and next has been called`() {
-        val resultSet = this.resultSet.copy(limit = 0)
-        whenever(resultSetExecutor.execute(serializedParameters, OFFSET)).thenReturn(resultExecutorResults.copy(numberOfRowsFromQuery = 1))
-        resultSet.next()
-        assertThat(resultSet.hasNext()).isFalse
+    fun `result set cannot be instantiated with zero limit`() {
+        assertThrows<IllegalArgumentException> {
+            this.resultSet.copy(limit = 0)
+        }
+    }
+
+    @Test
+    fun `result set cannot be instantiated with negative offset`() {
+        assertThrows<IllegalArgumentException> {
+            this.resultSet.copy(offset = -1)
+        }
     }
 
     @Test
@@ -121,12 +122,5 @@ class ResultSetImplTest {
         whenever(resultSetExecutor.execute(serializedParameters, OFFSET)).thenReturn(resultExecutorResults.copy(numberOfRowsFromQuery = 2))
         resultSet.next()
         assertThatThrownBy { resultSet.next() }.isInstanceOf(NoSuchElementException::class.java)
-    }
-
-    @Test
-    fun `next returns empty list when limit is 0`() {
-        val resultSet = this.resultSet.copy(limit = 0)
-        whenever(resultSetExecutor.execute(serializedParameters, OFFSET)).thenReturn(ResultSetExecutor.Results(emptyList(), 0))
-        assertThat(resultSet.next()).isEmpty()
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/ResultSetImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/ResultSetImplTest.kt
@@ -72,14 +72,13 @@ class ResultSetImplTest {
         assertThat(resultSet.hasNext()).isTrue
     }
 
-    /**
-     * Within the system, this scenario shouldn't be possible but a >= check has been added for safety.
-     */
     @Test
-    fun `hasNext returns true when the number of rows returned from next is greater than the limit`() {
-        whenever(resultSetExecutor.execute(serializedParameters, OFFSET)).thenReturn(resultExecutorResults.copy(numberOfRowsFromQuery = 12))
+    fun `hasNext returns false when the number of rows returned is over the limit but can't be divided with it without remainder`() {
+        whenever(resultSetExecutor.execute(serializedParameters, OFFSET)).thenReturn(
+            resultExecutorResults.copy(numberOfRowsFromQuery = 18) // Let's say we filtered out 10 and have 8 records
+        )
         resultSet.next()
-        assertThat(resultSet.hasNext()).isTrue
+        assertThat(resultSet.hasNext()).isFalse
     }
 
     @Test

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -116,6 +116,10 @@ class VaultNamedQueryExecutorImpl(
                 offsetOverride = internalOffset
             )
 
+            // If we have no filter, there's no need to continue the loop
+            if (vaultNamedQuery.filter == null)
+                return contractStateResults
+
             // If we can't fetch more states we just return the result set as-is
             if (contractStateResults.isEmpty())
                 break
@@ -124,11 +128,9 @@ class VaultNamedQueryExecutorImpl(
             internalOffset += contractStateResults.size
 
             // Apply filters (if there's any) and add the filtered results to the final result set
-            vaultNamedQuery.filter?.let { vaultNamedQueryFilter ->
-                filteredResults.addAll(contractStateResults.filter {
-                    vaultNamedQueryFilter.filter(it, deserializedParams)
-                })
-            }
+            filteredResults.addAll(contractStateResults.filter {
+                vaultNamedQuery.filter.filter(it, deserializedParams)
+            })
         }
 
         // Make sure we don't return more than the limit even if the list has overflown

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -222,7 +222,7 @@ class VaultNamedQueryExecutorImpl(
         }
     }
 
-    data class FilterResult(
+    private data class FilterResult(
         val results: List<StateAndRef<ContractState>>,
         val numberOfRowsFromQuery: Int
     )

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -77,10 +77,8 @@ class VaultNamedQueryExecutorImpl(
         return EntityResponse.newBuilder()
             .setResults(collectedResults.map { ByteBuffer.wrap(serializationService.serialize(it).bytes) })
             .setMetadata(KeyValuePairList(listOf(
-                KeyValuePair("numberOfRowsFromQuery", filteredAndTransformedResults.size.toString()),
-                KeyValuePair("newOffset", newOffset.toString())
-            )))
-            .build()
+                KeyValuePair("numberOfRowsFromQuery", (newOffset - request.offset).toString())
+            ))).build()
     }
 
     /**
@@ -131,7 +129,7 @@ class VaultNamedQueryExecutorImpl(
 
             // If we can't fetch more states we just return the result set as-is
             if (contractStateResults.isEmpty()) {
-                break
+                return Pair(emptyList(), internalOffset)
             }
 
             // Increase the internal offset, so we don't fetch the same results multiple times

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -100,8 +100,8 @@ class VaultNamedQueryExecutorImpl(
         request: FindWithNamedQuery,
         vaultNamedQuery: VaultNamedQuery,
         deserializedParams: Map<String, Any>
-    ): Set<StateAndRef<ContractState>> {
-        val filteredResults = mutableSetOf<StateAndRef<ContractState>>()
+    ): List<StateAndRef<ContractState>> {
+        val filteredResults = mutableListOf<StateAndRef<ContractState>>()
 
         var internalOffset = request.offset
         var currentRetry = 0
@@ -131,7 +131,8 @@ class VaultNamedQueryExecutorImpl(
             })
         }
 
-        return filteredResults
+        // Make sure we don't return more than the limit even if the list has overflown
+        return filteredResults.take(request.limit)
     }
 
     /**

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -109,7 +109,7 @@ class VaultNamedQueryExecutorImpl(
         while (filteredResults.size < request.limit && currentRetry < RESULT_SET_FILL_RETRY_LIMIT) {
             ++currentRetry
 
-            log.info("Executing try: $currentRetry, fetched ${filteredResults.size} number of results so far.")
+            log.debug("Executing try: $currentRetry, fetched ${filteredResults.size} number of results so far.")
 
             // Fetch the state and refs for the given transaction IDs
             val contractStateResults = fetchStateAndRefs(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -11,7 +11,6 @@ import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.orm.utils.transaction
 import net.corda.persistence.common.exceptions.NullParameterException
-import net.corda.utilities.seconds
 import net.corda.utilities.serialization.deserialize
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.ledger.utxo.ContractState

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -31,8 +31,6 @@ class VaultNamedQueryExecutorImpl(
         const val UTXO_TX_COMPONENT_TABLE = "utxo_transaction_component"
         const val TIMESTAMP_LIMIT_PARAM_NAME = "Corda_TimestampLimit"
 
-        const val RESULT_SET_FILL_RETRY_SLEEP_MS = 1000L
-
         // TODO Should this be configurable or hard-coded?
         const val RESULT_SET_FILL_RETRY_LIMIT = 5
 
@@ -131,9 +129,6 @@ class VaultNamedQueryExecutorImpl(
             filteredResults.addAll(contractStateResults.filter {
                 vaultNamedQuery.filter?.filter(it, deserializedParams) ?: true
             })
-
-            // Sleep 1 second to avoid heavy CPU usage
-            Thread.sleep(RESULT_SET_FILL_RETRY_SLEEP_MS)
         }
 
         return filteredResults

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/ExecuteCustomQueryExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/ExecuteCustomQueryExternalEventFactory.kt
@@ -49,7 +49,8 @@ class VaultNamedQueryExternalEventFactory(
     override fun resumeWith(checkpoint: FlowCheckpoint, response: EntityResponse): ResultSetExecutor.Results {
         return ResultSetExecutor.Results(
             serializedResults = response.results,
-            numberOfRowsFromQuery = response.metadata.items.single { it.key == "numberOfRowsFromQuery" }.value.toInt()
+            numberOfRowsFromQuery = response.metadata.items.single { it.key == "numberOfRowsFromQuery" }.value.toInt(),
+            newOffset = response.metadata.items.single { it.key == "newOffset" }.value.toInt()
         )
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/ExecuteCustomQueryExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/ExecuteCustomQueryExternalEventFactory.kt
@@ -49,8 +49,7 @@ class VaultNamedQueryExternalEventFactory(
     override fun resumeWith(checkpoint: FlowCheckpoint, response: EntityResponse): ResultSetExecutor.Results {
         return ResultSetExecutor.Results(
             serializedResults = response.results,
-            numberOfRowsFromQuery = response.metadata.items.single { it.key == "numberOfRowsFromQuery" }.value.toInt(),
-            newOffset = response.metadata.items.single { it.key == "newOffset" }.value.toInt()
+            numberOfRowsFromQuery = response.metadata.items.single { it.key == "numberOfRowsFromQuery" }.value.toInt()
         )
     }
 }

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetExecutor.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetExecutor.kt
@@ -22,5 +22,5 @@ fun interface ResultSetExecutor<R> : Serializable {
     @Suspendable
     fun execute(serializedParameters: Map<String, ByteBuffer>, offset: Int): Results
 
-    data class Results(val serializedResults: List<ByteBuffer>, val numberOfRowsFromQuery: Int, val newOffset: Int)
+    data class Results(val serializedResults: List<ByteBuffer>, val numberOfRowsFromQuery: Int)
 }

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetExecutor.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetExecutor.kt
@@ -16,8 +16,7 @@ fun interface ResultSetExecutor<R> : Serializable {
      * @param serializedParameters The serialized parameters of the [ResultSet].
      * @param offset The current offset of the [ResultSet].
      *
-     * @return A [Results] containing the serialized results, the number of rows the database retrieved from its query
-     * and the new offset to continue the paging from.
+     * @return A [Results] containing the serialized results, the number of rows the database retrieved from its query.
      */
     @Suspendable
     fun execute(serializedParameters: Map<String, ByteBuffer>, offset: Int): Results

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetExecutor.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetExecutor.kt
@@ -16,10 +16,11 @@ fun interface ResultSetExecutor<R> : Serializable {
      * @param serializedParameters The serialized parameters of the [ResultSet].
      * @param offset The current offset of the [ResultSet].
      *
-     * @return A [Results] containing the serialized results and the number of rows the database retrieved from its query.
+     * @return A [Results] containing the serialized results, the number of rows the database retrieved from its query
+     * and the new offset to continue the paging from.
      */
     @Suspendable
     fun execute(serializedParameters: Map<String, ByteBuffer>, offset: Int): Results
 
-    data class Results(val serializedResults: List<ByteBuffer>, val numberOfRowsFromQuery: Int)
+    data class Results(val serializedResults: List<ByteBuffer>, val numberOfRowsFromQuery: Int, val newOffset: Int)
 }


### PR DESCRIPTION
### Overview

Change the main named query executor logic to the following:
1. Execute the query for the first time and filter the results.  If the `limit`(page size) is filled up, return the results.
2. If not, then execute the query once again with the original `limit` and repeat until either
- the page size is reached after filtering 
- we run out of records from the database
- we reach the maximum number of retries (currently 5)

### Test plan

Tested using the e2e test cases from https://github.com/corda/corda-e2e-tests/pull/195 and verified the logs to trace that the logic works as expected.