### PR TITLE
CORE-8976: added notary match check

### DIFF
--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -78,7 +78,7 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
 
             val txDetails = validateRequest(requestPayload)
 
-            getCurrentNotaryAndValidateNotary(txDetails)
+            validateTransactionNotaryAgainstCurrentNotary(txDetails)
 
             if (logger.isTraceEnabled) {
                 logger.trace("Received notarization request for transaction {}", txDetails.id)
@@ -126,14 +126,15 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
      * This function will validate selected notary is valid notary to notarize.
      * */
     @Suspendable
-    private fun getCurrentNotaryAndValidateNotary(txDetails: NonValidatingNotaryTransactionDetails) {
-        val currentNotaryMemberProvidedCtx = memberLookup.myInfo().memberProvidedContext
-        val currentNotaryServiceName = currentNotaryMemberProvidedCtx.parse(NOTARY_SERVICE_NAME, MemberX500Name::class.java)
+    private fun validateTransactionNotaryAgainstCurrentNotary(txDetails: NonValidatingNotaryTransactionDetails) {
+        val currentNotaryServiceName = memberLookup
+            .myInfo()
+            .memberProvidedContext
+            .parse(NOTARY_SERVICE_NAME, MemberX500Name::class.java)
 
-        val payloadNotaryServiceName = txDetails.notaryName
-
-        require(currentNotaryServiceName == payloadNotaryServiceName) {
-            "Given notary service = $payloadNotaryServiceName is invalid"
+        require(currentNotaryServiceName == txDetails.notaryName) {
+            "Notary service on the transaction ${txDetails.notaryName} does not match the notary service represented" +
+                    " by this notary virtual node (${currentNotaryServiceName})"
         }
     }
 

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -137,6 +137,11 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
     @Suspendable
     private fun extractParts(requestPayload: NonValidatingNotarizationPayload): NonValidatingNotaryTransactionDetails {
         val filteredTx = requestPayload.transaction as UtxoFilteredTransaction
+
+        if (filteredTx.notaryKey != requestPayload.notaryKey) {
+            throw IllegalStateException("Unvalidated notary was used")
+        }
+
         // The notary component is not needed by us but we validate that it is present just in case
         requireNotNull(filteredTx.notaryName) {
             "Notary name component could not be found on the transaction"

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -21,7 +21,6 @@ import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
 import net.corda.v5.ledger.utxo.uniqueness.client.LedgerUniquenessCheckerClientService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.security.PublicKey
 
 /**
  * The server-side implementation of the non-validating notary logic.
@@ -34,7 +33,6 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
     private companion object {
         private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
-        const val NOTARY_KEYS = "corda.notary.keys"
         const val NOTARY_SERVICE_NAME = "corda.notary.service.name"
     }
 
@@ -131,16 +129,11 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
     private fun getCurrentNotaryAndValidateNotary(txDetails: NonValidatingNotaryTransactionDetails) {
         val currentNotaryMemberProvidedCtx = memberLookup.myInfo().memberProvidedContext
         val currentNotaryServiceName = currentNotaryMemberProvidedCtx.parse(NOTARY_SERVICE_NAME, MemberX500Name::class.java)
-        val currentNotaryKey = currentNotaryMemberProvidedCtx.parseList(NOTARY_KEYS, PublicKey::class.java).first()
 
         val payloadNotaryServiceName = txDetails.notaryName
-        val payloadNotaryKey = txDetails.notaryKey
 
         require(currentNotaryServiceName == payloadNotaryServiceName) {
             "Given notary service = $payloadNotaryServiceName is invalid"
-        }
-        require(currentNotaryKey == payloadNotaryKey) {
-            "Given notary key = $payloadNotaryKey is invalid"
         }
     }
 

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -331,7 +331,7 @@ class NonValidatingNotaryServerFlowImplTest {
 
         // 2. Get current notary and parse its data
         whenever(mockMemberLookup.myInfo()).thenReturn(notaryInfo)
-        whenever(mockMemberLookup.myInfo().memberProvidedContext).thenReturn(memberProvidedContext)
+        whenever(notaryInfo.memberProvidedContext).thenReturn(memberProvidedContext)
         whenever(memberProvidedContext.parse(NOTARY_SERVICE_NAME, MemberX500Name::class.java)).thenReturn(notaryServiceName)
 
         // 3. Check if any filtered transaction data should be overwritten

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -94,7 +94,7 @@ class NonValidatingNotaryServerFlowImplTest {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenThrow(
             TransactionNoAvailableKeysException("The publicKeys do not have any private counterparts available.", null)
         )
-        createAndCallServer(mockSuccessfulUniquenessClientService(), notaryServiceName) {
+        createAndCallServer(mockSuccessfulUniquenessClientService()) {
             assertThat(responseFromServer).hasSize(1)
 
             val responseError = responseFromServer.first().error
@@ -111,7 +111,6 @@ class NonValidatingNotaryServerFlowImplTest {
         // We sign with a key that is not part of the notary composite key
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            notaryServiceName,
             notaryServiceKey = notaryVNodeAliceKey
         ) {
             assertThat(responseFromServer).hasSize(1)
@@ -125,7 +124,7 @@ class NonValidatingNotaryServerFlowImplTest {
 
     @Test
     fun `Non-validating notary plugin server should respond with error if request signature is invalid`() {
-        createAndCallServer(mockSuccessfulUniquenessClientService(), notaryServiceName) {
+        createAndCallServer(mockSuccessfulUniquenessClientService()) {
             assertThat(responseFromServer).hasSize(1)
 
             val responseError = responseFromServer.first().error
@@ -138,7 +137,7 @@ class NonValidatingNotaryServerFlowImplTest {
 
     @Test
     fun `Non-validating notary plugin server should respond with error if the uniqueness check fails`() {
-        createAndCallServer(mockErrorUniquenessClientService(UniquenessCheckErrorReferenceStateUnknownImpl(emptyList())), notaryServiceName) {
+        createAndCallServer(mockErrorUniquenessClientService(UniquenessCheckErrorReferenceStateUnknownImpl(emptyList()))) {
             assertThat(responseFromServer).hasSize(1)
 
             val responseError = responseFromServer.first().error
@@ -151,7 +150,7 @@ class NonValidatingNotaryServerFlowImplTest {
 
     @Test
     fun `Non-validating notary plugin server should respond with error if an error encountered during uniqueness check`() {
-        createAndCallServer(mockThrowErrorUniquenessCheckClientService(), notaryServiceName) {
+        createAndCallServer(mockThrowErrorUniquenessCheckClientService()) {
             assertThat(responseFromServer).hasSize(1)
 
             val responseError = responseFromServer.first().error
@@ -171,7 +170,7 @@ class NonValidatingNotaryServerFlowImplTest {
         )
 
         createAndCallServer(
-            mockSuccessfulUniquenessClientService(), notaryServiceName
+            mockSuccessfulUniquenessClientService(),
         ) {
             assertThat(responseFromServer).hasSize(1)
 
@@ -184,11 +183,7 @@ class NonValidatingNotaryServerFlowImplTest {
 
     @Test
     fun `Non-validating notary plugin server should respond with error if time window not present on filtered tx`() {
-        createAndCallServer(
-            mockSuccessfulUniquenessClientService(),
-            notaryServiceName,
-            filteredTxContents = mapOf("timeWindow" to null)
-        ) {
+        createAndCallServer(mockSuccessfulUniquenessClientService(), filteredTxContents = mapOf("timeWindow" to null)) {
             assertThat(responseFromServer).hasSize(1)
 
             val responseError = responseFromServer.first().error
@@ -204,7 +199,6 @@ class NonValidatingNotaryServerFlowImplTest {
     fun `Non-validating notary plugin server should respond with error if notary name not present on filtered tx`() {
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            notaryServiceName,
             filteredTxContents = mapOf("notaryName" to null)) {
             assertThat(responseFromServer).hasSize(1)
 
@@ -221,7 +215,6 @@ class NonValidatingNotaryServerFlowImplTest {
     fun `Non-validating notary plugin server should respond with error if notary key not present on filtered tx`() {
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            notaryServiceName,
             filteredTxContents = mapOf("notaryKey" to null)) {
             assertThat(responseFromServer).hasSize(1)
 
@@ -241,7 +234,6 @@ class NonValidatingNotaryServerFlowImplTest {
 
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            notaryServiceName,
             filteredTxContents = mapOf("inputStateRefs" to mockInputStateProof)
         ) {
             assertThat(responseFromServer).hasSize(1)
@@ -260,11 +252,7 @@ class NonValidatingNotaryServerFlowImplTest {
         fun throwVerify() {
             throw IllegalArgumentException("DUMMY ERROR")
         }
-        createAndCallServer(
-            mockSuccessfulUniquenessClientService(),
-            notaryServiceName,
-            txVerificationLogic = ::throwVerify
-        ) {
+        createAndCallServer(mockSuccessfulUniquenessClientService(), txVerificationLogic = ::throwVerify) {
             assertThat(responseFromServer).hasSize(1)
 
             val responseError = responseFromServer.first().error
@@ -282,8 +270,7 @@ class NonValidatingNotaryServerFlowImplTest {
                 IllegalArgumentException::class.java.name,
                 "Unhandled error!"
             )
-        ), notaryServiceName
-            ) {
+        )) {
             assertThat(responseFromServer).hasSize(1)
 
             val responseError = responseFromServer.first().error
@@ -299,7 +286,6 @@ class NonValidatingNotaryServerFlowImplTest {
     fun `Non-validating notary plugin server should respond with error if notary identity invalid`() {
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            notaryServiceName,
             // What party we pass in here does not matter, it just needs to be different from the notary server party
             filteredTxContents = mapOf("notaryName" to MemberX500Name.parse("C=GB,L=London,O=Bob"))
         ) {
@@ -316,12 +302,11 @@ class NonValidatingNotaryServerFlowImplTest {
     @Suppress("LongParameterList")
     private fun createAndCallServer(
         clientService: LedgerUniquenessCheckerClientService,
-        notaryServiceName: MemberX500Name,
         notaryServiceKey: PublicKey = notaryServiceCompositeKey,
         filteredTxContents: Map<String, Any?> = emptyMap(),
         flowSession: FlowSession? = null,
         txVerificationLogic: () -> Unit = {},
-        extractData: (sigs: List<NotarizationResponse>) -> Unit,
+        extractData: (sigs: List<NotarizationResponse>) -> Unit
     ) {
         val txId = randomSecureHash()
 

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -45,7 +45,6 @@ import java.time.Instant
 class NonValidatingNotaryServerFlowImplTest {
 
     private companion object {
-        const val NOTARY_KEYS = "corda.notary.keys"
         const val NOTARY_SERVICE_NAME = "corda.notary.service.name"
 
         /* Cache for storing response from server */
@@ -334,7 +333,6 @@ class NonValidatingNotaryServerFlowImplTest {
         whenever(mockMemberLookup.myInfo()).thenReturn(notaryInfo)
         whenever(mockMemberLookup.myInfo().memberProvidedContext).thenReturn(memberProvidedContext)
         whenever(memberProvidedContext.parse(NOTARY_SERVICE_NAME, MemberX500Name::class.java)).thenReturn(notaryServiceName)
-        whenever(memberProvidedContext.parseList(NOTARY_KEYS, PublicKey::class.java)).thenReturn(listOf(notaryServiceKey))
 
         // 3. Check if any filtered transaction data should be overwritten
         val filteredTx = mock<UtxoFilteredTransaction> {


### PR DESCRIPTION
## Overview
This PR added a check if the notary in tx is valid notary that is the same as the current notary in the network.
### Test Plan
The unit test `NonValidatingNotaryServerFlowImpl` covers this scenario.

**Manual test**
I passed notary "O=AnotherNotaryService, L=London, C=GB" and tweaked `notaryRepresentative`(notary vnode) in `NonValidatingNotaryClientFlowImpl` with wrong notary as below:
 ```kotlin        
val session = flowMessaging.initiateFlow(MemberX500Name.parse("CN=Notary-afbe5058-36ad-4636-8f79-0296741dee9s, OU=Application, O=R3, L=London, C=GB"))
```
then ran MultipleNotariesTests.`Multiple Notaries - sanity check of multiple notaries by creating two states with different notaries for each()` where two notaries are available in the network.

I was able to see the expected error message in the log:
```
2023-09-01 14:47:35.769 [single-threaded-scheduled-executor-1] WARN  com.r3.corda.notary.plugin.nonvalidating.server.NonValidatingNotaryServerFlowImpl {corda.client.id=0de2a179-31e8-4392-b5d5-825bab5e90db-INITIATED, flow.id=e83c0c7d-b848-4555-a17c-04eb29d49217, session.event.id=0de2a179-31e8-4392-b5d5-825bab5e90db-INITIATED, vnode.id=EF5CF6FA0F4D} - **Error while processing request from client. Cause: java.lang.IllegalArgumentException: Given notary service = O=AnotherNotaryService, L=London, C=GB is invalid **
```