### PR TITLE
CORE-17051: Ensure pipeline context is updated with intermediate flow results

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -97,21 +97,18 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
                 "A transient exception was thrown the event that failed will be retried. event='${context.inputEvent}',  $exception"
             }
 
-            /**
-             * When retrying, the flow engine switches on whether to retry a previous event on whether the current input
-             * is a Wakeup or not. The mechanism for generating the Wakeup events that would trigger a retry has been
-             * removed, however, so publishing a Wakeup here is required to keep the retry feature alive.
-             *
-             * This is really only a temporary solution and a bit of a hack. Longer term this should be replaced with
-             * the new scheduler mechanism. It may also be possible to remove all sources of transient exceptions if
-             * the state storage solution is changed, which would allow this feature to be removed entirely.
-             */
             val payload = context.inputEventPayload ?: return@withEscalation process(
                 FlowFatalException(
                     "Could not process a retry as the input event has no payload.",
                     exception
                 ), context
             )
+
+            /**
+             * As we're still inside the retry window, republish the record that needs retrying here. If the system is
+             * under load, there may be some delay before it is retried. This is reasonable however, as the system may
+             * need to wait for the underlying transient problem to clear up.
+             */
             val records = createStatusRecord(context.checkpoint.flowId) {
                 flowMessageFactory.createFlowRetryingStatusMessage(context.checkpoint)
             } + flowRecordFactory.createFlowEventRecord(context.checkpoint.flowId, payload)
