### PR TITLE
CORE-17074: Upgrade Kotlin Metadata 0.6.2 -> 0.7.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ publicArtifactURL = https://download.corda.net/maven
 kotlin.code.style=official
 kotlinVersion=1.8.21
 kotlin.stdlib.default.dependency=false
-kotlinMetadataVersion=0.6.2
+kotlinMetadataVersion=0.7.0
 
 org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
@@ -36,7 +36,7 @@ dokkaVersion=1.8.+
 activationVersion=1.2.0
 ariesDynamicFrameworkExtensionVersion=1.3.6
 antlrVersion=2.7.7
-asmVersion=9.4
+asmVersion=9.5
 avroVersion=1.11.2
 awssdkVersion=2.20.60
 commonsVersion = 1.7

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -13,6 +13,7 @@ description "Bare bones Kotlin reflection within an OSGi framework."
 
 configurations {
     bundle {
+        canBeDeclared = false
         canBeResolved = false
     }
     bundle.extendsFrom runtimeClasspath

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinClassImpl.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/impl/KotlinClassImpl.kt
@@ -1,15 +1,6 @@
 @file:JvmName("KotlinClassUtils")
 package net.corda.kotlin.reflect.impl
 
-import kotlinx.metadata.KmClass
-import kotlinx.metadata.KmPackage
-import kotlinx.metadata.jvm.KotlinClassMetadata
-import net.corda.kotlin.reflect.KotlinClass
-import net.corda.kotlin.reflect.types.KFunctionInternal
-import net.corda.kotlin.reflect.types.KPropertyInternal
-import net.corda.kotlin.reflect.types.MemberSignature
-import net.corda.kotlin.reflect.types.jvmSuperClasses
-import net.corda.kotlin.reflect.types.toSignature
 import java.lang.reflect.Method
 import java.util.Collections.unmodifiableMap
 import kotlin.LazyThreadSafetyMode.PUBLICATION
@@ -38,8 +29,17 @@ import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.staticFunctions
 import kotlin.reflect.full.staticProperties
 import kotlin.reflect.full.superclasses
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.KmPackage
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import net.corda.kotlin.reflect.KotlinClass
+import net.corda.kotlin.reflect.types.KFunctionInternal
+import net.corda.kotlin.reflect.types.KPropertyInternal
+import net.corda.kotlin.reflect.types.MemberSignature
+import net.corda.kotlin.reflect.types.jvmSuperClasses
+import net.corda.kotlin.reflect.types.toSignature
 
-sealed class KotlinClassImpl<T : Any> constructor(
+sealed class KotlinClassImpl<T : Any>(
     @JvmField protected val clazz: Class<T>,
     @JvmField protected val klazz: KClass<T>,
     @JvmField protected val kClassPool: KClassPool
@@ -377,11 +377,14 @@ private fun <T : Any> Metadata.forKotlinType(
     pool: KClassPool
 ): KotlinClassImpl<T> {
     return when (val km = KotlinClassMetadata.read(this)) {
-        is KotlinClassMetadata.Class -> KotlinClassImpl.KmClassType(clazz, klazz, pool, km.toKmClass())
-        is KotlinClassMetadata.FileFacade -> KotlinClassImpl.KmPackageType(clazz, klazz, pool, km.toKmPackage())
-        is KotlinClassMetadata.MultiFileClassPart -> KotlinClassImpl.KmPackageType(clazz, klazz, pool, km.toKmPackage())
-        null -> throw IllegalArgumentException("Incompatible Kotlin metadata version '${metadataVersion.joinToString(".")}'.")
-        else -> throw IllegalArgumentException("Unsupported Kotlin class type: $km")
+        is KotlinClassMetadata.Class ->
+            KotlinClassImpl.KmClassType(clazz, klazz, pool, km.kmClass)
+        is KotlinClassMetadata.FileFacade ->
+            KotlinClassImpl.KmPackageType(clazz, klazz, pool, km.kmPackage)
+        is KotlinClassMetadata.MultiFileClassPart ->
+            KotlinClassImpl.KmPackageType(clazz, klazz, pool, km.kmPackage)
+        else ->
+            throw IllegalArgumentException("Unsupported Kotlin class type: $km")
     }
 }
 

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/JavaProperty.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/JavaProperty.kt
@@ -1,6 +1,5 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.jvm.JvmFieldSignature
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.Collections.singletonList
@@ -12,6 +11,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.starProjectedType
+import kotlinx.metadata.jvm.JvmFieldSignature
 
 open class JavaProperty<T, V>(
     final override val javaField: Field,

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/JavaStaticProperty.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/JavaStaticProperty.kt
@@ -1,6 +1,5 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.jvm.JvmFieldSignature
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.Objects
@@ -10,6 +9,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.starProjectedType
+import kotlinx.metadata.jvm.JvmFieldSignature
 
 open class JavaStaticProperty<V>(final override val javaField: Field): KProperty0<V>, KPropertyInternal<V> {
     override val annotations: List<Annotation>

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KPropertyInternal.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KPropertyInternal.kt
@@ -1,9 +1,9 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.jvm.JvmFieldSignature
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import kotlin.reflect.KProperty
+import kotlinx.metadata.jvm.JvmFieldSignature
 
 /**
  * Internal API for Kotlin properties.

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinFunction.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinFunction.kt
@@ -1,13 +1,5 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.Flag.Function.IS_EXTERNAL
-import kotlinx.metadata.Flag.Function.IS_INFIX
-import kotlinx.metadata.Flag.Function.IS_INLINE
-import kotlinx.metadata.Flag.Function.IS_OPERATOR
-import kotlinx.metadata.Flag.Function.IS_SUSPEND
-import kotlinx.metadata.KmFunction
-import kotlinx.metadata.jvm.lambdaClassOriginName
-import kotlinx.metadata.jvm.signature
 import java.lang.reflect.Method
 import java.util.Objects
 import kotlin.contracts.ExperimentalContracts
@@ -15,6 +7,17 @@ import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVisibility
+import kotlinx.metadata.KmFunction
+import kotlinx.metadata.isExternal
+import kotlinx.metadata.isInfix
+import kotlinx.metadata.isInline
+import kotlinx.metadata.isNullable
+import kotlinx.metadata.isOperator
+import kotlinx.metadata.isSuspend
+import kotlinx.metadata.jvm.lambdaClassOriginName
+import kotlinx.metadata.jvm.signature
+import kotlinx.metadata.modality
+import kotlinx.metadata.visibility
 
 class KotlinFunction<V> private constructor(
     private val kmFunction: KmFunction,
@@ -32,24 +35,24 @@ class KotlinFunction<V> private constructor(
     )
 
     override val isAbstract: Boolean
-        get() = isAbstract(javaMethod, kmFunction.flags)
+        get() = isAbstract(javaMethod, kmFunction.modality)
     override val isFinal: Boolean
-        get() = isFinal(javaMethod, kmFunction.flags)
+        get() = isFinal(javaMethod, kmFunction.modality)
     override val isOpen: Boolean
-        get() = isOpen(javaMethod, kmFunction.flags)
+        get() = isOpen(javaMethod, kmFunction.modality)
     override val isExternal: Boolean
-        get() = IS_EXTERNAL(kmFunction.flags)
+        get() = kmFunction.isExternal
     override val isInfix: Boolean
-        get() = IS_INFIX(kmFunction.flags)
+        get() = kmFunction.isInfix
     override val isInline: Boolean
-        get() = IS_INLINE(kmFunction.flags)
+        get() = kmFunction.isInline
     override val isOperator: Boolean
-        get() = IS_OPERATOR(kmFunction.flags)
+        get() = kmFunction.isOperator
     override val isSuspend: Boolean
-        get() = IS_SUSPEND(kmFunction.flags)
+        get() = kmFunction.isSuspend
 
     override val visibility: KVisibility?
-        get() = getVisibility(kmFunction.flags)
+        get() = getVisibility(kmFunction.visibility)
 
     override val annotations: List<Annotation>
         get() = TODO("KotlinFunction.annotations: Not yet implemented")
@@ -69,7 +72,9 @@ class KotlinFunction<V> private constructor(
             // (or vice versa), which means that the original "value parameter"
             // information no longer applies. So create a new KmFunction object
             // without any value parameters.
-            KmFunction(kmFunction.flags, kmFunction.name).also { kmf ->
+            @Suppress("deprecation")
+            KmFunction(kmFunction.name).also { kmf ->
+                kmf.flags = kmFunction.flags
                 // Copy values from KmFunction.
                 kmf.receiverParameterType = kmFunction.receiverParameterType
                 kmf.versionRequirements += kmFunction.versionRequirements

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinMutableProperty1.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinMutableProperty1.kt
@@ -1,14 +1,5 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.Flag.Function.IS_INFIX
-import kotlinx.metadata.Flag.Function.IS_INLINE
-import kotlinx.metadata.Flag.Function.IS_OPERATOR
-import kotlinx.metadata.Flag.Function.IS_SUSPEND
-import kotlinx.metadata.Flag.Property.IS_EXTERNAL
-import kotlinx.metadata.Flags
-import kotlinx.metadata.KmProperty
-import kotlinx.metadata.jvm.getterSignature
-import kotlinx.metadata.jvm.setterSignature
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.Objects
@@ -18,21 +9,29 @@ import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.starProjectedType
+import kotlinx.metadata.KmProperty
+import kotlinx.metadata.KmPropertyAccessorAttributes
+import kotlinx.metadata.isExternal
+import kotlinx.metadata.isInline
+import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.jvm.setterSignature
+import kotlinx.metadata.modality
+import kotlinx.metadata.visibility
 
 @Suppress("LongParameterList", "MaxLineLength")
 class KotlinMutableProperty1<T, V> private constructor(
-    property: KmProperty,
+    kmProperty: KmProperty,
     getterSignature: MemberSignature?,
     override val setterSignature: MemberSignature?,
     javaField: Field?,
     javaGetter: Method?,
     override val javaSetter: Method?,
     instanceClass: Class<*>
-) : KotlinProperty1<T, V>(property, getterSignature, javaField, javaGetter, instanceClass), KMutableProperty1<T, V>, KMutablePropertyAccessorInternal<V> {
-    constructor(property: KmProperty, declaringClass: Class<*>) : this(
-        property = property,
-        getterSignature = property.getterSignature?.toSignature(declaringClass.classLoader),
-        setterSignature = property.setterSignature?.toSignature(declaringClass.classLoader),
+) : KotlinProperty1<T, V>(kmProperty, getterSignature, javaField, javaGetter, instanceClass), KMutableProperty1<T, V>, KMutablePropertyAccessorInternal<V> {
+    constructor(kmProperty: KmProperty, declaringClass: Class<*>) : this(
+        kmProperty = kmProperty,
+        getterSignature = kmProperty.getterSignature?.toSignature(declaringClass.classLoader),
+        setterSignature = kmProperty.setterSignature?.toSignature(declaringClass.classLoader),
         javaField = null,
         javaGetter = null,
         javaSetter = null,
@@ -40,15 +39,15 @@ class KotlinMutableProperty1<T, V> private constructor(
     )
 
     override val isAbstract: Boolean
-        get() = isAbstract(javaGetter, javaSetter, kmProperty.flags)
+        get() = isAbstract(javaGetter, javaSetter, kmProperty.setter!!.modality)
     override val isFinal: Boolean
-        get() = isFinal(javaGetter, javaSetter, kmProperty.flags)
+        get() = isFinal(javaGetter, javaSetter, kmProperty.setter!!.modality)
 
     override val isJava: Boolean
         get() = super.isJava && !javaSetter.isKotlin
 
     override fun asPropertyFor(instanceClass: Class<*>) = KotlinMutableProperty1<T, V>(
-        property = kmProperty,
+        kmProperty = kmProperty,
         getterSignature = getterSignature,
         setterSignature = setterSignature,
         javaField = javaField,
@@ -58,7 +57,7 @@ class KotlinMutableProperty1<T, V> private constructor(
     )
 
     override fun withJavaAccessors(getter: Method, setter: Method) = KotlinMutableProperty1<T, V>(
-        property = kmProperty,
+        kmProperty = kmProperty,
         getterSignature = getter.toSignature(),
         setterSignature = setter.toSignature(),
         javaField = javaField,
@@ -67,7 +66,7 @@ class KotlinMutableProperty1<T, V> private constructor(
         instanceClass = instanceClass
     )
     override fun withJavaSetter(setter: Method) = KotlinMutableProperty1<T, V>(
-        property = kmProperty,
+        kmProperty = kmProperty,
         getterSignature = getterSignature,
         setterSignature = setter.toSignature(),
         javaField = javaField,
@@ -76,7 +75,7 @@ class KotlinMutableProperty1<T, V> private constructor(
         instanceClass = instanceClass
     )
     override fun withJavaGetter(getter: Method) = KotlinMutableProperty1<T, V>(
-        property = kmProperty,
+        kmProperty = kmProperty,
         getterSignature = getter.toSignature(),
         setterSignature = setterSignature,
         javaField = javaField,
@@ -85,7 +84,7 @@ class KotlinMutableProperty1<T, V> private constructor(
         instanceClass = instanceClass
     )
     override fun withJavaField(field: Field) = KotlinMutableProperty1<T, V>(
-        property = kmProperty,
+        kmProperty = kmProperty,
         getterSignature = getterSignature,
         setterSignature = setterSignature,
         javaField = field,
@@ -96,7 +95,7 @@ class KotlinMutableProperty1<T, V> private constructor(
 
     override val setter: KSetter1Internal<T, V> = Setter(
         name = "<set-${kmProperty.name}>",
-        flags = kmProperty.setterFlags,
+        attributes = kmProperty.setter!!,
         property = this,
         javaSetter
     )
@@ -126,26 +125,26 @@ class KotlinMutableProperty1<T, V> private constructor(
 
     private data class Setter<T, V>(
         override val name: String,
-        private val flags: Flags,
+        private val attributes: KmPropertyAccessorAttributes,
         override val property: KotlinMutableProperty1<T, V>,
         private val javaSetter: Method?
     ) : KSetter1Internal<T, V> {
         override val isAbstract: Boolean
-            get() = isAbstract(javaSetter, flags)
+            get() = isAbstract(javaSetter, attributes.modality)
         override val isFinal: Boolean
-            get() = isFinal(javaSetter, flags)
+            get() = isFinal(javaSetter, attributes.modality)
         override val isOpen: Boolean
-            get() = isOpen(javaSetter, flags)
+            get() = isOpen(javaSetter, attributes.modality)
         override val isExternal: Boolean
-            get() = IS_EXTERNAL(flags)
+            get() = attributes.isExternal
         override val isInfix: Boolean
-            get() = IS_INFIX(flags)
+            get() = false
         override val isInline: Boolean
-            get() = IS_INLINE(flags)
+            get() = attributes.isInline
         override val isOperator: Boolean
-            get() = IS_OPERATOR(flags)
+            get() = false
         override val isSuspend: Boolean
-            get() = IS_SUSPEND(flags)
+            get() = false
 
         override val annotations: List<Annotation>
             get() = TODO("KotlinMutableProperty1.Setter.annotations: Not yet implemented")
@@ -160,7 +159,7 @@ class KotlinMutableProperty1<T, V> private constructor(
         override val typeParameters: List<KTypeParameter>
             get() = TODO("KotlinMutableProperty1.Setter.typeParameters: Not yet implemented")
         override val visibility: KVisibility?
-            get() = getVisibility(flags)
+            get() = getVisibility(attributes.visibility)
 
         override val javaMethod: Method?
             get() = javaSetter
@@ -171,7 +170,7 @@ class KotlinMutableProperty1<T, V> private constructor(
             } else {
                 KotlinTransientFunction(
                     name = javaSetter.name,
-                    flags = flags,
+                    attributes = attributes,
                     returnType = returnType,
                     javaMethod = javaSetter,
                     instanceClass = property.instanceClass,

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinProperty1.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinProperty1.kt
@@ -1,17 +1,5 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.Flag.Function.IS_INFIX
-import kotlinx.metadata.Flag.Function.IS_INLINE
-import kotlinx.metadata.Flag.Function.IS_OPERATOR
-import kotlinx.metadata.Flag.Function.IS_SUSPEND
-import kotlinx.metadata.Flag.Property.IS_CONST
-import kotlinx.metadata.Flag.Property.IS_EXTERNAL
-import kotlinx.metadata.Flag.Property.IS_LATEINIT
-import kotlinx.metadata.Flags
-import kotlinx.metadata.KmProperty
-import kotlinx.metadata.jvm.JvmFieldSignature
-import kotlinx.metadata.jvm.fieldSignature
-import kotlinx.metadata.jvm.getterSignature
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.Collections.singletonList
@@ -22,6 +10,17 @@ import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVisibility
+import kotlinx.metadata.KmProperty
+import kotlinx.metadata.KmPropertyAccessorAttributes
+import kotlinx.metadata.isConst
+import kotlinx.metadata.isExternal
+import kotlinx.metadata.isInline
+import kotlinx.metadata.isLateinit
+import kotlinx.metadata.jvm.JvmFieldSignature
+import kotlinx.metadata.jvm.fieldSignature
+import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.modality
+import kotlinx.metadata.visibility
 
 @Suppress("LongParameterList")
 open class KotlinProperty1<T, V> protected constructor(
@@ -33,29 +32,29 @@ open class KotlinProperty1<T, V> protected constructor(
     @JvmField
     protected val instanceClass: Class<*>
 ) : KPropertyAccessorInternal<V>, KProperty1<T, V> {
-    constructor(property: KmProperty, declaringClass: Class<*>) : this(
-        kmProperty = property,
-        getterSignature = property.getterSignature?.toSignature(declaringClass.classLoader),
+    constructor(kmProperty: KmProperty, declaringClass: Class<*>) : this(
+        kmProperty = kmProperty,
+        getterSignature = kmProperty.getterSignature?.toSignature(declaringClass.classLoader),
         javaField = null,
         javaGetter = null,
         instanceClass = declaringClass
     )
 
     override val isAbstract: Boolean
-        get() = isAbstract(javaGetter, kmProperty.flags)
+        get() = isAbstract(javaGetter, kmProperty.modality)
     override val isFinal: Boolean
-        get() = isFinal(javaGetter, kmProperty.flags)
+        get() = isFinal(javaGetter, kmProperty.modality)
     final override val isOpen: Boolean
         get() = !isAbstract && !isFinal
     final override val isConst: Boolean
-        get() = IS_CONST(kmProperty.flags)
+        get() = kmProperty.isConst
     final override val isLateinit: Boolean
-        get() = IS_LATEINIT(kmProperty.flags)
+        get() = kmProperty.isLateinit
     override val isSuspend: Boolean
         get() = false
 
     final override val visibility: KVisibility?
-        get() = getVisibility(kmProperty.flags, isJava)
+        get() = getVisibility(kmProperty.visibility, isJava)
 
     override val annotations: List<Annotation>
         get() = TODO("KotlinProperty1.annotations: Not yet implemented")
@@ -109,7 +108,7 @@ open class KotlinProperty1<T, V> protected constructor(
     @Suppress("LeakingThis")
     final override val getter: KGetter1Internal<T, V> = Getter(
         name = "<get-${kmProperty.name}>",
-        flags = kmProperty.getterFlags,
+        attributes = kmProperty.getter,
         property = this,
         javaGetter
     )
@@ -155,26 +154,26 @@ open class KotlinProperty1<T, V> protected constructor(
 
     private data class Getter<T, V>(
         override val name: String,
-        private val flags: Flags,
+        private val attributes: KmPropertyAccessorAttributes,
         override val property: KotlinProperty1<T, V>,
         private val javaGetter: Method?
     ) : KGetter1Internal<T, V> {
         override val isAbstract: Boolean
-            get() = isAbstract(javaGetter, flags)
+            get() = isAbstract(javaGetter, attributes.modality)
         override val isFinal: Boolean
-            get() = isFinal(javaGetter, flags)
+            get() = isFinal(javaGetter, attributes.modality)
         override val isOpen: Boolean
-            get() = isOpen(javaGetter, flags)
+            get() = isOpen(javaGetter, attributes.modality)
         override val isExternal: Boolean
-            get() = IS_EXTERNAL(flags)
+            get() = attributes.isExternal
         override val isInfix: Boolean
-            get() = IS_INFIX(flags)
+            get() = false
         override val isInline: Boolean
-            get() = IS_INLINE(flags)
+            get() = attributes.isInline
         override val isOperator: Boolean
-            get() = IS_OPERATOR(flags)
+            get() = false
         override val isSuspend: Boolean
-            get() = IS_SUSPEND(flags)
+            get() = false
 
         override val annotations: List<Annotation>
             get() = TODO("Not yet implemented")
@@ -185,7 +184,7 @@ open class KotlinProperty1<T, V> protected constructor(
         override val typeParameters: List<KTypeParameter>
             get() = TODO("Not yet implemented")
         override val visibility: KVisibility?
-            get() = getVisibility(flags)
+            get() = getVisibility(attributes.visibility)
 
         override val javaMethod: Method?
             get() = javaGetter
@@ -196,7 +195,7 @@ open class KotlinProperty1<T, V> protected constructor(
             } else {
                 KotlinTransientFunction(
                     name = javaGetter.name,
-                    flags = flags,
+                    attributes = attributes,
                     returnType = property.returnType,
                     javaMethod = javaGetter,
                     instanceClass = property.instanceClass,

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinProperty2.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinProperty2.kt
@@ -1,17 +1,5 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.Flag.Function.IS_INFIX
-import kotlinx.metadata.Flag.Function.IS_INLINE
-import kotlinx.metadata.Flag.Function.IS_OPERATOR
-import kotlinx.metadata.Flag.Function.IS_SUSPEND
-import kotlinx.metadata.Flag.Property.IS_CONST
-import kotlinx.metadata.Flag.Property.IS_EXTERNAL
-import kotlinx.metadata.Flag.Property.IS_LATEINIT
-import kotlinx.metadata.Flags
-import kotlinx.metadata.KmProperty
-import kotlinx.metadata.jvm.JvmFieldSignature
-import kotlinx.metadata.jvm.fieldSignature
-import kotlinx.metadata.jvm.getterSignature
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.Collections.unmodifiableList
@@ -24,6 +12,17 @@ import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.starProjectedType
+import kotlinx.metadata.KmProperty
+import kotlinx.metadata.KmPropertyAccessorAttributes
+import kotlinx.metadata.isConst
+import kotlinx.metadata.isExternal
+import kotlinx.metadata.isInline
+import kotlinx.metadata.isLateinit
+import kotlinx.metadata.jvm.JvmFieldSignature
+import kotlinx.metadata.jvm.fieldSignature
+import kotlinx.metadata.jvm.getterSignature
+import kotlinx.metadata.modality
+import kotlinx.metadata.visibility
 
 @Suppress("LongParameterList")
 open class KotlinProperty2<D, E, V> protected constructor(
@@ -35,29 +34,29 @@ open class KotlinProperty2<D, E, V> protected constructor(
     @JvmField
     protected val instanceClass: Class<*>
 ) : KProperty2<D, E, V>, KPropertyAccessorInternal<V> {
-    constructor(property: KmProperty, declaringClass: Class<*>) : this(
-        kmProperty = property,
-        getterSignature = property.getterSignature?.toSignature(declaringClass.classLoader),
+    constructor(kmProperty: KmProperty, declaringClass: Class<*>) : this(
+        kmProperty = kmProperty,
+        getterSignature = kmProperty.getterSignature?.toSignature(declaringClass.classLoader),
         javaField = null,
         javaGetter = null,
         instanceClass = declaringClass
     )
 
     override val isAbstract: Boolean
-        get() = isAbstract(javaGetter, kmProperty.flags)
+        get() = isAbstract(javaGetter, kmProperty.modality)
     override val isFinal: Boolean
-        get() = isFinal(javaGetter, kmProperty.flags)
+        get() = isFinal(javaGetter, kmProperty.modality)
     final override val isOpen: Boolean
         get() = !isAbstract && !isFinal
     final override val isConst: Boolean
-        get() = IS_CONST(kmProperty.flags)
+        get() = kmProperty.isConst
     final override val isLateinit: Boolean
-        get() = IS_LATEINIT(kmProperty.flags)
+        get() = kmProperty.isLateinit
     override val isSuspend: Boolean
         get() = false
 
     final override val visibility: KVisibility?
-        get() = getVisibility(kmProperty.flags, isJava)
+        get() = getVisibility(kmProperty.visibility, isJava)
 
     override val annotations: List<Annotation>
         get() = TODO("KotlinProperty2.annotations: Not yet implemented")
@@ -120,7 +119,7 @@ open class KotlinProperty2<D, E, V> protected constructor(
     @Suppress("LeakingThis")
     final override val getter: KGetter2Internal<D, E, V> = Getter(
         name = "<get-${kmProperty.name}>",
-        flags = kmProperty.getterFlags,
+        attributes = kmProperty.getter,
         property = this,
         javaGetter,
     )
@@ -166,26 +165,26 @@ open class KotlinProperty2<D, E, V> protected constructor(
 
     private data class Getter<D, E, V>(
         override val name: String,
-        private val flags: Flags,
+        private val attributes: KmPropertyAccessorAttributes,
         override val property: KotlinProperty2<D, E, V>,
         private val javaGetter: Method?
     ) : KGetter2Internal<D, E, V> {
         override val isAbstract: Boolean
-            get() = isAbstract(javaGetter, flags)
+            get() = isAbstract(javaGetter, attributes.modality)
         override val isFinal: Boolean
-            get() = isFinal(javaGetter, flags)
+            get() = isFinal(javaGetter, attributes.modality)
         override val isOpen: Boolean
-            get() = isOpen(javaGetter, flags)
+            get() = isOpen(javaGetter, attributes.modality)
         override val isExternal: Boolean
-            get() = IS_EXTERNAL(flags)
+            get() = attributes.isExternal
         override val isInfix: Boolean
-            get() = IS_INFIX(flags)
+            get() = false
         override val isInline: Boolean
-            get() = IS_INLINE(flags)
+            get() = attributes.isInline
         override val isOperator: Boolean
-            get() = IS_OPERATOR(flags)
+            get() = false
         override val isSuspend: Boolean
-            get() = IS_SUSPEND(flags)
+            get() = false
 
         override val annotations: List<Annotation>
             get() = TODO("KotlinProperty2.Getter.annotations: Not yet implemented")
@@ -196,7 +195,7 @@ open class KotlinProperty2<D, E, V> protected constructor(
         override val typeParameters: List<KTypeParameter>
             get() = TODO("KotlinProperty2.Getter.typeParameters: Not yet implemented")
         override val visibility: KVisibility?
-            get() = getVisibility(flags)
+            get() = getVisibility(attributes.visibility)
 
         override val javaMethod: Method?
             get() = javaGetter
@@ -207,7 +206,7 @@ open class KotlinProperty2<D, E, V> protected constructor(
             } else {
                 KotlinTransientFunction(
                     name = javaGetter.name,
-                    flags = flags,
+                    attributes = attributes,
                     returnType = property.returnType,
                     javaMethod = javaGetter,
                     instanceClass = property.instanceClass,

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinTransientFunction.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinTransientFunction.kt
@@ -1,43 +1,42 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.Flag.Function.IS_EXTERNAL
-import kotlinx.metadata.Flag.Function.IS_INFIX
-import kotlinx.metadata.Flag.Function.IS_INLINE
-import kotlinx.metadata.Flag.Function.IS_OPERATOR
-import kotlinx.metadata.Flag.Function.IS_SUSPEND
-import kotlinx.metadata.Flags
 import java.lang.reflect.Method
 import java.util.Objects
 import kotlin.reflect.KParameter
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVisibility
+import kotlinx.metadata.KmPropertyAccessorAttributes
+import kotlinx.metadata.isExternal
+import kotlinx.metadata.isInline
+import kotlinx.metadata.modality
+import kotlinx.metadata.visibility
 
 @Suppress("LongParameterList")
 class KotlinTransientFunction<V>(
     override val name: String,
-    private val flags: Flags,
+    private val attributes: KmPropertyAccessorAttributes,
     override val returnType: KType,
     override val javaMethod: Method,
     private val instanceClass: Class<*>,
     private val isExtension: Boolean
 ) : KFunctionInternal<V>, Function<V>, KTransient {
     override val isAbstract: Boolean
-        get() = isAbstract(javaMethod, flags)
+        get() = isAbstract(javaMethod, attributes.modality)
     override val isFinal: Boolean
-        get() = isFinal(javaMethod, flags)
+        get() = isFinal(javaMethod, attributes.modality)
     override val isOpen: Boolean
-        get() = isOpen(javaMethod, flags)
+        get() = isOpen(javaMethod, attributes.modality)
     override val isExternal: Boolean
-        get() = IS_EXTERNAL(flags)
+        get() = attributes.isExternal
     override val isInfix: Boolean
-        get() = IS_INFIX(flags)
+        get() = false
     override val isInline: Boolean
-        get() = IS_INLINE(flags)
+        get() = attributes.isInline
     override val isOperator: Boolean
-        get() = IS_OPERATOR(flags)
+        get() = false
     override val isSuspend: Boolean
-        get() = IS_SUSPEND(flags)
+        get() = false
 
     override val annotations: List<Annotation>
         get() = TODO("Not yet implemented")
@@ -46,14 +45,14 @@ class KotlinTransientFunction<V>(
     override val typeParameters: List<KTypeParameter>
         get() = TODO("Not yet implemented")
     override val visibility: KVisibility?
-        get() = getVisibility(flags)
+        get() = getVisibility(attributes.visibility)
 
     override val signature: MemberSignature
         get() = javaMethod.toSignature()
 
     override fun asFunctionFor(instanceClass: Class<*>, isExtension: Boolean) = KotlinTransientFunction<V>(
         name = name,
-        flags = flags,
+        attributes = attributes,
         returnType = returnType,
         javaMethod = javaMethod,
         instanceClass = instanceClass,
@@ -62,7 +61,7 @@ class KotlinTransientFunction<V>(
 
     override fun withJavaMethod(method: Method) = KotlinTransientFunction<V>(
         name = method.name,
-        flags = flags,
+        attributes = attributes,
         returnType = method.returnType.createKType(returnType.isMarkedNullable),
         javaMethod = method,
         instanceClass = instanceClass,

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinType.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinType.kt
@@ -1,9 +1,10 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.KmType
 import kotlin.reflect.KClassifier
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
+import kotlinx.metadata.KmType
+import kotlinx.metadata.isNullable
 
 class KotlinType(private val kmType: KmType) : KType, KInternal {
     override val annotations: List<Annotation>

--- a/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinTypeParameter.kt
+++ b/libs/kotlin-reflection/src/main/kotlin/net/corda/kotlin/reflect/types/KotlinTypeParameter.kt
@@ -1,15 +1,15 @@
 package net.corda.kotlin.reflect.types
 
-import kotlinx.metadata.Flag.TypeParameter.IS_REIFIED
-import kotlinx.metadata.KmTypeParameter
-import kotlinx.metadata.KmVariance
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeParameter
 import kotlin.reflect.KVariance
+import kotlinx.metadata.KmTypeParameter
+import kotlinx.metadata.KmVariance
+import kotlinx.metadata.isReified
 
 class KotlinTypeParameter(private val kmTypeParameter: KmTypeParameter) : KTypeParameter, KInternal {
     override val isReified: Boolean
-        get() = IS_REIFIED(kmTypeParameter.flags)
+        get() = kmTypeParameter.isReified
     override val name: String
         get() = kmTypeParameter.name
     override val upperBounds: List<KType>


### PR DESCRIPTION
Kotlin Metadata 0.7.0 is a breaking change from 0.6.2, but thankfully it's just an internal dependency.

Also upgrade ASM 9.4 -> 9.5 for `-conditionalpackage` dependency.