### PR TITLE
CORE-17112: Avoid delete user or schema for BYODB scenario

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
@@ -13,7 +13,7 @@ import net.corda.db.core.DbPrivilege
  */
 internal interface VirtualNodeDb {
     val isPlatformManagedDb: Boolean
-    val ddlConnectionProvided: Boolean
+    val connectionProvided: Boolean
     val dbConnections: Map<DbPrivilege, DbConnection?>
     val dbType: VirtualNodeDbType
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
@@ -13,6 +13,7 @@ import net.corda.db.core.DbPrivilege
  */
 internal interface VirtualNodeDb {
     val isPlatformManagedDb: Boolean
+    val ddlConnectionProvided: Boolean
     val dbConnections: Map<DbPrivilege, DbConnection?>
     val dbType: VirtualNodeDbType
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
@@ -8,12 +8,13 @@ import net.corda.db.core.DbPrivilege
  * Represents a Virtual Node Database
  *
  * @property isPlatformManagedDb true if the database objects are managed by the Corda platform
+ * @property ddlConnectionProvided true if a DDL connection string has been provided
  * @property dbConnections Map of [DbPrivilege] type to its associated connection config.
  * @property dbType DB type (usage)
  */
 internal interface VirtualNodeDb {
     val isPlatformManagedDb: Boolean
-    val connectionProvided: Boolean
+    val ddlConnectionProvided: Boolean
     val dbConnections: Map<DbPrivilege, DbConnection?>
     val dbType: VirtualNodeDbType
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -113,10 +113,11 @@ internal class VirtualNodeDbFactoryImpl(
 
         val ddlProvided = ddlConfig?.isNotBlank() == true
         val hasConnections = dbConnections.values.any { it != null }
-        val isPlatformManagedDb = hasConnections && (usingClusterDb || ddlProvided)
+        val connectionStringsProvided = hasConnections && ddlProvided
 
         return VirtualNodeDbImpl(
-            isPlatformManagedDb,
+            usingClusterDb,
+            connectionStringsProvided,
             dbConnections,
             dbType,
             holdingIdentityShortHash,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -113,7 +113,7 @@ internal class VirtualNodeDbFactoryImpl(
 
         val ddlProvided = ddlConfig?.isNotBlank() == true
         val hasConnections = dbConnections.values.any { it != null }
-        val connectionStringsProvided = hasConnections && ddlProvided
+        val connectionStringsProvided = hasConnections && ddlProvided && !usingClusterDb
 
         return VirtualNodeDbImpl(
             usingClusterDb,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory
 @Suppress("LongParameterList")
 internal class VirtualNodeDbImpl(
     override val isPlatformManagedDb: Boolean,
-    override val connectionProvided: Boolean,
+    override val ddlConnectionProvided: Boolean,
     override val dbConnections: Map<DbPrivilege, DbConnection?>,
     override val dbType: VirtualNodeDbType,
     private val holdingIdentityShortHash: ShortHash,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory
 @Suppress("LongParameterList")
 internal class VirtualNodeDbImpl(
     override val isPlatformManagedDb: Boolean,
-    override val ddlConnectionProvided: Boolean,
+    override val connectionProvided: Boolean,
     override val dbConnections: Map<DbPrivilege, DbConnection?>,
     override val dbType: VirtualNodeDbType,
     private val holdingIdentityShortHash: ShortHash,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
@@ -41,17 +41,17 @@ internal class VirtualNodeDbImpl(
      */
     @Suppress("NestedBlockDepth")
     override fun createSchemasAndUsers() {
-        // Order is important because DB schema should be deleted first if DDL user already exists
-        for (privilege in listOf(DDL, DML)) {
-            dbConnections[privilege]!!.let { connection ->
-                val user = connection.getUser()
-                    ?: throw DBConfigurationException("DB user not known for connection ${connection.description}")
-                val password = connection.getPassword()
-                    ?: throw DBConfigurationException("DB password not known for connection ${connection.description}")
-                val dbSchema = dbType.getSchemaName(holdingIdentityShortHash)
-                // This covers scenario when previous virtual node on-boarding request failed after user was created
-                // Since connections are persisted at later point, user's password is lost, so user is re-created
-                if (isPlatformManagedDb) {
+        if (isPlatformManagedDb) {
+            // Order is important because DB schema should be deleted first if DDL user already exists
+            for (privilege in listOf(DDL, DML)) {
+                dbConnections[privilege]!!.let { connection ->
+                    val user = connection.getUser()
+                        ?: throw DBConfigurationException("DB user not known for connection ${connection.description}")
+                    val password = connection.getPassword()
+                        ?: throw DBConfigurationException("DB password not known for connection ${connection.description}")
+                    val dbSchema = dbType.getSchemaName(holdingIdentityShortHash)
+                    // This covers scenario when previous virtual node on-boarding request failed after user was created
+                    // Since connections are persisted at later point, user's password is lost, so user is re-created
                     if (virtualNodesDbAdmin.userExists(user)) {
                         if (privilege == DDL) {
                             log.info("User for connection ${connection.description} already exists in DB, schema will be deleted")
@@ -60,11 +60,11 @@ internal class VirtualNodeDbImpl(
                         log.info("User for connection ${connection.description} already exists in DB, it will be re-created")
                         virtualNodesDbAdmin.deleteUser(user)
                     }
+                    // When DML user is created, it is granted with privileges related to DB objects created by DDL user
+                    // (therefore DDL user has to be provided as grantee)
+                    val grantee = if (privilege == DML) dbConnections[DDL]!!.getUser() else null
+                    virtualNodesDbAdmin.createDbAndUser(dbSchema, user, password, privilege, grantee)
                 }
-                // When DML user is created, it is granted with privileges related to DB objects created by DDL user
-                // (therefore DDL user has to be provided as grantee)
-                val grantee = if (privilege == DML) dbConnections[DDL]!!.getUser() else null
-                virtualNodesDbAdmin.createDbAndUser(dbSchema, user, password, privilege, grantee)
             }
         }
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
@@ -68,7 +68,7 @@ internal class CreateVirtualNodeOperationHandler(
             }
 
             // For each of the platform DB's run the creation process
-            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb || it.connectionProvided }) {
+            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb || it.ddlConnectionProvided }) {
                 execLog.measureExecTime("create schema and user in ${vNodeDb.dbType} DB") {
                     vNodeDb.createSchemasAndUsers()
                 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
@@ -68,7 +68,7 @@ internal class CreateVirtualNodeOperationHandler(
             }
 
             // For each of the platform DB's run the creation process
-            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb }) {
+            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb || it.ddlConnectionProvided }) {
                 execLog.measureExecTime("create schema and user in ${vNodeDb.dbType} DB") {
                     vNodeDb.createSchemasAndUsers()
                 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
@@ -68,7 +68,7 @@ internal class CreateVirtualNodeOperationHandler(
             }
 
             // For each of the platform DB's run the creation process
-            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb || it.ddlConnectionProvided }) {
+            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb || it.connectionProvided }) {
                 execLog.measureExecTime("create schema and user in ${vNodeDb.dbType} DB") {
                     vNodeDb.createSchemasAndUsers()
                 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
@@ -68,11 +68,13 @@ internal class CreateVirtualNodeOperationHandler(
             }
 
             // For each of the platform DB's run the creation process
-            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb || it.ddlConnectionProvided }) {
+            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb }) {
                 execLog.measureExecTime("create schema and user in ${vNodeDb.dbType} DB") {
                     vNodeDb.createSchemasAndUsers()
                 }
+            }
 
+            for (vNodeDb in vNodeDbs.values.filter { it.isPlatformManagedDb || it.ddlConnectionProvided }) {
                 execLog.measureExecTime("apply DB migrations in ${vNodeDb.dbType} DB") {
                     vNodeDb.runDbMigration(VirtualNodeWriterProcessor.systemTerminatorTag)
                 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -177,7 +177,7 @@ class VirtualNodeDbFactoryImplTest {
     }
 
     @Test
-    fun `createVNodeDbs sets ddlConnectionProvided to true when provided with DML and DDL connection`() {
+    fun `createVNodeDbs sets ddlConnectionProvided to true and isPlatformManagedDb to false when provided with DML and DDL connection`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -193,10 +193,12 @@ class VirtualNodeDbFactoryImplTest {
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
         assertAll(dbs.map { (dbType, db) -> { assertTrue(db.ddlConnectionProvided, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.isPlatformManagedDb, dbType.name) } })
     }
 
     @Test
-    fun `createVNodeDbs sets ddlConnectionProvided to false when provided with DML connection but no DDL connection`() {
+    @Suppress("MaxLineLength")
+    fun `createVNodeDbs sets ddlConnectionProvided and isPlatformManaged to false when provided with DML connection but no DDL connection`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -212,10 +214,12 @@ class VirtualNodeDbFactoryImplTest {
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
         assertAll(dbs.map { (dbType, db) -> { assertFalse(db.ddlConnectionProvided, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.isPlatformManagedDb, dbType.name) } })
     }
 
     @Test
-    fun `createVNodeDbs sets ddlConnectionProvided to false when provided with DDL no DML connection - uses cluster DB, DDL ignored`() {
+    @Suppress("MaxLineLength")
+    fun `createVNodeDbs sets ddlConnectionProvided to false and isPlatformManagedDb to true when provided with DDL no DML connection - uses cluster DB, DDL ignored`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -231,6 +235,7 @@ class VirtualNodeDbFactoryImplTest {
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
         assertAll(dbs.map { (dbType, db) -> { assertFalse(db.ddlConnectionProvided, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
     }
 
     @Test

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -215,7 +215,7 @@ class VirtualNodeDbFactoryImplTest {
     }
 
     @Test
-    fun `createVNodeDbs sets connectionStringsProvided to true when provided with DDL no DML connection - uses cluster DB - DDL ignored`() {
+    fun `createVNodeDbs sets connectionStringsProvided to false when provided with DDL no DML connection - uses cluster DB - DDL ignored`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -230,7 +230,7 @@ class VirtualNodeDbFactoryImplTest {
 
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
-        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.connectionProvided, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.connectionProvided, dbType.name) } })
     }
 
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -177,7 +177,7 @@ class VirtualNodeDbFactoryImplTest {
     }
 
     @Test
-    fun `createVNodeDbs sets isPlatformManagedDb to true when provided with DML and DDL connection`() {
+    fun `createVNodeDbs sets connectionStringsProvided to true when provided with DML and DDL connection`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -192,11 +192,11 @@ class VirtualNodeDbFactoryImplTest {
 
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
-        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.connectionProvided, dbType.name) } })
     }
 
     @Test
-    fun `createVNodeDbs sets isPlatformManagedDb to false when provided with DML connection but no DDL connection`() {
+    fun `createVNodeDbs sets connectionStringsProvided to false when provided with DML connection but no DDL connection`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -211,11 +211,11 @@ class VirtualNodeDbFactoryImplTest {
 
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
-        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.isPlatformManagedDb, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.connectionProvided, dbType.name) } })
     }
 
     @Test
-    fun `createVNodeDbs sets isPlatformManagedDb to true when provided with DDL no DML connection - uses cluster DB - DDL ignored`() {
+    fun `createVNodeDbs sets connectionStringsProvided to true when provided with DDL no DML connection - uses cluster DB - DDL ignored`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -230,12 +230,12 @@ class VirtualNodeDbFactoryImplTest {
 
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
-        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.connectionProvided, dbType.name) } })
     }
 
 
     @Test
-    fun `createVNodeDbs sets isPlatformManagedDb to false when uniqueness is none`() {
+    fun `createVNodeDbs sets connectionStringsProvided to false when uniqueness is none`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -252,10 +252,10 @@ class VirtualNodeDbFactoryImplTest {
 
         // Uniqueness is set to false
         assertAll(dbs.filter { (dbType, _) -> dbType == VirtualNodeDbType.UNIQUENESS }
-            .map { (dbType, db) -> { assertFalse(db.isPlatformManagedDb, dbType.name) } })
+            .map { (dbType, db) -> { assertFalse(db.connectionProvided, dbType.name) } })
         // Other types are set to true
         assertAll(dbs.filter { (dbType, _) -> dbType != VirtualNodeDbType.UNIQUENESS }
-            .map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
+            .map { (dbType, db) -> { assertTrue(db.connectionProvided, dbType.name) } })
     }
 
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -177,7 +177,7 @@ class VirtualNodeDbFactoryImplTest {
     }
 
     @Test
-    fun `createVNodeDbs sets connectionStringsProvided to true when provided with DML and DDL connection`() {
+    fun `createVNodeDbs sets ddlConnectionProvided to true when provided with DML and DDL connection`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -192,11 +192,11 @@ class VirtualNodeDbFactoryImplTest {
 
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
-        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.connectionProvided, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertTrue(db.ddlConnectionProvided, dbType.name) } })
     }
 
     @Test
-    fun `createVNodeDbs sets connectionStringsProvided to false when provided with DML connection but no DDL connection`() {
+    fun `createVNodeDbs sets ddlConnectionProvided to false when provided with DML connection but no DDL connection`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -211,11 +211,11 @@ class VirtualNodeDbFactoryImplTest {
 
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
-        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.connectionProvided, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.ddlConnectionProvided, dbType.name) } })
     }
 
     @Test
-    fun `createVNodeDbs sets connectionStringsProvided to false when provided with DDL no DML connection - uses cluster DB, DDL ignored`() {
+    fun `createVNodeDbs sets ddlConnectionProvided to false when provided with DDL no DML connection - uses cluster DB, DDL ignored`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -230,11 +230,11 @@ class VirtualNodeDbFactoryImplTest {
 
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
-        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.connectionProvided, dbType.name) } })
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.ddlConnectionProvided, dbType.name) } })
     }
 
     @Test
