### PR TITLE
CORE-17300 Multi-SourceEventMediator - MessageBusConsumer 

### DIFF
--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -203,6 +203,20 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
         }
     }
 
+    override fun commitAsyncOffsets(callback: CordaConsumer.Callback?) {
+        dbAccess.writeOffsets(
+            lastReadOffset.map { (cordaTopicPartition, offset) ->
+                    CommittedPositionEntry(
+                        cordaTopicPartition.topic,
+                        groupId,
+                        cordaTopicPartition.partition,
+                        offset,
+                        ATOMIC_TRANSACTION,
+                    )
+                }
+        )
+    }
+
     override fun commitSyncOffsets(event: CordaConsumerRecord<K, V>, metaData: String?) {
         dbAccess.writeOffsets(
             listOf(

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -203,7 +203,7 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
         }
     }
 
-    override fun commitAsyncOffsets(callback: CordaConsumer.Callback?) {
+    override fun asyncCommitOffsets(callback: CordaConsumer.Callback?) {
         dbAccess.writeOffsets(
             lastReadOffset.map { (cordaTopicPartition, offset) ->
                     CommittedPositionEntry(
@@ -217,7 +217,7 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
         )
     }
 
-    override fun commitSyncOffsets(event: CordaConsumerRecord<K, V>, metaData: String?) {
+    override fun syncCommitOffsets(event: CordaConsumerRecord<K, V>, metaData: String?) {
         dbAccess.writeOffsets(
             listOf(
                 CommittedPositionEntry(

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -304,6 +304,17 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
         }
     }
 
+    override fun commitAsyncOffsets(callback: CordaConsumer.Callback?) {
+        consumer.commitAsync { offsets, exception ->
+            callback?.onCompletion(
+                offsets.entries.associate {
+                    it.key!!.toCordaTopicPartition(config.topicPrefix) to it.value.offset()
+                },
+                exception
+            )
+        }
+    }
+
     override fun commitSyncOffsets(event: CordaConsumerRecord<K, V>, metaData: String?) {
         val offsets = mutableMapOf<TopicPartition, OffsetAndMetadata>()
         val topicPartition = TopicPartition(config.topicPrefix + event.topic, event.partition)

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -304,7 +304,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
         }
     }
 
-    override fun commitAsyncOffsets(callback: CordaConsumer.Callback?) {
+    override fun asyncCommitOffsets(callback: CordaConsumer.Callback?) {
         consumer.commitAsync { offsets, exception ->
             callback?.onCompletion(
                 offsets.entries.associate {
@@ -315,7 +315,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
         }
     }
 
-    override fun commitSyncOffsets(event: CordaConsumerRecord<K, V>, metaData: String?) {
+    override fun syncCommitOffsets(event: CordaConsumerRecord<K, V>, metaData: String?) {
         val offsets = mutableMapOf<TopicPartition, OffsetAndMetadata>()
         val topicPartition = TopicPartition(config.topicPrefix + event.topic, event.partition)
         offsets[topicPartition] = OffsetAndMetadata(event.offset + 1, metaData)

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics
 import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.ChunkKey
 import net.corda.messagebus.api.CordaTopicPartition
+import net.corda.messagebus.api.consumer.CordaConsumer
 import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messagebus.api.consumer.CordaOffsetResetStrategy
@@ -24,6 +25,7 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
 import org.apache.kafka.clients.consumer.MockConsumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.clients.consumer.OffsetCommitCallback
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.AuthenticationException
@@ -43,6 +45,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -174,6 +177,36 @@ class CordaKafkaConsumerImplTest {
         cordaKafkaConsumer.close()
         verify(consumer, times(1)).close()
         verify(metricsBinder, times(1)).close()
+    }
+
+    @Test
+    fun testCommitAsyncOffsets() {
+        val callback = mock<CordaConsumer.Callback>()
+        assertThat(consumer.committed(setOf(partition))).isEmpty()
+
+        cordaKafkaConsumer.poll(Duration.ZERO)
+        cordaKafkaConsumer.commitAsyncOffsets(callback)
+
+        val committedPositionAfterPoll = consumer.committed(setOf(partition))
+        assertThat(committedPositionAfterPoll.values.first().offset()).isEqualTo(numberOfRecords)
+    }
+
+    @Test
+    fun testCommitAsyncOffsetsException() {
+        consumer = mock()
+        cordaKafkaConsumer = createConsumer(consumer)
+        val exception = CommitFailedException()
+        doAnswer {
+            val callback = it.arguments[0] as OffsetCommitCallback
+            callback.onComplete(mock(), exception)
+            null
+        }.whenever(consumer).commitAsync(any())
+        val callback = mock<CordaConsumer.Callback>()
+
+        cordaKafkaConsumer.commitAsyncOffsets(callback)
+
+        verify(consumer, times(1)).commitAsync(any())
+        verify(callback, times(1)).onCompletion(any(), eq(exception))
     }
 
     @Test

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -180,19 +180,19 @@ class CordaKafkaConsumerImplTest {
     }
 
     @Test
-    fun testCommitAsyncOffsets() {
+    fun testAsyncCommitOffsets() {
         val callback = mock<CordaConsumer.Callback>()
         assertThat(consumer.committed(setOf(partition))).isEmpty()
 
         cordaKafkaConsumer.poll(Duration.ZERO)
-        cordaKafkaConsumer.commitAsyncOffsets(callback)
+        cordaKafkaConsumer.asyncCommitOffsets(callback)
 
         val committedPositionAfterPoll = consumer.committed(setOf(partition))
         assertThat(committedPositionAfterPoll.values.first().offset()).isEqualTo(numberOfRecords)
     }
 
     @Test
-    fun testCommitAsyncOffsetsException() {
+    fun testAsyncCommitOffsetsException() {
         consumer = mock()
         cordaKafkaConsumer = createConsumer(consumer)
         val exception = CommitFailedException()
@@ -203,7 +203,7 @@ class CordaKafkaConsumerImplTest {
         }.whenever(consumer).commitAsync(any())
         val callback = mock<CordaConsumer.Callback>()
 
-        cordaKafkaConsumer.commitAsyncOffsets(callback)
+        cordaKafkaConsumer.asyncCommitOffsets(callback)
 
         verify(consumer, times(1)).commitAsync(any())
         verify(callback, times(1)).onCompletion(any(), eq(exception))
@@ -214,7 +214,7 @@ class CordaKafkaConsumerImplTest {
         val consumerRecord = CordaConsumerRecord(eventTopic, 1, 5L, "", "value", 0)
         assertThat(consumer.committed(setOf(partition))).isEmpty()
 
-        cordaKafkaConsumer.commitSyncOffsets(consumerRecord, "meta data")
+        cordaKafkaConsumer.syncCommitOffsets(consumerRecord, "meta data")
 
         val committedPositionAfterCommit = consumer.committed(setOf(partition))
         assertThat(committedPositionAfterCommit.values.first().offset()).isEqualTo(6)
@@ -228,7 +228,7 @@ class CordaKafkaConsumerImplTest {
         val consumerRecord = CordaConsumerRecord(eventTopic, 1, 5L, "", "value", 0)
         doThrow(CommitFailedException()).whenever(consumer).commitSync(anyMap())
         assertThatExceptionOfType(CordaMessageAPIFatalException::class.java).isThrownBy {
-            cordaKafkaConsumer.commitSyncOffsets(consumerRecord, "meta data")
+            cordaKafkaConsumer.syncCommitOffsets(consumerRecord, "meta data")
         }
         verify(consumer, times(1)).commitSync(anyMap())
     }

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
@@ -149,14 +149,14 @@ interface CordaConsumer<K : Any, V : Any> : AutoCloseable {
      * Asynchronously commit the consumer offsets.
      * @throws CordaMessageAPIFatalException fatal error occurred attempting to commit offsets.
      */
-    fun commitAsyncOffsets(callback: Callback?)
+    fun asyncCommitOffsets(callback: Callback?)
 
     /**
      * Synchronously commit the consumer offset for this [event] back to the topic partition.
      * Record [metaData] about this commit back on the [event] topic.
      * @throws CordaMessageAPIFatalException fatal error occurred attempting to commit offsets.
      */
-    fun commitSyncOffsets(event: CordaConsumerRecord<K, V>, metaData: String? = null)
+    fun syncCommitOffsets(event: CordaConsumerRecord<K, V>, metaData: String? = null)
 
     /**
      * Get metadata about the partitions for a given topic.

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
@@ -11,6 +11,13 @@ import java.time.Duration
 interface CordaConsumer<K : Any, V : Any> : AutoCloseable {
 
     /**
+     * Defines the callback for async commits.  If there was an exception it will be provided on this callback.
+     */
+    fun interface Callback {
+        fun onCompletion(offsets: Map<CordaTopicPartition, Long>, exception: Exception?)
+    }
+
+    /**
      * Subscribe to given [topics]. If not null, attach the rebalance [listener] to the [Consumer].
      * If a recoverable error occurs retry. If max retries is exceeded or a fatal error occurs then
      * a fatal exception is thrown.
@@ -137,6 +144,12 @@ interface CordaConsumer<K : Any, V : Any> : AutoCloseable {
      * @param offsetStrategy the strategy to apply when no last committed position exists
      */
     fun resetToLastCommittedPositions(offsetStrategy: CordaOffsetResetStrategy)
+
+    /**
+     * Asynchronously commit the consumer offsets.
+     * @throws CordaMessageAPIFatalException fatal error occurred attempting to commit offsets.
+     */
+    fun commitAsyncOffsets(callback: Callback?)
 
     /**
      * Synchronously commit the consumer offset for this [event] back to the topic partition.

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusConsumer.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusConsumer.kt
@@ -23,9 +23,9 @@ class MessageBusConsumer<K: Any, V: Any>(
     override fun poll(timeout: Duration): List<CordaConsumerRecord<K, V>> =
         consumer.poll(timeout)
 
-    override fun commitAsyncOffsets(): Deferred<Map<CordaTopicPartition, Long>> =
+    override fun asyncCommitOffsets(): Deferred<Map<CordaTopicPartition, Long>> =
         CompletableDeferred<Map<CordaTopicPartition, Long>>().apply {
-            consumer.commitAsyncOffsets { offsets, exception ->
+            consumer.asyncCommitOffsets { offsets, exception ->
                 if (exception != null) {
                     completeExceptionally(exception)
                 } else {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusConsumer.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusConsumer.kt
@@ -1,0 +1,42 @@
+package net.corda.messaging.mediator
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import net.corda.messagebus.api.CordaTopicPartition
+import net.corda.messagebus.api.consumer.CordaConsumer
+import net.corda.messagebus.api.consumer.CordaConsumerRecord
+import net.corda.messagebus.api.consumer.CordaOffsetResetStrategy
+import net.corda.messaging.api.mediator.MediatorConsumer
+import java.time.Duration
+
+/**
+ * Message bus consumer that reads messages from configured topic.
+ */
+class MessageBusConsumer<K: Any, V: Any>(
+    private val topic: String,
+    private val consumer: CordaConsumer<K, V>,
+): MediatorConsumer<K, V> {
+
+    override fun subscribe() =
+        consumer.subscribe(topic)
+
+    override fun poll(timeout: Duration): List<CordaConsumerRecord<K, V>> =
+        consumer.poll(timeout)
+
+    override fun commitAsyncOffsets(): Deferred<Map<CordaTopicPartition, Long>> =
+        CompletableDeferred<Map<CordaTopicPartition, Long>>().apply {
+            consumer.commitAsyncOffsets { offsets, exception ->
+                if (exception != null) {
+                    completeExceptionally(exception)
+                } else {
+                    complete(offsets)
+                }
+            }
+        }
+
+    override fun resetEventOffsetPosition() =
+        consumer.resetToLastCommittedPositions(CordaOffsetResetStrategy.EARLIEST)
+
+    override fun close() =
+        consumer.close()
+}

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
@@ -9,7 +9,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.times
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import java.time.Duration
 
 class MessageBusConsumerTest {

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
@@ -1,0 +1,80 @@
+package net.corda.messaging.mediator
+
+import kotlinx.coroutines.runBlocking
+import net.corda.messagebus.api.consumer.CordaConsumer
+import net.corda.messaging.api.mediator.MediatorMessage
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.times
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.time.Duration
+
+class MessageBusConsumerTest {
+    companion object {
+        private const val TOPIC = "topic"
+    }
+
+    private lateinit var cordaConsumer: CordaConsumer<String, String>
+    private lateinit var mediatorConsumer: MessageBusConsumer<String, String>
+
+    private val defaultHeaders: List<Pair<String, String>> = emptyList()
+    private val messageProps: MutableMap<String, Any> = mutableMapOf(
+        "topic" to "topic",
+        "key" to "key",
+        "headers" to defaultHeaders
+    )
+    private val message: MediatorMessage<Any> = MediatorMessage("value", messageProps)
+
+
+    @BeforeEach
+    fun setup() {
+        cordaConsumer = mock()
+        mediatorConsumer = MessageBusConsumer(TOPIC, cordaConsumer)
+    }
+
+    @Test
+    fun testSubscribe() {
+        mediatorConsumer.subscribe()
+
+        verify(cordaConsumer).subscribe(eq(TOPIC))
+    }
+
+    @Test
+    fun testPoll() {
+        val timeout = Duration.ofMillis(123)
+        mediatorConsumer.poll(timeout)
+
+        verify(cordaConsumer).poll(eq(timeout))
+    }
+
+    @Test
+    fun testCommitAsyncOffsets() {
+        mediatorConsumer.commitAsyncOffsets()
+
+        verify(cordaConsumer).commitAsyncOffsets(any())
+    }
+
+    @Test
+    fun testCommitAsyncOffsetsWithError() {
+        doReturn(CordaRuntimeException("")).whenever(cordaConsumer).commitAsyncOffsets(any())
+
+        assertThrows<CordaRuntimeException> {
+            runBlocking {
+                mediatorConsumer.commitAsyncOffsets().await()
+            }
+        }
+    }
+
+    @Test
+    fun testClose() {
+        mediatorConsumer.close()
+        verify(cordaConsumer, times(1)).close()
+    }
+}

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
@@ -57,18 +57,18 @@ class MessageBusConsumerTest {
 
     @Test
     fun testCommitAsyncOffsets() {
-        mediatorConsumer.commitAsyncOffsets()
+        mediatorConsumer.asyncCommitOffsets()
 
-        verify(cordaConsumer).commitAsyncOffsets(any())
+        verify(cordaConsumer).asyncCommitOffsets(any())
     }
 
     @Test
     fun testCommitAsyncOffsetsWithError() {
-        doThrow(CordaRuntimeException("")).whenever(cordaConsumer).commitAsyncOffsets(any())
+        doThrow(CordaRuntimeException("")).whenever(cordaConsumer).asyncCommitOffsets(any())
 
         assertThrows<CordaRuntimeException> {
             runBlocking {
-                mediatorConsumer.commitAsyncOffsets().await()
+                mediatorConsumer.asyncCommitOffsets().await()
             }
         }
     }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.times
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
@@ -7,13 +7,9 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.doThrow
 import org.mockito.Mockito.times
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import org.mockito.kotlin.*
 import java.time.Duration
 
 class MessageBusConsumerTest {
@@ -43,7 +39,7 @@ class MessageBusConsumerTest {
     fun testSubscribe() {
         mediatorConsumer.subscribe()
 
-        verify(cordaConsumer).subscribe(eq(TOPIC))
+        verify(cordaConsumer).subscribe(eq(TOPIC), anyOrNull())
     }
 
     @Test
@@ -63,7 +59,7 @@ class MessageBusConsumerTest {
 
     @Test
     fun testCommitAsyncOffsetsWithError() {
-        doReturn(CordaRuntimeException("")).whenever(cordaConsumer).commitAsyncOffsets(any())
+        doThrow(CordaRuntimeException("")).whenever(cordaConsumer).commitAsyncOffsets(any())
 
         assertThrows<CordaRuntimeException> {
             runBlocking {

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MediatorConsumer.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MediatorConsumer.kt
@@ -1,0 +1,36 @@
+package net.corda.messaging.api.mediator
+
+import kotlinx.coroutines.Deferred
+import net.corda.messagebus.api.CordaTopicPartition
+import net.corda.messagebus.api.consumer.CordaConsumerRecord
+import java.time.Duration
+
+/**
+ * Multi-source event mediator message consumer.
+ */
+interface MediatorConsumer<K : Any, V : Any> : AutoCloseable {
+
+    /**
+     * Subscribes to a message bus.
+     */
+    fun subscribe()
+
+    /**
+     * Poll messages from the consumer with a [timeout].
+     *
+     * @param timeout - The maximum time to block if there are no available messages.
+     */
+    fun poll(timeout: Duration): List<CordaConsumerRecord<K, V>>
+
+    /**
+     * Asynchronously commit the consumer offsets.
+     *
+     * @return [CompletableFuture] with committed offsets.
+     */
+    fun commitAsyncOffsets(): Deferred<Map<CordaTopicPartition, Long>>
+
+    /**
+     * Resets consumer's offsets to the last committed positions.
+     */
+    fun resetEventOffsetPosition()
+}

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MediatorConsumer.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MediatorConsumer.kt
@@ -23,14 +23,14 @@ interface MediatorConsumer<K : Any, V : Any> : AutoCloseable {
     fun poll(timeout: Duration): List<CordaConsumerRecord<K, V>>
 
     /**
-     * Asynchronously commit the consumer offsets.
+     * Asynchronously commit the consumer offsets. This function should be called only after `poll` was called.
      *
-     * @return [CompletableFuture] with committed offsets.
+     * @return [Deferred] with committed offsets.
      */
-    fun commitAsyncOffsets(): Deferred<Map<CordaTopicPartition, Long>>
+    fun asyncCommitOffsets(): Deferred<Map<CordaTopicPartition, Long>>
 
     /**
-     * Resets consumer's offsets to the last committed positions.
+     * Resets consumer's offsets to the last committed positions. Next poll will read from the last committed positions.
      */
     fun resetEventOffsetPosition()
 }


### PR DESCRIPTION
As part of the multi-source event mediator implementation we will have a new type of consumer which should be able to poll messages from different endpoints (from Kafka topics, as of today). This change introduces `MediatorConsumer` interface and `MessageBusConsumer` that implements it.