### PR TITLE
CORE-14685: Add explicit format parameters to property keys.

### DIFF
--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/processor/crypto/SigningKeyProvider.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/processor/crypto/SigningKeyProvider.kt
@@ -55,11 +55,12 @@ class SigningKeyProvider @Activate constructor(
 
     init {
         val localKeys = linkedMapOf<MemberX500Name, SigningKeyInfo>()
+        @Suppress("MaxLineLength")
         (properties[CORDA_MEMBER_COUNT] as? Int)?.also { localCount ->
             for (idx in 0 until localCount) {
-                (properties["$CORDA_MEMBER_X500_NAME.$idx"] as? String)?.let(MemberX500Name::parse)?.also { localMember ->
-                    (properties["$CORDA_MEMBER_PUBLIC_KEY.$idx"] as? ByteArray)?.let(schemeMetadata::decodePublicKey)?.let { publicKey ->
-                        (properties["$CORDA_MEMBER_PRIVATE_KEY.$idx"] as? ByteArray)?.also { privateBytes ->
+                (properties[CORDA_MEMBER_X500_NAME.format(idx)] as? String)?.let(MemberX500Name::parse)?.also { localMember ->
+                    (properties[CORDA_MEMBER_PUBLIC_KEY.format(idx)] as? ByteArray)?.let(schemeMetadata::decodePublicKey)?.let { publicKey ->
+                        (properties[CORDA_MEMBER_PRIVATE_KEY.format(idx)] as? ByteArray)?.also { privateBytes ->
                             val alias = UUID.randomUUID().toString()
                             val keyScheme = schemeMetadata.findKeyScheme(publicKey)
                             val keyFactory = schemeMetadata.findKeyFactory(keyScheme)

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/Constants.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/Constants.kt
@@ -12,10 +12,26 @@ const val DRIVER_SERVICE_FILTER = "(${DRIVER_SERVICE_NAME}=*)"
 const val CORDA_GROUP_PID = "net.corda.testing.driver.sandbox.Group"
 const val CORDA_GROUP_PARAMETERS = "net.corda.testing.driver.sandbox.group.parameters"
 const val CORDA_MEMBERSHIP_PID = "net.corda.testing.driver.sandbox.Membership"
+
+/**
+ * Property keys describing network members and their key-pairs:
+ * ```
+ * net.corda.testing.driver.sandbox.member.count = N
+ *
+ * net.corda.testing.driver.sandbox.member.X500.0 = <first member X500>
+ * net.corda.testing.driver.sandbox.member.PublicKey.0 = <first member encoded PublicKey>
+ * net.corda.testing.driver.sandbox.member.PrivateKey.0 = <first member encoded PrivateKey>
+ * ...
+ * net.corda.testing.driver.sandbox.member.X500.(N-1) = <Nth member X500>
+ * net.corda.testing.driver.sandbox.member.PublicKey.(N-1) = <Nth member encoded PublicKey>
+ * net.corda.testing.driver.sandbox.member.PrivateKey.(N-1) = <Nth member encoded PrivateKey>
+ * ```
+ * where `%d` is a format character to be populated using [String.format].
+ */
 const val CORDA_MEMBER_COUNT = "net.corda.testing.driver.sandbox.member.count"
-const val CORDA_MEMBER_X500_NAME = "net.corda.testing.driver.sandbox.member.X500"
-const val CORDA_MEMBER_PUBLIC_KEY = "net.corda.testing.driver.sandbox.member.PublicKey"
-const val CORDA_MEMBER_PRIVATE_KEY = "net.corda.testing.driver.sandbox.member.PrivateKey"
+const val CORDA_MEMBER_X500_NAME = "net.corda.testing.driver.sandbox.member.X500.%d"
+const val CORDA_MEMBER_PUBLIC_KEY = "net.corda.testing.driver.sandbox.member.PublicKey.%d"
+const val CORDA_MEMBER_PRIVATE_KEY = "net.corda.testing.driver.sandbox.member.PrivateKey.%d"
 
 const val FIRST_SESSION_KEY = "$SESSION_KEYS.0"
 const val DEFAULT_KEY_SCHEME = ECDSA_SECP256R1_CODE_NAME

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/EmbeddedNodeServiceImpl.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/EmbeddedNodeServiceImpl.kt
@@ -198,10 +198,10 @@ class EmbeddedNodeServiceImpl @Activate constructor(
             val properties = Hashtable<String, Any>()
             properties[CORDA_MEMBER_COUNT] = network.size
             network.entries.forEachIndexed { idx, entry ->
-                properties["$CORDA_MEMBER_X500_NAME.$idx"] = entry.key.toString()
+                properties[CORDA_MEMBER_X500_NAME.format(idx)] = entry.key.toString()
                 entry.value.also { keyPair ->
-                    properties["$CORDA_MEMBER_PRIVATE_KEY.$idx"] = keyPair.private.encoded
-                    properties["$CORDA_MEMBER_PUBLIC_KEY.$idx"] = keyPair.public.encoded
+                    properties[CORDA_MEMBER_PRIVATE_KEY.format(idx)] = keyPair.private.encoded
+                    properties[CORDA_MEMBER_PUBLIC_KEY.format(idx)] = keyPair.public.encoded
                 }
             }
             config.update(properties)

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/MembershipGroupControllerProviderImpl.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/MembershipGroupControllerProviderImpl.kt
@@ -252,8 +252,8 @@ class MembershipGroupControllerProviderImpl @Activate constructor(
         return buildMap {
             val memberCount = properties[CORDA_MEMBER_COUNT] as? Int ?: 0
             for (idx in 0 until memberCount) {
-                val memberX500Name = (properties["$CORDA_MEMBER_X500_NAME.$idx"] as? String)?.let(MemberX500Name::parse)
-                val publicKey = (properties["$CORDA_MEMBER_PUBLIC_KEY.$idx"] as? ByteArray)?.let(schemeMetadata::decodePublicKey)
+                val memberX500Name = (properties[CORDA_MEMBER_X500_NAME.format(idx)] as? String)?.let(MemberX500Name::parse)
+                val publicKey = (properties[CORDA_MEMBER_PUBLIC_KEY.format(idx)] as? ByteArray)?.let(schemeMetadata::decodePublicKey)
 
                 if (memberX500Name != null && publicKey != null) {
                     this[memberX500Name] = publicKey


### PR DESCRIPTION
Use `String.format()` to emphasise how these property keys are supposed to work.