-    fun `createVNodeDbs sets connectionStringsProvided to false when uniqueness is none`() {
+    fun `createVNodeDbs sets ddlConnectionProvided to false when uniqueness is none`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -251,10 +251,10 @@ class VirtualNodeDbFactoryImplTest {
 
         // Uniqueness is set to false
         assertAll(dbs.filter { (dbType, _) -> dbType == VirtualNodeDbType.UNIQUENESS }
-            .map { (dbType, db) -> { assertFalse(db.connectionProvided, dbType.name) } })
+            .map { (dbType, db) -> { assertFalse(db.ddlConnectionProvided, dbType.name) } })
         // Other types are set to true
         assertAll(dbs.filter { (dbType, _) -> dbType != VirtualNodeDbType.UNIQUENESS }
-            .map { (dbType, db) -> { assertTrue(db.connectionProvided, dbType.name) } })
+            .map { (dbType, db) -> { assertTrue(db.ddlConnectionProvided, dbType.name) } })
     }
 
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -158,7 +158,7 @@ class VirtualNodeDbFactoryImplTest {
     }
 
     @Test
-    fun `createVNodeDbs sets isPlatformManagedDb to true when using the cluster DB`() {
+    fun `createVNodeDbs sets ddlConnectionProvided to false and isPlatformManagedDb to true when using the cluster DB`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -173,6 +173,7 @@ class VirtualNodeDbFactoryImplTest {
 
         val dbs = impl.createVNodeDbs(ShortHash.of("1234123412341234"), request)
 
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.ddlConnectionProvided, dbType.name) } })
         assertAll(dbs.map { (dbType, db) -> { assertTrue(db.isPlatformManagedDb, dbType.name) } })
     }
 
