### PR TITLE
CORE-5101 Create Object Serialization tests

### DIFF
--- a/libs/serialization/serialization-kryo/build.gradle
+++ b/libs/serialization/serialization-kryo/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     testRuntimeOnly "co.paralleluniverse:quasar-core-osgi:$quasarVersion:framework-extension"
     testImplementation project(":testing:kryo-serialization-testkit")
     testRuntimeOnly "org.slf4j:slf4j-simple:$slf4jVersion"
+    testImplementation project(":libs:flows:flow-api")
+    testImplementation project(":components:flow:flow-service")
+    testImplementation project(":libs:crypto:crypto-core")
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project('cpks:serializable-cpk-one')

--- a/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
+++ b/libs/serialization/serialization-kryo/src/main/kotlin/net/corda/kryoserialization/DefaultKryoCustomizer.kt
@@ -27,6 +27,7 @@ import net.corda.kryoserialization.serializers.LoggerSerializer
 import net.corda.kryoserialization.serializers.NonSerializableSerializer
 import net.corda.kryoserialization.serializers.ThrowableSerializer
 import net.corda.kryoserialization.serializers.X509CertificateSerializer
+import net.corda.kryoserialization.serializers.X500PrincipalSerializer
 import net.corda.serialization.checkpoint.NonSerializable
 import net.corda.utilities.LazyMappedList
 import org.apache.avro.specific.SpecificRecord
@@ -42,6 +43,7 @@ import java.lang.reflect.Modifier.isPublic
 import java.security.cert.CertPath
 import java.security.cert.X509Certificate
 import java.util.Collections.unmodifiableSet
