### PR TITLE
CORE-16858 session initiation and context propagation issues

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/InitiateFlowAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/InitiateFlowAcceptanceTest.kt
@@ -46,6 +46,7 @@ class InitiateFlowAcceptanceTest : FlowServiceTestBase() {
             }
         }
     }
+
     @Test
     fun `Requesting counterparty info from the flow engine that has already sent a session init event does not send another SessionInit`() {
         given {

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/InitiateFlowAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/InitiateFlowAcceptanceTest.kt
@@ -46,7 +46,6 @@ class InitiateFlowAcceptanceTest : FlowServiceTestBase() {
             }
         }
     }
-
     @Test
     fun `Requesting counterparty info from the flow engine that has already sent a session init event does not send another SessionInit`() {
         given {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandler.kt
@@ -38,7 +38,7 @@ class CounterPartyFlowInfoRequestHandler @Activate constructor(
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.CounterPartyFlowInfo): FlowEventContext<Any> {
         try {
             val sessionInfo = request.sessionInfo
-            generateSessionService.generateSessionsNotCreated(context, setOf(sessionInfo), true)
+            generateSessionService.generateSessions(context, setOf(sessionInfo), true)
         } catch (e: FlowSessionStateException) {
             throw FlowPlatformException("Failed to send: ${e.message}. $PROTOCOL_MISMATCH_HINT", e)
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandler.kt
@@ -6,32 +6,27 @@ import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowPlatformException
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
-import net.corda.flow.pipeline.handlers.requests.sessions.service.InitiateFlowRequestService
+import net.corda.flow.pipeline.handlers.requests.sessions.service.GenerateSessionService
 import net.corda.flow.pipeline.handlers.waiting.sessions.PROTOCOL_MISMATCH_HINT
-import net.corda.flow.pipeline.sessions.FlowSessionManager
 import net.corda.flow.pipeline.sessions.FlowSessionStateException
-import net.corda.flow.utils.keyValuePairListOf
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.time.Instant
 
 /**
  * This class handles a request received by the Flow Engine from the flow fiber.
  * This [FlowIORequest.CounterPartyFlowInfo] request is used to get information about the counterparty which includes data such as the
  * protocol version running.
  * Sets the checkpoint as waiting for [CounterPartyFlowInfo].
- * If the session has not been initiated yet (i.e no SessionInit sent yet to counterparty) then call the [InitiateFlowRequestService] to
+ * If the session has not been initiated yet (i.e no SessionInit sent yet to counterparty) then call the [GenerateSessionService] to
  * trigger SessionInitiation. This will allow us to receive flow information from the counterparty.
  * If the session was already initiated then the session data would already be present in the checkpoint and would have been accessed by
  * the flow fiber from the flow checkpoint.
  */
 @Component(service = [FlowRequestHandler::class])
 class CounterPartyFlowInfoRequestHandler @Activate constructor(
-    @Reference(service = InitiateFlowRequestService::class)
-    private val initiateFlowRequestService: InitiateFlowRequestService,
-    @Reference(service = FlowSessionManager::class)
-    private val flowSessionManager: FlowSessionManager,
+    @Reference(service = GenerateSessionService::class)
+    private val generateSessionService: GenerateSessionService,
 ) : FlowRequestHandler<FlowIORequest.CounterPartyFlowInfo> {
 
     override val type = FlowIORequest.CounterPartyFlowInfo::class.java
@@ -43,15 +38,7 @@ class CounterPartyFlowInfoRequestHandler @Activate constructor(
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.CounterPartyFlowInfo): FlowEventContext<Any> {
         try {
             val sessionInfo = request.sessionInfo
-            initiateFlowRequestService.initiateFlowsNotInitiated(context, setOf(sessionInfo))
-            context.checkpoint.putSessionState(flowSessionManager.sendInitMessage(
-                context.checkpoint,
-                sessionInfo.sessionId,
-                keyValuePairListOf(sessionInfo.contextUserProperties),
-                keyValuePairListOf(sessionInfo.contextPlatformProperties),
-                sessionInfo.counterparty,
-                Instant.now()
-            ))
+            generateSessionService.generateSessionsNotCreated(context, setOf(sessionInfo), true)
         } catch (e: FlowSessionStateException) {
             throw FlowPlatformException("Failed to send: ${e.message}. $PROTOCOL_MISMATCH_HINT", e)
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandler.kt
@@ -24,7 +24,7 @@ class ReceiveRequestHandler @Activate constructor(
 
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.Receive): FlowEventContext<Any> {
         //generate init messages for sessions which do not exist yet
-        generateSessionService.generateSessionsNotCreated(context, request.sessions)
+        generateSessionService.generateSessionsNotCreated(context, request.sessions, true)
         return context
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandler.kt
@@ -24,7 +24,7 @@ class ReceiveRequestHandler @Activate constructor(
 
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.Receive): FlowEventContext<Any> {
         //generate init messages for sessions which do not exist yet
-        generateSessionService.generateSessionsNotCreated(context, request.sessions, true)
+        generateSessionService.generateSessions(context, request.sessions, true)
         return context
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandler.kt
@@ -5,15 +5,15 @@ import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
-import net.corda.flow.pipeline.handlers.requests.sessions.service.InitiateFlowRequestService
+import net.corda.flow.pipeline.handlers.requests.sessions.service.GenerateSessionService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 
 @Component(service = [FlowRequestHandler::class])
 class ReceiveRequestHandler @Activate constructor(
-    @Reference(service = InitiateFlowRequestService::class)
-    private val initiateFlowRequestService: InitiateFlowRequestService,
+    @Reference(service = GenerateSessionService::class)
+    private val generateSessionService: GenerateSessionService,
 ) : FlowRequestHandler<FlowIORequest.Receive> {
 
     override val type = FlowIORequest.Receive::class.java
@@ -24,7 +24,7 @@ class ReceiveRequestHandler @Activate constructor(
 
     override fun postProcess(context: FlowEventContext<Any>, request: FlowIORequest.Receive): FlowEventContext<Any> {
         //generate init messages for sessions which do not exist yet
-        initiateFlowRequestService.initiateFlowsNotInitiated(context, request.sessions)
+        generateSessionService.generateSessionsNotCreated(context, request.sessions)
         return context
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandler.kt
@@ -1,26 +1,26 @@
 package net.corda.flow.pipeline.handlers.requests.sessions
 
-import java.time.Instant
 import net.corda.data.flow.state.waiting.SessionData
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowPlatformException
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
-import net.corda.flow.pipeline.handlers.requests.sessions.service.InitiateFlowRequestService
+import net.corda.flow.pipeline.handlers.requests.sessions.service.GenerateSessionService
 import net.corda.flow.pipeline.handlers.waiting.sessions.PROTOCOL_MISMATCH_HINT
 import net.corda.flow.pipeline.sessions.FlowSessionManager
 import net.corda.flow.pipeline.sessions.FlowSessionStateException
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.time.Instant
 
 @Component(service = [FlowRequestHandler::class])
 class SendAndReceiveRequestHandler @Activate constructor(
     @Reference(service = FlowSessionManager::class)
     private val flowSessionManager: FlowSessionManager,
-    @Reference(service = InitiateFlowRequestService::class)
-    private val initiateFlowRequestService: InitiateFlowRequestService,
+    @Reference(service = GenerateSessionService::class)
+    private val generateSessionService: GenerateSessionService,
 ) : FlowRequestHandler<FlowIORequest.SendAndReceive> {
 
     override val type = FlowIORequest.SendAndReceive::class.java
@@ -36,7 +36,7 @@ class SendAndReceiveRequestHandler @Activate constructor(
         val checkpoint = context.checkpoint
 
         //generate init messages for sessions which do not exist yet
-        initiateFlowRequestService.initiateFlowsNotInitiated(context, request.sessionToInfo.keys)
+        generateSessionService.generateSessionsNotCreated(context, request.sessionToInfo.keys)
 
         try {
             checkpoint.putSessionStates(flowSessionManager.sendDataMessages(checkpoint, request.sessionToInfo, Instant.now()))

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandler.kt
@@ -36,7 +36,7 @@ class SendAndReceiveRequestHandler @Activate constructor(
         val checkpoint = context.checkpoint
 
         //generate init messages for sessions which do not exist yet
-        generateSessionService.generateSessionsNotCreated(context, request.sessionToInfo.keys)
+        generateSessionService.generateSessions(context, request.sessionToInfo.keys)
 
         try {
             checkpoint.putSessionStates(flowSessionManager.sendDataMessages(checkpoint, request.sessionToInfo, Instant.now()))

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandler.kt
@@ -32,7 +32,7 @@ class SendRequestHandler @Activate constructor(
         val checkpoint = context.checkpoint
         try {
             //generate session states for sessions which do not exist yet
-            generateSessionService.generateSessionsNotCreated(context, request.sessionPayloads.keys)
+            generateSessionService.generateSessions(context, request.sessionPayloads.keys)
             checkpoint.putSessionStates(flowSessionManager.sendDataMessages(checkpoint, request.sessionPayloads, Instant.now()))
         } catch (e: FlowSessionStateException) {
             throw FlowPlatformException("Failed to send: ${e.message}. $PROTOCOL_MISMATCH_HINT", e)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandler.kt
@@ -1,25 +1,25 @@
 package net.corda.flow.pipeline.handlers.requests.sessions
 
-import java.time.Instant
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowPlatformException
 import net.corda.flow.pipeline.handlers.requests.FlowRequestHandler
-import net.corda.flow.pipeline.handlers.requests.sessions.service.InitiateFlowRequestService
+import net.corda.flow.pipeline.handlers.requests.sessions.service.GenerateSessionService
 import net.corda.flow.pipeline.handlers.waiting.sessions.PROTOCOL_MISMATCH_HINT
 import net.corda.flow.pipeline.sessions.FlowSessionManager
 import net.corda.flow.pipeline.sessions.FlowSessionStateException
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import java.time.Instant
 
 @Component(service = [FlowRequestHandler::class])
 class SendRequestHandler @Activate constructor(
     @Reference(service = FlowSessionManager::class)
     private val flowSessionManager: FlowSessionManager,
-    @Reference(service = InitiateFlowRequestService::class)
-    private val initiateFlowRequestService: InitiateFlowRequestService,
+    @Reference(service = GenerateSessionService::class)
+    private val generateSessionService: GenerateSessionService,
 ) : FlowRequestHandler<FlowIORequest.Send> {
 
     override val type = FlowIORequest.Send::class.java
@@ -32,7 +32,7 @@ class SendRequestHandler @Activate constructor(
         val checkpoint = context.checkpoint
         try {
             //generate session states for sessions which do not exist yet
-            initiateFlowRequestService.initiateFlowsNotInitiated(context, request.sessionPayloads.keys)
+            generateSessionService.generateSessionsNotCreated(context, request.sessionPayloads.keys)
             checkpoint.putSessionStates(flowSessionManager.sendDataMessages(checkpoint, request.sessionPayloads, Instant.now()))
         } catch (e: FlowSessionStateException) {
             throw FlowPlatformException("Failed to send: ${e.message}. $PROTOCOL_MISMATCH_HINT", e)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
@@ -95,7 +95,7 @@ class GenerateSessionService @Activate constructor(
                     Instant.now()
                 )
 
-                if (sendInit) {
+                if (sendInit && newSessionState.sendEventsState.undeliveredMessages.isEmpty()) {
                     newSessionState = flowSessionManager.sendInitMessage(
                         context.checkpoint,
                         it.sessionId,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
@@ -31,6 +31,12 @@ class GenerateSessionService @Activate constructor(
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
+    /**
+     * For the given sessions in [sessionToInfo], return all the ones which do not have session states in the checkpoint yet.
+     * @param context flow pipeline context
+     * @param sessionToInfo sessions to check
+     * @return sessions which have not been created in the checkpoint yet
+     */
     fun getSessionsNotGenerated(
         context: FlowEventContext<Any>,
         sessionToInfo: Set<SessionInfo>
@@ -39,6 +45,12 @@ class GenerateSessionService @Activate constructor(
         return sessionToInfo.filter { checkpoint.getSessionState(it.sessionId) == null }.toSet()
     }
 
+    /**
+     * For the given sessions in [sessionToInfo], generate session states and save them to the checkpoint.
+     * @param context flow pipeline context
+     * @param sessionToInfo sessions to create
+     * @param sendInit True if a SessionInit should be scheduled as part of creating the session state.
+     */
     fun generateSessionsNotCreated(
         context: FlowEventContext<Any>,
         sessionToInfo: Set<SessionInfo>,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
@@ -56,21 +56,21 @@ class GenerateSessionService @Activate constructor(
         sessionToInfo: Set<SessionInfo>,
         sendInit: Boolean = false
     ) {
-        val sessionsNotInitiated = getSessionsNotGenerated(context, sessionToInfo)
-        if (sessionsNotInitiated.isNotEmpty()) {
-            generateSessionStates(context, sessionsNotInitiated, sendInit)
+        val sessionsNotGenerated = getSessionsNotGenerated(context, sessionToInfo)
+        if (sessionsNotGenerated.isNotEmpty()) {
+            generateSessionStates(context, sessionsNotGenerated, sendInit)
         }
     }
 
     @Suppress("ThrowsCount")
     private fun generateSessionStates(
         context: FlowEventContext<Any>,
-        sessionsNotInitiated: Set<SessionInfo>,
+        sessionsNotGenerated: Set<SessionInfo>,
         sendInit: Boolean
     ) {
         val checkpoint = context.checkpoint
 
-        logger.trace { "Initiating flows with sessionIds ${sessionsNotInitiated.map { it.sessionId }}" }
+        logger.trace { "Initiating flows with sessionIds ${sessionsNotGenerated.map { it.sessionId }}" }
         // throw an error if the session already exists (shouldn't really get here for real, but for this class, it's not valid)
         val protocolStore = try {
             flowSandboxService.get(checkpoint.holdingIdentity, checkpoint.cpkFileHashes).protocolStore
@@ -97,7 +97,7 @@ class GenerateSessionService @Activate constructor(
             put(FLOW_PROTOCOL_VERSIONS_SUPPORTED, protocolVersions.joinToString())
         }
 
-        sessionsNotInitiated.map { sessionInfo ->
+        sessionsNotGenerated.map { sessionInfo ->
             flowSessionManager.generateSessionState(
                 checkpoint,
                 sessionInfo.sessionId,
@@ -118,7 +118,7 @@ class GenerateSessionService @Activate constructor(
             }
         }
 
-        val sessionsNotInitiatedIds = sessionsNotInitiated.map { it.sessionId }.toSet()
+        val sessionsNotInitiatedIds = sessionsNotGenerated.map { it.sessionId }.toSet()
         initiatingFlowStackItem.sessions
             .filter { it.sessionId in sessionsNotInitiatedIds }
             .forEach { it.initiated = true }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
@@ -54,7 +54,7 @@ class GenerateSessionService @Activate constructor(
     private fun generateSessionStates(
         context: FlowEventContext<Any>,
         sessionsNotInitiated: Set<SessionInfo>,
-        sendInit: Boolean = false
+        sendInit: Boolean
     ) {
         val checkpoint = context.checkpoint
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
@@ -95,7 +95,7 @@ class GenerateSessionService @Activate constructor(
                     Instant.now()
                 )
 
-                if (sendInit && newSessionState.sendEventsState.undeliveredMessages.isEmpty()) {
+                if (sendInit) {
                     newSessionState = flowSessionManager.sendInitMessage(
                         context.checkpoint,
                         it.sessionId,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionService.kt
@@ -51,7 +51,7 @@ class GenerateSessionService @Activate constructor(
      * @param sessionToInfo sessions to create
      * @param sendInit True if a SessionInit should be scheduled as part of creating the session state.
      */
-    fun generateSessionsNotCreated(
+    fun generateSessions(
         context: FlowEventContext<Any>,
         sessionToInfo: Set<SessionInfo>,
         sendInit: Boolean = false

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
@@ -117,7 +117,8 @@ class FlowSessionManagerImpl @Activate constructor(
             checkpoint,
             sessionId,
             payload = SessionConfirm(),
-            instant
+            instant,
+            contextSessionProperties = contextSessionProperties
         )
     }
 
@@ -295,7 +296,8 @@ class FlowSessionManagerImpl @Activate constructor(
         checkpoint: FlowCheckpoint,
         sessionId: String,
         payload: Any,
-        instant: Instant
+        instant: Instant,
+        contextSessionProperties: KeyValuePairList? = null
     ): SessionState {
         val sessionState = getAndRequireSession(checkpoint, sessionId)
         val (initiatingIdentity, initiatedIdentity) = getInitiatingAndInitiatedParties(
@@ -313,7 +315,7 @@ class FlowSessionManagerImpl @Activate constructor(
                 .setInitiatedIdentity(initiatedIdentity)
                 .setSequenceNum(null)
                 .setPayload(payload)
-                .setContextSessionProperties(null)
+                .setContextSessionProperties(contextSessionProperties)
                 .build(),
             instant = instant,
             maxMsgSize = checkpoint.maxMessageSize

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/sessions/impl/FlowSessionManagerImpl.kt
@@ -118,7 +118,7 @@ class FlowSessionManagerImpl @Activate constructor(
             sessionId,
             payload = SessionConfirm(),
             instant,
-            contextSessionProperties = contextSessionProperties
+            contextSessionProperties
         )
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/RequestHandlerTestContext.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/RequestHandlerTestContext.kt
@@ -7,7 +7,7 @@ import net.corda.data.flow.event.FlowEvent
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
-import net.corda.flow.pipeline.handlers.requests.sessions.service.InitiateFlowRequestService
+import net.corda.flow.pipeline.handlers.requests.sessions.service.GenerateSessionService
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.flow.pipeline.sessions.FlowSessionManager
 import net.corda.flow.state.FlowCheckpoint
@@ -40,7 +40,7 @@ class RequestHandlerTestContext<PAYLOAD>(val payload: PAYLOAD) {
         .withValue(SESSION_FLOW_CLEANUP_TIME, ConfigValueFactory.fromAnyRef(10000))
         .withValue(PROCESSING_FLOW_CLEANUP_TIME, ConfigValueFactory.fromAnyRef(10000))
     val flowSandboxService = mock<FlowSandboxService>()
-    val initiateFlowReqService = mock<InitiateFlowRequestService>()
+    val initiateFlowReqService = mock<GenerateSessionService>()
     val isRetryEvent = false
 
     init {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandlerTest.kt
@@ -12,6 +12,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -45,12 +46,12 @@ class CounterPartyFlowInfoRequestHandlerTest {
     @Test
     fun `Initiates flows not initiated yet`() {
         handler.postProcess(testContext.flowEventContext, ioRequest)
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
     }
 
     @Test
     fun `Throws exception when any of the sessions are invalid`() {
-        whenever(testContext.initiateFlowReqService.generateSessionsNotCreated(any(), any()))
+        whenever(testContext.initiateFlowReqService.generateSessionsNotCreated(any(), any(), anyBoolean()))
             .thenThrow(FlowSessionStateException(""))
 
         assertThrows<FlowPlatformException> { handler.postProcess(testContext.flowEventContext, ioRequest) }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandlerTest.kt
@@ -46,12 +46,12 @@ class CounterPartyFlowInfoRequestHandlerTest {
     @Test
     fun `Initiates flows not initiated yet`() {
         handler.postProcess(testContext.flowEventContext, ioRequest)
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
     }
 
     @Test
     fun `Throws exception when any of the sessions are invalid`() {
-        whenever(testContext.initiateFlowReqService.generateSessionsNotCreated(any(), any(), anyBoolean()))
+        whenever(testContext.initiateFlowReqService.generateSessions(any(), any(), anyBoolean()))
             .thenThrow(FlowSessionStateException(""))
 
         assertThrows<FlowPlatformException> { handler.postProcess(testContext.flowEventContext, ioRequest) }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandlerTest.kt
@@ -26,7 +26,7 @@ class CounterPartyFlowInfoRequestHandlerTest {
         SessionInfo(sessionId1, testContext.counterparty)
     )
     private val handler =
-        CounterPartyFlowInfoRequestHandler(testContext.initiateFlowReqService, testContext.flowSessionManager)
+        CounterPartyFlowInfoRequestHandler(testContext.initiateFlowReqService)
 
 
     @Suppress("Unused")
@@ -45,13 +45,12 @@ class CounterPartyFlowInfoRequestHandlerTest {
     @Test
     fun `Initiates flows not initiated yet`() {
         handler.postProcess(testContext.flowEventContext, ioRequest)
-        verify(testContext.initiateFlowReqService).initiateFlowsNotInitiated(any(), any())
-        verify(testContext.flowSessionManager).sendInitMessage(any(), any(), any(), any(), any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
     }
 
     @Test
     fun `Throws exception when any of the sessions are invalid`() {
-        whenever(testContext.initiateFlowReqService.initiateFlowsNotInitiated(any(), any()))
+        whenever(testContext.initiateFlowReqService.generateSessionsNotCreated(any(), any()))
             .thenThrow(FlowSessionStateException(""))
 
         assertThrows<FlowPlatformException> { handler.postProcess(testContext.flowEventContext, ioRequest) }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/CounterPartyFlowInfoRequestHandlerTest.kt
@@ -12,8 +12,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -46,12 +46,12 @@ class CounterPartyFlowInfoRequestHandlerTest {
     @Test
     fun `Initiates flows not initiated yet`() {
         handler.postProcess(testContext.flowEventContext, ioRequest)
-        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), eq(true))
     }
 
     @Test
     fun `Throws exception when any of the sessions are invalid`() {
-        whenever(testContext.initiateFlowReqService.generateSessions(any(), any(), anyBoolean()))
+        whenever(testContext.initiateFlowReqService.generateSessions(any(), any(), eq(true)))
             .thenThrow(FlowSessionStateException(""))
 
         assertThrows<FlowPlatformException> { handler.postProcess(testContext.flowEventContext, ioRequest) }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
@@ -7,6 +7,7 @@ import net.corda.flow.fiber.FlowIORequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 
@@ -48,7 +49,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
 
         assertThat(outputContext.outputRecords).isEmpty()
     }
@@ -64,7 +65,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
         assertEquals(0, outputContext.outputRecords.size)
     }
 
@@ -79,7 +80,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
         assertEquals(flowEventContext, outputContext)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
@@ -7,8 +7,8 @@ import net.corda.flow.fiber.FlowIORequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 
 class ReceiveRequestHandlerTest {
@@ -49,7 +49,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), equals(true))
 
         assertThat(outputContext.outputRecords).isEmpty()
     }
@@ -65,7 +65,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), eq(true))
         assertEquals(0, outputContext.outputRecords.size)
     }
 
@@ -80,7 +80,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), eq(true))
         assertEquals(flowEventContext, outputContext)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 
 class ReceiveRequestHandlerTest {
 
@@ -20,7 +19,6 @@ class ReceiveRequestHandlerTest {
 
     private val testContext = RequestHandlerTestContext(Any())
     private val flowEventContext = testContext.flowEventContext
-    private val flowSessionManager = testContext.flowSessionManager
     private val receiveRequestHandler =
         ReceiveRequestHandler(testContext.initiateFlowReqService)
 
@@ -41,7 +39,6 @@ class ReceiveRequestHandlerTest {
 
     @Test
     fun `No output records if all sessions have already received the required data`() {
-        whenever(flowSessionManager.hasReceivedEvents(flowEventContext.checkpoint, listOf(SESSION_ID, ANOTHER_SESSION_ID))).thenReturn(true)
         val outputContext = receiveRequestHandler.postProcess(
             flowEventContext,
             FlowIORequest.Receive(
@@ -51,20 +48,13 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).initiateFlowsNotInitiated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
 
         assertThat(outputContext.outputRecords).isEmpty()
     }
 
     @Test
     fun `Does not create a Wakeup record if any the sessions have not already received events`() {
-        whenever(
-            flowSessionManager.hasReceivedEvents(
-                flowEventContext.checkpoint,
-                listOf(SESSION_ID, ANOTHER_SESSION_ID)
-            )
-        ).thenReturn(false)
-
         val outputContext = receiveRequestHandler.postProcess(
             flowEventContext,
             FlowIORequest.Receive(
@@ -74,18 +64,12 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).initiateFlowsNotInitiated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
         assertEquals(0, outputContext.outputRecords.size)
     }
 
     @Test
     fun `Does not modify the context when the sessions have not already received events`() {
-        whenever(
-            flowSessionManager.hasReceivedEvents(
-                flowEventContext.checkpoint,
-                listOf(SESSION_ID, ANOTHER_SESSION_ID)
-            )
-        ).thenReturn(false)
         val outputContext = receiveRequestHandler.postProcess(
             flowEventContext,
             FlowIORequest.Receive(
@@ -95,7 +79,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).initiateFlowsNotInitiated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
         assertEquals(flowEventContext, outputContext)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
@@ -49,7 +49,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
 
         assertThat(outputContext.outputRecords).isEmpty()
     }
@@ -65,7 +65,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
         assertEquals(0, outputContext.outputRecords.size)
     }
 
@@ -80,7 +80,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
         assertEquals(flowEventContext, outputContext)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/ReceiveRequestHandlerTest.kt
@@ -49,7 +49,7 @@ class ReceiveRequestHandlerTest {
                 )
             )
         )
-        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), equals(true))
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), eq(true))
 
         assertThat(outputContext.outputRecords).isEmpty()
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandlerTest.kt
@@ -65,7 +65,7 @@ class SendAndReceiveRequestHandlerTest {
             )
         ).thenReturn(true)
         val outputContext = handler.postProcess(testContext.flowEventContext, ioRequest)
-        verify(testContext.initiateFlowReqService).initiateFlowsNotInitiated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
         verify(testContext.flowCheckpoint).putSessionStates(listOf(sessionState1, sessionState2))
         verify(testContext.flowSessionManager).sendDataMessages(
             eq(testContext.flowCheckpoint),

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandlerTest.kt
@@ -66,7 +66,7 @@ class SendAndReceiveRequestHandlerTest {
             )
         ).thenReturn(true)
         val outputContext = handler.postProcess(testContext.flowEventContext, ioRequest)
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
         verify(testContext.flowCheckpoint).putSessionStates(listOf(sessionState1, sessionState2))
         verify(testContext.flowSessionManager).sendDataMessages(
             eq(testContext.flowCheckpoint),

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendAndReceiveRequestHandlerTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
@@ -65,7 +66,7 @@ class SendAndReceiveRequestHandlerTest {
             )
         ).thenReturn(true)
         val outputContext = handler.postProcess(testContext.flowEventContext, ioRequest)
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
         verify(testContext.flowCheckpoint).putSessionStates(listOf(sessionState1, sessionState2))
         verify(testContext.flowSessionManager).sendDataMessages(
             eq(testContext.flowCheckpoint),

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandlerTest.kt
@@ -65,7 +65,7 @@ class SendRequestHandlerTest {
             any(),
             any()
         )
-        verify(testContext.initiateFlowReqService).initiateFlowsNotInitiated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
         assertThat(outputContext.outputRecords).isEmpty()
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandlerTest.kt
@@ -66,7 +66,7 @@ class SendRequestHandlerTest {
             any(),
             any()
         )
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
+        verify(testContext.initiateFlowReqService).generateSessions(any(), any(), anyBoolean())
         assertThat(outputContext.outputRecords).isEmpty()
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/SendRequestHandlerTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
@@ -65,7 +66,7 @@ class SendRequestHandlerTest {
             any(),
             any()
         )
-        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any())
+        verify(testContext.initiateFlowReqService).generateSessionsNotCreated(any(), any(), anyBoolean())
         assertThat(outputContext.outputRecords).isEmpty()
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionServiceTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/sessions/service/GenerateSessionServiceTest.kt
@@ -77,14 +77,14 @@ class GenerateSessionServiceTest {
 
     @Test
     fun `Session init event sent to session manager and checkpoint updated with session state`() {
-        generateSessionService.generateSessionsNotCreated(testContext.flowEventContext, sessionInfo, true)
+        generateSessionService.generateSessions(testContext.flowEventContext, sessionInfo, true)
         verify(testContext.flowCheckpoint, times(2)).putSessionState(any())
         verify(testContext.flowSessionManager).generateSessionState(any(), any(), any(), any(), any())
     }
 
     @Test
     fun `No Session init event sent to session manager and checkpoint updated with session state`() {
-        generateSessionService.generateSessionsNotCreated(testContext.flowEventContext, sessionInfo, false)
+        generateSessionService.generateSessions(testContext.flowEventContext, sessionInfo, false)
         verify(testContext.flowCheckpoint, times(1)).putSessionState(any())
         verify(testContext.flowSessionManager).generateSessionState(any(), any(), any(), any(), any())
     }
@@ -93,7 +93,7 @@ class GenerateSessionServiceTest {
     fun `No initiating flow in the subflow stack throws platform exception`() {
         whenever(testContext.flowStack.nearestFirst(any())).thenReturn(null)
         assertThrows<FlowPlatformException> {
-            generateSessionService.generateSessionsNotCreated(testContext.flowEventContext, sessionInfo)
+            generateSessionService.generateSessions(testContext.flowEventContext, sessionInfo)
         }
     }
 
@@ -101,13 +101,13 @@ class GenerateSessionServiceTest {
     fun `No flows in the subflow stack throws fatal exception`() {
         whenever(testContext.flowStack.isEmpty()).thenReturn(true)
         assertThrows<FlowFatalException> {
-            generateSessionService.generateSessionsNotCreated(testContext.flowEventContext, sessionInfo)
+            generateSessionService.generateSessions(testContext.flowEventContext, sessionInfo)
         }
     }
 
     @Test
     fun `Does not add an output record`() {
-        generateSessionService.generateSessionsNotCreated(testContext.flowEventContext, sessionInfo)
+        generateSessionService.generateSessions(testContext.flowEventContext, sessionInfo)
         assertThat(testContext.flowEventContext.outputRecords).hasSize(0)
     }
 }


### PR DESCRIPTION
Fix issue where session context properties were not being exchanged properly.

Also fix an issue where calling receive as the first operation did not send a SessionInit message

This PR does not address the issue where it is not possible to exchange session properties after the first send when no data messages are received. i.e call send and then call getCounterPartyInfo https://r3-cev.atlassian.net/browse/CORE-16860