### PR TITLE
CORE-16389: Do not reuse AMQP SerializationOutput or DeserializationInput objects.

### DIFF
--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
@@ -2,8 +2,6 @@ package net.corda.sandbox.serialization.amqp
 
 import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
 import net.corda.internal.serialization.SerializationServiceImpl
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
 import net.corda.internal.serialization.registerCustomSerializers
@@ -73,8 +71,8 @@ class AMQPSerializationProvider @Activate constructor(
 
         val serializationService = SerializationMetricsWrapper(
             serializationService = SerializationServiceImpl(
-                SerializationOutput(factory),
-                DeserializationInput(factory),
+                outputFactory = factory,
+                inputFactory = factory,
                 AMQP_STORAGE_CONTEXT.withSandboxGroup(context.sandboxGroup) //todo double check in CORE-12472
             ),
             context

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationServiceImpl.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/SerializationServiceImpl.kt
@@ -3,6 +3,7 @@ package net.corda.internal.serialization
 import net.corda.base.internal.sequence
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.SerializationOutput
+import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.serialization.SerializationContext
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.serialization.SerializedBytes
@@ -10,8 +11,8 @@ import java.security.PrivilegedActionException
 import java.security.PrivilegedExceptionAction
 
 class SerializationServiceImpl(
-    private val serializationOutput: SerializationOutput,
-    private val deserializationInput: DeserializationInput,
+    private val outputFactory: SerializerFactory,
+    private val inputFactory: SerializerFactory,
     private val context: SerializationContext
 ) : SerializationService {
 
@@ -19,7 +20,7 @@ class SerializationServiceImpl(
         return try {
             @Suppress("deprecation", "removal")
             java.security.AccessController.doPrivileged(PrivilegedExceptionAction {
-                serializationOutput.serialize(obj, context)
+                SerializationOutput(outputFactory).serialize(obj, context)
             })
         } catch (e: PrivilegedActionException) {
             throw e.exception
@@ -30,7 +31,7 @@ class SerializationServiceImpl(
         return try {
             @Suppress("deprecation", "removal")
             java.security.AccessController.doPrivileged(PrivilegedExceptionAction {
-                deserializationInput.deserialize(serializedBytes.unwrap(), clazz, context)
+                DeserializationInput(inputFactory).deserialize(serializedBytes.unwrap(), clazz, context)
             })
         } catch (e: PrivilegedActionException) {
             throw e.exception
@@ -41,7 +42,7 @@ class SerializationServiceImpl(
         return try {
             @Suppress("deprecation", "removal")
             java.security.AccessController.doPrivileged(PrivilegedExceptionAction {
-                deserializationInput.deserialize(bytes.sequence(), clazz, context)
+                DeserializationInput(inputFactory).deserialize(bytes.sequence(), clazz, context)
             })
         } catch (e: PrivilegedActionException) {
             throw e.exception

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/DeserializationInput.kt
@@ -34,13 +34,14 @@ data class ObjectAndEnvelope<out T>(val obj: T, val envelope: Envelope)
  * @param serializerFactory This is the factory for [AMQPSerializer] instances and can be shared across multiple
  * instances and threads.
  */
-class DeserializationInput constructor(
+class DeserializationInput(
     private val serializerFactory: SerializerFactory
 ) {
-    private val objectHistory: MutableList<Any> = mutableListOf()
-    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val objectHistory = mutableListOf<Any>()
 
     companion object {
+        private val logger = LoggerFactory.getLogger(DeserializationInput::class.java)
+
         @VisibleForTesting
         @Throws(AMQPNoTypeNotSerializableException::class)
         fun <T> withDataBytes(

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/SerializationOutput.kt
@@ -27,8 +27,8 @@ data class BytesAndSchemas<T : Any>(
  * @param serializerFactory This is the factory for [AMQPSerializer] instances and can be shared across multiple
  * instances and threads.
  */
-open class SerializationOutput constructor(
-        internal val serializerFactory: LocalSerializerFactory
+open class SerializationOutput(
+    private val serializerFactory: LocalSerializerFactory
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/serialization/BaseSerializationService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/serialization/BaseSerializationService.kt
@@ -8,8 +8,6 @@ import net.corda.internal.serialization.SerializationContextImpl
 import net.corda.internal.serialization.SerializationServiceImpl
 import net.corda.internal.serialization.amqp.DefaultDescriptorBasedSerializerRegistry
 import net.corda.internal.serialization.amqp.DescriptorBasedSerializerRegistry
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
 import net.corda.internal.serialization.amqp.amqpMagic
@@ -63,10 +61,12 @@ class BaseSerializationService(
                 schemeMetadata,
                 context.sandboxGroup as SandboxGroup
             )
-            val output = SerializationOutput(factory)
-            val input = DeserializationInput(factory)
 
-            return SerializationServiceImpl(output, input, context)
+            return SerializationServiceImpl(
+                outputFactory = factory,
+                inputFactory = factory,
+                context
+            )
         }
 
         private class SimSandboxGroup(

--- a/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
+++ b/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
@@ -5,8 +5,6 @@ import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.flow.pipeline.sandbox.impl.FlowSandboxGroupContextImpl
 import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
 import net.corda.internal.serialization.SerializationServiceImpl
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.helper.createSerializerFactory
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.common.data.transaction.factory.WireTransactionFactory
@@ -100,8 +98,8 @@ abstract class CommonLedgerIntegrationTest {
         serializationService = SerializationServiceImpl(
             // Use different SerializerFactories for serializationOutput and deserializationInput to not let them share
             // anything unintentionally
-            serializationOutput = SerializationOutput(sandboxGroupContext.createSerializerFactory()),
-            deserializationInput = DeserializationInput(sandboxGroupContext.createSerializerFactory()),
+            outputFactory = sandboxGroupContext.createSerializerFactory(),
+            inputFactory = sandboxGroupContext.createSerializerFactory(),
             context = AMQP_STORAGE_CONTEXT.withSandboxGroup(sandboxGroupContext.sandboxGroup)
         )
 

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationService.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationService.kt
@@ -5,8 +5,6 @@ import net.corda.crypto.impl.serialization.PublicKeySerializer
 import net.corda.internal.serialization.SerializationServiceImpl
 import net.corda.internal.serialization.amqp.DefaultDescriptorBasedSerializerRegistry
 import net.corda.internal.serialization.amqp.DescriptorBasedSerializerRegistry
-import net.corda.internal.serialization.amqp.DeserializationInput
-import net.corda.internal.serialization.amqp.SerializationOutput
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
 import net.corda.internal.serialization.amqp.currentSandboxGroup
@@ -36,11 +34,13 @@ class TestSerializationService {
             cipherSchemeMetadata: CipherSchemeMetadata
         ) : SerializationService {
             val factory = getTestDefaultFactoryNoEvolution(registerMoreSerializers, cipherSchemeMetadata)
-            val output = SerializationOutput(factory)
-            val input = DeserializationInput(factory)
             val context = testSerializationContext
 
-            return SerializationServiceImpl(output, input, context)
+            return SerializationServiceImpl(
+                outputFactory = factory,
+                inputFactory = factory,
+                context
+            )
         }
     }
 }


### PR DESCRIPTION
In Corda 4, the `SerializationScheme` object creates a new `SerializationOutput` / `DeserializationInput` object for each serialization / deserialization request. However, this behaviour has been lost in the translation to Corda 5, with the result that `SerializationService` is currently non-reentrant.

Modify the `SerializationServiceImpl` to create a new `SerializationOutput` or `DeserializationInput` object, in the same way that `SerializationScheme` would have.

In actual practice, we would expect both serialization and deserialization to use the same `SerializerFactory`. However, it is convenient to allow them to be different here for the sake of testing.