### PR TITLE
CORE-14624: Made helm charts more flexible to allow for enterprise configuration more easily.

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -256,7 +256,8 @@ spec:
             {{- include "corda.rbacDbUserEnv" . | nindent 12 }}
             {{- include "corda.clusterDbEnv" . | nindent 12 }}
             {{- include "corda.restApiAdminSecretEnv" . | nindent 12 }}
-            {{- include "corda.cryptoDbUserEnv" . | nindent 12 }}
+            {{- include "corda.cryptoDbUsernameEnv" . | nindent 12 }}
+            {{- include "corda.cryptoDbPasswordEnv" . | nindent 12 }}
       containers:
         - name: apply
           image: {{ include "corda.bootstrapDbClientImage" . }}
@@ -310,7 +311,8 @@ spec:
               value: {{ .Values.bootstrap.db.crypto.schema | quote }}
             {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
             {{- include "corda.rbacDbUserEnv" . | nindent 12 }}
-            {{- include "corda.cryptoDbUserEnv" . | nindent 12 }}
+            {{- include "corda.cryptoDbUsernameEnv" . | nindent 12 }}
+            {{- include "corda.cryptoDbPasswordEnv" . | nindent 12 }}
             {{- include "corda.clusterDbEnv" . | nindent 12 }}
       volumes:
         - name: temp

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -424,7 +424,7 @@ Default name for crypto DB secret
 {{/*
 Crypto worker environment variable
 */}}
-{{- define "corda.cryptoDbUserEnv" -}}
+{{- define "corda.cryptoDbUsernameEnv" -}}
 - name: CRYPTO_DB_USER_USERNAME
   valueFrom:
     secretKeyRef:
@@ -435,6 +435,8 @@ Crypto worker environment variable
       name: {{ include "corda.cryptoDbDefaultSecretName" . | quote }}
       key: "username"
       {{- end }}
+{{- end }}
+{{- define "corda.cryptoDbPasswordEnv" -}}
 - name: CRYPTO_DB_USER_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -230,7 +230,9 @@ spec:
             value: {{ required (printf "Must specify workers.%s.kafka.sasl.password.value, workers.%s.kafka.sasl.password.valueFrom.secretKeyRef.name, kafka.sasl.password.value, or kafka.sasl.password.valueFrom.secretKeyRef.name" $worker $worker) $.Values.kafka.sasl.password.value }}
             {{- end }}
           {{- end }}
+        {{- if not (($.Values).vault).url }}
         {{- include "corda.configSaltAndPassphraseEnv" $ | nindent 10 }}
+        {{- end }}
         {{- /* TODO-[CORE-16419]: isolate StateManager database from the Cluster database */ -}}
         {{- if or $optionalArgs.clusterDbAccess $optionalArgs.stateManagerDbAccess }}
         {{- include "corda.clusterDbEnv" $ | nindent 10 }}


### PR DESCRIPTION
Do not propagate config salt and passphrase when using Vault.
 
Split out setting crypto DB username and password, so that if a consuming chart is passing password via Vault they do not need to include the password unnecesarily in the environment.