### PR TITLE
CORE-17202 - change default smoketest target to Combined Worker

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@driessamyn/CORE-17202/swap-default-smoketest-behaviour') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@driessamyn/CORE-17202/swap-default-smoketest-behaviour') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@driessamyn/CORE-17202/swap-default-smoketest-behaviour') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 import groovy.transform.Field
 import com.r3.build.utils.PipelineUtils

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@driessamyn/CORE-17202/swap-default-smoketest-behaviour') _
 
 import groovy.transform.Field
 import com.r3.build.utils.PipelineUtils
@@ -119,7 +119,7 @@ pipeline {
                         junit allowEmptyResults: true, testResults: '**/test-results/**/TEST-*.xml'
                     }
                 }
-        } 	        
+        }
     }
     post {
         always {

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -122,29 +122,35 @@ tasks.register('smokeTest', Test) {
     testClassesDirs = project.sourceSets["smokeTest"].output.classesDirs
     classpath = project.sourceSets["smokeTest"].runtimeClasspath
 
-    // TODO - switch default around so this can be run locally.
-    //  Also refactor property names to remove "health" now that they are more general purpose.
-    def combinedWorker = project.getProperties().getOrDefault("isCombinedWorker", false)
+    def combinedWorker = project.getProperties().getOrDefault("isCombinedWorker", true).toBoolean()
+    println "Running tests against ${ combinedWorker ? "combined worker" : "Kubernetes cluster" }"
 
     // Note these port values have to match what is setup as part of port forwarding at cluster bootstrap time.
     // E.g. during Jenkins pipeline setup.
-    def combinedWorkerAddress = "http://localhost:7004/"
-    systemProperty "cryptoWorkerHealthHttp",
-            project.getProperties().getOrDefault("cryptoWorkerHealthHttp", combinedWorker ? combinedWorkerAddress : "http://localhost:7001/")
-    systemProperty "restWorkerHealthHttp",
-            project.getProperties().getOrDefault("restWorkerHealthHttp", combinedWorker ? combinedWorkerAddress : "http://localhost:7002/")
-    systemProperty "flowWorkerHealthHttp",
-            project.getProperties().getOrDefault("flowWorkerHealthHttp", combinedWorker ? combinedWorkerAddress : "http://localhost:7003/")
-    systemProperty "flowMapperWorkerHealthHttp",
-            project.getProperties().getOrDefault("flowMapperWorkerHealthHttp", combinedWorker ? combinedWorkerAddress : "http://localhost:7004/")
-    systemProperty "verificationWorkerHealthHttp",
-            project.getProperties().getOrDefault("verificationWorkerHealthHttp", combinedWorker ? combinedWorkerAddress : "http://localhost:7005/")
-    systemProperty "dbWorkerHealthHttp",
-            project.getProperties().getOrDefault("dbWorkerHealthHttp", combinedWorker ? combinedWorkerAddress : "http://localhost:7006/")
-    systemProperty "persistenceWorkerHealthHttp",
-            project.getProperties().getOrDefault("persistenceWorkerHealthHttp", combinedWorker ? combinedWorkerAddress : "http://localhost:7007/")
-    systemProperty "uniquenessWorkerHealthHttp",
-            project.getProperties().getOrDefault("uniquenessWorkerHealthHttp", combinedWorker ? combinedWorkerAddress : "http://localhost:7008/")
+    def combinedWorkerUrl = "http://localhost:7004/"
+    def cryptoWorkerUrl = project.getProperties().getOrDefault("cryptoWorkerUrl", combinedWorker ? combinedWorkerUrl : "http://localhost:7001/")
+    systemProperty "cryptoWorkerUrl", cryptoWorkerUrl
+    println "Crypto worker url: $cryptoWorkerUrl"
+    def restWorkerUrl = project.getProperties().getOrDefault("restWorkerUrl", combinedWorker ? combinedWorkerUrl : "http://localhost:7002/")
+    systemProperty "restWorkerUrl", restWorkerUrl
+    println "REST worker url: $restWorkerUrl"
+    def flowWorkerUrl = project.getProperties().getOrDefault("flowWorkerUrl", combinedWorker ? combinedWorkerUrl : "http://localhost:7003/")
+    systemProperty "flowWorkerUrl",flowWorkerUrl
+    println "Flow worker url: $flowWorkerUrl"
+    def flowMapperWorkerUrl = project.getProperties().getOrDefault("flowMapperWorkerUrl", combinedWorker ? combinedWorkerUrl : "http://localhost:7004/")
+    systemProperty "flowMapperWorkerUrl", flowMapperWorkerUrl
+    println "Flow Mapper worker url: $flowMapperWorkerUrl"
+    def verificationWorkerUrl  = project.getProperties().getOrDefault("verificationWorkerUrl", combinedWorker ? combinedWorkerUrl : "http://localhost:7005/")
+    systemProperty "verificationWorkerUrl", verificationWorkerUrl
+    println "Verification worker url: $verificationWorkerUrl"
+    def dbWorkerUrl = project.getProperties().getOrDefault("dbWorkerUrl", combinedWorker ? combinedWorkerUrl : "http://localhost:7006/")
+    systemProperty "dbWorkerUrl", dbWorkerUrl
+    println "DB worker url: $dbWorkerUrl"
+    def persistenceWorkerUrl = project.getProperties().getOrDefault("persistenceWorkerUrl", combinedWorker ? combinedWorkerUrl : "http://localhost:7007/")
+    systemProperty "persistenceWorkerUrl", persistenceWorkerUrl
+    println "Persistence worker url: $persistenceWorkerUrl"
+    def uniquenessWorkerUrl = project.getProperties().getOrDefault("uniquenessWorkerUrl", combinedWorker ? combinedWorkerUrl : "http://localhost:7008/")
+    systemProperty "uniquenessWorkerUrl", uniquenessWorkerUrl
 
     jvmArgs '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED'
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ClusterBootstrapTest.kt
@@ -27,14 +27,14 @@ class ClusterBootstrapTest {
     }
 
     private val healthChecks = mapOf(
-        "crypto-worker" to System.getProperty("cryptoWorkerHealthHttp"),
-        "db-worker" to System.getProperty("dbWorkerHealthHttp"),
-        "flow-worker" to System.getProperty("flowWorkerHealthHttp"),
-        "flow-mapper-worker" to System.getProperty("flowMapperWorkerHealthHttp"),
-        "verification-worker" to System.getProperty("verificationWorkerHealthHttp"),
-        "persistence-worker" to System.getProperty("persistenceWorkerHealthHttp"),
-        "rest-worker" to System.getProperty("restWorkerHealthHttp"),
-        "uniqueness-worker" to System.getProperty("uniquenessWorkerHealthHttp"),
+        "crypto-worker" to System.getProperty("cryptoWorkerUrl"),
+        "db-worker" to System.getProperty("dbWorkerUrl"),
+        "flow-worker" to System.getProperty("flowWorkerUrl"),
+        "flow-mapper-worker" to System.getProperty("flowMapperWorkerUrl"),
+        "verification-worker" to System.getProperty("verificationWorkerUrl"),
+        "persistence-worker" to System.getProperty("persistenceWorkerUrl"),
+        "rest-worker" to System.getProperty("restWorkerUrl"),
+        "uniqueness-worker" to System.getProperty("uniquenessWorkerUrl"),
     )
     private val client = HttpClient.newBuilder().build()
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/UniquenessCheckerRPCSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/UniquenessCheckerRPCSmokeTests.kt
@@ -24,7 +24,6 @@ import net.corda.uniqueness.utils.UniquenessAssertions
 import net.corda.v5.crypto.SecureHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.slf4j.LoggerFactory
@@ -43,7 +42,6 @@ import kotlin.random.Random
 /**
  * Tests for the UniquenessChecker RPC service
  */
-@Tag("Unstable")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UniquenessCheckerRPCSmokeTests {
     private val httpClient: HttpClient = HttpClient.newBuilder()
@@ -121,7 +119,7 @@ class UniquenessCheckerRPCSmokeTests {
 
     @Test
     fun `RPC endpoint accepts a request and returns back a response`() {
-        val url = "${System.getProperty("uniquenessWorkerHealthHttp")}api/$PLATFORM_VERSION/uniqueness-checker"
+        val url = "${System.getProperty("uniquenessWorkerUrl")}api/$PLATFORM_VERSION/uniqueness-checker"
 
         logger.info("uniqueness url: $url")
         val serializedPayload = avroSerializer.serialize(payloadBuilder().build())


### PR DESCRIPTION
Currently the default smoketest target is Kubernetes. 
This PR, along with the pipeline change, flips this default so that it is Combined Worker, which should reduce friction when running the tests in a local environment.