### PR TITLE
CORE-16801 Add SignedGroupParametersProxy.equals(), SignedGroupParametersProxy.hashCode()

### DIFF
--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/groupparameters/serializer/amqp/SignedGroupParametersSerializer.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/groupparameters/serializer/amqp/SignedGroupParametersSerializer.kt
@@ -49,4 +49,22 @@ data class SignedGroupParametersProxy(
     val groupParameters: ByteArray,
     val mgmSignature: DigitalSignatureWithKey,
     val mgmSignatureSpec: SignatureSpec
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SignedGroupParametersProxy) return false
+
+        if (!groupParameters.contentEquals(other.groupParameters)) return false
+        if (mgmSignature != other.mgmSignature) return false
+        if (mgmSignatureSpec != other.mgmSignatureSpec) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = groupParameters.contentHashCode()
+        result = 31 * result + mgmSignature.hashCode()
+        result = 31 * result + mgmSignatureSpec.hashCode()
+        return result
+    }
+}


### PR DESCRIPTION
Compiler-generated default methods for data classes do not work correctly on ByteArrays.