### PR TITLE
CORE-16612: Force quasar to ignore metrics packages when instrumenting code

### DIFF
--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:osgi.annotation'
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'

--- a/libs/metrics/src/main/java/net/corda/metrics/package-info.java
+++ b/libs/metrics/src/main/java/net/corda/metrics/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.metrics;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
**Problem Description**
Sometimes when running flows, an exception can occur inside the metrics library indicating that an object is `null`, despite this not being possible from the compiler's perspective. This is happening because Quasar is instrumenting the metrics library, and incorrectly restoring the metrics object on the stack after a suspension. There is no suspendable code inside the metrics library, and so this instrumentation is not required.

**Solution**
Use the `@QuasarIgnoreAllPackages` annotation to force Quasar to not instrument these packages.

**Testing**
No new unit tests required. The change has been run in the test environment where the original problem was observed and this change addresses the issue.