### PR TITLE
CORE-16230 Split UniquenessProcessor into its own worker

### DIFF
--- a/.ci/JenkinsfileSnykDelta
+++ b/.ci/JenkinsfileSnykDelta
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 snykDelta(
   snykOrgId: 'corda5-snyk-org-id',

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -1,7 +1,5 @@
 #! groovy
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 import com.r3.build.enums.BuildEnvironment
 import com.r3.build.utils.PublishingUtils

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 import groovy.transform.Field
 import com.r3.build.utils.PipelineUtils

--- a/.ci/e2eTests/JenkinsfileCombinedWorkerLinux
+++ b/.ci/e2eTests/JenkinsfileCombinedWorkerLinux
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 combinedWorkerPipeline(
     agentOs : 'linux'

--- a/.ci/e2eTests/JenkinsfileCombinedWorkerWindows
+++ b/.ci/e2eTests/JenkinsfileCombinedWorkerWindows
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 combinedWorkerPipeline(
     agentOs : 'windows'

--- a/.ci/e2eTests/JenkinsfileMultiClusterTest
+++ b/.ci/e2eTests/JenkinsfileMultiClusterTest
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(
     dailyBuildCron: '0 */12 * * *',

--- a/.ci/e2eTests/JenkinsfileUnstableTest
+++ b/.ci/e2eTests/JenkinsfileUnstableTest
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(
     assembleAndCompile: true,

--- a/.ci/e2eTests/ethereum/Jenkinsfile
+++ b/.ci/e2eTests/ethereum/Jenkinsfile
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 ethereumInterop(
     deployEthereum: true,

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H 03 * * *',

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5',

--- a/.ci/nightly/JenkinsfileUnstableTests
+++ b/.ci/nightly/JenkinsfileUnstableTests
@@ -1,7 +1,5 @@
 //catch all job for flaky tests
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
     runIntegrationTests: true,

--- a/.ci/nightly/JenkinsfileWindowsCompatibility
+++ b/.ci/nightly/JenkinsfileWindowsCompatibility
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 windowsCompatibility(
     runIntegrationTests: true,

--- a/.ci/versionCompatibility/Jenkinsfile
+++ b/.ci/versionCompatibility/Jenkinsfile
@@ -1,5 +1,3 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaCompatibilityCheckPipeline(javaVersion: '17')

--- a/.ci/versionCompatibility/latest-version.Jenkinsfile
+++ b/.ci/versionCompatibility/latest-version.Jenkinsfile
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 // This build forces using the "very latest" version of the dependencies, regardless of which revision was chosen
 //  This is useful as it gives early indication of a downstream change that may introduce a breaking change

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@mbrkic-r3/CORE-16230/uniqueness-worker') _
-// TODO revert to 5.1 after branch above is merged to it
-// @Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',


### PR DESCRIPTION
Reverted to 5.1 branch of corda-shared-build-pipeline-steps (branch mbrkic-r3/CORE-16230/uniqueness-worker was used temporarily to minimize build risks until it was merged to 5.1)