### PR TITLE
CORE-16798: Quasar to ignore ledger-utxo-data, SignedGroupParametersSerializer to platform serializer.

### DIFF
--- a/libs/ledger/ledger-utxo-data/build.gradle
+++ b/libs/ledger/ledger-utxo-data/build.gradle
@@ -8,6 +8,7 @@ description 'Corda ledger UTXO data'
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-ledger-utxo'

--- a/libs/ledger/ledger-utxo-data/src/main/java/net/corda/ledger/utxo/data/package-info.java
+++ b/libs/ledger/ledger-utxo-data/src/main/java/net/corda/ledger/utxo/data/package-info.java
@@ -1,0 +1,4 @@
+@QuasarIgnoreSubPackages
+package net.corda.ledger.utxo.data;
+
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreSubPackages;

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/groupparameters/serializer/amqp/SignedGroupParametersSerializer.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/groupparameters/serializer/amqp/SignedGroupParametersSerializer.kt
@@ -3,27 +3,19 @@ package net.corda.ledger.utxo.data.groupparameters.serializer.amqp
 import net.corda.crypto.core.DigitalSignatureWithKey
 import net.corda.membership.lib.GroupParametersFactory
 import net.corda.membership.lib.SignedGroupParameters
-import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
-import net.corda.sandbox.type.UsedByFlow
-import net.corda.sandbox.type.UsedByVerification
 import net.corda.serialization.BaseProxySerializer
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.v5.crypto.SignatureSpec
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(
-    service = [ InternalCustomSerializer::class, UsedByFlow::class, UsedByVerification::class ],
-    property = [ CORDA_UNINJECTABLE_SERVICE ],
-    scope = PROTOTYPE
-)
+@Component(service = [ InternalCustomSerializer::class ])
 @Suppress("Unused")
 class SignedGroupParametersSerializer @Activate constructor(
     @Reference(service = GroupParametersFactory::class)
     private val groupParametersFactory: GroupParametersFactory
-) : BaseProxySerializer<SignedGroupParameters, SignedGroupParametersProxy>(), UsedByFlow, UsedByVerification {
+) : BaseProxySerializer<SignedGroupParameters, SignedGroupParametersProxy>() {
     override val type
         get() = SignedGroupParameters::class.java
 


### PR DESCRIPTION
Configure `ledger-utxo-data` bundle so that Quasar does not try to instrument it.

Also convert `SignedGroupParametersSerializer` into a platform custom serializer rather than a per-sandbox one since its only dependency is `GroupParametersFactory`, which is also a platform service.