### PR TITLE
ES-1305: silence interop notifications in release/os/* slack channel

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -7,5 +7,6 @@ endToEndPipeline(
     gradleTestTargetsToExecute: ['smokeTest', 'e2eTest'],
     usePackagedCordaHelmChart: false,
     // TODO - remove this when J17 is the default in the pipeline
-    javaVersion: '17'
+    javaVersion: '17',
+    enableNotifications : false
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,5 +15,6 @@ cordaPipeline(
     // allow publishing an installer to a download site
     publishToDownloadSiteTask: ':tools:plugins:publish',
     // TODO - remove this when J17 is the default in the pipeline
-    javaVersion: '17'
+    javaVersion: '17',
+    enableNotifications : false
     )


### PR DESCRIPTION
Silence build failure notifications in the release/os/* slack channel for this branch as it is excess noise here 