### PR TITLE
CORE-14685: Separate notary service X500 name from its member X500 name.

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@5.1-pre-breaking-changes') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/MembershipGroupControllerProviderImpl.kt
+++ b/testing/driver/driver-engine/src/main/kotlin/net/corda/testing/driver/sandbox/MembershipGroupControllerProviderImpl.kt
@@ -56,6 +56,7 @@ import net.corda.membership.lib.toSortedMap
 import net.corda.membership.lib.toWire
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.membership.read.NotaryVirtualNodeLookup
+import net.corda.testing.driver.node.EmbeddedNodeService.toNotaryWorkerName
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigestAlgorithmName.SHA2_256
 import net.corda.v5.crypto.SecureHash
@@ -119,7 +120,7 @@ class MembershipGroupControllerProviderImpl @Activate constructor(
     private val groupParameters = parseGroupParameters(properties)
     private val notaries = layeredPropertyMapFactory.createMap(groupParameters.toMap())
         .parseList("corda.notary.service.", NotaryInfo::class.java)
-        .associateBy(NotaryInfo::getName)
+        .associateBy { toNotaryWorkerName(it.name) }
 
     private val membershipInfo = ConcurrentHashMap<HoldingIdentity, MemberInfo>()
     private val groupControllers = ConcurrentHashMap<HoldingIdentity, MembershipGroupController>()

--- a/testing/driver/driver-testing/src/test/java/net/corda/testing/driver/tests/DriverJavaTest.java
+++ b/testing/driver/driver-testing/src/test/java/net/corda/testing/driver/tests/DriverJavaTest.java
@@ -24,6 +24,7 @@ class DriverJavaTest {
     private static final MemberX500Name ALICE = MemberX500Name.parse("CN=Alice, OU=Testing, O=R3, L=London, C=GB");
     private static final MemberX500Name BOB = MemberX500Name.parse("CN=Bob, OU=Testing, O=R3, L=San Francisco, C=US");
     private static final MemberX500Name LUCY = MemberX500Name.parse("CN=Lucy, OU=Testing, O=R3, L=Rome, C=IT");
+    private static final MemberX500Name LUCY_WORKER = MemberX500Name.parse("CN=Lucy(Worker), OU=Testing, O=R3, L=Rome, C=IT");
     private static final MemberX500Name ZAPHOD = MemberX500Name.parse("CN=Zaphod, OU=Testing, O=HGTTG, L=Sirius, C=BG");
 
     @SuppressWarnings("JUnitMalformedDeclaration")
@@ -44,11 +45,11 @@ class DriverJavaTest {
 
             assertThat(dsl.nodesFor("mandelbrot"))
                 .hasEntrySatisfying(ALICE, vNode -> assertThat(aliceNodes).contains(vNode))
-                .doesNotContainKeys(BOB, LUCY);
+                .doesNotContainKeys(BOB, LUCY, LUCY_WORKER);
 
             assertThat(dsl.nodesFor("extendable-cpb"))
                 .hasEntrySatisfying(ALICE, vNode -> assertThat(aliceNodes).contains(vNode))
-                .doesNotContainKeys(BOB, LUCY);
+                .doesNotContainKeys(BOB, LUCY, LUCY_WORKER);
 
             dsl.node("mandelbrot", ALICE, alice ->
                 assertThat(alice.getStatus()).isEqualTo(ACTIVE)
@@ -57,16 +58,18 @@ class DriverJavaTest {
                 assertThat(alice.getStatus()).isEqualTo(ACTIVE)
             );
 
-            dsl.group("mandelbrot", group ->
-                group.member(LUCY, lucy ->
-                    assertThat(lucy.getStatus()).isEqualTo(ACTIVE)
-                )
-            );
-            dsl.group("extendable-cpb", group ->
-                group.member(LUCY, lucy ->
-                    assertThat(lucy.getStatus()).isEqualTo(ACTIVE)
-                )
-            );
+            dsl.group("mandelbrot", group -> {
+                assertThat(group.members()).containsExactlyInAnyOrder(ALICE, LUCY_WORKER);
+                group.member(LUCY_WORKER, lucyWorker ->
+                    assertThat(lucyWorker.getStatus()).isEqualTo(ACTIVE)
+                );
+            });
+            dsl.group("extendable-cpb", group -> {
+                assertThat(group.members()).containsExactlyInAnyOrder(ALICE, LUCY_WORKER);
+                group.member(LUCY_WORKER, lucyWorker ->
+                    assertThat(lucyWorker.getStatus()).isEqualTo(ACTIVE)
+                );
+            });
         });
     }
 

--- a/testing/driver/src/main/java/net/corda/testing/driver/node/EmbeddedNodeService.java
+++ b/testing/driver/src/main/java/net/corda/testing/driver/node/EmbeddedNodeService.java
@@ -13,8 +13,35 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Objects.requireNonNull;
+
 @DoNotImplement
 public interface EmbeddedNodeService {
+    /**
+     * This tag is appended to the {@code commonName} field
+     * of each Notary service's {@link MemberX500Name} to
+     * generate the {@link MemberX500Name} for its vNode.
+     */
+    String NOTARY_WORKER_TAG = "(Worker)";
+
+    /**
+     * @param x500Name The {@link MemberX500Name} for a notary service.
+     * @return The {@link MemberX500Name} for a notary service's virtual node.
+     */
+    @NotNull
+    static MemberX500Name toNotaryWorkerName(@NotNull MemberX500Name x500Name) {
+        requireNonNull(x500Name, "x500Name cannot be null");
+        final String commonName = x500Name.getCommonName();
+        return new MemberX500Name(
+            (commonName == null ? "" : commonName) + NOTARY_WORKER_TAG,
+            x500Name.getOrganizationUnit(),
+            x500Name.getOrganization(),
+            x500Name.getLocality(),
+            x500Name.getState(),
+            x500Name.getCountry()
+        );
+    }
+
     void configure(@NotNull Duration timeout);
 
     @NotNull


### PR DESCRIPTION
An actual notary service should be provided by one or more "worker" virtual nodes, none of whose X500 names matches the notary service's X500 name.

Adjust the driver's mock network to provide a separate X500 name for each notary service's "worker" virtual node, to make it more realistic.