### PR TITLE
CORE-15950 Allow changes to notary keys during reregistration

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -24,6 +24,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTI
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_SUSPENDED
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.SERIAL
 import net.corda.membership.lib.MemberInfoExtension.Companion.SESSION_KEYS
@@ -191,7 +192,7 @@ internal class StartRegistrationHandler(
                         it.key.startsWith(SESSION_KEYS) ||
                         it.key.startsWith(LEDGER_KEYS) ||
                         it.key.startsWith(ROLES_PREFIX) ||
-                        it.key.startsWith("corda.notary")
+                        it.key.startsWith(NOTARY_SERVICE_PREFIX)
                     }
                 validateRegistrationRequest(
                     diff.isEmpty()

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -33,7 +33,7 @@ import net.corda.data.p2p.app.OutboundUnauthenticatedMessage
 import net.corda.data.p2p.app.OutboundUnauthenticatedMessageHeader
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.libs.platform.PlatformInfoProvider
-import net.corda.libs.platform.PlatformVersion
+import net.corda.libs.platform.PlatformVersion.CORDA_5_1
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -460,8 +460,7 @@ class DynamicMemberRegistrationService @Activate constructor(
                 }.apply {
                     if (isNotEmpty()) {
                         throw InvalidMembershipRegistrationException(
-                            "Fields ${joinToString(prefix = "[", postfix = "]") { it.key }} cannot be added, removed or " +
-                                    "updated during re-registration."
+                            "Fields ${this.map { it.key }} cannot be added, removed or updated during re-registration."
                         )
                     }
                 }
@@ -481,13 +480,9 @@ class DynamicMemberRegistrationService @Activate constructor(
             currentSerial: Long?,
             mgmPlatformVersion: Int,
         ) {
-            if (
-                (submittedSerial > 0 || (currentSerial != null && currentSerial > 0))
-                && mgmPlatformVersion < PlatformVersion.CORDA_5_1.value
-            ) {
-                throw InvalidMembershipRegistrationException(
-                    "MGM is on a lower version where re-registration is not supported."
-                )
+            if ((submittedSerial > 0 || (currentSerial != null && currentSerial > 0)) && mgmPlatformVersion < CORDA_5_1.value) {
+                throw InvalidMembershipRegistrationException("MGM is on a lower version where re-registration " +
+                        "is not supported.")
             }
         }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -2,9 +2,6 @@ package net.corda.membership.impl.registration.dynamic.member
 
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
-import java.nio.ByteBuffer
-import java.security.PublicKey
-import java.util.UUID
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationGetService
 import net.corda.configuration.read.ConfigurationReadService
@@ -36,6 +33,7 @@ import net.corda.data.p2p.app.OutboundUnauthenticatedMessage
 import net.corda.data.p2p.app.OutboundUnauthenticatedMessageHeader
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.libs.platform.PlatformVersion
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -60,6 +58,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_ROLE
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
@@ -116,6 +115,9 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.security.PublicKey
+import java.util.UUID
 
 @Suppress("LongParameterList")
 @Component(service = [MemberRegistrationService::class])
@@ -454,11 +456,12 @@ class DynamicMemberRegistrationService @Activate constructor(
                     it.key.startsWith(SESSION_KEYS) ||
                     it.key.startsWith(LEDGER_KEYS) ||
                     it.key.startsWith(ROLES_PREFIX) ||
-                    it.key.startsWith("corda.notary")
+                    it.key.startsWith(NOTARY_SERVICE_PREFIX)
                 }.apply {
-                    require(isEmpty()) {
+                    if (isNotEmpty()) {
                         throw InvalidMembershipRegistrationException(
-                            "Fields ${this.map { it.key }} cannot be added, removed or updated during re-registration."
+                            "Fields ${joinToString(prefix = "[", postfix = "]") { it.key }} cannot be added, removed or " +
+                                    "updated during re-registration."
                         )
                     }
                 }
@@ -478,9 +481,13 @@ class DynamicMemberRegistrationService @Activate constructor(
             currentSerial: Long?,
             mgmPlatformVersion: Int,
         ) {
-            if ((submittedSerial > 0 || (currentSerial != null && currentSerial > 0)) && mgmPlatformVersion < 50100) {
-                throw InvalidMembershipRegistrationException("MGM is on a lower version where re-registration " +
-                        "is not supported.")
+            if (
+                (submittedSerial > 0 || (currentSerial != null && currentSerial > 0))
+                && mgmPlatformVersion < PlatformVersion.CORDA_5_1.value
+            ) {
+                throw InvalidMembershipRegistrationException(
+                    "MGM is on a lower version where re-registration is not supported."
+                )
             }
         }
 

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -139,14 +139,15 @@ class MemberInfoExtension {
         /**
          * Notary role properties
          */
-        const val NOTARY_KEYS = "corda.notary.keys"
-        const val NOTARY_SERVICE_NAME = "corda.notary.service.name"
-        const val NOTARY_SERVICE_PROTOCOL = "corda.notary.service.flow.protocol.name"
-        const val NOTARY_SERVICE_PROTOCOL_VERSIONS = "corda.notary.service.flow.protocol.version.%s"
-        const val NOTARY_KEYS_ID = "corda.notary.keys.%s.id"
-        const val NOTARY_KEY_PEM = "corda.notary.keys.%s.pem"
-        const val NOTARY_KEY_HASH = "corda.notary.keys.%s.hash"
-        const val NOTARY_KEY_SPEC = "corda.notary.keys.%s.signature.spec"
+        const val NOTARY_KEYS_PREFIX = "corda.notary.keys"
+        const val NOTARY_SERVICE_PREFIX = "corda.notary.service"
+        const val NOTARY_SERVICE_NAME = "$NOTARY_SERVICE_PREFIX.name"
+        const val NOTARY_SERVICE_PROTOCOL = "$NOTARY_SERVICE_PREFIX.flow.protocol.name"
+        const val NOTARY_SERVICE_PROTOCOL_VERSIONS = "$NOTARY_SERVICE_PREFIX.flow.protocol.version.%s"
+        const val NOTARY_KEYS_ID = "$NOTARY_KEYS_PREFIX.%s.id"
+        const val NOTARY_KEY_PEM = "$NOTARY_KEYS_PREFIX.%s.pem"
+        const val NOTARY_KEY_HASH = "$NOTARY_KEYS_PREFIX.%s.hash"
+        const val NOTARY_KEY_SPEC = "$NOTARY_KEYS_PREFIX.%s.signature.spec"
 
         /** Key name for TLS certificate subject. */
         const val TLS_CERTIFICATE_SUBJECT = "corda.tls.certificate.subject"
@@ -294,7 +295,7 @@ class MemberInfoExtension {
          * added notary key. Might be an empty list if the member is not a notary VNode.
          */
         @JvmStatic
-        val MemberInfo.notaryKeys: List<PublicKey> get() = memberProvidedContext.parseList(NOTARY_KEYS)
+        val MemberInfo.notaryKeys: List<PublicKey> get() = memberProvidedContext.parseList(NOTARY_KEYS_PREFIX)
 
         private fun MemberInfo.getOrCalculateKeyHashes(
             key: String,


### PR DESCRIPTION
With this change, it should be possible on the client (member) side and the server (mgm) side to request that a member's notary key list is changed during re-registration. This includes adding, removing and changing notary keys. It should not be possible to change any other notary related properties.

This PR covers the validation aspect only and does not include updating the group parameters.