### PR TITLE
CORE-17261 - Clarify logs for stale serial number

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -173,8 +173,8 @@ internal class StartRegistrationHandler(
                 }
                 validateRegistrationRequest(activeOrSuspendedInfo!!.serial <= registrationRequest.serial!!) {
                     "Registration request was submitted for an older version of member info. " +
-                            "The submitted serial was ${registrationRequest.serial}, but the latest serial is ${activeOrSuspendedInfo.serial}. " +
-                            "Please submit a new request with an up-to-date serial number."
+                    "The submitted serial was ${registrationRequest.serial}, but the latest serial is ${activeOrSuspendedInfo.serial}. " +
+                    "Please submit a new request with an up-to-date serial number."
                 }
             } else if (registrationRequest.serial!! == 0L) { // initial registration
                 validateRegistrationRequest(activeOrSuspendedInfo == null) {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -169,11 +169,12 @@ internal class StartRegistrationHandler(
             }
             if (registrationRequest.serial!! > 0) { //re-registration
                 validateRegistrationRequest(activeOrSuspendedInfo != null) {
-                    "Member has not registered previously so serial number should be 0."
+                    "Member has not registered previously so serial number should be 0, but it was ${registrationRequest.serial}."
                 }
                 validateRegistrationRequest(activeOrSuspendedInfo!!.serial <= registrationRequest.serial!!) {
                     "Registration request was submitted for an older version of member info. " +
-                            "Please submit a new request."
+                            "The submitted serial was ${registrationRequest.serial}, but the latest serial is ${activeOrSuspendedInfo.serial}. " +
+                            "Please submit a new request with an up-to-date serial number."
                 }
             } else if (registrationRequest.serial!! == 0L) { // initial registration
                 validateRegistrationRequest(activeOrSuspendedInfo == null) {


### PR DESCRIPTION
Adding some more information in the logs shown in the MGM side when a member provides a wrong serial number, e.g. to include the submitted serial and the latest one. 