### PR TITLE
ES-1256 Expose pod and container security contexts in Helm chart

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -70,10 +70,10 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.tolerations" . | nindent 6 }}
       serviceAccountName: {{ include "corda.bootstrapPreinstallServiceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: 10001
-        runAsGroup: 10002
-        fsGroup: 1000
+        {{ . | toYaml }}
+      {{- end }}
       containers:
         - name: preinstall-checks
           image: {{ include "corda.bootstrapCliImage" . }}
@@ -135,10 +135,10 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.tolerations" $ | nindent 6 }}
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: 10001
-        runAsGroup: 10002
-        fsGroup: 1000
+        {{ . | toYaml }}
+      {{- end }}
       containers:
         - name: fin
           image: {{ include "corda.bootstrapCliImage" . }}
@@ -223,10 +223,10 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.tolerations" . | nindent 6 }}
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: 10001
-        runAsGroup: 10002
-        fsGroup: 1000
+        {{ . | toYaml }}
+      {{- end }}
       containers:
         - name: create-topics
           image: {{ include "corda.bootstrapCliImage" . }}
@@ -369,10 +369,10 @@ spec:
       {{- include "corda.imagePullSecrets" . | nindent 6 }}
       {{- include "corda.tolerations" . | nindent 6 }}
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: 10001
-        runAsGroup: 10002
-        fsGroup: 1000
+        {{ . | toYaml }}
+      {{- end }}
       containers:
         - name: create-rbac-role-user-admin
           image: {{ include "corda.bootstrapCliImage" . }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -72,7 +72,7 @@ spec:
       serviceAccountName: {{ include "corda.bootstrapPreinstallServiceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml }}
+        {{ . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: preinstall-checks
@@ -137,7 +137,7 @@ spec:
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml }}
+        {{ . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: fin
@@ -225,7 +225,7 @@ spec:
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml }}
+        {{ . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: create-topics
@@ -371,7 +371,7 @@ spec:
       {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml }}
+        {{ . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: create-rbac-role-user-admin

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -74,7 +74,7 @@ Container security context
 {{- if not .Values.dumpHostPath }}
 {{- with .Values.containerSecurityContext }}
 securityContext:
-  {{ . | toYaml }}
+  {{ . | toYaml | nindent 2}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -72,14 +72,10 @@ Container security context
 */}}
 {{- define "corda.containerSecurityContext" -}}
 {{- if not .Values.dumpHostPath }}
+{{- with .Values.containerSecurityContext }}
 securityContext:
-  runAsUser: 10001
-  runAsGroup: 10002
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: true
-  capabilities:
-    drop:
-      - "ALL"
+  {{ . | toYaml }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -106,7 +106,7 @@ spec:
       {{- if and ( not $.Values.dumpHostPath ) ( not .profiling.enabled ) }}
       {{- with $.Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml }}
+        {{ . | toYaml | nindent 8 }}
       {{- end }}
       {{- end }}
       {{- include "corda.imagePullSecrets" $ | nindent 6 }}

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -104,10 +104,10 @@ spec:
         {{- include "corda.workerSelectorLabels" ( list $ $worker ) | nindent 8 }}
     spec:
       {{- if and ( not $.Values.dumpHostPath ) ( not .profiling.enabled ) }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: 10001
-        runAsGroup: 10002
-        fsGroup: 1000
+        {{ . | toYaml }}
+      {{- end }}
       {{- end }}
       {{- include "corda.imagePullSecrets" $ | nindent 6 }}
       {{- include "corda.tolerations" $ | nindent 6 }}

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -104,7 +104,7 @@ spec:
         {{- include "corda.workerSelectorLabels" ( list $ $worker ) | nindent 8 }}
     spec:
       {{- if and ( not $.Values.dumpHostPath ) ( not .profiling.enabled ) }}
-      {{- with .Values.podSecurityContext }}
+      {{- with $.Values.podSecurityContext }}
       securityContext:
         {{ . | toYaml }}
       {{- end }}

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -330,6 +330,24 @@
                     }
                 },
                 "sysctls": {
+                    "items": {
+                        "description": "Sysctl defines a kernel parameter to be set",
+                        "properties": {
+                            "name": {
+                                "description": "Name of a property to set",
+                                "type": "string"
+                            },
+                            "value": {
+                                "description": "Value of a property to set",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name",
+                            "value"
+                        ],
+                        "type": "object"
+                    },
                     "description": "sysctls holds a list of namespaced sysctls used for the pod",
                     "type": [
                         "array",

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -121,6 +121,128 @@
                 "Always"
             ]
         },
+        "containerSecurityContext": {
+            "type": "object",
+            "default": {},
+            "title": "define privilege and access control settings for a pod",
+            "properties": {
+                "runAsUser": {
+                    "type": "integer",
+                    "title": "specify what user ID that processes will run with",
+                    "examples": [
+                        "10001"
+                    ]
+                },
+                "runAsGroup": {
+                    "type": "integer",
+                    "title": "specify what group ID that processes will run with",
+                    "examples": [
+                        "10002"
+                    ]
+                },
+                "fsGroup": {
+                    "type": "integer",
+                    "title": "specify supplementary group ID that processes will run with",
+                    "examples": [
+                        "1000"
+                    ]
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "enable scraping of worker metrics through Prometheus annotations",
+                    "examples": [
+                        false
+                    ]
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "mount the container's root filesystem as read-only",
+                    "examples": [
+                        true
+                    ]
+                },
+                "capabilities": {
+                    "type": "object",
+                    "default": {},
+                    "title": "linux capabilities for users",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "default": [],
+                            "title": "capabilities to drop"
+                        },
+                        "add": {
+                            "type": "array",
+                            "default": [],
+                            "title": "capabilities to add"
+                        }
+                    }
+                }
+            }
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "default": {},
+            "title": "define privilege and access control settings for a pod",
+            "properties": {
+                "runAsUser": {
+                    "type": "integer",
+                    "title": "specify what user ID that processes will run with",
+                    "examples": [
+                        "10001"
+                    ]
+                },
+                "runAsGroup": {
+                    "type": "integer",
+                    "title": "specify what group ID that processes will run with",
+                    "examples": [
+                        "10002"
+                    ]
+                },
+                "fsGroup": {
+                    "type": "integer",
+                    "title": "specify supplementary group ID that processes will run with",
+                    "examples": [
+                        "1000"
+                    ]
+                },
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "enable scraping of worker metrics through Prometheus annotations",
+                    "examples": [
+                        false
+                    ]
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "mount the container's root filesystem as read-only",
+                    "examples": [
+                        true
+                    ]
+                },
+                "capabilities": {
+                    "type": "object",
+                    "default": {},
+                    "title": "linux capabilities for users",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "default": [],
+                            "title": "capabilities to drop"
+                        },
+                        "add": {
+                            "type": "array",
+                            "default": [],
+                            "title": "capabilities to add"
+                        }
+                    }
+                }
+            }
+        },
         "resources": {
             "type": "object",
             "default": {},

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -133,6 +133,13 @@
                         "10001"
                     ]
                 },
+                "runAsNonRoot": {
+                    "type": "boolean", 
+                    "description": "indicates that the container must run as a non-root user",
+                    "examples": [
+                        true
+                    ]
+                }, 
                 "runAsGroup": {
                     "type": "integer",
                     "title": "specify what group ID that processes will run with",
@@ -140,25 +147,30 @@
                         "10002"
                     ]
                 },
-                "fsGroup": {
-                    "type": "integer",
-                    "title": "specify supplementary group ID that processes will run with",
-                    "examples": [
-                        "1000"
-                    ]
-                },
                 "allowPrivilegeEscalation": {
                     "type": "boolean",
-                    "default": false,
                     "title": "enable scraping of worker metrics through Prometheus annotations",
                     "examples": [
-                        false
+                        true
                     ]
                 },
                 "readOnlyRootFilesystem": {
                     "type": "boolean",
-                    "default": true,
                     "title": "mount the container's root filesystem as read-only",
+                    "examples": [
+                        true
+                    ]
+                },
+                "procMount": {
+                    "type": "string", 
+                    "description": "denotes the type of proc mount to use for the containers - cannot be set when spec.os.name is windows", 
+                    "examples": [
+                        "DefaultProcMount"
+                    ]
+                }, 
+                "privileged": {
+                    "type": "boolean",
+                    "title": "run container in privileged mode",
                     "examples": [
                         true
                     ]
@@ -168,15 +180,89 @@
                     "default": {},
                     "title": "linux capabilities for users",
                     "properties": {
-                        "drop": {
-                            "type": "array",
-                            "default": [],
-                            "title": "capabilities to drop"
-                        },
                         "add": {
-                            "type": "array",
-                            "default": [],
-                            "title": "capabilities to add"
+                            "items": {
+                                "type": [
+                                    "string", 
+                                    "null"
+                                ]
+                            }, 
+                            "type": [
+                                "array", 
+                                "null"
+                            ], 
+                            "description": "added capabilities"
+                        }, 
+                        "drop": {
+                            "items": {
+                                "type": [
+                                    "string", 
+                                    "null"
+                                ]
+                            }, 
+                            "type": [
+                                "array", 
+                                "null"
+                            ], 
+                            "description": "removed capabilities"
+                        }
+                    }
+                },
+                "seccompProfile": {
+                    "type": "object",
+                    "description": "the seccomp options to use by the containers in this pod - this field cannot be set if spec.os.name is windows",
+                    "properties": {
+                        "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied",
+                            "type": "string"
+                        },
+                        "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used",
+                            "type": "string"
+                        }
+                    }
+                },
+                "seLinuxOptions": {
+                    "type": "object",
+                    "description": "SELinuxOptions are the labels to be applied to the container",
+                    "properties": {
+                        "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
+                            "type": "string"
+                        },
+                        "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
+                            "type": "string"
+                        },
+                        "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "windowsOptions": {
+                    "type": "object",
+                    "description": "the Windows specific settings applied to all containers",
+                    "properties": {
+                        "gmsaCredentialSpec": {
+                            "description": "this is where the GMSA admission webhook inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field",
+                            "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                            "description": "the name of the GMSA credential spec to use",
+                            "type": "string"
+                        },
+                        "hostProcess": {
+                            "description": "determines if a container should be run as a 'Host Process' container",
+                            "type": "string"
+                        },
+                        "runAsUserName": {
+                            "description": "the UserName in Windows to run the entrypoint of the container process",
+                            "type": "string"
                         }
                     }
                 }
