### PR TITLE
CORE-16808: Remove non-CloudWatch AWS-SDK jars from the OSGi system bundle.

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-app.gradle
+++ b/buildSrc/src/main/groovy/corda.common-app.gradle
@@ -79,20 +79,21 @@ dependencies {
     systemPackages "org.slf4j:slf4j-api:$slf4jVersion"
     systemPackages project(':osgi-framework-api')
     systemPackages "software.amazon.awssdk:cloudwatch:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:protocol-core:$awssdkVersion"
     systemPackages "software.amazon.awssdk:sdk-core:$awssdkVersion"
     systemPackages "software.amazon.awssdk:auth:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:http-client-spi:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:regions:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:annotations:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:utils:$awssdkVersion"
     systemPackages "software.amazon.awssdk:aws-core:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:metrics-spi:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:json-utils:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:endpoints-spi:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:sts:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:profiles:$awssdkVersion"
-    systemPackages "software.amazon.awssdk:aws-query-protocol:$awssdkVersion"
+
+    bootstrapClasspath "software.amazon.awssdk:protocol-core:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:http-client-spi:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:regions:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:annotations:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:utils:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:metrics-spi:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:json-utils:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:endpoints-spi:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:sts:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:profiles:$awssdkVersion"
+    bootstrapClasspath "software.amazon.awssdk:aws-query-protocol:$awssdkVersion"
 }
 
 TaskProvider<Jar> jarTask = tasks.named('jar', Jar) {


### PR DESCRIPTION
We should not be including _any_ AWS-SDK jars inside the OSGi system bundle in the first place, but there's no reason whatsoever to export jars that nothing inside the OSGi framework actually needs to use!

Alternatively, see #4574.