### PR TITLE
CORE-17114 Pre-install check improvements

### DIFF
--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckLimits.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckLimits.kt
@@ -20,8 +20,6 @@ class CheckLimits : Callable<Int>, PluginContext() {
     private var defaultRequests: ResourceValues? = null
     private var defaultLimits: ResourceValues? = null
 
-    private var resourceRequestsChecked = false
-
     private fun parseMemoryString(memoryString: String): Double {
         val regex = Regex("(\\d+)([EPTGMKk]?i?[Bb]?)?")
 
@@ -81,13 +79,48 @@ class CheckLimits : Callable<Int>, PluginContext() {
 
     // use the checkResource function to check each individual resource
     private fun checkResources(resources: ResourceConfig?, name: String) {
-        resourceRequestsChecked = true
-
         val requests: ResourceValues? = resources?.requests ?: defaultRequests
         val limits: ResourceValues? = resources?.limits ?: defaultLimits
 
-        logger.info("${name.uppercase()}:")
+        checkCpu(requests, limits, name)
+        checkMemory(requests, limits, name)
+    }
 
+    private fun checkCpu(requests: ResourceValues?, limits: ResourceValues?, name: String) {
+        try {
+            if (requests?.cpu == null) {
+                requests?.cpu = defaultRequests?.cpu
+            }
+            if (limits?.cpu == null) {
+                limits?.cpu = defaultLimits?.cpu
+            }
+
+            if (requests?.cpu != null || limits?.cpu != null) {
+                if (requests?.cpu == null || limits?.cpu == null) {
+                    report.addEntry(ReportEntry("${name.uppercase()} cpu resources contains both a request and a limit", false))
+                    return
+                }
+                report.addEntry(ReportEntry("${name.uppercase()} cpu resources contains both a request and a limit", true))
+                logger.info("${name.uppercase()} CPU: \n\t request - ${requests.cpu}\n\t limit - ${limits.cpu}")
+                val limit: Double = parseCpuString(limits.cpu!!)
+                val request: Double = parseCpuString(requests.cpu!!)
+                report.addEntry(ReportEntry("Parse \"$name\" cpu resource strings", true))
+
+                if (limit >= request) {
+                    report.addEntry(ReportEntry("$name cpu requests do not exceed limits", true))
+                } else {
+                    report.addEntry(ReportEntry("$name cpu requests do not exceed limits", false,
+                        ResourceLimitsExceededException("Request ($requests.cpu!!) is greater than it's limit ($limits.cpu!!)")))
+                }
+            }
+
+        } catch(e: IllegalArgumentException) {
+            report.addEntry(ReportEntry("Parse \"$name\" cpu resource strings", false, e))
+        }
+    }
+
+    // use the checkResource function to check each individual resource
+    private fun checkMemory(requests: ResourceValues?, limits: ResourceValues?, name: String) {
         try {
             if (requests?.memory == null) {
                 requests?.memory = defaultRequests?.memory
@@ -102,43 +135,21 @@ class CheckLimits : Callable<Int>, PluginContext() {
                     return
                 }
                 report.addEntry(ReportEntry("${name.uppercase()} memory resources contains both a request and a limit", true))
-                logger.info("Memory: \n\t request - ${requests.memory}\n\t limit - ${limits.memory}")
+                logger.info("${name.uppercase()} Memory: \n\t request - ${requests.memory}\n\t limit - ${limits.memory}")
                 val limit = parseMemoryString(limits.memory!!)
                 val request = parseMemoryString(requests.memory!!)
-                if (limit < request) {
-                    throw ResourceLimitsExceededException("Request ($requests.memory!!) is greater than it's limit ($limits.memory!!)")
+                report.addEntry(ReportEntry("Parse \"$name\" memory resource strings", true))
+
+                if (limit >= request) {
+                    report.addEntry(ReportEntry("$name memory requests do not exceed limits", true))
+                } else {
+                    report.addEntry(ReportEntry("$name memory requests do not exceed limits", false,
+                        ResourceLimitsExceededException("Request ($requests.memory!!) is greater than it's limit ($limits.memory!!)")))
                 }
             }
 
-            if (requests?.cpu == null) {
-                requests?.cpu = defaultRequests?.cpu
-            }
-            if (limits?.cpu == null) {
-                limits?.cpu = defaultLimits?.cpu
-            }
-
-            if (requests?.cpu != null || limits?.cpu != null) {
-                if (requests?.cpu == null || limits?.cpu == null) {
-                    report.addEntry(ReportEntry("${name.uppercase()} cpu resources contains both a request and a limit", false))
-                    return
-                }
-                report.addEntry(ReportEntry("${name.uppercase()} cpu resources contains both a request and a limit", true))
-                logger.info("CPU: \n\t request - ${requests.cpu}\n\t limit - ${limits.cpu}")
-                val limit: Double = parseCpuString(limits.cpu!!)
-                val request: Double = parseCpuString(requests.cpu!!)
-                if (limit < request) {
-                    throw ResourceLimitsExceededException("Request ($requests.cpu!!) is greater than it's limit ($limits.cpu!!)")
-                }
-            }
-
-            report.addEntry(ReportEntry("Parse \"$name\" resource strings", true))
-            report.addEntry(ReportEntry("$name requests do not exceed limits", true))
         } catch(e: IllegalArgumentException) {
-            report.addEntry(ReportEntry("Parse \"$name\" resource strings", false, e))
-            return
-        } catch (e: ResourceLimitsExceededException) {
-            report.addEntry(ReportEntry("$name requests do not exceed limits", false, e))
-            return
+            report.addEntry(ReportEntry("Parse \"$name\" memory resource strings", false, e))
         }
     }
 

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
@@ -101,11 +101,14 @@ class PreInstallPlugin : Plugin() {
                 throw SecretException("No secret key provided with secret name $secretName.")
             }
             return try {
-                val secret: Secret = if (namespace != null) {
+                val secret: Secret? = if (namespace != null) {
                     checkNamespace(namespace)
                     client.secrets().inNamespace(namespace).withName(secretName).get()
                 } else {
                     client.secrets().withName(secretName).get()
+                }
+                if (secret == null) {
+                    throw SecretException("Secret $secretName not found.")
                 }
                 val encoded = secret.data[secretKey] ?: throw SecretException("Secret $secretName has no key $secretKey.")
                 String(Base64.getDecoder().decode(encoded))

--- a/tools/plugins/preinstall/src/test/kotlin/net/corda/cli/plugins/preinstall/CheckLimitsTest.kt
+++ b/tools/plugins/preinstall/src/test/kotlin/net/corda/cli/plugins/preinstall/CheckLimitsTest.kt
@@ -15,6 +15,7 @@ class CheckLimitsTest {
         val ret = CommandLine(limits).execute(path)
 
         assertTrue(limits.report.toString().contains("Parse resource properties from YAML: PASSED"))
+        assertTrue(limits.report.toString().contains("Parse resource properties from YAML: PASSED"))
         assertEquals(0, ret)
     }
 
@@ -24,7 +25,8 @@ class CheckLimitsTest {
         val limits = CheckLimits()
         val ret = CommandLine(limits).execute(path)
 
-        assertTrue(limits.report.toString().contains("bootstrap requests do not exceed limits: PASSED"))
+        assertTrue(limits.report.toString().contains("bootstrap cpu requests do not exceed limits: PASSED"))
+        assertTrue(limits.report.toString().contains("bootstrap memory requests do not exceed limits: PASSED"))
         assertEquals(0, ret)
     }
 
@@ -34,7 +36,8 @@ class CheckLimitsTest {
         val limits = CheckLimits()
         val ret = CommandLine(limits).execute(path)
 
-        assertTrue(limits.report.toString().contains("bootstrap requests do not exceed limits: FAILED"))
+        assertTrue(limits.report.toString().contains("bootstrap cpu requests do not exceed limits: FAILED"))
+        assertTrue(limits.report.toString().contains("bootstrap memory requests do not exceed limits: FAILED"))
         assertEquals(1, ret)
     }
 
@@ -44,7 +47,8 @@ class CheckLimitsTest {
         val limits = CheckLimits()
         val ret = CommandLine(limits).execute(path)
 
-        assertTrue(limits.report.toString().contains("Parse \"bootstrap\" resource strings: FAILED"))
+        assertTrue(limits.report.toString().contains("Parse \"bootstrap\" cpu resource strings: FAILED"))
+        assertTrue(limits.report.toString().contains("Parse \"bootstrap\" memory resource strings: FAILED"))
         assertEquals(1, ret)
     }
 
@@ -54,7 +58,8 @@ class CheckLimitsTest {
         val limits = CheckLimits()
         val ret = CommandLine(limits).execute(path)
 
-        assertTrue(limits.report.toString().contains("Parse \"bootstrap\" resource strings: PASSED"))
+        assertTrue(limits.report.toString().contains("Parse \"bootstrap\" cpu resource strings: PASSED"))
+        assertTrue(limits.report.toString().contains("Parse \"bootstrap\" memory resource strings: PASSED"))
         assertEquals(0, ret)
     }
 

--- a/tools/plugins/preinstall/src/test/resources/LimitsTestOverLimits.yaml
+++ b/tools/plugins/preinstall/src/test/resources/LimitsTestOverLimits.yaml
@@ -1,7 +1,7 @@
 resources:
   requests:
     memory: "200E"
-    cpu: "500Gb"
+    cpu: "500G"
   limits:
     memory: "1250Mib"
-    cpu: "1000B"
+    cpu: "1000k"

--- a/values-prereqs.yaml
+++ b/values-prereqs.yaml
@@ -18,6 +18,9 @@ bootstrap:
   restApiAdmin:
     password:
       value: "admin"
+  # Disable pre-install check as we are not specifying resources
+  preinstallCheck:
+    enabled: false
   db:
     cluster:
       password:

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,9 @@ bootstrap:
   restApiAdmin:
     password:
       value: "admin"
+  # Disable pre-install check as we are not specifying resources
+  preinstallCheck:
+    enabled: false
   db:
     cluster:
       password:


### PR DESCRIPTION
A few improvements to the pre-install check:

- Handle `null` when looking up secret
- Output single-line resource check info messages
- Always check both memory and CPU resources
- Update developer `values.yaml` and `values-prereqs.yaml` to disable the preinstall check as they do not specify resources (as is the preference in a low resource environment)