### PR TITLE
ES-1228: Update helm publishing job to ensure J17 compatibility

### DIFF
--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -5,7 +5,7 @@ import com.r3.build.enums.BuildEnvironment
 import com.r3.build.utils.PublishingUtils
 
 int cpus = 1
-BuildEnvironment buildEnvironment = BuildEnvironment.AMD64_LINUX
+BuildEnvironment buildEnvironment = BuildEnvironment.AMD64_LINUX_JAVA17
 
 PublishingUtils publishingUtils = new PublishingUtils(this)
 
@@ -20,8 +20,7 @@ pipeline {
             label ([
                     "gradle-build",
                     "${cpus}cpus",
-                    "${buildEnvironment.buildArchitecture.toString().toLowerCase()}",
-                    "${buildEnvironment.buildOperatingSystem.toString().toLowerCase()}"
+                    "${buildEnvironment.jenkinsLabel}"
             ].join('-'))
             showRawYaml false
             defaultContainer 'build'


### PR DESCRIPTION
- Ensure we use J17 when building on this job
- Update pod labels in line with the latest standards, this ensures JDK version is included in the label and we do not accidentally re-use a J11 pod from a non 5.1 branch 

Tested: https://ci02.dev.r3.com/job/Corda5/job/Publish%20Helm%20Pipeline/job/ES-1228-Fix-helm-publish-pipeline-to-use-J17/