### PR TITLE
CORE-16330 Scheduler fixes

### DIFF
--- a/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
+++ b/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
@@ -63,13 +63,15 @@ class SchedulerEventHandler(
     }
 
     private fun triggerAndScheduleNext(coordinator: LifecycleCoordinator) = try {
-        schedulerLog.getLastTriggerAndLock(schedule.taskName, schedulerName).use {
-            if (it.secondsSinceLastScheduledTrigger >= schedule.scheduleIntervalInSeconds) {
+        schedulerLog.getLastTriggerAndLock(schedule.taskName, schedulerName).use { schedulerLock ->
+            if (schedulerLock.secondsSinceLastScheduledTrigger >= schedule.scheduleIntervalInSeconds) {
                 publisher.publish(schedule.taskName, schedule.scheduleTriggerTopic)
+                schedulerLock.updateAndRelease(schedulerName)
             } else {
                 logger.debug { "Skipping publishing task scheduler for ${schedule.taskName} " +
-                        "because it has only been ${it.secondsSinceLastScheduledTrigger} " +
+                        "because it has only been ${schedulerLock.secondsSinceLastScheduledTrigger} " +
                         "since the last trigger." }
+                schedulerLock.release()
             }
         }
         scheduleNext(coordinator)

--- a/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
+++ b/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
@@ -66,12 +66,11 @@ class SchedulerEventHandler(
         schedulerLog.getLastTriggerAndLock(schedule.taskName, schedulerName).use { schedulerLock ->
             if (schedulerLock.secondsSinceLastScheduledTrigger >= schedule.scheduleIntervalInSeconds) {
                 publisher.publish(schedule.taskName, schedule.scheduleTriggerTopic)
-                schedulerLock.updateAndRelease(schedulerName)
+                schedulerLock.updateLog(schedulerName)
             } else {
                 logger.debug { "Skipping publishing task scheduler for ${schedule.taskName} " +
                         "because it has only been ${schedulerLock.secondsSinceLastScheduledTrigger} " +
                         "since the last trigger." }
-                schedulerLock.release()
             }
         }
         scheduleNext(coordinator)

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,6 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
+#cordaApiVersion=5.1.0.xxx-SNAPSHOT
 cordaApiVersion=5.1.0.19-beta+
 
 disruptorVersion=3.4.4

--- a/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLock.kt
+++ b/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLock.kt
@@ -20,14 +20,14 @@ interface SchedulerLock : AutoCloseable {
     val secondsSinceLastScheduledTrigger: Long
 
     /**
-     * Updates the scheduler log entry with the current timestamp and releases it in the database.
+     * Updates the scheduler log entry with the current timestamp.
      *
      * @param schedulerId is the name/id of the current process.
      */
-    fun updateAndRelease(schedulerId: String)
+    fun updateLog(schedulerId: String)
 
     /**
-     * Releases the scheduler log entry in the database without updating it.
+     * Releases the log entry in the database.
      */
-    fun release()
+    override fun close()
 }

--- a/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLock.kt
+++ b/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLock.kt
@@ -20,8 +20,14 @@ interface SchedulerLock : AutoCloseable {
     val secondsSinceLastScheduledTrigger: Long
 
     /**
-     * Update the Scheduler Log with the current timestamp.
-     * `schedulerId` is the name/id of the current process.
+     * Updates the scheduler log entry with the current timestamp and releases it in the database.
+     *
+     * @param schedulerId is the name/id of the current process.
      */
     fun updateAndRelease(schedulerId: String)
+
+    /**
+     * Releases the scheduler log entry in the database without updating it.
+     */
+    fun release()
 }

--- a/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLock.kt
+++ b/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLock.kt
@@ -2,7 +2,7 @@ package net.corda.libs.scheduler.datamodel
 
 /**
  * Represents a lock on a given Task, allowing to find out when the last time was one was triggered.
- * This lock must be released by calling `updateAndRelease` or will be released when closing the `ScheduleLock`.
+ * This lock must be released by closing the `ScheduleLock`.
  */
 interface SchedulerLock : AutoCloseable {
     /**

--- a/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLockImpl.kt
+++ b/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLockImpl.kt
@@ -21,17 +21,13 @@ class SchedulerLockImpl(
         secondsSinceLastScheduledTrigger = log.lastScheduled.until(log.now, ChronoUnit.SECONDS)
     }
 
-    override fun updateAndRelease(schedulerId: String) {
+    override fun updateLog(schedulerId: String) {
         log.schedulerId = schedulerId
         logEntityRepository.updateLog(taskName, schedulerId, em)
-        tx.commit()
-    }
-
-    override fun release() {
-        tx.rollback()
     }
 
     override fun close() {
+        tx.commit()
         em.close()
     }
 }

--- a/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLockImpl.kt
+++ b/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/SchedulerLockImpl.kt
@@ -27,6 +27,10 @@ class SchedulerLockImpl(
         tx.commit()
     }
 
+    override fun release() {
+        tx.rollback()
+    }
+
     override fun close() {
         em.close()
     }

--- a/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/db/TaskSchedulerLogEntityRepository.kt
+++ b/libs/scheduler/scheduler-datamodel/src/main/kotlin/net/corda/libs/scheduler/datamodel/db/TaskSchedulerLogEntityRepository.kt
@@ -21,8 +21,11 @@ class TaskSchedulerLogEntityRepository {
         val readQuery = em.createNamedQuery(TASK_SCHEDULER_LOG_GET_QUERY_NAME, TaskSchedulerLogEntity::class.java)
         readQuery.setParameter(TASK_SCHEDULER_LOG_QUERY_PARAM_NAME, taskName)
         readQuery.lockMode = LockModeType.PESSIMISTIC_WRITE
-        return readQuery.resultList.singleOrNull()?: TaskSchedulerLogEntity(taskName, schedulerId, Instant.MIN, Date.from(
-            Instant.now()))
+        return readQuery.resultList.singleOrNull()?:
+            TaskSchedulerLogEntity(taskName, schedulerId, Instant.MIN, Date.from(Instant.now()))
+                .also {
+                    em.persist(it)
+                }
     }
 
     /**

--- a/libs/scheduler/scheduler-datamodel/src/test/kotlin/SchedulerLockTest.kt
+++ b/libs/scheduler/scheduler-datamodel/src/test/kotlin/SchedulerLockTest.kt
@@ -61,7 +61,7 @@ class SchedulerLockTest {
     }
 
     @Test
-    fun `when close, commit the tx and the close em`() {
+    fun `when close, commit the tx and close the em`() {
         SchedulerLockImpl("superman", "hulk", em, repo).close()
         verify(tx).commit()
         verify(em).close()

--- a/libs/scheduler/scheduler-datamodel/src/test/kotlin/SchedulerLockTest.kt
+++ b/libs/scheduler/scheduler-datamodel/src/test/kotlin/SchedulerLockTest.kt
@@ -53,17 +53,17 @@ class SchedulerLockTest {
     }
 
     @Test
-    fun `when updateAndRelease update and commit`() {
+    fun `when updateLog update`() {
         SchedulerLockImpl("superman", "hulk", em, repo).use {
             it.updateLog("thor")
             verify(repo).updateLog("superman", "thor", em)
-            verify(tx).commit()
         }
     }
 
     @Test
-    fun `when close, close em`() {
+    fun `when close, commit the tx and the close em`() {
         SchedulerLockImpl("superman", "hulk", em, repo).close()
+        verify(tx).commit()
         verify(em).close()
     }
 }

--- a/libs/scheduler/scheduler-datamodel/src/test/kotlin/SchedulerLockTest.kt
+++ b/libs/scheduler/scheduler-datamodel/src/test/kotlin/SchedulerLockTest.kt
@@ -55,7 +55,7 @@ class SchedulerLockTest {
     @Test
     fun `when updateAndRelease update and commit`() {
         SchedulerLockImpl("superman", "hulk", em, repo).use {
-            it.updateAndRelease("thor")
+            it.updateLog("thor")
             verify(repo).updateLog("superman", "thor", em)
             verify(tx).commit()
         }


### PR DESCRIPTION
Adding a topic for the `Scheduler` allowed us to go past the error: "_net.corda.messaging.api.exception.CordaMessageAPIFatalException: Cannot find topic X_" and then revealed the below issues:

1. we were not using `SchedulerLock.updateAndRelease` which also commits the scheduler lock's DB transaction and so we would get: "_Caused by: java.sql.SQLTransientConnectionException: HikariP not available, request timed out after X ms._" after a while, because we were closing the entity manager without committing the transaction first.
2. we were not persisting the scheduled task to `task_scheduler_log` DB table. 

* changes `SchedulerLock.updateAndRelease` to only update the DB log entry and moves the releasing of the DB log entry (committing the DB transaction) to the `SchedulerLock.close` method.
* persists the scheduled task to `task_scheduler_log` DB table. 
