### PR TITLE
CORE-17166 Add cpiSummary.filecheckSum to DigitalSignatureMetadata in TransactionSignatureService

### DIFF
--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/Extensions.FlowEngine.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/Extensions.FlowEngine.kt
@@ -1,0 +1,21 @@
+package net.corda.ledger.common.flow.impl.transaction
+
+import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
+import net.corda.v5.application.flows.FlowContextPropertyKeys
+import net.corda.v5.application.flows.FlowEngine
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.ledger.common.transaction.CordaPackageSummary
+
+fun FlowEngine.getCpiSummary(): CordaPackageSummary =
+    with(this) {
+        CordaPackageSummaryImpl(
+            name = flowContextProperties[FlowContextPropertyKeys.CPI_NAME]
+                ?: throw CordaRuntimeException("CPI name is not accessible"),
+            version = flowContextProperties[FlowContextPropertyKeys.CPI_VERSION]
+                ?: throw CordaRuntimeException("CPI version is not accessible"),
+            signerSummaryHash = flowContextProperties[FlowContextPropertyKeys.CPI_SIGNER_SUMMARY_HASH]
+                ?: throw CordaRuntimeException("CPI signer summary hash is not accessible"),
+            fileChecksum = flowContextProperties[FlowContextPropertyKeys.CPI_FILE_CHECKSUM]
+                ?: throw CordaRuntimeException("CPI file checksum is not accessible"),
+        )
+    }

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/Extensions.FlowEngine.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/Extensions.FlowEngine.kt
@@ -7,15 +7,13 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 
 fun FlowEngine.getCpiSummary(): CordaPackageSummary =
-    with(this) {
-        CordaPackageSummaryImpl(
-            name = flowContextProperties[FlowContextPropertyKeys.CPI_NAME]
-                ?: throw CordaRuntimeException("CPI name is not accessible"),
-            version = flowContextProperties[FlowContextPropertyKeys.CPI_VERSION]
-                ?: throw CordaRuntimeException("CPI version is not accessible"),
-            signerSummaryHash = flowContextProperties[FlowContextPropertyKeys.CPI_SIGNER_SUMMARY_HASH]
-                ?: throw CordaRuntimeException("CPI signer summary hash is not accessible"),
-            fileChecksum = flowContextProperties[FlowContextPropertyKeys.CPI_FILE_CHECKSUM]
-                ?: throw CordaRuntimeException("CPI file checksum is not accessible"),
-        )
-    }
+    CordaPackageSummaryImpl(
+        name = flowContextProperties[FlowContextPropertyKeys.CPI_NAME]
+            ?: throw CordaRuntimeException("CPI name is not accessible"),
+        version = flowContextProperties[FlowContextPropertyKeys.CPI_VERSION]
+            ?: throw CordaRuntimeException("CPI version is not accessible"),
+        signerSummaryHash = flowContextProperties[FlowContextPropertyKeys.CPI_SIGNER_SUMMARY_HASH]
+            ?: throw CordaRuntimeException("CPI signer summary hash is not accessible"),
+        fileChecksum = flowContextProperties[FlowContextPropertyKeys.CPI_FILE_CHECKSUM]
+            ?: throw CordaRuntimeException("CPI file checksum is not accessible"),
+    )

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -2,7 +2,6 @@ package net.corda.ledger.common.flow.impl.transaction
 
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.crypto.core.bytes
-import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 import net.corda.ledger.common.data.transaction.SignableData
 import net.corda.ledger.common.data.transaction.getBatchMerkleTreeDigestProvider
 import net.corda.ledger.common.flow.transaction.TransactionSignatureServiceInternal
@@ -13,13 +12,10 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.crypto.SignatureSpecService
 import net.corda.v5.application.crypto.SigningService
-import net.corda.v5.application.flows.FlowContextPropertyKeys
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SignatureSpec
-import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.v5.ledger.common.transaction.TransactionWithMetadata
@@ -125,7 +121,7 @@ class TransactionSignatureServiceImpl @Activate constructor(
         signatureSpec: SignatureSpec,
         batchSettings: Map<String, String> = emptyMap()
     ): DigitalSignatureMetadata {
-        val cpiSummary = getCpiSummary()
+        val cpiSummary = flowEngine.getCpiSummary()
         return DigitalSignatureMetadata(
             Instant.now(),
             signatureSpec,
@@ -133,22 +129,10 @@ class TransactionSignatureServiceImpl @Activate constructor(
                 "platformVersion" to platformInfoProvider.activePlatformVersion.toString(),
                 "cpiName" to cpiSummary.name,
                 "cpiVersion" to cpiSummary.version,
-                "cpiSignerSummaryHash" to cpiSummary.signerSummaryHash.toString()
+                "cpiSignerSummaryHash" to cpiSummary.signerSummaryHash.toString(),
+                "cpiFileChecksum" to cpiSummary.fileChecksum.toString()
             ) + batchSettings
         )
     }
 
