### PR TITLE
CORE-17058 - Add minVersion for network endpoints introduced in 5.1

### DIFF
--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -3,6 +3,7 @@ package net.corda.membership.rest.v1
 import net.corda.rest.RestResource
 import net.corda.rest.annotations.HttpPOST
 import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.annotations.RestPathParameter
 
 /**
@@ -36,6 +37,7 @@ interface MGMAdminRestResource : RestResource {
      */
     @HttpPOST(
         path = "{holdingIdentityShortHash}/force-decline/{requestId}",
+        minVersion = RestApiVersion.C5_1,
         description = "This method enables you to force decline an in-progress registration request that may be stuck" +
                 " or displaying some other unexpected behaviour."
     )

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMRestResource.kt
@@ -560,6 +560,7 @@ interface MGMRestResource : RestResource {
      */
     @HttpPOST(
         path = "{holdingIdentityShortHash}/group-parameters",
+        minVersion = RestApiVersion.C5_1,
         description = "This API allows you to make changes to the group parameters by submitting an updated version " +
                 "of the group parameters.",
         responseDescription = "The newly updated group parameters"

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v1.json
@@ -2440,54 +2440,6 @@
         }
       }
     },
-    "/mgm/{holdingidentityshorthash}/group-parameters" : {
-      "post" : {
-        "tags" : [ "MGM API" ],
-        "description" : "This API allows you to make changes to the group parameters by submitting an updated version of the group parameters.",
-        "operationId" : "post_mgm__holdingidentityshorthash__group_parameters",
-        "parameters" : [ {
-          "name" : "holdingidentityshorthash",
-          "in" : "path",
-          "description" : "The holding identity ID of the MGM",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The holding identity ID of the MGM",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "description" : "requestBody",
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/RestGroupParameters"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "The newly updated group parameters",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/RestGroupParameters"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/mgm/{holdingidentityshorthash}/info" : {
       "get" : {
         "tags" : [ "MGM API" ],
@@ -2954,47 +2906,6 @@
                 }
               }
             }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/mgmadmin/{holdingidentityshorthash}/force-decline/{requestid}" : {
-      "post" : {
-        "tags" : [ "MGM Admin API" ],
-        "description" : "This method enables you to force decline an in-progress registration request that may be stuck or displaying some other unexpected behaviour.",
-        "operationId" : "post_mgmadmin__holdingidentityshorthash__force_decline__requestid_",
-        "parameters" : [ {
-          "name" : "holdingidentityshorthash",
-          "in" : "path",
-          "description" : "The holding identity ID of the MGM of the membership group",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The holding identity ID of the MGM of the membership group",
-            "nullable" : false,
-            "example" : "string"
-          }
-        }, {
-          "name" : "requestid",
-          "in" : "path",
-          "description" : "ID of the registration request",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "ID of the registration request",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Success"
           },
           "401" : {
             "description" : "Unauthorized"
@@ -5631,3 +5542,4 @@
     }
   }
 }
+


### PR DESCRIPTION
Setting `minVersion` to 5.1 for network endpoints that were introduced in 5.1 and didn't have one, so they were falling back to the default (5.0).

In order to identify the endpoints, I did a diff between the v1 baseline files in the branches `release/os/5.0` and `release/os/5.1` 