### PR TITLE
CORE-16653: Re-enable the start flow acceptance tests

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowIoRequestSetup.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowIoRequestSetup.kt
@@ -4,9 +4,9 @@ import net.corda.flow.fiber.FlowIORequest
 
 interface FlowIoRequestSetup {
 
-    fun suspendsWith(flowIoRequest: FlowIORequest<*>)
+    fun suspendsWith(flowIoRequest: FlowIORequest<*>) : FlowIoRequestSetup
 
-    fun completedSuccessfullyWith(result: String?)
+    fun completedSuccessfullyWith(result: String?) : FlowIoRequestSetup
 
-    fun completedWithError(exception: Exception)
+    fun completedWithError(exception: Exception) : FlowIoRequestSetup
 }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -438,7 +438,7 @@ class FlowServiceTestContext @Activate constructor(
         testRuns.forEachIndexed { iteration, testRun ->
             log.info("Start test run for input/output set $iteration")
             flowFiberFactory.fiber.reset()
-            flowFiberFactory.fiber.ioToCompleteWith = testRun.ioRequest
+            flowFiberFactory.fiber.setIoRequests(testRun.ioRequests)
             val response = flowEventProcessor.onNext(lastPublishedState, testRun.event)
             testRun.flowContinuation = flowFiberFactory.fiber.flowContinuation
             testRun.response = response
@@ -534,20 +534,25 @@ class FlowServiceTestContext @Activate constructor(
 
         return object : FlowIoRequestSetup {
 
-            override fun suspendsWith(flowIoRequest: FlowIORequest<*>) {
-                testRun.ioRequest = FlowIORequest.FlowSuspended(
-                    ByteBuffer.wrap(byteArrayOf()),
-                    flowIoRequest,
-                    FlowFiberImpl(UUID.randomUUID(), ClientStartedFlow(FakeFlow(), FakeClientRequestBody()), currentScheduler)
+            override fun suspendsWith(flowIoRequest: FlowIORequest<*>) : FlowIoRequestSetup {
+                testRun.ioRequests.add(
+                    FlowIORequest.FlowSuspended(
+                        ByteBuffer.wrap(byteArrayOf()),
+                        flowIoRequest,
+                        FlowFiberImpl(UUID.randomUUID(), ClientStartedFlow(FakeFlow(), FakeClientRequestBody()), currentScheduler)
+                    )
                 )
+                return this
             }
 
-            override fun completedSuccessfullyWith(result: String?) {
-                testRun.ioRequest = FlowIORequest.FlowFinished(result)
+            override fun completedSuccessfullyWith(result: String?) : FlowIoRequestSetup {
+                testRun.ioRequests.add(FlowIORequest.FlowFinished(result))
+                return this
             }
 
-            override fun completedWithError(exception: Exception) {
-                testRun.ioRequest = FlowIORequest.FlowFailed(exception)
+            override fun completedWithError(exception: Exception) : FlowIoRequestSetup {
+                testRun.ioRequests.add(FlowIORequest.FlowFailed(exception))
+                return this
             }
         }
     }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/TestRun.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/TestRun.kt
@@ -10,7 +10,7 @@ import net.corda.messaging.api.records.Record
 class TestRun(
     val event: Record<String, FlowEvent>
 ) {
-    var ioRequest: FlowIORequest<*>? = null
+    val ioRequests: MutableList<FlowIORequest<*>> = mutableListOf()
     var response: StateAndEventProcessor.Response<Checkpoint>? = null
     var flowContinuation: FlowContinuation? = null
 }


### PR DESCRIPTION
**Problem description**

As part of the removing wakeup events work, the acceptance tests were temporarily disabled, as fixing these was likely to involve a lot of code churn. These need to be re-enabled. The first set to look at is the start flow acceptance tests.

**Solution**

The acceptance test infrastructure requires some changes to support potentially running the fiber multiple times:

- Allow multiple flow IO requests to be declared as output from the fiber.
- Change the fake fiber to output each declared IO request in turn, so that multiple runs of the fiber can be simulated.
- Remove references to feeding wakeup events into the flow pipeline.
- Remove references to expecting wakeup events to be returned from the pipeline.

Note that in some cases the test behaviour also changes, due to the fiber now running through multiple steps in a single test.

**Testing**

The start flow acceptance tests should now pass.