### PR TITLE
CORE-15804: Set uniqueness DB string to null when config string is none

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbConnections.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbConnections.kt
@@ -18,4 +18,4 @@ class VirtualNodeDbConnections(
     /** Uniqueness DDL DB connection ID */
     val uniquenessDdlConnectionId: UUID? = null,
     /** Uniqueness DML DB connection ID */
-    val uniquenessDmlConnectionId: UUID)
+    val uniquenessDmlConnectionId: UUID? = null)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -91,10 +91,19 @@ internal class VirtualNodeDbFactoryImpl(
         val connectionsProvided = !dmlConfig.isNullOrBlank()
         val dbConnections =
             if (connectionsProvided) {
-                mapOf(
-                    Pair(DDL, ddlConfig?.let { createConnection(dbType, holdingIdentityShortHash, DDL, ddlConfig) }),
-                    Pair(DML, dmlConfig?.let { createConnection(dbType, holdingIdentityShortHash, DML, dmlConfig) })
-                )
+                if (dbType == UNIQUENESS && dmlConfig == "none") {
+                    mapOf(
+                        Pair(DDL, null),
+                        Pair(DML, null)
+                    )
+                } else {
+                    mapOf(
+                        Pair(
+                            DDL,
+                            ddlConfig?.let { createConnection(dbType, holdingIdentityShortHash, DDL, ddlConfig) }),
+                        Pair(DML, dmlConfig?.let { createConnection(dbType, holdingIdentityShortHash, DML, dmlConfig) })
+                    )
+                }
             } else {
                 mapOf(
                     Pair(DDL, createClusterConnection(dbType, holdingIdentityShortHash, DDL)),

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
@@ -138,7 +138,7 @@ internal class CreateVirtualNodeServiceImpl(
                     cryptoDdlConnectionId = persistConnection(em, vNodeDbs, CRYPTO, DDL, updateActor),
                     cryptoDmlConnectionId = persistConnection(em, vNodeDbs, CRYPTO, DML, updateActor)!!,
                     uniquenessDdlConnectionId = persistConnection(em, vNodeDbs, UNIQUENESS, DDL, updateActor),
-                    uniquenessDmlConnectionId = persistConnection(em, vNodeDbs, UNIQUENESS, DML, updateActor)!!
+                    uniquenessDmlConnectionId = persistConnection(em, vNodeDbs, UNIQUENESS, DML, updateActor)
                 )
 
                 holdingIdentityRepository.put(em, holdingIdentity)

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -15,6 +15,7 @@ import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.schema.configuration.DatabaseConfig
 import net.corda.schema.configuration.VirtualNodeDatasourceConfig
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbFactoryImpl
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
@@ -145,7 +146,10 @@ class VirtualNodeDbFactoryImplTest {
         // VNode DML min pool size needs to be 0, because VNodes connections can pile up and exhaust the DB
         verify(vaultDmlConfig).withValue(DatabaseConfig.DB_POOL_MIN_SIZE, ConfigValueFactory.fromAnyRef(0))
 
-        val uniquenessDmlConfig = dbs[VirtualNodeDbType.UNIQUENESS]?.dbConnections?.get(DbPrivilege.DML)?.config!!
-        verify(uniquenessDmlConfig, never()).withValue(eq(DatabaseConfig.JDBC_DRIVER), any())
+        val uniquenessDmlConfig = dbs[VirtualNodeDbType.UNIQUENESS]?.dbConnections?.get(DbPrivilege.DML)?.config
+        assertNull(uniquenessDmlConfig)
+
+        val uniquenessDdlConfig = dbs[VirtualNodeDbType.UNIQUENESS]?.dbConnections?.get(DbPrivilege.DDL)?.config
+        assertNull(uniquenessDdlConfig)
     }
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -109,5 +109,43 @@ class VirtualNodeDbFactoryImplTest {
         verify(vaultDmlConfig).withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(10))
         // VNode DML min pool size needs to be 0, because VNodes connections can pile up and exhaust the DB
         verify(vaultDmlConfig).withValue(DatabaseConfig.DB_POOL_MIN_SIZE, ConfigValueFactory.fromAnyRef(0))
+
+        val uniquenessDmlConfig = dbs[VirtualNodeDbType.UNIQUENESS]?.dbConnections?.get(DbPrivilege.DML)?.config!!
+        verify(uniquenessDmlConfig, never()).withValue(eq(DatabaseConfig.JDBC_DRIVER), any())
+
+    }
+
+    @Test
+    fun `createVNodeDbs creates expected VNode datasource configuration with no uniqueness db`() {
+        val request = mock<VirtualNodeCreateRequest> {
+            on { vaultDdlConnection } doReturn ""
+            on { vaultDmlConnection } doReturn ""
+            on { cryptoDdlConnection } doReturn ""
+            on { cryptoDmlConnection } doReturn ""
+            on { uniquenessDdlConnection } doReturn "none"
+            on { uniquenessDmlConnection } doReturn "none"
+        }
+
+        val dbs = impl.createVNodeDbs(
+            ShortHash.of("1234123412341234"),
+            request,
+        )
+
+
+        val vaultDdlConfig = dbs[VirtualNodeDbType.VAULT]?.dbConnections?.get(DbPrivilege.DDL)?.config!!
+        verify(vaultDdlConfig, never()).withValue(eq(DatabaseConfig.JDBC_DRIVER), any())
+        verify(vaultDdlConfig).withValue(DatabaseConfig.JDBC_URL, ConfigValueFactory.fromAnyRef(JDBC_URL))
+        verify(vaultDdlConfig).withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(1))
+        verify(vaultDdlConfig, never()).withValue(eq(DatabaseConfig.DB_POOL_MIN_SIZE), any())
+
+        val vaultDmlConfig = dbs[VirtualNodeDbType.VAULT]?.dbConnections?.get(DbPrivilege.DML)?.config!!
+        verify(vaultDmlConfig, never()).withValue(eq(DatabaseConfig.JDBC_DRIVER), any())
+        verify(vaultDmlConfig).withValue(DatabaseConfig.JDBC_URL, ConfigValueFactory.fromAnyRef(JDBC_URL))
+        verify(vaultDmlConfig).withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(10))
+        // VNode DML min pool size needs to be 0, because VNodes connections can pile up and exhaust the DB
+        verify(vaultDmlConfig).withValue(DatabaseConfig.DB_POOL_MIN_SIZE, ConfigValueFactory.fromAnyRef(0))
+
+        val uniquenessDmlConfig = dbs[VirtualNodeDbType.UNIQUENESS]?.dbConnections?.get(DbPrivilege.DML)?.config!!
+        verify(uniquenessDmlConfig, never()).withValue(eq(DatabaseConfig.JDBC_DRIVER), any())
     }
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/ExampleData.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/ExampleData.kt
@@ -55,8 +55,8 @@ internal fun getValidRequest(): VirtualNodeCreateRequest {
 internal fun getVNodeDb(
     dbType: VirtualNodeDbType,
     isPlatformManagedDb: Boolean = true,
-    ddlConnection: DbConnection = mock(),
-    dmlConnection: DbConnection = mock(),
+    ddlConnection: DbConnection? = mock(),
+    dmlConnection: DbConnection? = mock(),
 ): VirtualNodeDb {
     return  mock<VirtualNodeDb>().apply {
         whenever(this.isPlatformManagedDb).thenReturn(isPlatformManagedDb)

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/services/CreateVirtualNodeServiceImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/services/CreateVirtualNodeServiceImplTest.kt
@@ -68,10 +68,23 @@ class CreateVirtualNodeServiceImplTest {
         uniquenessDmlDbConnectionDetails
     )
 
+    private val uniquenessPlatformManagedVirtualNodeDbNullUniqueness = getVNodeDb(
+        UNIQUENESS,
+        true,
+        null,
+        null
+    )
+
     private val virtualNodeDbs = mapOf(
         VAULT to vaultPlatformManagedVirtualNodeDb,
         CRYPTO to cryptoUserManagedVirtualNodeDb,
         UNIQUENESS to uniquenessPlatformManagedVirtualNodeDb,
+    )
+
+    private val virtualNodeDbsNullUniqueness = mapOf(
+        VAULT to vaultPlatformManagedVirtualNodeDb,
+        CRYPTO to cryptoUserManagedVirtualNodeDb,
+        UNIQUENESS to uniquenessPlatformManagedVirtualNodeDbNullUniqueness,
     )
 
     private val entityManager = mock<EntityManager>().apply {
@@ -245,6 +258,91 @@ class CreateVirtualNodeServiceImplTest {
             updateActor,
             externalMessagingRouteConfig = null
         )
+    }
+
+    @Suppress("LongMethod")
+    @Test
+    fun `persist virtual node db meta data, no uniqueness db`() {
+        val updateActor = "ua"
+
+        val vaultDdlDbConnectionDetailsId = UUID.randomUUID()
+        val vaultDmlDbConnectionDetailsId = UUID.randomUUID()
+        val cryptoDdlDbConnectionDetailsId = UUID.randomUUID()
+        val cryptoDmlDbConnectionDetailsId = UUID.randomUUID()
+
+        whenever(
+            dbConnectionManager.putConnection(
+                entityManager,
+                vaultDdlDbConnectionDetails.name,
+                DDL,
+                vaultDdlDbConnectionDetails.config,
+                vaultDdlDbConnectionDetails.description,
+                updateActor
+            )
+        ).thenReturn(vaultDdlDbConnectionDetailsId)
+
+        whenever(
+            dbConnectionManager.putConnection(
+                entityManager,
+                vaultDmlDbConnectionDetails.name,
+                DML,
+                vaultDmlDbConnectionDetails.config,
+                vaultDmlDbConnectionDetails.description,
+                updateActor
+            )
+        ).thenReturn(vaultDmlDbConnectionDetailsId)
+
+        whenever(
+            dbConnectionManager.putConnection(
+                entityManager,
+                cryptoDdlDbConnectionDetails.name,
+                DDL,
+                cryptoDdlDbConnectionDetails.config,
+                cryptoDdlDbConnectionDetails.description,
+                updateActor
+            )
+        ).thenReturn(cryptoDdlDbConnectionDetailsId)
+
+        whenever(
+            dbConnectionManager.putConnection(
+                entityManager,
+                cryptoDmlDbConnectionDetails.name,
+                DML,
+                cryptoDmlDbConnectionDetails.config,
+                cryptoDmlDbConnectionDetails.description,
+                updateActor
+            )
+        ).thenReturn(cryptoDmlDbConnectionDetailsId)
+
+        whenever(
+            dbConnectionManager.putConnection(
+                entityManager,
+                uniquenessDdlDbConnectionDetails.name,
+                DDL,
+                uniquenessDdlDbConnectionDetails.config,
+                uniquenessDdlDbConnectionDetails.description,
+                updateActor
+            )
+        ).thenReturn(null)
+
+        whenever(
+            dbConnectionManager.putConnection(
+                entityManager,
+                uniquenessDmlDbConnectionDetails.name,
+                DML,
+                uniquenessDmlDbConnectionDetails.config,
+                uniquenessDmlDbConnectionDetails.description,
+                updateActor
+            )
+        ).thenReturn(null)
+
+        target.persistHoldingIdAndVirtualNode(
+            ALICE_HOLDING_ID1,
+            virtualNodeDbsNullUniqueness,
+            CPI_IDENTIFIER1,
+            updateActor,
+            externalMessagingRouteConfig = null
+        )
 
         verify(holdingIdentityRepository).put(entityManager, ALICE_HOLDING_ID1)
 
@@ -256,8 +354,8 @@ class CreateVirtualNodeServiceImplTest {
             vaultDmlDbConnectionDetailsId,
             cryptoDdlDbConnectionDetailsId,
             cryptoDmlDbConnectionDetailsId,
-            uniquenessDdlDbConnectionDetailsId,
-            uniquenessDmlDbConnectionDetailsId,
+            null,
+            null,
             externalMessagingRouteConfig = null
         )
     }

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -30,7 +30,7 @@ data class VirtualNodeInfo(
     /** Uniqueness DDL DB connection ID */
     val uniquenessDdlConnectionId: UUID? = null,
     /** Uniqueness DML DB connection ID */
-    val uniquenessDmlConnectionId: UUID,
+    val uniquenessDmlConnectionId: UUID? = null,
     /** HSM connection ID */
     val hsmConnectionId: UUID? = null,
     /** Current state of the virtual node instance */


### PR DESCRIPTION
This PR makes the uniqueness connection string optional. When creating a vNode, passing "none" for the Dml connection string will store null in the equivalent connection string. 