### PR TITLE
CORE-10087 - Introduce utils needed to migrate network tests to the e2e-tests repo

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -7,6 +7,7 @@ import net.corda.crypto.test.certificates.generation.FileSystemCertificatesAutho
 import net.corda.crypto.test.certificates.generation.KeysFactoryDefinitions
 import net.corda.crypto.test.certificates.generation.toPem
 import net.corda.e2etest.utilities.config.SingleClusterTestConfigManager
+import net.corda.e2etest.utilities.config.TestConfigManager
 import net.corda.rest.ResponseCode
 import net.corda.rest.annotations.RestApiVersion
 import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
@@ -96,12 +97,6 @@ fun ClusterInfo.importCertificate(
     }
 }
 
-/**
- * Disable certificate revocation checks.
- * CRL checks disabled is the default for E2E tests so this doesn't attempt to revert after use.
- */
-fun ClusterInfo.disableCertificateRevocationChecks() {
-    SingleClusterTestConfigManager(this)
-        .load(P2P_GATEWAY_CONFIG, "sslConfig.revocationCheck.mode", "OFF")
-        .apply()
+fun TestConfigManager.disableCertificateRevocationChecks() {
+        load(P2P_GATEWAY_CONFIG, "sslConfig.revocationCheck.mode", "OFF")
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -6,7 +6,6 @@ import net.corda.crypto.test.certificates.generation.CertificateAuthorityFactory
 import net.corda.crypto.test.certificates.generation.FileSystemCertificatesAuthority
 import net.corda.crypto.test.certificates.generation.KeysFactoryDefinitions
 import net.corda.crypto.test.certificates.generation.toPem
-import net.corda.e2etest.utilities.config.SingleClusterTestConfigManager
 import net.corda.e2etest.utilities.config.TestConfigManager
 import net.corda.rest.ResponseCode
 import net.corda.rest.annotations.RestApiVersion

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -96,7 +96,3 @@ fun ClusterInfo.importCertificate(
         }
     }
 }
