### PR TITLE
CORE-17171: Resolve some Gradle warnings about deprecated functionality.

### DIFF
--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -53,9 +53,10 @@ dependencies {
 def testingBundle = tasks.register('testingBundle', Bundle) {
     archiveClassifier = 'tests'
     from sourceSets.integrationTest.output
-    sourceSet = sourceSets.integrationTest
 
     bundle {
+        sourceSet = sourceSets.integrationTest
+        classpath = sourceSets.integrationTest.compileClasspath
         bnd """\
 Bundle-SymbolicName: \${task.archiveBaseName}-\${task.archiveClassifier}
 Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}

--- a/components/chunking/chunk-db-write-impl/build.gradle
+++ b/components/chunking/chunk-db-write-impl/build.gradle
@@ -88,7 +88,9 @@ tasks.named('test', Test) {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 DynamicImport-Package: org.hibernate.proxy
 '''
+    }
 }

--- a/components/crypto/crypto-persistence-model/build.gradle
+++ b/components/crypto/crypto-persistence-model/build.gradle
@@ -24,7 +24,9 @@ dependencies {
 // This is required for Hibernate Proxy generation. Without it OSGi will report:
 // java.lang.ClassNotFoundException: org.hibernate.proxy.HibernateProxy
 tasks.named('jar', Jar) {
-    bnd '''\
-    DynamicImport-Package: org.hibernate.proxy
-    '''
+    bundle {
+        bnd '''\
+DynamicImport-Package: org.hibernate.proxy
+'''
+    }
 }

--- a/components/uniqueness/backing-store-impl/build.gradle
+++ b/components/uniqueness/backing-store-impl/build.gradle
@@ -85,9 +85,11 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
-    DynamicImport-Package: org.hibernate.proxy
-    '''
+    bundle {
+        bnd '''\
+DynamicImport-Package: org.hibernate.proxy
+'''
+    }
 }
 
 tasks.register('backingStoreBenchmark', Test) {
@@ -105,9 +107,7 @@ tasks.register('backingStoreBenchmark', Test) {
     systemProperty "postgresPassword", project.getProperty("postgresPassword")
     systemProperty "postgresPort", project.getProperty("postgresPort")
     systemProperty "postgresUser", project.getProperty("postgresUser")
-}
 
-backingStoreBenchmark {
     // Ensures benchmark is always re-run if executed from the console
     outputs.upToDateWhen { false }
 }

--- a/libs/application/application-db-setup/build.gradle
+++ b/libs/application/application-db-setup/build.gradle
@@ -44,9 +44,11 @@ dependencies {
 // without `resolution=optional` which then fails to resolve at runtime.
 // https://bnd.bndtools.org/instructions/noclassforname.html
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 -noclassforname: true
 Import-Package: org.postgresql;resolution:=optional,\
     *
 '''
+    }
 }

--- a/libs/chunking/chunking-datamodel/build.gradle
+++ b/libs/chunking/chunking-datamodel/build.gradle
@@ -29,7 +29,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 DynamicImport-Package: org.hibernate.proxy
 '''
+    }
 }

--- a/libs/configuration/configuration-datamodel/build.gradle
+++ b/libs/configuration/configuration-datamodel/build.gradle
@@ -28,7 +28,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 DynamicImport-Package: org.hibernate.proxy
 '''
+    }
 }

--- a/libs/crypto/crypto-impl/build.gradle
+++ b/libs/crypto/crypto-impl/build.gradle
@@ -37,7 +37,8 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd """\
+    bundle {
+        bnd """\
 Import-Package:\
     org.bouncycastle.jcajce.provider.config,\
     org.bouncycastle.jcajce.provider.digest,\
@@ -52,4 +53,5 @@ Import-Package:\
     org.bouncycastle.jcajce.provider.util,\
     *
 """
+    }
 }

--- a/libs/db/db-core/build.gradle
+++ b/libs/db/db-core/build.gradle
@@ -30,9 +30,11 @@ dependencies {
 
 //  `DataSourceFactory` providers are in the jdbc drivers that we *dynamically* load at runtime
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 -noclassforname: true
 Import-Package: org.osgi.service.jdbc;resolution:=optional,\
     *
 '''
+    }
 }

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -75,8 +75,9 @@ Sealed: true
 def testingBundle = tasks.register('testingBundle', Bundle) {
     archiveClassifier = 'tests'
     from sourceSets.integrationTest.output
-    sourceSet = sourceSets.integrationTest
     bundle {
+        sourceSet = sourceSets.integrationTest
+        classpath = sourceSets.integrationTest.compileClasspath
         bnd '''\
 Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}
 Sealed: true

--- a/libs/membership/certificates-datamodel/build.gradle
+++ b/libs/membership/certificates-datamodel/build.gradle
@@ -17,7 +17,9 @@ dependencies {
 // This is required for Hibernate Proxy generation. Without it OSGi will report:
 // java.lang.ClassNotFoundException: org.hibernate.proxy.HibernateProxy
 tasks.named('jar', Jar) {
-    bnd '''\
-    DynamicImport-Package: org.hibernate.proxy
-    '''
+    bundle {
+        bnd '''\
+DynamicImport-Package: org.hibernate.proxy
+'''
+    }
 }

--- a/libs/membership/membership-datamodel/build.gradle
+++ b/libs/membership/membership-datamodel/build.gradle
@@ -28,7 +28,9 @@ dependencies {
 // This is required for Hibernate Proxy generation. Without it OSGi will report:
 // java.lang.ClassNotFoundException: org.hibernate.proxy.HibernateProxy
 tasks.named('jar', Jar) {
-    bnd '''\
-    DynamicImport-Package: org.hibernate.proxy
-    '''
+    bundle {
+        bnd '''\
+DynamicImport-Package: org.hibernate.proxy
+'''
+    }
 }

--- a/libs/messaging/db-message-bus-datamodel/build.gradle
+++ b/libs/messaging/db-message-bus-datamodel/build.gradle
@@ -15,7 +15,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 DynamicImport-Package: org.hibernate.proxy
 '''
+    }
 }

--- a/libs/permissions/permission-datamodel/build.gradle
+++ b/libs/permissions/permission-datamodel/build.gradle
@@ -44,7 +44,9 @@ dependencies {
 // This is required for Hibernate Proxy generation. Without it OSGi will report:
 // java.lang.ClassNotFoundException: org.hibernate.proxy.HibernateProxy
 tasks.named('jar', Jar) {
-    bnd '''\
-    DynamicImport-Package: org.hibernate.proxy
-    '''
+    bundle {
+        bnd '''\
+DynamicImport-Package: org.hibernate.proxy
+'''
+    }
 }

--- a/libs/scheduler/scheduler-datamodel/build.gradle
+++ b/libs/scheduler/scheduler-datamodel/build.gradle
@@ -29,7 +29,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 DynamicImport-Package: org.hibernate.proxy
 '''
+    }
 }

--- a/libs/state-manager/state-manager-db-impl/build.gradle
+++ b/libs/state-manager/state-manager-db-impl/build.gradle
@@ -38,7 +38,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 DynamicImport-Package: org.hibernate.proxy
 '''
+    }
 }

--- a/libs/virtual-node/cpi-datamodel/build.gradle
+++ b/libs/virtual-node/cpi-datamodel/build.gradle
@@ -30,7 +30,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 DynamicImport-Package: org.hibernate.proxy
 '''
+    }
 }

--- a/libs/virtual-node/virtual-node-datamodel/build.gradle
+++ b/libs/virtual-node/virtual-node-datamodel/build.gradle
@@ -31,7 +31,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 DynamicImport-Package: org.hibernate.proxy
 '''
+    }
 }

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -84,12 +84,15 @@ dependencies {
 def testingBundle = tasks.register('testingBundle', Bundle) {
     archiveClassifier = 'tests'
     from sourceSets.integrationTest.output
-    sourceSet = sourceSets.integrationTest
 
-    bnd """\
+    bundle {
+        sourceSet = sourceSets.integrationTest
+        classpath = sourceSets.integrationTest.compileClasspath
+        bnd """\
 Bundle-SymbolicName: \${task.archiveBaseName}-\${task.archiveClassifier}
     Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons.annotation.Testable;CONCRETE}
 """
+    }
 }
 
 def dbResolve = tasks.register('dbResolve', Resolve) {


### PR DESCRIPTION
Refactor `Jar` and `Bundle` tasks to resolve Gradle deprecation warnings:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
```
The `sourceSet` and `classpath` configuration should now be done via the `bundle` extension.
