### PR TITLE
CORE-15391 Add support for custom checkpoint state

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -1,8 +1,11 @@
 package net.corda.flow.state.impl
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import java.nio.ByteBuffer
 import java.time.Instant
 import net.corda.data.ExceptionEnvelope
+import net.corda.data.KeyValuePair
+import net.corda.data.KeyValuePairList
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
 import net.corda.data.flow.event.FlowEvent
@@ -25,6 +28,19 @@ class FlowCheckpointImpl(
     private val config: SmartConfig,
     instantProvider: () -> Instant
 ) : FlowCheckpoint {
+
+    init {
+        if (checkpoint.customState == null) {
+            val newCustomState = KeyValuePairList.newBuilder()
+                .setItems(listOf())
+                .build()
+            checkpoint.customState = newCustomState
+        }
+    }
+
+    private companion object {
+        val objectMapper = ObjectMapper()
+    }
 
     private val pipelineStateManager = PipelineStateManager(checkpoint.pipelineState, config, instantProvider)
     private var flowStateManager = checkpoint.flowState?.let(::FlowStateManager)
@@ -128,9 +144,6 @@ class FlowCheckpointImpl(
     override val initialPlatformVersion: Int
         get() = checkpoint.initialPlatformVersion
 
-    override val flowMetricsState: String
-        get() = checkpoint.flowMetricsState ?: "{}"
-
     override fun initFlowState(flowStartContext: FlowStartContext, cpkFileHashes: Set<SecureHash>) {
         if (flowStateManager != null) {
             val key = flowStartContext.statusKey
@@ -213,8 +226,25 @@ class FlowCheckpointImpl(
         pipelineStateManager.setPendingPlatformError(type, message)
     }
 
-    override fun setMetricsState(stateJson: String) {
-        checkpoint.flowMetricsState = stateJson
+    override fun writeCustomState(state: Any) {
+        val key = state.javaClass.name
+        val newState = KeyValuePair.newBuilder()
+            .setKey(key)
+            .setValue(objectMapper.writeValueAsString(state))
+            .build()
+
+        checkpoint.customState = KeyValuePairList
+            .newBuilder()
+            .setItems(checkpoint.customState.items.filterNot { it.key == key } + newState)
+            .build()
+    }
+
+    override fun <T> readCustomState(clazz: Class<T>): T? {
+        return checkpoint.customState.items
+            .firstOrNull { it.key == clazz.name }
+            ?.let {
+                objectMapper.readValue(it.value, clazz)
+            }
     }
 
     override fun toAvro(): Checkpoint? {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -29,6 +29,13 @@ class FlowCheckpointImpl(
     instantProvider: () -> Instant
 ) : FlowCheckpoint {
 
+    /**
+     * It's important that we guard against null values for default fields added between versions of the Avro object.
+     * An edge condition exists where an existing checkpoint for a previous version can be loaded
+     * by the newer version. In these cases any new, default fields will be null. initFlowState() is only called when
+     * the checkpoint is first created, so it's important we check these fields each time we create an instance
+     * of FlowCheckpointImpl.
+     */
     init {
         if (checkpoint.customState == null) {
             val newCustomState = KeyValuePairList.newBuilder()

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/state/FlowCheckpointImplTest.kt
@@ -7,6 +7,7 @@ import java.time.Instant
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePair
+import net.corda.data.KeyValuePairList
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
 import net.corda.data.flow.event.FlowEvent
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 
+@Suppress("LargeClass")
 class FlowCheckpointImplTest {
     private val flowConfig = ConfigFactory.empty()
         .withValue(FlowConfig.PROCESSING_MAX_FLOW_SLEEP_DURATION, ConfigValueFactory.fromAnyRef(60000L))
@@ -284,7 +286,12 @@ class FlowCheckpointImplTest {
         flowCheckpoint.suspendedOn = "A"
         flowCheckpoint.waitingFor = waitingFor
         val flowStackItem =
-            flowCheckpoint.flowStack.pushWithContext(flow, userPropertiesLevel0.avro, platformPropertiesLevel0.avro, mock())
+            flowCheckpoint.flowStack.pushWithContext(
+                flow,
+                userPropertiesLevel0.avro,
+                platformPropertiesLevel0.avro,
+                mock()
+            )
         flowCheckpoint.putSessionState(session1)
         flowCheckpoint.serializedFiber = serializedFiber
 
@@ -297,7 +304,8 @@ class FlowCheckpointImplTest {
         assertThat(avroCheckpoint.flowState.fiber).isEqualTo(serializedFiber)
         assertThat(avroCheckpoint.pipelineState.maxFlowSleepDuration).isEqualTo(60000)
 
-        assertThat(avroCheckpoint.flowState.flowStackItems[0].contextUserProperties).isEqualTo(userPropertiesLevel0.avro)
+        assertThat(avroCheckpoint.flowState.flowStackItems[0].contextUserProperties)
+            .isEqualTo(userPropertiesLevel0.avro)
         assertThat(avroCheckpoint.flowState.flowStackItems[0].contextPlatformProperties).isEqualTo(
             platformPropertiesLevel0.avro
         )
@@ -517,10 +525,12 @@ class FlowCheckpointImplTest {
 
     @Test
     fun `rollback - original state restored when checkpoint rolled back from init`() {
-        val flowCheckpoint = createFlowCheckpoint(setupAvroCheckpoint(initialiseFlowState = false,
-            retryState = RetryState().apply {
-                retryCount = 1
-        }))
+        val flowCheckpoint = createFlowCheckpoint(
+            setupAvroCheckpoint(initialiseFlowState = false,
+                retryState = RetryState().apply {
+                    retryCount = 1
+                })
+        )
         val context = FlowStartContext().apply {
             statusKey = FlowKey(FLOW_ID_1, BOB_X500_HOLDING_IDENTITY)
             identity = BOB_X500_HOLDING_IDENTITY
@@ -764,6 +774,86 @@ class FlowCheckpointImplTest {
         val avroCheckpoint = flowCheckpoint.toAvro()
         assertThat(avroCheckpoint!!.flowState!!.externalEventState).isEqualTo(externalEventState)
     }
+
+    @Test
+    fun `existing checkpoint - read missing custom state returns null`() {
+        val checkpoint = setupAvroCheckpoint()
+        val flowCheckpoint = createFlowCheckpoint(checkpoint)
+        val storedState = flowCheckpoint.readCustomState(ExampleCustomState::class.java)
+        assertThat(storedState).isNull()
+    }
+
+    @Test
+    fun `existing checkpoint - read  custom state`() {
+        val checkpoint = setupAvroCheckpoint()
+        val avroState = KeyValuePair.newBuilder()
+            .setKey(ExampleCustomState::class.java.name)
+            .setValue("{ \"name\": \"test\"}")
+            .build()
+        checkpoint.customState = KeyValuePairList.newBuilder()
+            .setItems(listOf(avroState))
+            .build()
+
+        val flowCheckpoint = createFlowCheckpoint(checkpoint)
+        val storedState = flowCheckpoint.readCustomState(ExampleCustomState::class.java)
+        assertThat(storedState).isNotNull
+        assertThat(storedState!!.name).isEqualTo("test")
+    }
+
+    @Test
+    fun `existing checkpoint - write new custom state updates avro`() {
+        val checkpoint = setupAvroCheckpoint()
+        val flowCheckpoint = createFlowCheckpoint(checkpoint)
+        flowCheckpoint.writeCustomState(ExampleCustomState().apply { name = "test" })
+
+        val expectedAvroCustomState = KeyValuePairList.newBuilder()
+            .setItems(
+                listOf(
+                    KeyValuePair.newBuilder()
+                        .setKey(ExampleCustomState::class.java.name)
+                        .setValue("{\"name\":\"test\"}")
+                        .build()
+                )
+            )
+            .build()
+
+        val avroCheckpoint = flowCheckpoint.toAvro()
+        assertThat(avroCheckpoint!!.customState).isEqualTo(expectedAvroCustomState)
+    }
+
+    @Test
+    fun `existing checkpoint - write updated custom state updates avro`() {
+        val checkpoint = setupAvroCheckpoint()
+        val flowCheckpoint = createFlowCheckpoint(checkpoint)
+
+        val existingAvroCustomState = KeyValuePair.newBuilder()
+            .setKey(ExampleCustomState::class.java.name)
+            .setValue("{\"name\":\"test1\"}")
+            .build()
+        checkpoint.customState = KeyValuePairList.newBuilder()
+            .setItems(listOf(existingAvroCustomState))
+            .build()
+
+        flowCheckpoint.writeCustomState(ExampleCustomState().apply { name = "test2" })
+
+        val expectedAvroCustomState = KeyValuePairList.newBuilder()
+            .setItems(
+                listOf(
+                    KeyValuePair.newBuilder()
+                        .setKey(ExampleCustomState::class.java.name)
+                        .setValue("{\"name\":\"test2\"}")
+                        .build()
+                )
+            )
+            .build()
+
+        val avroCheckpoint = flowCheckpoint.toAvro()
+        assertThat(avroCheckpoint!!.customState).isEqualTo(expectedAvroCustomState)
+    }
+}
+
+class ExampleCustomState {
+    var name: String? = null
 }
 
 @InitiatingFlow(protocol = "valid-example")

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=.1.0.18-alpha-1694076421682
+cordaApiVersion=5.1.0.18-alpha-1694089690239
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.18-beta+
+cordaApiVersion=.1.0.18-alpha-1694076421682
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
 #cordaApiVersion=5.1.0.xxx-SNAPSHOT
-cordaApiVersion=5.1.0.18-alpha-1694089690239
+cordaApiVersion=5.1.0.18-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
@@ -16,6 +16,7 @@ import net.corda.virtualnode.HoldingIdentity
 /**
  * The FlowCheckpoint provides an API for managing the checkpoint during the processing of a flow.
  */
+@Suppress("TooManyFunctions")
 interface FlowCheckpoint : NonSerializable {
     val cpkFileHashes: Set<SecureHash>
 
@@ -55,8 +56,6 @@ interface FlowCheckpoint : NonSerializable {
 
     val initialPlatformVersion: Int
 
-    val flowMetricsState: String
-
     fun initFlowState(flowStartContext: FlowStartContext, cpkFileHashes: Set<SecureHash>)
 
     fun getSessionState(sessionId: String): SessionState?
@@ -79,7 +78,9 @@ interface FlowCheckpoint : NonSerializable {
 
     fun setPendingPlatformError(type: String, message: String)
 
-    fun setMetricsState(stateJson :String)
+    fun <T> readCustomState(clazz:Class<T>): T?
+
+    fun writeCustomState(state:Any)
 
     fun toAvro(): Checkpoint?
 }


### PR DESCRIPTION
Add support for custom state to be stored in the checkpoint. This has been added to allow external flow event handlers to store local state that can span flow suspensions. As part of this change the state used for metrics has been migrated to use the new custom state.