@@ -239,7 +240,7 @@ class VirtualNodeDbFactoryImplTest {
     }
 
     @Test
-    fun `createVNodeDbs sets ddlConnectionProvided to false when uniqueness is none`() {
+    fun `createVNodeDbs sets ddlConnectionProvided and isPlatformManagedDb to false for uniqueness when uniqueness is none`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -260,6 +261,8 @@ class VirtualNodeDbFactoryImplTest {
         // Other types are set to true
         assertAll(dbs.filter { (dbType, _) -> dbType != VirtualNodeDbType.UNIQUENESS }
             .map { (dbType, db) -> { assertTrue(db.ddlConnectionProvided, dbType.name) } })
+        // isPlatformManagedDb is set to false
+        assertAll(dbs.map { (dbType, db) -> { assertFalse(db.isPlatformManagedDb, dbType.name) } })
     }
 
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -215,7 +215,7 @@ class VirtualNodeDbFactoryImplTest {
     }
 
     @Test
-    fun `createVNodeDbs sets connectionStringsProvided to false when provided with DDL no DML connection - uses cluster DB - DDL ignored`() {
+    fun `createVNodeDbs sets connectionStringsProvided to false when provided with DDL no DML connection - uses cluster DB, DDL ignored`() {
         val request = VirtualNodeCreateRequest(
             /* holdingId = */ mock(),
             /* cpiFileChecksum = */ "",
@@ -232,7 +232,6 @@ class VirtualNodeDbFactoryImplTest {
 
         assertAll(dbs.map { (dbType, db) -> { assertFalse(db.connectionProvided, dbType.name) } })
     }
-
 
     @Test
     fun `createVNodeDbs sets connectionStringsProvided to false when uniqueness is none`() {

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -210,7 +210,7 @@ class VirtualNodeDbImplTest {
 
     private fun createVirtualNodeDb(
         isPlatformManagedDb: Boolean,
-        connectionProvided: Boolean = false,
+        ddlConnectionProvided: Boolean = false,
         dbConnections: Map<DbPrivilege, DbConnection> = mapOf(
             DbPrivilege.DDL to ddlConnection,
             DbPrivilege.DML to dmlConnection,
@@ -218,7 +218,7 @@ class VirtualNodeDbImplTest {
     ): VirtualNodeDbImpl {
         return VirtualNodeDbImpl(
             isPlatformManagedDb,
-            connectionProvided,
+            ddlConnectionProvided,
             dbConnections,
             dbType,
             holdingIdShortHash,

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -210,6 +210,7 @@ class VirtualNodeDbImplTest {
 
     private fun createVirtualNodeDb(
         isPlatformManagedDb: Boolean,
+        ddlProvided: Boolean = false, // this is currently wrong
         dbConnections: Map<DbPrivilege, DbConnection> = mapOf(
             DbPrivilege.DDL to ddlConnection,
             DbPrivilege.DML to dmlConnection,
@@ -217,6 +218,7 @@ class VirtualNodeDbImplTest {
     ): VirtualNodeDbImpl {
         return VirtualNodeDbImpl(
             isPlatformManagedDb,
+            ddlProvided,
             dbConnections,
             dbType,
             holdingIdShortHash,

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -210,7 +210,7 @@ class VirtualNodeDbImplTest {
 
     private fun createVirtualNodeDb(
         isPlatformManagedDb: Boolean,
-        ddlProvided: Boolean = false, // this is currently wrong
+        connectionProvided: Boolean = false,
         dbConnections: Map<DbPrivilege, DbConnection> = mapOf(
             DbPrivilege.DDL to ddlConnection,
             DbPrivilege.DML to dmlConnection,
@@ -218,7 +218,7 @@ class VirtualNodeDbImplTest {
     ): VirtualNodeDbImpl {
         return VirtualNodeDbImpl(
             isPlatformManagedDb,
-            ddlProvided,
+            connectionProvided,
             dbConnections,
             dbType,
             holdingIdShortHash,


### PR DESCRIPTION
- Split `isPlatformManagedDb` into two separate flags to use the cluster db and for when the connection strings are specified