### PR TITLE
CORE-16983 Interop / Jackson serializers and deserializers for DigitalSignatureAndMetadata

### DIFF
--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     implementation project(':libs:platform-info')
     implementation project(":libs:serialization:serialization-avro")
     implementation project(":libs:tracing")
+    implementation project(':libs:crypto:merkle-impl')
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/interop/ProofOfActionSerializers.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/interop/ProofOfActionSerializers.kt
@@ -1,0 +1,295 @@
+@file:Suppress("WildcardImport")
+package net.corda.flow.application.services.impl.interop
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonToken
+import com.fasterxml.jackson.databind.*
+import com.fasterxml.jackson.databind.module.SimpleModule
+import net.corda.base.internal.ByteSequence
+import net.corda.base.internal.OpaqueBytes
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
+import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.core.SecureHashImpl
+import net.corda.crypto.core.parseSecureHash
+import net.corda.crypto.merkle.impl.IndexedMerkleLeafImpl
+import net.corda.crypto.merkle.impl.MerkleProofImpl
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.crypto.DigitalSignatureMetadata
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.SignatureSpec
+import net.corda.v5.crypto.merkle.IndexedMerkleLeaf
+import net.corda.v5.crypto.merkle.MerkleProof
+import net.corda.v5.crypto.merkle.MerkleProofType
+import java.lang.RuntimeException
+import java.time.Instant
+
+object ProofOfActionSerialisationModule {
+    val module = SimpleModule().apply {
+        addSerializer(MerkleProof::class.java, MerkleProofSerializer())
+        addDeserializer(MerkleProof::class.java, MerkleProofDeserializer())
+        addSerializer(SignatureSpec::class.java, SignatureSpecSerializer())
+        addDeserializer(SignatureSpec::class.java, SignatureSpecDeserializer())
+        addSerializer(DigitalSignatureMetadata::class.java, DigitalSignatureMetadataSerializer())
+        addDeserializer(DigitalSignatureMetadata::class.java, DigitalSignatureMetadataDeserializer())
+        addSerializer(DigitalSignature.WithKeyId::class.java, DigitalSignatureWithKeyIdSerializer())
+        addSerializer(DigitalSignatureWithKeyId::class.java, DigitalSignatureWithKeyIdSerializer())
+        addDeserializer(DigitalSignature.WithKeyId::class.java, DigitalSignatureWithKeyIdDeserializer())
+        addSerializer(DigitalSignatureAndMetadata::class.java, DigitalSignatureAndMetadataSerializer())
+        addDeserializer(DigitalSignatureAndMetadata::class.java, DigitalSignatureAndMetadataDeserializer())
+        addSerializer(IndexedMerkleLeaf::class.java, IndexedMerkleLeafSerializer())
+        addDeserializer(IndexedMerkleLeaf::class.java, IndexedMerkleLeafDeserializer())
+        addSerializer(OpaqueBytes::class.java, OpaqueBytesSerializer())
+        addDeserializer(OpaqueBytes::class.java, OpaqueBytesDeserializer())
+        addSerializer(ByteSequence::class.java, ByteSequenceSerializer())
+        addDeserializer(ByteSequence::class.java, ByteSequenceDeserializer())
+        addSerializer(SecureHash::class.java, SecureHashSerializer())
+        addSerializer(SecureHashImpl::class.java, SecureHashSerializer())
+        addDeserializer(SecureHash::class.java, SecureHashDeserializer())
+        addSerializer(IndexedMerkleLeaf::class.java, IndexedMerkleLeafSerializer())
+        addSerializer(IndexedMerkleLeafImpl::class.java, IndexedMerkleLeafSerializer())
+        addDeserializer(IndexedMerkleLeaf::class.java, IndexedMerkleLeafDeserializer())
+    }
+}
+
+class IndexedMerkleLeafSerializer : JsonSerializer<IndexedMerkleLeaf>() {
+    override fun serialize(
+        leaf: IndexedMerkleLeaf,
+        gen: JsonGenerator,
+        serializers: SerializerProvider
+    ) {
+        gen.writeStartObject()
+        gen.writeObjectField("index", leaf.getIndex())
+        gen.writeObjectField("nonce", leaf.getNonce())
+        gen.writeObjectField("leafData", leaf.getLeafData())
+        gen.writeEndObject()
+    }
+}
+
+class IndexedMerkleLeafDeserializer : JsonDeserializer<IndexedMerkleLeaf>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): IndexedMerkleLeafImpl {
+        val node: JsonNode = parser.codec.readTree(parser)
+        val index = node.get("index").asInt()
+        val nonce = if (node.has("nonce")) node.get("nonce").binaryValue() else null
+        val leafData = node.get("leafData").binaryValue()
+
+        return IndexedMerkleLeafImpl(index, nonce, leafData)
+    }
+}
+
+class MerkleProofSerializer : JsonSerializer<MerkleProof>() {
+    override fun serialize(
+        merkleProof: MerkleProof,
+        generator: JsonGenerator,
+        provider: SerializerProvider
+    ) {
+        generator.writeStartObject()
+        generator.writeStringField("proofType", merkleProof.getProofType().name)
+        generator.writeNumberField("treeSize", merkleProof.getTreeSize())
+        generator.writeArrayFieldStart("leaves")
+        for (leaf in merkleProof.leaves) {
+            generator.writeObject(leaf)
+        }
+        generator.writeEndArray()
+        generator.writeArrayFieldStart("hashes")
+        for (hash in merkleProof.hashes) {
+            generator.writeObject(hash)
+        }
+        generator.writeEndArray()
+        generator.writeEndObject()
+    }
+}
+
+class MerkleProofDeserializer : JsonDeserializer<MerkleProof>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): MerkleProof {
+        val node: JsonNode = parser.codec.readTree(parser)
+        val proofType = MerkleProofType.valueOf(node.get("proofType").asText())
+        val treeSize = node.get("treeSize").asInt()
+        val leavesNode = node.get("leaves")
+        val leaves = mutableListOf<IndexedMerkleLeaf>()
+        for (leafNode in leavesNode) {
+            val leaf = parser.codec.treeToValue(leafNode, IndexedMerkleLeaf::class.java)
+            leaves.add(leaf)
+        }
+        val hashesNode = node.get("hashes")
+        val hashes = mutableListOf<SecureHash>()
+        for (hashNode in hashesNode) {
+            val hash = parser.codec.treeToValue(hashNode, SecureHash::class.java)
+            hashes.add(hash)
+        }
+        return MerkleProofImpl(proofType, treeSize, leaves, hashes)
+    }
+}
+
+class SignatureSpecSerializer : JsonSerializer<SignatureSpec>() {
+    override fun serialize(
+        spec: SignatureSpec,
+        generator: JsonGenerator,
+        provider: SerializerProvider
+    ) {
+        generator.writeString(spec.getSignatureName())
+    }
+}
+
+class SignatureSpecDeserializer : JsonDeserializer<SignatureSpec>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): SignatureSpec {
+        val signatureName = parser.text
+        return SignatureSpecImpl(signatureName)
+    }
+}
+
+
+class DigitalSignatureMetadataSerializer : JsonSerializer<DigitalSignatureMetadata>() {
+    override fun serialize(
+        metadata: DigitalSignatureMetadata,
+        generator: JsonGenerator,
+        provider: SerializerProvider
+    ) {
+        generator.writeStartObject()
+        generator.writeStringField("timestamp", metadata.timestamp.toString())
+        generator.writeObjectField("signatureSpec", metadata.signatureSpec)
+        generator.writeObjectField("properties", metadata.properties)
+        generator.writeEndObject()
+    }
+}
+
+class DigitalSignatureMetadataDeserializer : JsonDeserializer<DigitalSignatureMetadata>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): DigitalSignatureMetadata {
+        val node = parser.codec.readTree(parser) as JsonNode
+        val timestamp = Instant.parse(node.get("timestamp").asText())
+        val signatureSpec = parser.codec.treeToValue(node.get("signatureSpec"), SignatureSpec::class.java)
+        @Suppress("unchecked_cast")
+        val properties = parser.codec.treeToValue(node.get("properties"), Map::class.java).toMutableMap() as MutableMap<String, String>
+        return DigitalSignatureMetadata(timestamp, signatureSpec, properties)
+    }
+}
+
+class DigitalSignatureAndMetadataSerializer : JsonSerializer<DigitalSignatureAndMetadata>() {
+    override fun serialize(
+        signatureAndMetadata: DigitalSignatureAndMetadata,
+        generator: JsonGenerator,
+        provider: SerializerProvider
+    ) {
+        generator.writeStartObject()
+        generator.writeObjectField("signature", signatureAndMetadata.signature)
+        generator.writeObjectField("metadata", signatureAndMetadata.metadata)
+        generator.writeObjectField("proof", signatureAndMetadata.proof)
+        generator.writeEndObject()
+    }
+}
+
+class OpaqueBytesSerializer : JsonSerializer<OpaqueBytes>() {
+    override fun serialize(
+        opaqueBytes: OpaqueBytes,
+        generator: JsonGenerator,
+        provider: SerializerProvider
+    ) {
+        generator.writeBinary(opaqueBytes.getBytes())
+    }
+}
+
+class OpaqueBytesDeserializer : JsonDeserializer<OpaqueBytes>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): OpaqueBytes {
+        val bytes = parser.getBinaryValue()
+        return OpaqueBytes(bytes)
+    }
+}
+
+class DigitalSignatureAndMetadataDeserializer : JsonDeserializer<DigitalSignatureAndMetadata>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): DigitalSignatureAndMetadata {
+        val node = parser.codec.readTree(parser) as JsonNode
+        val signature = parser.codec.treeToValue(node.get("signature"), DigitalSignature.WithKeyId::class.java)
+        val metadata = parser.codec.treeToValue(node.get("metadata"), DigitalSignatureMetadata::class.java)
+        val proof = parser.codec.treeToValue(node.get("proof"), MerkleProof::class.java)
+        return DigitalSignatureAndMetadata(signature, metadata, proof)
+    }
+}
+
+class ByteSequenceSerializer : JsonSerializer<ByteSequence>() {
+    override fun serialize(
+        byteSequence: ByteSequence,
+        generator: JsonGenerator,
+        provider: SerializerProvider
+    ) {
+        generator.writeBinary(byteSequence.getBytes())
+    }
+}
+
+class ByteSequenceDeserializer : JsonDeserializer<ByteSequence>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): ByteSequence {
+        val bytes = parser.getBinaryValue()
+        return OpaqueBytes(bytes)
+    }
+}
+
+class DigitalSignatureWithKeyIdSerializer : JsonSerializer<DigitalSignature.WithKeyId>() {
+    override fun serialize(
+        signature: DigitalSignature.WithKeyId?,
+        generator: JsonGenerator?,
+        provider: SerializerProvider
+    ) {
+        generator!!.writeStartObject()
+        generator.writeObjectField("by", signature!!.by)
+        generator.writeFieldName("bytes")
+        generator.writeBinary(signature.bytes)
+        generator.writeEndObject()
+    }
+}
+
+class DigitalSignatureWithKeyIdDeserializer : JsonDeserializer<DigitalSignature.WithKeyId>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): DigitalSignature.WithKeyId {
+        val node = parser.codec.readTree(parser) as JsonNode
+        val by = parser.codec.treeToValue(node.get("by"), SecureHash::class.java)
+        val bytes = node.get("bytes").binaryValue()
+        return DigitalSignatureWithKeyId(by, bytes)
+    }
+}
+
+class SecureHashSerializer : JsonSerializer<SecureHash>() {
+    override fun serialize(
+        secureHash: SecureHash,
+        generator: JsonGenerator,
+        provider: SerializerProvider
+    ) {
+        generator.writeString(secureHash.toString())
+    }
+}
+
+@Suppress("TooGenericExceptionThrown")
+class SecureHashDeserializer : JsonDeserializer<SecureHash>() {
+    override fun deserialize(
+        parser: JsonParser,
+        ctxt: DeserializationContext
+    ): SecureHash {
+        if (parser.currentToken == JsonToken.VALUE_STRING) {
+            return parseSecureHash(parser.text)
+        }
+
+        throw RuntimeException("Expected a string for SecureHash")
+    }
+}

