### PR TITLE
CORE-10598 Use 5.1 REST endpoints for Membership E2E Tests

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -17,7 +17,7 @@ import java.time.Instant
 @Suppress("TooManyFunctions")
 class ClusterBuilder {
     
-    private companion object {
+    internal companion object {
         val REST_API_VERSION_PATH = RestApiVersion.C5_1.versionPath
     }
     

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -12,6 +12,7 @@ import java.io.File
 import java.net.URLEncoder.encode
 import java.nio.charset.Charset.defaultCharset
 import java.time.Duration
+import net.corda.rest.annotations.RestApiVersion
 
 /**
  * Calls the necessary endpoints to create a vnode, and onboard the MGM to that vnode.
@@ -351,7 +352,7 @@ fun ClusterInfo.deprecatedSuspendMember(
         interval(1.seconds)
         command {
             post(
-                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/suspend",
+                "/api/${RestApiVersion.C5_0.versionPath}/mgm/$mgmHoldingId/suspend",
                 "{ \"x500Name\": \"$x500Name\", \"serialNumber\": $serialNumber }"
             )
         }
@@ -397,7 +398,7 @@ fun ClusterInfo.deprecatedActivateMember(
         interval(1.seconds)
         command {
             post(
-                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/activate",
+                "/api/${RestApiVersion.C5_0.versionPath}/mgm/$mgmHoldingId/activate",
                 "{ \"x500Name\": \"$x500Name\", \"serialNumber\": $serialNumber }"
             )
         }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -67,7 +67,7 @@ fun ClusterInfo.exportGroupPolicy(
     assertWithRetryIgnoringExceptions {
         interval(2.seconds)
         timeout(30.seconds)
-        command { get("/api/v1/mgm/$mgmHoldingId/info") }
+        command { get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/info") }
         condition { it.code == ResponseCode.OK.statusCode }
     }.body
 }
@@ -79,7 +79,7 @@ fun ClusterInfo.createApprovalRule(
     mgmHoldingId: String,
     regex: String,
     label: String
-) = createApprovalRuleCommon("/api/v1/mgm/$mgmHoldingId/approval/rules", regex, label)
+) = createApprovalRuleCommon("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approval/rules", regex, label)
 
 /**
  * Attempt to create a pre-auth approval rule.
@@ -88,7 +88,7 @@ fun ClusterInfo.createPreAuthApprovalRule(
     mgmHoldingId: String,
     regex: String,
     label: String
-) = createApprovalRuleCommon("/api/v1/mgm/$mgmHoldingId/approval/rules/preauth", regex, label)
+) = createApprovalRuleCommon("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approval/rules/preauth", regex, label)
 
 /**
  * Attempt to create an approval rule at a given resource URL.
@@ -116,7 +116,7 @@ private fun ClusterInfo.createApprovalRuleCommon(
 fun ClusterInfo.deleteApprovalRule(
     mgmHoldingId: String,
     ruleId: String
-) = delete("/api/v1/mgm/$mgmHoldingId/approval/rules/$ruleId")
+) = delete("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approval/rules/$ruleId")
 
 /**
  * Attempt to delete a pre-auth approval rule.
@@ -124,7 +124,7 @@ fun ClusterInfo.deleteApprovalRule(
 fun ClusterInfo.deletePreAuthApprovalRule(
     mgmHoldingId: String,
     ruleId: String
-) = delete("/api/v1/mgm/$mgmHoldingId/approval/rules/preauth/$ruleId")
+) = delete("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approval/rules/preauth/$ruleId")
 
 /**
  * Attempt to delete a resource at a given URL with retries.
@@ -157,7 +157,12 @@ fun ClusterInfo.createPreAuthToken(
 
     assertWithRetryIgnoringExceptions {
         interval(1.seconds)
-        command { post("/api/v1/mgm/$mgmHoldingId/preauthtoken", ObjectMapper().writeValueAsString(payload)) }
+        command {
+            post(
+                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/preauthtoken",
+                ObjectMapper().writeValueAsString(payload)
+            )
+        }
         condition { it.code == ResponseCode.OK.statusCode }
     }.toJson()["id"].textValue()
 }
@@ -173,7 +178,12 @@ fun ClusterInfo.revokePreAuthToken(
     cluster {
         assertWithRetry {
             interval(1.seconds)
-            command { put("/api/v1/mgm/$mgmHoldingId/preauthtoken/revoke/$tokenId", "{\"remarks\": \"$remark\"}") }
+            command {
+                put(
+                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/preauthtoken/revoke/$tokenId",
+                "{\"remarks\": \"$remark\"}"
+                )
+            }
             condition { it.code == ResponseCode.OK.statusCode }
         }
     }
@@ -197,7 +207,7 @@ fun ClusterInfo.getPreAuthTokens(
     val query = queries.joinToString(prefix = "?", separator = "&")
     assertWithRetryIgnoringExceptions {
         interval(1.seconds)
-        command { get("/api/v1/mgm/$mgmHoldingId/preauthtoken$query") }
+        command { get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/preauthtoken$query") }
         condition { it.code == ResponseCode.OK.statusCode }
     }.toJson()
 }
@@ -218,7 +228,7 @@ fun ClusterInfo.waitForPendingRegistrationReviews(
         assertWithRetryIgnoringExceptions {
             timeout(2.minutes)
             interval(3.seconds)
-            command { get("/api/v1/mgm/$mgmHoldingId/registrations$query") }
+            command { get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/registrations$query") }
             condition {
                 val json = it.toJson().firstOrNull()
                 it.code == ResponseCode.OK.statusCode
@@ -239,7 +249,7 @@ fun ClusterInfo.approveRegistration(
     cluster {
         assertWithRetry {
             interval(1.seconds)
-            command { post("/api/v1/mgm/$mgmHoldingId/approve/$registrationId", "") }
+            command { post("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approve/$registrationId", "") }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
         }
     }
@@ -256,7 +266,7 @@ fun ClusterInfo.declineRegistration(
         assertWithRetry {
             interval(1.seconds)
             command { post(
-                "/api/v1/mgm/$mgmHoldingId/decline/$registrationId",
+                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/decline/$registrationId",
                 "{\"reason\": \"Declined by automated test with runId $testRunUniqueId.\"}")
             }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
@@ -310,6 +320,30 @@ private fun ClusterInfo.createMgmRegistrationContext(
 fun ClusterInfo.suspendMember(
     mgmHoldingId: String,
     x500Name: String,
+    serialNumber: Int,
+) = cluster {
+    assertWithRetry {
+        timeout(15.seconds)
+        interval(1.seconds)
+        command {
+            post(
+                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/suspend",
+                "{ \"x500Name\": \"$x500Name\", \"serialNumber\": $serialNumber }"
+            )
+        }
+        condition { it.code == ResponseCode.NO_CONTENT.statusCode || it.code == ResponseCode.CONFLICT.statusCode }
+    }
+}
+
+/**
+ * Suspend a member identified by [x500Name].
+ * Suspension is performed by the MGM identified by [mgmHoldingId].
+ *
+ * Used to test RestApiVersion.C5_0, this version allows the serial number to be Null.
+ */
+fun ClusterInfo.deprecatedSuspendMember(
+    mgmHoldingId: String,
+    x500Name: String,
     serialNumber: Int? = null,
 ) = cluster {
     assertWithRetry {
@@ -317,7 +351,7 @@ fun ClusterInfo.suspendMember(
         interval(1.seconds)
         command {
             post(
-                "/api/v1/mgm/$mgmHoldingId/suspend",
+                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/suspend",
                 "{ \"x500Name\": \"$x500Name\", \"serialNumber\": $serialNumber }"
             )
         }
@@ -332,6 +366,30 @@ fun ClusterInfo.suspendMember(
 fun ClusterInfo.activateMember(
     mgmHoldingId: String,
     x500Name: String,
+    serialNumber: Int,
+) = cluster {
+    assertWithRetry {
+        timeout(15.seconds)
+        interval(1.seconds)
+        command {
+            post(
+                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/activate",
+                "{ \"x500Name\": \"$x500Name\", \"serialNumber\": $serialNumber }"
+            )
+        }
+        condition { it.code == ResponseCode.NO_CONTENT.statusCode || it.code == ResponseCode.CONFLICT.statusCode }
+    }
+}
+
+/**
+ * Activate a member identified by [x500Name].
+ * Activation is performed by the MGM identified by [mgmHoldingId].
+ *
+ * Used to test RestApiVersion.C5_0, this version allows the serial number to be Null.
+ */
+fun ClusterInfo.deprecatedActivateMember(
+    mgmHoldingId: String,
+    x500Name: String,
     serialNumber: Int? = null,
 ) = cluster {
     assertWithRetry {
@@ -339,7 +397,7 @@ fun ClusterInfo.activateMember(
         interval(1.seconds)
         command {
             post(
-                "/api/v1/mgm/$mgmHoldingId/activate",
+                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/activate",
                 "{ \"x500Name\": \"$x500Name\", \"serialNumber\": $serialNumber }"
             )
         }
@@ -361,7 +419,10 @@ fun ClusterInfo.updateGroupParameters(
         timeout(15.seconds)
         interval(1.seconds)
         command {
-            post("/api/v1/mgm/$mgmHoldingId/group-parameters", ObjectMapper().writeValueAsString(payload))
+            post(
+                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/group-parameters",
+                ObjectMapper().writeValueAsString(payload)
+            )
         }
         condition { it.code == ResponseCode.OK.statusCode }
     }.toJson()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -311,7 +311,7 @@ fun ClusterInfo.lookup(
         interval(1.seconds)
         command {
             val additionalQuery = statuses.joinToString(prefix = "?", separator = "&") { "statuses=$it" }
-            get("/api/v1/members/$holdingId$additionalQuery")
+            get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/members/$holdingId$additionalQuery")
         }
         condition { it.code == ResponseCode.OK.statusCode }
     }
@@ -327,7 +327,7 @@ fun ClusterInfo.lookupGroupParameters(
         timeout(15.seconds)
         interval(1.seconds)
         command {
-            get("/api/v1/members/$holdingId/group-parameters")
+            get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/members/$holdingId/group-parameters")
         }
         condition { it.code == ResponseCode.OK.statusCode }
     }


### PR DESCRIPTION
Use the default REST endpoint version for the Membership E2E Tests. As we should use the latest where possible and add an E2E tests where nessary to test the old endpoints, where the behaviour of these differs. i.e. If we deprecated the old endpoint.