### PR TITLE
CORE-15304 Categorise persistence exceptions

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualTransactionReaderImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/consensual/impl/ConsensualTransactionReaderImpl.kt
@@ -2,18 +2,18 @@ package net.corda.ledger.persistence.consensual.impl
 
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.PersistTransaction
+import net.corda.ledger.common.data.transaction.PrivacySalt
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTransactionStatus
 import net.corda.ledger.persistence.consensual.ConsensualTransactionReader
-import net.corda.persistence.common.exceptions.NullParameterException
+import net.corda.persistence.common.exceptions.MissingAccountContextPropertyException
 import net.corda.utilities.serialization.deserialize
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
-import net.corda.ledger.common.data.transaction.PrivacySalt
 
 class ConsensualTransactionReaderImpl(
     serializer: SerializationService,
@@ -33,7 +33,7 @@ class ConsensualTransactionReaderImpl(
 
     override val account: String
         get() = externalEventContext.contextProperties.items.find { it.key == CORDA_ACCOUNT || it.key == CORDA_INITIATOR_ACCOUNT}?.value
-            ?: throw NullParameterException("Flow external event context property '${CORDA_ACCOUNT}' not set")
+            ?: throw MissingAccountContextPropertyException()
 
     override val status: TransactionStatus
         get() = transaction.status.toTransactionStatus()

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTransactionReaderImpl.kt
@@ -14,7 +14,7 @@ import net.corda.ledger.utxo.data.state.cast
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
-import net.corda.persistence.common.exceptions.NullParameterException
+import net.corda.persistence.common.exceptions.MissingAccountContextPropertyException
 import net.corda.persistence.common.getSerializationService
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.utilities.serialization.deserialize
@@ -70,7 +70,7 @@ class UtxoTransactionReaderImpl(
 
     override val account: String
         get() = externalEventContext.contextProperties.items.find { it.key == CORDA_ACCOUNT }?.value
-            ?: throw NullParameterException("Flow external event context property '${CORDA_ACCOUNT}' not set")
+            ?: throw MissingAccountContextPropertyException()
 
     override val privacySalt: PrivacySalt
         get() = signedTransaction.wireTransaction.privacySalt

--- a/components/persistence/persistence-service-common/build.gradle
+++ b/components/persistence/persistence-service-common/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(':libs:virtual-node:sandbox-group-context')
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
+    implementation "org.hibernate:hibernate-core:$hibernateVersion"
 
     runtimeOnly project(":libs:crypto:crypto-serialization-impl")
 

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/PersistenceExceptionCategorizer.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/PersistenceExceptionCategorizer.kt
@@ -1,0 +1,8 @@
+package net.corda.persistence.common
+
+internal interface PersistenceExceptionCategorizer {
+
+    fun categorize(exception: Exception): PersistenceExceptionType
+}
+
+internal enum class PersistenceExceptionType { FATAL, PLATFORM, TRANSIENT }

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/PersistenceExceptionCategorizerImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/PersistenceExceptionCategorizerImpl.kt
@@ -1,0 +1,50 @@
+package net.corda.persistence.common
+
+import net.corda.persistence.common.PersistenceExceptionType.FATAL
+import net.corda.persistence.common.PersistenceExceptionType.PLATFORM
+import net.corda.persistence.common.PersistenceExceptionType.TRANSIENT
+import org.hibernate.ResourceClosedException
+import org.hibernate.SessionException
+import org.hibernate.TransactionException
+import org.hibernate.cache.CacheException
+import org.hibernate.exception.JDBCConnectionException
+import org.hibernate.exception.LockAcquisitionException
+import java.sql.SQLTransientConnectionException
+import javax.persistence.LockTimeoutException
+import javax.persistence.OptimisticLockException
+import javax.persistence.PessimisticLockException
+import javax.persistence.QueryTimeoutException
+import javax.persistence.RollbackException
+import javax.persistence.TransactionRequiredException
+
+internal class PersistenceExceptionCategorizerImpl : PersistenceExceptionCategorizer {
+    override fun categorize(exception: Exception): PersistenceExceptionType {
+        return when {
+            isTransient(exception) -> TRANSIENT
+            isFatal(exception) -> FATAL
+            else -> PLATFORM
+        }
+    }
+
+    private fun isFatal(exception: Exception): Boolean {
+        return when (exception) {
+            // [PersistenceException]s
+            is TransactionRequiredException, is ResourceClosedException, is SessionException -> true
+            else -> false
+        }
+    }
+
+    private fun isTransient(exception: Exception): Boolean {
+        return when (exception) {
+            // [PersistenceException]s
+            is LockTimeoutException, is OptimisticLockException, is PessimisticLockException, is QueryTimeoutException, is RollbackException -> true
+            // [JDBCException]s
+            is org.hibernate.PessimisticLockException, is org.hibernate.QueryTimeoutException, is JDBCConnectionException, is LockAcquisitionException -> true
+            // [HibernateException]s
+            // [CacheException] not too sure.
+            is TransactionException, is CacheException -> true
+            is SQLTransientConnectionException -> exception.message?.lowercase()?.contains("connection is not available") == true
+            else -> false
+        }
+    }
+}

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/PersistenceExceptionCategorizerImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/PersistenceExceptionCategorizerImpl.kt
@@ -37,12 +37,20 @@ internal class PersistenceExceptionCategorizerImpl : PersistenceExceptionCategor
     private fun isTransient(exception: Exception): Boolean {
         return when (exception) {
             // [PersistenceException]s
-            is LockTimeoutException, is OptimisticLockException, is PessimisticLockException, is QueryTimeoutException, is RollbackException -> true
+            is LockTimeoutException,
+            is OptimisticLockException,
+            is PessimisticLockException,
+            is QueryTimeoutException,
+            is RollbackException,
             // [JDBCException]s
-            is org.hibernate.PessimisticLockException, is org.hibernate.QueryTimeoutException, is JDBCConnectionException, is LockAcquisitionException -> true
+            is org.hibernate.PessimisticLockException,
+            is org.hibernate.QueryTimeoutException,
+            is JDBCConnectionException,
+            is LockAcquisitionException,
             // [HibernateException]s
-            // [CacheException] not too sure.
-            is TransactionException, is CacheException -> true
+            is TransactionException,
+            is CacheException -> true
+            // Exception thrown by Hikari
             is SQLTransientConnectionException -> exception.message?.lowercase()?.contains("connection is not available") == true
             else -> false
         }

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/ResponseFactoryImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/ResponseFactoryImpl.kt
@@ -9,22 +9,31 @@ import net.corda.flow.external.events.responses.factory.ExternalEventResponseFac
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.exceptions.KafkaMessageSizeException
 import net.corda.persistence.common.exceptions.NullParameterException
+import net.corda.v5.base.annotations.VisibleForTesting
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
 import java.io.NotSerializableException
+import java.sql.SQLException
 import javax.persistence.PersistenceException
 
 @Component(service = [ResponseFactory::class])
-class ResponseFactoryImpl @Activate constructor(
+class ResponseFactoryImpl @VisibleForTesting internal constructor(
     @Reference(service = ExternalEventResponseFactory::class)
-    private val externalEventResponseFactory: ExternalEventResponseFactory
+    private val externalEventResponseFactory: ExternalEventResponseFactory,
+    private val persistenceExceptionCategorizer: PersistenceExceptionCategorizer
 ) : ResponseFactory {
 
     private companion object{
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
+
+    @Activate
+    constructor(
+        @Reference(service = ExternalEventResponseFactory::class)
+        externalEventResponseFactory: ExternalEventResponseFactory
+    ) : this(externalEventResponseFactory, PersistenceExceptionCategorizerImpl())
 
     override fun successResponse(
         flowExternalEventContext: ExternalEventContext,
@@ -34,16 +43,25 @@ class ResponseFactoryImpl @Activate constructor(
     }
 
     override fun errorResponse(externalEventContext : ExternalEventContext, exception: Exception) = when (exception) {
-        is CpkNotAvailableException, is VirtualNodeException ->
+        is CpkNotAvailableException, is VirtualNodeException -> {
             transientErrorResponse(externalEventContext, exception)
-        is NotSerializableException ->
+        }
+        is NotSerializableException -> {
             platformErrorResponse(externalEventContext, exception)
-        is KafkaMessageSizeException, is NullParameterException ->
+        }
+        is KafkaMessageSizeException, is NullParameterException -> {
             fatalErrorResponse(externalEventContext, exception)
-        is PersistenceException ->
-            transientErrorResponse(externalEventContext, exception)
-        else ->
+        }
+        is PersistenceException, is SQLException -> {
+            when (persistenceExceptionCategorizer.categorize(exception)) {
+                PersistenceExceptionType.FATAL -> fatalErrorResponse(externalEventContext, exception)
+                PersistenceExceptionType.PLATFORM -> platformErrorResponse(externalEventContext, exception)
+                PersistenceExceptionType.TRANSIENT -> transientErrorResponse(externalEventContext, exception)
+            }
+        }
+        else -> {
             platformErrorResponse(externalEventContext, exception)
+        }
     }
 
     override fun transientErrorResponse(

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/ResponseFactoryImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/ResponseFactoryImpl.kt
@@ -20,7 +20,6 @@ import javax.persistence.PersistenceException
 
 @Component(service = [ResponseFactory::class])
 class ResponseFactoryImpl @VisibleForTesting internal constructor(
-    @Reference(service = ExternalEventResponseFactory::class)
     private val externalEventResponseFactory: ExternalEventResponseFactory,
     private val persistenceExceptionCategorizer: PersistenceExceptionCategorizer
 ) : ResponseFactory {

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/ResponseFactoryImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/ResponseFactoryImpl.kt
@@ -8,6 +8,7 @@ import net.corda.flow.external.events.responses.exceptions.VirtualNodeException
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.exceptions.KafkaMessageSizeException
+import net.corda.persistence.common.exceptions.MissingAccountContextPropertyException
 import net.corda.persistence.common.exceptions.NullParameterException
 import net.corda.v5.base.annotations.VisibleForTesting
 import org.osgi.service.component.annotations.Activate
@@ -45,10 +46,10 @@ class ResponseFactoryImpl @VisibleForTesting internal constructor(
         is CpkNotAvailableException, is VirtualNodeException -> {
             transientErrorResponse(externalEventContext, exception)
         }
-        is NotSerializableException -> {
+        is NotSerializableException, is NullParameterException -> {
             platformErrorResponse(externalEventContext, exception)
         }
-        is KafkaMessageSizeException, is NullParameterException -> {
+        is KafkaMessageSizeException, is MissingAccountContextPropertyException -> {
             fatalErrorResponse(externalEventContext, exception)
         }
         is PersistenceException, is SQLException -> {

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/exceptions/MissingAccountContextPropertyException.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/exceptions/MissingAccountContextPropertyException.kt
@@ -1,0 +1,3 @@
+package net.corda.persistence.common.exceptions
+
+class MissingAccountContextPropertyException : Exception("Flow external event context property 'corda.account' not set")

--- a/components/persistence/persistence-service-common/src/test/kotlin/net/corda/persistence/common/PersistenceExceptionCategorizerImplTest.kt
+++ b/components/persistence/persistence-service-common/src/test/kotlin/net/corda/persistence/common/PersistenceExceptionCategorizerImplTest.kt
@@ -1,0 +1,102 @@
+package net.corda.persistence.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.hibernate.QueryException
+import org.hibernate.ResourceClosedException
+import org.hibernate.SessionException
+import org.hibernate.TransactionException
+import org.hibernate.cache.CacheException
+import org.hibernate.exception.GenericJDBCException
+import org.hibernate.exception.JDBCConnectionException
+import org.hibernate.exception.LockAcquisitionException
+import org.hibernate.exception.SQLGrammarException
+import org.hibernate.procedure.NoSuchParameterException
+import org.hibernate.procedure.ParameterMisuseException
+import org.hibernate.property.access.spi.PropertyAccessException
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.sql.SQLException
+import java.sql.SQLTransientConnectionException
+import java.util.stream.Stream
+import javax.persistence.EntityExistsException
+import javax.persistence.EntityNotFoundException
+import javax.persistence.LockTimeoutException
+import javax.persistence.NonUniqueResultException
+import javax.persistence.OptimisticLockException
+import javax.persistence.PessimisticLockException
+import javax.persistence.QueryTimeoutException
+import javax.persistence.RollbackException
+import javax.persistence.TransactionRequiredException
+
+class PersistenceExceptionCategorizerImplTest {
+
+    private companion object {
+
+        private const val DUMMY_MESSAGE = "dummy"
+        private const val DUMMY_SQL = "sql"
+        private val DUMMY_SQL_EXCEPTION = SQLException()
+
+        @JvmStatic
+        fun transientPersistenceExceptions(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(LockTimeoutException()),
+                Arguments.of(OptimisticLockException()),
+                Arguments.of(PessimisticLockException()),
+                Arguments.of(QueryTimeoutException()),
+                Arguments.of(RollbackException()),
+                Arguments.of(org.hibernate.PessimisticLockException(DUMMY_MESSAGE, DUMMY_SQL_EXCEPTION, DUMMY_SQL)),
+                Arguments.of(org.hibernate.QueryTimeoutException(DUMMY_MESSAGE, DUMMY_SQL_EXCEPTION, DUMMY_SQL)),
+                Arguments.of(JDBCConnectionException(DUMMY_MESSAGE, DUMMY_SQL_EXCEPTION, DUMMY_SQL)),
+                Arguments.of(LockAcquisitionException(DUMMY_MESSAGE, DUMMY_SQL_EXCEPTION, DUMMY_SQL)),
+                Arguments.of(TransactionException(DUMMY_MESSAGE)),
+                Arguments.of(CacheException(DUMMY_MESSAGE)),
+                Arguments.of(SQLTransientConnectionException("Connection is not available, request timed out after"))
+            )
+        }
+
+        @JvmStatic
+        fun platformPersistenceExceptions(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(EntityExistsException()),
+                Arguments.of(EntityNotFoundException()),
+                Arguments.of(NonUniqueResultException()),
+                Arguments.of(SQLGrammarException(DUMMY_MESSAGE, DUMMY_SQL_EXCEPTION)),
+                Arguments.of(GenericJDBCException(DUMMY_MESSAGE, DUMMY_SQL_EXCEPTION)),
+                Arguments.of(QueryException(DUMMY_MESSAGE, DUMMY_SQL_EXCEPTION)),
+                Arguments.of(NoSuchParameterException(DUMMY_MESSAGE)),
+                Arguments.of(ParameterMisuseException(DUMMY_MESSAGE)),
+                Arguments.of(PropertyAccessException(DUMMY_MESSAGE)),
+            )
+        }
+
+        @JvmStatic
+        fun fatalPersistenceExceptions(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(TransactionRequiredException()),
+                Arguments.of(ResourceClosedException(DUMMY_MESSAGE)),
+                Arguments.of(SessionException(DUMMY_MESSAGE)),
+            )
+        }
+    }
+
+    private val persistenceExceptionCategorizer = PersistenceExceptionCategorizerImpl()
+
+    @ParameterizedTest(name = "{0} is categorized as a transient persistence exception")
+    @MethodSource("transientPersistenceExceptions")
+    fun `transient persistence exceptions`(exception: Exception) {
+        assertThat(persistenceExceptionCategorizer.categorize(exception)).isEqualTo(PersistenceExceptionType.TRANSIENT)
+    }
+
+    @ParameterizedTest(name = "{0} is categorized as a platform persistence exception")
+    @MethodSource("platformPersistenceExceptions")
+    fun `platform persistence exceptions`(exception: Exception) {
+        assertThat(persistenceExceptionCategorizer.categorize(exception)).isEqualTo(PersistenceExceptionType.PLATFORM)
+    }
+
+    @ParameterizedTest(name = "{0} is categorized as a fatal persistence exception")
+    @MethodSource("fatalPersistenceExceptions")
+    fun `fatal persistence exceptions`(exception: Exception) {
+        assertThat(persistenceExceptionCategorizer.categorize(exception)).isEqualTo(PersistenceExceptionType.FATAL)
+    }
+}

--- a/components/persistence/persistence-service-common/src/test/kotlin/net/corda/persistence/common/ResponseFactoryImplTest.kt
+++ b/components/persistence/persistence-service-common/src/test/kotlin/net/corda/persistence/common/ResponseFactoryImplTest.kt
@@ -16,6 +16,7 @@ import java.io.NotSerializableException
 import java.sql.SQLException
 import javax.persistence.PersistenceException
 
+@Suppress("MaxLineLength")
 class ResponseFactoryImplTest {
 
     private companion object {

--- a/components/persistence/persistence-service-common/src/test/kotlin/net/corda/persistence/common/ResponseFactoryImplTest.kt
+++ b/components/persistence/persistence-service-common/src/test/kotlin/net/corda/persistence/common/ResponseFactoryImplTest.kt
@@ -7,6 +7,7 @@ import net.corda.flow.external.events.responses.exceptions.VirtualNodeException
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.exceptions.KafkaMessageSizeException
+import net.corda.persistence.common.exceptions.MissingAccountContextPropertyException
 import net.corda.persistence.common.exceptions.NullParameterException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -57,16 +58,22 @@ class ResponseFactoryImplTest {
     }
 
     @Test
+    fun `errorResponse creates and returns a platform error response when the input exception is NullParameterException`() {
+        val exception = NullParameterException("")
+        whenever(externalEventResponseFactory.platformError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
     fun `errorResponse creates and returns a fatal error response when the input exception is KafkaMessageSizeException`() {
         val exception = KafkaMessageSizeException("")
         whenever(externalEventResponseFactory.fatalError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
         assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
     }
 
-    // I think this is wrong and should be platform, review this!!
     @Test
-    fun `errorResponse creates and returns a fatal error response when the input exception is NullParameterException`() {
-        val exception = NullParameterException("")
+    fun `errorResponse creates and returns a fatal error response when the input exception is MissingAccountContextPropertyException`() {
+        val exception = MissingAccountContextPropertyException()
         whenever(externalEventResponseFactory.fatalError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
         assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
     }

--- a/components/persistence/persistence-service-common/src/test/kotlin/net/corda/persistence/common/ResponseFactoryImplTest.kt
+++ b/components/persistence/persistence-service-common/src/test/kotlin/net/corda/persistence/common/ResponseFactoryImplTest.kt
@@ -1,0 +1,148 @@
+package net.corda.persistence.common
+
+import net.corda.data.flow.event.FlowEvent
+import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.flow.external.events.responses.exceptions.CpkNotAvailableException
+import net.corda.flow.external.events.responses.exceptions.VirtualNodeException
+import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
+import net.corda.messaging.api.records.Record
+import net.corda.persistence.common.exceptions.KafkaMessageSizeException
+import net.corda.persistence.common.exceptions.NullParameterException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.NotSerializableException
+import java.sql.SQLException
+import javax.persistence.PersistenceException
+
+class ResponseFactoryImplTest {
+
+    private companion object {
+        val FLOW_EXTERNAL_EVENT_CONTEXT = ExternalEventContext()
+        val RECORD = Record("topic", "key", FlowEvent())
+    }
+
+    private val externalEventResponseFactory = mock<ExternalEventResponseFactory>()
+    private val persistenceExceptionCategorizer = mock<PersistenceExceptionCategorizer>()
+    private val responseFactory = ResponseFactoryImpl(externalEventResponseFactory, persistenceExceptionCategorizer)
+
+    @Test
+    fun `successResponse creates and returns a successful response`() {
+        val payload = "payload"
+        whenever(externalEventResponseFactory.success(FLOW_EXTERNAL_EVENT_CONTEXT, payload)).thenReturn(RECORD)
+        assertThat(responseFactory.successResponse(FLOW_EXTERNAL_EVENT_CONTEXT, payload)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a transient error response when the input exception is CpkNotAvailableException`() {
+        val exception = CpkNotAvailableException("")
+        whenever(externalEventResponseFactory.transientError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a transient error response when the input exception is VirtualNodeException`() {
+        val exception = VirtualNodeException("")
+        whenever(externalEventResponseFactory.transientError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a platform error response when the input exception is NotSerializableException`() {
+        val exception = NotSerializableException()
+        whenever(externalEventResponseFactory.platformError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a fatal error response when the input exception is KafkaMessageSizeException`() {
+        val exception = KafkaMessageSizeException("")
+        whenever(externalEventResponseFactory.fatalError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    // I think this is wrong and should be platform, review this!!
+    @Test
+    fun `errorResponse creates and returns a fatal error response when the input exception is NullParameterException`() {
+        val exception = NullParameterException("")
+        whenever(externalEventResponseFactory.fatalError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a fatal error response when the input exception is PersistenceException and categorized as fatal`() {
+        val exception = PersistenceException()
+        whenever(persistenceExceptionCategorizer.categorize(exception)).thenReturn(PersistenceExceptionType.FATAL)
+        whenever(externalEventResponseFactory.fatalError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a platform error response when the input exception is PersistenceException and categorized as platform`() {
+        val exception = PersistenceException()
+        whenever(persistenceExceptionCategorizer.categorize(exception)).thenReturn(PersistenceExceptionType.PLATFORM)
+        whenever(externalEventResponseFactory.platformError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a transient error response when the input exception is PersistenceException and categorized as transient`() {
+        val exception = PersistenceException()
+        whenever(persistenceExceptionCategorizer.categorize(exception)).thenReturn(PersistenceExceptionType.TRANSIENT)
+        whenever(externalEventResponseFactory.transientError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a fatal error response when the input exception is SQLException and categorized as fatal`() {
+        val exception = SQLException()
+        whenever(persistenceExceptionCategorizer.categorize(exception)).thenReturn(PersistenceExceptionType.FATAL)
+        whenever(externalEventResponseFactory.fatalError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a platform error response when the input exception is SQLException and categorized as platform`() {
+        val exception = SQLException()
+        whenever(persistenceExceptionCategorizer.categorize(exception)).thenReturn(PersistenceExceptionType.PLATFORM)
+        whenever(externalEventResponseFactory.platformError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a transient error response when the input exception is SQLException and categorized as transient`() {
+        val exception = SQLException()
+        whenever(persistenceExceptionCategorizer.categorize(exception)).thenReturn(PersistenceExceptionType.TRANSIENT)
+        whenever(externalEventResponseFactory.transientError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `errorResponse creates and returns a platform error response for exceptions without specified behaviour`() {
+        val exception = Exception()
+        whenever(externalEventResponseFactory.platformError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.errorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `transientErrorResponse creates and returns a transient response`() {
+        val exception = Exception()
+        whenever(externalEventResponseFactory.transientError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.transientErrorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `platformErrorResponse creates and returns a platform response`() {
+        val exception = Exception()
+        whenever(externalEventResponseFactory.platformError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.platformErrorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+
+    @Test
+    fun `fatalErrorResponse creates and returns a fatal response`() {
+        val exception = Exception()
+        whenever(externalEventResponseFactory.fatalError(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).thenReturn(RECORD)
+        assertThat(responseFactory.fatalErrorResponse(FLOW_EXTERNAL_EVENT_CONTEXT, exception)).isEqualTo(RECORD)
+    }
+}


### PR DESCRIPTION
In the flow and ledger persistence code, categorise the persistence
exceptions that occur so that we can handle them appropriately.

`PersistenceException` and `SQLException` will now default to be
platform errors (meaning they return an error to user code) rather
than transient errors which led to unnecessary retries. For a subset
of exceptions, transient or fatal errors will be returned depending on
the exceptions.