### PR TITLE
CORE-16615: introduce unconsumed visible state by type query

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -41,6 +41,8 @@ interface UtxoPersistenceService {
 
     fun <T: ContractState> findUnconsumedVisibleStatesByType(stateClass: Class<out T>): List<UtxoTransactionOutputDto>
 
+    fun <T: ContractState> findUnconsumedVisibleStatesByExactType(stateClass: Class<out T>): List<UtxoTransactionOutputDto>
+
     fun resolveStateRefs(stateRefs: List<StateRef>): List<UtxoTransactionOutputDto>
 
     fun persistTransaction(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -25,9 +25,15 @@ interface UtxoRepository {
         transactionId: String
     ): Map<Int, List<ByteArray>>
 
-    /** Retrieves transaction component leafs related to visible unspent states */
+    /** Retrieves transaction component leafs related to visible unspent states and subclass states */
     fun findUnconsumedVisibleStatesByType(
         entityManager: EntityManager
+    ):  List<UtxoTransactionOutputDto>
+
+    /** Retrieves transaction component leafs related to visible unspent states */
+    fun findUnconsumedVisibleStatesByExactType(
+        entityManager: EntityManager,
+        stateClassType: String
     ):  List<UtxoTransactionOutputDto>
 
     /** Retrieves transaction component leafs related to specific StateRefs */

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -27,8 +27,7 @@ interface UtxoRepository {
 
     /** Retrieves transaction component leafs related to visible unspent states */
     fun findUnconsumedVisibleStatesByType(
-        entityManager: EntityManager,
-        stateClassType: String
+        entityManager: EntityManager
     ):  List<UtxoTransactionOutputDto>
 
     /** Retrieves transaction component leafs related to specific StateRefs */

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -25,12 +25,12 @@ interface UtxoRepository {
         transactionId: String
     ): Map<Int, List<ByteArray>>
 
-    /** Retrieves transaction component leafs related to visible unspent states by type and subtypes */
+    /** Retrieves transaction component leaves related to visible unspent states and subclass states.*/
     fun findUnconsumedVisibleStatesByType(
         entityManager: EntityManager
     ):  List<UtxoTransactionOutputDto>
 
-    /** Retrieves transaction component leafs related to visible unspent states */
+    /** Retrieves transaction component leaves related to visible unspent states */
     fun findUnconsumedVisibleStatesByExactType(
         entityManager: EntityManager,
         stateClassType: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -27,7 +27,8 @@ interface UtxoRepository {
 
     /** Retrieves transaction component leafs related to visible unspent states */
     fun findUnconsumedVisibleStatesByType(
-        entityManager: EntityManager
+        entityManager: EntityManager,
+        stateClassType: String
     ):  List<UtxoTransactionOutputDto>
 
     /** Retrieves transaction component leafs related to specific StateRefs */

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -25,7 +25,7 @@ interface UtxoRepository {
         transactionId: String
     ): Map<Int, List<ByteArray>>
 
-    /** Retrieves transaction component leafs related to visible unspent states and subclass states and subclass states */
+    /** Retrieves transaction component leafs related to visible unspent states by type and subtypes */
     fun findUnconsumedVisibleStatesByType(
         entityManager: EntityManager
     ):  List<UtxoTransactionOutputDto>

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -25,7 +25,7 @@ interface UtxoRepository {
         transactionId: String
     ): Map<Int, List<ByteArray>>
 
-    /** Retrieves transaction component leafs related to visible unspent states and subclass states */
+    /** Retrieves transaction component leafs related to visible unspent states and subclass states and subclass states */
     fun findUnconsumedVisibleStatesByType(
         entityManager: EntityManager
     ):  List<UtxoTransactionOutputDto>

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -46,6 +46,32 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
             ORDER BY tc_output.created, tc_output.transaction_id, tc_output.leaf_idx"""
             .trimIndent()
 
+    override val findUnconsumedVisibleStatesByExactType: String
+        get() = """
+            SELECT tc_output.transaction_id, 
+            tc_output.leaf_idx, 
+            tc_output_info.data as output_info_data,
+            tc_output.data AS output_data 
+            FROM {h-schema}utxo_visible_transaction_state AS rts
+            JOIN {h-schema}utxo_transaction_component AS tc_output_info
+                ON tc_output_info.transaction_id = rts.transaction_id
+                AND tc_output_info.leaf_idx = rts.leaf_idx
+                AND tc_output_info.group_idx = ${UtxoComponentGroup.OUTPUTS_INFO.ordinal}
+            JOIN {h-schema}utxo_transaction_component AS tc_output
+                ON tc_output.transaction_id = tc_output_info.transaction_id
+                AND tc_output.leaf_idx = tc_output_info.leaf_idx
+                AND tc_output.group_idx = ${UtxoComponentGroup.OUTPUTS.ordinal}
+            JOIN {h-schema}utxo_transaction_output AS tx_o
+                ON tx_o.transaction_id = tc_output.transaction_id
+                AND tx_o.leaf_idx = tc_output.leaf_idx
+            JOIN {h-schema}utxo_transaction_status AS ts
+                ON ts.transaction_id = tx_o.transaction_id
+            WHERE (tx_o.type = :type    
+                AND rts.consumed IS NULL
+                AND ts.status = :verified)
+            ORDER BY tc_output.created, tc_output.transaction_id, tc_output.leaf_idx"""
+            .trimIndent()
+
     override val findTransactionSignatures: String
         get() = """
             SELECT signature

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -66,9 +66,9 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
                 AND tx_o.leaf_idx = tc_output.leaf_idx
             JOIN {h-schema}utxo_transaction_status AS ts
                 ON ts.transaction_id = tx_o.transaction_id
-            WHERE (tx_o.type = :type    
+            WHERE tx_o.type = :type    
                 AND rts.consumed IS NULL
-                AND ts.status = :verified)
+                AND ts.status = :verified
             ORDER BY tc_output.created, tc_output.transaction_id, tc_output.leaf_idx"""
             .trimIndent()
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -39,12 +39,8 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
                 ON tc_output.transaction_id = tc_output_info.transaction_id
                 AND tc_output.leaf_idx = tc_output_info.leaf_idx
                 AND tc_output.group_idx = ${UtxoComponentGroup.OUTPUTS.ordinal}
-            JOIN {h-schema}utxo_transaction_output AS tx_output
-                ON tx_output.transaction_id = tc_output.transaction_id
-                AND tx_output.leaf_idx = tc_output.leaf_idx
             JOIN {h-schema}utxo_transaction_status AS ts
-                ON ts.transaction_id = tx_output.transaction_id
-            AND tx_output.type = :type    
+                ON ts.transaction_id = tc_output.transaction_id
             AND rts.consumed IS NULL
             AND ts.status = :verified
             ORDER BY tc_output.created, tc_output.transaction_id, tc_output.leaf_idx"""

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -39,8 +39,12 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
                 ON tc_output.transaction_id = tc_output_info.transaction_id
                 AND tc_output.leaf_idx = tc_output_info.leaf_idx
                 AND tc_output.group_idx = ${UtxoComponentGroup.OUTPUTS.ordinal}
+            JOIN {h-schema}utxo_transaction_output AS tx_output
+                ON tx_output.transaction_id = tc_output.transaction_id
+                AND tx_output.leaf_idx = tc_output.leaf_idx
             JOIN {h-schema}utxo_transaction_status AS ts
-                ON ts.transaction_id = tc_output.transaction_id
+                ON ts.transaction_id = tx_output.transaction_id
+            AND tx_output.type = :type    
             AND rts.consumed IS NULL
             AND ts.status = :verified
             ORDER BY tc_output.created, tc_output.transaction_id, tc_output.leaf_idx"""

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -108,6 +108,12 @@ class UtxoPersistenceServiceImpl(
         }
     }
 
+    override fun <T: ContractState> findUnconsumedVisibleStatesByExactType(stateClass: Class<out T>): List<UtxoTransactionOutputDto> {
+        return entityManagerFactory.transaction { em ->
+            repository.findUnconsumedVisibleStatesByExactType(em, stateClass.canonicalName)
+        }
+    }
+
     override fun resolveStateRefs(stateRefs: List<StateRef>): List<UtxoTransactionOutputDto> {
         return entityManagerFactory.transaction { em ->
             repository.resolveStateRefs(em, stateRefs)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -18,6 +18,7 @@ import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.libs.packaging.hash
 import net.corda.orm.utils.transaction
+import net.corda.utilities.serialization.deserialize
 import net.corda.utilities.time.Clock
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.marshalling.JsonMarshallingService
@@ -100,7 +101,10 @@ class UtxoPersistenceServiceImpl(
 
     override fun <T: ContractState> findUnconsumedVisibleStatesByType(stateClass: Class<out T>): List<UtxoTransactionOutputDto> {
         return entityManagerFactory.transaction { em ->
-            repository.findUnconsumedVisibleStatesByType(em, stateClass.canonicalName)
+            repository.findUnconsumedVisibleStatesByType(em)
+        }.filter {
+            val contractState = serializationService.deserialize<ContractState>(it.data)
+            stateClass.isInstance(contractState)
         }
     }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -18,7 +18,6 @@ import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.libs.packaging.hash
 import net.corda.orm.utils.transaction
-import net.corda.utilities.serialization.deserialize
 import net.corda.utilities.time.Clock
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.marshalling.JsonMarshallingService
@@ -101,10 +100,7 @@ class UtxoPersistenceServiceImpl(
 
     override fun <T: ContractState> findUnconsumedVisibleStatesByType(stateClass: Class<out T>): List<UtxoTransactionOutputDto> {
         return entityManagerFactory.transaction { em ->
-            repository.findUnconsumedVisibleStatesByType(em)
-        }.filter {
-            val contractState = serializationService.deserialize<ContractState>(it.data)
-            stateClass.isInstance(contractState)
+            repository.findUnconsumedVisibleStatesByType(em, stateClass.canonicalName)
         }
     }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -26,6 +26,11 @@ interface UtxoQueryProvider {
     val findUnconsumedVisibleStatesByType: String
 
     /**
+     * @property findUnconsumedVisibleStatesByExactType SQL text for [UtxoRepositoryImpl.findUnconsumedVisibleStatesByExactType].
+     */
+    val findUnconsumedVisibleStatesByExactType: String
+
+    /**
      * @property findTransactionSignatures SQL text for [UtxoRepositoryImpl.findTransactionSignatures].
      */
     val findTransactionSignatures: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -91,12 +91,10 @@ class UtxoRepositoryImpl @Activate constructor(
     }
 
     override fun findUnconsumedVisibleStatesByType(
-        entityManager: EntityManager,
-        stateClassType: String
+        entityManager: EntityManager
     ): List<UtxoTransactionOutputDto> {
         return entityManager.createNativeQuery(queryProvider.findUnconsumedVisibleStatesByType, Tuple::class.java)
             .setParameter("verified", TransactionStatus.VERIFIED.value)
-            .setParameter("type", stateClassType)
             .resultListAsTuples()
             .map { t ->
                 UtxoTransactionOutputDto(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -90,18 +90,6 @@ class UtxoRepositoryImpl @Activate constructor(
             .mapToComponentGroups(UtxoComponentGroupMapper(transactionId))
     }
 
-    private fun mapToUtxoTransactionOutputDto(queryObj: Query): List<UtxoTransactionOutputDto> {
-        return queryObj.resultListAsTuples()
-            .map { t ->
-                UtxoTransactionOutputDto(
-                    t[0] as String, // transactionId
-                    t[1] as Int,    // leaf ID
-                    t[2] as ByteArray, // outputs info data
-                    t[3] as ByteArray  // outputs data
-                )
-            }
-    }
-
     private fun findUnconsumedVisibleStates(
         entityManager: EntityManager,
         query: String,
@@ -379,4 +367,16 @@ class UtxoRepositoryImpl @Activate constructor(
 
     @Suppress("UNCHECKED_CAST")
     private fun Query.resultListAsTuples() = resultList as List<Tuple>
+
+    private fun mapToUtxoTransactionOutputDto(queryObj: Query): List<UtxoTransactionOutputDto> {
+        return queryObj.resultListAsTuples()
+            .map { t ->
+                UtxoTransactionOutputDto(
+                    t[0] as String, // transactionId
+                    t[1] as Int,    // leaf ID
+                    t[2] as ByteArray, // outputs info data
+                    t[3] as ByteArray  // outputs data
+                )
+            }
+    }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -106,6 +106,24 @@ class UtxoRepositoryImpl @Activate constructor(
             }
     }
 
+    override fun findUnconsumedVisibleStatesByExactType(
+        entityManager: EntityManager,
+        stateClassType: String
+    ): List<UtxoTransactionOutputDto> {
+        return entityManager.createNativeQuery(queryProvider.findUnconsumedVisibleStatesByExactType, Tuple::class.java)
+            .setParameter("verified", TransactionStatus.VERIFIED.value)
+            .setParameter("type", stateClassType)
+            .resultListAsTuples()
+            .map { t ->
+                UtxoTransactionOutputDto(
+                    t[0] as String, // transactionId
+                    t[1] as Int, // leaf ID
+                    t[2] as ByteArray, // outputs info data
+                    t[3] as ByteArray // outputs data
+                )
+            }
+    }
+
     override fun resolveStateRefs(
         entityManager: EntityManager,
         stateRefs: List<StateRef>

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -91,10 +91,12 @@ class UtxoRepositoryImpl @Activate constructor(
     }
 
     override fun findUnconsumedVisibleStatesByType(
-        entityManager: EntityManager
+        entityManager: EntityManager,
+        stateClassType: String
     ): List<UtxoTransactionOutputDto> {
         return entityManager.createNativeQuery(queryProvider.findUnconsumedVisibleStatesByType, Tuple::class.java)
             .setParameter("verified", TransactionStatus.VERIFIED.value)
+            .setParameter("type", stateClassType)
             .resultListAsTuples()
             .map { t ->
                 UtxoTransactionOutputDto(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -102,7 +102,7 @@ class UtxoRepositoryImpl @Activate constructor(
             queryObj.setParameter("type", stateClassType)
         }
 
-        return mapToUtxoTransactionOutputDto(queryObj)
+        return queryObj.mapToUtxoTransactionOutputDto()
     }
 
     override fun findUnconsumedVisibleStatesByType(
@@ -122,12 +122,11 @@ class UtxoRepositoryImpl @Activate constructor(
         entityManager: EntityManager,
         stateRefs: List<StateRef>
     ): List<UtxoTransactionOutputDto> {
-        val queryObj = entityManager.createNativeQuery(queryProvider.resolveStateRefs, Tuple::class.java)
+        return entityManager.createNativeQuery(queryProvider.resolveStateRefs, Tuple::class.java)
             .setParameter("transactionIds", stateRefs.map { it.transactionId.toString() })
             .setParameter("stateRefs", stateRefs.map { it.toString() })
             .setParameter("verified", TransactionStatus.VERIFIED.value)
-
-        return mapToUtxoTransactionOutputDto(queryObj)
+            .mapToUtxoTransactionOutputDto()
     }
 
     override fun findTransactionSignatures(
@@ -368,8 +367,8 @@ class UtxoRepositoryImpl @Activate constructor(
     @Suppress("UNCHECKED_CAST")
     private fun Query.resultListAsTuples() = resultList as List<Tuple>
 
-    private fun mapToUtxoTransactionOutputDto(queryObj: Query): List<UtxoTransactionOutputDto> {
-        return queryObj.resultListAsTuples()
+    private fun Query.mapToUtxoTransactionOutputDto(): List<UtxoTransactionOutputDto> {
+        return resultListAsTuples()
             .map { t ->
                 UtxoTransactionOutputDto(
                     t[0] as String, // transactionId

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.persistence.utxo.impl
 import net.corda.data.ledger.persistence.FindSignedGroupParameters
 import net.corda.data.ledger.persistence.FindSignedLedgerTransaction
 import net.corda.data.ledger.persistence.FindTransaction
+import net.corda.data.ledger.persistence.FindUnconsumedStatesByExactType
 import net.corda.data.ledger.persistence.FindUnconsumedStatesByType
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.data.ledger.persistence.LedgerTypes
@@ -22,6 +23,7 @@ import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoExecuteNamedQ
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedGroupParametersRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedLedgerTransactionRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindTransactionRequestHandler
+import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindUnconsumedStatesByExactTypeRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindUnconsumedStatesByTypeRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoPersistSignedGroupParametersIfDoNotExistRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoPersistTransactionIfDoesNotExistRequestHandler
@@ -88,6 +90,15 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
             }
             is FindUnconsumedStatesByType -> {
                 UtxoFindUnconsumedStatesByTypeRequestHandler(
+                    req,
+                    sandbox,
+                    externalEventContext,
+                    persistenceService,
+                    outputRecordFactory
+                )
+            }
+            is FindUnconsumedStatesByExactType -> {
+                UtxoFindUnconsumedStatesByExactTypeRequestHandler(
                     req,
                     sandbox,
                     externalEventContext,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindUnconsumedStatesByExactTypeRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindUnconsumedStatesByExactTypeRequestHandler.kt
@@ -1,0 +1,34 @@
+package net.corda.ledger.persistence.utxo.impl.request.handlers
+
+import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.data.ledger.persistence.FindUnconsumedStatesByExactType
+import net.corda.ledger.persistence.common.RequestHandler
+import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
+import net.corda.ledger.persistence.utxo.UtxoPersistenceService
+import net.corda.messaging.api.records.Record
+import net.corda.sandboxgroupcontext.SandboxGroupContext
+import net.corda.v5.ledger.utxo.ContractState
+
+@Suppress("LongParameterList")
+class UtxoFindUnconsumedStatesByExactTypeRequestHandler(
+    private val findUnconsumedStatesByExactType: FindUnconsumedStatesByExactType,
+    private val sandbox: SandboxGroupContext,
+    private val externalEventContext: ExternalEventContext,
+    private val persistenceService: UtxoPersistenceService,
+    private val utxoOutputRecordFactory: UtxoOutputRecordFactory
+) : RequestHandler {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun execute(): List<Record<*, *>> {
+        val stateType = sandbox.sandboxGroup.loadClassFromMainBundles(findUnconsumedStatesByExactType.stateClassName)
+        require(ContractState::class.java.isAssignableFrom(stateType)) {
+            "Provided ${findUnconsumedStatesByExactType.stateClassName} is not type of ContractState"
+        }
+
+        val visibleStates = persistenceService.findUnconsumedVisibleStatesByExactType(
+            stateType as Class<out ContractState>
+        )
+
+        return listOf(utxoOutputRecordFactory.getStatesSuccessRecord(visibleStates, externalEventContext))
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -106,6 +106,11 @@ class UtxoLedgerServiceImpl @Activate constructor(
     }
 
     @Suspendable
+    override fun <T : ContractState> findUnconsumedStatesByExactType(type: Class<T>): List<StateAndRef<T>> {
+        return utxoLedgerStateQueryService.findUnconsumedStatesByExactType(type)
+    }
+
+    @Suspendable
     override fun finalize(
         signedTransaction: UtxoSignedTransaction,
         sessions: List<FlowSession>

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
@@ -5,6 +5,7 @@ enum class LedgerPersistenceMetricOperationName {
     FindGroupParameters,
     FindSignedLedgerTransactionWithStatus,
     FindTransactionWithStatus,
+    FindUnconsumedStatesByExactType,
     FindUnconsumedStatesByType,
     FindWithNamedQuery,
     PersistSignedGroupParametersIfDoNotExist,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerStateQueryService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerStateQueryService.kt
@@ -11,7 +11,7 @@ import net.corda.v5.ledger.utxo.StateRef
  */
 interface UtxoLedgerStateQueryService {
     /**
-     * Find unconsumed visible states of type [stateClass].
+     * Find unconsumed visible states of type [stateClass] and that of subclasses.
      *
      * @param stateClass The class of the aimed states.
      * @return The result [StateAndRef]s.
@@ -20,6 +20,17 @@ interface UtxoLedgerStateQueryService {
      */
     @Suspendable
     fun <T: ContractState> findUnconsumedStatesByType(stateClass: Class<out T>): List<StateAndRef<T>>
+
+    /**
+     * Find unconsumed visible states of type [stateClass].
+     *
+     * @param stateClass The class of the aimed states.
+     * @return The result [StateAndRef]s.
+     *
+     * @throws CordaPersistenceException if an error happens during find operation.
+     */
+    @Suspendable
+    fun <T: ContractState> findUnconsumedStatesByExactType(stateClass: Class<out T>): List<StateAndRef<T>>
 
     /**
      * Resolve [StateRef]s to [StateAndRef]s

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindUnconsumedStatesByExactTypeExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindUnconsumedStatesByExactTypeExternalEventFactory.kt
@@ -1,0 +1,54 @@
+package net.corda.ledger.utxo.flow.impl.persistence.external.events
+
+import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.data.ledger.persistence.FindUnconsumedStatesByExactType
+import net.corda.data.ledger.persistence.LedgerPersistenceRequest
+import net.corda.data.ledger.persistence.LedgerTypes
+import net.corda.data.ledger.persistence.UtxoTransactionOutputs
+import net.corda.flow.external.events.factory.ExternalEventFactory
+import net.corda.flow.external.events.factory.ExternalEventRecord
+import net.corda.flow.state.FlowCheckpoint
+import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
+import net.corda.schema.Schemas
+import net.corda.virtualnode.toAvro
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import java.time.Clock
+
+@Component(service = [ExternalEventFactory::class])
+class FindUnconsumedStatesByExactTypeExternalEventFactory(
+    private val clock: Clock
+) : ExternalEventFactory<FindUnconsumedStatesByTypeParameters, UtxoTransactionOutputs, List<UtxoTransactionOutputDto>>
+{
+    @Activate
+    constructor() : this(Clock.systemUTC())
+
+    override val responseType = UtxoTransactionOutputs::class.java
+
+    override fun createExternalEvent(
+        checkpoint: FlowCheckpoint,
+        flowExternalEventContext: ExternalEventContext,
+        parameters: FindUnconsumedStatesByTypeParameters
+    ): ExternalEventRecord {
+        return ExternalEventRecord(
+            topic = Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC,
+            payload = LedgerPersistenceRequest.newBuilder()
+                .setTimestamp(clock.instant())
+                .setHoldingIdentity(checkpoint.holdingIdentity.toAvro())
+                .setRequest(createRequest(parameters))
+                .setFlowExternalEventContext(flowExternalEventContext)
+                .setLedgerType(LedgerTypes.UTXO)
+                .build()
+        )
+    }
+
+    private fun createRequest(parameters: FindUnconsumedStatesByTypeParameters): Any {
+        return FindUnconsumedStatesByExactType(parameters.stateClass.canonicalName)
+    }
+
+    override fun resumeWith(checkpoint: FlowCheckpoint, response: UtxoTransactionOutputs): List<UtxoTransactionOutputDto> {
+        return response.transactionOutputs.map {
+            UtxoTransactionOutputDto(it.transactionId, it.index, it.info.array(), it.data.array())
+        }
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindUnconsumedStatesByExactTypeExternalEventFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindUnconsumedStatesByExactTypeExternalEventFactoryTest.kt
@@ -1,0 +1,62 @@
+package net.corda.ledger.utxo.flow.impl.persistence.external.events
+
+import net.corda.data.KeyValuePairList
+import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.data.ledger.persistence.FindUnconsumedStatesByExactType
+import net.corda.data.ledger.persistence.LedgerPersistenceRequest
+import net.corda.data.ledger.persistence.LedgerTypes
+import net.corda.flow.state.FlowCheckpoint
+import net.corda.schema.Schemas
+import net.corda.v5.ledger.utxo.ContractState
+import net.corda.virtualnode.toCorda
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.security.PublicKey
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+class FindUnconsumedStatesByExactTypeExternalEventFactoryTest {
+
+    class TestContractState : ContractState {
+        override fun getParticipants(): List<PublicKey> {
+            return emptyList()
+        }
+    }
+
+    @Test
+    fun `creates a record containing an UtxoLedgerRequest with a FindUnconsumedStatesByExactType payload`() {
+        val checkpoint = mock<FlowCheckpoint>()
+        val stateClass = TestContractState()::class.java
+        val externalEventContext = ExternalEventContext(
+            "request id",
+            "flow id",
+            KeyValuePairList(emptyList())
+        )
+        val testClock = Clock.fixed(Instant.now(), ZoneId.of("UTC"))
+
+        whenever(checkpoint.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
+
+        val externalEventRecord = FindUnconsumedStatesByExactTypeExternalEventFactory(testClock).createExternalEvent(
+            checkpoint,
+            externalEventContext,
+            FindUnconsumedStatesByTypeParameters(stateClass)
+        )
+
+        assertEquals(Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC, externalEventRecord.topic)
+        assertNull(externalEventRecord.key)
+        assertEquals(
+            LedgerPersistenceRequest(
+                testClock.instant(),
+                ALICE_X500_HOLDING_IDENTITY,
+                LedgerTypes.UTXO,
+                FindUnconsumedStatesByExactType(stateClass.canonicalName),
+                externalEventContext
+            ),
+            externalEventRecord.payload
+        )
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.23-alpha-1695641486569
+cordaApiVersion=5.1.0.23-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.22-alpha-1695628679695
+cordaApiVersion=5.1.0.23-alpha-1695641486569
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.22-beta+
+cordaApiVersion=5.1.0.22-alpha-1695628679695
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimUtxoLedgerService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimUtxoLedgerService.kt
@@ -29,6 +29,7 @@ import net.corda.v5.membership.NotaryInfo
 /**
  * Simulator implementation of [UtxoLedgerService]
  */
+@Suppress("TooManyFunctions")
 class SimUtxoLedgerService(
     member: MemberX500Name,
     private val fiber: SimFiber,
@@ -127,6 +128,10 @@ class SimUtxoLedgerService(
             SimStateAndRef(transactionState, stateRef)
         }
         return stateAndRefs
+    }
+
+    override fun <T : ContractState> findUnconsumedStatesByExactType(type: Class<T>): List<StateAndRef<T>> {
+        TODO("Not implemented yet")
     }
 
     /**

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimUtxoLedgerService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimUtxoLedgerService.kt
@@ -103,9 +103,6 @@ class SimUtxoLedgerService(
      * [UtxoTransactionOutputEntity] based on [ContractState] type. Converts the entities fetched into [StateAndRef]
      * by deserializing the contractStateData and encumbranceData
      *
-     * Unlike real implementation, this function filters by type using db query instead of in-memory, which means
-     * it finds the exact types rather than finding them including their subclasses
-     *
      * @param type The [ContractState] type to filter unconsumed states
      */
     @Suppress("UNCHECKED_CAST")
@@ -133,14 +130,8 @@ class SimUtxoLedgerService(
         return stateAndRefs
     }
 
-    /**
-     * This does exactly the same thing as [findUnconsumedStatesByType] unlike real implementation where it finds
-     * the states by type and its subclasses, both functions will find them excluding subclasses.
-     *
-     * @param type The [ContractState] type to filter unconsumed states
-     */
     override fun <T : ContractState> findUnconsumedStatesByExactType(type: Class<T>): List<StateAndRef<T>> {
-       return findUnconsumedStatesByType(type)
+        TODO("Not implemented yet")
     }
 
     /**

--- a/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimUtxoLedgerService.kt
+++ b/simulator/runtime/src/main/kotlin/net/corda/simulator/runtime/ledger/utxo/SimUtxoLedgerService.kt
@@ -103,6 +103,9 @@ class SimUtxoLedgerService(
      * [UtxoTransactionOutputEntity] based on [ContractState] type. Converts the entities fetched into [StateAndRef]
      * by deserializing the contractStateData and encumbranceData
      *
+     * Unlike real implementation, this function filters by type using db query instead of in-memory, which means
+     * it finds the exact types rather than finding them including their subclasses
+     *
      * @param type The [ContractState] type to filter unconsumed states
      */
     @Suppress("UNCHECKED_CAST")
@@ -130,8 +133,14 @@ class SimUtxoLedgerService(
         return stateAndRefs
     }
 
+    /**
+     * This does exactly the same thing as [findUnconsumedStatesByType] unlike real implementation where it finds
+     * the states by type and its subclasses, both functions will find them excluding subclasses.
+     *
+     * @param type The [ContractState] type to filter unconsumed states
+     */
     override fun <T : ContractState> findUnconsumedStatesByExactType(type: Class<T>): List<StateAndRef<T>> {
-        TODO("Not implemented yet")
+       return findUnconsumedStatesByType(type)
     }
 
     /**


### PR DESCRIPTION
This PR includes updates such as:
- introduce `findUnconsumedVisibleStatesByExactType` that finds unconsumed states by their exact type unlike `findUnconsumedVisibleStatesByExactType` that finds its subclass typed states.
- filter data by type in db query rather than in-memory filter

**Test Plan**
- Replaced flow`UtxoQueryWithEncumberedStatesFlow` used in `Utxo Ledger - findUnconsumedStatesByType` to use `findUnconsumedStatesByExactType` instead of `findUnconsumedStatesByType`. The test Passes.
- Added `FindUnconsumedStatesByExactTypeExternalEventFactoryTest`