### PR TITLE
CORE-9569 Remove Direct Access to Consumers From StateAndEventConsumer

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -50,7 +50,6 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
 
     private var nullableProducer: CordaProducer? = null
     private var nullableStateAndEventConsumer: StateAndEventConsumer<K, S, E>? = null
-    private var nullableEventConsumer: CordaConsumer<K, E>? = null
     private var threadLooper =
         ThreadLooper(log, config, lifecycleCoordinatorFactory, "state/event processing thread", ::runConsumeLoop)
 
@@ -65,10 +64,6 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
                 ?: throw IllegalStateException("Unexpected access to null stateAndEventConsumer.")
         }
 
-    private val eventConsumer: CordaConsumer<K, E>
-        get() {
-            return nullableEventConsumer ?: throw IllegalStateException("Unexpected access to null eventConsumer.")
-        }
 
     private val eventTopic = config.topic
     private val stateTopic = getStateAndEventStateTopic(config.topic)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -137,10 +137,8 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
                     }
                 )
                 nullableRebalanceListener = rebalanceListener
-                val eventConsumerTmp = stateAndEventConsumerTmp.eventConsumer
                 nullableStateAndEventConsumer = stateAndEventConsumerTmp
-                nullableEventConsumer = eventConsumerTmp
-                eventConsumerTmp.subscribe(eventTopic, rebalanceListener)
+                nullableStateAndEventConsumer!!.subscribe(eventTopic, rebalanceListener)
                 threadLooper.updateLifecycleStatus(LifecycleStatus.UP)
 
                 while (!threadLooper.loopStopped) {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumer.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumer.kt
@@ -7,6 +7,7 @@ import net.corda.messaging.api.subscription.listener.StateAndEventListener
 import net.corda.messaging.subscription.consumer.listener.StateAndEventConsumerRebalanceListener
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import java.time.Clock
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
 /**
@@ -95,6 +96,7 @@ interface StateAndEventConsumer<K : Any, S : Any, E : Any> : AutoCloseable {
     fun beginningOffsets(newStatePartitions: List<CordaTopicPartition>): Map<CordaTopicPartition, Long>
 
     fun endOffsets(newStatePartitions: List<CordaTopicPartition>): Map<CordaTopicPartition, Long>
+    fun poll(timeout: Duration): Unit
 
     /**
      * Direct access to [eventConsumer] and [stateConsumer].

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumer.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumer.kt
@@ -4,6 +4,7 @@ import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.consumer.CordaConsumer
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messaging.api.subscription.listener.StateAndEventListener
+import net.corda.messaging.subscription.consumer.listener.StateAndEventConsumerRebalanceListener
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
@@ -89,12 +90,17 @@ interface StateAndEventConsumer<K : Any, S : Any, E : Any> : AutoCloseable {
      */
     @Throws(RebalanceInProgressException::class)
     fun waitForFunctionToFinish(function: () -> Any, maxTimeout: Long, timeoutErrorMessage: String) : CompletableFuture<Any>
+    fun subscribe(eventTopic: String, rebalanceListener: StateAndEventConsumerRebalanceListener)
+    fun assignment(): Set<CordaTopicPartition>
+    fun beginningOffsets(newStatePartitions: List<CordaTopicPartition>): Map<CordaTopicPartition, Long>
+
+    fun endOffsets(newStatePartitions: List<CordaTopicPartition>): Map<CordaTopicPartition, Long>
 
     /**
      * Direct access to [eventConsumer] and [stateConsumer].
      * @Suppress("ForbiddenComment")
      * TODO: remove direct access to consumers. See https://r3-cev.atlassian.net/browse/CORE-9569.
      */
-    val eventConsumer: CordaConsumer<K, E>
-    val stateConsumer: CordaConsumer<K, S>
+    //val eventConsumer: CordaConsumer<K, E>
+    //val stateConsumer: CordaConsumer<K, S>
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -298,6 +298,10 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
     override fun endOffsets(newStatePartitions: List<CordaTopicPartition>)
         = eventConsumer.endOffsets(newStatePartitions)
 
+    override fun poll(timeout: Duration) {
+        eventConsumer.poll(timeout)
+    }
+
     /**
      * Helper method to poll events from a paused [eventConsumer], should only be used to prevent it from being kicked
      * out of the consumer group and only when all partitions are paused as to not lose any events.

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/StateAndEventConsumerRebalanceListenerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/listener/StateAndEventConsumerRebalanceListenerImpl.kt
@@ -21,7 +21,6 @@ internal class StateAndEventConsumerRebalanceListenerImpl<K : Any, S : Any, E : 
 
     private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.clientId}")
     private val currentStates = partitionState.currentStates
-    private val stateConsumer = stateAndEventConsumer.stateConsumer
 
     /**
      *  This rebalance is called for the event consumer, though most of the work is to ensure the state consumer
@@ -33,7 +32,7 @@ internal class StateAndEventConsumerRebalanceListenerImpl<K : Any, S : Any, E : 
         stateAndEventConsumer.onPartitionsAssigned(partitions.toSet())
 
         val newStatePartitions = partitions.toStateTopics()
-        val statePartitions = stateConsumer.assignment() + newStatePartitions
+        val statePartitions = stateAndEventConsumer.assignment() + newStatePartitions
 
         // Initialise the housekeeping here but the sync and updates
         // will be handled in the normal poll cycle
@@ -80,8 +79,8 @@ internal class StateAndEventConsumerRebalanceListenerImpl<K : Any, S : Any, E : 
     }
 
     private fun filterSyncablePartitions(newStatePartitions: List<CordaTopicPartition>): List<Pair<Int, Long>> {
-        val beginningOffsets = stateConsumer.beginningOffsets(newStatePartitions)
-        val endOffsets = stateConsumer.endOffsets(newStatePartitions)
+        val beginningOffsets = stateAndEventConsumer.beginningOffsets(newStatePartitions)
+        val endOffsets = stateAndEventConsumer.endOffsets(newStatePartitions)
         return newStatePartitions.mapNotNull {
             val beginningOffset = beginningOffsets[it] ?: 0
             val endOffset = endOffsets[it] ?: 0

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/listener/StateAndEventConsumerRebalanceListenerImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/consumer/listener/StateAndEventConsumerRebalanceListenerImplTest.kt
@@ -99,15 +99,12 @@ class StateAndEventConsumerRebalanceListenerImplTest {
     private fun setupMocks(): Mocks {
         val listener: StateAndEventListener<String, String> = mock()
         val stateAndEventConsumer: StateAndEventConsumer<String, String, String> = mock()
-        val eventConsumer: CordaConsumer<String, String> = mock()
         val stateConsumer: CordaConsumer<String, String> = mock()
 
         val topicPartitions = setOf(CordaTopicPartition(TOPIC, 0))
         val mapFactory = mock<MapFactory<String, Pair<Long, String>>>()
 
         doAnswer { topicPartitions }.whenever(stateConsumer).assignment()
-        whenever(stateAndEventConsumer.eventConsumer).thenReturn(eventConsumer)
-        whenever(stateAndEventConsumer.stateConsumer).thenReturn(stateConsumer)
 
         return Mocks(listener, stateAndEventConsumer, mapFactory, topicPartitions)
     }


### PR DESCRIPTION
Remove public access to `eventConsumer` and `stateConsumer` from `StateAndEventConsumer`.
