### PR TITLE
CORE-16992: Set to Corda managed schema if using cluster DB or DDL provided

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -15,8 +15,11 @@ import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.schema.configuration.DatabaseConfig
 import net.corda.schema.configuration.VirtualNodeDatasourceConfig
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbFactoryImpl
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -27,6 +30,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class VirtualNodeDbFactoryImplTest {
+
     private val smartConfigFactory = mock<SmartConfigFactory> {
         on { makeSecret(any(), any()) } doAnswer {
             mock<SmartConfig> {
@@ -152,4 +156,81 @@ class VirtualNodeDbFactoryImplTest {
         val uniquenessDdlConfig = dbs[VirtualNodeDbType.UNIQUENESS]?.dbConnections?.get(DbPrivilege.DDL)?.config
         assertNull(uniquenessDdlConfig)
     }
+
+    @Test
+    fun `createVNodeDbs sets isPlatformManagedDb to true when using the cluster DB`() {
+        val request = VirtualNodeCreateRequest(
+            /* holdingId = */ mock(),
+            /* cpiFileChecksum = */ "",
+            /* vaultDdlConnection = */ "",
+            /* vaultDmlConnection = */ "",
+            /* cryptoDdlConnection = */ "",
+            /* cryptoDmlConnection = */ "",
+            /* uniquenessDdlConnection = */ "",
+            /* uniquenessDmlConnection = */ "",
+            /* updateActor = */ ""
+        )
+
+        val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
+
+        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
+    }
+
+    @Test
+    fun `createVNodeDbs sets isPlatformManagedDb to true when provided with DML and DDL connection`() {
+        val request = VirtualNodeCreateRequest(
+            /* holdingId = */ mock(),
+            /* cpiFileChecksum = */ "",
+            /* vaultDdlConnection = */ "{}",
+            /* vaultDmlConnection = */ "{}",
+            /* cryptoDdlConnection = */ "{}",
+            /* cryptoDmlConnection = */ "{}",
+            /* uniquenessDdlConnection = */ "{}",
+            /* uniquenessDmlConnection = */ "{}",
+            /* updateActor = */ ""
+        )
+
+        val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
+
+        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
+    }
+
+    @Test
+    fun `createVNodeDbs sets isPlatformManagedDb to false when provided with DML connection but no DDL connection`() {
+        val request = VirtualNodeCreateRequest(
+            /* holdingId = */ mock(),
+            /* cpiFileChecksum = */ "",
+            /* vaultDdlConnection = */ "",
+            /* vaultDmlConnection = */ "{}",
+            /* cryptoDdlConnection = */ "",
+            /* cryptoDmlConnection = */ "{}",
+            /* uniquenessDdlConnection = */ "",
+            /* uniquenessDmlConnection = */ "{}",
+            /* updateActor = */ ""
+        )
+
+        val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
+
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.isPlatformManagedDb, dbType.name) } })
+    }
+
+    @Test
+    fun `createVNodeDbs sets isPlatformManagedDb to true when provided with DDL no DML connection - uses cluster DB - DDL ignored`() {
+        val request = VirtualNodeCreateRequest(
+            /* holdingId = */ mock(),
+            /* cpiFileChecksum = */ "",
+            /* vaultDdlConnection = */ "{}",
+            /* vaultDmlConnection = */ "",
+            /* cryptoDdlConnection = */ "{}",
+            /* cryptoDmlConnection = */ "",
+            /* uniquenessDdlConnection = */ "{}",
+            /* uniquenessDmlConnection = */ "",
+            /* updateActor = */ ""
+        )
+
+        val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
+
+        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
+    }
+
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -233,4 +233,29 @@ class VirtualNodeDbFactoryImplTest {
         assertAll(dbs.map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
     }
 
+
+    @Test
+    fun `createVNodeDbs sets isPlatformManagedDb to false when uniqueness is none`() {
+        val request = VirtualNodeCreateRequest(
+            /* holdingId = */ mock(),
+            /* cpiFileChecksum = */ "",
+            /* vaultDdlConnection = */ "{}",
+            /* vaultDmlConnection = */ "{}",
+            /* cryptoDdlConnection = */ "{}",
+            /* cryptoDmlConnection = */ "{}",
+            /* uniquenessDdlConnection = */ "none",
+            /* uniquenessDmlConnection = */ "none",
+            /* updateActor = */ ""
+        )
+
+        val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
+
+        // Uniqueness is set to false
+        assertAll(dbs.filter { (dbType, _) -> dbType == VirtualNodeDbType.UNIQUENESS }
+            .map { (dbType, db) -> { assertFalse(db.isPlatformManagedDb, dbType.name) } })
+        // Other types are set to true
+        assertAll(dbs.filter { (dbType, _) -> dbType != VirtualNodeDbType.UNIQUENESS }
+            .map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
+    }
+
 }


### PR DESCRIPTION
* `isPlatformManagedDb` will be set to true if we are using the cluster DB or if DDL connection string provided
* Invert the if statement to reduce the number of NOT operations in use and make the method easier to understand