### PR TITLE
CORE-13620 Idempotency id table housekeeping

### DIFF
--- a/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
+++ b/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
@@ -17,6 +17,7 @@ import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.osgi.api.Application
 import net.corda.osgi.api.Shutdown
 import net.corda.processors.db.DBProcessor
+import net.corda.processors.scheduler.SchedulerProcessor
 import net.corda.processors.token.cache.TokenCacheProcessor
 import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.tracing.configureTracing
@@ -37,6 +38,8 @@ class DBWorker @Activate constructor(
     private val processor: DBProcessor,
     @Reference(service = TokenCacheProcessor::class)
     private val tokenCacheProcessor: TokenCacheProcessor,
+    @Reference(service = SchedulerProcessor::class)
+    private val schedulerProcessor: SchedulerProcessor,
     @Reference(service = Shutdown::class)
     private val shutDownService: Shutdown,
     @Reference(service = WorkerMonitor::class)
@@ -85,6 +88,7 @@ class DBWorker @Activate constructor(
 
         processor.start(config)
         tokenCacheProcessor.start(config)
+        schedulerProcessor.start(config)
     }
 
     override fun shutdown() {
@@ -92,6 +96,7 @@ class DBWorker @Activate constructor(
         processor.stop()
         webServer.stop()
         tokenCacheProcessor.stop()
+        schedulerProcessor.stop()
         shutdownTracing()
     }
 }

--- a/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
+++ b/applications/workers/release/db-worker/src/test/kotlin/net/corda/applications/workers/db/test/ConfigTests.kt
@@ -52,6 +52,7 @@ class ConfigTests {
         val dbWorker = DBWorker(
             dbProcessor,
             mock(),
+            mock(),
             DummyShutdown(),
             DummyWorkerMonitor(),
             DummyWebServer(),
@@ -96,6 +97,7 @@ class ConfigTests {
         val dbWorker = DBWorker(
             dbProcessor,
             mock(),
+            mock(),
             DummyShutdown(),
             DummyWorkerMonitor(),
             DummyWebServer(),
@@ -130,6 +132,7 @@ class ConfigTests {
         val dbWorker = DBWorker(
             dbProcessor,
             mock(),
+            mock(),
             DummyShutdown(),
             DummyWorkerMonitor(),
             DummyWebServer(),
@@ -162,6 +165,7 @@ class ConfigTests {
         val dbWorker = DBWorker(
             dbProcessor,
             mock(),
+            mock(),
             DummyShutdown(),
             DummyWorkerMonitor(),
             DummyWebServer(),
@@ -187,6 +191,7 @@ class ConfigTests {
         val dbProcessor = DummyDBProcessor()
         val dbWorker = DBWorker(
             dbProcessor,
+            mock(),
             mock(),
             DummyShutdown(),
             DummyWorkerMonitor(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.20-alpha-1695214982425
+cordaApiVersion=5.1.0.20-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.20-beta+
+cordaApiVersion=5.1.0.20-alpha-1695214982425
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
@@ -8,11 +8,11 @@ import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepository
 import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepositoryImpl
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
-import net.corda.orm.utils.use
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.UUID
@@ -82,6 +82,8 @@ class RequestsIdsRepositoryTest {
             requestsIdsRepository.persist(requestId1, em)
         }
 
+        Thread.sleep(1)
+
         entityManagerFactory.createEntityManager().transaction { em ->
             requestsIdsRepository.persist(requestId2, em)
         }
@@ -95,7 +97,8 @@ class RequestsIdsRepositoryTest {
         assertTrue(request1Time < request2Time)
     }
 
-    // Might want to Disable this test as it adds significant time overhead to the test pipeline
+    @Disabled("Disabling due to its time overhead of 2 seconds. " +
+            "The test, however, is valid to assert `requestsIdsRepository.deleteRequestsOlderThan` works")
     @Test
     fun `deletes older requests`() {
         val requestId1 = UUID.randomUUID()

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
@@ -8,7 +8,9 @@ import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepository
 import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepositoryImpl
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
+import net.corda.orm.utils.use
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -54,6 +56,15 @@ class RequestsIdsRepositoryTest {
     fun cleanup() {
         dbConfig.close()
         entityManagerFactory.close()
+    }
+
+    @AfterEach
+    fun cleanUpAfterEach() {
+        entityManagerFactory.createEntityManager().transaction {
+            it.createNativeQuery(
+                "DELETE FROM ${DbSchema.VNODE_PERSISTENCE_REQUEST_ID_TABLE}"
+            ).executeUpdate()
+        }
     }
 
     private val requestsIdsRepository: RequestsIdsRepository = RequestsIdsRepositoryImpl()

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
@@ -79,6 +79,7 @@ class RequestsIdsRepositoryTest {
         assertTrue(request1Time < request2Time)
     }
 
+    // Might want to Disable this test as it adds significant time overhead to the test pipeline
     @Test
     fun `deletes older requests`() {
         val requestId1 = UUID.randomUUID()

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
@@ -6,6 +6,7 @@ import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
 import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepository
 import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepositoryImpl
+import net.corda.orm.EntityManagerConfiguration
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.utils.transaction
 import org.junit.jupiter.api.AfterAll
@@ -21,10 +22,8 @@ import javax.persistence.EntityManagerFactory
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RequestsIdsRepositoryTest {
 
-    private val dbConfig = run {
-        //System.setProperty("postgresPort", "5432")
-        DbUtils.getEntityManagerConfiguration(this::class.java.simpleName)
-    }
+    @Suppress("JoinDeclarationAndAssignment")
+    private val dbConfig: EntityManagerConfiguration
 
     private val entityManagerFactory: EntityManagerFactory
 
@@ -37,6 +36,9 @@ class RequestsIdsRepositoryTest {
      * [entityManagerFactory].
      */
     init {
+        //System.setProperty("postgresPort", "5432")
+        dbConfig = DbUtils.getEntityManagerConfiguration(this::class.java.simpleName)
+
         val dbChange = ClassloaderChangeLog(
             linkedSetOf(
                 ClassloaderChangeLog.ChangeLogResourceFiles(

--- a/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/integrationTest/kotlin/net/corda/libs/configuration/datamodel/tests/RequestsIdsRepositoryTest.kt
@@ -1,0 +1,126 @@
+package net.corda.libs.configuration.datamodel.tests
+
+import net.corda.db.admin.impl.ClassloaderChangeLog
+import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
+import net.corda.db.schema.DbSchema
+import net.corda.db.testkit.DbUtils
+import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepository
+import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepositoryImpl
+import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
+import net.corda.orm.utils.transaction
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.UUID
+import javax.persistence.EntityManagerFactory
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RequestsIdsRepositoryTest {
+    private val dbConfig = DbUtils.getEntityManagerConfiguration(this::class.java.simpleName)
+    private val entityManagerFactory: EntityManagerFactory
+
+    private companion object {
+        private const val VNODE_VAULT_MIGRATION_FILE_LOCATION = "net/corda/db/schema/vnode-vault/db.changelog-master.xml"
+    }
+
+    /**
+     * Creates an in-memory database, applies the relevant migration scripts, and initialises
+     * [entityManagerFactory].
+     */
+    init {
+        val dbChange = ClassloaderChangeLog(
+            linkedSetOf(
+                ClassloaderChangeLog.ChangeLogResourceFiles(
+                    DbSchema::class.java.packageName,
+                    listOf(VNODE_VAULT_MIGRATION_FILE_LOCATION),
+                    DbSchema::class.java.classLoader
+                )
+            )
+        )
+        dbConfig.dataSource.connection.use { connection ->
+            LiquibaseSchemaMigratorImpl().updateDb(connection, dbChange)
+        }
+        entityManagerFactory = EntityManagerFactoryFactoryImpl().create(
+            this::class.java.simpleName,
+            emptyList(),
+            dbConfig
+        )
+    }
+
+    @Suppress("Unused")
+    @AfterAll
+    fun cleanup() {
+        dbConfig.close()
+        entityManagerFactory.close()
+    }
+
+    private val requestsIdsRepository: RequestsIdsRepository = RequestsIdsRepositoryImpl()
+
+    @Test
+    fun `inserts into request ids table`() {
+        val requestId1 = UUID.randomUUID()
+        val requestId2 = UUID.randomUUID()
+        entityManagerFactory.createEntityManager().transaction { em ->
+            requestsIdsRepository.persist(requestId1, em)
+        }
+
+        entityManagerFactory.createEntityManager().transaction { em ->
+            requestsIdsRepository.persist(requestId2, em)
+        }
+
+        val storedRequestIds = getStoredRequestIds()
+        assertEquals(2, storedRequestIds.size)
+        assertEquals(requestId1, storedRequestIds[0].first)
+        assertEquals(requestId2, storedRequestIds[1].first)
+        val request1Time = storedRequestIds[0].second
+        val request2Time = storedRequestIds[1].second
+        assertTrue(request1Time < request2Time)
+    }
+
+    @Test
+    fun `deletes older requests`() {
+        val requestId1 = UUID.randomUUID()
+        val requestId2 = UUID.randomUUID()
+        entityManagerFactory.createEntityManager().transaction { em ->
+            requestsIdsRepository.persist(requestId1, em)
+        }
+
+        entityManagerFactory.createEntityManager().transaction { em ->
+            requestsIdsRepository.persist(requestId2, em)
+        }
+        var storedRequestIds = getStoredRequestIds()
+        assertEquals(2, storedRequestIds.size)
+        Thread.sleep(2000)
+        entityManagerFactory.createEntityManager().transaction { em ->
+            requestsIdsRepository.persist(UUID.randomUUID(), em)
+        }
+        entityManagerFactory.createEntityManager().transaction { em ->
+            requestsIdsRepository.deleteRequestsOlderThan(1, em)
+        }
+
+        storedRequestIds = getStoredRequestIds()
+        assertEquals(1, storedRequestIds.size)
+    }
+
+    private fun getStoredRequestIds(): List<Pair<UUID, java.sql.Timestamp>> =
+        dbConfig.dataSource.connection.use {
+            val rs = it.prepareStatement(
+                "SELECT * FROM ${DbSchema.VNODE_PERSISTENCE_REQUEST_ID_TABLE} ORDER BY insert_ts"
+            ).use { stmt ->
+                stmt.executeQuery()
+            }
+
+            val list = mutableListOf<Pair<UUID, java.sql.Timestamp>>()
+            while (rs.next()) {
+                list.add(
+                    Pair(
+                        UUID.fromString(rs.getString(1)),
+                        rs.getTimestamp(2)
+                    )
+                )
+            }
+            list
+        }
+}

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/RequestsIdsRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/RequestsIdsRepository.kt
@@ -6,6 +6,8 @@ import javax.persistence.EntityManager
 
 interface RequestsIdsRepository {
     fun persist(requestId: UUID, em: EntityManager)
+
+    fun deleteRequestsOlderThan(intervalInSeconds: Long, em: EntityManager)
 }
 
 class RequestsIdsRepositoryImpl : RequestsIdsRepository {
@@ -16,6 +18,16 @@ class RequestsIdsRepositoryImpl : RequestsIdsRepository {
             VALUES (:requestId)
         """.trimIndent()
         ).setParameter("requestId", requestId.toString())
+            .executeUpdate()
+    }
+
+    override fun deleteRequestsOlderThan(intervalInSeconds: Long, em: EntityManager) {
+        em.createNativeQuery(
+            """
+                DELETE FROM {h-schema}$VNODE_PERSISTENCE_REQUEST_ID_TABLE
+                WHERE insert_ts < (NOW() - :intervalInSeconds SECOND)
+            """.trimIndent()
+        ).setParameter("intervalInSeconds", intervalInSeconds)
             .executeUpdate()
     }
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/RequestsIdsRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/RequestsIdsRepository.kt
@@ -25,9 +25,8 @@ class RequestsIdsRepositoryImpl : RequestsIdsRepository {
         em.createNativeQuery(
             """
                 DELETE FROM {h-schema}$VNODE_PERSISTENCE_REQUEST_ID_TABLE
-                WHERE insert_ts < (NOW() - :intervalInSeconds SECOND)
+                WHERE insert_ts < NOW() - INTERVAL '1' SECOND * $intervalInSeconds 
             """.trimIndent()
-        ).setParameter("intervalInSeconds", intervalInSeconds)
-            .executeUpdate()
+        ).executeUpdate()
     }
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/RequestsIdsRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/RequestsIdsRepository.kt
@@ -25,8 +25,9 @@ class RequestsIdsRepositoryImpl : RequestsIdsRepository {
         em.createNativeQuery(
             """
                 DELETE FROM {h-schema}$VNODE_PERSISTENCE_REQUEST_ID_TABLE
-                WHERE insert_ts < NOW() - INTERVAL '1' SECOND * $intervalInSeconds 
+                WHERE insert_ts < NOW() - INTERVAL '1' SECOND * :intervalInSeconds 
             """.trimIndent()
-        ).executeUpdate()
+        ).setParameter("intervalInSeconds", intervalInSeconds)
+            .executeUpdate()
     }
 }

--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/RequestsIdsRepository.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/RequestsIdsRepository.kt
@@ -14,9 +14,9 @@ class RequestsIdsRepositoryImpl : RequestsIdsRepository {
     override fun persist(requestId: UUID, em: EntityManager) {
         em.createNativeQuery(
             """
-            INSERT INTO {h-schema}$VNODE_PERSISTENCE_REQUEST_ID_TABLE(request_id)
-            VALUES (:requestId)
-        """.trimIndent()
+                INSERT INTO {h-schema}$VNODE_PERSISTENCE_REQUEST_ID_TABLE(request_id)
+                VALUES (:requestId)
+            """.trimIndent()
         ).setParameter("requestId", requestId.toString())
             .executeUpdate()
     }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -281,7 +281,6 @@ class DBProcessorImpl @Activate constructor(
         coordinator.updateStatus(event.status)
     }
 
-    @Suppress("warnings")
     private fun onConfigChangedEvent(
         event: ConfigChangedEvent,
         coordinator: LifecycleCoordinator

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -301,9 +301,7 @@ class DBProcessorImpl @Activate constructor(
                 messagingConfig,
                 null
             )
-        }.also {
-            it.start()
-        }
+        }.start()
     }
 
     private fun onStartEvent() {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -166,6 +166,8 @@ class DBProcessorImpl @Activate constructor(
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val REGISTRATION = "REGISTRATION"
         private const val CONFIG = "CONFIG"
+
+        private const val DEDUPLICATION_TABLE_CLEAN_UP_GROUP = "deduplication.table.clean.up"
     }
 
     private val dependentComponents = DependentComponents.of(
@@ -293,7 +295,7 @@ class DBProcessorImpl @Activate constructor(
         deduplicationTableCleanUpSubscription?.close()
         val messagingConfig = event.config.getConfig(ConfigKeys.MESSAGING_CONFIG)
         deduplicationTableCleanUpSubscription = subscriptionFactory.createDurableSubscription(
-            SubscriptionConfig("asd", VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC),
+            SubscriptionConfig(DEDUPLICATION_TABLE_CLEAN_UP_GROUP, VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC),
             DeduplicationTableCleanUpProcessor(
                 dbConnectionManager,
                 virtualNodeInfoReadService,

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -58,6 +58,7 @@ import net.corda.permissions.storage.writer.PermissionStorageWriterService
 import net.corda.processors.db.DBProcessor
 import net.corda.processors.db.internal.schedule.DeduplicationTableCleanUpProcessor
 import net.corda.reconciliation.ReconcilerFactory
+import net.corda.schema.Schemas.VirtualNode.VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC
 import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.ConfigKeys
@@ -292,7 +293,7 @@ class DBProcessorImpl @Activate constructor(
         deduplicationTableCleanUpSubscription?.close()
         val messagingConfig = event.config.getConfig(ConfigKeys.MESSAGING_CONFIG)
         deduplicationTableCleanUpSubscription = subscriptionFactory.createDurableSubscription(
-            SubscriptionConfig("asd", "virtual.node.deduplication.table.clean.up"),
+            SubscriptionConfig("asd", VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC),
             DeduplicationTableCleanUpProcessor(
                 dbConnectionManager,
                 virtualNodeInfoReadService,

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -12,7 +12,6 @@ import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.cpiinfo.write.CpiInfoWriteService
 import net.corda.cpk.read.CpkReadService
 import net.corda.cpk.write.CpkWriteService
-import net.corda.data.scheduler.ScheduledTaskTrigger
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
 import net.corda.libs.configuration.SmartConfig
@@ -48,7 +47,6 @@ import net.corda.membership.persistence.service.MembershipPersistenceService
 import net.corda.membership.read.GroupParametersReaderService
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.orm.JpaEntitiesRegistry

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -22,6 +22,7 @@ import net.corda.libs.cpi.datamodel.CpiEntities
 import net.corda.libs.cpi.datamodel.repository.factory.CpiCpkRepositoryFactory
 import net.corda.libs.scheduler.datamodel.SchedulerEntities
 import net.corda.libs.virtualnode.datamodel.VirtualNodeEntities
+import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepositoryImpl
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -292,7 +293,11 @@ class DBProcessorImpl @Activate constructor(
         val messagingConfig = event.config.getConfig(ConfigKeys.MESSAGING_CONFIG)
         deduplicationTableCleanUpSubscription = subscriptionFactory.createDurableSubscription(
             SubscriptionConfig("asd", "virtual.node.deduplication.table.clean.up"),
-            DeduplicationTableCleanUpProcessor(),
+            DeduplicationTableCleanUpProcessor(
+                dbConnectionManager,
+                virtualNodeInfoReadService,
+                RequestsIdsRepositoryImpl()
+            ),
             messagingConfig,
             null
         ).also {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/DBProcessorImpl.kt
@@ -56,7 +56,7 @@ import net.corda.permissions.storage.writer.PermissionStorageWriterService
 import net.corda.processors.db.DBProcessor
 import net.corda.processors.db.internal.schedule.DeduplicationTableCleanUpProcessor
 import net.corda.reconciliation.ReconcilerFactory
-import net.corda.schema.Schemas.VirtualNode.VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC
+import net.corda.schema.Schemas.ScheduledTask.SCHEDULED_TASK_DB_PROCESSOR
 import net.corda.schema.configuration.BootConfig.BOOT_DB
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.ConfigKeys
@@ -292,7 +292,7 @@ class DBProcessorImpl @Activate constructor(
         val messagingConfig = event.config.getConfig(ConfigKeys.MESSAGING_CONFIG)
         coordinator.createManagedResource(DEDUPLICATION_TABLE_MANAGED_RESOURCE) {
             subscriptionFactory.createDurableSubscription(
-                SubscriptionConfig(DEDUPLICATION_TABLE_CLEAN_UP_GROUP, VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC),
+                SubscriptionConfig(DEDUPLICATION_TABLE_CLEAN_UP_GROUP, SCHEDULED_TASK_DB_PROCESSOR),
                 DeduplicationTableCleanUpProcessor(
                     dbConnectionManager,
                     virtualNodeInfoReadService,

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
@@ -68,7 +68,7 @@ class DeduplicationTableCleanUpProcessor(
                 }
             }
         } catch (e: Exception) {
-            log.info("Cleaning up deduplication table for vnode: ${virtualNodeInfo.holdingIdentity.shortHash} FAILED", e)
+            log.warn("Cleaning up deduplication table for vnode: ${virtualNodeInfo.holdingIdentity.shortHash} FAILED", e)
         }
     }
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
@@ -1,0 +1,22 @@
+package net.corda.processors.db.internal.schedule
+
+import net.corda.data.scheduler.ScheduledTaskTrigger
+import net.corda.messaging.api.processor.DurableProcessor
+import net.corda.messaging.api.records.Record
+import org.slf4j.LoggerFactory
+
+class DeduplicationTableCleanUpProcessor : DurableProcessor<String, ScheduledTaskTrigger> {
+    companion object {
+        private val log = LoggerFactory.getLogger(DeduplicationTableCleanUpProcessor::class.java)
+    }
+
+    override val keyClass: Class<String>
+        get() = String::class.java
+    override val valueClass: Class<ScheduledTaskTrigger>
+        get() = ScheduledTaskTrigger::class.java
+
+    override fun onNext(events: List<Record<String, ScheduledTaskTrigger>>): List<Record<*, *>> {
+        log.info("Processed the ScheduledTaskTrigger!")
+        return emptyList()
+    }
+}

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
@@ -28,7 +28,7 @@ class DeduplicationTableCleanUpProcessor(
         get() = ScheduledTaskTrigger::class.java
 
     override fun onNext(events: List<Record<String, ScheduledTaskTrigger>>): List<Record<*, *>> {
-        // TODO Add metric/ count time around it
+        // TODO Add metric around it?
         log.info("Cleaning up deduplication table for all vnodes")
         val startTime = System.nanoTime()
         virtualNodeInfoReadService.getAll().forEach {

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
@@ -32,33 +32,35 @@ class DeduplicationTableCleanUpProcessor(
 
     override fun onNext(events: List<Record<String, ScheduledTaskTrigger>>): List<Record<*, *>> {
         // TODO Add metric around it?
-        events.forEach { it ->
-            val taskName = it.key
-            if (taskName == DEDUPLICATION_TABLE_CLEAN_UP_TASK) {
+        events
+            .filter {
+                val taskName = it.key
+                taskName == DEDUPLICATION_TABLE_CLEAN_UP_TASK
+            }.forEach { _ ->
                 log.info("Cleaning up deduplication table for all vnodes")
                 val startTime = System.nanoTime()
-                virtualNodeInfoReadService.getAll().forEach {
-                    log.debug { "Cleaning up deduplication table for vnode: ${it.holdingIdentity.shortHash}" }
-                    dbConnectionManager.createEntityManagerFactory(
-                        it.vaultDmlConnectionId,
-                        // We don't really want to make use of any entities here.
-                        object : JpaEntitiesSet {
-                            override val persistenceUnitName: String
-                                get() = ""
-                            override val classes: Set<Class<*>>
-                                get() = emptySet()
-                        }
-                    ).use { emf ->
-                        emf.createEntityManager().transaction { em ->
-                            // TODO The below interval needs to be made configurable
-                            requestsIdsRepository.deleteRequestsOlderThan(120, em)
+                virtualNodeInfoReadService.getAll()
+                    .forEach {
+                        log.debug { "Cleaning up deduplication table for vnode: ${it.holdingIdentity.shortHash}" }
+                        dbConnectionManager.createEntityManagerFactory(
+                            it.vaultDmlConnectionId,
+                            // We don't really want to make use of any entities here.
+                            object : JpaEntitiesSet {
+                                override val persistenceUnitName: String
+                                    get() = ""
+                                override val classes: Set<Class<*>>
+                                    get() = emptySet()
+                            }
+                        ).use { emf ->
+                            emf.createEntityManager().transaction { em ->
+                                // TODO The below interval needs to be made configurable
+                                requestsIdsRepository.deleteRequestsOlderThan(120, em)
+                            }
                         }
                     }
-                }
                 val cleanUpTime = Duration.ofNanos(System.nanoTime() - startTime)
                 log.info("Cleaning up deduplication table for all vnodes COMPLETED in ${cleanUpTime.toMillis()} ms")
             }
-        }
         // TODO Fix the response (at the minute the Scheduler ignores them)
         return emptyList()
     }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
@@ -1,11 +1,22 @@
 package net.corda.processors.db.internal.schedule
 
 import net.corda.data.scheduler.ScheduledTaskTrigger
+import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.libs.virtualnode.datamodel.repository.RequestsIdsRepository
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
+import net.corda.orm.JpaEntitiesSet
+import net.corda.orm.utils.transaction
+import net.corda.orm.utils.use
+import net.corda.utilities.debug
+import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.LoggerFactory
 
-class DeduplicationTableCleanUpProcessor : DurableProcessor<String, ScheduledTaskTrigger> {
+class DeduplicationTableCleanUpProcessor(
+    private val dbConnectionManager: DbConnectionManager,
+    private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
+    private val requestsIdsRepository: RequestsIdsRepository
+) : DurableProcessor<String, ScheduledTaskTrigger> {
     companion object {
         private val log = LoggerFactory.getLogger(DeduplicationTableCleanUpProcessor::class.java)
     }
@@ -16,7 +27,30 @@ class DeduplicationTableCleanUpProcessor : DurableProcessor<String, ScheduledTas
         get() = ScheduledTaskTrigger::class.java
 
     override fun onNext(events: List<Record<String, ScheduledTaskTrigger>>): List<Record<*, *>> {
-        log.info("Processed the ScheduledTaskTrigger!")
+        // TODO Add metric/ count time around it
+        log.info("Cleaning up deduplication tables for all vnodes")
+        virtualNodeInfoReadService.getAll().forEach {
+            log.debug { "Cleaning up deduplication table for vnode: ${it.holdingIdentity.shortHash}" }
+            val emf = dbConnectionManager.createEntityManagerFactory(
+                it.vaultDmlConnectionId,
+                // We don't really want to make use of any entities here.
+                object : JpaEntitiesSet {
+                    override val persistenceUnitName: String
+                        get() = ""
+                    override val classes: Set<Class<*>>
+                        get() = emptySet()
+                }
+            )
+
+            emf.use {
+                it.createEntityManager().transaction { em ->
+                    // TODO The below interval needs to be made configurable
+                    requestsIdsRepository.deleteRequestsOlderThan(120, em)
+                }
+            }
+        }
+
+        log.info("Cleaning up deduplication tables for all vnodes COMPLETED")
         return emptyList()
     }
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
@@ -33,7 +33,7 @@ class DeduplicationTableCleanUpProcessor(
         val startTime = System.nanoTime()
         virtualNodeInfoReadService.getAll().forEach {
             log.debug { "Cleaning up deduplication table for vnode: ${it.holdingIdentity.shortHash}" }
-            val emf = dbConnectionManager.createEntityManagerFactory(
+            dbConnectionManager.createEntityManagerFactory(
                 it.vaultDmlConnectionId,
                 // We don't really want to make use of any entities here.
                 object : JpaEntitiesSet {
@@ -42,10 +42,8 @@ class DeduplicationTableCleanUpProcessor(
                     override val classes: Set<Class<*>>
                         get() = emptySet()
                 }
-            )
-
-            emf.use {
-                it.createEntityManager().transaction { em ->
+            ).use { emf ->
+                emf.createEntityManager().transaction { em ->
                     // TODO The below interval needs to be made configurable
                     requestsIdsRepository.deleteRequestsOlderThan(120, em)
                 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/schedule/DeduplicationTableCleanUpProcessor.kt
@@ -11,6 +11,7 @@ import net.corda.orm.utils.use
 import net.corda.utilities.debug
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.LoggerFactory
+import java.time.Duration
 
 class DeduplicationTableCleanUpProcessor(
     private val dbConnectionManager: DbConnectionManager,
@@ -28,7 +29,8 @@ class DeduplicationTableCleanUpProcessor(
 
     override fun onNext(events: List<Record<String, ScheduledTaskTrigger>>): List<Record<*, *>> {
         // TODO Add metric/ count time around it
-        log.info("Cleaning up deduplication tables for all vnodes")
+        log.info("Cleaning up deduplication table for all vnodes")
+        val startTime = System.nanoTime()
         virtualNodeInfoReadService.getAll().forEach {
             log.debug { "Cleaning up deduplication table for vnode: ${it.holdingIdentity.shortHash}" }
             val emf = dbConnectionManager.createEntityManagerFactory(
@@ -49,8 +51,9 @@ class DeduplicationTableCleanUpProcessor(
                 }
             }
         }
-
-        log.info("Cleaning up deduplication tables for all vnodes COMPLETED")
+        val cleanUpTime = Duration.ofNanos(System.nanoTime() - startTime)
+        log.info("Cleaning up deduplication table for all vnodes COMPLETED in ${cleanUpTime.toMillis()} ms")
+        // TODO Fix the response
         return emptyList()
     }
 }

--- a/processors/scheduler-processor/build.gradle
+++ b/processors/scheduler-processor/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-db-schema'
     implementation 'net.corda:corda-notary-plugin'
+    implementation 'net.corda:corda-topic-schema'
 
     runtimeOnly project(':components:configuration:configuration-write-service-impl')
     runtimeOnly project(':components:configuration:configuration-read-service-impl')

--- a/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
+++ b/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
@@ -64,10 +64,7 @@ class SchedulerProcessorImpl @Activate constructor(
 
     // now just hardcoding schedulers here until CORE-16331 is picked up, when we should take this from config
     private val schedules = listOf<Schedule>(
-        // example schedule, delete/replace when we have a real one, uncomment for testing
         Schedule("clean-up-deduplication-table", 120, VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC)
-//        Schedule("say-hello", 60, "telephone"),
-//        Schedule("say-goodbye", 600, "telephone"),
     )
     private var schedulers: Schedulers? = null
 

--- a/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
+++ b/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
@@ -64,6 +64,7 @@ class SchedulerProcessorImpl @Activate constructor(
     // now just hardcoding schedulers here until CORE-16331 is picked up, when we should take this from config
     private val schedules = listOf<Schedule>(
         // example schedule, delete/replace when we have a real one, uncomment for testing
+        Schedule("clean-up-deduplication-table", 20, "virtual.node.deduplication.table.clean.up")
 //        Schedule("say-hello", 60, "telephone"),
 //        Schedule("say-goodbye", 600, "telephone"),
     )

--- a/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
+++ b/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
@@ -20,7 +20,7 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.processors.scheduler.SchedulerProcessor
-import net.corda.schema.Schemas.VirtualNode.VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC
+import net.corda.schema.Schemas.ScheduledTask.SCHEDULED_TASK_DB_PROCESSOR
 import net.corda.schema.configuration.BootConfig
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -64,7 +64,7 @@ class SchedulerProcessorImpl @Activate constructor(
 
     // now just hardcoding schedulers here until CORE-16331 is picked up, when we should take this from config
     private val schedules = listOf<Schedule>(
-        Schedule("clean-up-deduplication-table", 120, VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC)
+        Schedule("clean-up-deduplication-table", 120, SCHEDULED_TASK_DB_PROCESSOR)
     )
     private var schedulers: Schedulers? = null
 

--- a/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
+++ b/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
@@ -52,7 +52,7 @@ class SchedulerProcessorImpl @Activate constructor(
     companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
-        private const val CLEAN_UP_DEDUPLICATION_TABLE_TASK = "clean-up-deduplication-table-task"
+        private const val DEDUPLICATION_TABLE_CLEAN_UP_TASK = "deduplication-table-clean-up-task"
     }
 
     private val dependentComponents = DependentComponents.of(
@@ -66,7 +66,7 @@ class SchedulerProcessorImpl @Activate constructor(
 
     // now just hardcoding schedulers here until CORE-16331 is picked up, when we should take this from config
     private val schedules = listOf<Schedule>(
-        Schedule(CLEAN_UP_DEDUPLICATION_TABLE_TASK, 120, SCHEDULED_TASK_DB_PROCESSOR)
+        Schedule(DEDUPLICATION_TABLE_CLEAN_UP_TASK, 120, SCHEDULED_TASK_DB_PROCESSOR)
     )
     private var schedulers: Schedulers? = null
 

--- a/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
+++ b/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
@@ -20,6 +20,7 @@ import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.processors.scheduler.SchedulerProcessor
+import net.corda.schema.Schemas.VirtualNode.VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC
 import net.corda.schema.configuration.BootConfig
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -64,7 +65,7 @@ class SchedulerProcessorImpl @Activate constructor(
     // now just hardcoding schedulers here until CORE-16331 is picked up, when we should take this from config
     private val schedules = listOf<Schedule>(
         // example schedule, delete/replace when we have a real one, uncomment for testing
-        Schedule("clean-up-deduplication-table", 120, "virtual.node.deduplication.table.clean.up")
+        Schedule("clean-up-deduplication-table", 120, VIRTUAL_NODE_DEDUPLICATION_TABLE_CLEAN_UP_TOPIC)
 //        Schedule("say-hello", 60, "telephone"),
 //        Schedule("say-goodbye", 600, "telephone"),
     )

--- a/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
+++ b/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
@@ -51,6 +51,8 @@ class SchedulerProcessorImpl @Activate constructor(
 
     companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+
+        private const val CLEAN_UP_DEDUPLICATION_TABLE_TASK = "clean-up-deduplication-table-task"
     }
 
     private val dependentComponents = DependentComponents.of(
@@ -64,7 +66,7 @@ class SchedulerProcessorImpl @Activate constructor(
 
     // now just hardcoding schedulers here until CORE-16331 is picked up, when we should take this from config
     private val schedules = listOf<Schedule>(
-        Schedule("clean-up-deduplication-table", 120, SCHEDULED_TASK_DB_PROCESSOR)
+        Schedule(CLEAN_UP_DEDUPLICATION_TABLE_TASK, 120, SCHEDULED_TASK_DB_PROCESSOR)
     )
     private var schedulers: Schedulers? = null
 

--- a/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
+++ b/processors/scheduler-processor/src/main/kotlin/net/corda/processors/scheduler/impl/SchedulerProcessorImpl.kt
@@ -64,7 +64,7 @@ class SchedulerProcessorImpl @Activate constructor(
     // now just hardcoding schedulers here until CORE-16331 is picked up, when we should take this from config
     private val schedules = listOf<Schedule>(
         // example schedule, delete/replace when we have a real one, uncomment for testing
-        Schedule("clean-up-deduplication-table", 20, "virtual.node.deduplication.table.clean.up")
+        Schedule("clean-up-deduplication-table", 120, "virtual.node.deduplication.table.clean.up")
 //        Schedule("say-hello", 60, "telephone"),
 //        Schedule("say-goodbye", 600, "telephone"),
     )


### PR DESCRIPTION
Introduces housekeeping functionality for the deduplication table as a `Scheduler` task.

- adds `DELETE` query for "old" request ids.
- adds clean up functionality in a Kafka consumer (`DurableProcessor`) to consume from the `Scheduler`.
- adds the `Scheduler` to the `DBWorker`.


**Testing:**
- the `DELETE` query was tested it works against both in memory and postgres DBs at integration level.
- the cluster was deployed and vnodes were created then db-worker logs were monitored to witness the execution of the scheduled task and also monitored for potential errors.

api PR: https://github.com/corda/corda-api/pull/1249