### PR TITLE
CORE-15808: Remove 'releasable=true' from tracing/build.gradle

### DIFF
--- a/libs/tracing/build.gradle
+++ b/libs/tracing/build.gradle
@@ -4,10 +4,6 @@ plugins {
 }
 description 'Tracing'
 
-ext {
-    releasable = true
-}
-
 dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'


### PR DESCRIPTION
This change simply removes the 'releasable=true' extension from the Gradle build file for the tracing module