### PR TITLE
ES-1184: Ensure correct CLI version used in release builds 

### DIFF
--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -145,7 +145,6 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
         } else {
             it.baseImageTag = (cordaCliIncluded) ? "latest-local-${cliVersion}" : "unstable-${cliVersion}"
         }
-        it.baseImageTag = (cordaCliIncluded) ? "latest-local-${cliVersion}" : "unstable-${cliVersion}"
     }
 
     if (project.hasProperty('useDockerDaemon')) {

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -140,6 +140,11 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
         baseImageTag = cliBaseTag
     } else {
         String cliVersion = pluginHostVersion.replaceAll(/(.*\d)\D*$/, '$1') // drop suffix i.e beta-+
+        if (['RC', 'GA'].contains(System.getenv('RELEASE_TYPE'))) {
+            it.baseImageTag = cliVersion
+        } else {
+            it.baseImageTag = (cordaCliIncluded) ? "latest-local-${cliVersion}" : "unstable-${cliVersion}"
+        }
         it.baseImageTag = (cordaCliIncluded) ? "latest-local-${cliVersion}" : "unstable-${cliVersion}"
     }
 


### PR DESCRIPTION
If in a GA or an RC build, we should be using the version of the CLI set in `gradle.properties` i.e. 5.1.0-HC03, for example,

Existing logic ended up setting `baseImageTag` as `unstable-5.1.0-HC03` in the above example which is incorrect, for release branch builds / PRs the existing logic is correct but for release builds we need to lose the unstable prefix and just take `cliVersion`

Note, for HCs RELEASE_TYPE is set to RC also, this env var is set by CI server