### PR TITLE
CORE-16653: Re-enable further acceptance tests

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ExternalEventAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ExternalEventAcceptanceTest.kt
@@ -31,11 +31,11 @@ import org.osgi.test.junit5.service.ServiceExtension
 
 @ExtendWith(ServiceExtension::class)
 @Execution(ExecutionMode.SAME_THREAD)
-@Disabled
 class ExternalEventAcceptanceTest : FlowServiceTestBase() {
 
     private companion object {
         const val REQUEST_ID = "requestId"
+        const val SECOND_REQUEST_ID = "secondRequestId"
         const val TOPIC = "topic"
         const val KEY = "key"
         val FLOW_START_CONTEXT = mapOf("key" to "value")
@@ -133,7 +133,7 @@ class ExternalEventAcceptanceTest : FlowServiceTestBase() {
 
         `when` {
             externalEventReceived(FLOW_ID1, REQUEST_ID, response)
-                .suspendsWith(FlowIORequest.ForceCheckpoint)
+                .completedSuccessfullyWith("hello")
         }
 
         then {
@@ -208,7 +208,7 @@ class ExternalEventAcceptanceTest : FlowServiceTestBase() {
                 )
 
             externalEventReceived(FLOW_ID1, REQUEST_ID, STRING_RESPONSE)
-                .suspendsWith(FlowIORequest.ForceCheckpoint)
+                .completedSuccessfullyWith("hello")
         }
 
         then {
@@ -244,6 +244,11 @@ class ExternalEventAcceptanceTest : FlowServiceTestBase() {
                 )
         }
 
+        `when` {
+            // Use this as a trigger for the pipeline - an external event not the one we are expecting.
+            externalEventReceived(FLOW_ID1, SECOND_REQUEST_ID, ANY_INPUT)
+        }
+
         then {
             expectOutputForFlow(FLOW_ID1) {
                 flowDidNotResume()
@@ -271,6 +276,11 @@ class ExternalEventAcceptanceTest : FlowServiceTestBase() {
                         EXTERNAL_EVENT_CONTEXT
                     )
                 )
+        }
+
+        `when` {
+            // Use this as a trigger for the pipeline - an external event not the one we are expecting.
+            externalEventReceived(FLOW_ID1, SECOND_REQUEST_ID, ANY_INPUT)
         }
 
         then {
@@ -385,6 +395,11 @@ class ExternalEventAcceptanceTest : FlowServiceTestBase() {
         // Wait for the resend window to be passed
         Thread.sleep(10.seconds.toMillis())
 
+        `when` {
+            // Use this as a trigger for the pipeline - an external event not the one we are expecting.
+            externalEventReceived(FLOW_ID1, SECOND_REQUEST_ID, ANY_INPUT)
+        }
+
         then {
             expectOutputForFlow(FLOW_ID1) {
                 externalEvent(TOPIC, KEY, ANY_INPUT)
@@ -419,7 +434,6 @@ class ExternalEventAcceptanceTest : FlowServiceTestBase() {
 
         `when` {
             externalEventReceived(FLOW_ID1, REQUEST_ID, ANY_RESPONSE)
-                .suspendsWith(FlowIORequest.ForceCheckpoint)
         }
 
         then {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
@@ -176,7 +176,7 @@ class SendAcceptanceTest : FlowServiceTestBase() {
 
     @Test
     @Disabled
-    fun `Calling 'send' on a session that is confirmed sets a wakeup event and data message`() {
+    fun `Calling 'send' on a session that is confirmed sets a data message`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")
                 .suspendsWith(

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
@@ -44,7 +44,7 @@ class SendAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
-    fun `Calling 'send' on initiated sessions sends a session data event and schedules a wakeup event`() {
+    fun `Calling 'send' on initiated sessions sends a session data event`() {
         given {
             initiateTwoFlows(this)
                 .suspendsWith(FlowIORequest.Receive(setOf(SessionInfo(SESSION_ID_2, initiatedIdentityMemberName))))

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SendAcceptanceTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
 import org.osgi.test.junit5.service.ServiceExtension
+import java.util.concurrent.Flow
 
 @ExtendWith(ServiceExtension::class)
 @Execution(ExecutionMode.SAME_THREAD)
@@ -46,7 +47,7 @@ class SendAcceptanceTest : FlowServiceTestBase() {
     fun `Calling 'send' on initiated sessions sends a session data event and schedules a wakeup event`() {
         given {
             initiateTwoFlows(this)
-                .suspendsWith(FlowIORequest.ForceCheckpoint)
+                .suspendsWith(FlowIORequest.Receive(setOf(SessionInfo(SESSION_ID_2, initiatedIdentityMemberName))))
         }
 
         `when` {
@@ -56,17 +57,18 @@ class SendAcceptanceTest : FlowServiceTestBase() {
                     SessionInfo(SESSION_ID_1, initiatedIdentityMemberName) to  DATA_MESSAGE_1,
                     SessionInfo(SESSION_ID_2, initiatedIdentityMemberName) to  DATA_MESSAGE_2,
                 )))
+                .completedSuccessfullyWith("hello")
         }
 
         then {
             expectOutputForFlow(FLOW_ID1) {
                 sessionDataEvents(SESSION_ID_1 to DATA_MESSAGE_1, SESSION_ID_2 to DATA_MESSAGE_2)
-                wakeUpEvent()
             }
         }
     }
 
     @Test
+    @Disabled
     fun `Calling 'send' on an invalid session fails and reports the exception to user code`() {
         given {
             initiateSingleFlow(this, 2)
@@ -97,6 +99,7 @@ class SendAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
+    @Disabled
     fun `Calling 'send' multiple times on initiated sessions resumes the flow and sends a session data events each time`() {
         given {
             initiateTwoFlows(this)
@@ -133,6 +136,7 @@ class SendAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
+    @Disabled
     fun `Given a flow resumes after receiving session data events calling 'send' on the sessions sends session data events and no session ack for the session that resumed the flow`() {
         given {
             initiateTwoFlows(this)
@@ -171,6 +175,7 @@ class SendAcceptanceTest : FlowServiceTestBase() {
     }
 
     @Test
+    @Disabled
     fun `Calling 'send' on a session that is confirmed sets a wakeup event and data message`() {
         given {
             startFlowEventReceived(FLOW_ID1, REQUEST_ID1, ALICE_HOLDING_IDENTITY, CPI1, "flow start data")


### PR DESCRIPTION
**Problem description**

The acceptance tests were disabled as part of removing `Wakeup` events from the flow pipeline. These need to be re-enabled.

**Solution**

This PR fixes the external event, flow finished and flow failed acceptance tests. This leaves just acceptance tests that depend on the session functionality to re-enable. As there are changes being made elsewhere to change how the session layer works, it is likely that these tests will need some collaboration to enable.

**Testing**

Newly enabled acceptance tests pass.