### PR TITLE
CORE-15958 - Registration should fail when using EDDSA for scheme ED25519 for session keys

### DIFF
--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
@@ -33,7 +33,7 @@ class KeySpecExtractor(
             SM2_CODE_NAME to SignatureSpecs.SM2_SM3,
             SPHINCS256_CODE_NAME to SignatureSpecs.SPHINCS256_SHA512,
         )
-        private val validSpecsNames = mapOf(
+        private val validSpecsNamesForSessionKeys = mapOf(
             ECDSA_SECP256K1_CODE_NAME to listOf(
                 SignatureSpecs.ECDSA_SHA256,
                 SignatureSpecs.ECDSA_SHA384,
@@ -49,11 +49,26 @@ class KeySpecExtractor(
             RSA_CODE_NAME to listOf(SignatureSpecs.RSA_SHA256, SignatureSpecs.RSA_SHA384, SignatureSpecs.RSA_SHA512)
                 .map { it.signatureName },
         )
+        private val validSpecsNames = mapOf(
+            EDDSA_ED25519_CODE_NAME to listOf(SignatureSpecs.EDDSA_ED25519.signatureName),
+            GOST3410_GOST3411_CODE_NAME to listOf(SignatureSpecs.GOST3410_GOST3411.signatureName),
+            SM2_CODE_NAME to listOf(SignatureSpecs.SM2_SM3.signatureName),
+            SPHINCS256_CODE_NAME to listOf(SignatureSpecs.SPHINCS256_SHA512.signatureName),
+        ) + validSpecsNamesForSessionKeys
 
-        fun CryptoSigningKey.validateSpecName(specName: String) {
-            val validSpecs = validSpecsNames[this.schemeCodeName]
-                ?: throw IllegalArgumentException("Could not identify spec for key scheme ${this.schemeCodeName}.")
-            if (!validSpecs.contains(specName)) {
+        fun CryptoSigningKey.validateSpecName(specName: String, type: KeySpecType = KeySpecType.OTHER) {
+            val validSpecs = if (type == KeySpecType.SESSION) {
+                requireNotNull(validSpecsNamesForSessionKeys[this.schemeCodeName]) {
+                    "Invalid key scheme is used for session key or " +
+                            "could not identify spec for key scheme ${this.schemeCodeName}. The following " +
+                            "schemes should be used when generating session keys: ${validSpecsNamesForSessionKeys.keys}"
+                }
+            } else {
+                requireNotNull(validSpecsNames[this.schemeCodeName]) {
+                    "Could not identify spec for key scheme ${this.schemeCodeName}."
+                }
+            }
+            require(validSpecs.contains(specName)) {
                 throw IllegalArgumentException(
                     "Invalid key spec $specName. Valid specs for key scheme ${this.schemeCodeName} are $validSpecs."
                 )
@@ -69,5 +84,9 @@ class KeySpecExtractor(
             ),
         ).firstOrNull() ?: throw CordaRuntimeException("Public key is not owned by $tenantId")
         return keyInfo.spec ?: throw CordaRuntimeException("Can not find spec for ${keyInfo.schemeCodeName}")
+    }
+
+    enum class KeySpecType {
+        SESSION, OTHER
     }
 }

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
@@ -68,9 +68,7 @@ class KeySpecExtractor(
                 }
             }
             require(validSpecs.contains(specName)) {
-                throw IllegalArgumentException(
-                    "Invalid key spec $specName. Valid specs for key scheme ${this.schemeCodeName} are $validSpecs."
-                )
+                "Invalid key spec $specName. Valid specs for key scheme ${this.schemeCodeName} are $validSpecs."
             }
         }
     }

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
@@ -59,9 +59,8 @@ class KeySpecExtractor(
         fun CryptoSigningKey.validateSpecName(specName: String, type: KeySpecType = KeySpecType.OTHER) {
             val validSpecs = if (type == KeySpecType.SESSION) {
                 requireNotNull(validSpecsNamesForSessionKeys[this.schemeCodeName]) {
-                    "Invalid key scheme is used for session key or " +
-                            "could not identify spec for key scheme ${this.schemeCodeName}. The following " +
-                            "schemes should be used when generating session keys: ${validSpecsNamesForSessionKeys.keys}"
+                    "Invalid key scheme ${this.schemeCodeName}. The following " +
+                            "schemes could be used when generating session keys: ${validSpecsNamesForSessionKeys.keys}"
                 }
             } else {
                 requireNotNull(validSpecsNames[this.schemeCodeName]) {

--- a/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
+++ b/components/membership/membership-p2p/src/main/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractor.kt
@@ -46,12 +46,8 @@ class KeySpecExtractor(
                 SignatureSpecs.ECDSA_SHA512,
             )
                 .map { it.signatureName },
-            EDDSA_ED25519_CODE_NAME to listOf(SignatureSpecs.EDDSA_ED25519.signatureName),
-            GOST3410_GOST3411_CODE_NAME to listOf(SignatureSpecs.GOST3410_GOST3411.signatureName),
             RSA_CODE_NAME to listOf(SignatureSpecs.RSA_SHA256, SignatureSpecs.RSA_SHA384, SignatureSpecs.RSA_SHA512)
                 .map { it.signatureName },
-            SM2_CODE_NAME to listOf(SignatureSpecs.SM2_SM3.signatureName),
-            SPHINCS256_CODE_NAME to listOf(SignatureSpecs.SPHINCS256_SHA512.signatureName),
         )
 
         fun CryptoSigningKey.validateSpecName(specName: String) {

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractorTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractorTest.kt
@@ -69,7 +69,7 @@ class KeySpecExtractorTest {
         val exception = assertThrows<IllegalArgumentException> {
             key.validateSpecName(SignatureSpecs.EDDSA_ED25519.signatureName, KeySpecExtractor.KeySpecType.SESSION)
         }
-        assertThat(exception).hasMessageContaining("Invalid key scheme is used for session key")
+        assertThat(exception).hasMessageContaining("Invalid key scheme")
     }
 
     @Test

--- a/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractorTest.kt
+++ b/components/membership/membership-p2p/src/test/kotlin/net/corda/membership/p2p/helpers/KeySpecExtractorTest.kt
@@ -7,6 +7,7 @@ import net.corda.crypto.core.ShortHash
 import net.corda.data.crypto.wire.CryptoSigningKey
 import net.corda.membership.p2p.helpers.KeySpecExtractor.Companion.validateSpecName
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.crypto.KeySchemeCodes
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -57,6 +58,26 @@ class KeySpecExtractorTest {
             key.validateSpecName(SignatureSpecs.ECDSA_SHA256.signatureName)
         }
         assertThat(exception).hasMessageContaining("Could not identify spec for key scheme nop")
+    }
+
+    @Test
+    fun `validateSpecName throws exception for invalid schemeCodeName for session key`() {
+        val key = mock<CryptoSigningKey> {
+            on { schemeCodeName } doReturn KeySchemeCodes.EDDSA_ED25519_CODE_NAME
+        }
+
+        val exception = assertThrows<IllegalArgumentException> {
+            key.validateSpecName(SignatureSpecs.EDDSA_ED25519.signatureName, KeySpecExtractor.KeySpecType.SESSION)
+        }
+        assertThat(exception).hasMessageContaining("Invalid key scheme is used for session key")
+    }
+
+    @Test
+    fun `validateSpecName throws exception for invalid spec name for session key`() {
+        val exception = assertThrows<IllegalArgumentException> {
+            signingKey.validateSpecName(SignatureSpecs.EDDSA_ED25519.signatureName, KeySpecExtractor.KeySpecType.SESSION)
+        }
+        assertThat(exception).hasMessageContaining("Invalid key spec ${SignatureSpecs.EDDSA_ED25519.signatureName}.")
     }
 
     @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -1265,7 +1265,7 @@ class DynamicMemberRegistrationServiceTest {
             val exception = assertThrows<InvalidMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, context.toMap())
             }
-            assertThat(exception).hasMessageContaining("Invalid key scheme is used for session key")
+            assertThat(exception).hasMessageContaining("Invalid key scheme")
         }
 
         @Test

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -100,6 +100,7 @@ import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.membership.MembershipSchema
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.KeySchemeCodes.ECDSA_SECP256R1_CODE_NAME
+import net.corda.v5.crypto.KeySchemeCodes.EDDSA_ED25519_CODE_NAME
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.membership.MGMContext
 import net.corda.v5.membership.MemberContext
@@ -1244,6 +1245,41 @@ class DynamicMemberRegistrationServiceTest {
                 registrationService.register(registrationResultId, member, newContext.toMap())
             }
             assertThat(exception).hasMessageContaining("cannot be added, removed or updated")
+        }
+
+        @Test
+        fun `registration fails when invalid key scheme is used for session key`() {
+            val sessionCryptoSigningKeyWithInvalidScheme: CryptoSigningKey = mock {
+                on { publicKey } doReturn ByteBuffer.wrap(SESSION_KEY.toByteArray())
+                on { id } doReturn SESSION_KEY_ID
+                on { schemeCodeName } doReturn EDDSA_ED25519_CODE_NAME
+                on { category } doReturn SESSION_INIT
+            }
+            whenever(cryptoOpsClient.lookupKeysByIds(memberId.value, listOf(ShortHash.of(SESSION_KEY_ID)))).doReturn(
+                listOf(sessionCryptoSigningKeyWithInvalidScheme)
+            )
+
+            postConfigChangedEvent()
+            registrationService.start()
+
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, context.toMap())
+            }
+            assertThat(exception).hasMessageContaining("Invalid key scheme is used for session key")
+        }
+
+        @Test
+        fun `registration fails when invalid session key spec is used`() {
+            val context = context.filterNot { it.key == SESSION_KEYS_SIGNATURE_SPEC.format(0) } +
+                    mapOf(SESSION_KEYS_SIGNATURE_SPEC.format(0) to SignatureSpecs.EDDSA_ED25519.signatureName)
+
+            postConfigChangedEvent()
+            registrationService.start()
+
+            val exception = assertThrows<InvalidMembershipRegistrationException> {
+                registrationService.register(registrationResultId, member, context.toMap())
+            }
+            assertThat(exception).hasMessageContaining("Invalid key spec ${SignatureSpecs.EDDSA_ED25519.signatureName}.")
         }
 
         @Test


### PR DESCRIPTION
The p2p e2e session protocol does not support EDDSA at the moment, it only supports RSA and ECDSA. Every request that tries to use any other scheme apart from RSA and ECDSA for session keys should be marked as invalid.

**Testing**
1) Generated session key using CORDA.EDDSA.ED25519 scheme and tried to register
<img width="1696" alt="Screenshot 2023-09-06 at 09 49 41" src="https://github.com/corda/corda-runtime-os/assets/61757742/abdc735b-695b-45af-8f92-0cb57132192b">
<img width="1680" alt="Screenshot 2023-09-06 at 15 20 15" src="https://github.com/corda/corda-runtime-os/assets/61757742/119833a5-22fc-440f-a7fa-f811283ed4bf">


2) Generated session key using CORDA.ECDSA.SECP256R1 scheme, but defined EdDSA as signature spec in the registration context
<img width="1693" alt="Screenshot 2023-09-06 at 09 53 21" src="https://github.com/corda/corda-runtime-os/assets/61757742/49bbb6db-2ad8-4e1d-b21e-fbacf19c7f65">

