### PR TITLE
CORE-16623 : Changes for p2p parameters

### DIFF
--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/stub/GroupPolicyProviderStub.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/stub/GroupPolicyProviderStub.kt
@@ -12,6 +12,8 @@ internal class GroupPolicyProviderStub : GroupPolicyProvider {
         callback: (HoldingIdentity, GroupPolicy) -> Unit,
     ) = run { }
 
+    override fun getP2PParameters(holdingIdentity: HoldingIdentity) = throw UnsupportedOperationException()
+
     override val isRunning = true
 
     override fun start() = Unit

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
@@ -177,13 +177,13 @@ class MessageConverter {
             message: InboundUnauthenticatedMessage,
             source: HoldingIdentity,
             destMemberInfo: MemberInfo,
-            groupPolicy: GroupPolicy,
+            networkType: NetworkType,
         ): LinkOutMessage {
             return createLinkOutMessage(
                 message,
                 source,
                 destMemberInfo,
-                groupPolicy.networkType,
+                networkType,
                 )
         }
 
@@ -232,10 +232,10 @@ class MessageConverter {
                         "which is not in the network map. The message was discarded.")
                 return null
             }
-            val groupPolicy = groupPolicyProvider.getGroupPolicy(source)
-            if (groupPolicy == null) {
+            val p2pParams = groupPolicyProvider.getP2PParameters(source)
+            if (p2pParams == null) {
                 logger.warn(
-                    "Could not find the group info in the " +
+                    "Could not find the p2p parameters in the " +
                         "GroupPolicyProvider for our identity = $source. The message was discarded."
                 )
                 return null
@@ -245,7 +245,7 @@ class MessageConverter {
                 result,
                 source,
                 destMemberInfo,
-                groupPolicy.networkType,
+                p2pParams.networkType,
             )
         }
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
@@ -15,7 +15,6 @@ import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.lib.MemberInfoExtension.Companion.endpoints
 import net.corda.membership.lib.MemberInfoExtension.Companion.holdingIdentity
-import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.p2p.crypto.protocol.ProtocolConstants
 import net.corda.p2p.crypto.protocol.api.AuthenticatedEncryptionSession

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
@@ -140,7 +140,7 @@ internal class InMemorySessionReplayer(
             return
         }
 
-        val networkType = groupPolicyProvider.getGroupPolicy(messageReplay.sessionCounterparties.ourId)?.networkType
+        val networkType = groupPolicyProvider.getP2PParameters(messageReplay.sessionCounterparties.ourId)?.networkType
         if (networkType == null) {
             logger.warn("Attempted to replay a session negotiation message (type ${messageReplay.message::class.java.simpleName}) but" +
                 " could not find the network type in the GroupPolicyProvider for ${messageReplay.sessionCounterparties.ourId}." +

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/grouppolicy/GroupPolicyExt.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/grouppolicy/GroupPolicyExt.kt
@@ -5,22 +5,22 @@ import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants
 
-internal val GroupPolicy.networkType: NetworkType
+internal val GroupPolicy.P2PParameters.networkType: NetworkType
     get() {
-        return when(this.p2pParameters.tlsPki) {
+        return when(this.tlsPki) {
             GroupPolicyConstants.PolicyValues.P2PParameters.TlsPkiMode.STANDARD -> NetworkType.CORDA_5
             GroupPolicyConstants.PolicyValues.P2PParameters.TlsPkiMode.CORDA_4 -> NetworkType.CORDA_4
-            else -> throw IllegalStateException("Invalid tlsPki value: ${this.p2pParameters.tlsPki}")
+            else -> throw IllegalStateException("Invalid tlsPki value: ${this.tlsPki}")
         }
     }
 
-internal val GroupPolicy.protocolModes: Set<ProtocolMode>
+internal val GroupPolicy.P2PParameters.protocolModes: Set<ProtocolMode>
     get() {
-        return when(this.p2pParameters.protocolMode) {
+        return when(this.protocolMode) {
             GroupPolicyConstants.PolicyValues.P2PParameters.ProtocolMode.AUTH_ENCRYPT
                 -> setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION)
             GroupPolicyConstants.PolicyValues.P2PParameters.ProtocolMode.AUTH
                 -> setOf(ProtocolMode.AUTHENTICATION_ONLY)
-            else -> throw IllegalStateException("Invalid protocol mode: ${this.p2pParameters.protocolMode}")
+            else -> throw IllegalStateException("Invalid protocol mode: ${this.protocolMode}")
         }
     }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -23,6 +23,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.metrics.CordaMetrics
 import net.corda.p2p.linkmanager.LinkManager
 import net.corda.p2p.linkmanager.common.MessageConverter
+import net.corda.p2p.linkmanager.grouppolicy.networkType
 import net.corda.p2p.linkmanager.hosting.LinkManagerHostingMap
 import net.corda.p2p.linkmanager.inbound.InboundAssignmentListener
 import net.corda.p2p.linkmanager.membership.NetworkMessagingValidator
@@ -208,17 +209,17 @@ internal class OutboundMessageProcessor(
             return listOf(Record(Schemas.P2P.P2P_IN_TOPIC, LinkManager.generateKey(), AppMessage(inboundMessage)))
         } else if (destMemberInfo != null) {
             val source = message.header.source.toCorda()
-            val groupPolicy = groupPolicyProvider.getGroupPolicy(source)
-            if (groupPolicy == null) {
+            val p2pParams = groupPolicyProvider.getP2PParameters(source)
+            if (p2pParams == null) {
                 //TODO extended warn statement added temporarily for Interop Team, revert to debug as part of CORE-10683
                 logger.warn(
-                    "Could not find the group information in the GroupPolicyProvider for $source to ${message.header.destination}. " +
+                    "Could not find the p2p parameters in the GroupPolicyProvider for $source to ${message.header.destination}. " +
                     "The message ${message.header.messageId} was discarded."
                 )
                 return emptyList()
             }
 
-            val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(inboundMessage, source, destMemberInfo, groupPolicy)
+            val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(inboundMessage, source, destMemberInfo, p2pParams.networkType)
             //TODO logger info level and source identity added temporarily for Interop Team, revert to debug as part of CORE-10683
             logger.info ("Sending outbound message ${message.header.messageId} to ${message.header.destination} " +
                     "for ${linkOutMessage.header.address}." )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -219,7 +219,12 @@ internal class OutboundMessageProcessor(
                 return emptyList()
             }
 
-            val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(inboundMessage, source, destMemberInfo, p2pParams.networkType)
+            val linkOutMessage = MessageConverter.linkOutFromUnauthenticatedMessage(
+                inboundMessage,
+                source,
+                destMemberInfo,
+                p2pParams.networkType
+            )
             //TODO logger info level and source identity added temporarily for Interop Team, revert to debug as part of CORE-10683
             logger.info ("Sending outbound message ${message.header.messageId} to ${message.header.destination} " +
                     "for ${linkOutMessage.header.address}." )

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -631,6 +631,12 @@ class P2PLayerEndToEndTest {
                     it.identity.id == id
                 }?.groupPolicy
             }
+            on { getP2PParameters(any()) } doAnswer {
+                val id: HoldingIdentity = it.getArgument(0)
+                localInfos.firstOrNull {
+                    it.identity.id == id
+                }?.groupPolicy?.p2pParameters
+            }
         }
         private val otherHostMembers = ConcurrentHashMap<MemberX500Name, MemberInfo>()
         private val otherHostMembersByKey = ConcurrentHashMap<SecureHash, MemberInfo>()

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/MessageConverterTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/MessageConverterTest.kt
@@ -170,7 +170,7 @@ class MessageConverterTest {
         val flowMessage = authenticatedMessageAndKey(us, peer, ByteBuffer.wrap("DATA".toByteArray()))
         assertThat(MessageConverter.linkOutMessageFromAuthenticatedMessageAndKey(flowMessage, session, groups, members, 1)).isNull()
         loggingInterceptor.assertSingleWarning(
-            "Could not find the group info in the GroupPolicyProvider for our identity = $us." +
+            "Could not find the p2p parameters in the GroupPolicyProvider for our identity = $us." +
                 " The message was discarded."
         )
     }
@@ -192,7 +192,7 @@ class MessageConverterTest {
         val groups = mockGroups(emptyList())
         assertThat(MessageConverter.linkOutMessageFromAck(message, us, peer, session, groups, members)).isNull()
         loggingInterceptor.assertSingleWarning(
-            "Could not find the group info in the GroupPolicyProvider for our identity = $us." +
+            "Could not find the p2p parameters in the GroupPolicyProvider for our identity = $us." +
                     " The message was discarded."
         )
     }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
@@ -570,7 +570,7 @@ class OutboundMessageProcessorTest {
     @Test
     fun `unauthenticated messages are dropped if group info is not available`() {
         val groupPolicyProvider = mock<GroupPolicyProvider> {
-            on { getGroupPolicy(localIdentity) } doReturn null
+            on { getP2PParameters(localIdentity) } doReturn null
         }
 
         val processor = OutboundMessageProcessor(

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -203,7 +203,7 @@ class SessionManagerTest {
         on { p2pParameters } doReturn parameters
     }
     private val groupPolicyProvider = mock<GroupPolicyProvider> {
-        on { getGroupPolicy(OUR_PARTY) } doReturn groupPolicy
+        on { getP2PParameters(OUR_PARTY) } doReturn parameters
     }
     private val membershipGroupReader = mock<MembershipGroupReader> {
         on { lookup(eq(OUR_PARTY.x500Name), any()) } doReturn OUR_MEMBER_INFO
@@ -470,12 +470,12 @@ class SessionManagerTest {
         whenever(protocolInitiator.generateInitiatorHello()).thenReturn(initiatorHello)
         val anotherInitiatorHello = mock<InitiatorHelloMessage>()
         whenever(secondProtocolInitiator.generateInitiatorHello()).thenReturn(anotherInitiatorHello)
-        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+        whenever(groupPolicyProvider.getP2PParameters(OUR_PARTY)).thenReturn(null)
 
         val sessionState = sessionManager.processOutboundMessage(message)
         assertThat(sessionState).isInstanceOf(SessionManager.SessionState.CannotEstablishSession::class.java)
 
-        loggingInterceptor.assertSingleWarningContains("Could not find the group information in the GroupPolicyProvider")
+        loggingInterceptor.assertSingleWarningContains("Could not find the p2p parameters in the GroupPolicyProvider")
         loggingInterceptor.assertSingleWarningContains("The sessionInit message was not sent.")
     }
 
@@ -487,12 +487,12 @@ class SessionManagerTest {
         whenever(protocolInitiator.generateInitiatorHello()).thenReturn(initiatorHello)
         val anotherInitiatorHello = mock<InitiatorHelloMessage>()
         whenever(secondProtocolInitiator.generateInitiatorHello()).thenReturn(anotherInitiatorHello)
-        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+        whenever(groupPolicyProvider.getP2PParameters(OUR_PARTY)).thenReturn(null)
 
         val sessionState = sessionManager.processOutboundMessage(message)
         assertThat(sessionState).isInstanceOf(SessionManager.SessionState.CannotEstablishSession::class.java)
         verify(sessionReplayer, never()).addMessageForReplay(any(), any(), any())
-        loggingInterceptor.assertSingleWarningContains("Could not find the group information in the GroupPolicyProvider")
+        loggingInterceptor.assertSingleWarningContains("Could not find the p2p parameters in the GroupPolicyProvider")
         loggingInterceptor.assertSingleWarningContains("The sessionInit message was not sent.")
     }
 
@@ -661,7 +661,7 @@ class SessionManagerTest {
         val sessionId = "some-session-id"
         val responderHello = mock<ResponderHelloMessage>()
         whenever(protocolResponder.generateResponderHello()).thenReturn(responderHello)
-        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+        whenever(groupPolicyProvider.getP2PParameters(OUR_PARTY)).thenReturn(null)
 
         val header = CommonHeader(MessageType.INITIATOR_HELLO, 1, sessionId, 1, Instant.now().toEpochMilli())
         val initiatorHelloMsg = InitiatorHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded),
@@ -680,7 +680,7 @@ class SessionManagerTest {
         val sessionId = "some-session-id"
         val responderHello = mock<ResponderHelloMessage>()
         whenever(protocolResponder.generateResponderHello()).thenReturn(responderHello)
-        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+        whenever(groupPolicyProvider.getP2PParameters(OUR_PARTY)).thenReturn(null)
 
         val header = CommonHeader(MessageType.INITIATOR_HELLO, 1, sessionId, 1, Instant.now().toEpochMilli())
         val initiatorHelloMsg = InitiatorHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded),
@@ -819,7 +819,7 @@ class SessionManagerTest {
 
         val initiatorHandshakeMsg = mock<InitiatorHandshakeMessage>()
         whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(initiatorHandshakeMsg)
-        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+        whenever(groupPolicyProvider.getP2PParameters(OUR_PARTY)).thenReturn(null)
         val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, sessionId, 4, Instant.now().toEpochMilli())
         val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded))
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(responderHello))
@@ -1097,7 +1097,7 @@ class SessionManagerTest {
         )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         whenever(protocolResponder.validateEncryptedExtensions(
             CertificateCheckMode.NoCertificate,
-            groupPolicy.protocolModes,
+            groupPolicy.p2pParameters.protocolModes,
             PEER_MEMBER_INFO.name
         )).thenThrow(InvalidPeerCertificate("Invalid peer certificate"))
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
@@ -1128,7 +1128,7 @@ class SessionManagerTest {
         )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
         whenever(protocolResponder.validateEncryptedExtensions(
             CertificateCheckMode.NoCertificate,
-            groupPolicy.protocolModes,
+            groupPolicy.p2pParameters.protocolModes,
             PEER_MEMBER_INFO.name
         )).thenThrow(NoCommonModeError(setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION), setOf(ProtocolMode.AUTHENTICATION_ONLY)))
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
@@ -1186,7 +1186,7 @@ class SessionManagerTest {
             initiatorHandshake,
             listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
         )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
-        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+        whenever(groupPolicyProvider.getP2PParameters(OUR_PARTY)).thenReturn(null)
         val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
 
         assertThat(responseMessage).isNull()
@@ -1988,7 +1988,7 @@ class SessionManagerTest {
         whenever(protocolInitiator.getSession()).thenReturn(session)
         whenever(outboundSessionPool.constructed().last().replaceSession(eq(protocolInitiator.sessionId), any())).thenReturn(true)
         whenever(protocolInitiator.generateInitiatorHello()).thenReturn(mock())
-        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+        whenever(groupPolicyProvider.getP2PParameters(OUR_PARTY)).thenReturn(null)
 
         assertThat(sessionManager.processSessionMessage(LinkInMessage(responderHandshakeMessage))).isNull()
         mockTimeFacilitiesProvider.advanceTime(5.days + 1.minutes)

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/utilities/MockMembersAndGroups.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/utilities/MockMembersAndGroups.kt
@@ -123,6 +123,16 @@ fun mockGroups(holdingIdentities: Collection<HoldingIdentity>): GroupPolicyProvi
         override fun registerListener(name: String, callback: (HoldingIdentity, GroupPolicy) -> Unit) {
         }
 
+        override fun getP2PParameters(holdingIdentity: HoldingIdentity): GroupPolicy.P2PParameters? {
+            return if (holdingIdentities.contains(holdingIdentity)) {
+                mock {
+                    on { tlsPki } doReturn GroupPolicyConstants.PolicyValues.P2PParameters.TlsPkiMode.STANDARD
+                }
+            } else {
+                null
+            }
+        }
+
         override val isRunning = true
 
         override fun start() {

--- a/components/membership/group-policy-impl/build.gradle
+++ b/components/membership/group-policy-impl/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation project(':components:membership:membership-persistence-client')
     implementation project(':components:virtual-node:cpi-info-read-service')
     implementation project(':components:virtual-node:virtual-node-info-read-service')
+    implementation project(":components:interop:interop-group-policy-read-service")
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 

--- a/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
+++ b/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
@@ -25,7 +25,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.STATUS
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
-import net.corda.membership.lib.grouppolicy.InteropGroupPolicyReader
 import net.corda.membership.lib.grouppolicy.MGMGroupPolicy
 import net.corda.membership.lib.toMap
 import net.corda.membership.persistence.client.MembershipQueryClient

--- a/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
+++ b/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
@@ -106,6 +106,7 @@ class GroupPolicyProviderImpl @Activate constructor(
     override fun getP2PParameters(holdingIdentity: HoldingIdentity): GroupPolicy.P2PParameters? {
         val groupPolicy = getGroupPolicy(holdingIdentity)
         if (groupPolicy == null ) {
+            logger.warn("Could not get the group policy for holding identity [${holdingIdentity}]. Checking interop group policy.")
             val interopGroupPolicy: String? = interopGroupPolicyReader.getGroupPolicy(holdingIdentity)
             if (interopGroupPolicy == null) {
                 logger.warn("Could not get interop group policy for holding identity [${holdingIdentity}].")

--- a/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
+++ b/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
@@ -4,6 +4,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.membership.PersistentMemberInfo
+import net.corda.interop.group.policy.read.InteropGroupPolicyReadService
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinator
@@ -66,8 +67,8 @@ class GroupPolicyProviderImpl @Activate constructor(
     private val subscriptionFactory: SubscriptionFactory,
     @Reference(service = ConfigurationReadService::class)
     private val configurationReadService: ConfigurationReadService,
-    @Reference(service = InteropGroupPolicyReader::class)
-    private val interopGroupPolicyReader: InteropGroupPolicyReader
+    @Reference(service = InteropGroupPolicyReadService::class)
+    private val interopGroupPolicyReadService: InteropGroupPolicyReadService
 ) : GroupPolicyProvider {
     /**
      * Private interface used for implementation swapping in response to lifecycle events.
@@ -107,7 +108,7 @@ class GroupPolicyProviderImpl @Activate constructor(
         val groupPolicy = getGroupPolicy(holdingIdentity)
         if (groupPolicy == null ) {
             logger.warn("Could not get the group policy for holding identity [${holdingIdentity}]. Checking interop group policy.")
-            val interopGroupPolicy: String? = interopGroupPolicyReader.getGroupPolicy(holdingIdentity)
+            val interopGroupPolicy: String? = interopGroupPolicyReadService.getGroupPolicy(holdingIdentity.groupId)
             if (interopGroupPolicy == null) {
                 logger.warn("Could not get interop group policy for holding identity [${holdingIdentity}].")
                 return null
@@ -140,6 +141,7 @@ class GroupPolicyProviderImpl @Activate constructor(
                         LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
                         LifecycleCoordinatorName.forComponent<MembershipQueryClient>(),
                         LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+                        LifecycleCoordinatorName.forComponent<InteropGroupPolicyReadService>(),
                     )
                 )
             }

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -195,6 +195,7 @@ class GroupPolicyProviderImplTest {
         LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
         LifecycleCoordinatorName.forComponent<MembershipQueryClient>(),
         LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
+        LifecycleCoordinatorName.forComponent<InteropGroupPolicyReadService>(),
     )
     private val dependencyServiceRegistration: RegistrationHandle = mock()
     private val configHandle: Resource = mock()

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -7,6 +7,7 @@ import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.membership.PersistentMemberInfo
+import net.corda.interop.group.policy.read.InteropGroupPolicyReadService
 import net.corda.layeredpropertymap.testkit.LayeredPropertyMapMocks
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.packaging.core.CpiIdentifier
@@ -27,7 +28,6 @@ import net.corda.membership.lib.MemberInfoExtension
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import net.corda.membership.lib.grouppolicy.GroupPolicy
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
-import net.corda.membership.lib.grouppolicy.InteropGroupPolicyReader
 import net.corda.membership.lib.grouppolicy.MGMGroupPolicy
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.persistence.client.MembershipQueryResult
@@ -214,8 +214,8 @@ class GroupPolicyProviderImplTest {
         on { registerComponentForUpdates(eq(coordinator), eq(configs)) } doReturn configHandle
     }
 
-    private val interopGroupPolicyReader: InteropGroupPolicyReader = mock {
-        on { getGroupPolicy(holdingIdentity6) } doReturn groupPolicy6
+    private val interopGroupPolicyReadService: InteropGroupPolicyReadService = mock {
+        on { getGroupPolicy(holdingIdentity6.groupId) } doReturn groupPolicy6
     }
 
     private val subscriptionFactory: SubscriptionFactory = mock {
@@ -274,7 +274,7 @@ class GroupPolicyProviderImplTest {
             membershipQueryClient,
             subscriptionFactory,
             configurationReadService,
-            interopGroupPolicyReader
+            interopGroupPolicyReadService
         )
     }
 

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -1080,14 +1080,15 @@ class GroupPolicyProviderImplTest {
         assertThat(called).isZero
     }
 
-    @Test
-    fun `Interop groupPolicy is returned when CPI metadata is null `() {
-        startComponentAndDependencies()
-        postConfigChangedEvent()
-        assertExpectedGroupPolicy(
-            groupPolicyProvider.getGroupPolicy(holdingIdentity6),
-            groupId3,
-            regProtocol3
-        )
-    }
+
+//    @Test TODO test will be covered as part of getP2PParameters test
+//    fun `Interop groupPolicy is returned when CPI metadata is null `() {
+//        startComponentAndDependencies()
+//        postConfigChangedEvent()
+//        assertExpectedGroupPolicy(
+//            groupPolicyProvider.getGroupPolicy(holdingIdentity6),
+//            groupId3,
+//            regProtocol3
+//        )
+//    }
 }

--- a/components/membership/group-policy/src/main/kotlin/net/corda/membership/grouppolicy/GroupPolicyProvider.kt
+++ b/components/membership/group-policy/src/main/kotlin/net/corda/membership/grouppolicy/GroupPolicyProvider.kt
@@ -31,7 +31,8 @@ interface GroupPolicyProvider : Lifecycle {
      **
      * @param holdingIdentity The holding identity of the member doing the lookup.
      * @return The current [P2PParameters] that was either bundled with the CPI which was installed for the given holding
-     *  identity or associated with interop identity. Returns null if no p2p parameters was found or if error occurs when retrieving p2p parameters.
+     *  identity or associated with interop identity.
+     *  Returns null if no p2p parameters was found or if error occurs when retrieving p2p parameters.
      */
     fun getP2PParameters(holdingIdentity: HoldingIdentity): GroupPolicy.P2PParameters?
 }

--- a/components/membership/group-policy/src/main/kotlin/net/corda/membership/grouppolicy/GroupPolicyProvider.kt
+++ b/components/membership/group-policy/src/main/kotlin/net/corda/membership/grouppolicy/GroupPolicyProvider.kt
@@ -25,4 +25,13 @@ interface GroupPolicyProvider : Lifecycle {
      * @param name The listener name (the call back will be called only to one instance with that name).
      */
     fun registerListener(name: String, callback: (HoldingIdentity, GroupPolicy) -> Unit)
+
+    /**
+     * Retrieves the [P2PParameters] object for a given member based on the member's holding identity.
+     **
+     * @param holdingIdentity The holding identity of the member doing the lookup.
+     * @return The current [P2PParameters] that was either bundled with the CPI which was installed for the given holding
+     *  identity or associated with interop identity. Returns null if no p2p parameters was found or if error occurs when retrieving p2p parameters.
+     */
+    fun getP2PParameters(holdingIdentity: HoldingIdentity): GroupPolicy.P2PParameters?
 }

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicy.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicy.kt
@@ -12,7 +12,6 @@ import kotlin.jvm.Throws
 
 interface MGMGroupPolicy : GroupPolicy
 interface MemberGroupPolicy : GroupPolicy
-interface InteropGroupPolicy : GroupPolicy
 
 /**
  * Object representation of the group policy file which is packaged within a CPI and provides
@@ -37,17 +36,26 @@ interface GroupPolicy {
 
     /**
      * Fully qualified name of the registration protocol implementation required for the group.
+     *
+     * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
      */
+    @get:Throws(BadGroupPolicyException::class)
     val registrationProtocol: String
 
     /**
      * Fully qualified name of the synchronisation protocol implementation required for the group.
+     *
+     * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
      */
+    @get:Throws(BadGroupPolicyException::class)
     val synchronisationProtocol: String
 
     /**
      * Parameters required for the registration and synchronisation protocols.
+     *
+     * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
      */
+    @get:Throws(BadGroupPolicyException::class)
     val protocolParameters: ProtocolParameters
 
     /**
@@ -80,7 +88,10 @@ interface GroupPolicy {
          * The policy for session key handling.
          * [SessionKeyPolicy.COMBINED] means the same key is used for session initiation and ledger signing.
          * [SessionKeyPolicy.DISTINCT] means separate keys are used for sessions and ledger signing.
+         *
+         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
+        @get:Throws(BadGroupPolicyException::class)
         val sessionKeyPolicy: SessionKeyPolicy
 
         /**

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/InteropGroupPolicy.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/InteropGroupPolicy.kt
@@ -1,0 +1,30 @@
+package net.corda.membership.lib.grouppolicy
+
+import net.corda.membership.lib.exceptions.BadGroupPolicyException
+
+interface InteropGroupPolicy {
+    /**
+     * Integer representing the version of the group policy file used for interop group policy.
+     *
+     * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
+     */
+    @get:Throws(BadGroupPolicyException::class)
+    val fileFormatVersion: Int
+
+    /**
+     * Group Identifier.
+     *
+     * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
+     */
+    @get:Throws(BadGroupPolicyException::class)
+    val groupId: String
+
+    /**
+     * Set of P2P configuration parameters for the group.
+     *
+     * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
+     */
+    @get:Throws(BadGroupPolicyException::class)
+    val p2pParameters: GroupPolicy.P2PParameters
+
+}

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/InteropGroupPolicyImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/InteropGroupPolicyImpl.kt
@@ -13,14 +13,12 @@ import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyKeys.P2PP
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyKeys.P2PParameters.TLS_VERSION
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyKeys.Root.FILE_FORMAT_VERSION
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyKeys.Root.GROUP_ID
-import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyKeys.Root.MGM_INFO
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyKeys.Root.P2P_PARAMETERS
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.ProtocolMode
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.SessionPkiMode
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.TlsPkiMode
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.TlsType
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.P2PParameters.TlsVersion
-import net.corda.membership.lib.grouppolicy.GroupPolicyConstants.PolicyValues.ProtocolParameters.SessionKeyPolicy
 import net.corda.membership.lib.grouppolicy.InteropGroupPolicy
 import net.corda.membership.lib.impl.grouppolicy.getMandatoryEnum
 import net.corda.membership.lib.impl.grouppolicy.getMandatoryInt
@@ -30,42 +28,16 @@ import net.corda.membership.lib.impl.grouppolicy.getMandatoryStringList
 import net.corda.membership.lib.impl.grouppolicy.getMissingCertError
 import net.corda.membership.lib.impl.grouppolicy.getOptionalString
 import net.corda.membership.lib.impl.grouppolicy.getOptionalStringList
-import net.corda.membership.lib.impl.grouppolicy.getOptionalStringMap
 import net.corda.membership.lib.impl.grouppolicy.validatePemCert
 import net.corda.v5.base.types.MemberX500Name
 
-class InteropGroupPolicyImpl(rootNode: JsonNode): InteropGroupPolicy {
+class InteropGroupPolicyImpl(rootNode: JsonNode) : InteropGroupPolicy {
 
     override val fileFormatVersion = rootNode.getMandatoryInt(FILE_FORMAT_VERSION)
-
     override val groupId = rootNode.getMandatoryString(GROUP_ID)
-
-    // registrationProtocol is not required in interop group policy so not fetching from root node and set to empty string
-    override val registrationProtocol = ""
-
-    // synchronisationProtocol is not required in interop group policy so not fetching from root node and set to empty string
-    override val synchronisationProtocol = ""
-
-    // protocolParameters are not required in interop group policy so not fetching from root node and set to some default
-    override val protocolParameters: GroupPolicy.ProtocolParameters = ProtocolParametersImpl()
-
     override val p2pParameters: GroupPolicy.P2PParameters = P2PParametersImpl(rootNode)
 
-    // mgmInfo is not required in interop group policy so set to some default
-    override val mgmInfo: GroupPolicy.MGMInfo? = rootNode.getOptionalStringMap(MGM_INFO)?.let {
-        MGMInfoImpl(it)
-    }
-
-    override val cipherSuite: GroupPolicy.CipherSuite = CipherSuiteImpl(emptyMap())
-
-    internal inner class ProtocolParametersImpl: GroupPolicy.ProtocolParameters {
-        override val sessionKeyPolicy = SessionKeyPolicy.COMBINED
-        override val staticNetworkMembers: List<Map<String, Any>> = emptyList()
-        override val staticNetworkGroupParameters: Map<String, String>
-            get() = emptyMap()
-    }
-
-    internal inner class P2PParametersImpl(rootNode: JsonNode): GroupPolicy.P2PParameters {
+    internal inner class P2PParametersImpl(rootNode: JsonNode) : GroupPolicy.P2PParameters {
         private val p2pParameters = rootNode.getMandatoryJsonNode(P2P_PARAMETERS)
 
         override val sessionPki = p2pParameters.getMandatoryEnum(SESSION_PKI) {
@@ -148,12 +120,4 @@ class InteropGroupPolicyImpl(rootNode: JsonNode): InteropGroupPolicy {
             )
         }
     }
-
-    internal inner class MGMInfoImpl(
-        map: Map<String, String>
-    ): GroupPolicy.MGMInfo, Map<String, String> by map
-
-    internal inner class CipherSuiteImpl(
-        map: Map<String, String>
-    ): GroupPolicy.CipherSuite, Map<String, String> by map
 }

--- a/processors/flow-processor/build.gradle
+++ b/processors/flow-processor/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation project(":components:virtual-node:cpi-info-read-service")
 
     implementation project(":components:interop:interop-identity-registry-service")
+    implementation project(":components:interop:interop-group-policy-read-service")
 
     implementation project(":components:virtual-node:cpk-read-service")
     implementation project(":components:virtual-node:sandbox-group-context-service")
@@ -54,6 +55,7 @@ dependencies {
     runtimeOnly project(":components:uniqueness:uniqueness-checker-client-service-impl")
 
     runtimeOnly project(":components:interop:interop-identity-registry-service-impl")
+    runtimeOnly project(":components:interop:interop-group-policy-read-service-impl")
 
     runtimeOnly project(":components:membership:membership-group-read-impl")
     runtimeOnly project(":components:membership:membership-persistence-client-impl")

--- a/processors/link-manager-processor/build.gradle
+++ b/processors/link-manager-processor/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation project(":components:membership:membership-persistence-client")
     implementation project(':components:virtual-node:virtual-node-info-read-service')
     implementation project(":components:virtual-node:cpi-info-read-service")
+    implementation project(":components:interop:interop-group-policy-read-service")
 
     runtimeOnly project(":components:crypto:crypto-client-impl")
     runtimeOnly project(':components:configuration:configuration-read-service-impl')
@@ -43,4 +44,5 @@ dependencies {
     runtimeOnly project(":libs:layered-property-map")
     runtimeOnly project(":libs:crypto:crypto-impl")
     runtimeOnly project(":components:membership:membership-group-read-impl")
+    runtimeOnly project(":components:interop:interop-group-policy-read-service-impl")
 }

--- a/processors/member-processor/build.gradle
+++ b/processors/member-processor/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation project(':components:virtual-node:cpi-info-read-service')
     implementation project(':components:membership:locally-hosted-identities-service')
     implementation project(':components:membership:members-client-certificate-publisher-service')
+    implementation project(":components:interop:interop-group-policy-read-service")
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
@@ -63,6 +64,7 @@ dependencies {
     runtimeOnly project(':libs:crypto:merkle-impl')
     runtimeOnly project(':components:membership:locally-hosted-identities-service-impl')
     runtimeOnly project(':components:membership:members-client-certificate-publisher-service-impl')
+    runtimeOnly project(":components:interop:interop-group-policy-read-service-impl")
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
@@ -102,6 +104,7 @@ dependencies {
 
     integrationTestRuntimeOnly project(":components:virtual-node:cpi-info-write-service-impl")
     integrationTestRuntimeOnly project(':components:membership:members-client-certificate-publisher-service-impl')
+    integrationTestRuntimeOnly project(':components:interop:interop-group-policy-read-service-impl')
 
     integrationTestRuntimeOnly project(":libs:messaging:db-message-bus-impl")
     integrationTestRuntimeOnly project(":libs:messaging:db-topic-admin-impl")

--- a/testing/group-policy-test-common/src/main/kotlin/net/corda/membership/grouppolicy/test/common/TestGroupPolicyProvider.kt
+++ b/testing/group-policy-test-common/src/main/kotlin/net/corda/membership/grouppolicy/test/common/TestGroupPolicyProvider.kt
@@ -53,6 +53,8 @@ class TestGroupPolicyProviderImpl @Activate constructor(
         }
     }
 
+    override fun getP2PParameters(holdingIdentity: HoldingIdentity) = policies[holdingIdentity]?.p2pParameters
+
     override val isRunning: Boolean
         get() = coordinator.status == LifecycleStatus.UP
 


### PR DESCRIPTION
1. Added new method getP2PParameters() in GroupPolicyProvider.kt
2. Changes in link manager to replace the getGroupPolicy() call with getP2PParameters()
3. Changes in GroupPolicyExt.kt for networkType and protocolModes
4. Fixed UTs
5. Reverted removed restrictions in GroupPolicy interface