### PR TITLE
CORE-17113 Backchain resolution race condition

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
@@ -122,9 +122,7 @@ class TransactionBackchainReceiverFlowV1(
             }
         }
 
-        if (sortedTransactionIds.isNotEmpty()) {
-            session.send(TransactionBackchainRequestV1.Stop)
-        }
+        session.send(TransactionBackchainRequestV1.Stop)
 
         utxoLedgerMetricRecorder.recordTransactionBackchainLength(sortedTransactionIds.size)
 
@@ -135,8 +133,8 @@ class TransactionBackchainReceiverFlowV1(
     private fun retrieveGroupParameters(
         retrievedTransaction: UtxoSignedTransaction
     ) {
-        if(version == TransactionBackChainResolutionVersion.V1){
-            log.trace("Backchain resolution of $initialTransactionIds - Group parameters retrieval is not available in V1")
+        if (version == TransactionBackChainResolutionVersion.V1) {
+            log.trace { "Backchain resolution of $initialTransactionIds - Group parameters retrieval is not available in V1" }
             return
         }
         val retrievedTransactionId = retrievedTransaction.id

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainResolutionFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainResolutionFlowV1.kt
@@ -49,6 +49,7 @@ class TransactionBackchainResolutionFlowV1(
             initialTransactionIds.filter { utxoLedgerPersistenceService.findSignedTransaction(it, VERIFIED) != null }.toSet()
         val originalTransactionsToRetrieve = initialTransactionIds - alreadyVerifiedTransactions
         if (originalTransactionsToRetrieve.isNotEmpty()) {
+            // this log line is worded poorly
             log.debug {
                 "Backchain resolution of $initialTransactionIds - Transaction needs to resolve its dependencies of " +
                         "$originalTransactionsToRetrieve in its backchain, starting transaction backchain resolution"

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainResolutionFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainResolutionFlowV1.kt
@@ -49,10 +49,9 @@ class TransactionBackchainResolutionFlowV1(
             initialTransactionIds.filter { utxoLedgerPersistenceService.findSignedTransaction(it, VERIFIED) != null }.toSet()
         val originalTransactionsToRetrieve = initialTransactionIds - alreadyVerifiedTransactions
         if (originalTransactionsToRetrieve.isNotEmpty()) {
-            // this log line is worded poorly
             log.debug {
-                "Backchain resolution of $initialTransactionIds - Transaction needs to resolve its dependencies of " +
-                        "$originalTransactionsToRetrieve in its backchain, starting transaction backchain resolution"
+                "Backchain resolution of $initialTransactionIds - Resolving unseen transactions $originalTransactionsToRetrieve" +
+                        ", starting transaction backchain resolution"
             }
             val topologicalSort = flowEngine.subFlow(
                 TransactionBackchainReceiverFlowV1(

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
@@ -7,11 +7,13 @@ import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.utxo.flow.impl.UtxoLedgerMetricRecorder
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TopologicalSort
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackChainResolutionVersion
+import net.corda.ledger.utxo.flow.impl.flows.backchain.v2.TransactionBackchainReceiverFlowV2Test
 import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
 import net.corda.ledger.utxo.flow.impl.persistence.TransactionExistenceStatus
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.libs.configuration.SmartConfig
+import net.corda.membership.lib.SignedGroupParameters
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.crypto.SecureHash
@@ -21,6 +23,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -29,6 +32,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 
 @Suppress("MaxLineLength")
@@ -117,8 +121,8 @@ class TransactionBackchainReceiverFlowV1Test {
     fun `a transaction without any dependencies does not need resolving`() {
         assertThat(callTransactionBackchainReceiverFlow(emptySet()).complete()).isEmpty()
 
-        verifyNoInteractions(session)
-        verifyNoInteractions(utxoLedgerPersistenceService)
+        verify(session).send(TransactionBackchainRequestV1.Stop)
+        verifyNoMoreInteractions(session)
         verifyNoInteractions(
             utxoLedgerGroupParametersPersistenceService,
             signedGroupParametersVerifier
@@ -192,6 +196,44 @@ class TransactionBackchainReceiverFlowV1Test {
         verify(session).sendAndReceive(List::class.java, TransactionBackchainRequestV1.Get(setOf(TX_ID_1)))
         verify(session).sendAndReceive(List::class.java, TransactionBackchainRequestV1.Get(setOf(TX_ID_2)))
         verify(session, never()).sendAndReceive(List::class.java, TransactionBackchainRequestV1.Get(setOf(TX_ID_3)))
+        verify(utxoLedgerPersistenceService).persistIfDoesNotExist(retrievedTransaction1, UNVERIFIED)
+        verify(utxoLedgerPersistenceService).persistIfDoesNotExist(retrievedTransaction2, UNVERIFIED)
+        verify(utxoLedgerPersistenceService, never()).persistIfDoesNotExist(retrievedTransaction3, UNVERIFIED)
+        verifyNoInteractions(
+            utxoLedgerGroupParametersPersistenceService,
+            signedGroupParametersVerifier
+        )
+    }
+
+    @Test
+    fun `receiving only transactions that are stored locally as VERIFIED does not have their dependencies added to the transactions to retrieve and stops resolution`() {
+        whenever(utxoLedgerPersistenceService.findSignedTransaction(TX_ID_1)).thenReturn(retrievedTransaction1)
+
+        whenever(session.sendAndReceive(eq(List::class.java), any())).thenReturn(
+            listOf(retrievedTransaction1),
+            listOf(retrievedTransaction2)
+        )
+
+        whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+
+        whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
+            .thenReturn(TransactionExistenceStatus.VERIFIED to listOf(PACKAGE_SUMMARY))
+
+        whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
+        whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
+        whenever(retrievedTransaction1.referenceStateRefs).thenReturn(listOf(TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1))
+
+        whenever(retrievedTransaction2.id).thenReturn(TX_ID_2)
+        whenever(retrievedTransaction2.inputStateRefs).thenReturn(emptyList())
+        whenever(retrievedTransaction2.referenceStateRefs).thenReturn(emptyList())
+
+        assertThat(callTransactionBackchainReceiverFlow(setOf(TX_ID_1, TX_ID_2)).complete()).isEqualTo(emptyList<SecureHash>())
+
+        verify(session).sendAndReceive(List::class.java, TransactionBackchainRequestV1.Get(setOf(TX_ID_1)))
+        verify(session).sendAndReceive(List::class.java, TransactionBackchainRequestV1.Get(setOf(TX_ID_2)))
+        verify(session, never()).sendAndReceive(List::class.java, TransactionBackchainRequestV1.Get(setOf(TX_ID_3)))
+        verify(session).send(TransactionBackchainRequestV1.Stop)
         verify(utxoLedgerPersistenceService).persistIfDoesNotExist(retrievedTransaction1, UNVERIFIED)
         verify(utxoLedgerPersistenceService).persistIfDoesNotExist(retrievedTransaction2, UNVERIFIED)
         verify(utxoLedgerPersistenceService, never()).persistIfDoesNotExist(retrievedTransaction3, UNVERIFIED)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
@@ -7,13 +7,11 @@ import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.utxo.flow.impl.UtxoLedgerMetricRecorder
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TopologicalSort
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackChainResolutionVersion
-import net.corda.ledger.utxo.flow.impl.flows.backchain.v2.TransactionBackchainReceiverFlowV2Test
 import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
 import net.corda.ledger.utxo.flow.impl.persistence.TransactionExistenceStatus
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.libs.configuration.SmartConfig
-import net.corda.membership.lib.SignedGroupParameters
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.crypto.SecureHash
@@ -23,7 +21,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq


### PR DESCRIPTION
Fix a race-condition in backchain resolution where:

- Two flows resolve backchains containing the same transactions.
- Flow A resolves all the transactions first and completes.
- Flow B then sees all these transactions as verified and does not persist them.
- Flow B hangs because we only send a stop if at least one transaction was persisted.

To resolve this we have removed an `isNotEmpty` check when sending the stop message. After looking at the code, we could not identify a reason to keep the check in place.