### PR TITLE
CORE-15820 - Added the tests so deprecated warnings are ignored

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoTokenObserverMap.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoTokenObserverMap.kt
@@ -1,9 +1,11 @@
 package net.corda.ledger.persistence.utxo
 
 import net.corda.v5.ledger.utxo.ContractState
-import net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver
 
 interface UtxoTokenObserverMap {
-    fun getObserverFor(contactStateType: Class<*>): UtxoLedgerTokenStateObserver<ContractState>?
+    @Suppress("DEPRECATION")
+    fun getObserverFor(
+        contactStateType: Class<*>
+    ): net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<ContractState>?
 }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTokenObserverMapImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoTokenObserverMapImpl.kt
@@ -4,13 +4,15 @@ import net.corda.ledger.persistence.utxo.UtxoTokenObserverMap
 import net.corda.persistence.common.getTokenStateObservers
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.v5.ledger.utxo.ContractState
-import net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver
 
 
 class UtxoTokenObserverMapImpl(private val sandboxGroupContext: SandboxGroupContext) :
     UtxoTokenObserverMap {
 
-    override fun getObserverFor(contactStateType: Class<*>): UtxoLedgerTokenStateObserver<ContractState>? {
+    @Suppress("DEPRECATION")
+    override fun getObserverFor(
+        contactStateType: Class<*>
+    ): net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<ContractState>? {
         return sandboxGroupContext.getTokenStateObservers()[contactStateType]
     }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionRequestHandler.kt
@@ -11,7 +11,6 @@ import net.corda.messaging.api.records.Record
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
-import net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.v5.ledger.utxo.observer.UtxoTokenPoolKey
 import net.corda.virtualnode.HoldingIdentity
@@ -64,8 +63,9 @@ class UtxoPersistTransactionRequestHandler @Suppress("LongParameterList") constr
             }
         }
 
