### PR TITLE
CORE-13119 Rollback ledger custom queries to offset-based paging

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.persistence.query.execution.impl
 
+import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.persistence.EntityResponse
 import net.corda.data.persistence.FindWithNamedQuery
@@ -10,17 +11,12 @@ import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionOutputDto
 import net.corda.orm.utils.transaction
 import net.corda.persistence.common.exceptions.NullParameterException
-import net.corda.utilities.debug
 import net.corda.utilities.serialization.deserialize
-import net.corda.utilities.trace
 import net.corda.v5.application.serialization.SerializationService
-import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
-import java.sql.Timestamp
-import java.time.Instant
 import javax.persistence.EntityManagerFactory
 import javax.persistence.Tuple
 
@@ -40,87 +36,11 @@ class VaultNamedQueryExecutorImpl(
         val log = LoggerFactory.getLogger(VaultNamedQueryExecutorImpl::class.java)
     }
 
-    /*
-     * Captures data passed back and forth between this query execution and the caller in a flow
-     * processor to enable subsequent pages to know where to resume from. Data is opaque outside
-     * this class.
-     *
-     * This class is not part of the corda-api data module because it is not exposed outside of the
-     * internal query API.
-     */
-    @CordaSerializable
-    data class ResumePoint(
-        val created: Instant,
-        val txId: String,
-        val leafIdx: Int
-    )
-
-    /*
-     * Stores query results following processing / filtering, in a form ready to return to the
-     * caller.
-     */
-    private data class ProcessedQueryResults(
-        val results: List<StateAndRef<ContractState>>,
-        val resumePoint: ResumePoint?,
-        val numberOfRowsFromQuery: Int
-    )
-
-    /*
-     * Stores the raw query data retrieved from an SQL query row.
-     */
-    private inner class RawQueryData(sqlRow: Tuple) {
-
-        private val txId = sqlRow[0] as String
-        private val leafIdx = sqlRow[1] as Int
-        private val outputInfoData = sqlRow[2] as ByteArray
-        private val outputData = sqlRow[3] as ByteArray
-        private val created = (sqlRow[4] as Timestamp).toInstant()
-
-        val stateAndRef: StateAndRef<ContractState> by lazy {
-            UtxoTransactionOutputDto(txId, leafIdx, outputInfoData, outputData)
-                .toStateAndRef(serializationService)
-        }
-
-        val resumePoint: ResumePoint? by lazy {
-            created?.let { ResumePoint(created, txId, leafIdx) }
-        }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) return true
-            if (javaClass != other?.javaClass) return false
-
-            other as RawQueryData
-
-            if (txId != other.txId) return false
-            if (leafIdx != other.leafIdx) return false
-            if (created != other.created) return false
-
-            return true
-        }
-
-        override fun hashCode(): Int {
-            var result = txId.hashCode()
-            result = 31 * result + leafIdx
-            result = 31 * result + (created?.hashCode() ?: 0)
-            return result
-        }
-    }
-
-    /*
-     * Stores a set of raw query data returned from a single database query invocation. To support
-     * paging, this not only returns the raw query data, but also a `hasMore` flag to indicate
-     * whether another page of data is available.
-     */
-    private data class RawQueryResults(
-        val results: List<RawQueryData>,
-        val hasMore: Boolean
-    )
-
     override fun executeQuery(
         request: FindWithNamedQuery
     ): EntityResponse {
 
-        log.debug { "Executing query: ${request.queryName}" }
+        log.debug("Executing query: ${request.queryName}")
 
         // Get the query from the registry and make sure it exists
         val vaultNamedQuery = registry.getQuery(request.queryName)
@@ -132,19 +52,16 @@ class VaultNamedQueryExecutorImpl(
 
         // Deserialize the parameters into readable objects instead of bytes
         val deserializedParams = request.parameters.mapValues {
-            serializationService.deserialize<Any>(it.value.array())
+            serializationService.deserialize(it.value.array(), Any::class.java)
         }
 
         // Fetch and filter the results and try to fill up the page size then map the results
         // mapNotNull has no effect as of now, but we keep it for safety purposes
-        val (fetchedRecords, resumePoint, numberOfRowsReturned) = filterResultsAndFillPageSize(
+        val (fetchedRecords, numberOfRowsFromQuery) = filterResultsAndFillPageSize(
             request,
             vaultNamedQuery,
             deserializedParams
         )
-
-        log.trace { "Fetched ${fetchedRecords.size} records in this page " +
-                "(${numberOfRowsReturned - fetchedRecords.size} records filtered)" }
 
         val filteredAndTransformedResults = fetchedRecords.mapNotNull {
             vaultNamedQuery.mapper?.transform(it, deserializedParams) ?: it
@@ -156,14 +73,12 @@ class VaultNamedQueryExecutorImpl(
             deserializedParams
         )?.results?.filterNotNull() ?: filteredAndTransformedResults
 
-        // Return the filtered/transformed/collected (if present) result to the caller
-        val response = EntityResponse.newBuilder()
+        // Return the filtered/transformed/collected (if present) result and the offset to continue the paging from to the caller
+        return EntityResponse.newBuilder()
             .setResults(collectedResults.map { ByteBuffer.wrap(serializationService.serialize(it).bytes) })
-
-        response.resumePoint = resumePoint?.let { ByteBuffer.wrap(serializationService.serialize(it).bytes) }
-        response.metadata = KeyValuePairList(emptyList())
-
-        return response.build()
+            .setMetadata(KeyValuePairList(listOf(
+                KeyValuePair("numberOfRowsFromQuery", numberOfRowsFromQuery.toString())
+            ))).build()
     }
 
     /**
@@ -182,119 +97,86 @@ class VaultNamedQueryExecutorImpl(
      * If any of these conditions happen, we just return the result set as-is without filling
      * up the "page size".
      *
-     * The returned [ProcessedQueryResults] object provides the collated query results
-     * post-filtering, a [ResumePoint] if there is another page of data to be returned, and the
-     * total number of rows returned from executed queries for informational purposes.
+     * Will return a pair of the fetched and "filtered" results from the database and the offset
+     * that the paging can be continued from.
      */
     private fun filterResultsAndFillPageSize(
         request: FindWithNamedQuery,
         vaultNamedQuery: VaultNamedQuery,
         deserializedParams: Map<String, Any>
-    ): ProcessedQueryResults {
-        val filteredRawData = mutableListOf<RawQueryData>()
+    ): FilterResult {
+        val filteredResults = mutableListOf<StateAndRef<ContractState>>()
 
         var currentRetry = 0
         var numberOfRowsFromQuery = 0
-        var currentResumePoint = request.resumePoint?.let {
-            serializationService.deserialize<ResumePoint>(request.resumePoint.array())
-        }
 
-        while (filteredRawData.size < request.limit && currentRetry < RESULT_SET_FILL_RETRY_LIMIT ) {
+        while (filteredResults.size < request.limit && currentRetry < RESULT_SET_FILL_RETRY_LIMIT) {
             ++currentRetry
 
-            log.trace { "Executing try: $currentRetry, fetched ${filteredRawData.size} number of results so far." }
+            log.trace("Executing try: $currentRetry, fetched ${filteredResults.size} number of results so far.")
 
             // Fetch the state and refs for the given transaction IDs
-            val rawResults = fetchStateAndRefs(
+            val contractStateResults = fetchStateAndRefs(
                 request,
                 vaultNamedQuery.query.query,
-                currentResumePoint
+                offset = request.offset + numberOfRowsFromQuery
             )
 
             // If we have no filter, there's no need to continue the loop
             if (vaultNamedQuery.filter == null) {
-                with (rawResults) {
-                    return ProcessedQueryResults(
-                        results.map { it.stateAndRef },
-                        if (hasMore) results.last().resumePoint else null,
-                        results.size
-                    )
-                }
-            }
-
-            rawResults.results.forEach { result ->
-                ++numberOfRowsFromQuery
-                if (vaultNamedQuery.filter.filter(result.stateAndRef, deserializedParams)) {
-                    filteredRawData.add(result)
-                }
-
-
-                if (filteredRawData.size >= request.limit) {
-                    // Page filled. We need to set the resume point based on the final filtered
-                    // result (as we may be throwing out additional records returned by the query).
-                    // Note that we should never get to the > part of the condition; this is a
-                    // purely defensive check.
-                    //
-                    // There are more results if either we didn't get through all the results
-                    // returned by the query invocation, or if the query itself indicated there are
-                    // more results to return.
-                    val moreResults = (result != rawResults.results.last()) || rawResults.hasMore
-
-                    return ProcessedQueryResults(
-                        filteredRawData.map { it.stateAndRef },
-                        if (moreResults) filteredRawData.last().resumePoint else null,
-                        numberOfRowsFromQuery
-                    )
-                }
+                return FilterResult(
+                    results = contractStateResults,
+                    numberOfRowsFromQuery = contractStateResults.size
+                )
             }
 
             // If we can't fetch more states we just return the result set as-is
-            if (!rawResults.hasMore) {
-                currentResumePoint = null
+            if (contractStateResults.isEmpty()) {
                 break
-            } else {
-                currentResumePoint = rawResults.results.last().resumePoint
+            }
+
+            contractStateResults.forEach { contractStateResult ->
+                ++numberOfRowsFromQuery
+                if (vaultNamedQuery.filter.filter(contractStateResult, deserializedParams)) {
+                    filteredResults.add(contractStateResult)
+                }
+
+                if (filteredResults.size >= request.limit) {
+                    return FilterResult(
+                        results = filteredResults,
+                        numberOfRowsFromQuery = numberOfRowsFromQuery
+                    )
+                }
             }
         }
 
-        return ProcessedQueryResults(
-            filteredRawData.map { it.stateAndRef },
-            currentResumePoint,
-            numberOfRowsFromQuery
+        return FilterResult(
+            results = filteredResults,
+            numberOfRowsFromQuery = numberOfRowsFromQuery
         )
     }
 
     /**
-     * A function that fetches the contract states that belong to the given transaction IDs.
-     * The data stored in the component table will be deserialized into contract states using
-     * component groups.
-     *
-     * Each invocation of this function represents a single distinct query to the database.
+     * A function that fetches the contract states that belong to the given transaction IDs. The data stored in the
+     * component table will be deserialized into contract states using component groups.
      */
     private fun fetchStateAndRefs(
         request: FindWithNamedQuery,
         whereJson: String?,
-        resumePoint: ResumePoint?
-    ): RawQueryResults {
+        offset: Int
+    ): List<StateAndRef<ContractState>> {
 
         validateParameters(request)
 
         @Suppress("UNCHECKED_CAST")
-        val resultList = entityManagerFactory.transaction { em ->
-
-            val resumePointExpr = resumePoint?.let {
-                " AND ((tc_output.created > :created) OR " +
-                "(tc_output.created = :created AND tc_output.transaction_id > :txId) OR " +
-                "(tc_output.created = :created AND tc_output.transaction_id = :txId AND tc_output.leaf_idx > :leafIdx))"
-            } ?: ""
+        return entityManagerFactory.transaction { em ->
 
             val query = em.createNativeQuery(
                 """
                     SELECT tc_output.transaction_id,
                         tc_output.leaf_idx,
                         tc_output_info.data as output_info_data,
-                        tc_output.data AS output_data,
-                        tc_output.created AS created
+                        tc_output.data AS output_data
                         FROM $UTXO_VISIBLE_TX_TABLE AS visible_states
                         JOIN $UTXO_TX_COMPONENT_TABLE AS tc_output_info
                              ON tc_output_info.transaction_id = visible_states.transaction_id
@@ -305,38 +187,28 @@ class VaultNamedQueryExecutorImpl(
                              AND tc_output_info.leaf_idx = tc_output.leaf_idx
                              AND tc_output.group_idx = ${UtxoComponentGroup.OUTPUTS.ordinal}
                         WHERE ($whereJson)
-                        $resumePointExpr
                         AND visible_states.created <= :$TIMESTAMP_LIMIT_PARAM_NAME
                         ORDER BY tc_output.created, tc_output.transaction_id, tc_output.leaf_idx
                 """,
-                Tuple::class.java)
-
-            if (resumePoint != null) {
-                log.trace { "Query is resuming from $resumePoint" }
-                query.setParameter("created", resumePoint.created)
-                query.setParameter("txId", resumePoint.txId)
-                query.setParameter("leafIdx", resumePoint.leafIdx)
-            }
+                Tuple::class.java
+            )
 
             request.parameters.filter { it.value != null }.forEach { rec ->
                 val bytes = rec.value.array()
                 query.setParameter(rec.key, serializationService.deserialize(bytes))
             }
 
-            query.firstResult = request.offset
-            // Getting one more than requested allows us to identify if there are more results to
-            // return in a subsequent page
-            query.maxResults = request.limit + 1
+            query.firstResult = offset
+            query.maxResults = request.limit
 
             query.resultList as List<Tuple>
-        }
-
-        return if (resultList.size > request.limit) {
-            // We need to truncate the list to the number requested, but also flag that there is
-            // another page to be returned
-            RawQueryResults(resultList.subList(0, request.limit).map { RawQueryData(it) }, hasMore = true)
-        } else {
-            RawQueryResults(resultList.map { RawQueryData(it) }, hasMore = false)
+        }.map { t ->
+            UtxoTransactionOutputDto(
+                t[0] as String, // transactionId
+                t[1] as Int, // leaf ID
+                t[2] as ByteArray, // outputs info data
+                t[3] as ByteArray // outputs data
+            ).toStateAndRef(serializationService)
         }
     }
 
@@ -349,4 +221,9 @@ class VaultNamedQueryExecutorImpl(
             throw NullParameterException(msg)
         }
     }
+
+    private data class FilterResult(
+        val results: List<StateAndRef<ContractState>>,
+        val numberOfRowsFromQuery: Int
+    )
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.flow.persistence.query.OffsetResultSetExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
-import net.corda.flow.persistence.query.StableResultSetExecutor
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.ALICE_X500_HOLDING_IDENTITY
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.VaultNamedQueryExternalEventFactory
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
@@ -42,7 +42,7 @@ class VaultNamedParameterizedQueryImplTest {
     private val resultSetFactory = mock<ResultSetFactory>()
     private val resultSet = mock<ResultSet<Any>>()
     private val clock = mock<Clock>()
-    private val resultSetExecutorCaptor = argumentCaptor<StableResultSetExecutor<Any>>()
+    private val resultSetExecutorCaptor = argumentCaptor<OffsetResultSetExecutor<Any>>()
     private val mapCaptor = argumentCaptor<Map<String, Any>>()
 
     private val query = VaultNamedParameterizedQueryImpl(
@@ -59,7 +59,7 @@ class VaultNamedParameterizedQueryImplTest {
 
     @BeforeEach
     fun beforeEach() {
-        whenever(resultSetFactory.create(mapCaptor.capture(), any(), any(), resultSetExecutorCaptor.capture())).thenReturn(resultSet)
+        whenever(resultSetFactory.create(mapCaptor.capture(), any(), any(), any(), resultSetExecutorCaptor.capture())).thenReturn(resultSet)
         whenever(resultSet.next()).thenReturn(results)
         whenever(clock.instant()).thenReturn(later)
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
@@ -70,16 +70,21 @@ class VaultNamedParameterizedQueryImplTest {
     @Test
     fun `setLimit updates the limit`() {
         query.execute()
-        verify(resultSetFactory).create(any(), eq(1), any<Class<Any>>(), any())
+        verify(resultSetFactory).create(any(), eq(1), any(), any<Class<Any>>(), any())
 
         query.setLimit(10)
         query.execute()
-        verify(resultSetFactory).create(any(), eq(10), any<Class<Any>>(), any())
+        verify(resultSetFactory).create(any(), eq(10), any(), any<Class<Any>>(), any())
     }
 
     @Test
-    fun `setOffset is not supported`() {
-        assertThatThrownBy { query.setOffset(10) }.isInstanceOf(UnsupportedOperationException::class.java)
+    fun `setOffset updates the offset`() {
+        query.execute()
+        verify(resultSetFactory).create(any(), any(), eq(0), any<Class<Any>>(), any())
+
+        query.setOffset(10)
+        query.execute()
+        verify(resultSetFactory).create(any(), any(), eq(10), any<Class<Any>>(), any())
     }
 
     @Test
@@ -90,6 +95,11 @@ class VaultNamedParameterizedQueryImplTest {
     @Test
     fun `setLimit cannot be zero`() {
         assertThatThrownBy { query.setLimit(0) }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `setOffset cannot be negative`() {
+        assertThatThrownBy { query.setOffset(-1) }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test
@@ -165,7 +175,7 @@ class VaultNamedParameterizedQueryImplTest {
     @Test
     fun `execute creates a result set, gets the next page and returns the result set`() {
         assertThat(query.execute()).isEqualTo(resultSet)
-        verify(resultSetFactory).create(any(), any(), any<Class<Any>>(), any())
+        verify(resultSetFactory).create(any(), any(), any(), any<Class<Any>>(), any())
         verify(resultSet).next()
     }
 
@@ -177,7 +187,7 @@ class VaultNamedParameterizedQueryImplTest {
         query.execute()
 
         val resultSetExecutor = resultSetExecutorCaptor.firstValue
-        assertThatThrownBy { resultSetExecutor.execute(emptyMap(), null) }.isInstanceOf(CordaPersistenceException::class.java)
+        assertThatThrownBy { resultSetExecutor.execute(emptyMap(), 0) }.isInstanceOf(CordaPersistenceException::class.java)
     }
 
     @Test
@@ -188,6 +198,6 @@ class VaultNamedParameterizedQueryImplTest {
         query.execute()
 
         val resultSetExecutor = resultSetExecutorCaptor.firstValue
-        assertThatThrownBy { resultSetExecutor.execute(emptyMap(), null) }.isInstanceOf(IllegalStateException::class.java)
+        assertThatThrownBy { resultSetExecutor.execute(emptyMap(), 0) }.isInstanceOf(IllegalStateException::class.java)
     }
 }


### PR DESCRIPTION
This PR temporarily reverts ledger custom queries from using stable query paging (introduced in #4548) back to offset query paging.

This is to unblock QA testing, as this change requires QA test adaptations. Stable-query paging will be re-introduced shortly.