### PR TITLE
CORE-14685: Driver DSL now remembers its virtual nodes to support lookups.

### DIFF
--- a/buildSrc/src/main/groovy/corda.driver-tests.gradle
+++ b/buildSrc/src/main/groovy/corda.driver-tests.gradle
@@ -51,7 +51,7 @@ pluginManager.withPlugin('java') {
     pluginManager.withPlugin('jacoco') {
         tasks.withType(Test).configureEach {
             jacoco {
-                enabled = false
+                enabled = System.getenv().containsKey('JENKINS_URL')
             }
         }
     }

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/network/MembershipGroupImpl.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/network/MembershipGroupImpl.kt
@@ -19,7 +19,6 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
-import net.corda.virtualnode.toAvro
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -40,13 +39,6 @@ class MembershipGroupImpl @Activate constructor(
 
     override fun getName(holdingIdentity: AvroHoldingIdentity): String {
         return getVirtualNodeInfo(holdingIdentity.toCorda()).cpiIdentifier.name
-    }
-
-    override fun getAnyMemberOf(groupName: String): AvroHoldingIdentity {
-        val virtualNodeInfo = virtualNodeInfoReadService.getAll().firstOrNull { vNode ->
-            vNode.cpiIdentifier.name == groupName
-        } ?: throw AssertionError("Group '$groupName' not found")
-        return virtualNodeInfo.holdingIdentity.toAvro()
     }
 
     override fun getMembers(holdingIdentity: AvroHoldingIdentity): Set<MemberX500Name> {

--- a/testing/driver/driver-testing/src/integrationTest/java/net/corda/testing/driver/tests/FlowDriverJavaTest.java
+++ b/testing/driver/driver-testing/src/integrationTest/java/net/corda/testing/driver/tests/FlowDriverJavaTest.java
@@ -1,0 +1,104 @@
+package net.corda.testing.driver.tests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.r3.corda.demo.mandelbrot.CalculateBlockFlow;
+import com.r3.corda.demo.mandelbrot.RequestMessage;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import net.corda.testing.driver.AllTestsDriver;
+import net.corda.testing.driver.DriverNodes;
+import net.corda.v5.base.types.MemberX500Name;
+import net.corda.virtualnode.VirtualNodeInfo;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@Timeout(value = 5, unit = MINUTES)
+@TestInstance(PER_CLASS)
+class FlowDriverJavaTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowDriverJavaTest.class);
+
+    private static final MemberX500Name ALICE = MemberX500Name.parse("CN=Alice, OU=Testing, O=R3, L=London, C=GB");
+    private static final MemberX500Name BOB = MemberX500Name.parse("CN=Bob, OU=Testing, O=R3, L=San Francisco, C=US");
+    private final ObjectMapper jsonMapper = new ObjectMapper();
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    @RegisterExtension
+    final AllTestsDriver driver = new DriverNodes(ALICE, BOB).forAllTests();
+
+    @BeforeAll
+    void start() {
+        // Ensure that we use the corda-driver bundle rather than a directory of its classes.
+        assertThat(DriverNodes.class.getProtectionDomain().getCodeSource().getLocation().getPath()).endsWith(".jar");
+
+        driver.run(dsl ->
+            dsl.startNodes(Set.of(ALICE, BOB)).forEach(vNode ->
+                LOGGER.info("VirtualNode({}): {}", vNode.getHoldingIdentity().getX500Name(), vNode)
+            )
+        );
+        LOGGER.info("{} and {} started successfully", ALICE.getCommonName(), BOB.getCommonName());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(RequestProvider.class)
+    void testMandelbrotFlow(RequestMessage request) {
+        final Map<MemberX500Name, VirtualNodeInfo> mandelbrot = driver.let(dsl ->
+            dsl.nodesFor("mandelbrot")
+        );
+
+        final String aliceResult = driver.let(dsl ->
+            dsl.runFlow(mandelbrot.get(ALICE), CalculateBlockFlow.class, () ->
+                jsonMapper.writeValueAsString(request)
+            )
+        );
+        assertNotNull(aliceResult, "aliceResult must not be null");
+        LOGGER.info("Alice Mandelbrot Block={}", aliceResult);
+
+        final String bobResult = driver.let(dsl ->
+            dsl.runFlow(mandelbrot.get(BOB), CalculateBlockFlow.class, () ->
+                jsonMapper.writeValueAsString(request)
+            )
+        );
+        assertNotNull(bobResult, "bobResult must not be null");
+        LOGGER.info("Bob Mandelbrot Block={}", bobResult);
+    }
+
+    private static class RequestProvider implements ArgumentsProvider {
+        @Override
+        @NotNull
+        public Stream<? extends Arguments> provideArguments(@NotNull ExtensionContext context) {
+            return Stream.of(
+                Arguments.of(createRequestMessage(100.0, 20.2)),
+                Arguments.of(createRequestMessage(253.7, -10.1)),
+                Arguments.of(createRequestMessage(854.9, 120.6)),
+                Arguments.of(createRequestMessage(-577.2, 88.8)),
+                Arguments.of(createRequestMessage(14.5, 37.3))
+            );
+        }
+
+        @NotNull
+        private RequestMessage createRequestMessage(double startX, double startY) {
+            final RequestMessage request = new RequestMessage();
+            request.setStartX(startX);
+            request.setStartY(startY);
+            request.setWidth(50.0);
+            request.setHeight(50.0);
+            return request;
+        }
+    }
+}

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/ConsensualLedgerTests.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/ConsensualLedgerTests.kt
@@ -58,13 +58,10 @@ class ConsensualLedgerTests {
     @BeforeAll
     fun start() {
         driver.run { dsl ->
-            dsl.startNodes(setOf(alice, bob, charlie)).onEach { vNode ->
+            dsl.startNodes(setOf(alice, bob, charlie)).forEach { vNode ->
                 logger.info("VirtualNode({}): {}", vNode.holdingIdentity.x500Name, vNode)
-            }.filter { vNode ->
-                vNode.cpiIdentifier.name == "ledger-consensual-demo-app"
-            }.associateByTo(consensualLedger) { vNode ->
-                vNode.holdingIdentity.x500Name
             }
+            consensualLedger += dsl.nodesFor("ledger-consensual-demo-app")
             assertThat(consensualLedger).hasSize(3)
         }
         logger.info("{}, {} and {} started successfully", alice.commonName, bob.commonName, charlie.commonName)

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/FlowTests.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/FlowTests.kt
@@ -39,11 +39,10 @@ class FlowTests {
     @BeforeAll
     fun start() {
         aliceCorDapp = driver.let { dsl ->
-            dsl.startNodes(setOf(alice, bob)).onEach { vNode ->
+            dsl.startNodes(setOf(alice, bob)).forEach { vNode ->
                 logger.info("VirtualNode({}): {}", vNode.holdingIdentity.x500Name, vNode)
-            }.single { vNode ->
-                vNode.cpiIdentifier.name == "test-cordapp" && vNode.holdingIdentity.x500Name == alice
             }
+            dsl.nodeFor("test-cordapp", alice)
         }
         logger.info("{} and {} started successfully", alice.commonName, bob.commonName)
     }

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/NotaryFlowTests.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/NotaryFlowTests.kt
@@ -39,11 +39,10 @@ class NotaryFlowTests {
     @BeforeAll
     fun start() {
         aliceCorDapp = driver.let { dsl ->
-            dsl.startNodes(setOf(alice, bob)).onEach { vNode ->
+            dsl.startNodes(setOf(alice, bob)).forEach { vNode ->
                 logger.info("VirtualNode({}): {}", vNode.holdingIdentity.x500Name, vNode)
-            }.single { vNode ->
-                vNode.cpiIdentifier.name == "test-cordapp" && vNode.holdingIdentity.x500Name == alice
             }
+            dsl.nodeFor("test-cordapp", alice)
         }
         logger.info("{} and {} started successfully", alice.commonName, bob.commonName)
     }

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/TokenBalanceQueryTests.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/TokenBalanceQueryTests.kt
@@ -54,13 +54,10 @@ class TokenBalanceQueryTests {
     @BeforeAll
     fun start() {
         driver.run { dsl ->
-            dsl.startNodes(setOf(alice, bob)).onEach { vNode ->
+            dsl.startNodes(setOf(alice, bob)).forEach { vNode ->
                 logger.info("VirtualNode({}): {}", vNode.holdingIdentity.x500Name, vNode)
-            }.filter { vNode ->
-                vNode.cpiIdentifier.name == "ledger-utxo-demo-app"
-            }.associateByTo(utxoLedger) { vNode ->
-                vNode.holdingIdentity.x500Name
             }
+            utxoLedger += dsl.nodesFor("ledger-utxo-demo-app")
             assertThat(utxoLedger).hasSize(2)
         }
         logger.info("{} and {} started successfully", alice.commonName, bob.commonName)

--- a/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/UtxoLedgerTests.kt
+++ b/testing/driver/driver-testing/src/integrationTest/kotlin/net/corda/testing/driver/tests/UtxoLedgerTests.kt
@@ -67,13 +67,10 @@ class UtxoLedgerTests {
     @BeforeAll
     fun start() {
         driver.run { dsl ->
-            dsl.startNodes(setOf(alice, bob, charlie)).onEach { vNode ->
+            dsl.startNodes(setOf(alice, bob, charlie)).forEach { vNode ->
                 logger.info("VirtualNode({}): {}", vNode.holdingIdentity.x500Name, vNode)
-            }.filter { vNode ->
-                vNode.cpiIdentifier.name == "ledger-utxo-demo-app"
-            }.associateByTo(utxoLedger) { vNode ->
-                vNode.holdingIdentity.x500Name
             }
+            utxoLedger += dsl.nodesFor("ledger-utxo-demo-app")
             assertThat(utxoLedger).hasSize(3)
         }
         logger.info("{}, {} and {} started successfully", alice.commonName, bob.commonName, charlie.commonName)

--- a/testing/driver/src/main/java/net/corda/testing/driver/AbstractDriver.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/AbstractDriver.java
@@ -24,9 +24,9 @@ abstract class AbstractDriver {
     private DriverDSLImpl driver;
 
     AbstractDriver(
-        @NotNull Map<MemberX500Name, KeyPair> members,
-        @NotNull Map<MemberX500Name, KeyPair> notaries,
-        @NotNull Set<KeyValuePair> groupParameters
+        @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> members,
+        @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> notaries,
+        @NotNull Set<@NotNull KeyValuePair> groupParameters
     ) {
         requireNonNull(members, "members must not be null");
         requireNonNull(notaries, "notaries must not be null");

--- a/testing/driver/src/main/java/net/corda/testing/driver/AllTestsDriver.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/AllTestsDriver.java
@@ -12,20 +12,20 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class AllTestsDriver extends AbstractDriver implements BeforeAllCallback, AfterAllCallback {
     AllTestsDriver(
-        @NotNull Map<MemberX500Name, KeyPair> members,
-        @NotNull Map<MemberX500Name, KeyPair> notaries,
-        @NotNull Set<KeyValuePair> groupParameters
+        @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> members,
+        @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> notaries,
+        @NotNull Set<@NotNull KeyValuePair> groupParameters
     ) {
         super(members, notaries, groupParameters);
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
+    public void beforeAll(@NotNull ExtensionContext context) {
         createDriver(context);
     }
 
     @Override
-    public void afterAll(ExtensionContext context) throws Exception {
+    public void afterAll(@NotNull ExtensionContext context) throws Exception {
         destroyDriver(context);
     }
 }

--- a/testing/driver/src/main/java/net/corda/testing/driver/DriverDSL.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/DriverDSL.java
@@ -1,6 +1,7 @@
 package net.corda.testing.driver;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import net.corda.testing.driver.function.ThrowingConsumer;
@@ -18,27 +19,34 @@ import org.jetbrains.annotations.Unmodifiable;
 public interface DriverDSL {
     @NotNull
     @Unmodifiable
-    List<VirtualNodeInfo> startNodes(@NotNull @Unmodifiable Set<MemberX500Name> memberNames);
+    List<@NotNull VirtualNodeInfo> startNodes(@NotNull @Unmodifiable Set<@NotNull MemberX500Name> memberNames);
+
+    @NotNull
+    VirtualNodeInfo nodeFor(@NotNull String groupName, @NotNull MemberX500Name member);
+
+    @NotNull
+    @Unmodifiable
+    Map<@NotNull MemberX500Name, @NotNull VirtualNodeInfo> nodesFor(@NotNull String groupName);
 
     @Nullable
     String runFlow(
         @NotNull VirtualNodeInfo virtualNodeInfo,
         @NotNull Class<? extends ClientStartableFlow> flowClass,
-        @NotNull ThrowingSupplier<String> flowArgMapper
+        @NotNull ThrowingSupplier<@NotNull String> flowArgMapper
     );
 
     void node(
         @NotNull VirtualNodeInfo virtualNodeInfo,
-        @NotNull ThrowingConsumer<Member> action
+        @NotNull ThrowingConsumer<@NotNull Member> action
     );
 
     void groupFor(
         @NotNull VirtualNodeInfo virtualNodeInfo,
-        @NotNull ThrowingConsumer<MembershipGroupDSL> action
+        @NotNull ThrowingConsumer<@NotNull MembershipGroupDSL> action
     );
 
     void group(
         @NotNull String groupName,
-        @NotNull ThrowingConsumer<MembershipGroupDSL> action
+        @NotNull ThrowingConsumer<@NotNull MembershipGroupDSL> action
     );
 }

--- a/testing/driver/src/main/java/net/corda/testing/driver/DriverNodes.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/DriverNodes.java
@@ -47,7 +47,7 @@ public final class DriverNodes {
 
     @NotNull
     @Unmodifiable
-    private static Set<Integer> setOf(int value, int @NotNull... otherValues) {
+    private static Set<@NotNull Integer> setOf(int value, int @NotNull... otherValues) {
         final Set<Integer> items = new LinkedHashSet<>();
         items.add(value);
         for (int otherValue : otherValues) {
@@ -76,9 +76,9 @@ public final class DriverNodes {
     }
 
     @NotNull
-    private static Map<MemberX500Name, KeyPair> createNetwork(
+    private static Map<@NotNull MemberX500Name, @NotNull KeyPair> createNetwork(
         @NotNull KeyPairGenerator keyPairGenerator,
-        @NotNull Set<MemberX500Name> members
+        @NotNull Set<@NotNull MemberX500Name> members
     ) {
         final Map<MemberX500Name, KeyPair> map = new LinkedHashMap<>();
         for (MemberX500Name member : members) {
@@ -87,7 +87,7 @@ public final class DriverNodes {
         return map;
     }
 
-    public DriverNodes(@NotNull Set<MemberX500Name> members) {
+    public DriverNodes(@NotNull Set<@NotNull MemberX500Name> members) {
         requireNonNull(members, "members must not be null");
         this.members = members;
         notaries = new LinkedHashMap<>();
@@ -118,9 +118,9 @@ public final class DriverNodes {
     private interface DriverConstructor<T extends AbstractDriver> {
         @NotNull
         T build(
-            @NotNull Map<MemberX500Name, KeyPair> members,
-            @NotNull Map<MemberX500Name, KeyPair> notaries,
-            @NotNull Set<KeyValuePair> groupParameters
+            @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> members,
+            @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> notaries,
+            @NotNull Set<@NotNull KeyValuePair> groupParameters
         );
     }
 
@@ -162,8 +162,8 @@ public final class DriverNodes {
         private int notaryIndex;
 
         GroupParametersBuilder(
-            @NotNull Map<MemberX500Name, Set<Integer>> notaries,
-            @NotNull Map<MemberX500Name, KeyPair> notaryNetwork
+            @NotNull Map<@NotNull MemberX500Name, @NotNull Set<@NotNull Integer>> notaries,
+            @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> notaryNetwork
         ) {
             this.notaries = notaries;
             this.notaryNetwork = notaryNetwork;
@@ -185,7 +185,7 @@ public final class DriverNodes {
         }
 
         @NotNull
-        private List<KeyValuePair> createNotaryProtocol(@NotNull Set<Integer> protocolVersions) {
+        private List<@NotNull KeyValuePair> createNotaryProtocol(@NotNull Set<@NotNull Integer> protocolVersions) {
             final List<KeyValuePair> result = new ArrayList<>();
             result.add(new KeyValuePair(
                 String.format("corda.notary.service.%d.flow.protocol.name", notaryIndex),
@@ -204,8 +204,8 @@ public final class DriverNodes {
 
         @NotNull
         @Unmodifiable
-        Set<KeyValuePair> build() {
-            for (Map.Entry<MemberX500Name, Set<Integer>> notary : notaries.entrySet()) {
+        Set<@NotNull KeyValuePair> build() {
+            for (Map.Entry<@NotNull MemberX500Name, @NotNull Set<@NotNull Integer>> notary : notaries.entrySet()) {
                 final MemberX500Name notaryName = notary.getKey();
                 groupParameters.add(createNotaryName(notaryName));
                 groupParameters.add(createNotaryKey(notaryNetwork.get(notaryName)));

--- a/testing/driver/src/main/java/net/corda/testing/driver/EachTestDriver.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/EachTestDriver.java
@@ -12,20 +12,20 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 public final class EachTestDriver extends AbstractDriver implements BeforeEachCallback, AfterEachCallback {
     EachTestDriver(
-        @NotNull Map<MemberX500Name, KeyPair> members,
-        @NotNull Map<MemberX500Name, KeyPair> notaries,
-        @NotNull Set<KeyValuePair> groupParameters
+        @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> members,
+        @NotNull Map<@NotNull MemberX500Name, @NotNull KeyPair> notaries,
+        @NotNull Set<@NotNull KeyValuePair> groupParameters
     ) {
         super(members, notaries, groupParameters);
     }
 
     @Override
-    public void beforeEach(ExtensionContext context) {
+    public void beforeEach(@NotNull ExtensionContext context) {
         createDriver(context);
     }
 
     @Override
-    public void afterEach(ExtensionContext context) throws Exception {
+    public void afterEach(@NotNull ExtensionContext context) throws Exception {
         destroyDriver(context);
     }
 }

--- a/testing/driver/src/main/java/net/corda/testing/driver/MembershipGroupDSL.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/MembershipGroupDSL.java
@@ -15,7 +15,7 @@ public interface MembershipGroupDSL {
 
     @NotNull
     @Unmodifiable
-    Set<MemberX500Name> members();
+    Set<@NotNull MemberX500Name> members();
 
-    void member(@NotNull MemberX500Name name, @NotNull ThrowingConsumer<Member> action);
+    void member(@NotNull MemberX500Name name, @NotNull ThrowingConsumer<@NotNull Member> action);
 }

--- a/testing/driver/src/main/java/net/corda/testing/driver/node/EmbeddedNodeService.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/node/EmbeddedNodeService.java
@@ -19,11 +19,18 @@ public interface EmbeddedNodeService {
 
     @NotNull
     @Unmodifiable
-    Set<VirtualNodeInfo> loadVirtualNodes(@NotNull @Unmodifiable Set<MemberX500Name> names, @NotNull URI fileURI);
+    Set<@NotNull VirtualNodeInfo> loadVirtualNodes(
+        @NotNull
+        @Unmodifiable
+        Set<@NotNull MemberX500Name> names,
 
-    void loadSystemCpi(@NotNull @Unmodifiable Set<MemberX500Name> names, @NotNull URI fileURI);
+        @NotNull
+        URI fileURI
+    );
 
-    void setGroupParameters(@NotNull @Unmodifiable Set<KeyValuePair> groupParameters);
+    void loadSystemCpi(@NotNull @Unmodifiable Set<@NotNull MemberX500Name> names, @NotNull URI fileURI);
 
-    void setMembershipGroup(@NotNull @Unmodifiable Map<MemberX500Name, KeyPair> network);
+    void setGroupParameters(@NotNull @Unmodifiable Set<@NotNull KeyValuePair> groupParameters);
+
+    void setMembershipGroup(@NotNull @Unmodifiable Map<@NotNull MemberX500Name, @NotNull KeyPair> network);
 }

--- a/testing/driver/src/main/java/net/corda/testing/driver/node/FlowErrorException.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/node/FlowErrorException.java
@@ -1,11 +1,13 @@
 package net.corda.testing.driver.node;
 
+import org.jetbrains.annotations.Nullable;
+
 public class FlowErrorException extends RuntimeException {
-    public FlowErrorException(String message, Throwable cause) {
+    public FlowErrorException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 
-    public FlowErrorException(String message) {
+    public FlowErrorException(@Nullable String message) {
         super(message);
     }
 }

--- a/testing/driver/src/main/java/net/corda/testing/driver/node/FlowFatalException.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/node/FlowFatalException.java
@@ -1,11 +1,13 @@
 package net.corda.testing.driver.node;
 
+import org.jetbrains.annotations.Nullable;
+
 public class FlowFatalException extends RuntimeException {
-    public FlowFatalException(String message, Throwable cause) {
+    public FlowFatalException(@Nullable String message, @Nullable Throwable cause) {
         super(message, cause);
     }
 
-    public FlowFatalException(String message) {
+    public FlowFatalException(@Nullable String message) {
         super(message);
     }
 }

--- a/testing/driver/src/main/java/net/corda/testing/driver/node/MembershipGroup.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/node/MembershipGroup.java
@@ -14,11 +14,8 @@ public interface MembershipGroup {
     String getName(@NotNull HoldingIdentity holdingIdentity);
 
     @NotNull
-    HoldingIdentity getAnyMemberOf(@NotNull String groupName);
-
-    @NotNull
     @Unmodifiable
-    Set<MemberX500Name> getMembers(@NotNull HoldingIdentity holdingIdentity);
+    Set<@NotNull MemberX500Name> getMembers(@NotNull HoldingIdentity holdingIdentity);
 
-    void virtualNode(@NotNull HoldingIdentity holdingIdentity, @NotNull ThrowingConsumer<Member> action);
+    void virtualNode(@NotNull HoldingIdentity holdingIdentity, @NotNull ThrowingConsumer<@NotNull Member> action);
 }


### PR DESCRIPTION
Store the `VirtualNodeInfo` objects that `startNodes` returns, so that `DriverDSL` can support a look-up API:
- `VirtualNodeInfo nodeFor(String groupName, MemberX500Name member)`
- `Map<MemberX500Name, VirtualNodeInfo> nodesFor(String groupName)`

This also allows us to simplify the `group()` API.