@@ -187,59 +273,117 @@
             "default": {},
             "title": "define privilege and access control settings for a pod",
             "properties": {
+                "runAsNonRoot": {
+                    "type": "boolean", 
+                    "description": "indicates that the container must run as a non-root user",
+                    "examples": [
+                        true
+                    ]
+                }, 
+                "fsGroup": {
+                    "type": "integer", 
+                    "description": "a special supplemental group that applies to all containers in a pod", 
+                    "format": "int64",
+                    "examples": [
+                        "1000"
+                    ]
+                },
+                "fsGroupChangePolicy": {
+                    "type": "string", 
+                    "description": "defines behavior of changing ownership and permission of the volume before being exposed inside Pod", 
+                    "enum": ["Always", "OnRootMismatch"]
+                }, 
+                "seccompProfile": {
+                    "type": "object",
+                    "description": "the seccomp options to use by the containers in this pod - this field cannot be set if spec.os.name is windows",
+                    "properties": {
+                        "type": {
+                            "description": "type indicates which kind of seccomp profile will be applied",
+                            "type": "string"
+                        },
+                        "localhostProfile": {
+                            "description": "localhostProfile indicates a profile defined in a file on the node should be used",
+                            "type": "string"
+                        }
+                    }
+                },
+                "seLinuxOptions": {
+                    "type": "object",
+                    "description": "SELinuxOptions are the labels to be applied to the container",
+                    "properties": {
+                        "level": {
+                            "description": "Level is SELinux level label that applies to the container.",
+                            "type": "string"
+                        },
+                        "role": {
+                            "description": "Role is a SELinux role label that applies to the container.",
+                            "type": "string"
+                        },
+                        "type": {
+                            "description": "Type is a SELinux type label that applies to the container.",
+                            "type": "string"
+                        },
+                        "user": {
+                            "description": "User is a SELinux user label that applies to the container.",
+                            "type": "string"
+                        }
+                    }
+                },
+                "sysctls": {
+                    "description": "sysctls holds a list of namespaced sysctls used for the pod",
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "windowsOptions": {
+                    "type": "object",
+                    "description": "the Windows specific settings applied to all containers",
+                    "properties": {
+                        "gmsaCredentialSpec": {
+                            "description": "this is where the GMSA admission webhook inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field",
+                            "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                            "description": "the name of the GMSA credential spec to use",
+                            "type": "string"
+                        },
+                        "hostProcess": {
+                            "description": "determines if a container should be run as a 'Host Process' container",
+                            "type": "string"
+                        },
+                        "runAsUserName": {
+                            "description": "the UserName in Windows to run the entrypoint of the container process",
+                            "type": "string"
+                        }
+                    }
+                },
+                "supplementalGroups": {
+                    "items": {
+                        "type": "integer", 
+                        "format": "int64"
+                    }, 
+                    "type": [
+                        "array", 
+                        "null"
+                    ], 
+                    "description": "a list of groups applied to the first process run in each container, in addition to the container's primary GID"
+                }, 
                 "runAsUser": {
-                    "type": "integer",
-                    "title": "specify what user ID that processes will run with",
+                    "type": "integer", 
+                    "description": "The UID to run the entrypoint of the container process", 
+                    "format": "int64",
                     "examples": [
                         "10001"
                     ]
                 },
                 "runAsGroup": {
-                    "type": "integer",
-                    "title": "specify what group ID that processes will run with",
+                    "type": "integer", 
+                    "description": "The GID to run the entrypoint of the container process", 
+                    "format": "int64",
                     "examples": [
                         "10002"
                     ]
-                },
-                "fsGroup": {
-                    "type": "integer",
-                    "title": "specify supplementary group ID that processes will run with",
-                    "examples": [
-                        "1000"
-                    ]
-                },
-                "allowPrivilegeEscalation": {
-                    "type": "boolean",
-                    "default": false,
-                    "title": "enable scraping of worker metrics through Prometheus annotations",
-                    "examples": [
-                        false
-                    ]
-                },
-                "readOnlyRootFilesystem": {
-                    "type": "boolean",
-                    "default": true,
-                    "title": "mount the container's root filesystem as read-only",
-                    "examples": [
-                        true
-                    ]
-                },
-                "capabilities": {
-                    "type": "object",
-                    "default": {},
-                    "title": "linux capabilities for users",
-                    "properties": {
-                        "drop": {
-                            "type": "array",
-                            "default": [],
-                            "title": "capabilities to drop"
-                        },
-                        "add": {
-                            "type": "array",
-                            "default": [],
-                            "title": "capabilities to add"
-                        }
-                    }
                 }
             }
         },

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -30,7 +30,7 @@ containerSecurityContext:
   allowPrivilegeEscalation: false
   # -- mount the container's root filesystem as read-only
   readOnlyRootFilesystem: true
-  # -- linux capabilities for users
+  # linux capabilities for users
   capabilities:
     # -- capabilities to drop
     drop:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -20,6 +20,31 @@ image:
   # -- worker image tag, defaults to Chart appVersion
   tag: ""
 
+# define privilege and access control settings for a container
+containerSecurityContext:
+  # -- specify what user ID that processes will run with
+  runAsUser: 10001
+  # -- specify what group ID that processes will run with
+  runAsGroup: 10002
+  # -- enable privilege escalation
+  allowPrivilegeEscalation: false
+  # -- mount the container's root filesystem as read-only
+  readOnlyRootFilesystem: true
+  # -- linux capabilities for users
+  capabilities:
+    # -- capabilities to drop
+    drop:
+      - "ALL"
+
+# define privilege and access control settings for a pod
+podSecurityContext:
+  # -- specify what user ID that processes will run with
+  runAsUser: 10001
+  # -- specify what group ID that processes will run with
+  runAsGroup: 10002
+  # -- specify supplementary group ID that processes will run with
+  fsGroup: 1000
+
 # -- extra labels to add to all deployed objects
 commonLabels: {}
 


### PR DESCRIPTION
This enables the security contexts to be unset so that they can be automatically populated in an OpenShift environment.