### PR TITLE
CORE-14685: Add API for selecting node by group name and X500 name.

### DIFF
--- a/testing/driver/driver-testing/src/test/java/net/corda/testing/driver/tests/DriverJavaTest.java
+++ b/testing/driver/driver-testing/src/test/java/net/corda/testing/driver/tests/DriverJavaTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import static net.corda.testing.driver.node.MemberStatus.ACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -48,6 +49,24 @@ class DriverJavaTest {
             assertThat(dsl.nodesFor("extendable-cpb"))
                 .hasEntrySatisfying(ALICE, vNode -> assertThat(aliceNodes).contains(vNode))
                 .doesNotContainKeys(BOB, LUCY);
+
+            dsl.node("mandelbrot", ALICE, alice ->
+                assertThat(alice.getStatus()).isEqualTo(ACTIVE)
+            );
+            dsl.node("extendable-cpb", ALICE, alice ->
+                assertThat(alice.getStatus()).isEqualTo(ACTIVE)
+            );
+
+            dsl.group("mandelbrot", group ->
+                group.member(LUCY, lucy ->
+                    assertThat(lucy.getStatus()).isEqualTo(ACTIVE)
+                )
+            );
+            dsl.group("extendable-cpb", group ->
+                group.member(LUCY, lucy ->
+                    assertThat(lucy.getStatus()).isEqualTo(ACTIVE)
+                )
+            );
         });
     }
 

--- a/testing/driver/src/main/java/net/corda/testing/driver/DriverDSL.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/DriverDSL.java
@@ -40,6 +40,12 @@ public interface DriverDSL {
         @NotNull ThrowingConsumer<@NotNull Member> action
     );
 
+    void node(
+        @NotNull String groupName,
+        @NotNull MemberX500Name memberName,
+        @NotNull ThrowingConsumer<@NotNull Member> action
+    );
+
     void groupFor(
         @NotNull VirtualNodeInfo virtualNodeInfo,
         @NotNull ThrowingConsumer<@NotNull MembershipGroupDSL> action

--- a/testing/driver/src/main/kotlin/net/corda/testing/driver/impl/DriverDSLImpl.kt
+++ b/testing/driver/src/main/kotlin/net/corda/testing/driver/impl/DriverDSLImpl.kt
@@ -429,6 +429,12 @@ internal class DriverDSLImpl(
         MembershipGroupManager(this).forVirtualNode(virtualNodeInfo.holdingIdentity, TIMEOUT, action)
     }
 
+    override fun node(groupName: String, memberName: MemberX500Name, action: ThrowingConsumer<Member>) {
+        val memberNode = virtualNodeInfo[VirtualNodeKey(groupName, memberName)]
+            ?: throw AssertionError("Member '$memberName' not found for group '$groupName'")
+        node(memberNode, action)
+    }
+
     override fun groupFor(virtualNodeInfo: VirtualNodeInfo, action: ThrowingConsumer<MembershipGroupDSL>) {
         MembershipGroupManager(this).forMembershipGroup(virtualNodeInfo.holdingIdentity, TIMEOUT, action)
     }
@@ -437,7 +443,7 @@ internal class DriverDSLImpl(
         val anyMemberNode = virtualNodeInfo.values.firstOrNull { vNode ->
             vNode.cpiIdentifier.name == groupName
         } ?: throw AssertionError("Group '$groupName' not found")
-        return groupFor(anyMemberNode, action)
+        groupFor(anyMemberNode, action)
     }
 
     @Throws(InterruptedException::class)


### PR DESCRIPTION
Add missing API for selecting a virtual node by both its group name and its X500 name.