--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     testImplementation project(':libs:serialization:serialization-amqp')
     testImplementation project(':libs:serialization:serialization-kryo')
     testImplementation project(':testing:ledger:ledger-utxo-base-test')
+    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project(':testing:sandboxes-testkit')

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -83,7 +83,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
         val wireTransaction = wireTransactionFactory.create(componentGroups)
 
         utxoLedgerTransactionVerificationService.verify(utxoLedgerTransactionFactory.create(wireTransaction))
-
+        //simon
         val signaturesWithMetadata =
             transactionSignatureService.sign(
                 wireTransaction,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -83,7 +83,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
         val wireTransaction = wireTransactionFactory.create(componentGroups)
 
         utxoLedgerTransactionVerificationService.verify(utxoLedgerTransactionFactory.create(wireTransaction))
-        //simon
+
         val signaturesWithMetadata =
             transactionSignatureService.sign(
                 wireTransaction,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/interop/serialisation/ProofOfActionSerializationTests.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/interop/serialisation/ProofOfActionSerializationTests.kt
@@ -1,0 +1,141 @@
+@file:Suppress("WildcardImport")
+package net.corda.interop.serialisation
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import net.corda.common.json.serializers.standardTypesModule
+import net.corda.crypto.impl.CompositeKeyProviderImpl
+import net.corda.flow.application.services.impl.interop.*
+import net.corda.ledger.common.testkit.anotherPublicKeyExample
+import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
+import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.utxo.flow.impl.transaction.*
+import net.corda.ledger.utxo.test.UtxoLedgerTest
+import net.corda.ledger.utxo.testkit.UtxoCommandExample
+import net.corda.ledger.utxo.testkit.getUtxoStateExample
+import net.corda.ledger.utxo.testkit.utxoTimeWindowExample
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.membership.NotaryInfo
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.security.KeyPairGenerator
+import java.security.spec.ECGenParameterSpec
+import java.util.*
+import kotlin.test.assertEquals
+
+class ProofOfActionSerializationTests : UtxoLedgerTest() {
+    companion object {
+
+        private lateinit var signedTransaction: UtxoSignedTransactionInternal
+
+        private val kpg: KeyPairGenerator = KeyPairGenerator.getInstance("EC").apply {
+            initialize(ECGenParameterSpec("secp256r1"))
+        }
+        private val notaryNode1PublicKey = kpg.generateKeyPair().public
+        private val notaryNode2PublicKey = kpg.generateKeyPair().public
+        private val notaryKey =
+            CompositeKeyProviderImpl().createFromKeys(listOf(notaryNode1PublicKey, notaryNode2PublicKey), 1).also {
+                println(it)
+            }
+        private val notaryX500Name = MemberX500Name.parse("O=ExampleNotaryService, L=London, C=GB")
+        private val notary = notaryX500Name
+
+        private val jsonMapper =
+            JsonMapper.builder().enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build().apply {
+                registerModule(KotlinModule.Builder().build())
+                registerModule(JavaTimeModule())
+                enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+                setTimeZone(TimeZone.getTimeZone("UTC"))
+                disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                registerModule(standardTypesModule())
+                /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+                /* Here is System under the test : ProofOfActionSerialisationModule.module */
+                registerModule(ProofOfActionSerialisationModule.module)
+            }
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        val notaryInfo = mock<NotaryInfo>().also {
+            whenever(it.name).thenReturn(notaryX500Name)
+            whenever(it.publicKey).thenReturn(notaryKey)
+        }
+        whenever(mockNotaryLookup.lookup(notaryX500Name)).thenReturn(notaryInfo)
+        signedTransaction = UtxoTransactionBuilderImpl(
+            utxoSignedTransactionFactory,
+            mockNotaryLookup
+        )
+            .setNotary(notary)
+            .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
+            .addOutputState(getUtxoStateExample())
+            .addSignatories(listOf(anotherPublicKeyExample))
+            .addCommand(UtxoCommandExample())
+            .toSignedTransaction() as UtxoSignedTransactionInternal
+    }
+
+    @Test
+    fun secureHash() {
+        val by: SecureHash = getSignatureWithMetadataExample(notaryNode1PublicKey).by
+        val json = jsonMapper.writeValueAsString(by)
+        val deserializeObject = jsonMapper.readValue(json, SecureHash::class.java)
+        assertEquals(by, deserializeObject)
+    }
+
+    @Test
+    fun digitalSignatureWithKeyId() {
+        val signature: DigitalSignature.WithKeyId = getSignatureWithMetadataExample(notaryNode1PublicKey).signature
+        val json = jsonMapper.writeValueAsString(signature)
+        val deserializeObject = jsonMapper.readValue(json, DigitalSignature.WithKeyId::class.java)
+        assertEquals(signature, deserializeObject)
+    }
+
+    @Test
+    fun digitalSignatureAndMetadataWithoutProof() {
+        val signature: DigitalSignatureAndMetadata = getSignatureWithMetadataExample(notaryNode1PublicKey)
+        assertNull(signature.proof)
+        val json = jsonMapper.writeValueAsString(signature)
+        val deserializeObject = jsonMapper.readValue(json, DigitalSignatureAndMetadata::class.java)
+        assertEquals(signature, deserializeObject)
+    }
+
+    @Test
+    fun digitalSignatureAndMetadata() {
+        val batchSignatures = realSingingService.signBatch(listOf(signedTransaction), listOf(publicKeyExample))
+        val signature: DigitalSignatureAndMetadata = batchSignatures.first().first()
+        assertNotNull(signature.proof)
+        val json = jsonMapper.writeValueAsString(signature)
+        val deserializedObject = jsonMapper.readValue(json, DigitalSignatureAndMetadata::class.java)
+        assertEquals(signature, deserializedObject)
+    }
+
+    @Test
+    fun testWithoutProofOfActionModule() {
+        // Mapper without ProofOfActionSerialisationModule.module
+        val jsonMapper =
+            JsonMapper.builder().enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build().apply {
+                registerModule(KotlinModule.Builder().build())
+                registerModule(JavaTimeModule())
+                enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+                setTimeZone(TimeZone.getTimeZone("UTC"))
+                disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                registerModule(standardTypesModule())
+            }
+        val batchSignatures = realSingingService.signBatch(listOf(signedTransaction), listOf(publicKeyExample))
+        val signature: DigitalSignatureAndMetadata = batchSignatures.first().first()
+        assertNotNull(signature.proof)
+        val json = jsonMapper.writeValueAsString(signature)
+        assertThrowsExactly(com.fasterxml.jackson.databind.exc.InvalidDefinitionException::class.java) {
+            jsonMapper.readValue(json, DigitalSignatureAndMetadata::class.java)
+        }
+    }
+}

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PublicKeyExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PublicKeyExample.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.common.testkit
 
+import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.PublicKey
 import java.security.spec.ECGenParameterSpec
@@ -12,3 +13,5 @@ val publicKeyExample: PublicKey = kpg
 
 val anotherPublicKeyExample: PublicKey = kpg
     .generateKeyPair().public
+
+val keyPairExample: KeyPair = kpg.generateKeyPair()

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -1,13 +1,22 @@
 package net.corda.ledger.utxo.test
 
+import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
+import net.corda.crypto.cipher.suite.SignatureSpecs
+import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.core.fullIdHash
+import net.corda.crypto.merkle.impl.MerkleTreeProviderImpl
+import net.corda.flow.application.crypto.SignatureSpecServiceImpl
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
+import net.corda.ledger.common.flow.impl.transaction.TransactionSignatureServiceImpl
 import net.corda.ledger.common.flow.impl.transaction.filtered.factory.FilteredTransactionFactoryImpl
+import net.corda.ledger.common.flow.transaction.TransactionSignatureVerificationServiceInternal
 import net.corda.ledger.common.test.CommonLedgerTest
 import net.corda.ledger.common.testkit.anotherPublicKeyExample
 import net.corda.ledger.common.testkit.fakeTransactionSignatureService
-import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.common.testkit.FakePlatformInfoProvider
+import net.corda.ledger.common.testkit.keyPairExample
 import net.corda.ledger.utxo.flow.impl.UtxoLedgerServiceImpl
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
@@ -24,10 +33,17 @@ import net.corda.ledger.utxo.testkit.getUtxoSignedTransactionExample
 import net.corda.ledger.utxo.testkit.notaryX500Name
 import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
+import net.corda.v5.application.crypto.SigningService
+import net.corda.v5.application.flows.FlowContextProperties
+import net.corda.v5.application.flows.FlowContextPropertyKeys
+import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.membership.NotaryInfo
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.security.PrivateKey
+import java.security.Signature
 
 abstract class UtxoLedgerTest : CommonLedgerTest() {
     private val mockUtxoLedgerPersistenceService = mock<UtxoLedgerPersistenceService>()
@@ -42,10 +58,12 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
     private val mockExternalEventExecutor = mock<ExternalEventExecutor>()
     private val mockResultSetFactory = mock<ResultSetFactory>()
 
+    private val notaryKeyPair = keyPairExample
+
     val mockNotaryLookup = mock<NotaryLookup>().also{
         val notaryExampleInfo = mock<NotaryInfo>().also {
             whenever(it.name).thenReturn(notaryX500Name)
-            whenever(it.publicKey).thenReturn(publicKeyExample)
+            whenever(it.publicKey).thenReturn(notaryKeyPair.public)
         }
 
         val anotherNotaryExampleInfo = mock<NotaryInfo>().also {
@@ -118,4 +136,48 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
 
     // This is the only not stateless.
     val utxoTransactionBuilder = UtxoTransactionBuilderImpl(utxoSignedTransactionFactory, mockNotaryLookup)
+
+    private fun signData(data: ByteArray, privateKey: PrivateKey): ByteArray {
+        val signature =
+            Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName)
+        signature.initSign(privateKey)
+        signature.update(data)
+        return signature.sign()
+    }
+
+    val realSingingService = TransactionSignatureServiceImpl(serializationServiceWithWireTx,
+        signingService = mock<SigningService>().also {
+            whenever(it.findMySigningKeys(any())).thenReturn(mapOf(notaryKeyPair.public to notaryKeyPair.public))
+            whenever(
+                it.sign(any(), any(), any())
+            ).thenReturn(
+                DigitalSignatureWithKeyId(
+                    notaryKeyPair.public.fullIdHash(),
+                    signData("abcdefgsfdsf".toByteArray(), notaryKeyPair.private)
+                    // TODO the method signs hardcoded string only,
+                    // try to change to use the actual parameter (byte array) passes to sign method
+                )
+            )
+        },
+        signatureSpecService = SignatureSpecServiceImpl(CipherSchemeMetadataImpl()),
+        merkleTreeProvider = MerkleTreeProviderImpl(digestService),
+        platformInfoProvider = FakePlatformInfoProvider(),
+        flowEngine = mock<FlowEngine>().also {
+            whenever(it.flowContextProperties).thenReturn(object : FlowContextProperties {
+                override fun put(key: String, value: String) {
+                    TODO("Not yet implemented")
+                }
+
+                override fun get(key: String): String? =
+                    when (key) {
+                        FlowContextPropertyKeys.CPI_NAME -> "Cordapp1"
+                        FlowContextPropertyKeys.CPI_VERSION -> "1"
+                        FlowContextPropertyKeys.CPI_SIGNER_SUMMARY_HASH -> "hash1234"
+                        // else FlowContextPropertyKeys.CPI_FILE_CHECKSUM
+                        else -> "1213213213"
+                    }
+            })
+        },
+        transactionSignatureVerificationServiceInternal = mock<TransactionSignatureVerificationServiceInternal>()
+    )
 }


### PR DESCRIPTION
Jackson serializers and deserializers for `DigitalSignatureAndMetadata` including all nested types used inside `DigitalSignatureAndMetadata` and especially proof of batch signature.

 The test using extended UtxoLedgerTest class which produces transaction with a Merkle tree proof - signed by "signBatch".
 Due to quite awkward dependencies between modules, the test is in UTXO module - as only this module can produce a sample signature with proof - this could be improved.

**TODO** OSGI issue to resolve -see failed Jenkins build

The second part of the work would be to add those serializes to the Facade Jackson module and modify Cordapp to send them (+ Facade).