@@ -194,8 +191,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             // correctly. This shouldn't matter however - in this case we're treating the issue as the flow never
             // starting at all. We'll still log that the error was seen.
             log.warn(
-                "Could not create a flow status message for a failed flow with ID $id as " +
-                        "the flow start context was missing."
+                "Could not create a flow status message for a flow with ID $id as the flow start context was missing."
             )
             listOf()
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
@@ -82,7 +82,10 @@ internal class FlowEventPipelineImpl(
     }
 
     override fun executeFlow(timeout: Long): FlowEventPipeline {
-        context = flowExecutionPipelineStage.runFlow(context, timeout)
+        context = flowExecutionPipelineStage.runFlow(context, timeout) {
+            // Ensure the most up-to-date version of the context is visible in case an error occurs.
+            context = it
+        }
         return this
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
@@ -32,14 +32,8 @@ class FlowEventPipelineImplTest {
 
     private val payload = ExternalEventResponse("foo")
     private val waitingForWakeup = WaitingFor(WakeUpWaitingFor())
-    private val retryStartFlow = StartFlow()
 
     private val RUN_OR_CONTINUE_TIMEOUT = 60000L
-
-    private val retryEvent = FlowEvent().apply {
-        flowId = FLOW_ID_1
-        payload = retryStartFlow
-    }
 
     private val mockHoldingIdentity = mock<HoldingIdentity>().apply {
         whenever(shortHash).thenReturn(ShortHash.Companion.of("0123456789abc"))

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -72,7 +73,7 @@ class FlowEventPipelineImplTest {
     }
 
     private val mockFlowExecutionPipelineStage = mock<FlowExecutionPipelineStage>().apply {
-        whenever(runFlow(any(), any())).thenReturn(outputContext)
+        whenever(runFlow(any(), any(), any())).thenReturn(outputContext)
     }
 
     private val virtualNodeInfo = mock<VirtualNodeInfo>()
@@ -124,7 +125,7 @@ class FlowEventPipelineImplTest {
     fun `execute flow invokes the execute flow pipeline stage`() {
         val pipeline = buildPipeline()
         pipeline.executeFlow(RUN_OR_CONTINUE_TIMEOUT)
-        verify(mockFlowExecutionPipelineStage).runFlow(defaultinputContext, RUN_OR_CONTINUE_TIMEOUT)
+        verify(mockFlowExecutionPipelineStage).runFlow(eq(defaultinputContext), eq(RUN_OR_CONTINUE_TIMEOUT), any())
     }
 
     @Test

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
@@ -2,12 +2,10 @@ package net.corda.flow.pipeline.impl
 
 import net.corda.crypto.core.ShortHash
 import net.corda.data.flow.FlowStartContext
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.data.flow.state.waiting.external.ExternalEventResponse
 import net.corda.flow.BOB_X500
-import net.corda.flow.FLOW_ID_1
 import net.corda.flow.pipeline.FlowGlobalPostProcessor
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowMarkedForKillException

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStageTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStageTest.kt
@@ -79,8 +79,12 @@ class FlowExecutionPipelineStageTest {
             ioRequestTypeConverter
         )
 
+        var contextUpdateCount = 0
         val context = createContext(checkpoint = checkpoint)
-        val outputContext = stage.runFlow(context, TIMEOUT)
+        val outputContext = stage.runFlow(context, TIMEOUT) {
+            contextUpdateCount++
+        }
+        assertEquals(1, contextUpdateCount)
         assertEquals(newContext, outputContext)
         verifyInteractions(fiberOutputs)
         verify(checkpoint).waitingFor = WaitingFor(ExternalEventResponse())
@@ -116,8 +120,12 @@ class FlowExecutionPipelineStageTest {
         )
 
         val context = createContext(checkpoint = checkpoint)
-        val outputContext = stage.runFlow(context, TIMEOUT)
+        var contextUpdateCount = 0
+        val outputContext = stage.runFlow(context, TIMEOUT) {
+            contextUpdateCount++
+        }
         assertEquals(secondContext, outputContext)
+        assertEquals(2, contextUpdateCount)
         verifyInteractions(fiberOutputs)
         verify(checkpoint).waitingFor = WaitingFor(ExternalEventResponse())
         verify(checkpoint).suspendedOn = fiberOutput::class.qualifiedName
@@ -149,8 +157,12 @@ class FlowExecutionPipelineStageTest {
         )
 
         val context = createContext(checkpoint = checkpoint)
-        val outputContext = stage.runFlow(context, TIMEOUT)
+        var contextUpdateCount = 0
+        val outputContext = stage.runFlow(context, TIMEOUT) {
+            contextUpdateCount++
+        }
         assertEquals(context, outputContext)
+        assertEquals(0, contextUpdateCount)
         verifyInteractions(fiberOutputs)
         verify(checkpoint, never()).waitingFor = any()
         verify(checkpoint, never()).suspendedOn = any()
@@ -181,7 +193,7 @@ class FlowExecutionPipelineStageTest {
         )
 
         val context = createContext(checkpoint = checkpoint)
-        val outputContext = stage.runFlow(context, TIMEOUT)
+        val outputContext = stage.runFlow(context, TIMEOUT) {}
         assertEquals(newContext, outputContext)
         verifyInteractions(fiberOutputs)
         verify(checkpoint).waitingFor = WaitingFor(ExternalEventResponse())
@@ -211,7 +223,7 @@ class FlowExecutionPipelineStageTest {
         )
 
         val context = createContext(checkpoint = checkpoint)
-        val outputContext = stage.runFlow(context, TIMEOUT)
+        val outputContext = stage.runFlow(context, TIMEOUT) {}
         assertEquals(newContext, outputContext)
         verifyInteractions(fiberOutputs)
         verify(checkpoint).waitingFor = WaitingFor(null)
@@ -246,7 +258,7 @@ class FlowExecutionPipelineStageTest {
         )
 
         val context = createContext(checkpoint = checkpoint)
-        val outputContext = stage.runFlow(context, TIMEOUT)
+        val outputContext = stage.runFlow(context, TIMEOUT) {}
         assertEquals(newContext, outputContext)
         verifyInteractions(fiberOutputs)
         verify(checkpoint).waitingFor = WaitingFor(null)
@@ -276,7 +288,7 @@ class FlowExecutionPipelineStageTest {
 
         val context = createContext()
         assertThrows<FlowFatalException> {
-            stage.runFlow(context, TIMEOUT)
+            stage.runFlow(context, TIMEOUT) {}
         }
     }
 
@@ -303,7 +315,7 @@ class FlowExecutionPipelineStageTest {
 
         val context = createContext()
         assertThrows<FlowFatalException> {
-            stage.runFlow(context, TIMEOUT)
+            stage.runFlow(context, TIMEOUT) {}
         }
     }
 
@@ -336,7 +348,7 @@ class FlowExecutionPipelineStageTest {
         )
 
         val context = createContext(checkpoint = checkpoint)
-        val outputContext = stage.runFlow(context, TIMEOUT)
+        val outputContext = stage.runFlow(context, TIMEOUT) {}
         assertEquals(secondContext, outputContext)
     }
 


### PR DESCRIPTION
**Problem statement**

The flow engine was recently updated to execute user code through multiple suspension points when processing a single event. When it does this, a new user code execution stage keeps track of the intermediate context. However, if an error occurs during processing then the context used to handle the error will be the one from before any fiber code was executed. This means that in some circumstances the flow engine incorrectly thinks the checkpoint is yet to be initialized, and so it will not publish a status update for the flow.

**Solution**

Ensure the flow pipeline is informed of context changes as the fiber is executed. This means that if an error is thrown, the most up-to-date `FlowEventContext` will be used to handle the error.

**Testing**

Passing full e2e test run.

**Other changes**

- Updated a misleading log line about being unable to update status. This can happen if the flow is not failing.
- Updated a misleading comment. The old comment was describing behaviour that is no longer present.