### PR TITLE
CORE-17074: Include JetBrains attribution for kotlin-reflection library.

### DIFF
--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -11,6 +11,23 @@ plugins {
 
 description "Bare bones Kotlin reflection within an OSGi framework."
 
+pluginManager.withPlugin('maven-publish') {
+    publishing {
+        publications.configureEach {
+            pom {
+                // Include attribution for kotlinx-metadata-jvm library.
+                developers {
+                    developer {
+                        name = 'Kotlin Team'
+                        organization = 'JetBrains'
+                        organizationUrl = 'https://www.jetbrains.com'
+                    }
+                }
+            }
+        }
+    }
+}
+
 configurations {
     bundle {
         canBeDeclared = false
@@ -82,14 +99,6 @@ def resolve = tasks.register('resolve', Resolve) {
     }
 }
 
-// Gradle enterprise does not pick up OSGI tests by default as they they are of type TestOSGi rather than standard
-def importOSGiJunitXml = tasks.register('importOSGiJUnitXml', ImportJUnitXmlReports) {
-    dialect = GENERIC
-    reports.from(fileTree("$testResultsDir/integrationTest").matching {
-        include '**/TEST-*.xml'
-    })
-}
-
 def testOSGi = tasks.register('testOSGi', TestOSGi) {
     resultsDirectory = file("$testResultsDir/integrationTest")
     bundles = files(
@@ -98,6 +107,15 @@ def testOSGi = tasks.register('testOSGi', TestOSGi) {
         testingBundle
     )
     bndrun = resolve.flatMap { it.outputBndrun }
+}
+
+// Gradle enterprise does not pick up OSGI tests by default as they they are of type TestOSGi rather than standard
+tasks.register('importOSGiJUnitXml', ImportJUnitXmlReports) {
+    dependsOn testOSGi
+    dialect = GENERIC
+    reports.from(fileTree("$testResultsDir/integrationTest").matching {
+        include '**/TEST-*.xml'
+    })
 }
 
 tasks.named('integrationTest') {


### PR DESCRIPTION
Include attribution for the `kotlinx-metadata-jvm` library into the published POM for `kotlin-reflection`.

This library uses Apache Licence 2.0.