-
-fun TestConfigManager.disableCertificateRevocationChecks() {
-        load(P2P_GATEWAY_CONFIG, "sslConfig.revocationCheck.mode", "OFF")
-}

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -85,12 +85,13 @@ fun ClusterInfo.generateCsr(
 fun ClusterInfo.importCertificate(
     file: File,
     usage: String,
-    alias: String
+    alias: String,
+    holdingIdentity: String? = null
 ) {
     cluster {
         assertWithRetryIgnoringExceptions {
             interval(1.seconds)
-            command { importCertificate(file, usage, alias) }
+            command { importCertificate(file, usage, alias, holdingIdentity) }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
         }
     }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CertificateUtils.kt
@@ -6,10 +6,8 @@ import net.corda.crypto.test.certificates.generation.CertificateAuthorityFactory
 import net.corda.crypto.test.certificates.generation.FileSystemCertificatesAuthority
 import net.corda.crypto.test.certificates.generation.KeysFactoryDefinitions
 import net.corda.crypto.test.certificates.generation.toPem
-import net.corda.e2etest.utilities.config.TestConfigManager
 import net.corda.rest.ResponseCode
 import net.corda.rest.annotations.RestApiVersion
-import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 import net.corda.utilities.seconds
 import org.assertj.core.api.Assertions.assertThat
 import org.bouncycastle.openssl.PEMParser

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -102,12 +102,30 @@ class ClusterBuilder {
     fun deprecatedImportCertificate(resourceName: String, usage: String, alias: String) =
         uploadCertificateResource("/api/${RestApiVersion.C5_0.versionPath}/certificates/cluster/$usage", resourceName, alias)
 
+    /**
+     * If [holdingIdentity] is not specified, it will be uploaded as a cluster-level certificate.
+     * If [holdingIdentity] is specified, it will be uploaded as a vnode-level certificate under the specified vnode.
+     */
+    fun importCertificate(file: File, usage: String, alias: String, holdingIdentityId: String?): SimpleResponse {
+        return if (holdingIdentityId == null) {
+            importClusterCertificate(file, usage, alias)
+        } else {
+            importVnodeCertificate(file, usage, alias, holdingIdentityId)
+        }
+    }
 
-    fun importCertificate(file: File, usage: String, alias: String) =
+    private fun importClusterCertificate(file: File, usage: String, alias: String) =
         uploadCertificateFile(
             "/api/$REST_API_VERSION_PATH/${REST_API_VERSION_PATH.certificatePath()}/cluster/$usage",
             file,
             alias,
+        )
+
+    private fun importVnodeCertificate(file: File, usage: String, alias: String, holdingIdentityId: String) =
+        uploadCertificateFile(
+            "/api/$REST_API_VERSION_PATH/${REST_API_VERSION_PATH.certificatePath()}/vnode/$holdingIdentityId/$usage",
+            file,
+            alias
         )
 
     fun getCertificateChain(usage: String, alias: String) =

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -571,11 +571,11 @@ class ClusterBuilder {
 
     fun configureNetworkParticipant(
         holdingIdentityShortHash: String,
-        sessionKeyId: String
-    ) =
-        put(
-            "/api/$REST_API_VERSION_PATH/network/setup/$holdingIdentityShortHash",
-            body = """
+        sessionKeyId: String,
+        sessionKeyCertAlias: String? = null
+    ): SimpleResponse {
+        val body = if (sessionKeyCertAlias == null) {
+            """
                 {
                     "p2pTlsCertificateChainAlias": "$CERT_ALIAS_P2P",
                     "useClusterLevelTlsCertificateAndKey": true,
@@ -585,7 +585,25 @@ class ClusterBuilder {
                     }]
                 }
             """.trimIndent()
+        } else {
+            """
+                {
+                    "p2pTlsCertificateChainAlias": "$CERT_ALIAS_P2P",
+                    "useClusterLevelTlsCertificateAndKey": true,
+                    "sessionKeysAndCertificates": [{
+                      "preferred": true,
+                      "sessionKeyId": "$sessionKeyId",
+                      "sessionCertificateChainAlias": "$sessionKeyCertAlias"
+                    }]
+                }
+            """.trimIndent()
+        }
+        return put(
+            "/api/$REST_API_VERSION_PATH/network/setup/$holdingIdentityShortHash",
+            body = body
         )
+    }
+
 }
 
 fun <T> cluster(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -590,9 +590,9 @@ class ClusterBuilder {
     fun configureNetworkParticipant(
         holdingIdentityShortHash: String,
         sessionKeyId: String,
-        sessionKeyCertAlias: String? = null
+        sessionCertAlias: String? = null
     ): SimpleResponse {
-        val body = if (sessionKeyCertAlias == null) {
+        val body = if (sessionCertAlias == null) {
             """
                 {
                     "p2pTlsCertificateChainAlias": "$CERT_ALIAS_P2P",
@@ -611,7 +611,7 @@ class ClusterBuilder {
                     "sessionKeysAndCertificates": [{
                       "preferred": true,
                       "sessionKeyId": "$sessionKeyId",
-                      "sessionCertificateChainAlias": "$sessionKeyCertAlias"
+                      "sessionCertificateChainAlias": "$sessionCertAlias"
                     }]
                 }
             """.trimIndent()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -592,30 +592,30 @@ class ClusterBuilder {
         sessionKeyId: String,
         sessionCertAlias: String? = null
     ): SimpleResponse {
-        val body = if (sessionCertAlias == null) {
+        val sessionKeysSection = if (sessionCertAlias == null) {
             """
-                {
-                    "p2pTlsCertificateChainAlias": "$CERT_ALIAS_P2P",
-                    "useClusterLevelTlsCertificateAndKey": true,
                     "sessionKeysAndCertificates": [{
                       "preferred": true,
                       "sessionKeyId": "$sessionKeyId"
                     }]
-                }
-            """.trimIndent()
+            """.trim()
         } else {
             """
-                {
-                    "p2pTlsCertificateChainAlias": "$CERT_ALIAS_P2P",
-                    "useClusterLevelTlsCertificateAndKey": true,
                     "sessionKeysAndCertificates": [{
                       "preferred": true,
                       "sessionKeyId": "$sessionKeyId",
                       "sessionCertificateChainAlias": "$sessionCertAlias"
                     }]
+            """.trim()
+        }
+        val body =
+            """
+                {
+                    "p2pTlsCertificateChainAlias": "$CERT_ALIAS_P2P",
+                    "useClusterLevelTlsCertificateAndKey": true,
+                    $sessionKeysSection
                 }
             """.trimIndent()
-        }
         return put(
             "/api/$REST_API_VERSION_PATH/network/setup/$holdingIdentityShortHash",
             body = body

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -42,7 +42,7 @@ fun ClusterInfo.onboardMgm(
             it.deleteOnExit()
             it.writeBytes(mgmSessionCert.toByteArray())
         }
-        importCertificate(mgmSessionCertFile, CERT_USAGE_SESSION, "$CERT_ALIAS_SESSION-$mgmHoldingId")
+        importCertificate(mgmSessionCertFile, CERT_USAGE_SESSION, "$CERT_ALIAS_SESSION-$mgmHoldingId", mgmHoldingId)
     }
 
     addSoftHsmFor(mgmHoldingId, CAT_PRE_AUTH)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -35,6 +35,7 @@ fun ClusterInfo.onboardMgm(
         mgmHoldingId, "$mgmHoldingId$CAT_SESSION_INIT", CAT_SESSION_INIT, DEFAULT_KEY_SCHEME
     )
     var mgmSessionCert: String? = null
+    val mgmSessionCertAlias = "$CERT_ALIAS_SESSION-$mgmHoldingId"
     if (groupPolicyConfig.sessionPkiMode == "Standard") {
         val mgmSessionCsr = generateCsr(mgmName, sessionKeyId, mgmHoldingId)
         mgmSessionCert = getCa().generateCert(mgmSessionCsr)
@@ -42,7 +43,7 @@ fun ClusterInfo.onboardMgm(
             it.deleteOnExit()
             it.writeBytes(mgmSessionCert.toByteArray())
         }
-        importCertificate(mgmSessionCertFile, CERT_USAGE_SESSION, "$CERT_ALIAS_SESSION-$mgmHoldingId", mgmHoldingId)
+        importCertificate(mgmSessionCertFile, CERT_USAGE_SESSION, mgmSessionCertAlias, mgmHoldingId)
     }
 
     addSoftHsmFor(mgmHoldingId, CAT_PRE_AUTH)
@@ -68,7 +69,7 @@ fun ClusterInfo.onboardMgm(
     }
     val registrationId = register(mgmHoldingId, registrationContext, waitForApproval = true)
     if (mgmSessionCert != null) {
-        configureNetworkParticipant(mgmHoldingId, sessionKeyId, mgmSessionCert)
+        configureNetworkParticipant(mgmHoldingId, sessionKeyId, mgmSessionCertAlias)
     } else {
         configureNetworkParticipant(mgmHoldingId, sessionKeyId)
     }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -56,7 +56,6 @@ fun ClusterInfo.onboardMgm(
     )
 
     if (!keyExists(TENANT_P2P, "$TENANT_P2P$CAT_TLS", CAT_TLS)) {
-        disableCertificateRevocationChecks()
         val tlsKeyId = createKeyFor(TENANT_P2P, "$TENANT_P2P$CAT_TLS", CAT_TLS, DEFAULT_KEY_SCHEME)
         val mgmTlsCsr = generateCsr(mgmName, tlsKeyId)
         val mgmTlsCert = File.createTempFile("${this.hashCode()}$CAT_TLS", ".pem").also {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -4,6 +4,7 @@ package net.corda.e2etest.utilities
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import net.corda.crypto.test.certificates.generation.toPem
+import net.corda.e2etest.utilities.ClusterBuilder.Companion.REST_API_VERSION_PATH
 import net.corda.e2etest.utilities.types.NetworkOnboardingMetadata
 import net.corda.rest.ResponseCode
 import net.corda.utilities.minutes
@@ -13,7 +14,6 @@ import java.net.URLEncoder.encode
 import java.nio.charset.Charset.defaultCharset
 import java.time.Duration
 import net.corda.rest.annotations.RestApiVersion
-import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
@@ -85,7 +85,7 @@ fun ClusterInfo.exportGroupPolicy(
     assertWithRetryIgnoringExceptions {
         interval(2.seconds)
         timeout(30.seconds)
-        command { get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/info") }
+        command { get("/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/info") }
         condition { it.code == ResponseCode.OK.statusCode }
     }.body
 }
@@ -97,7 +97,7 @@ fun ClusterInfo.createApprovalRule(
     mgmHoldingId: String,
     regex: String,
     label: String
-) = createApprovalRuleCommon("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approval/rules", regex, label)
+) = createApprovalRuleCommon("/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/approval/rules", regex, label)
 
 /**
  * Attempt to create a pre-auth approval rule.
@@ -106,7 +106,7 @@ fun ClusterInfo.createPreAuthApprovalRule(
     mgmHoldingId: String,
     regex: String,
     label: String
-) = createApprovalRuleCommon("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approval/rules/preauth", regex, label)
+) = createApprovalRuleCommon("/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/approval/rules/preauth", regex, label)
 
 /**
  * Attempt to create an approval rule at a given resource URL.
@@ -134,7 +134,7 @@ private fun ClusterInfo.createApprovalRuleCommon(
 fun ClusterInfo.deleteApprovalRule(
     mgmHoldingId: String,
     ruleId: String
-) = delete("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approval/rules/$ruleId")
+) = delete("/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/approval/rules/$ruleId")
 
 /**
  * Attempt to delete a pre-auth approval rule.
@@ -142,7 +142,7 @@ fun ClusterInfo.deleteApprovalRule(
 fun ClusterInfo.deletePreAuthApprovalRule(
     mgmHoldingId: String,
     ruleId: String
-) = delete("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approval/rules/preauth/$ruleId")
+) = delete("/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/approval/rules/preauth/$ruleId")
 
 /**
  * Attempt to delete a resource at a given URL with retries.
@@ -177,7 +177,7 @@ fun ClusterInfo.createPreAuthToken(
         interval(1.seconds)
         command {
             post(
-                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/preauthtoken",
+                "/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/preauthtoken",
                 ObjectMapper().writeValueAsString(payload)
             )
         }
@@ -198,7 +198,7 @@ fun ClusterInfo.revokePreAuthToken(
             interval(1.seconds)
             command {
                 put(
-                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/preauthtoken/revoke/$tokenId",
+                "/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/preauthtoken/revoke/$tokenId",
                 "{\"remarks\": \"$remark\"}"
                 )
             }
@@ -225,7 +225,7 @@ fun ClusterInfo.getPreAuthTokens(
     val query = queries.joinToString(prefix = "?", separator = "&")
     assertWithRetryIgnoringExceptions {
         interval(1.seconds)
-        command { get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/preauthtoken$query") }
+        command { get("/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/preauthtoken$query") }
         condition { it.code == ResponseCode.OK.statusCode }
     }.toJson()
 }
@@ -246,7 +246,7 @@ fun ClusterInfo.waitForPendingRegistrationReviews(
         assertWithRetryIgnoringExceptions {
             timeout(2.minutes)
             interval(3.seconds)
-            command { get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/registrations$query") }
+            command { get("/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/registrations$query") }
             condition {
                 val json = it.toJson().firstOrNull()
                 it.code == ResponseCode.OK.statusCode
@@ -267,7 +267,7 @@ fun ClusterInfo.approveRegistration(
     cluster {
         assertWithRetry {
             interval(1.seconds)
-            command { post("/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/approve/$registrationId", "") }
+            command { post("/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/approve/$registrationId", "") }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
         }
     }
@@ -284,7 +284,7 @@ fun ClusterInfo.declineRegistration(
         assertWithRetry {
             interval(1.seconds)
             command { post(
-                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/decline/$registrationId",
+                "/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/decline/$registrationId",
                 "{\"reason\": \"Declined by automated test with runId $testRunUniqueId.\"}")
             }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
@@ -345,7 +345,7 @@ fun ClusterInfo.suspendMember(
         interval(1.seconds)
         command {
             post(
-                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/suspend",
+                "/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/suspend",
                 "{ \"x500Name\": \"$x500Name\", \"serialNumber\": $serialNumber }"
             )
         }
@@ -391,7 +391,7 @@ fun ClusterInfo.activateMember(
         interval(1.seconds)
         command {
             post(
-                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/activate",
+                "/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/activate",
                 "{ \"x500Name\": \"$x500Name\", \"serialNumber\": $serialNumber }"
             )
         }
@@ -438,7 +438,7 @@ fun ClusterInfo.updateGroupParameters(
         interval(1.seconds)
         command {
             post(
-                "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/group-parameters",
+                "/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/group-parameters",
                 ObjectMapper().writeValueAsString(payload)
             )
         }
@@ -454,7 +454,7 @@ fun ClusterInfo.allowClientCertificates(certificatePem: String, mgmHoldingId: St
         .subjectX500Principal
 
     val encodedSubject = encode(subject.toString(), StandardCharsets.UTF_8)
-    val endpoint = "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/mutual-tls/allowed-client-certificate-subjects/$encodedSubject"
+    val endpoint = "/api/$REST_API_VERSION_PATH/mgm/$mgmHoldingId/mutual-tls/allowed-client-certificate-subjects/$encodedSubject"
     cluster {
         assertWithRetryIgnoringExceptions {
             timeout(15.seconds)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MGMUtils.kt
@@ -438,15 +438,13 @@ fun ClusterInfo.allowClientCertificates(certificatePem: String, mgmHoldingId: St
         .first()
         .subjectX500Principal
 
+    val endpoint = "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/mutual-tls/allowed-client-certificate-subjects/$subject"
     cluster {
         assertWithRetryIgnoringExceptions {
             timeout(15.seconds)
             interval(1.seconds)
             command {
-                put(
-                    "/api/${ClusterBuilder.REST_API_VERSION_PATH}/mgm/$mgmHoldingId/mutual-tls/allowed-client-certificate-subjects/$subject",
-                    ""
-                )
+                put(endpoint,"")
             }
             condition { it.code == ResponseCode.OK.statusCode }
         }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -64,6 +64,7 @@ fun ClusterInfo.onboardMember(
     addSoftHsmFor(holdingId, CAT_SESSION_INIT)
     val sessionKeyId = createKeyFor(holdingId, "$holdingId$CAT_SESSION_INIT", CAT_SESSION_INIT, DEFAULT_KEY_SCHEME)
     var memberSessionCert: String? = null
+    val mgmSessionCertAlias = "$CERT_ALIAS_SESSION-$holdingId"
     if (useSessionCertificate) {
         val memberSessionCsr = generateCsr(x500Name, sessionKeyId, holdingId)
         memberSessionCert = getCa().generateCert(memberSessionCsr)
@@ -71,7 +72,7 @@ fun ClusterInfo.onboardMember(
             it.deleteOnExit()
             it.writeBytes(memberSessionCert.toByteArray())
         }
-        importCertificate(mgmSessionCertFile, CERT_USAGE_SESSION, "$CERT_ALIAS_SESSION-$holdingId", holdingId)
+        importCertificate(mgmSessionCertFile, CERT_USAGE_SESSION, mgmSessionCertAlias, holdingId)
     }
 
     addSoftHsmFor(holdingId, CAT_LEDGER)
@@ -95,7 +96,7 @@ fun ClusterInfo.onboardMember(
     ) + (getAdditionalContext?.let { it(holdingId) } ?: emptyMap())
 
     if (memberSessionCert != null) {
-        configureNetworkParticipant(holdingId, sessionKeyId, memberSessionCert)
+        configureNetworkParticipant(holdingId, sessionKeyId, mgmSessionCertAlias)
     } else {
         configureNetworkParticipant(holdingId, sessionKeyId)
     }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -65,7 +65,7 @@ fun ClusterInfo.onboardMember(
     val sessionKeyId = createKeyFor(holdingId, "$holdingId$CAT_SESSION_INIT", CAT_SESSION_INIT, DEFAULT_KEY_SCHEME)
     var memberSessionCert: String? = null
     if (useSessionCertificate) {
-        val memberSessionCsr = generateCsr(x500Name, sessionKeyId)
+        val memberSessionCsr = generateCsr(x500Name, sessionKeyId, holdingId)
         memberSessionCert = getCa().generateCert(memberSessionCsr)
         val mgmSessionCertFile = File.createTempFile("${this.hashCode()}$CAT_SESSION_INIT", ".pem").also {
             it.deleteOnExit()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -54,7 +54,7 @@ fun ClusterInfo.onboardMember(
     x500Name: String,
     waitForApproval: Boolean = true,
     getAdditionalContext: ((holdingId: String) -> Map<String, String>)? = null,
-    certificateUploadedCallback: (String) -> Unit = {},
+    tlsCertificateUploadedCallback: (String) -> Unit = {},
     useSessionCertificate: Boolean = false
 ): NetworkOnboardingMetadata {
     conditionallyUploadCpiSigningCertificate()
@@ -87,7 +87,7 @@ fun ClusterInfo.onboardMember(
             it.writeBytes(tlsCert.toByteArray())
         }
         importCertificate(tlsCertFile, CERT_USAGE_P2P, CERT_ALIAS_P2P)
-        certificateUploadedCallback(tlsCert)
+        tlsCertificateUploadedCallback(tlsCert)
     }
 
     val registrationContext = createRegistrationContext(
@@ -140,7 +140,7 @@ fun ClusterInfo.onboardNotaryMember(
     x500Name: String,
     wait: Boolean = true,
     getAdditionalContext: ((holdingId: String) -> Map<String, String>)? = null,
-    certificateUploadedCallback: (String) -> Unit = {}
+    tlsCertificateUploadedCallback: (String) -> Unit = {}
 ) = onboardMember(
     resourceName,
     cpiName,
@@ -160,7 +160,7 @@ fun ClusterInfo.onboardNotaryMember(
             "corda.notary.keys.0.signature.spec" to DEFAULT_SIGNATURE_SPEC
         ) + (getAdditionalContext?.let { it(holdingId) } ?: emptyMap())
     },
-    certificateUploadedCallback = certificateUploadedCallback
+    tlsCertificateUploadedCallback = tlsCertificateUploadedCallback
 )
 
 /**

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -78,7 +78,6 @@ fun ClusterInfo.onboardMember(
     val ledgerKeyId = createKeyFor(holdingId, "$holdingId$CAT_LEDGER", CAT_LEDGER, DEFAULT_KEY_SCHEME)
 
     if (!keyExists(TENANT_P2P, "$TENANT_P2P$CAT_TLS", CAT_TLS)) {
-        disableCertificateRevocationChecks()
         val tlsKeyId = createKeyFor(TENANT_P2P, "$TENANT_P2P$CAT_TLS", CAT_TLS, DEFAULT_KEY_SCHEME)
         val tlsCsr = generateCsr(x500Name, tlsKeyId)
         val tlsCert = getCa().generateCert(tlsCsr)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -71,7 +71,7 @@ fun ClusterInfo.onboardMember(
             it.deleteOnExit()
             it.writeBytes(memberSessionCert.toByteArray())
         }
-        importCertificate(mgmSessionCertFile, CERT_USAGE_SESSION, "$CERT_ALIAS_SESSION-$holdingId")
+        importCertificate(mgmSessionCertFile, CERT_USAGE_SESSION, "$CERT_ALIAS_SESSION-$holdingId", holdingId)
     }
 
     addSoftHsmFor(holdingId, CAT_LEDGER)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -168,12 +168,12 @@ fun ClusterInfo.onboardNotaryMember(
 fun ClusterInfo.configureNetworkParticipant(
     holdingId: String,
     sessionKeyId: String,
-    sessionKeyCert: String? = null
+    sessionCertAlias: String? = null
 ) {
     return cluster {
         assertWithRetryIgnoringExceptions {
             interval(1.seconds)
-            command { configureNetworkParticipant(holdingId, sessionKeyId, sessionKeyCert) }
+            command { configureNetworkParticipant(holdingId, sessionKeyId, sessionCertAlias) }
             condition { it.code == ResponseCode.NO_CONTENT.statusCode }
             failMessage("Failed to configure member '$holdingId' as a network participant")
         }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/common/CommonConfigUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/common/CommonConfigUtils.kt
@@ -1,0 +1,8 @@
+package net.corda.e2etest.utilities.config.common
+
+import net.corda.e2etest.utilities.config.TestConfigManager
+import net.corda.schema.configuration.ConfigKeys
+
+fun TestConfigManager.disableCertificateRevocationChecks() {
+    load(ConfigKeys.P2P_GATEWAY_CONFIG, "sslConfig.revocationCheck.mode", "OFF")
+}


### PR DESCRIPTION
## Changes
Introduce utilities needed for e2e testing in order to migrate some e2e tests into the e2e-tests repo (`MultiClusterDynamicNetworkTest` and `SessionCertificateTest`). As part of this, I extracted disabling the certificate revocation checks from the `onboardMember` / `onboardMgm` functions, so that it can be executed along with any other config changes needed within the test. Otherwise, this could revert any changes on the same section performed by within the test (e.g. when trying to change tls mode, which is in the same gateway section as revocation checks). I also removed usage of any proxy utils that are targeted for removal/deprecation from e2e testing and stuck to using the existing utilities (this meant I had to introduce a couple of new functions that were not available).

To make reviewing easier, a follow-up PR will come that will remove the migrated tests and move the remaining tests (`SingleClusterDynamicNetworkTest` and `StaticNetworkTest`)  into the smoke test suite.

## Testing
Most of the testing (apart from the gates here) was done as part of https://github.com/corda/corda-e2e-tests/pull/231 that makes use of these changes.