### PR TITLE
CORE-15562 Add QuasarIgnoreAllPackages to net.corda.internal.serialization.amqp

### DIFF
--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
     compileOnly "biz.aQute.bnd:biz.aQute.bnd.annotation:$bndlibVersion"
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-application"

--- a/libs/serialization/serialization-amqp/src/main/java/net/corda/internal/serialization/amqp/package-info.java
+++ b/libs/serialization/serialization-amqp/src/main/java/net/corda/internal/serialization/amqp/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.internal.serialization.amqp;
 
 import org.osgi.annotation.bundle.Export;
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;


### PR DESCRIPTION
**Problems:**
1.
CORE-15562 showed NPEs with similar stack trace:
```
"message": "Internal deserialization failure: java.lang.NullPointerException: null",
        "name": "java.io.NotSerializableException",
        "extendedStackTrace": [
            {
                "class": "net.corda.internal.serialization.amqp.DeserializationInput",
                "method": "des",
                "file": "DeserializationInput.kt",
                "line": 113
            },
            {
                "class": "net.corda.internal.serialization.amqp.DeserializationInput",
                "method": "deserialize",
                "file": "DeserializationInput.kt",
                "line": 126
            },
            {
                "class": "net.corda.internal.serialization.SerializationServiceImpl",
                "method": "deserialize$lambda$2",
                "file": "SerializationServiceImpl.kt",
                "line": 43
            },
            {
                "class": "java.security.AccessController",
                "method": "doPrivileged",
                "file": "AccessController.java",
                "line": -2
            },
            {
                "class": "net.corda.internal.serialization.SerializationServiceImpl",
                "method": "deserialize",
                "file": "SerializationServiceImpl.kt",
                "line": 42
            },
```
2. Some E2E tests failed with NPEs referencing ` at net.corda.internal.serialization.amqp.` calls.
3. CORE-16346's NPEs look related to serialization as well.
4. https://github.com/corda/corda-runtime-os/pull/4548/ produced 3's stacktraces.

**Solution**
The commonality in these reports is the serialization.
We exclude the related module from Quasar instrumentation.

**Test**
Testing proved to be quite problematic since the nature of the bug depends on the micro timing of the execution.
@relyafi confirmed that the current PR removed the null pointer exceptions, which emerged when tested this: https://github.com/corda/corda-runtime-os/pull/4548/.
