### PR TITLE
CORE-17123: Fix dependency substitution for jars wrapped as OSGi bundles.

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda.common-library.gradle
@@ -22,9 +22,21 @@ configurations {
     configureEach {
         resolutionStrategy {
             dependencySubstitution {
-                substitute module('antlr:antlr') using project(':libs:antlr')
-                substitute module('de.javakaffee:kryo-serializers') using project(':libs:serialization:kryo-serializers')
-                substitute module('software.amazon.awssdk:cloudwatch') using project(':libs:awssdk')
+                substitute module('antlr:antlr') using variant(project(':libs:antlr')) {
+                    attributes {
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                    }
+                }
+                substitute module('de.javakaffee:kryo-serializers') using variant(project(':libs:serialization:kryo-serializers')) {
+                    attributes {
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                    }
+                }
+                substitute module('software.amazon.awssdk:cloudwatch') using variant(project(':libs:awssdk')) {
+                    attributes {
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                    }
+                }
             }
         }
     }

--- a/libs/antlr/build.gradle
+++ b/libs/antlr/build.gradle
@@ -1,4 +1,4 @@
-import aQute.bnd.version.MavenVersion
+import static aQute.bnd.version.MavenVersion.parseMavenString
 
 plugins {
     id 'java-library'
@@ -17,7 +17,7 @@ tasks.named('jar', Jar) {
     archiveBaseName = 'corda-antlr'
 
     ext {
-        bundleVersion = MavenVersion.parseMavenString(antlrVersion).OSGiVersion
+        bundleVersion = parseMavenString(antlrVersion).OSGiVersion
     }
 
     bundle {
@@ -78,5 +78,5 @@ publishing {
 }
 
 artifactoryPublish {
-    publications('antlr')
+    publications 'antlr'
 }

--- a/libs/awssdk/build.gradle
+++ b/libs/awssdk/build.gradle
@@ -1,3 +1,5 @@
+import static aQute.bnd.version.MavenVersion.parseMavenString
+
 plugins {
     id 'biz.aQute.bnd.builder'
     id 'com.jfrog.artifactory'
@@ -28,11 +30,15 @@ dependencies {
 tasks.named('jar', Jar) {
     archiveBaseName = 'corda-awssdk'
 
+    ext {
+        bundleVersion = parseMavenString(awssdkVersion).OSGiVersion
+    }
+
     bundle {
         bnd """\
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.awssdk
-Bundle-Version: ${awssdkVersion}
+Bundle-Version: \${task.bundleVersion}
 Export-Package: \
     !software.amazon.awssdk.http.apache.*,\
     !software.amazon.awssdk.http.nio.netty.*,\
@@ -86,5 +92,5 @@ publishing {
 }
 
 artifactoryPublish {
-    publications('awsSDK')
+    publications 'awsSDK'
 }

--- a/libs/serialization/kryo-serializers/build.gradle
+++ b/libs/serialization/kryo-serializers/build.gradle
@@ -39,12 +39,16 @@ dependencies {
 def jar = tasks.named('jar', Jar) {
     archiveBaseName = 'kryo-serializers'
 
+    ext {
+        bundleVersion = parseMavenString(kryoSerializersVersion).OSGiVersion
+    }
+
     bundle {
         bnd """\
 Automatic-Module-Name: de.javakaffee.kryoserializers
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.kryo-serializers
-Bundle-Version: ${kryoSerializersVersion}
+Bundle-Version: \${task.bundleVersion}
 Export-Package: \
     de.javakaffee.kryoserializers.*
 Import-Package: \
@@ -107,5 +111,5 @@ publishing {
 }
 
 artifactoryPublish {
-    publications('kryoSerializers')
+    publications 'kryoSerializers'
 }


### PR DESCRIPTION
Ensure that Gradle's dependency substitution selects the `JAR` artifact for each of the modules that wraps a third-party jar as an OSGi bundle.

Also clean up their respective `build.gradle` scripts to make them all consistent.