### PR TITLE
CORE-17115: Send error messages back to the counterparty when data is received and the mapper state is null

### DIFF
--- a/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/RecordFactoryImpl.kt
+++ b/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/RecordFactoryImpl.kt
@@ -38,14 +38,14 @@ class RecordFactoryImpl @Activate constructor(
     private val sessionEventSerializer = cordaAvroSerializationFactory.createAvroSerializer<SessionEvent> { }
 
     override fun forwardError(
-        sessionEvent: SessionEvent,
+        sourceEvent: SessionEvent,
         exceptionEnvelope: ExceptionEnvelope,
         instant: Instant,
         flowConfig: SmartConfig,
         flowId: String
     ): Record<*, *> {
         return buildSessionRecord(
-            sessionEvent,
+            sourceEvent,
             SessionError(
                 exceptionEnvelope
             ),
@@ -56,17 +56,42 @@ class RecordFactoryImpl @Activate constructor(
     }
 
     override fun forwardEvent(
-        sessionEvent: SessionEvent,
+        sourceEvent: SessionEvent,
         instant: Instant,
         flowConfig: SmartConfig,
         flowId: String
     ): Record<*, *> {
         return buildSessionRecord(
-            sessionEvent,
-            sessionEvent.payload,
+            sourceEvent,
+            sourceEvent.payload,
             instant,
             flowConfig,
             flowId
+        )
+    }
+
+    override fun sendBackError(
+        sourceEvent: SessionEvent,
+        exceptionEnvelope: ExceptionEnvelope,
+        instant: Instant,
+        flowConfig: SmartConfig
+    ): Record<*, *> {
+        if (sourceEvent.messageDirection == MessageDirection.INBOUND) {
+            // In this case, the mapper should send the error back from where it came. To do this, switch the message
+            // direction to OUTBOUND and then use the usual forwarding machinery to ensure it goes to the right place.
+            sourceEvent.messageDirection = MessageDirection.OUTBOUND
+        } else {
+            // The mapper does not have the flow ID available to it, and so cannot send the session error back. Raise an
+            // error instead. At present this is done by providing a `null` flow ID, and letting the forwarding code
+            // raise an error when it discovers it needs it.
+            sourceEvent.messageDirection = MessageDirection.INBOUND
+        }
+        return buildSessionRecord(
+            sourceEvent,
+            SessionError(exceptionEnvelope),
+            instant,
+            flowConfig,
+            null
         )
     }
 
@@ -91,7 +116,7 @@ class RecordFactoryImpl @Activate constructor(
         newPayload: Any,
         timestamp: Instant,
         config: SmartConfig,
-        flowId: String
+        flowId: String?
     ) : Record<*, *> {
         val outputTopic = getSessionEventOutputTopic(sourceEvent)
         val (newDirection, sessionId) = when (outputTopic) {
@@ -112,6 +137,10 @@ class RecordFactoryImpl @Activate constructor(
         )
         return when (outputTopic) {
             Schemas.Flow.FLOW_EVENT_TOPIC -> {
+                if (flowId == null) {
+                    throw IllegalArgumentException("Flow ID is required to forward an event back to the flow event" +
+                            "topic, but it was not provided.")
+                }
                 Record(outputTopic, flowId, FlowEvent(flowId, sessionEvent))
             }
             Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC -> {

--- a/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
+++ b/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
@@ -55,15 +55,14 @@ class SessionEventExecutor(
             // back from where it came. Note that at present if the flow engine sends a data message without first
             // sending an init message this will result in failure, as the mapper has no knowledge of the flow ID to
             // respond on.
-            val outputRecord = recordFactory.forwardError(
+            val outputRecord = recordFactory.sendBackError(
                 sessionEvent,
                 ExceptionEnvelope(
                     "FlowMapper-SessionExpired",
                     "Tried to process session event for expired session with sessionId ${sessionEvent.sessionId}"
                 ),
                 instant,
-                flowConfig,
-                "invalid-flow-id"
+                flowConfig
             )
             FlowMapperResult(null, listOf(outputRecord))
         } else {

--- a/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
+++ b/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
@@ -51,6 +51,10 @@ class SessionEventExecutor(
                 "Flow mapper received session event for session which does not exist. Session may have expired. Returning error to " +
                         "counterparty. Key: $eventKey, Event: class ${sessionEvent.payload::class.java}, $sessionEvent"
             )
+            // In this case, the error message should not be forwarded through the mapper, and instead should be sent
+            // back from where it came. Note that at present if the flow engine sends a data message without first
+            // sending an init message this will result in failure, as the mapper has no knowledge of the flow ID to
+            // respond on.
             val outputRecord = recordFactory.forwardError(
                 sessionEvent,
                 ExceptionEnvelope(

--- a/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
+++ b/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
@@ -12,6 +12,7 @@ import net.corda.flow.mapper.executor.FlowMapperEventExecutor
 import net.corda.flow.mapper.factory.RecordFactory
 import net.corda.libs.configuration.SmartConfig
 import org.slf4j.LoggerFactory
+import java.lang.IllegalArgumentException
 import java.time.Instant
 
 @Suppress("LongParameterList")
@@ -55,16 +56,23 @@ class SessionEventExecutor(
             // back from where it came. Note that at present if the flow engine sends a data message without first
             // sending an init message this will result in failure, as the mapper has no knowledge of the flow ID to
             // respond on.
-            val outputRecord = recordFactory.sendBackError(
-                sessionEvent,
-                ExceptionEnvelope(
-                    "FlowMapper-SessionExpired",
-                    "Tried to process session event for expired session with sessionId ${sessionEvent.sessionId}"
-                ),
-                instant,
-                flowConfig
-            )
-            FlowMapperResult(null, listOf(outputRecord))
+            val outputRecords = try {
+                val record = recordFactory.sendBackError(
+                    sessionEvent,
+                    ExceptionEnvelope(
+                        "FlowMapper-SessionExpired",
+                        "Tried to process session event for expired session with sessionId ${sessionEvent.sessionId}"
+                    ),
+                    instant,
+                    flowConfig
+                )
+                listOf(record)
+            } catch (e: IllegalArgumentException) {
+                log.warn("Flow mapper received an outbound session message for session ${sessionEvent.sessionId} where " +
+                        "the session does not exist. Discarding the message.")
+                listOf()
+            }
+            FlowMapperResult(null, outputRecords)
         } else {
             log.warn(
                 "Flow mapper received error event from counterparty for session which does not exist. Session may have expired. " +

--- a/components/flow/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/RecordFactoryImplTest.kt
+++ b/components/flow/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/RecordFactoryImplTest.kt
@@ -37,6 +37,7 @@ internal class RecordFactoryImplTest {
     companion object {
         private const val SESSION_ID = "session-id"
         private const val FLOW_ID = "flow-id"
+        private const val SEQUENCE_NUMBER = 1
         private val alice = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "1")
         private val bob = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "1")
     }
@@ -81,7 +82,7 @@ internal class RecordFactoryImplTest {
             SessionError(
                 ExceptionEnvelope(
                     "FlowMapper-SessionError",
-                    "Received SessionError with sessionId 1"
+                    "Received SessionError with sessionId $SESSION_ID"
                 )
             ),
             null
@@ -90,8 +91,9 @@ internal class RecordFactoryImplTest {
         val record = recordFactoryImplSameCluster.forwardError(
             sessionEvent,
             ExceptionEnvelope(
-            "FlowMapper-SessionError",
-            "Received SessionError with sessionId 1"),
+                "FlowMapper-SessionError",
+                "Received SessionError with sessionId $SESSION_ID"
+            ),
             timestamp,
             flowConfig,
             "my-flow-id"
@@ -119,7 +121,7 @@ internal class RecordFactoryImplTest {
             SessionError(
                 ExceptionEnvelope(
                     "FlowMapper-SessionError",
-                    "Received SessionError with sessionId 1"
+                    "Received SessionError with sessionId $SESSION_ID"
                 )
             ),
             null
@@ -129,7 +131,7 @@ internal class RecordFactoryImplTest {
             sessionEvent,
             ExceptionEnvelope(
                 "FlowMapper-SessionError",
-                "Received SessionError with sessionId 1"),
+                "Received SessionError with sessionId $SESSION_ID"),
             timestamp,
             flowConfig,
             FLOW_ID
@@ -149,7 +151,7 @@ internal class RecordFactoryImplTest {
             MessageDirection.INBOUND,
             timestamp,
             SESSION_ID,
-            1,
+            SEQUENCE_NUMBER,
             alice,
             bob,
             SessionData(ByteBuffer.wrap("data".toByteArray()), null),
@@ -159,7 +161,7 @@ internal class RecordFactoryImplTest {
             sessionEvent,
             ExceptionEnvelope(
                 "FlowMapper-SessionError",
-                "Received SessionError with sessionId 1"),
+                "Received SessionError with sessionId $SESSION_ID"),
             timestamp,
             flowConfig,
             FLOW_ID
@@ -179,7 +181,7 @@ internal class RecordFactoryImplTest {
             MessageDirection.OUTBOUND,
             timestamp,
             SESSION_ID,
-            1,
+            SEQUENCE_NUMBER,
             alice,
             bob,
             SessionData(),
@@ -207,7 +209,7 @@ internal class RecordFactoryImplTest {
             MessageDirection.OUTBOUND,
             timestamp,
             SESSION_ID,
-            1,
+            SEQUENCE_NUMBER,
             HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "1"),
             HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "1"),
             SessionData(
@@ -236,7 +238,7 @@ internal class RecordFactoryImplTest {
             MessageDirection.INBOUND,
             Instant.now(),
             SESSION_ID,
-            1,
+            SEQUENCE_NUMBER,
             alice,
             bob,
             SessionData(ByteBuffer.wrap("data".toByteArray()), null),
@@ -263,7 +265,7 @@ internal class RecordFactoryImplTest {
             MessageDirection.INBOUND,
             timestamp,
             SESSION_ID,
-            1,
+            SEQUENCE_NUMBER,
             alice,
             bob,
             SessionData(ByteBuffer.wrap("data".toByteArray()), null),
@@ -271,7 +273,7 @@ internal class RecordFactoryImplTest {
         )
         val msgPayload = ExceptionEnvelope(
             "FlowMapper-SessionError",
-            "Received SessionError with sessionId 1"
+            "Received SessionError with sessionId $SESSION_ID"
         )
         val record = recordFactoryImplDifferentCluster.sendBackError(
             sessionEvent,
@@ -299,7 +301,7 @@ internal class RecordFactoryImplTest {
             MessageDirection.INBOUND,
             timestamp,
             SESSION_ID,
-            1,
+            SEQUENCE_NUMBER,
             alice,
             bob,
             SessionData(ByteBuffer.wrap("data".toByteArray()), null),
@@ -307,7 +309,7 @@ internal class RecordFactoryImplTest {
         )
         val msgPayload = ExceptionEnvelope(
             "FlowMapper-SessionError",
-            "Received SessionError with sessionId 1"
+            "Received SessionError with sessionId $SESSION_ID"
         )
         val record = recordFactoryImplSameCluster.sendBackError(
             sessionEvent,
@@ -330,7 +332,7 @@ internal class RecordFactoryImplTest {
             MessageDirection.OUTBOUND,
             timestamp,
             SESSION_ID,
-            1,
+            SEQUENCE_NUMBER,
             alice,
             bob,
             SessionData(ByteBuffer.wrap("data".toByteArray()), null),

--- a/components/flow/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutorTest.kt
+++ b/components/flow/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutorTest.kt
@@ -32,9 +32,11 @@ class SessionEventExecutorTest {
     private val flowConfig = SmartConfigImpl.empty().withValue(SESSION_P2P_TTL, ConfigValueFactory.fromAnyRef(10000))
     private val sessionEventSerializer = mock<CordaAvroSerializer<SessionEvent>>()
     private val record = Record("Topic", "Key", "Value")
+    private val sendBackRecord = Record("Topic", "Key", "Value2")
     private val recordFactory = mock<RecordFactory>{
         on { forwardError(any(), any(), any(), any(), any()) } doReturn record
         on { forwardEvent(any(), any(), any(), any()) } doReturn record
+        on { sendBackError(any(), any(), any(), any()) } doReturn sendBackRecord
     }
     private val sessionInitProcessor = mock<SessionInitProcessor>()
 
@@ -118,7 +120,7 @@ class SessionEventExecutorTest {
         assertThat(outboundEvents.size).isEqualTo(1)
 
         val outputRecord = outboundEvents.first()
-        assertThat(outputRecord.value).isEqualTo("Value")
+        assertThat(outputRecord.value).isEqualTo("Value2")
     }
 
     @Test

--- a/components/flow/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/executor/SessionInitProcessorTest.kt
+++ b/components/flow/flow-mapper-impl/src/test/kotlin/net/corda/flow/mapper/impl/executor/SessionInitProcessorTest.kt
@@ -23,24 +23,33 @@ class SessionInitProcessorTest {
 
     private val recordFactory = object : RecordFactory {
         override fun forwardEvent(
-            sessionEvent: SessionEvent,
+            sourceEvent: SessionEvent,
             instant: Instant,
             flowConfig: SmartConfig,
             flowId: String
         ): Record<*, *> {
-            return if (sessionEvent.messageDirection == MessageDirection.INBOUND) {
-                Record(Schemas.Flow.FLOW_EVENT_TOPIC, flowId, FlowEvent(flowId, sessionEvent))
+            return if (sourceEvent.messageDirection == MessageDirection.INBOUND) {
+                Record(Schemas.Flow.FLOW_EVENT_TOPIC, flowId, FlowEvent(flowId, sourceEvent))
             } else {
                 Record(Schemas.P2P.P2P_OUT_TOPIC, "sessionId", "")
             }
         }
 
         override fun forwardError(
-            sessionEvent: SessionEvent,
+            sourceEvent: SessionEvent,
             exceptionEnvelope: ExceptionEnvelope,
             instant: Instant,
             flowConfig: SmartConfig,
             flowId: String
+        ): Record<*, *> {
+            TODO("Not yet implemented")
+        }
+
+        override fun sendBackError(
+            sourceEvent: SessionEvent,
+            exceptionEnvelope: ExceptionEnvelope,
+            instant: Instant,
+            flowConfig: SmartConfig
         ): Record<*, *> {
             TODO("Not yet implemented")
         }

--- a/components/flow/flow-mapper-service/build.gradle
+++ b/components/flow/flow-mapper-service/build.gradle
@@ -40,10 +40,10 @@ dependencies {
     integrationTestImplementation project(":components:membership:locally-hosted-identities-service")
     integrationTestImplementation project(":testing:db-message-bus-testkit")
     integrationTestImplementation project(":libs:flows:flow-utils")
+    integrationTestImplementation project(":libs:virtual-node:virtual-node-info")
 
     integrationTestRuntimeOnly project(":components:configuration:configuration-read-service-impl")
     integrationTestRuntimeOnly project(":components:flow:flow-mapper-impl")
-    integrationTestRuntimeOnly project(":components:membership:locally-hosted-identities-service-impl")
     integrationTestRuntimeOnly project(":libs:crypto:cipher-suite-impl")
     integrationTestRuntimeOnly project(":libs:lifecycle:lifecycle-impl")
     integrationTestRuntimeOnly project(":libs:messaging:messaging-impl")

--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/DummyLocallyHostedIdentitiesService.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/DummyLocallyHostedIdentitiesService.kt
@@ -1,0 +1,30 @@
+package net.corda.session.mapper.service.integration
+
+import net.corda.membership.locally.hosted.identities.IdentityInfo
+import net.corda.membership.locally.hosted.identities.LocallyHostedIdentitiesService
+import net.corda.virtualnode.HoldingIdentity
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+
+@Component(service = [LocallyHostedIdentitiesService::class])
+class DummyLocallyHostedIdentitiesService @Activate constructor() : LocallyHostedIdentitiesService {
+
+    private val identityMap = mutableMapOf<HoldingIdentity, IdentityInfo>()
+
+    override fun getIdentityInfo(identity: HoldingIdentity): IdentityInfo? {
+        return identityMap[identity]
+    }
+
+    fun setIdentityInfo(identity: HoldingIdentity, identityInfo: IdentityInfo) {
+        identityMap[identity] = identityInfo
+    }
+
+    override val isRunning: Boolean
+        get() = true
+
+    override fun start() {
+    }
+
+    override fun stop() {
+    }
+}

--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/FlowMapperServiceIntegrationTest.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/FlowMapperServiceIntegrationTest.kt
@@ -14,6 +14,7 @@ import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.event.session.SessionData
+import net.corda.data.flow.event.session.SessionError
 import net.corda.data.flow.event.session.SessionInit
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.p2p.HostedIdentityEntry
@@ -22,6 +23,7 @@ import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.flow.utils.emptyKeyValuePairList
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigImpl
+import net.corda.membership.locally.hosted.identities.IdentityInfo
 import net.corda.membership.locally.hosted.identities.LocallyHostedIdentitiesService
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.publisher.config.PublisherConfig
@@ -29,6 +31,7 @@ import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
+import net.corda.schema.Schemas
 import net.corda.schema.Schemas.Config.CONFIG_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC
@@ -42,6 +45,7 @@ import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import net.corda.session.mapper.service.FlowMapperService
 import net.corda.test.flow.util.buildSessionEvent
+import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -51,8 +55,10 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.service.ServiceExtension
+import java.lang.AssertionError
 import java.lang.System.currentTimeMillis
 import java.nio.ByteBuffer
+import java.security.KeyPairGenerator
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -93,6 +99,10 @@ class FlowMapperServiceIntegrationTest {
 
     private val schemaVersion = ConfigurationSchemaVersion(1, 0)
 
+    private val aliceHoldingIdentity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group1")
+    private val bobHoldingIdentity = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group1")
+    private val charlieHoldingIdentity = HoldingIdentity("CN=Charlie, O=Charlie Corp, L=LDN, C=GB", "group1")
+
 
     @BeforeEach
     fun setup() {
@@ -100,39 +110,21 @@ class FlowMapperServiceIntegrationTest {
             setup = true
             val publisher = publisherFactory.createPublisher(PublisherConfig(clientId), messagingConfig)
             setupConfig(publisher)
+            val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
+            keyPairGenerator.initialize(2048)
+            val publicKey = keyPairGenerator.generateKeyPair().public
+            val alice = aliceHoldingIdentity.toCorda()
+            val bob = bobHoldingIdentity.toCorda()
+            val aliceIdentityInfo = IdentityInfo(alice, listOf(), publicKey)
+            val bobIdentityInfo = IdentityInfo(bob, listOf(), publicKey)
 
-            val aliceHoldingIdentity = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group1")
-            val bobHoldingIdentity = HoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "group1")
-
-            val tlsTenantId = "tlsTenantId"
-            val tlsCertificates = mutableListOf<String>()
-            val sessionPublicKey = "sessionPublicKey"
-            val sessionCertificates = listOf("sessionCertificates")
-            val preferredSessionKeyAndCert = HostedIdentitySessionKeyAndCert(sessionPublicKey, sessionCertificates)
-            val alternativeSessionKeysAndCerts = mutableListOf<HostedIdentitySessionKeyAndCert>()
-
-            val bobHostedIdentityEntry = HostedIdentityEntry(
-                bobHoldingIdentity,
-                tlsTenantId,
-                tlsCertificates,
-                preferredSessionKeyAndCert,
-                alternativeSessionKeysAndCerts
+            (locallyHostedIdentityService as DummyLocallyHostedIdentitiesService).setIdentityInfo(
+                alice, aliceIdentityInfo
+            )
+            (locallyHostedIdentityService as DummyLocallyHostedIdentitiesService).setIdentityInfo(
+                bob, bobIdentityInfo
             )
 
-            val aliceHostedIdentityEntry = HostedIdentityEntry(
-                aliceHoldingIdentity,
-                tlsTenantId,
-                tlsCertificates,
-                preferredSessionKeyAndCert,
-                alternativeSessionKeysAndCerts
-            )
-
-            val holdingIdentityToKey: List<Record<String, HostedIdentityEntry>> = listOf(
-                Record("p2p.hosted.identities", "bob", bobHostedIdentityEntry),
-                Record("p2p.hosted.identities", "alice", aliceHostedIdentityEntry)
-            )
-
-            publisher.publish(holdingIdentityToKey)
             flowMapperService.start()
             locallyHostedIdentityService.start()
         }
@@ -151,6 +143,7 @@ class FlowMapperServiceIntegrationTest {
                     MessageDirection.OUTBOUND, testId, 1, SessionData(ByteBuffer.wrap("bytes".toByteArray()), SessionInit(
                         testId, testId, emptyKeyValuePairList(), emptyKeyValuePairList()
                     )),
+                    initiatedIdentity = charlieHoldingIdentity,
                     contextSessionProps = emptyKeyValuePairList()
                 )
             )
@@ -306,7 +299,9 @@ class FlowMapperServiceIntegrationTest {
                 buildSessionEvent(
                     MessageDirection.OUTBOUND, testId, 1, SessionInit(
                         testId, testId, emptyKeyValuePairList(), emptyKeyValuePairList()
-                    ), contextSessionProps = emptyKeyValuePairList()
+                    ),
+                    initiatedIdentity = charlieHoldingIdentity,
+                    contextSessionProps = emptyKeyValuePairList()
                 )
             )
         )
@@ -334,6 +329,7 @@ class FlowMapperServiceIntegrationTest {
                     testId,
                     2,
                     SessionData(ByteBuffer.wrap("".toByteArray()), null),
+                    initiatedIdentity = charlieHoldingIdentity,
                     contextSessionProps = emptyKeyValuePairList()
                 )
             )
@@ -355,6 +351,49 @@ class FlowMapperServiceIntegrationTest {
         flowEventSub.close()
     }
 
+
+    @Test
+    fun `when the flow mapper receives an inbound session message for a non-existent session, an error is returned`() {
+        val testId = "test5"
+        val publisher = publisherFactory.createPublisher(PublisherConfig(testId), messagingConfig)
+
+        //send data, no state
+        val sessionDataEvent = Record<Any, Any>(
+            FLOW_MAPPER_EVENT_TOPIC, testId, FlowMapperEvent(
+                buildSessionEvent(
+                    MessageDirection.INBOUND,
+                    testId,
+                    2,
+                    SessionData(ByteBuffer.wrap("".toByteArray()), null),
+                    initiatingIdentity = aliceHoldingIdentity,
+                    initiatedIdentity = bobHoldingIdentity,
+                    contextSessionProps = emptyKeyValuePairList()
+                )
+            )
+        )
+
+        val mapperLatch = CountDownLatch(2) // The initial message and the error back.
+        val records = mutableListOf<SessionEvent>()
+        val mapperSub = subscriptionFactory.createPubSubSubscription(
+            SubscriptionConfig("$testId-mapper", FLOW_MAPPER_EVENT_TOPIC),
+            TestFlowMapperProcessor(mapperLatch, records),
+            messagingConfig
+        )
+        mapperSub.start()
+        try {
+            publisher.publish(listOf(sessionDataEvent))
+            assertTrue(mapperLatch.await(10, TimeUnit.SECONDS))
+        } finally {
+            mapperSub.close()
+        }
+        val requiredSessionID = "$testId-INITIATED"
+        val event = records.find {
+            it.sessionId == requiredSessionID
+        } ?: throw AssertionError("No event matching required session ID $requiredSessionID was found")
+        assertThat(event.messageDirection).isEqualTo(MessageDirection.INBOUND)
+        assertThat(event.sessionId).isEqualTo("$testId-INITIATED")
+        assertThat(event.payload).isInstanceOf(SessionError::class.java)
+    }
 
     private fun setupConfig(publisher: Publisher) {
         val bootConfig = smartConfigFactory.create(ConfigFactory.parseString(bootConf))

--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestFlowMapperProcessor.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestFlowMapperProcessor.kt
@@ -1,0 +1,28 @@
+package net.corda.session.mapper.service.integration
+
+import net.corda.data.flow.event.SessionEvent
+import net.corda.data.flow.event.mapper.FlowMapperEvent
+import net.corda.messaging.api.processor.DurableProcessor
+import net.corda.messaging.api.processor.PubSubProcessor
+import net.corda.messaging.api.records.Record
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Future
+
+class TestFlowMapperProcessor(
+    private val latch: CountDownLatch,
+    private val records: MutableList<SessionEvent>
+): PubSubProcessor<String, FlowMapperEvent> {
+
+    override fun onNext(event: Record<String, FlowMapperEvent>): Future<Unit> {
+        latch.countDown()
+        val sessionEvent = event.value?.payload as? SessionEvent ?: throw IllegalArgumentException("Not a session event")
+        records.add(sessionEvent)
+        return CompletableFuture.completedFuture(Unit)
+    }
+
+    override val keyClass: Class<String>
+        get() = String::class.java
+    override val valueClass: Class<FlowMapperEvent>
+        get() = FlowMapperEvent::class.java
+}

--- a/components/flow/flow-mapper/src/main/kotlin/net/corda/flow/mapper/factory/RecordFactory.kt
+++ b/components/flow/flow-mapper/src/main/kotlin/net/corda/flow/mapper/factory/RecordFactory.kt
@@ -7,34 +7,75 @@ import net.corda.messaging.api.records.Record
 import java.time.Instant
 
 /**
- * Create [Record]
- * Topic for [Record] is returned based on:
- * - The message direction
- * - whether the counterparty is on the same cluster (local)
- * @return A record for p2p.out or local
+ * Factory for constructing records for flow session events, based on a source event received by the mapper.
+ *
+ * When the mapper receives a flow session event, it must decide what to do with it. Instances of [RecordFactory] are
+ * responsible for constructing a record to be correctly forwarded once it has been established that forwarding the
+ * session event is the correct thing to do.
  */
 interface RecordFactory {
 
     /**
-     * Forward [Record] of [SessionEvent] using:
-     * @return A record of SessionEvent
+     * Forward a session event to the correct place, based on the source session event.
+     *
+     * Inbound events are sent to the local flow engine. Outbound events are forwarded to the relevant counterparty.
+     *
+     * @param sourceEvent The source session event to be forwarded
+     * @param instant A timestamp of when this event was received in the mapper
+     * @param flowConfig The current flow processor configuration
+     * @param flowId The flow ID of the mapper state held for this event (if applicable). Required for inbound events.
+     * @return A [Record] with the correct topic, key, and payload for the required destination.
      */
     fun forwardEvent(
-        sessionEvent: SessionEvent,
+        sourceEvent: SessionEvent,
         instant: Instant,
         flowConfig: SmartConfig,
         flowId: String
         ): Record<*, *>
 
     /**
-     * Forward [Record] of [SessionError]
-     * @return A record of SessionError
+     * Forward a session error to the correct place, based on the source session event.
+     *
+     * Inbound events trigger an error to be sent to the local flow engine. Outbound events trigger an error to be sent
+     * to the relevant counterparty.
+     *
+     * This method should be used to pass errors onwards, or to turn an event into an error without changing the
+     * direction it is currently travelling.
+     *
+     * @param sourceEvent The source session event to be forwarded
+     * @param exceptionEnvelope The error to forward onwards.
+     * @param instant A timestamp of when this event was received in the mapper
+     * @param flowConfig The current flow processor configuration
+     * @param flowId The flow ID of the mapper state held for this event (if applicable). Required for inbound events.
+     * @return A [Record] with the correct topic, key, and payload for the required destination.
      */
     fun forwardError(
-        sessionEvent: SessionEvent,
+        sourceEvent: SessionEvent,
         exceptionEnvelope: ExceptionEnvelope,
         instant: Instant,
         flowConfig: SmartConfig,
         flowId: String
+    ): Record<*, *>
+
+    /**
+     * Create an error record to be sent back to the party that created the source event.
+     *
+     * Inbound events are sent back to the counterparty that originally sent the event. Outbound events are not
+     * currently handled as the flow ID is unlikely to be available in this case.
+     *
+     * This method should be used to short circuit passing a session error to the local flow engine. Usually this will
+     * happen if the error is for a flow that does not exist on the local flow engine's side.
+     *
+     * @param sourceEvent The source event that triggered the error
+     * @param exceptionEnvelope The error to send back
+     * @param instant A timestamp of when this event was received in the mapper
+     * @param flowConfig The current flow processor configuration
+     * @return A [Record] with the correct topic, key, and payload for the required destination.
+     */
+    fun sendBackError(
+        sourceEvent: SessionEvent,
+        exceptionEnvelope: ExceptionEnvelope,
+        instant: Instant,
+        flowConfig: SmartConfig
     ): Record<*, *>
 }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -393,6 +393,7 @@ class FlowServiceTestContext @Activate constructor(
             flowId,
             sessionInitiatingIdentity,
             sessionInitiatedIdentity,
+
             flowFiberCache
         )
         assertions.add(assertionsCapture)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -393,7 +393,6 @@ class FlowServiceTestContext @Activate constructor(
             flowId,
             sessionInitiatingIdentity,
             sessionInitiatedIdentity,
-
             flowFiberCache
         )
         assertions.add(assertionsCapture)


### PR DESCRIPTION
**Problem statement**

The flow mapper may receive a session event from a counterparty containing just data with no init information. If this happens and the mapper does not know about the session, then this is an error that should be returned to the counterparty. However, at the moment this error is forwarded directly to the local flow engine.

**Solution**

Add a method to the `RecordFactory` to send errors back, rather than forwarding them onwards, and invoke that from the session event handler in this situation. This keeps the logic for generating records to send in the `RecordFactory`, while still ensuring that the session error is sent in the correct direction.

**Testing**

- New unit and integration tests.