### PR TITLE
CORE-16822 - Token Selection - When a token service event fails it should report an error back to the flow

### DIFF
--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EntityConverterImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EntityConverterImpl.kt
@@ -65,7 +65,8 @@ class EntityConverterImpl : EntityConverter {
             toTokenPoolKey(avroPoolKey),
             // HACK: Added for testing will be removed by CORE-5722 (ledger integration)
             null,
-            null,
+            "",
+            "",
             tokenLedgerChange.consumedTokens.map { toCachedToken(it) },
             tokenLedgerChange.producedTokens.map { toCachedToken(it) }
         )

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/BalanceQuery.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/BalanceQuery.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.utxo.token.cache.entities
 
 data class BalanceQuery(
-    val externalEventRequestId: String,
-    val flowId: String,
+    override val externalEventRequestId: String,
+    override val flowId: String,
     override val tagRegex: String?,
     override val ownerHash: String?,
     override val poolKey: TokenPoolKey,

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/ClaimQuery.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/ClaimQuery.kt
@@ -3,8 +3,8 @@ package net.corda.ledger.utxo.token.cache.entities
 import java.math.BigDecimal
 
 data class ClaimQuery(
-    val externalEventRequestId: String,
-    val flowId: String,
+    override val externalEventRequestId: String,
+    override val flowId: String,
     val targetAmount: BigDecimal,
     override val tagRegex: String?,
     override val ownerHash: String?,

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/ClaimRelease.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/ClaimRelease.kt
@@ -2,8 +2,8 @@ package net.corda.ledger.utxo.token.cache.entities
 
 data class ClaimRelease(
     val claimId: String,
-    val externalEventRequestId: String,
-    val flowId: String,
+    override val externalEventRequestId: String,
+    override val flowId: String,
     val usedTokens: Set<String>,
     override val poolKey: TokenPoolKey
 ) : TokenEvent

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/LedgerChange.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/LedgerChange.kt
@@ -3,7 +3,8 @@ package net.corda.ledger.utxo.token.cache.entities
 data class LedgerChange(
     override val poolKey: TokenPoolKey,
     val claimId: String?, // HACK: Added for testing will be removed by CORE-5722 (ledger integration)
-    val flowId: String?, // HACK: Added for testing will be removed by CORE-5722 (ledger integration)
+    override val externalEventRequestId: String,
+    override val flowId: String,
     val consumedTokens: List<CachedToken>,
     val producedTokens: List<CachedToken>
 ) : TokenEvent

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/TokenEvent.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/entities/TokenEvent.kt
@@ -6,5 +6,7 @@ package net.corda.ledger.utxo.token.cache.entities
  * @property poolKey The key of the specific token pool the event is for
  */
 interface TokenEvent {
+    val externalEventRequestId: String
+    val flowId: String
     val poolKey: TokenPoolKey
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheEventProcessorFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheEventProcessorFactoryImpl.kt
@@ -70,7 +70,7 @@ class TokenCacheEventProcessorFactoryImpl @Activate constructor(
             createHandler(TokenLedgerChangeEventHandler()),
             createHandler(TokenBalanceQueryEventHandler(recordFactory, availableTokenService)),
         )
-        return TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, eventHandlerMap)
+        return TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, eventHandlerMap, externalEventResponseFactory)
     }
 
     private inline fun <reified T : TokenEvent> createHandler(

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
@@ -1,8 +1,11 @@
 package net.corda.ledger.utxo.token.cache.services
 
+import net.corda.data.KeyValuePairList
+import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
+import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.utxo.token.cache.converters.EntityConverter
 import net.corda.ledger.utxo.token.cache.converters.EventConverter
 import net.corda.ledger.utxo.token.cache.entities.TokenEvent
@@ -17,6 +20,7 @@ class TokenCacheEventProcessor constructor(
     private val entityConverter: EntityConverter,
     private val tokenPoolCache: TokenPoolCache,
     private val tokenCacheEventHandlerMap: Map<Class<*>, TokenEventHandler<in TokenEvent>>,
+    private val externalEventResponseFactory: ExternalEventResponseFactory
 ) : StateAndEventProcessor<TokenPoolCacheKey, TokenPoolCacheState, TokenPoolCacheEvent> {
 
     private companion object {
@@ -34,9 +38,14 @@ class TokenCacheEventProcessor constructor(
         event: Record<TokenPoolCacheKey, TokenPoolCacheEvent>
     ): StateAndEventProcessor.Response<TokenPoolCacheState> {
 
-        try {
-            val tokenEvent = eventConverter.convert(event.value)
+        val tokenEvent = try {
+            eventConverter.convert(event.value)
+        } catch (e: Exception) {
+            log.error("Unexpected error while processing event '${event}'. The event will be sent to the DLQ.", e)
+            return StateAndEventProcessor.Response(state, listOf(), markForDLQ = true)
+        }
 
+        return try {
             val nonNullableState = state ?: TokenPoolCacheState().apply {
                 this.poolKey = event.key
                 this.availableTokens = listOf()
@@ -67,13 +76,20 @@ class TokenCacheEventProcessor constructor(
             val result = handler.handle(tokenCache, poolCacheState, tokenEvent)
                 ?: return StateAndEventProcessor.Response(poolCacheState.toAvro(), listOf())
 
-            return StateAndEventProcessor.Response(
+            StateAndEventProcessor.Response(
                 poolCacheState.toAvro(),
                 listOf(result)
             )
         } catch (e: Exception) {
-            log.error("Unexpected error while processing event '${event}'. The event will be sent to the DLQ.", e)
-            return StateAndEventProcessor.Response(state, listOf(), markForDLQ = true)
+            val responseMessage = externalEventResponseFactory.platformError(
+                ExternalEventContext(
+                    tokenEvent.externalEventRequestId,
+                    tokenEvent.flowId,
+                    KeyValuePairList(listOf())
+                ),
+                e
+            )
+            StateAndEventProcessor.Response(state, listOf(responseMessage), markForDLQ = true)
         }
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
@@ -89,7 +89,7 @@ class TokenCacheEventProcessor constructor(
                 ),
                 e
             )
-            StateAndEventProcessor.Response(state, listOf(responseMessage), markForDLQ = true)
+            StateAndEventProcessor.Response(state, listOf(responseMessage), markForDLQ = false)
         }
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EventConverterImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EventConverterImplTest.kt
@@ -25,7 +25,7 @@ class EventConverterImplTest {
     private val entityConverter = mock<EntityConverter>()
     private val claimQuery = ClaimQuery("","", BigDecimal(0), "", "", POOL_KEY)
     private val claimRelease = ClaimRelease("","", "", setOf(), POOL_KEY)
-    private val ledgerChange = LedgerChange(POOL_KEY,"","", listOf(), listOf())
+    private val ledgerChange = LedgerChange(POOL_KEY,"","", "", listOf(), listOf())
 
     @BeforeEach
     fun setup() {

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenLedgerChangeEventHandlerTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/handlers/TokenLedgerChangeEventHandlerTest.kt
@@ -23,7 +23,7 @@ class TokenLedgerChangeEventHandlerTest {
     fun `produced tokens are not added to the cache`() {
         val token1 = mock<CachedToken>().apply { whenever(stateRef).thenReturn("s1") }
 
-        val ledgerChange = LedgerChange(POOL_KEY,"","", listOf(), listOf(token1))
+        val ledgerChange = LedgerChange(POOL_KEY,"","", "", listOf(), listOf(token1))
 
         val target = TokenLedgerChangeEventHandler()
         val result = target.handle(tokenCache, poolCacheState, ledgerChange)
@@ -38,7 +38,7 @@ class TokenLedgerChangeEventHandlerTest {
         val token1 = mock<CachedToken>().apply { whenever(stateRef).thenReturn("s1") }
         val token2 = mock<CachedToken>().apply { whenever(stateRef).thenReturn("s2") }
 
-        val ledgerChange = LedgerChange(POOL_KEY,"","", listOf(token1, token2), listOf())
+        val ledgerChange = LedgerChange(POOL_KEY,"","", "", listOf(token1, token2), listOf())
 
         val target = TokenLedgerChangeEventHandler()
         val result = target.handle(tokenCache, poolCacheState, ledgerChange)

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenCacheEventProcessorTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenCacheEventProcessorTest.kt
@@ -87,7 +87,7 @@ class TokenCacheEventProcessorTest {
 
         assertThat(result.responseEvents).isNotEmpty()
         assertThat(result.updatedState).isSameAs(stateIn)
-        assertThat(result.markForDLQ).isTrue
+        assertThat(result.markForDLQ).isFalse()
     }
 
     @Test
@@ -116,7 +116,7 @@ class TokenCacheEventProcessorTest {
 
         assertThat(result.responseEvents).isNotEmpty()
         assertThat(result.updatedState).isSameAs(stateIn)
-        assertThat(result.markForDLQ).isTrue
+        assertThat(result.markForDLQ).isFalse()
     }
 
     @Test

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenCacheEventProcessorTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenCacheEventProcessorTest.kt
@@ -72,16 +72,24 @@ class TokenCacheEventProcessorTest {
     fun `when the event has no payload the event should be sent to the DLQ`() {
 
         val target =
-            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap, externalEventResponseFactory)
+            TokenCacheEventProcessor(
+                eventConverter,
+                entityConverter,
+                tokenPoolCache,
+                tokenCacheEventHandlerMap,
+                externalEventResponseFactory
+            )
 
         val result = target.onNext(stateIn, eventIn)
 
         verify(externalEventResponseFactory).platformError(
-            eq(ExternalEventContext(
-                FakeTokenEvent().externalEventRequestId,
-                FakeTokenEvent().flowId,
-                KeyValuePairList(listOf())
-            )),
+            eq(
+                ExternalEventContext(
+                    FakeTokenEvent().externalEventRequestId,
+                    FakeTokenEvent().flowId,
+                    KeyValuePairList(listOf())
+                )
+            ),
             any<Throwable>()
         )
 
@@ -106,11 +114,13 @@ class TokenCacheEventProcessorTest {
         val result = target.onNext(stateIn, eventIn)
 
         verify(externalEventResponseFactory).platformError(
-            eq(ExternalEventContext(
-                FakeTokenEvent().externalEventRequestId,
-                FakeTokenEvent().flowId,
-                KeyValuePairList(listOf())
-            )),
+            eq(
+                ExternalEventContext(
+                    FakeTokenEvent().externalEventRequestId,
+                    FakeTokenEvent().flowId,
+                    KeyValuePairList(listOf())
+                )
+            ),
             any<Throwable>()
         )
 

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenCacheEventProcessorTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenCacheEventProcessorTest.kt
@@ -1,8 +1,11 @@
 package net.corda.ledger.utxo.token.cache.impl.services
 
+import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.FlowEvent
+import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
+import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.utxo.token.cache.converters.EntityConverter
 import net.corda.ledger.utxo.token.cache.converters.EventConverter
 import net.corda.ledger.utxo.token.cache.entities.PoolCacheState
@@ -18,6 +21,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -32,6 +36,10 @@ class TokenCacheEventProcessorTest {
     private val event = FakeTokenEvent()
     private val tokenPoolCache = TokenPoolCacheImpl()
     private val cachePoolState = mock<PoolCacheState>()
+    private val externalEventResponseFactory = mock<ExternalEventResponseFactory> {
+        on { platformError(any(), any<Throwable>()) } doReturn mock<Record<String, FlowEvent>>()
+    }
+
     private val stateIn = TokenPoolCacheState()
     private val tokenPoolCacheEvent = TokenPoolCacheEvent(POOL_CACHE_KEY, null)
     private val eventIn = Record(
@@ -50,7 +58,7 @@ class TokenCacheEventProcessorTest {
     @Test
     fun `when an unexpected processing exception is thrown the event will be sent to the DLQ`() {
         val target =
-            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap)
+            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap, mock())
         whenever(eventConverter.convert(any())).thenThrow(IllegalStateException())
 
         val result = target.onNext(stateIn, eventIn)
@@ -64,11 +72,20 @@ class TokenCacheEventProcessorTest {
     fun `when the event has no payload the event should be sent to the DLQ`() {
 
         val target =
-            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap)
+            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap, externalEventResponseFactory)
 
         val result = target.onNext(stateIn, eventIn)
 
-        assertThat(result.responseEvents).isEmpty()
+        verify(externalEventResponseFactory).platformError(
+            eq(ExternalEventContext(
+                FakeTokenEvent().externalEventRequestId,
+                FakeTokenEvent().flowId,
+                KeyValuePairList(listOf())
+            )),
+            any<Throwable>()
+        )
+
+        assertThat(result.responseEvents).isNotEmpty()
         assertThat(result.updatedState).isSameAs(stateIn)
         assertThat(result.markForDLQ).isTrue
     }
@@ -78,11 +95,26 @@ class TokenCacheEventProcessorTest {
         tokenPoolCacheEvent.payload = 1
 
         val target =
-            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap)
+            TokenCacheEventProcessor(
+                eventConverter,
+                entityConverter,
+                tokenPoolCache,
+                tokenCacheEventHandlerMap,
+                externalEventResponseFactory
+            )
 
         val result = target.onNext(stateIn, eventIn)
 
-        assertThat(result.responseEvents).isEmpty()
+        verify(externalEventResponseFactory).platformError(
+            eq(ExternalEventContext(
+                FakeTokenEvent().externalEventRequestId,
+                FakeTokenEvent().flowId,
+                KeyValuePairList(listOf())
+            )),
+            any<Throwable>()
+        )
+
+        assertThat(result.responseEvents).isNotEmpty()
         assertThat(result.updatedState).isSameAs(stateIn)
         assertThat(result.markForDLQ).isTrue
     }
@@ -107,7 +139,7 @@ class TokenCacheEventProcessorTest {
             .thenReturn(handlerResponse)
 
         val target =
-            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap)
+            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap, mock())
 
         val result = target.onNext(stateIn, eventIn)
 
@@ -131,7 +163,7 @@ class TokenCacheEventProcessorTest {
             .thenReturn(handlerResponse)
 
         val target =
-            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap)
+            TokenCacheEventProcessor(eventConverter, entityConverter, tokenPoolCache, tokenCacheEventHandlerMap, mock())
 
         val result = target.onNext(null, eventIn)
 
@@ -150,8 +182,11 @@ class TokenCacheEventProcessorTest {
     }
 
     class FakeTokenEvent : TokenEvent {
+        override val externalEventRequestId: String
+            get() = "externalEventRequestId-not-set"
+        override val flowId: String
+            get() = "flowId-not-set"
         override val poolKey: TokenPoolKey
             get() = POOL_KEY
-
     }
 }


### PR DESCRIPTION
Before this change, flows would hang whenever there was an issue in the token selection service. This fix ensure that the flow status changes to FAILURE if an error is raised by the token selection service.