### PR TITLE
CORE-17173: Improve coverage of NonInjectableSingletonTest.

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -483,7 +483,7 @@ class SandboxGroupContextServiceImpl @Activate constructor(
         private val serviceFilter: String?,
         private val sourceContext: BundleContext,
         private val serviceComponentRuntime: ServiceComponentRuntime,
-        private val serviceIndex: Map<String, MutableSet<ServiceReference<*>>>,
+        private val serviceIndex: Map<String, Set<ServiceReference<*>>>,
         private val injectables: MutableMap<ServiceReference<*>, ServiceDefinition>
     ) {
         private val nonInjectables = mutableMapOf<ServiceReference<*>, ServiceDefinition>()


### PR DESCRIPTION
Update test to allow `UUIDInternalServiceImpl` to inject multiple `UUIDProvider` references.