### PR TITLE
CORE-17258 - Disable unstable test temporarily

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/UniquenessCheckerRPCSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/UniquenessCheckerRPCSmokeTests.kt
@@ -24,6 +24,7 @@ import net.corda.uniqueness.utils.UniquenessAssertions
 import net.corda.v5.crypto.SecureHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.slf4j.LoggerFactory
@@ -42,6 +43,7 @@ import kotlin.random.Random
 /**
  * Tests for the UniquenessChecker RPC service
  */
+@Tag("Unstable")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UniquenessCheckerRPCSmokeTests {
     private val httpClient: HttpClient = HttpClient.newBuilder()


### PR DESCRIPTION
Disable `UniquenessCheckerRPCSmokeTests` as it started failing consistently recently, until it can be fixed.