### PR TITLE
CORE-15807: Split Tracing Module

### DIFF
--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-application"
 
+    implementation("io.zipkin.brave:brave-context-slf4j:$braveVersion")
+    implementation("io.zipkin.brave:brave-instrumentation-servlet:$braveVersion")
+
     implementation project(":libs:rest:rest-server")
     implementation "net.corda:corda-crypto"
     implementation "io.javalin:javalin-osgi:$javalinVersion"

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -34,7 +34,12 @@ import net.corda.utilities.debug
 import net.corda.utilities.executeWithStdErrSuppressed
 import net.corda.utilities.trace
 import org.eclipse.jetty.http2.HTTP2Cipher
-import org.eclipse.jetty.server.*
+import org.eclipse.jetty.server.HttpConfiguration
+import org.eclipse.jetty.server.HttpConnectionFactory
+import org.eclipse.jetty.server.SecureRequestCustomizer
+import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server.SslConnectionFactory
 import org.eclipse.jetty.servlet.FilterHolder
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory
@@ -195,7 +200,8 @@ internal class RestServerInternal(
                     // This is necessary due to "before" matching logic cannot tell path "testEntity/:id" from
                     // "testEntity/getprotocolversion" and mistakenly finds "before" handler where there should be none.
                     // Javalin provides no way for modifying "before" handler finding logic.
-                    if (resourceProvider.httpNoAuthRequiredGetRoutes.none { routeInfo -> routeInfo.fullPath == it.path() } && it.method() == "GET") {
+                    if (resourceProvider.httpNoAuthRequiredGetRoutes.none { routeInfo -> routeInfo.fullPath == it.path() } &&
+                        it.method() == "GET") {
                         val clientHttpRequestContext = ClientHttpRequestContext(it)
                         val authorizingSubject =
                             authenticate(clientHttpRequestContext, restAuthProvider, credentialResolver)

--- a/libs/tracing/build.gradle
+++ b/libs/tracing/build.gradle
@@ -28,14 +28,6 @@ dependencies {
     implementation("io.zipkin.brave:brave-context-slf4j:$braveVersion")
     implementation("io.zipkin.brave:brave-instrumentation-servlet:$braveVersion")
 
-    implementation "io.javalin:javalin-osgi:$javalinVersion"
-    constraints {
-        implementation("org.eclipse.jetty:jetty-server:$jettyVersion") {
-            because 'Javalin uses an older version of Jetty which is exposed to CVE-2023-26048 and CVE-2023-26049. ' +
-                    'This might be resolved in the future versions of Javalin.'
-        }
-    }
-
     testImplementation "org.assertj:assertj-core:$assertjVersion"
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/TraceThis.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/TraceThis.kt
@@ -7,8 +7,12 @@ import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
-import net.corda.tracing.impl.*
+import net.corda.tracing.impl.TracingState
+import net.corda.tracing.impl.BraveTracingService
+import net.corda.tracing.impl.PerSecond
+import net.corda.tracing.impl.Unlimited
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.tracing.impl.SampleRate
 import java.util.concurrent.ExecutorService
 
 private fun parseUnsignedIntWithErrorHandling(string: String) = try {

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/TracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/TracingService.kt
@@ -1,9 +1,9 @@
 package net.corda.tracing
 
+import brave.http.HttpTracing
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
 import java.util.concurrent.ExecutorService
-import javax.servlet.Filter
 
 interface TracingService : AutoCloseable {
 
@@ -17,13 +17,14 @@ interface TracingService : AutoCloseable {
 
     fun nextSpan(
         operationName: String,
-        headers: List<Pair<String, String>>): TraceContext
+        headers: List<Pair<String, String>>
+    ): TraceContext
 
     fun getOrCreateBatchPublishTracing(clientId: String): BatchPublishTracing
 
     fun wrapWithTracingExecutor(executor: ExecutorService): ExecutorService
 
-    fun getTracedServletFilter(): Filter
+    fun getTracing(): HttpTracing
 
     fun traceBatch(operationName: String): BatchRecordTracer
 }

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/impl/BraveTracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/impl/BraveTracingService.kt
@@ -17,7 +17,6 @@ import brave.sampler.Matchers.and
 import brave.sampler.RateLimitingSampler
 import brave.sampler.Sampler
 import brave.sampler.SamplerFunction
-import brave.servlet.TracingFilter
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
 import net.corda.tracing.BatchPublishTracing
@@ -30,11 +29,12 @@ import zipkin2.reporter.AsyncReporter
 import zipkin2.reporter.Reporter
 import zipkin2.reporter.brave.ZipkinSpanHandler
 import zipkin2.reporter.urlconnection.URLConnectionSender
-import java.util.Stack
+import java.util.*
 import java.util.concurrent.ExecutorService
 import java.util.logging.Level
 import java.util.logging.Logger
-import javax.servlet.Filter
+
+//import javax.servlet.Filter
 
 internal sealed interface SampleRate
 internal object Unlimited : SampleRate
@@ -93,6 +93,7 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
         tracingBuilder.addSpanHandler(spanHandler)
         tracingBuilder.build().also(resourcesToClose::push)
     }
+
 
     private fun sampler(samplesPerSecond: SampleRate): Sampler = when (samplesPerSecond) {
         is PerSecond -> {
@@ -187,8 +188,8 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
         return tracing.currentTraceContext().executorService(executor)
     }
 
-    override fun getTracedServletFilter(): Filter {
-        return TracingFilter.create(httpTracing)
+    override fun getTracing(): HttpTracing {
+        return httpTracing
     }
 
     override fun close() {

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/impl/NoopTracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/impl/NoopTracingService.kt
@@ -96,7 +96,7 @@ class NoopTracingService : TracingService {
     }
 
     override fun getTracing(): HttpTracing {
-        return TODO("Provide the return value")
+        TODO("Not yet implemented")
     }
 
     override fun traceBatch(operationName: String): BatchRecordTracer {

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/impl/NoopTracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/impl/NoopTracingService.kt
@@ -1,5 +1,6 @@
 package net.corda.tracing.impl
 
+import brave.http.HttpTracing
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
 import net.corda.tracing.BatchPublishTracing
@@ -7,11 +8,6 @@ import net.corda.tracing.BatchRecordTracer
 import net.corda.tracing.TraceContext
 import net.corda.tracing.TracingService
 import java.util.concurrent.ExecutorService
-import javax.servlet.Filter
-import javax.servlet.FilterChain
-import javax.servlet.FilterConfig
-import javax.servlet.ServletRequest
-import javax.servlet.ServletResponse
 
 @Suppress("UNUSED_PARAMETER")
 class NoopTracingService : TracingService {
@@ -27,7 +23,7 @@ class NoopTracingService : TracingService {
         }
 
         override fun markInScope(): AutoCloseable {
-            return AutoCloseable {  }
+            return AutoCloseable { }
         }
 
         override fun errorAndFinish(e: Exception) {
@@ -50,18 +46,6 @@ class NoopTracingService : TracingService {
 
         override fun completeSpanFor(correlationId: String, outputRecord: Record<*, *>): Record<*, *> {
             return outputRecord
-        }
-    }
-
-    class NoopServletTraceFilter : Filter {
-        override fun init(filterConfig: FilterConfig?) {
-        }
-
-        override fun doFilter(request: ServletRequest?, response: ServletResponse?, chain: FilterChain?) {
-            chain?.doFilter(request, response)
-        }
-
-        override fun destroy() {
         }
     }
 
@@ -111,8 +95,8 @@ class NoopTracingService : TracingService {
         return executor
     }
 
-    override fun getTracedServletFilter(): Filter {
-        return NoopServletTraceFilter()
+    override fun getTracing(): HttpTracing {
+        return TODO("Provide the return value")
     }
 
     override fun traceBatch(operationName: String): BatchRecordTracer {


### PR DESCRIPTION
The tracing project has Javalin as an implementation dependency, this is only needed because of the `configureJavalinForTracing` method which handles tracing for HTTP requests. However, this means that everything that uses `:libs:tracing` gets `jetty-server` as a runtime dependency even when not needed. To mediate this issue, this PR moves `configureJavalinForTracing` from tracing to rest, since rest is the only project that invokes this method. This allows for the complete removal of the Javalin dependency from tracing.