### PR TITLE
CORE-13935 added check if ExternalEventStateType is OK when resending external event, set it to RETRY and increment the retry count

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImpl.kt
@@ -172,7 +172,10 @@ class ExternalEventManagerImpl(
                 }
                 if (externalEventState.status.type == ExternalEventStateType.OK) {
                     externalEventState.status.exception =
-                        ExceptionEnvelope("Unreceived Error", "Event retried but did not receive an error, Ensure all workers are running")
+                        ExceptionEnvelope(
+                            "NoResponse",
+                            "Received no response for external event request, ensure all workers are running"
+                        )
                     externalEventState.status.type = ExternalEventStateType.RETRY
                     externalEventState.retries = externalEventState.retries.inc()
                 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImplTest.kt
@@ -487,8 +487,8 @@ class ExternalEventManagerImplTest {
         assertEquals(payload.array(), record.value)
         if(stateType == ExternalEventStateType.OK) {
             val expectedException = ExceptionEnvelope(
-                "Unreceived Error",
-                "Event retried but did not receive an error, Ensure all workers are running"
+                "NoResponse",
+                "Received no response for external event request, ensure all workers are running"
             )
 
             assertEquals(ExternalEventStateType.RETRY, updatedExternalEventState.status.type)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/external/events/impl/ExternalEventManagerImplTest.kt
@@ -449,4 +449,57 @@ class ExternalEventManagerImplTest {
         assertEquals(now.plusSeconds(1), updatedExternalEventState.sendTimestamp)
         assertNull(record)
     }
+
+    @ParameterizedTest
+    @EnumSource(names = ["RETRY", "OK"])
+    @Suppress("MaxLineLength")
+    fun `getEventToSend sets the state status to RETRY, increments the retry count, sets the exception and returns an external event if the sendTimestamp is surpassed and the status is OK`(stateType: ExternalEventStateType) {
+        val now = Instant.now().truncatedTo(ChronoUnit.MILLIS)
+        val key = ByteBuffer.wrap(KEY.toByteArray())
+        val payload = ByteBuffer.wrap(byteArrayOf(1, 2, 3))
+
+        val externalEvent = ExternalEvent().apply {
+            this.topic = TOPIC
+            this.key = key
+            this.payload = payload
+            this.timestamp = now.minusSeconds(10)
+        }
+
+        val externalEventState = ExternalEventState().apply {
+            requestId = REQUEST_ID_1
+            eventToSend = externalEvent
+            sendTimestamp = now.minusSeconds(1)
+            status = ExternalEventStateStatus(stateType, ExceptionEnvelope())
+        }
+
+        whenever(config.getLong(FlowConfig.EXTERNAL_EVENT_MESSAGE_RESEND_WINDOW)).thenReturn(1.seconds.toMillis())
+
+        val (updatedExternalEventState, record) = externalEventManager.getEventToSend(
+            externalEventState,
+            now,
+            config
+        )
+
+        assertEquals(now, updatedExternalEventState.eventToSend.timestamp)
+        assertEquals(now.plusSeconds(1), updatedExternalEventState.sendTimestamp)
+        assertEquals(TOPIC, record!!.topic)
+        assertEquals(key.array(), record.key)
+        assertEquals(payload.array(), record.value)
+        if(stateType == ExternalEventStateType.OK) {
+            val expectedException = ExceptionEnvelope(
+                "Unreceived Error",
+                "Event retried but did not receive an error, Ensure all workers are running"
+            )
+
+            assertEquals(ExternalEventStateType.RETRY, updatedExternalEventState.status.type)
+            assertEquals(1, updatedExternalEventState.retries)
+            assertEquals(expectedException, updatedExternalEventState.status.exception)
+        } else{
+            val nullExceptionEnvelope = ExceptionEnvelope(null, null)
+
+            assertEquals(ExternalEventStateType.RETRY, updatedExternalEventState.status.type)
+            assertEquals(0, updatedExternalEventState.retries)
+            assertEquals(nullExceptionEnvelope, updatedExternalEventState.status.exception)
+        }
+    }
 }


### PR DESCRIPTION
### Context
Currently it is possible that an external event can be retried indefinitely if the external event response doesn't include an error (This is the behaviour being seen in the ticket, when there are no DbWorkers). This means the external event state status doesn't get set to RETRY and the retry count doesn't get incremented.

### Solution
In the `getEventToSend` method I have implemented a check when the event is being retried, to see if the external event state type is `OK`. If it is `OK`, it gets set to `RETRY`, an appropriate exception is set and the retry count is incremented.