### PR TITLE
CORE-15342 Revise errors for member and virtual node not found

### DIFF
--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
@@ -38,6 +38,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.membership.client.CouldNotFindEntityException
+import net.corda.membership.client.Entity
 import net.corda.membership.client.MGMResourceClient
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.EPOCH_KEY
@@ -453,13 +454,13 @@ class MGMResourceClientImpl @Activate constructor(
         fun mgmHoldingIdentity(holdingIdentityShortHash: ShortHash): HoldingIdentity {
             val holdingIdentity =
                 virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)?.holdingIdentity
-                    ?: throw CouldNotFindEntityException("virtual node", holdingIdentityShortHash)
+                    ?: throw CouldNotFindEntityException(Entity.VIRTUAL_NODE, holdingIdentityShortHash)
 
             val reader = membershipGroupReaderProvider.getGroupReader(holdingIdentity)
 
             val filteredMembers =
                 reader.lookup(holdingIdentity.x500Name)
-                    ?:throw CouldNotFindEntityException("member", holdingIdentityShortHash)
+                    ?:throw CouldNotFindEntityException(Entity.MEMBER, holdingIdentityShortHash)
 
             if (!filteredMembers.isMgm) {
                 throw MemberNotAnMgmException(holdingIdentityShortHash)

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MGMResourceClientImpl.kt
@@ -37,7 +37,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MGMResourceClient
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.EPOCH_KEY
@@ -453,13 +453,13 @@ class MGMResourceClientImpl @Activate constructor(
         fun mgmHoldingIdentity(holdingIdentityShortHash: ShortHash): HoldingIdentity {
             val holdingIdentity =
                 virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)?.holdingIdentity
-                    ?: throw CouldNotFindMemberException(holdingIdentityShortHash)
+                    ?: throw CouldNotFindEntityException("virtual node", holdingIdentityShortHash)
 
             val reader = membershipGroupReaderProvider.getGroupReader(holdingIdentity)
 
             val filteredMembers =
                 reader.lookup(holdingIdentity.x500Name)
-                    ?:throw CouldNotFindMemberException(holdingIdentityShortHash)
+                    ?:throw CouldNotFindEntityException("member", holdingIdentityShortHash)
 
             if (!filteredMembers.isMgm) {
                 throw MemberNotAnMgmException(holdingIdentityShortHash)

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
@@ -25,6 +25,7 @@ import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.membership.client.CouldNotFindEntityException
+import net.corda.membership.client.Entity
 import net.corda.membership.client.MemberResourceClient
 import net.corda.membership.client.RegistrationProgressNotFoundException
 import net.corda.membership.client.ServiceNotReadyException
@@ -247,7 +248,7 @@ class MemberResourceClientImpl @Activate constructor(
             val holdingIdentity =
                 virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
                     ?.holdingIdentity
-                    ?: throw CouldNotFindEntityException("virtual node", holdingIdentityShortHash)
+                    ?: throw CouldNotFindEntityException(Entity.VIRTUAL_NODE, holdingIdentityShortHash)
             try {
                 asyncPublisher.publish(
                     listOf(
@@ -357,7 +358,7 @@ class MemberResourceClientImpl @Activate constructor(
 
         override fun checkRegistrationProgress(holdingIdentityShortHash: ShortHash): List<RegistrationRequestStatusDto> {
             val holdingIdentity = virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
-                ?: throw CouldNotFindEntityException("virtual node", holdingIdentityShortHash)
+                ?: throw CouldNotFindEntityException(Entity.VIRTUAL_NODE, holdingIdentityShortHash)
             return try {
                 membershipQueryClient.queryRegistrationRequests(
                     holdingIdentity.holdingIdentity
@@ -374,7 +375,7 @@ class MemberResourceClientImpl @Activate constructor(
             registrationRequestId: String,
         ): RegistrationRequestStatusDto {
             val holdingIdentity = virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
-                ?: throw CouldNotFindEntityException("virtual node", holdingIdentityShortHash)
+                ?: throw CouldNotFindEntityException(Entity.VIRTUAL_NODE, holdingIdentityShortHash)
             return try {
                 val status =
                     membershipQueryClient.queryRegistrationRequest(

--- a/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
+++ b/components/membership/membership-client-impl/src/main/kotlin/net/corda/membership/impl/client/MemberResourceClientImpl.kt
@@ -24,7 +24,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MemberResourceClient
 import net.corda.membership.client.RegistrationProgressNotFoundException
 import net.corda.membership.client.ServiceNotReadyException
@@ -247,7 +247,7 @@ class MemberResourceClientImpl @Activate constructor(
             val holdingIdentity =
                 virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
                     ?.holdingIdentity
-                    ?: throw CouldNotFindMemberException(holdingIdentityShortHash)
+                    ?: throw CouldNotFindEntityException("virtual node", holdingIdentityShortHash)
             try {
                 asyncPublisher.publish(
                     listOf(
@@ -357,7 +357,7 @@ class MemberResourceClientImpl @Activate constructor(
 
         override fun checkRegistrationProgress(holdingIdentityShortHash: ShortHash): List<RegistrationRequestStatusDto> {
             val holdingIdentity = virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
-                ?: throw CouldNotFindMemberException(holdingIdentityShortHash)
+                ?: throw CouldNotFindEntityException("virtual node", holdingIdentityShortHash)
             return try {
                 membershipQueryClient.queryRegistrationRequests(
                     holdingIdentity.holdingIdentity
@@ -374,7 +374,7 @@ class MemberResourceClientImpl @Activate constructor(
             registrationRequestId: String,
         ): RegistrationRequestStatusDto {
             val holdingIdentity = virtualNodeInfoReadService.getByHoldingIdentityShortHash(holdingIdentityShortHash)
-                ?: throw CouldNotFindMemberException(holdingIdentityShortHash)
+                ?: throw CouldNotFindEntityException("virtual node", holdingIdentityShortHash)
             return try {
                 val status =
                     membershipQueryClient.queryRegistrationRequest(

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MGMResourceClientTest.kt
@@ -44,7 +44,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.membership.lib.ContextDeserializationException
 import net.corda.membership.lib.EndpointInfoFactory
@@ -506,7 +506,7 @@ class MGMResourceClientTest {
             )
         )
 
-        assertThrows<CouldNotFindMemberException> {
+        assertThrows<CouldNotFindEntityException> {
             mgmResourceClient.generateGroupPolicy(ShortHash.of("000000000000"))
         }
         mgmResourceClient.stop()
@@ -522,7 +522,7 @@ class MGMResourceClientTest {
         )
         whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-        assertThrows<CouldNotFindMemberException> {
+        assertThrows<CouldNotFindEntityException> {
             mgmResourceClient.generateGroupPolicy(shortHash)
         }
         mgmResourceClient.stop()
@@ -584,7 +584,7 @@ class MGMResourceClientTest {
             mgmResourceClient.start()
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.addApprovalRule(
                     ShortHash.of("000000000000"),
                     ApprovalRuleParams(RULE_REGEX, ApprovalRuleType.STANDARD, RULE_LABEL)
@@ -599,7 +599,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.addApprovalRule(
                     shortHash, ApprovalRuleParams(RULE_REGEX, ApprovalRuleType.STANDARD, RULE_LABEL)
                 )
@@ -661,7 +661,7 @@ class MGMResourceClientTest {
             mgmResourceClient.start()
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.deleteApprovalRule(
                     ShortHash.of("000000000000"), RULE_ID, RULE_TYPE
                 )
@@ -675,7 +675,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.deleteApprovalRule(
                     shortHash, RULE_ID, RULE_TYPE
                 )
@@ -734,7 +734,7 @@ class MGMResourceClientTest {
             mgmResourceClient.start()
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.getApprovalRules(
                     ShortHash.of("000000000000"), ApprovalRuleType.STANDARD
                 )
@@ -748,7 +748,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.getApprovalRules(
                     shortHash, ApprovalRuleType.STANDARD
                 )
@@ -810,7 +810,7 @@ class MGMResourceClientTest {
             mgmResourceClient.start()
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.viewRegistrationRequests(
                     ShortHash.of("000000000000"), memberName, true
                 )
@@ -824,7 +824,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.viewRegistrationRequests(
                     shortHash, memberName, true
                 )
@@ -974,7 +974,7 @@ class MGMResourceClientTest {
             mgmResourceClient.start()
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.reviewRegistrationRequest(
                     ShortHash.of("000000000000"),
                     REQUEST_ID.uuid(),
@@ -990,7 +990,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.reviewRegistrationRequest(
                     shortHash,
                     REQUEST_ID.uuid(),
@@ -1170,7 +1170,7 @@ class MGMResourceClientTest {
             mgmResourceClient.start()
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.forceDeclineRegistrationRequest(
                     ShortHash.of("000000000000"),
                     REQUEST_ID.uuid(),
@@ -1185,7 +1185,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.forceDeclineRegistrationRequest(
                     shortHash,
                     REQUEST_ID.uuid(),
@@ -1814,7 +1814,7 @@ class MGMResourceClientTest {
         fun `suspendMember should fail if the member cannot be found`() {
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.suspendMember(
                     ShortHash.of("000000000000"),
                     memberName
@@ -1827,7 +1827,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.suspendMember(shortHash, memberName)
             }
         }
@@ -2016,7 +2016,7 @@ class MGMResourceClientTest {
         fun `activateMember should fail if the member cannot be found`() {
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.activateMember(
                     ShortHash.of("000000000000"),
                     memberName
@@ -2029,7 +2029,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.activateMember(shortHash, memberName)
             }
         }
@@ -2158,7 +2158,7 @@ class MGMResourceClientTest {
         fun `updateGroupParameters should fail if the member cannot be found`() {
             setUpRpcSender(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.updateGroupParameters(
                     ShortHash.of("000000000000"),
                     mockUpdate
@@ -2171,7 +2171,7 @@ class MGMResourceClientTest {
             setUpRpcSender(null)
             whenever(groupReader.lookup(mgmX500Name)).doReturn(null)
 
-            assertThrows<CouldNotFindMemberException> {
+            assertThrows<CouldNotFindEntityException> {
                 mgmResourceClient.updateGroupParameters(shortHash, mockUpdate)
             }
         }

--- a/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MemberResourceClientTest.kt
+++ b/components/membership/membership-client-impl/src/test/kotlin/net/corda/membership/impl/client/MemberResourceClientTest.kt
@@ -26,7 +26,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.Resource
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.RegistrationProgressNotFoundException
 import net.corda.membership.client.ServiceNotReadyException
 import net.corda.membership.client.dto.MemberInfoSubmittedDto
@@ -436,7 +436,7 @@ class MemberResourceClientTest {
         memberOpsClient.start()
         setUpConfig()
 
-        assertThrows<CouldNotFindMemberException> {
+        assertThrows<CouldNotFindEntityException> {
             memberOpsClient.checkRegistrationProgress(holdingIdentityId)
         }
     }
@@ -540,7 +540,7 @@ class MemberResourceClientTest {
         memberOpsClient.start()
         setUpConfig()
 
-        assertThrows<CouldNotFindMemberException> {
+        assertThrows<CouldNotFindEntityException> {
             memberOpsClient.checkSpecificRegistrationProgress(holdingIdentityId, "registration id")
         }
     }
@@ -643,7 +643,7 @@ class MemberResourceClientTest {
         memberOpsClient.start()
         setUpConfig()
 
-        assertThrows<CouldNotFindMemberException> {
+        assertThrows<CouldNotFindEntityException> {
             memberOpsClient.startRegistration(holdingIdentityId, context)
         }
     }

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/CouldNotFindEntityException.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/CouldNotFindEntityException.kt
@@ -1,0 +1,7 @@
+package net.corda.membership.client
+
+import net.corda.crypto.core.ShortHash
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+class CouldNotFindEntityException(entity: String, holdingIdentityShortHash: ShortHash) :
+    CordaRuntimeException("Could not find $entity: $holdingIdentityShortHash")

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/CouldNotFindEntityException.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/CouldNotFindEntityException.kt
@@ -3,5 +3,5 @@ package net.corda.membership.client
 import net.corda.crypto.core.ShortHash
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
-class CouldNotFindEntityException(entity: String, holdingIdentityShortHash: ShortHash) :
+class CouldNotFindEntityException(val entity: String, holdingIdentityShortHash: ShortHash) :
     CordaRuntimeException("Could not find $entity: $holdingIdentityShortHash")

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/CouldNotFindEntityException.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/CouldNotFindEntityException.kt
@@ -3,5 +3,12 @@ package net.corda.membership.client
 import net.corda.crypto.core.ShortHash
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
-class CouldNotFindEntityException(val entity: String, holdingIdentityShortHash: ShortHash) :
+class CouldNotFindEntityException(val entity: Entity, holdingIdentityShortHash: ShortHash) :
     CordaRuntimeException("Could not find $entity: $holdingIdentityShortHash")
+
+enum class Entity(private val label: String) {
+    MEMBER("member"),
+    VIRTUAL_NODE("virtual node");
+
+    override fun toString(): String = label
+}

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/CouldNotFindMemberException.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/CouldNotFindMemberException.kt
@@ -1,7 +1,0 @@
-package net.corda.membership.client
-
-import net.corda.crypto.core.ShortHash
-import net.corda.v5.base.exceptions.CordaRuntimeException
-
-class CouldNotFindMemberException(holdingIdentityShortHash: ShortHash) :
-    CordaRuntimeException("Could not find member: $holdingIdentityShortHash")

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
@@ -28,10 +28,10 @@ interface MGMResourceClient : Lifecycle {
      *
      * @return [String] Generated Group Policy Response.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      */
-    @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class)
+    @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class)
     fun generateGroupPolicy(holdingIdentityShortHash: ShortHash): String
 
     fun mutualTlsAllowClientCertificate(
@@ -98,11 +98,11 @@ interface MGMResourceClient : Lifecycle {
      *
      * @return Details of the newly persisted approval rule.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [MembershipPersistenceException] If an identical rule already exists.
      */
-    @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class, MembershipPersistenceException::class)
+    @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class, MembershipPersistenceException::class)
     fun addApprovalRule(
         holdingIdentityShortHash: ShortHash,
         ruleParams: ApprovalRuleParams
@@ -117,10 +117,10 @@ interface MGMResourceClient : Lifecycle {
      * @return Approval rules as a collection of [ApprovalRuleDetails], or an empty collection if no rules have been
      * added.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      */
-    @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class)
+    @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class)
     fun getApprovalRules(holdingIdentityShortHash: ShortHash, ruleType: ApprovalRuleType): Collection<ApprovalRuleDetails>
 
     /**
@@ -130,11 +130,11 @@ interface MGMResourceClient : Lifecycle {
      * @param ruleId ID of the group approval rule to be deleted.
      * @param ruleType The approval rule type for this rule. See [ApprovalRuleType] for the available types.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [MembershipPersistenceException] If the specified rule does not exist.
      */
-    @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class, MembershipPersistenceException::class)
+    @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class, MembershipPersistenceException::class)
     fun deleteApprovalRule(holdingIdentityShortHash: ShortHash, ruleId: String, ruleType: ApprovalRuleType)
 
     /**
@@ -148,10 +148,10 @@ interface MGMResourceClient : Lifecycle {
      *
      * @return Registration requests as a collection of [RegistrationRequestDetails].
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      */
-    @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class)
+    @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class)
     fun viewRegistrationRequests(
         holdingIdentityShortHash: ShortHash,
         requestSubjectX500Name: MemberX500Name?,
@@ -167,13 +167,13 @@ interface MGMResourceClient : Lifecycle {
      * @param approve Set to 'true' if request is approved, 'false' if declined.
      * @param reason Reason if registration request is declined.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [IllegalArgumentException] If request is not found, if request is not pending review, or if member name
      * is missing from the context.
      * @throws [ContextDeserializationException] If request cannot be deserialized.
      */
-    @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class, IllegalArgumentException::class)
+    @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class, IllegalArgumentException::class)
     fun reviewRegistrationRequest(
         holdingIdentityShortHash: ShortHash,
         requestId: UUID,
@@ -188,11 +188,11 @@ interface MGMResourceClient : Lifecycle {
      * @param holdingIdentityShortHash The holding identity ID of the MGM of the membership group.
      * @param requestId ID of the registration request.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [IllegalArgumentException] If the request is not found, or has already been approved/declined.
      */
-    @Throws(CouldNotFindMemberException::class, MemberNotAnMgmException::class, IllegalArgumentException::class)
+    @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class, IllegalArgumentException::class)
     fun forceDeclineRegistrationRequest(
         holdingIdentityShortHash: ShortHash,
         requestId: UUID,
@@ -206,13 +206,13 @@ interface MGMResourceClient : Lifecycle {
      * @param serialNumber Optional. Serial number of the member's [MemberInfo].
      * @param reason Optional. Reason for suspension.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [IllegalArgumentException] If the member to be suspended is the MGM itself.
      * @throws [NoSuchElementException] If the member to be suspended is not found.
      */
     @Throws(
-        CouldNotFindMemberException::class,
+        CouldNotFindEntityException::class,
         MemberNotAnMgmException::class,
         IllegalArgumentException::class,
         NoSuchElementException::class
@@ -232,13 +232,13 @@ interface MGMResourceClient : Lifecycle {
      * @param serialNumber Optional. Serial number of the member's [MemberInfo].
      * @param reason Optional. Reason for activation.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [IllegalArgumentException] If the member to be activated is the MGM itself.
      * @throws [NoSuchElementException] If the member to be activated is not found.
      */
     @Throws(
-        CouldNotFindMemberException::class,
+        CouldNotFindEntityException::class,
         MemberNotAnMgmException::class,
         IllegalArgumentException::class,
         NoSuchElementException::class
@@ -256,11 +256,11 @@ interface MGMResourceClient : Lifecycle {
      * @param holdingIdentityShortHash The holding identity ID of the MGM of the membership group.
      * @param newGroupParameters Updated version of the group parameters.
      *
-     * @throws [CouldNotFindMemberException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      */
     @Throws(
-        CouldNotFindMemberException::class,
+        CouldNotFindEntityException::class,
         MemberNotAnMgmException::class,
     )
     fun updateGroupParameters(

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MGMResourceClient.kt
@@ -28,7 +28,7 @@ interface MGMResourceClient : Lifecycle {
      *
      * @return [String] Generated Group Policy Response.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      */
     @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class)
@@ -98,7 +98,7 @@ interface MGMResourceClient : Lifecycle {
      *
      * @return Details of the newly persisted approval rule.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [MembershipPersistenceException] If an identical rule already exists.
      */
@@ -117,7 +117,7 @@ interface MGMResourceClient : Lifecycle {
      * @return Approval rules as a collection of [ApprovalRuleDetails], or an empty collection if no rules have been
      * added.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      */
     @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class)
@@ -130,7 +130,7 @@ interface MGMResourceClient : Lifecycle {
      * @param ruleId ID of the group approval rule to be deleted.
      * @param ruleType The approval rule type for this rule. See [ApprovalRuleType] for the available types.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [MembershipPersistenceException] If the specified rule does not exist.
      */
@@ -148,7 +148,7 @@ interface MGMResourceClient : Lifecycle {
      *
      * @return Registration requests as a collection of [RegistrationRequestDetails].
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      */
     @Throws(CouldNotFindEntityException::class, MemberNotAnMgmException::class)
@@ -167,7 +167,7 @@ interface MGMResourceClient : Lifecycle {
      * @param approve Set to 'true' if request is approved, 'false' if declined.
      * @param reason Reason if registration request is declined.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [IllegalArgumentException] If request is not found, if request is not pending review, or if member name
      * is missing from the context.
@@ -188,7 +188,7 @@ interface MGMResourceClient : Lifecycle {
      * @param holdingIdentityShortHash The holding identity ID of the MGM of the membership group.
      * @param requestId ID of the registration request.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [IllegalArgumentException] If the request is not found, or has already been approved/declined.
      */
@@ -206,7 +206,7 @@ interface MGMResourceClient : Lifecycle {
      * @param serialNumber Optional. Serial number of the member's [MemberInfo].
      * @param reason Optional. Reason for suspension.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [IllegalArgumentException] If the member to be suspended is the MGM itself.
      * @throws [NoSuchElementException] If the member to be suspended is not found.
@@ -232,7 +232,7 @@ interface MGMResourceClient : Lifecycle {
      * @param serialNumber Optional. Serial number of the member's [MemberInfo].
      * @param reason Optional. Reason for activation.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      * @throws [IllegalArgumentException] If the member to be activated is the MGM itself.
      * @throws [NoSuchElementException] If the member to be activated is not found.
@@ -256,7 +256,7 @@ interface MGMResourceClient : Lifecycle {
      * @param holdingIdentityShortHash The holding identity ID of the MGM of the membership group.
      * @param newGroupParameters Updated version of the group parameters.
      *
-     * @throws [CouldNotFindEntityException] If there is no member with [holdingIdentityShortHash].
+     * @throws [CouldNotFindEntityException] If there is no member or virtual node with [holdingIdentityShortHash].
      * @throws [MemberNotAnMgmException] If the member identified by [holdingIdentityShortHash] is not an MGM.
      */
     @Throws(

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MemberResourceClient.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MemberResourceClient.kt
@@ -18,7 +18,7 @@ interface MemberResourceClient : Lifecycle {
      * @param registrationContext The member's or MGM's registration context required for on-boarding within a group,
      *   which will be later part of the member provided context of the [MemberInfo]. In case of MGM registration some
      *   parts of the context will be used for building the [GroupPolicy] as well.
-     * @throws CouldNotFindMemberException if the member in `holdingIdentityShortHash` can not be found.
+     * @throws CouldNotFindEntityException if the member in `holdingIdentityShortHash` can not be found.
      * @return [RegistrationRequestProgressDto] to indicate the status of the request at time of submission.
      */
     fun startRegistration(

--- a/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MemberResourceClient.kt
+++ b/components/membership/membership-client/src/main/kotlin/net/corda/membership/client/MemberResourceClient.kt
@@ -18,7 +18,7 @@ interface MemberResourceClient : Lifecycle {
      * @param registrationContext The member's or MGM's registration context required for on-boarding within a group,
      *   which will be later part of the member provided context of the [MemberInfo]. In case of MGM registration some
      *   parts of the context will be used for building the [GroupPolicy] as well.
-     * @throws CouldNotFindEntityException if the member in `holdingIdentityShortHash` can not be found.
+     * @throws CouldNotFindEntityException If there is no virtual node with [holdingIdentityShortHash].
      * @return [RegistrationRequestProgressDto] to indicate the status of the request at time of submission.
      */
     fun startRegistration(

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
@@ -100,7 +100,7 @@ class MGMAdminRestResourceImpl @Activate constructor(
                     parseRegistrationRequestId(requestId)
                 )
             } catch (e: CouldNotFindEntityException) {
-                throw ResourceNotFoundException("Holding Identity", holdingIdentityShortHash)
+                throw ResourceNotFoundException(e.entity, holdingIdentityShortHash)
             } catch (e: MemberNotAnMgmException) {
                 throw InvalidInputDataException(
                     details = mapOf("holdingIdentityShortHash" to holdingIdentityShortHash),

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
@@ -6,7 +6,7 @@ import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MGMResourceClient
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.membership.impl.rest.v1.lifecycle.RestResourceLifecycleHandler
@@ -99,7 +99,7 @@ class MGMAdminRestResourceImpl @Activate constructor(
                     ShortHash.parseOrThrow(holdingIdentityShortHash),
                     parseRegistrationRequestId(requestId)
                 )
-            } catch (e: CouldNotFindMemberException) {
+            } catch (e: CouldNotFindEntityException) {
                 throw ResourceNotFoundException("Holding Identity", holdingIdentityShortHash)
             } catch (e: MemberNotAnMgmException) {
                 throw InvalidInputDataException(

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -21,7 +21,7 @@ import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MGMResourceClient
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.membership.rest.v1.MGMRestResource
@@ -792,7 +792,7 @@ class MGMRestResourceImpl internal constructor(
         ): T {
             return try {
                 func.invoke(ShortHash.parseOrThrow(holdingIdentityShortHash))
-            } catch (e: CouldNotFindMemberException) {
+            } catch (e: CouldNotFindEntityException) {
                 holdingIdentityNotFound(holdingIdentityShortHash)
             } catch (e: MemberNotAnMgmException) {
                 notAnMgmError(holdingIdentityShortHash)

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -719,9 +719,6 @@ class MGMRestResourceImpl internal constructor(
             throw ResourceNotFoundException("${e.message}")
         }
 
-        private fun holdingIdentityNotFound(holdingIdentityShortHash: String): Nothing =
-            throw ResourceNotFoundException("Holding Identity", holdingIdentityShortHash)
-
         private fun notAnMgmError(holdingIdentityShortHash: String): Nothing =
             throw InvalidInputDataException(
                 details = mapOf("holdingIdentityShortHash" to holdingIdentityShortHash),
@@ -793,7 +790,7 @@ class MGMRestResourceImpl internal constructor(
             return try {
                 func.invoke(ShortHash.parseOrThrow(holdingIdentityShortHash))
             } catch (e: CouldNotFindEntityException) {
-                holdingIdentityNotFound(holdingIdentityShortHash)
+                throw ResourceNotFoundException(e.entity, holdingIdentityShortHash)
             } catch (e: MemberNotAnMgmException) {
                 notAnMgmError(holdingIdentityShortHash)
             } catch (e: CordaRPCAPIPartitionException) {

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MemberRegistrationRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MemberRegistrationRestResourceImpl.kt
@@ -9,7 +9,7 @@ import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MemberResourceClient
 import net.corda.membership.client.RegistrationProgressNotFoundException
 import net.corda.membership.client.ServiceNotReadyException
@@ -134,7 +134,7 @@ class MemberRegistrationRestResourceImpl @Activate constructor(
                     ShortHash.parseOrThrow(holdingIdentityShortHash),
                     memberRegistrationContext
                 ).fromDto()
-            } catch (e: CouldNotFindMemberException) {
+            } catch (e: CouldNotFindEntityException) {
                 throw ResourceNotFoundException(
                     "holdingIdentityShortHash",
                     holdingIdentityShortHash,
@@ -149,7 +149,7 @@ class MemberRegistrationRestResourceImpl @Activate constructor(
                 memberResourceClient.checkRegistrationProgress(
                     ShortHash.parseOrThrow(holdingIdentityShortHash)
                 ).map { it.fromDto() }
-            } catch (e: CouldNotFindMemberException) {
+            } catch (e: CouldNotFindEntityException) {
                 throw ResourceNotFoundException(e.message!!)
             } catch (e: ContextDeserializationException) {
                 throw InternalServerException(e.message!!)
@@ -171,7 +171,7 @@ class MemberRegistrationRestResourceImpl @Activate constructor(
                 ).fromDto()
             } catch (e: RegistrationProgressNotFoundException) {
                 throw ResourceNotFoundException(e.message!!)
-            } catch (e: CouldNotFindMemberException) {
+            } catch (e: CouldNotFindEntityException) {
                 throw ResourceNotFoundException(e.message!!)
             } catch (e: ContextDeserializationException) {
                 throw InternalServerException(e.message!!)

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MemberRegistrationRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MemberRegistrationRestResourceImpl.kt
@@ -136,7 +136,7 @@ class MemberRegistrationRestResourceImpl @Activate constructor(
                 ).fromDto()
             } catch (e: CouldNotFindEntityException) {
                 throw ResourceNotFoundException(
-                    "holdingIdentityShortHash",
+                    e.entity,
                     holdingIdentityShortHash,
                 )
             } catch (e: CordaRPCAPIPartitionException) {

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
@@ -3,7 +3,7 @@ package net.corda.membership.impl.rest.v1
 import net.corda.crypto.core.ShortHash
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MGMResourceClient
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.rest.exception.BadRequestException
@@ -104,7 +104,7 @@ class MGMAdminRestResourceTest {
         fun `forceDeclineRegistrationRequest throws resource not found for invalid member`() {
             whenever(mgmResourceClient.forceDeclineRegistrationRequest(
                 HOLDING_IDENTITY_ID.shortHash(), REQUEST_ID.uuid()
-            )).doThrow(mock<CouldNotFindMemberException>())
+            )).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmAdminRestResource.forceDeclineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.core.ShortHash
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.membership.client.CouldNotFindEntityException
+import net.corda.membership.client.Entity
 import net.corda.membership.client.MGMResourceClient
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.rest.exception.BadRequestException
@@ -103,7 +104,7 @@ class MGMAdminRestResourceTest {
         @Test
         fun `forceDeclineRegistrationRequest throws resource not found for invalid member`() {
             val couldNotFindEntityException = mock<CouldNotFindEntityException> {
-                on { entity } doReturn "test"
+                on { entity } doReturn Entity.MEMBER
             }
             whenever(mgmResourceClient.forceDeclineRegistrationRequest(
                 HOLDING_IDENTITY_ID.shortHash(), REQUEST_ID.uuid()

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceTest.kt
@@ -102,9 +102,12 @@ class MGMAdminRestResourceTest {
 
         @Test
         fun `forceDeclineRegistrationRequest throws resource not found for invalid member`() {
+            val couldNotFindEntityException = mock<CouldNotFindEntityException> {
+                on { entity } doReturn "test"
+            }
             whenever(mgmResourceClient.forceDeclineRegistrationRequest(
                 HOLDING_IDENTITY_ID.shortHash(), REQUEST_ID.uuid()
-            )).doThrow(mock<CouldNotFindEntityException>())
+            )).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmAdminRestResource.forceDeclineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceTest.kt
@@ -18,6 +18,7 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.membership.client.CouldNotFindEntityException
+import net.corda.membership.client.Entity
 import net.corda.membership.client.MGMResourceClient
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.membership.lib.ContextDeserializationException
@@ -118,7 +119,7 @@ class MGMRestResourceTest {
         on { createAvroDeserializer(any(), eq(KeyValuePairList::class.java)) } doReturn deserializer
     }
     private val couldNotFindEntityException = mock<CouldNotFindEntityException> {
-        on { entity } doReturn "test"
+        on { entity } doReturn Entity.VIRTUAL_NODE
     }
 
     private val mgmRestResource = MGMRestResourceImpl(
@@ -1035,7 +1036,7 @@ class MGMRestResourceTest {
             startService()
             whenever(
                 mgmResourceClient.generatePreAuthToken(any(), any(), anyOrNull(), anyOrNull())
-            ).doThrow(CouldNotFindEntityException("virtual node", ShortHash.of(HOLDING_IDENTITY_ID)))
+            ).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.generatePreAuthToken(HOLDING_IDENTITY_ID, PreAuthTokenRequest(subject, Duration.ofDays(5)))
@@ -1106,7 +1107,7 @@ class MGMRestResourceTest {
             startService()
             whenever(
                 mgmResourceClient.getPreAuthTokens(any(), anyOrNull(), anyOrNull(), any())
-            ).doThrow(CouldNotFindEntityException("virtual node", ShortHash.of(HOLDING_IDENTITY_ID)))
+            ).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.getPreAuthTokens(HOLDING_IDENTITY_ID, null, null, false)
@@ -1169,7 +1170,7 @@ class MGMRestResourceTest {
             startService()
             whenever(
                 mgmResourceClient.revokePreAuthToken(any(), any(), anyOrNull())
-            ).doThrow(CouldNotFindEntityException("virtual node", ShortHash.of(HOLDING_IDENTITY_ID)))
+            ).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.revokePreAuthToken(HOLDING_IDENTITY_ID, tokenId.toString())

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceTest.kt
@@ -117,6 +117,9 @@ class MGMRestResourceTest {
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroDeserializer(any(), eq(KeyValuePairList::class.java)) } doReturn deserializer
     }
+    private val couldNotFindEntityException = mock<CouldNotFindEntityException> {
+        on { entity } doReturn "test"
+    }
 
     private val mgmRestResource = MGMRestResourceImpl(
         cordaAvroSerializationFactory,
@@ -166,7 +169,7 @@ class MGMRestResourceTest {
         @Test
         fun `generateGroupPolicy throws resource not found for invalid member`() {
             startService()
-            whenever(mgmResourceClient.generateGroupPolicy(any())).doThrow(mock<CouldNotFindEntityException>())
+            whenever(mgmResourceClient.generateGroupPolicy(any())).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.generateGroupPolicy(HOLDING_IDENTITY_ID)
@@ -212,7 +215,7 @@ class MGMRestResourceTest {
         @Test
         fun `addGroupApprovalRule throws resource not found for invalid member`() {
             startService()
-            whenever(mgmResourceClient.addApprovalRule(any(), any())).doThrow(mock<CouldNotFindEntityException>())
+            whenever(mgmResourceClient.addApprovalRule(any(), any())).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.addGroupApprovalRule(HOLDING_IDENTITY_ID, ApprovalRuleRequestParams(RULE_REGEX, RULE_LABEL))
@@ -287,7 +290,7 @@ class MGMRestResourceTest {
         @Test
         fun `deleteGroupApprovalRule throws resource not found for invalid member`() {
             startService()
-            whenever(mgmResourceClient.deleteApprovalRule(any(), any(), eq(STANDARD))).doThrow(mock<CouldNotFindEntityException>())
+            whenever(mgmResourceClient.deleteApprovalRule(any(), any(), eq(STANDARD))).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.deleteGroupApprovalRule(HOLDING_IDENTITY_ID, RULE_ID)
@@ -347,7 +350,7 @@ class MGMRestResourceTest {
         @Test
         fun `getGroupApprovalRules throws resource not found for invalid member`() {
             startService()
-            whenever(mgmResourceClient.getApprovalRules(any(), any())).doThrow(mock<CouldNotFindEntityException>())
+            whenever(mgmResourceClient.getApprovalRules(any(), any())).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.getGroupApprovalRules(HOLDING_IDENTITY_ID)
@@ -397,7 +400,7 @@ class MGMRestResourceTest {
 
         @Test
         fun `viewRegistrationRequests throws resource not found for invalid member`() {
-            whenever(mgmResourceClient.viewRegistrationRequests(any(), eq(null), eq(false))).doThrow(mock<CouldNotFindEntityException>())
+            whenever(mgmResourceClient.viewRegistrationRequests(any(), eq(null), eq(false))).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.viewRegistrationRequests(HOLDING_IDENTITY_ID)
@@ -467,7 +470,7 @@ class MGMRestResourceTest {
         fun `approveRegistrationRequest throws resource not found for invalid member`() {
             whenever(mgmResourceClient.reviewRegistrationRequest(
                 ShortHash.of(HOLDING_IDENTITY_ID), REQUEST_ID.uuid(), true
-            )).doThrow(mock<CouldNotFindEntityException>())
+            )).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.approveRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)
@@ -536,7 +539,7 @@ class MGMRestResourceTest {
         fun `declineRegistrationRequest throws resource not found for invalid member`() {
             whenever(mgmResourceClient.reviewRegistrationRequest(
                 ShortHash.of(HOLDING_IDENTITY_ID), REQUEST_ID.uuid(), false, manualDeclinationReason
-            )).doThrow(mock<CouldNotFindEntityException>())
+            )).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.declineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID, manualDeclinationReason)
@@ -805,7 +808,7 @@ class MGMRestResourceTest {
 
         @Test
         fun `it throws resource not found for invalid member`() {
-            onCallingClientService().doThrow(mock<CouldNotFindEntityException>())
+            onCallingClientService().doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 callFunctionUnderTest(
@@ -916,7 +919,7 @@ class MGMRestResourceTest {
 
         @Test
         fun `it throws resource not found for invalid member`() {
-            onCallingClientService().doThrow(mock<CouldNotFindEntityException>())
+            onCallingClientService().doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 callFunctionUnderTest()
@@ -977,7 +980,7 @@ class MGMRestResourceTest {
 
         @Test
         fun `deleteGroupApprovalRule throws resource not found for invalid member`() {
-            whenCallingClientService().doThrow(mock<CouldNotFindEntityException>())
+            whenCallingClientService().doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 callFunctionUnderTest(HOLDING_IDENTITY_ID, RULE_ID)
@@ -1238,7 +1241,7 @@ class MGMRestResourceTest {
         fun `suspendMember throws resource not found for invalid member`() {
             whenever(mgmResourceClient.suspendMember(
                 ShortHash.of(HOLDING_IDENTITY_ID), MemberX500Name.parse(subject), SERIAL, REASON
-            )).doThrow(mock<CouldNotFindEntityException>())
+            )).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.suspendMember(HOLDING_IDENTITY_ID, suspensionActivationParameters)
@@ -1380,7 +1383,7 @@ class MGMRestResourceTest {
         fun `activateMember throws resource not found for invalid member`() {
             whenever(mgmResourceClient.activateMember(
                 ShortHash.of(HOLDING_IDENTITY_ID), MemberX500Name.parse(subject), SERIAL, REASON
-            )).doThrow(mock<CouldNotFindEntityException>())
+            )).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.activateMember(HOLDING_IDENTITY_ID, suspensionActivationParameters)
@@ -1517,7 +1520,7 @@ class MGMRestResourceTest {
         fun `updateGroupParameters throws resource not found for invalid member`() {
             whenever(mgmResourceClient.updateGroupParameters(
                 ShortHash.of(HOLDING_IDENTITY_ID), mockUpdate.parameters
-            )).doThrow(mock<CouldNotFindEntityException>())
+            )).doThrow(couldNotFindEntityException)
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.updateGroupParameters(HOLDING_IDENTITY_ID, mockUpdate)

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceTest.kt
@@ -17,7 +17,7 @@ import net.corda.rest.exception.ServiceUnavailableException
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MGMResourceClient
 import net.corda.membership.client.MemberNotAnMgmException
 import net.corda.membership.lib.ContextDeserializationException
@@ -166,7 +166,7 @@ class MGMRestResourceTest {
         @Test
         fun `generateGroupPolicy throws resource not found for invalid member`() {
             startService()
-            whenever(mgmResourceClient.generateGroupPolicy(any())).doThrow(mock<CouldNotFindMemberException>())
+            whenever(mgmResourceClient.generateGroupPolicy(any())).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.generateGroupPolicy(HOLDING_IDENTITY_ID)
@@ -212,7 +212,7 @@ class MGMRestResourceTest {
         @Test
         fun `addGroupApprovalRule throws resource not found for invalid member`() {
             startService()
-            whenever(mgmResourceClient.addApprovalRule(any(), any())).doThrow(mock<CouldNotFindMemberException>())
+            whenever(mgmResourceClient.addApprovalRule(any(), any())).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.addGroupApprovalRule(HOLDING_IDENTITY_ID, ApprovalRuleRequestParams(RULE_REGEX, RULE_LABEL))
@@ -287,7 +287,7 @@ class MGMRestResourceTest {
         @Test
         fun `deleteGroupApprovalRule throws resource not found for invalid member`() {
             startService()
-            whenever(mgmResourceClient.deleteApprovalRule(any(), any(), eq(STANDARD))).doThrow(mock<CouldNotFindMemberException>())
+            whenever(mgmResourceClient.deleteApprovalRule(any(), any(), eq(STANDARD))).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.deleteGroupApprovalRule(HOLDING_IDENTITY_ID, RULE_ID)
@@ -347,7 +347,7 @@ class MGMRestResourceTest {
         @Test
         fun `getGroupApprovalRules throws resource not found for invalid member`() {
             startService()
-            whenever(mgmResourceClient.getApprovalRules(any(), any())).doThrow(mock<CouldNotFindMemberException>())
+            whenever(mgmResourceClient.getApprovalRules(any(), any())).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.getGroupApprovalRules(HOLDING_IDENTITY_ID)
@@ -397,7 +397,7 @@ class MGMRestResourceTest {
 
         @Test
         fun `viewRegistrationRequests throws resource not found for invalid member`() {
-            whenever(mgmResourceClient.viewRegistrationRequests(any(), eq(null), eq(false))).doThrow(mock<CouldNotFindMemberException>())
+            whenever(mgmResourceClient.viewRegistrationRequests(any(), eq(null), eq(false))).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.viewRegistrationRequests(HOLDING_IDENTITY_ID)
@@ -467,7 +467,7 @@ class MGMRestResourceTest {
         fun `approveRegistrationRequest throws resource not found for invalid member`() {
             whenever(mgmResourceClient.reviewRegistrationRequest(
                 ShortHash.of(HOLDING_IDENTITY_ID), REQUEST_ID.uuid(), true
-            )).doThrow(mock<CouldNotFindMemberException>())
+            )).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.approveRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID)
@@ -536,7 +536,7 @@ class MGMRestResourceTest {
         fun `declineRegistrationRequest throws resource not found for invalid member`() {
             whenever(mgmResourceClient.reviewRegistrationRequest(
                 ShortHash.of(HOLDING_IDENTITY_ID), REQUEST_ID.uuid(), false, manualDeclinationReason
-            )).doThrow(mock<CouldNotFindMemberException>())
+            )).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.declineRegistrationRequest(HOLDING_IDENTITY_ID, REQUEST_ID, manualDeclinationReason)
@@ -805,7 +805,7 @@ class MGMRestResourceTest {
 
         @Test
         fun `it throws resource not found for invalid member`() {
-            onCallingClientService().doThrow(mock<CouldNotFindMemberException>())
+            onCallingClientService().doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 callFunctionUnderTest(
@@ -916,7 +916,7 @@ class MGMRestResourceTest {
 
         @Test
         fun `it throws resource not found for invalid member`() {
-            onCallingClientService().doThrow(mock<CouldNotFindMemberException>())
+            onCallingClientService().doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 callFunctionUnderTest()
@@ -977,7 +977,7 @@ class MGMRestResourceTest {
 
         @Test
         fun `deleteGroupApprovalRule throws resource not found for invalid member`() {
-            whenCallingClientService().doThrow(mock<CouldNotFindMemberException>())
+            whenCallingClientService().doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 callFunctionUnderTest(HOLDING_IDENTITY_ID, RULE_ID)
@@ -1032,7 +1032,7 @@ class MGMRestResourceTest {
             startService()
             whenever(
                 mgmResourceClient.generatePreAuthToken(any(), any(), anyOrNull(), anyOrNull())
-            ).doThrow(CouldNotFindMemberException(ShortHash.of(HOLDING_IDENTITY_ID)))
+            ).doThrow(CouldNotFindEntityException("virtual node", ShortHash.of(HOLDING_IDENTITY_ID)))
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.generatePreAuthToken(HOLDING_IDENTITY_ID, PreAuthTokenRequest(subject, Duration.ofDays(5)))
@@ -1103,7 +1103,7 @@ class MGMRestResourceTest {
             startService()
             whenever(
                 mgmResourceClient.getPreAuthTokens(any(), anyOrNull(), anyOrNull(), any())
-            ).doThrow(CouldNotFindMemberException(ShortHash.of(HOLDING_IDENTITY_ID)))
+            ).doThrow(CouldNotFindEntityException("virtual node", ShortHash.of(HOLDING_IDENTITY_ID)))
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.getPreAuthTokens(HOLDING_IDENTITY_ID, null, null, false)
@@ -1166,7 +1166,7 @@ class MGMRestResourceTest {
             startService()
             whenever(
                 mgmResourceClient.revokePreAuthToken(any(), any(), anyOrNull())
-            ).doThrow(CouldNotFindMemberException(ShortHash.of(HOLDING_IDENTITY_ID)))
+            ).doThrow(CouldNotFindEntityException("virtual node", ShortHash.of(HOLDING_IDENTITY_ID)))
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.revokePreAuthToken(HOLDING_IDENTITY_ID, tokenId.toString())
@@ -1238,7 +1238,7 @@ class MGMRestResourceTest {
         fun `suspendMember throws resource not found for invalid member`() {
             whenever(mgmResourceClient.suspendMember(
                 ShortHash.of(HOLDING_IDENTITY_ID), MemberX500Name.parse(subject), SERIAL, REASON
-            )).doThrow(mock<CouldNotFindMemberException>())
+            )).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.suspendMember(HOLDING_IDENTITY_ID, suspensionActivationParameters)
@@ -1380,7 +1380,7 @@ class MGMRestResourceTest {
         fun `activateMember throws resource not found for invalid member`() {
             whenever(mgmResourceClient.activateMember(
                 ShortHash.of(HOLDING_IDENTITY_ID), MemberX500Name.parse(subject), SERIAL, REASON
-            )).doThrow(mock<CouldNotFindMemberException>())
+            )).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.activateMember(HOLDING_IDENTITY_ID, suspensionActivationParameters)
@@ -1517,7 +1517,7 @@ class MGMRestResourceTest {
         fun `updateGroupParameters throws resource not found for invalid member`() {
             whenever(mgmResourceClient.updateGroupParameters(
                 ShortHash.of(HOLDING_IDENTITY_ID), mockUpdate.parameters
-            )).doThrow(mock<CouldNotFindMemberException>())
+            )).doThrow(mock<CouldNotFindEntityException>())
 
             assertThrows<ResourceNotFoundException> {
                 mgmRestResource.updateGroupParameters(HOLDING_IDENTITY_ID, mockUpdate)

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MemberRegistrationRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MemberRegistrationRestResourceTest.kt
@@ -7,6 +7,7 @@ import net.corda.rest.exception.ServiceUnavailableException
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.membership.client.CouldNotFindEntityException
+import net.corda.membership.client.Entity
 import net.corda.membership.client.MemberResourceClient
 import net.corda.membership.client.RegistrationProgressNotFoundException
 import net.corda.membership.client.ServiceNotReadyException
@@ -98,7 +99,7 @@ class MemberRegistrationRestResourceTest {
         memberRegistrationRestResource.start()
         memberRegistrationRestResource.activate("")
         whenever(memberResourceClient.startRegistration(any(), any()))
-            .doThrow(CouldNotFindEntityException("member", holdingIdShortHash))
+            .doThrow(CouldNotFindEntityException(Entity.VIRTUAL_NODE, holdingIdShortHash))
 
         assertThrows<ResourceNotFoundException> {
             memberRegistrationRestResource.startRegistration(HOLDING_IDENTITY_ID, MemberRegistrationRequest(emptyMap()))
@@ -168,7 +169,7 @@ class MemberRegistrationRestResourceTest {
     fun `checkRegistrationProgress throw 404 when member can not be found`() {
         whenever(
             memberResourceClient.checkRegistrationProgress(holdingIdShortHash)
-        ).doThrow(CouldNotFindEntityException("member", holdingIdShortHash))
+        ).doThrow(CouldNotFindEntityException(Entity.VIRTUAL_NODE, holdingIdShortHash))
         memberRegistrationRestResource.start()
         memberRegistrationRestResource.activate("")
 
@@ -229,7 +230,7 @@ class MemberRegistrationRestResourceTest {
     @Test
     fun `checkSpecificRegistrationProgress throw 404 when the member can not be found`() {
         whenever(memberResourceClient.checkSpecificRegistrationProgress(holdingIdShortHash, REQUEST_ID))
-            .doThrow(CouldNotFindEntityException("member", holdingIdShortHash))
+            .doThrow(CouldNotFindEntityException(Entity.VIRTUAL_NODE, holdingIdShortHash))
         memberRegistrationRestResource.start()
         memberRegistrationRestResource.activate("")
 

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MemberRegistrationRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MemberRegistrationRestResourceTest.kt
@@ -6,7 +6,7 @@ import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.rest.exception.ServiceUnavailableException
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.membership.client.CouldNotFindMemberException
+import net.corda.membership.client.CouldNotFindEntityException
 import net.corda.membership.client.MemberResourceClient
 import net.corda.membership.client.RegistrationProgressNotFoundException
 import net.corda.membership.client.ServiceNotReadyException
@@ -97,7 +97,8 @@ class MemberRegistrationRestResourceTest {
     fun `starting registration with invalid member will fail`() {
         memberRegistrationRestResource.start()
         memberRegistrationRestResource.activate("")
-        whenever(memberResourceClient.startRegistration(any(), any())).doThrow(CouldNotFindMemberException(holdingIdShortHash))
+        whenever(memberResourceClient.startRegistration(any(), any()))
+            .doThrow(CouldNotFindEntityException("member", holdingIdShortHash))
 
         assertThrows<ResourceNotFoundException> {
             memberRegistrationRestResource.startRegistration(HOLDING_IDENTITY_ID, MemberRegistrationRequest(emptyMap()))
@@ -167,7 +168,7 @@ class MemberRegistrationRestResourceTest {
     fun `checkRegistrationProgress throw 404 when member can not be found`() {
         whenever(
             memberResourceClient.checkRegistrationProgress(holdingIdShortHash)
-        ).doThrow(CouldNotFindMemberException(holdingIdShortHash))
+        ).doThrow(CouldNotFindEntityException("member", holdingIdShortHash))
         memberRegistrationRestResource.start()
         memberRegistrationRestResource.activate("")
 
@@ -228,7 +229,7 @@ class MemberRegistrationRestResourceTest {
     @Test
     fun `checkSpecificRegistrationProgress throw 404 when the member can not be found`() {
         whenever(memberResourceClient.checkSpecificRegistrationProgress(holdingIdShortHash, REQUEST_ID))
-            .doThrow(CouldNotFindMemberException(holdingIdShortHash))
+            .doThrow(CouldNotFindEntityException("member", holdingIdShortHash))
         memberRegistrationRestResource.start()
         memberRegistrationRestResource.activate("")
 


### PR DESCRIPTION
Change error messages returned via the REST API to distinguish between scenarios when a member is not found in the member list, and when a virtual node corresponding to the provided holding identity is not found. 


REST responses now specify the entity (member or virtual node) that was not found, so that it is clear if the problem occurred because the member list was missing certain information, or if the virtual node did not exist. For example -

<img width="446" alt="Screenshot 2023-08-30 at 13 10 45" src="https://github.com/corda/corda-runtime-os/assets/17948697/baec3cc9-984f-4602-bb63-c37b6fdc75d2">
