### PR TITLE
CORE-17030 - Fix up SyncRPCSubscriptionlog level when response payload is null

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/SyncRPCSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/SyncRPCSubscriptionImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.subscription
 
-import java.util.UUID
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -15,6 +14,7 @@ import net.corda.web.api.HTTPMethod
 import net.corda.web.api.WebHandler
 import net.corda.web.api.WebServer
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 
 /**
@@ -83,7 +83,7 @@ internal class SyncRPCSubscriptionImpl<REQUEST : Any, RESPONSE : Any>(
                     context.result(serializedResponse)
                     context
                 } else {
-                    log.error("Response Payload was Null")
+                    log.warn("Response Payload was Null")
                     context.result("Response Payload was Null")
                     context.status(ResponseCode.BAD_REQUEST)
                     context


### PR DESCRIPTION
Expected log level is warning in this case as errors are reserved for cases where the processor cannot continue.