+    @Suppress("DEPRECATION")
     private fun onCommit(
-        observer: UtxoLedgerTokenStateObserver<ContractState>,
+        observer: net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<ContractState>,
         stateAndRef: StateAndRef<ContractState>
     ): List<Pair<StateAndRef<*>, UtxoToken>> {
         return try {

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxContextTypes.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/EntitySandboxContextTypes.kt
@@ -6,7 +6,6 @@ import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.utxo.ContractState
-import net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver
 import javax.persistence.EntityManagerFactory
 
 /**
@@ -31,8 +30,10 @@ fun SandboxGroupContext.getEntityManagerFactory(): EntityManagerFactory =
                     "${virtualNodeContext.holdingIdentity}"
         )
 
+@Suppress("DEPRECATION")
 fun SandboxGroupContext.getTokenStateObservers()
-        : Map<Class<out ContractState>, UtxoLedgerTokenStateObserver<ContractState>?> = getObjectByKey(
+        : Map<Class<out ContractState>, net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<ContractState>?>
+= getObjectByKey(
     EntitySandboxContextTypes.SANDBOX_TOKEN_STATE_OBSERVERS
 ) ?: throw CordaRuntimeException(
     "Token State Observers not found within the sandbox for identity: ${virtualNodeContext.holdingIdentity}"

--- a/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
+++ b/components/persistence/persistence-service-common/src/main/kotlin/net/corda/persistence/common/internal/EntitySandboxServiceImpl.kt
@@ -26,7 +26,6 @@ import net.corda.sandboxgroupcontext.service.registerCustomJsonSerializers
 import net.corda.utilities.debug
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.ContractState
-import net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryFactory
 import net.corda.v5.ledger.utxo.query.json.ContractStateVaultJsonFactory
 import net.corda.virtualnode.HoldingIdentity
@@ -189,9 +188,12 @@ class EntitySandboxServiceImpl @Activate constructor(
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun requireSingleObserverToState(
-        tokenStateObserverMap: Map<Class<ContractState>, List<UtxoLedgerTokenStateObserver<ContractState>>>
-    ): Map<Class<ContractState>, UtxoLedgerTokenStateObserver<ContractState>?> {
+        tokenStateObserverMap: Map<Class<
+                ContractState>,
+                List<net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<ContractState>>>
+    ): Map<Class<ContractState>, net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<ContractState>?> {
 
         return tokenStateObserverMap.entries.associate { contractStateTypeToObservers  ->
             val numberOfObservers = contractStateTypeToObservers.value.size
@@ -207,18 +209,19 @@ class EntitySandboxServiceImpl @Activate constructor(
         }
     }
 
+    @Suppress("DEPRECATION")
     private fun getObserverFromClassName(
         className: String,
         ctx: MutableSandboxGroupContext
-    ): UtxoLedgerTokenStateObserver<ContractState>? {
+    ): net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<ContractState>? {
         val clazz = ctx.sandboxGroup.loadClassFromMainBundles(
             className,
-            UtxoLedgerTokenStateObserver::class.java
+            net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver::class.java
         )
 
         return try {
             @Suppress("unchecked_cast")
-            clazz.getConstructor().newInstance() as UtxoLedgerTokenStateObserver<ContractState>
+            clazz.getConstructor().newInstance() as net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<ContractState>
         } catch (e: Exception) {
             logger.error(
                 "The UtxoLedgerTokenStateObserver '${clazz}' must implement a default public constructor.",

--- a/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/com/r3/corda/demo/utxo/contract/UtxoDemoTokenStateObserver.kt
+++ b/testing/cpbs/ledger-utxo-demo-contract/src/main/kotlin/com/r3/corda/demo/utxo/contract/UtxoDemoTokenStateObserver.kt
@@ -1,7 +1,6 @@
 package com.r3.corda.demo.utxo.contract
 
 import net.corda.v5.application.crypto.DigestService
-import net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.v5.ledger.utxo.observer.UtxoTokenFilterFields
 import net.corda.v5.ledger.utxo.observer.UtxoTokenPoolKey
@@ -12,8 +11,8 @@ const val TOKEN_SYMBOL = "USD"
 const val TOKEN_TYPE = "TestUtxoState"
 val TOKEN_AMOUNT = BigDecimal.TEN
 
-@Suppress("UNUSED")
-class UtxoDemoTokenStateObserver : UtxoLedgerTokenStateObserver<TestUtxoState> {
+@Suppress("UNUSED", "DEPRECATION")
+class UtxoDemoTokenStateObserver : net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<TestUtxoState> {
 
     override fun getStateType(): Class<TestUtxoState> {
         return TestUtxoState::class.java

--- a/testing/cpbs/packaging-verification-contract-v1/src/main/kotlin/com/r3/corda/testing/packagingverification/contract/SimpleTokenStateObserver.kt
+++ b/testing/cpbs/packaging-verification-contract-v1/src/main/kotlin/com/r3/corda/testing/packagingverification/contract/SimpleTokenStateObserver.kt
@@ -1,12 +1,12 @@
 package com.r3.corda.testing.packagingverification.contract
 
 import net.corda.v5.application.crypto.DigestService
-import net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.v5.ledger.utxo.observer.UtxoTokenFilterFields
 import net.corda.v5.ledger.utxo.observer.UtxoTokenPoolKey
 
-class SimpleTokenStateObserver : UtxoLedgerTokenStateObserver<SimpleState> {
+@Suppress("DEPRECATION")
+class SimpleTokenStateObserver : net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver<SimpleState> {
     override fun getStateType() = SimpleState::class.java
 
     override fun onCommit(state: SimpleState, digestService: DigestService) = UtxoToken(


### PR DESCRIPTION
This change is required to be able to merge the changes in the API that made `net.corda.v5.ledger.utxo.observer.UtxoLedgerTokenStateObserver` deprecated. Keep in mind that warnings are treated as errors which aborts the build if deprecated code is used.