### PR TITLE
CORE-15179: Ensure vaultDml EntityManagerFactory always has its entities.

### DIFF
--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/AvailableTokenServiceImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/AvailableTokenServiceImpl.kt
@@ -6,13 +6,14 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.schema.CordaDb
 import net.corda.flow.external.events.responses.exceptions.VirtualNodeException
 import net.corda.ledger.utxo.token.cache.entities.AvailTokenQueryResult
 import net.corda.ledger.utxo.token.cache.entities.CachedToken
 import net.corda.ledger.utxo.token.cache.repositories.UtxoTokenRepository
 import net.corda.ledger.utxo.token.cache.entities.TokenBalance
 import net.corda.ledger.utxo.token.cache.entities.TokenPoolKey
-import net.corda.orm.JpaEntitiesSet
+import net.corda.orm.JpaEntitiesRegistry
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.VirtualNodeInfo
 
@@ -22,6 +23,8 @@ class AvailableTokenServiceImpl @Activate constructor(
     private val virtualNodeInfoService: VirtualNodeInfoReadService,
     @Reference
     private val dbConnectionManager: DbConnectionManager,
+    @Reference
+    private val jpaEntitiesRegistry: JpaEntitiesRegistry,
     @Reference
     private val utxoTokenRepository: UtxoTokenRepository
 ) : AvailableTokenService, SingletonSerializeAsToken {
@@ -52,7 +55,8 @@ class AvailableTokenServiceImpl @Activate constructor(
     private fun getOrCreateEntityManagerFactory(virtualNode: VirtualNodeInfo) =
         dbConnectionManager.getOrCreateEntityManagerFactory(
             virtualNode.vaultDmlConnectionId,
-            JpaEntitiesSet.create("emptySet", emptySet()) // No entity required. The mapping will be manually done
+            jpaEntitiesRegistry.get(CordaDb.Vault.persistenceUnitName)
+                ?: throw IllegalStateException("persistenceUnitName ${CordaDb.Vault.persistenceUnitName} is not registered.")
         )
 
     private fun getVirtualNodeInfo(poolKey: TokenPoolKey) =


### PR DESCRIPTION
The `EntityManagerFactory` for `vaultDmlConnectionId` is expected to contain the Vault entities. See:
- `net.corda.membership.impl.persistence.service.handler.BasePersisteceHandler`
- `net.corda.membership.certificate.service.impl.DbClientImpl`
- `net.corda.processors.db.internal.reconcile.db.MemberInfoReconciler`
- and others...? (I'm not claiming this list is exhaustive.)

So if `AvailableTokensService` is going to `getOrCreate()` this particular EMF then it should create it _correctly_, if necessary. Otherwise the next component that wants to `getOrCreate()` the EMF for `vaultDmlConnectionId` may receive one without any entities inside.