### PR TITLE
CORE-15803: Create vnode without uniqueness db

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.18-beta+
+cordaApiVersion=5.1.0.18-alpha-1693906345798
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.18-alpha-1693906345798
+cordaApiVersion=5.1.0.18-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
+++ b/libs/virtual-node/virtual-node-info/src/main/kotlin/net/corda/virtualnode/VirtualNodeInfo.kt
@@ -70,7 +70,7 @@ fun VirtualNodeInfo.toAvro(): VirtualNodeInfoAvro =
             .setCryptoDdlConnectionId(cryptoDdlConnectionId?.let{ cryptoDdlConnectionId.toString() })
             .setCryptoDmlConnectionId(cryptoDmlConnectionId.toString())
             .setUniquenessDdlConnectionId(uniquenessDdlConnectionId?.let{ uniquenessDdlConnectionId.toString() })
-            .setUniquenessDmlConnectionId(uniquenessDmlConnectionId.toString())
+            .setUniquenessDmlConnectionId(uniquenessDmlConnectionId?.let{ uniquenessDmlConnectionId.toString() })
             .setHsmConnectionId(hsmConnectionId?.let { hsmConnectionId.toString() })
             .setFlowP2pOperationalStatus(flowP2pOperationalStatus.toAvro())
             .setFlowStartOperationalStatus(flowStartOperationalStatus.toAvro())
@@ -93,7 +93,7 @@ fun VirtualNodeInfoAvro.toCorda(): VirtualNodeInfo {
         cryptoDdlConnectionId?.let { UUID.fromString(cryptoDdlConnectionId) },
         UUID.fromString(cryptoDmlConnectionId),
         uniquenessDdlConnectionId?.let { UUID.fromString(uniquenessDdlConnectionId) },
-        UUID.fromString(uniquenessDmlConnectionId),
+        uniquenessDmlConnectionId?.let { UUID.fromString(uniquenessDmlConnectionId) },
         hsmConnectionId?.let { UUID.fromString(hsmConnectionId) },
         OperationalStatus.fromAvro(flowP2pOperationalStatus),
         OperationalStatus.fromAvro(flowStartOperationalStatus),


### PR DESCRIPTION
Updates `VirtualNodeInfo.toAvro()` and `VirtualNodeInfo.toCorda()` methods to allow uniquenessDmlConnectionId to be null. Following the changes in https://github.com/corda/corda-runtime-os/pull/4529 

Change to corda-api to allow uniquenessDmlConnectionId to be nullable https://github.com/corda/corda-api/pull/1234
E2E test in https://github.com/corda/corda-e2e-tests/pull/217
