### PR TITLE
CORE-16585: Fix re-registration on vNode upgrade

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -238,14 +238,15 @@ internal class VirtualNodeUpgradeOperationHandler(
                     } catch (e: ContextDeserializationException) {
                         logger.warn(
                             "Could not deserialize previous registration context for ${holdingIdentity.shortHash}. " +
-                                    "Re-registration won't be attempted."
+                                    "Re-registration will not be attempted."
                         )
                     }
 
                 is MembershipQueryResult.Failure ->
                     logger.warn(
-                        "Failed to query for an APPROVED previous request: ${registrationRequest.errorMsg}. " +
-                                "Re-registration won't be attempted."
+                        "Failed to query for an APPROVED previous registration request for ${holdingIdentity.shortHash}: " +
+                                "${registrationRequest.errorMsg}. " +
+                                "Re-registration will not be attempted."
                     )
             }
         }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -221,13 +221,13 @@ internal class VirtualNodeUpgradeOperationHandler(
                 val registrationRequestDetails = (registrationRequest as MembershipQueryResult.Success)
                     .payload
                     .first()
-                val updatedSerial = (registrationRequestDetails.serial + 1).toString()
+                val updatedSerial = registrationRequestDetails.serial + 1
                 val registrationContext = registrationRequestDetails
                     .memberProvidedContext.data.array()
                     .deserializeContext(keyValuePairListDeserializer)
                     .toMutableMap()
 
-                registrationContext[MemberInfoExtension.SERIAL] = updatedSerial
+                registrationContext[MemberInfoExtension.SERIAL] = updatedSerial.toString()
 
                 memberResourceClient.startRegistration(
                     holdingIdentity.shortHash,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -214,21 +214,20 @@ internal class VirtualNodeUpgradeOperationHandler(
             registrationRequestsCheck is MembershipQueryResult.Success
             && registrationRequestsCheck.payload.isNotEmpty()
         ) {
-            val membershipGroupReader = membershipGroupReaderProvider.getGroupReader(holdingIdentity)
-            val x500Name = membershipGroupReader.owningMember
+            val x500Name = membershipGroupReaderProvider.getGroupReader(holdingIdentity).owningMember
             val registrationRequest = membershipQueryClient
                 .queryRegistrationRequests(holdingIdentity, x500Name, listOf(APPROVED), 1)
             try {
                 val registrationRequestDetails = (registrationRequest as MembershipQueryResult.Success)
                     .payload
                     .first()
-                val previousSerial = (registrationRequestDetails.serial+1).toString()
+                val updatedSerial = (registrationRequestDetails.serial + 1).toString()
                 val registrationContext = registrationRequestDetails
                     .memberProvidedContext.data.array()
                     .deserializeContext(keyValuePairListDeserializer)
                     .toMutableMap()
 
-                registrationContext[MemberInfoExtension.SERIAL] = previousSerial
+                registrationContext[MemberInfoExtension.SERIAL] = updatedSerial
 
                 memberResourceClient.startRegistration(
                     holdingIdentity.shortHash,


### PR DESCRIPTION
This PR fixes re-registration by getting the serial from the correct field.

- Query for only `APPROVED` registration requests
- Get previous serial from `serial` field
- Attach serial to all re-registration requests