### PR TITLE
CORE-17062 - Token Selection - Update how an instance of `TokenClaim` is created

### DIFF
--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/internal/PoolCacheStateImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/internal/PoolCacheStateImpl.kt
@@ -57,10 +57,10 @@ class PoolCacheStateImpl(private val cacheState: TokenPoolCacheState) : PoolCach
     }
 
     private fun createClaim(claimId: String, selectedTokens: List<CachedToken>): TokenClaim {
-        return TokenClaim().apply {
-            this.claimId = claimId
-            this.claimedTokens = selectedTokens.map { it.toAvro() }
-        }
+        return TokenClaim.newBuilder()
+            .setClaimId(claimId)
+            .setClaimedTokens(selectedTokens.map { it.toAvro() })
+            .build()
     }
 
     private fun createClaimedTokenMap(): Map<String, CachedToken> {


### PR DESCRIPTION
Before, a `TokenClaim` instance was created using the default constructor plus the apply method. This strategy should be avoided because the defaults specified in the Avro schema are not applied to the fields that are not explicitly set inside the apply method. All objects are set to null if they are not explicitly set which causes issues when data is serialised to Json and the Avro schema does not accept a null value.