### PR TITLE
CORE-12472 p2p serializer ledger tweaks

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -128,6 +128,7 @@ class ConsensualLedgerMessageProcessorTests {
         val ctx = virtualNode.entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
 
         val transaction = createTestTransaction(ctx)
+        // transaction.wireTransaction.componentGroupLists.mapIndexed { i, it -> it.mapIndexed { j, d -> println("   QQ Q   $i $j: ${d.decodeToString()}") } }
 
         // Serialise tx into bytebuffer and add to PersistTransaction payload
         val serializedTransaction = ctx.serialize(transaction)

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -128,7 +128,6 @@ class ConsensualLedgerMessageProcessorTests {
         val ctx = virtualNode.entitySandboxService.get(virtualNodeInfo.holdingIdentity, cpkFileHashes)
 
         val transaction = createTestTransaction(ctx)
-        // transaction.wireTransaction.componentGroupLists.mapIndexed { i, it -> it.mapIndexed { j, d -> println("   QQ Q   $i $j: ${d.decodeToString()}") } }
 
         // Serialise tx into bytebuffer and add to PersistTransaction payload
         val serializedTransaction = ctx.serialize(transaction)
@@ -181,7 +180,6 @@ class ConsensualLedgerMessageProcessorTests {
         assertThat(entityResponse.results).hasSize(1)
         val retrievedTransaction = ctx.deserialize<SignedTransactionContainer>(entityResponse.results.first())
         assertThat(retrievedTransaction).isEqualTo(transaction)
-        // todo re-check with CORE-12472
         assertThat(entityResponse.results.first()).isEqualTo(serializedTransaction)
     }
 

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
@@ -1,6 +1,6 @@
 package net.corda.sandbox.serialization.amqp
 
-import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
+import net.corda.internal.serialization.AMQP_P2P_CONTEXT
 import net.corda.internal.serialization.SerializationServiceImpl
 import net.corda.internal.serialization.amqp.SerializerFactory
 import net.corda.internal.serialization.amqp.SerializerFactoryBuilder
@@ -73,7 +73,7 @@ class AMQPSerializationProvider @Activate constructor(
             serializationService = SerializationServiceImpl(
                 outputFactory = factory,
                 inputFactory = factory,
-                AMQP_STORAGE_CONTEXT.withSandboxGroup(context.sandboxGroup) //todo double check in CORE-12472
+                AMQP_P2P_CONTEXT.withSandboxGroup(context.sandboxGroup) //todo double check in CORE-12472
             ),
             context
         )

--- a/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
+++ b/components/virtual-node/sandbox-amqp/src/main/kotlin/net/corda/sandbox/serialization/amqp/AMQPSerializationProvider.kt
@@ -73,7 +73,7 @@ class AMQPSerializationProvider @Activate constructor(
             serializationService = SerializationServiceImpl(
                 outputFactory = factory,
                 inputFactory = factory,
-                AMQP_P2P_CONTEXT.withSandboxGroup(context.sandboxGroup) //todo double check in CORE-12472
+                AMQP_P2P_CONTEXT.withSandboxGroup(context.sandboxGroup)
             ),
             context
         )

--- a/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
+++ b/libs/serialization/serialization-amqp/src/integrationTest/kotlin/net/corda/serialization/amqp/test/AMQPwithOSGiSerializationTests.kt
@@ -1,7 +1,7 @@
 package net.corda.serialization.amqp.test
 
 import net.corda.base.internal.OpaqueBytes
-import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
+import net.corda.internal.serialization.AMQP_P2P_CONTEXT
 import net.corda.internal.serialization.CordaSerializationEncoding.SNAPPY
 import net.corda.internal.serialization.amqp.DeserializationInput
 import net.corda.internal.serialization.amqp.IllegalCustomSerializerException
@@ -56,7 +56,7 @@ class AMQPwithOSGiSerializationTests {
         private const val TIMEOUT_MILLIS = 10000L
     }
 
-    private val testSerializationContext = AMQP_STORAGE_CONTEXT.withEncoding(SNAPPY)
+    private val testSerializationContext = AMQP_P2P_CONTEXT.withEncoding(SNAPPY)
 
     @RegisterExtension
     private val lifecycle = EachTestLifecycle()

--- a/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
+++ b/libs/serialization/serialization-amqp/src/test/kotlin/net/corda/internal/serialization/amqp/SerializationOutputTests.kt
@@ -785,8 +785,7 @@ class SerializationOutputTests {
         assertSame(parentContainer.left, parentContainer.right)
 
         val parentCopy = serdes(parentContainer)
-        // todo revert to assertSame in CORE-12472
-        assertNotSame(parentCopy.left, parentCopy.right)
+        assertSame(parentCopy.left, parentCopy.right)
     }
 
     @CordaSerializable
@@ -816,8 +815,7 @@ class SerializationOutputTests {
         val factory = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val factory2 = SerializerFactoryBuilder.build(testSerializationContext.currentSandboxGroup())
         val objCopy = serdes(obj, factory, factory2)
-        // todo revert to assertSame in CORE-12472
-        assertNotSame(objCopy.a, objCopy.b)
+        assertSame(objCopy.a, objCopy.b)
     }
 
     class Spike private constructor(val a: String) {

--- a/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
+++ b/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
@@ -3,7 +3,7 @@ package net.corda.ledger.common.integration.test
 import net.corda.common.json.validation.JsonValidator
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.flow.pipeline.sandbox.impl.FlowSandboxGroupContextImpl
-import net.corda.internal.serialization.AMQP_STORAGE_CONTEXT
+import net.corda.internal.serialization.AMQP_P2P_CONTEXT
 import net.corda.internal.serialization.SerializationServiceImpl
 import net.corda.internal.serialization.amqp.helper.createSerializerFactory
 import net.corda.ledger.common.data.transaction.WireTransaction
@@ -102,7 +102,7 @@ abstract class CommonLedgerIntegrationTest {
             // anything unintentionally
             outputFactory = sandboxGroupContext.createSerializerFactory(),
             inputFactory = sandboxGroupContext.createSerializerFactory(),
-            context = AMQP_STORAGE_CONTEXT.withSandboxGroup(sandboxGroupContext.sandboxGroup)
+            context = AMQP_P2P_CONTEXT.withSandboxGroup(sandboxGroupContext.sandboxGroup)
         )
 
         wireTransaction = wireTransactionFactory.createExample(jsonMarshallingService, jsonValidator)

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/WireTransactionExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/WireTransactionExample.kt
@@ -34,7 +34,7 @@ fun WireTransactionFactory.createExample(
         componentGroups +
         List(
             (metadata as TransactionMetadataInternal).getNumberOfComponentGroups() - 1 - componentGroups.size,
-        ) { emptyList() }
+        ) { arrayListOf() }
     return create(allGroupLists)
 }
 

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationContext.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationContext.kt
@@ -37,7 +37,7 @@ private class MockSandboxGroup(
 val testSerializationContext = SerializationContextImpl(
     preferredSerializationVersion = amqpMagic,
     properties = mutableMapOf(),
-    objectReferencesEnabled = false,
+    objectReferencesEnabled = false, // CORE-12472
     useCase = SerializationContext.UseCase.Testing,
     encoding = null,
     sandboxGroup = MockSandboxGroup(UUID.randomUUID())

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationContext.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestSerializationContext.kt
@@ -37,7 +37,7 @@ private class MockSandboxGroup(
 val testSerializationContext = SerializationContextImpl(
     preferredSerializationVersion = amqpMagic,
     properties = mutableMapOf(),
-    objectReferencesEnabled = false, // CORE-12472
+    objectReferencesEnabled = true,
     useCase = SerializationContext.UseCase.Testing,
     encoding = null,
     sandboxGroup = MockSandboxGroup(UUID.randomUUID())


### PR DESCRIPTION
Problem:
WireTransactionFactoryImpl and WireTransactionExample filled the gaps in sparse WireTransactions with a different approach.
The first used `arrayListOf()` and the second used `emptyList()`, which are equal but may get serialized differently if object referencing is enabled and there are at least two. The first creates new empty arrays for each filling, but the second fills the gaps with the same instance.
This broke `ConsensualLedgerMessageProcessorTests.kt` since it compared the first serialization's output with the serialized object from the DB worker. (The first is essentially the serialization of the WireTransactionExample, and the second is the serialization of WireTransactionFactoryImpl when gaps are present.)

Filling the gaps, using `arrayListOf()` in both cases consistently lets us use object referencing and the P2P serializer everywhere. Based on our current understanding, object referencing keeps the serialization's determinism.
