### PR TITLE
CORE-17024: Remove the non-serializable FlowCheckpointImpl from the fiber stack

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/impl/FlowSessionImpl.kt
@@ -117,12 +117,16 @@ class FlowSessionImpl(
 
     @Suspendable
     override fun close() {
-        val flowCheckpoint = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint
-        val sessionState = flowCheckpoint.getSessionState(sourceSessionId)
-        if(sessionState?.status != SessionStateType.CLOSED) {
+        if (canCloseSession()) {
             fiber.suspend(FlowIORequest.CloseSessions(setOf(sourceSessionId)))
             log.trace { "Closing session: $sourceSessionId" }
         }
+    }
+
+    private fun canCloseSession() : Boolean {
+        val flowCheckpoint = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint
+        val sessionState = flowCheckpoint.getSessionState(sourceSessionId)
+        return sessionState?.status != SessionStateType.CLOSED
     }
 
     private fun serialize(payload: Any): ByteArray {


### PR DESCRIPTION
**Problem statement**

It is possible to accidentally attempt to serialize `FlowCheckpointImpl`, because the fiber may attempt to suspend in `FlowSessionImpl.close` while the checkpoint object is on the stack. `FlowCheckpointImpl` is marked as non-serializable, so attempting to do this will fail, triggering a flow failure.

**Solution**

Move the code referencing the flow checkpoint to a separate private method that is no longer on the stack at the point the function suspends. This ensures that the problematic class is not pulled in by Kryo.

Note that the new function does not itself need to be `@Suspendable` as the fiber cannot suspend in the function body.

**Testing**

Ran the e2etests with this fix in place, with the previously failing tests now passing.