-    private fun getCpiSummary(): CordaPackageSummary =
-        with(flowEngine) {
-            CordaPackageSummaryImpl(
-                name = flowContextProperties[FlowContextPropertyKeys.CPI_NAME]
-                    ?: throw CordaRuntimeException("CPI name is not accessible"),
-                version = flowContextProperties[FlowContextPropertyKeys.CPI_VERSION]
-                    ?: throw CordaRuntimeException("CPI version is not accessible"),
-                signerSummaryHash = flowContextProperties[FlowContextPropertyKeys.CPI_SIGNER_SUMMARY_HASH]
-                    ?: throw CordaRuntimeException("CPI signer summary hash is not accessible"),
-                fileChecksum = flowContextProperties[FlowContextPropertyKeys.CPI_FILE_CHECKSUM]
-                    ?: throw CordaRuntimeException("CPI file checksum is not accessible"),
-            )
-        }
 }

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/TransactionSignatureServiceImpl.kt
@@ -134,5 +134,4 @@ class TransactionSignatureServiceImpl @Activate constructor(
             ) + batchSettings
         )
     }
-
 }

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/factory/TransactionMetadataFactoryImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/factory/TransactionMetadataFactoryImpl.kt
@@ -3,14 +3,12 @@ package net.corda.ledger.common.flow.impl.transaction.factory
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
+import net.corda.ledger.common.flow.impl.transaction.getCpiSummary
 import net.corda.ledger.common.flow.transaction.factory.TransactionMetadataFactory
 import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
-import net.corda.v5.application.flows.FlowContextPropertyKeys
 import net.corda.v5.application.flows.FlowEngine
-import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
@@ -34,7 +32,7 @@ class TransactionMetadataFactoryImpl @Activate constructor(
         val metadata = mapOf(
             TransactionMetadataImpl.DIGEST_SETTINGS_KEY to WireTransactionDigestSettings.defaultValues,
             TransactionMetadataImpl.PLATFORM_VERSION_KEY to platformInfoProvider.activePlatformVersion,
-            TransactionMetadataImpl.CPI_METADATA_KEY to getCpiSummary(),
+            TransactionMetadataImpl.CPI_METADATA_KEY to flowEngine.getCpiSummary(),
             TransactionMetadataImpl.CPK_METADATA_KEY to getCpkSummaries(),
             TransactionMetadataImpl.SCHEMA_VERSION_KEY to TransactionMetadataImpl.SCHEMA_VERSION
         )
@@ -53,20 +51,6 @@ class TransactionMetadataFactoryImpl @Activate constructor(
                 version = cpk.cpkId.version,
                 signerSummaryHash = cpk.cpkId.signerSummaryHash.toString(),
                 fileChecksum = cpk.fileChecksum.toString()
-            )
-        }
-
-    private fun getCpiSummary(): CordaPackageSummary =
-        with(flowEngine) {
-            CordaPackageSummaryImpl(
-                name = flowContextProperties[FlowContextPropertyKeys.CPI_NAME]
-                    ?: throw CordaRuntimeException("CPI name is not accessible"),
-                version = flowContextProperties[FlowContextPropertyKeys.CPI_VERSION]
-                    ?: throw CordaRuntimeException("CPI version is not accessible"),
-                signerSummaryHash = flowContextProperties[FlowContextPropertyKeys.CPI_SIGNER_SUMMARY_HASH]
-                    ?: throw CordaRuntimeException("CPI signer summary hash is not accessible"),
-                fileChecksum = flowContextProperties[FlowContextPropertyKeys.CPI_FILE_CHECKSUM]
-                    ?: throw CordaRuntimeException("CPI file checksum is not accessible"),
             )
         }
 }


### PR DESCRIPTION
CORE-17166 Adding cpiSummary.filecheckSum to DigitalSignatureMetadata in TransactionSignatureService, because that is also required to identify the running CPI.