+import javax.security.auth.x500.X500Principal
 
 class DefaultKryoCustomizer {
 
@@ -94,6 +96,7 @@ class DefaultKryoCustomizer {
 
                 addDefaultSerializer(Logger::class.java, LoggerSerializer)
                 addDefaultSerializer(X509Certificate::class.java, X509CertificateSerializer)
+                addDefaultSerializer(X500Principal::class.java, X500PrincipalSerializer())
                 addDefaultSerializer(Class::class.java, classSerializer)
                 addDefaultSerializer(
                     LinkedHashMapIteratorSerializer.getIterator()::class.java.superclass,

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/PlatformClassSerializationTests.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/PlatformClassSerializationTests.kt
@@ -229,7 +229,7 @@ class PlatformClassSerializationTests {
 
         val cause = Throwable("TestException")
 
-        val exception = CordaRuntimeException("TestClassName", "Nobody Expects The Spanish Inquisition", cause)
+        val exception = CordaRuntimeException("TestClassName", "Test Exception Message", cause)
 
         kryo.writeClassAndObject(output, exception)
         val tested = kryo.readClassAndObject(Input(output.buffer)) as CordaRuntimeException

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/PlatformClassSerializationTests.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/PlatformClassSerializationTests.kt
@@ -37,7 +37,9 @@ class PlatformClassSerializationTests {
     private val flowContext = mock<FlowContext>()
     private val signatureSpec = mock<CustomSignatureSpec>()
     private val digitalSignature = mock<DigitalSignatureWithKeyId>()
-    private val digitalsignatureMetadata = DigitalSignatureMetadata(Instant.now(), signatureSpec, mapOf("key" to "Value"))
+    private val digitalsignatureMetadata =
+        DigitalSignatureMetadata(Instant.now(), signatureSpec, mapOf("key" to "Value"))
+
     @Test
     fun `FlowInfo serialization test`() {
         val output = Output(100)
@@ -92,13 +94,21 @@ class PlatformClassSerializationTests {
         kryo.register(FlowSession::class.java)
         val counterParty = MemberX500Name("Alice", "Alice Corp", "LDN", "GB")
 
-        val flowSession: FlowSession = FlowSessionImpl(counterParty, "SessionId1", mockFlowFiberService, serializationService, flowContext, FlowSessionImpl.Direction.INITIATING_SIDE)
+        val flowSession: FlowSession = FlowSessionImpl(
+            counterParty,
+            "SessionId1",
+            mockFlowFiberService,
+            serializationService,
+            flowContext,
+            FlowSessionImpl.Direction.INITIATING_SIDE
+        )
 
         kryo.writeClassAndObject(output, flowSession)
         val tested = kryo.readClassAndObject(Input(output.buffer)) as FlowSession
 
         Assertions.assertThat(tested.contextProperties).isEqualTo(flowSession.contextProperties)
     }
+
     @Test
     fun `DigitalSignatureAndMetadata serialization test`() {
         val output = Output(10000)
@@ -118,6 +128,7 @@ class PlatformClassSerializationTests {
         Assertions.assertThat(tested.signature).isEqualTo(signatureAndMeta.signature)
         Assertions.assertThat(tested.metadata).isEqualTo(signatureAndMeta.metadata)
     }
+
     @Test
     fun `InitiatedBy serialization test`() {
         val output = Output(10000)
@@ -129,7 +140,7 @@ class PlatformClassSerializationTests {
         )
         kryo.register(InitiatedBy::class.java)
 
-        val initiatedBy = InitiatedBy(protocol="testingSerialization", version = intArrayOf(1234))
+        val initiatedBy = InitiatedBy(protocol = "testingSerialization", version = intArrayOf(1234))
 
         kryo.writeClassAndObject(output, initiatedBy)
         val tested = kryo.readClassAndObject(Input(output.buffer)) as InitiatedBy
@@ -138,6 +149,7 @@ class PlatformClassSerializationTests {
         Assertions.assertThat(tested.protocol).isEqualTo(initiatedBy.protocol)
         Assertions.assertThat(tested.version).isEqualTo(initiatedBy.version)
     }
+
     @Test
     fun `InitiatingFlow serialization test`() {
         val output = Output(10000)
@@ -149,7 +161,7 @@ class PlatformClassSerializationTests {
         )
         kryo.register(InitiatingFlow::class.java)
 
-        val initiatingFlow = InitiatingFlow(protocol="testingSerialization", version = intArrayOf(1234))
+        val initiatingFlow = InitiatingFlow(protocol = "testingSerialization", version = intArrayOf(1234))
 
         kryo.writeClassAndObject(output, initiatingFlow)
         val tested = kryo.readClassAndObject(Input(output.buffer)) as InitiatingFlow
@@ -158,6 +170,7 @@ class PlatformClassSerializationTests {
         Assertions.assertThat(tested.protocol).isEqualTo(initiatingFlow.protocol)
         Assertions.assertThat(tested.version).isEqualTo(initiatingFlow.version)
     }
+
     @Test
     fun `SecureHash serialization test`() {
         val output = Output(10000)
@@ -178,6 +191,7 @@ class PlatformClassSerializationTests {
         Assertions.assertThat(tested.algorithm).isEqualTo(hash.algorithm)
         Assertions.assertThat(tested.bytes).isEqualTo(hash.bytes)
     }
+
     @Test
     fun `SignatureSpec serialization test`() {
         val output = Output(10000)
@@ -197,6 +211,7 @@ class PlatformClassSerializationTests {
         Assertions.assertThat(tested).isEqualTo(sigSpec)
         Assertions.assertThat(tested.signatureName).isEqualTo(sigSpec.signatureName)
     }
+
     @Test
     fun `DigestAlgorithmName serialization test`() {
         val output = Output(10000)
@@ -216,6 +231,7 @@ class PlatformClassSerializationTests {
         Assertions.assertThat(tested).isEqualTo(digestAlgorithmName)
         Assertions.assertThat(tested.name).isEqualTo(digestAlgorithmName.name)
     }
+
     @Test
     fun `CordaRuntimeException serialization test`() {
         val output = Output(10000)

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/PlatformClassSerializationTests.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/PlatformClassSerializationTests.kt
@@ -1,0 +1,114 @@
+package net.corda.kryoserialization.serializers
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.flow.application.serialization.SerializationServiceInternal
+import net.corda.flow.application.sessions.impl.FlowInfoImpl
+import net.corda.flow.application.sessions.impl.FlowSessionImpl
+import net.corda.flow.fiber.FlowFiberService
+import net.corda.flow.state.FlowContext
+import net.corda.kryoserialization.DefaultKryoCustomizer
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.crypto.DigitalSignatureMetadata
+import net.corda.v5.application.messaging.FlowInfo
+import net.corda.v5.application.messaging.FlowSession
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.crypto.core.DigitalSignatureWithKeyId
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.time.Instant
+
+class PlatformClassSerializationTests {
+    private val mockFlowFiberService = mock<FlowFiberService>()
+    private val serializationService = mock<SerializationServiceInternal>()
+    private val flowContext = mock<FlowContext>()
+    private val signatureSpec = mock<CustomSignatureSpec>()
+    private val digitalSignature = mock<DigitalSignatureWithKeyId>()
+    private val digitalsignatureMetadata = DigitalSignatureMetadata(Instant.now(), signatureSpec, mapOf("key" to "Value"))
+    @Test
+    fun `FlowInfo serialization test`() {
+        val output = Output(100)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(FlowInfo::class.java)
+
+        val info: FlowInfo = FlowInfoImpl("test", 1)
+
+        kryo.writeClassAndObject(output, info)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as FlowInfo
+
+        Assertions.assertThat(tested.protocol()).isEqualTo(info.protocol())
+        Assertions.assertThat(tested.protocolVersion()).isEqualTo(info.protocolVersion())
+
+    }
+
+    @Test
+    fun `DigitalSignatureMetadata serialization test`() {
+        val output = Output(10000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(FlowInfo::class.java)
+
+        val signatureMeta = digitalsignatureMetadata
+
+        kryo.writeClassAndObject(output, signatureMeta)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as DigitalSignatureMetadata
+
+        Assertions.assertThat(tested.properties).isEqualTo(signatureMeta.properties)
+        Assertions.assertThat(tested.timestamp).isEqualTo(signatureMeta.timestamp)
+    }
+
+    @Disabled
+    @Test
+    fun `FlowSession serialization test`() {
+        val output = Output(1000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(FlowSession::class.java)
+        val counterParty = MemberX500Name("Alice", "Alice Corp", "LDN", "GB")
+
+        val flowSession: FlowSession = FlowSessionImpl(counterParty, "SessionId1", mockFlowFiberService, serializationService, flowContext, FlowSessionImpl.Direction.INITIATING_SIDE)
+
+
+        kryo.writeClassAndObject(output, flowSession)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as FlowSession
+
+        Assertions.assertThat(tested.contextProperties).isEqualTo(flowSession.contextProperties)
+    }
+    @Test
+    fun `DigitalSignatureAndMetadata serialization test`() {
+        val output = Output(10000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(FlowInfo::class.java)
+
+        val signatureAndMeta = DigitalSignatureAndMetadata(digitalSignature, digitalsignatureMetadata)
+
+        kryo.writeClassAndObject(output, signatureAndMeta)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as DigitalSignatureAndMetadata
+
+        Assertions.assertThat(tested.signature).isEqualTo(signatureAndMeta.signature)
+        Assertions.assertThat(tested.metadata).isEqualTo(signatureAndMeta.metadata)
+
+    }
+}

--- a/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/PlatformClassSerializationTests.kt
+++ b/libs/serialization/serialization-kryo/src/test/kotlin/net/corda/kryoserialization/serializers/PlatformClassSerializationTests.kt
@@ -4,6 +4,7 @@ import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.io.Input
 import com.esotericsoftware.kryo.io.Output
 import net.corda.crypto.cipher.suite.CustomSignatureSpec
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.flow.application.serialization.SerializationServiceInternal
 import net.corda.flow.application.sessions.impl.FlowInfoImpl
 import net.corda.flow.application.sessions.impl.FlowSessionImpl
@@ -16,6 +17,14 @@ import net.corda.v5.application.messaging.FlowInfo
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.bytes
+import net.corda.v5.application.flows.InitiatedBy
+import net.corda.v5.application.flows.InitiatingFlow
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.SignatureSpec
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -85,7 +94,6 @@ class PlatformClassSerializationTests {
 
         val flowSession: FlowSession = FlowSessionImpl(counterParty, "SessionId1", mockFlowFiberService, serializationService, flowContext, FlowSessionImpl.Direction.INITIATING_SIDE)
 
-
         kryo.writeClassAndObject(output, flowSession)
         val tested = kryo.readClassAndObject(Input(output.buffer)) as FlowSession
 
@@ -109,6 +117,125 @@ class PlatformClassSerializationTests {
 
         Assertions.assertThat(tested.signature).isEqualTo(signatureAndMeta.signature)
         Assertions.assertThat(tested.metadata).isEqualTo(signatureAndMeta.metadata)
+    }
+    @Test
+    fun `InitiatedBy serialization test`() {
+        val output = Output(10000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(InitiatedBy::class.java)
 
+        val initiatedBy = InitiatedBy(protocol="testingSerialization", version = intArrayOf(1234))
+
+        kryo.writeClassAndObject(output, initiatedBy)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as InitiatedBy
+
+        Assertions.assertThat(tested).isEqualTo(initiatedBy)
+        Assertions.assertThat(tested.protocol).isEqualTo(initiatedBy.protocol)
+        Assertions.assertThat(tested.version).isEqualTo(initiatedBy.version)
+    }
+    @Test
+    fun `InitiatingFlow serialization test`() {
+        val output = Output(10000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(InitiatingFlow::class.java)
+
+        val initiatingFlow = InitiatingFlow(protocol="testingSerialization", version = intArrayOf(1234))
+
+        kryo.writeClassAndObject(output, initiatingFlow)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as InitiatingFlow
+
+        Assertions.assertThat(tested).isEqualTo(initiatingFlow)
+        Assertions.assertThat(tested.protocol).isEqualTo(initiatingFlow.protocol)
+        Assertions.assertThat(tested.version).isEqualTo(initiatingFlow.version)
+    }
+    @Test
+    fun `SecureHash serialization test`() {
+        val output = Output(10000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(SecureHash::class.java)
+
+        val hash: SecureHash = SecureHashImpl("TestAlgorithmName", "1234".toByteArray())
+
+        kryo.writeClassAndObject(output, hash)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as SecureHash
+
+        Assertions.assertThat(tested).isEqualTo(hash)
+        Assertions.assertThat(tested.algorithm).isEqualTo(hash.algorithm)
+        Assertions.assertThat(tested.bytes).isEqualTo(hash.bytes)
+    }
+    @Test
+    fun `SignatureSpec serialization test`() {
+        val output = Output(10000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(SignatureSpec::class.java)
+
+        val sigSpec: SignatureSpec = SignatureSpecImpl("TestSignatureName")
+
+        kryo.writeClassAndObject(output, sigSpec)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as SignatureSpec
+
+        Assertions.assertThat(tested).isEqualTo(sigSpec)
+        Assertions.assertThat(tested.signatureName).isEqualTo(sigSpec.signatureName)
+    }
+    @Test
+    fun `DigestAlgorithmName serialization test`() {
+        val output = Output(10000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(DigestAlgorithmName::class.java)
+
+        val digestAlgorithmName = DigestAlgorithmName("TestName")
+
+        kryo.writeClassAndObject(output, digestAlgorithmName)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as DigestAlgorithmName
+
+        Assertions.assertThat(tested).isEqualTo(digestAlgorithmName)
+        Assertions.assertThat(tested.name).isEqualTo(digestAlgorithmName.name)
+    }
+    @Test
+    fun `CordaRuntimeException serialization test`() {
+        val output = Output(10000)
+        val kryo = Kryo()
+        DefaultKryoCustomizer.customize(
+            kryo,
+            emptyMap(),
+            ClassSerializer(mock())
+        )
+        kryo.register(CordaRuntimeException::class.java)
+
+        val cause = Throwable("TestException")
+
+        val exception = CordaRuntimeException("TestClassName", "Nobody Expects The Spanish Inquisition", cause)
+
+        kryo.writeClassAndObject(output, exception)
+        val tested = kryo.readClassAndObject(Input(output.buffer)) as CordaRuntimeException
+
+        Assertions.assertThat(tested.originalExceptionClassName).isEqualTo(exception.originalExceptionClassName)
+        Assertions.assertThat(tested.message).isEqualTo(exception.message)
+        Assertions.assertThat(tested.cause.toString()).isEqualTo(exception.cause.toString())
     }
 }


### PR DESCRIPTION
When a custom Kryo serializer is developed a unit test is written to ensure objects of the type it targets are serialized and deserialized correctly. However, there are no tests to ensure objects of other types are serialized correctly so I am creating some tests for these classes.