### PR TITLE
CORE-13225 - Make publisher reference atomic

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaPublisherImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaPublisherImpl.kt
@@ -42,7 +42,8 @@ internal class CordaPublisherImpl(
         private const val QUEUE_SIZE = 200
     }
 
-    private val cordaProducer: AtomicReference<CordaProducer?> = AtomicReference(cordaProducerBuilder.createProducer(producerConfig, config.messageBusConfig))
+    private val cordaProducer: AtomicReference<CordaProducer?> = AtomicReference(cordaProducerBuilder
+        .createProducer(producerConfig, config.messageBusConfig))
 
     private data class Batch(val records: List<Record<*, *>>, val future: CompletableFuture<Unit>)
     private val queue = ArrayBlockingQueue<Batch>(QUEUE_SIZE)


### PR DESCRIPTION
Some tests (currently observed e2e tests only) seem to fail (rarely) due to what looks like a Kafka producer fencing issue. The initial attempt to resolve this issue, which impacts test stability, made the publisher reference atomic (Corda publishers are wrappers over standard Kafka producers) to ensure that resetting the publisher would ensure the new instance was visible in every thread using it, avoiding having two producer references with the same transactional ID. This fix proved insufficient over time as more failures were reported. This is because other publishers would fail 

Recent analysis reveals that there is a quite specific order of publishers which cause the issue. Meaning, if the first publisher is fixed, the next one would eventually cause the same issue. For example, logs from failures from the last 5 months show that the issue is always caused first by **VirtualNodeInfoWriterComponent**. A fix there would eventually show that the **CpiInfoWriterComponent** will fail. Fixing that as well simply makes the issue appear in **ChunkDbWriter**.

**Proposed solution** - ensure **all references** are atomic by moving initial fix to the Corda publisher code;

Log statements from when the issue started in VirtualNodeInfoWriterComponent

`[pod/corda-bob-db-worker-7cf4cd766f-6k69g/corda-bob-db-worker] 14:45:06.712 [lifecycle-coordinator-41] INFO  net.corda.messaging.publisher.CordaPublisherImpl {} - Producer clientId VIRTUAL_NODE_INFO_WRITER, transactional true, failed to send, resetting producer
[pod/corda-bob-db-worker-7cf4cd766f-6k69g/corda-bob-db-worker] net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset: Error occurred beginning transaction for CordaKafkaProducer with clientId VIRTUAL_NODE_INFO_WRITER`

Log statements from when the issue started in CpiInfoWriterComponent

`[pod/corda-bob-db-worker-5bfc868499-6m7d2/corda-bob-db-worker] 08:34:47.945 [lifecycle-coordinator-57] INFO  net.corda.messaging.publisher.CordaPublisherImpl {} - Producer clientId CPI_INFO_WRITER, transactional true, failed to send, resetting producer
[pod/corda-bob-db-worker-5bfc868499-6m7d2/corda-bob-db-worker] net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset: Error occurred beginning transaction for CordaKafkaProducer with clientId CPI_INFO_WRITER`

Log statements from when the issue started in ChunkDbWriter

`[pod/corda-bob-db-worker-744b8fd4d9-j65pn/corda-bob-db-worker] 13:27:07.877 [durable processing thread cpi.chunk.writer-cpi.upload] INFO  net.corda.messaging.publisher.CordaPublisherImpl {} - Producer clientId chunk-writer, transactional true, failed to send, resetting producer
[pod/corda-bob-db-worker-744b8fd4d9-j65pn/corda-bob-db-worker] net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset: Error occurred beginning transaction for CordaKafkaProducer with clientId chunk-writer`

**Observations**: 

- issues seems to exclusively happen only during reconciliation process
- root cause is still unknown (logs don't show any other errors before); services going up and down a lot during reconciliation might have something to do with it
- something in Kafka throws an `IllegalStateException` when a producer tries to **begin** a transaction; our code handles this by resetting the published (close existing producer -> blocks until all messages are sent; create new instance with the same transactional ID)
