### PR TITLE
CORE-16177: Align Kotlin coroutines with other wrapped bundles.

### DIFF
--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -54,7 +54,7 @@ kotlin {
 dependencies {
     // NO CORDA DEPENDENCIES!!
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    implementation project(path: ':libs:kotlin-coroutines', configuration: 'bundle')
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$kotlinCoroutinesVersion"
 
     // Avoid having the schema names and keys scattered across projects
     smokeTestImplementation "net.corda:corda-config-schema:$cordaApiVersion"

--- a/buildSrc/src/main/groovy/corda.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda.common-library.gradle
@@ -22,9 +22,26 @@ configurations {
     configureEach {
         resolutionStrategy {
             dependencySubstitution {
-                substitute module('antlr:antlr') using project(':libs:antlr')
-                substitute module('de.javakaffee:kryo-serializers') using project(':libs:serialization:kryo-serializers')
-                substitute module('software.amazon.awssdk:cloudwatch') using project(':libs:awssdk')
+                substitute module('antlr:antlr') using variant(project(':libs:antlr')) {
+                    attributes {
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                    }
+                }
+                substitute module('de.javakaffee:kryo-serializers') using variant(project(':libs:serialization:kryo-serializers')) {
+                    attributes {
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                    }
+                }
+                substitute module('org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm') using variant(project(':libs:kotlin-coroutines')) {
+                    attributes {
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                    }
+                }
+                substitute module('software.amazon.awssdk:cloudwatch') using variant(project(':libs:awssdk')) {
+                    attributes {
+                        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements, LibraryElements.JAR))
+                    }
+                }
             }
         }
     }

--- a/libs/kotlin-coroutines/build.gradle
+++ b/libs/kotlin-coroutines/build.gradle
@@ -1,3 +1,5 @@
+import static aQute.bnd.version.MavenVersion.parseMavenString
+
 plugins {
     id 'biz.aQute.bnd.builder'
     id 'com.jfrog.artifactory'
@@ -21,11 +23,15 @@ dependencies {
 def jar = tasks.named('jar', Jar) {
     archiveBaseName = 'corda-kotlin-coroutines'
 
+    ext {
+        bundleVersion = parseMavenString(kotlinCoroutinesVersion).OSGiVersion
+    }
+
     bundle {
         bnd """\
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.kotlin-coroutines
-Bundle-Version: ${kotlinCoroutinesVersion}
+Bundle-Version: \${task.bundleVersion}
 Import-Package: \
     android.os;resolution:=optional,\
     sun.misc;resolution:=optional,\


### PR DESCRIPTION
Ensure that Corda always uses our "wrapped" Kotlin Coroutines OSGi bundle. The smoke tests can continue to use the original unwrapped jar because these run outside an OSGi framework.