### PR TITLE
ES-1230: Publish second Combined Worker jar with Kafka bus enabled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@connelm/ES-1230/publish-kafka-combined-worker') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@connelm/ES-1230/publish-kafka-combined-worker5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@connelm/ES-1230/publish-kafka-combined-worker') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@connelm/ES-1230/publish-kafka-combined-worker5.1') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -121,14 +121,17 @@ tasks.named('jar', Jar) {
 
 publishing {
     publications {
-        maven(MavenPublication) {
-            artifactId 'corda-combined-worker'
-            groupId project.group
+        configureEach {
             pom {
-                name = 'corda-combined-worker'
-                description = 'corda-combined-worker'
-                url = 'https://github.com/corda/corda-runtime-os'
+                if (!project.hasProperty('busImpl')) {
+                    name = 'corda-combined-worker'
+                    description = 'corda-combined-worker'
+                } else {
+                    name = 'corda-combined-worker-kakfa'
+                    description = 'corda-combined-worker-kafka'
+                }
 
+                url = 'https://github.com/corda/corda-runtime-os'
                 scm {
                     url = 'https://github.com/corda/corda-runtime-os'
                 }
@@ -150,8 +153,13 @@ publishing {
                 }
             }
         }
+        if (!project.hasProperty('busImpl')) {
+            maven(MavenPublication) {
+                artifactId 'corda-combined-worker'
+                groupId project.group
 
-        if (project.hasProperty('busImpl')) {
+            }
+        } else {
             kafkaCombinedWorker(MavenPublication) {
                 artifactId 'corda-combined-worker-kafka'
                 artifact appJar

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -123,6 +123,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             artifactId 'corda-combined-worker'
+
             groupId project.group
             pom {
                 name = 'corda-combined-worker'
@@ -148,6 +149,15 @@ publishing {
                         email = 'dev@corda.net'
                     }
                 }
+            }
+        }
+
+        if (project.hasProperty('busImpl')) {
+            kafkaCombinedWorker(MavenPublication) {
+                artifactId 'corda-combined-worker-kafka'
+                artifact appJar
+                groupId project.group
+                version project.version
             }
         }
     }

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -123,7 +123,6 @@ publishing {
     publications {
         maven(MavenPublication) {
             artifactId 'corda-combined-worker'
-
             groupId project.group
             pom {
                 name = 'corda-combined-worker'

--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -157,7 +157,6 @@ publishing {
             maven(MavenPublication) {
                 artifactId 'corda-combined-worker'
                 groupId project.group
-
             }
         } else {
             kafkaCombinedWorker(MavenPublication) {

--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -538,17 +538,19 @@ artifacts {
 pluginManager.withPlugin('maven-publish') {
     publishing {
         publications {
-            maven(MavenPublication) {
-                artifactId appJarBaseName
-                artifact appJar
+            if (!project.hasProperty('busImpl')) {
+                maven(MavenPublication) {
+                    artifactId appJarBaseName
+                    artifact appJar
 
-                afterEvaluate { proj ->
-                    groupId proj.group
-                    version proj.version
+                    afterEvaluate { proj ->
+                        groupId proj.group
+                        version proj.version
 
-                    try {
-                        artifact tasks.named('sourcesJar', Jar)
-                    } catch (UnknownTaskException ignored) {
+                        try {
+                            artifact tasks.named('sourcesJar', Jar)
+                        } catch (UnknownTaskException ignored) {
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Add new maven publication for `kafkaCombinedWorker` which is the kafak message bus implementation of the combined worker, only publish this if the property `busImpl` is present.

Change also needed in `corda.common-app.gradle` to ensure we do not clobber the original combined worker as with out this both would be re published with the kafka implementation 


Associated pipeline change - https://github.com/corda/corda-shared-build-pipeline-steps/pull/1107 