### PR TITLE
CORE-17276 Refactor DB bootstrap into two containers

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -139,62 +139,201 @@ spec:
       securityContext:
         {{- . | toYaml | nindent 8 }}
       {{- end }}
-      containers:
-        - name: fin
+      initContainers:
+        - name: generate
           image: {{ include "corda.bootstrapCliImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          command:
-            - /bin/bash
-            - -e
-            - -c
-          args: ["echo", "'DB Bootstrapped'"]
+          command: [ 'sh', '-c', '-e' ]
+          args:
+            - |
+              #!/bin/sh
+
+              set -ev
+
+              JDBC_URL="jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}"
+
+              echo 'Generating DB specification'
+              mkdir /tmp/db
+              java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar database spec \
+                -g "config:${DB_CLUSTER_SCHEMA},rbac:${DB_RBAC_SCHEMA},crypto:${DB_CRYPTO_SCHEMA},stateManager:${DB_STATE_MANAGER_SCHEMA}" \
+                -u "${PGUSER}" -p "${PGPASSWORD}" \
+                --jdbc-url "${JDBC_URL}" \
+                -c -l /tmp/db
+
+              echo 'Generating RBAC initial DB configuration'
+              mkdir /tmp/rbac
+              java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar initial-config create-db-config \
+                -u "${RBAC_DB_USER_USERNAME}" -p "${RBAC_DB_USER_PASSWORD}" \
+                --name "corda-rbac" \
+                --jdbc-url "${JDBC_URL}?currentSchema=${DB_RBAC_SCHEMA}" \
+                --jdbc-pool-max-size {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }} \
+              {{- with .Values.bootstrap.db.rbac.dbConnectionPool.minSize }}
+                --jdbc-pool-min-size {{ . | quote }}
+              {{- end }}
+                ${DB_RBAC_MIN_POOL_SIZE_ARGS} \
+                --idle-timeout {{ .Values.bootstrap.db.rbac.dbConnectionPool.idleTimeoutSeconds | quote }} \
+                --max-lifetime {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxLifetimeSeconds | quote }} \
+                --keepalive-time {{ .Values.bootstrap.db.rbac.dbConnectionPool.keepaliveTimeSeconds | quote }} \
+                --validation-timeout {{ .Values.bootstrap.db.rbac.dbConnectionPool.validationTimeoutSeconds | quote }} \
+              {{- if (((.Values).config).vault).url }}
+                -t "VAULT" --vault-path "dbsecrets" --key "rbac-db-password" \
+              {{- else }}
+                --salt "${SALT}" --passphrase "${PASSPHRASE}" \
+              {{- end }}
+                -l /tmp/rbac
+
+              echo 'Generating virtual nodes initial DB configuration'
+              mkdir /tmp/vnodes
+              java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar initial-config create-db-config \
+                -a -u "${DB_CLUSTER_USERNAME}" -p "${DB_CLUSTER_PASSWORD}" \
+                --name "corda-virtual-nodes" \
+                --jdbc-url "${JDBC_URL}" \
+                --jdbc-pool-max-size {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }} \
+              {{- with .Values.bootstrap.db.rbac.dbConnectionPool.minSize }}
+                --jdbc-pool-min-size {{ . | quote }}
+              {{- end }}
+                ${DB_RBAC_MIN_POOL_SIZE_ARGS} \
+                --idle-timeout {{ .Values.bootstrap.db.rbac.dbConnectionPool.idleTimeoutSeconds | quote }} \
+                --max-lifetime {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxLifetimeSeconds | quote }} \
+                --keepalive-time {{ .Values.bootstrap.db.rbac.dbConnectionPool.keepaliveTimeSeconds | quote }} \
+                --validation-timeout {{ .Values.bootstrap.db.rbac.dbConnectionPool.validationTimeoutSeconds | quote }} \
+              {{- if (((.Values).config).vault).url }}
+                -t "VAULT" --vault-path "dbsecrets" --key "vnodes-db-password" \
+              {{- else }}
+                --salt "${SALT}" --passphrase "${PASSPHRASE}" \
+              {{- end }}
+                -l /tmp/vnodes
+
+              echo 'Generating crypto initial DB configuration'
+              mkdir /tmp/crypto
+              java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar initial-config create-db-config \
+                -u "${CRYPTO_DB_USER_USERNAME}" -p "${CRYPTO_DB_USER_PASSWORD}" \
+                --name "corda-crypto" \
+                --jdbc-url "${JDBC_URL}?currentSchema=${DB_CRYPTO_SCHEMA}" \
+                --jdbc-pool-max-size {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxSize | quote }} \
+              {{- with .Values.bootstrap.db.crypto.dbConnectionPool.minSize }}
+                --jdbc-pool-min-size {{ . | quote }}
+              {{- end }}
+                ${DB_RBAC_MIN_POOL_SIZE_ARGS} \
+                --idle-timeout {{ .Values.bootstrap.db.crypto.dbConnectionPool.idleTimeoutSeconds | quote }} \
+                --max-lifetime {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxLifetimeSeconds | quote }} \
+                --keepalive-time {{ .Values.bootstrap.db.crypto.dbConnectionPool.keepaliveTimeSeconds | quote }} \
+                --validation-timeout {{ .Values.bootstrap.db.crypto.dbConnectionPool.validationTimeoutSeconds | quote }} \
+              {{- if (((.Values).config).vault).url }}
+                -t "VAULT" --vault-path "dbsecrets" --key "crypto-db-password" \
+              {{- else }}
+                --salt "${SALT}" --passphrase "${PASSPHRASE}" \
+              {{- end }}
+                $CRYPTO_ENCRYPTION_ARGS \
+                -l /tmp/crypto
+
+              echo 'Generating REST API user initial configuration'
+              java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar initial-config create-user-config \
+                -u "${REST_API_ADMIN_USERNAME}" -p "${REST_API_ADMIN_PASSWORD}" \
+                -l /tmp
+
+              echo 'Generating crypto initial configuration'
+              java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar initial-config create-crypto-config \
+                --salt "${SALT}" --passphrase "${PASSPHRASE}" \
+              {{- if (((.Values).config).vault).url }}
+                -t "VAULT" --vault-path "cryptosecrets" -ks "salt" -kp "passphrase" \
+              {{- end }}
+                -l /tmp
           workingDir: /tmp
           volumeMounts:
             - mountPath: /tmp
               name: temp
-      initContainers:
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "db" "Values" .Values "Chart" .Chart "Release" .Release "schema" "RBAC" "namePostfix" "schemas" "sequenceNumber" 1) | nindent 8 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "rbac" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "RBAC_DB_USER" "schema" "RBAC" "sequenceNumber" 3) | nindent 8 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "vnodes" "longName" "virtual-nodes" "dbName" "rbac" "admin" "true" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "DB_CLUSTER" "sequenceNumber" 5) | nindent 8 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto" "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "CRYPTO_DB_USER"  "schema" "CRYPTO" "sequenceNumber" 7) | nindent 8 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "rest"  "Values" .Values "Chart" .Chart "Release" .Release "environmentVariablePrefix" "REST_API_ADMIN"  "schema" "RBAC"  "searchPath" "RBAC" "subCommand" "create-user-config" "namePostfix" "admin" "sqlFile" "rbac-config.sql" "sequenceNumber" 9) | nindent 8 }}
-        - name: 11-create-db-users-and-grant
+            {{- include "corda.log4jVolumeMount" . | nindent 12 }}
+          env:
+            - name: DB_CLUSTER_SCHEMA
+              value: {{ .Values.db.cluster.schema | quote }}
+            - name: DB_RBAC_SCHEMA
+              value: {{ .Values.bootstrap.db.rbac.schema | quote }}
+            - name: DB_CRYPTO_SCHEMA
+              value: {{ .Values.bootstrap.db.crypto.schema | quote }}
+            - name: DB_STATE_MANAGER_SCHEMA
+              value: {{ .Values.bootstrap.db.stateManager.schema | quote }}
+            {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
+            {{- include "corda.configSaltAndPassphraseEnv" . | nindent 12 }}
+            {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
+            {{- include "corda.rbacDbUserEnv" . | nindent 12 }}
+            {{- include "corda.clusterDbEnv" . | nindent 12 }}
+            {{- include "corda.restApiAdminSecretEnv" . | nindent 12 }}
+            {{- include "corda.cryptoDbUserEnv" . | nindent 12 }}
+      containers:
+        - name: apply
           image: {{ include "corda.bootstrapDbClientImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          command: [ '/bin/bash', '-e', '-c' ]
+          command: [ 'sh', '-c', '-e' ]
           args:
             - |
-              psql -v ON_ERROR_STOP=1 -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} {{ include "corda.clusterDbName" . }} << SQL
-                GRANT USAGE ON SCHEMA {{ .Values.db.cluster.schema }} TO "$DB_CLUSTER_USERNAME";
-                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA {{ .Values.db.cluster.schema }} TO "$DB_CLUSTER_USERNAME";
-                GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA {{ .Values.db.cluster.schema }} TO "$DB_CLUSTER_USERNAME";
-                DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$RBAC_DB_USER_USERNAME') THEN RAISE NOTICE 'Role "$RBAC_DB_USER_USERNAME" already exists'; ELSE CREATE USER "$RBAC_DB_USER_USERNAME" WITH ENCRYPTED PASSWORD '$RBAC_DB_USER_PASSWORD'; END IF; END \$\$;
-                GRANT USAGE ON SCHEMA {{ .Values.bootstrap.db.rbac.schema }} TO "$RBAC_DB_USER_USERNAME";
-                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA {{ .Values.bootstrap.db.rbac.schema }} TO "$RBAC_DB_USER_USERNAME";
-                DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$CRYPTO_DB_USER_USERNAME') THEN RAISE NOTICE 'Role "$CRYPTO_DB_USER_USERNAME" already exists'; ELSE CREATE USER "$CRYPTO_DB_USER_USERNAME" WITH ENCRYPTED PASSWORD '$CRYPTO_DB_USER_PASSWORD'; END IF; END \$\$;
-                GRANT USAGE ON SCHEMA {{ .Values.bootstrap.db.crypto.schema }} TO "$CRYPTO_DB_USER_USERNAME";
-                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA {{ .Values.bootstrap.db.crypto.schema }} TO "$CRYPTO_DB_USER_USERNAME";
+              #!/bin/sh
+
+              set -ev
+
+              echo 'Applying DB specification'
+              for f in /tmp/db/*.sql; do
+                psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -f "$f" --dbname "${DB_CLUSTER_NAME}"
+              done
+
+              echo 'Applying RBAC initial DB configuration'
+              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -f /tmp/rbac/db-config.sql --dbname "dbname=${DB_CLUSTER_NAME} options=--search_path=${DB_CLUSTER_SCHEMA}"
+
+              echo 'Applying virtual nodes initial DB configuration'
+              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -f /tmp/vnodes/db-config.sql --dbname "dbname=${DB_CLUSTER_NAME} options=--search_path=${DB_CLUSTER_SCHEMA}"
+
+              echo 'Applying crypto initial DB configuration'
+              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -f /tmp/crypto/db-config.sql --dbname "dbname=${DB_CLUSTER_NAME} options=--search_path=${DB_CLUSTER_SCHEMA}"
+
+              echo 'Applying REST API user initial configuration'
+              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -f /tmp/rbac-config.sql --dbname "dbname=${DB_CLUSTER_NAME} options=--search_path=${DB_RBAC_SCHEMA}"
+
+              echo 'Creating users and granting permissions'
+              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" "${DB_CLUSTER_NAME}" << SQL
+                GRANT USAGE ON SCHEMA ${DB_CLUSTER_SCHEMA} TO "${DB_CLUSTER_USERNAME}";
+                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_CLUSTER_SCHEMA} TO "${DB_CLUSTER_USERNAME}";
+                GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA ${DB_CLUSTER_SCHEMA} TO "${DB_CLUSTER_USERNAME}";
+                DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${RBAC_DB_USER_USERNAME}') THEN RAISE NOTICE 'Role "${RBAC_DB_USER_USERNAME}" already exists'; ELSE CREATE USER "${RBAC_DB_USER_USERNAME}" WITH ENCRYPTED PASSWORD '${RBAC_DB_USER_PASSWORD}'; END IF; END \$\$;
+                GRANT USAGE ON SCHEMA ${DB_RBAC_SCHEMA} TO "$RBAC_DB_USER_USERNAME";
+                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_RBAC_SCHEMA} TO "$RBAC_DB_USER_USERNAME";
+                DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${CRYPTO_DB_USER_USERNAME}') THEN RAISE NOTICE 'Role "${CRYPTO_DB_USER_USERNAME}" already exists'; ELSE CREATE USER "${CRYPTO_DB_USER_USERNAME}" WITH ENCRYPTED PASSWORD '$CRYPTO_DB_USER_PASSWORD'; END IF; END \$\$;
+                GRANT USAGE ON SCHEMA ${DB_CRYPTO_SCHEMA} TO "${CRYPTO_DB_USER_USERNAME}";
+                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_CRYPTO_SCHEMA} TO "${CRYPTO_DB_USER_USERNAME}";
               SQL
+
+              echo 'Applying crypto initial configuration'
+              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -f /tmp/crypto-config.sql --dbname "dbname=${DB_CLUSTER_NAME} options=--search_path=${DB_CLUSTER_SCHEMA}"
+
+              echo 'DB Bootstrapped'
           volumeMounts:
             - mountPath: /tmp
               name: temp
           env:
-          {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
-          {{- include "corda.rbacDbUserEnv" . | nindent 12 }}
-          {{- include "corda.cryptoDbUserEnv" . | nindent 12 }}
-          {{- include "corda.clusterDbEnv" . | nindent 12 }}
-        {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto-config" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql" "sequenceNumber" 12) | nindent 8 }}
+            - name: DB_CLUSTER_HOST
+              value: {{ required "A db host is required" .Values.db.cluster.host | quote }}
+            - name: DB_CLUSTER_PORT
+              value: {{ include "corda.clusterDbPort" . | quote }}
+            - name: DB_CLUSTER_NAME
+              value: {{ include "corda.clusterDbName" . | quote }}
+            - name: DB_CLUSTER_SCHEMA
+              value: {{ .Values.db.cluster.schema | quote }}
+            - name: DB_RBAC_SCHEMA
+              value: {{ .Values.bootstrap.db.rbac.schema | quote }}
+            - name: DB_CRYPTO_SCHEMA
+              value: {{ .Values.bootstrap.db.crypto.schema | quote }}
+            {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
+            {{- include "corda.rbacDbUserEnv" . | nindent 12 }}
+            {{- include "corda.cryptoDbUserEnv" . | nindent 12 }}
+            {{- include "corda.clusterDbEnv" . | nindent 12 }}
       volumes:
         - name: temp
           emptyDir: {}
-        {{ include "corda.log4jVolume" . | nindent 8 }}
-
-      {{- include "corda.bootstrapNodeSelector" . | nindent 6 }}
-
+        {{- include "corda.log4jVolume" . | nindent 8 }}
+      {{- include "corda.bootstrapNodeSelector" . | indent 6 }}
       restartPolicy: Never
   backoffLimit: 0
 {{- end }}
@@ -495,100 +634,4 @@ Bootstrap Corda CLI environment variables
   value: {{ .Values.logging.level }}
 - name: CORDA_CLI_HOME_DIR
   value: "/tmp"
-{{- end }}
-
-
-{{/*
-Bootstrap declaration to declare an initial container for running corda-cli initial-config, then
-a second init container to execute the output SQL to the relevant database
-*/}}
-
-{{- define "corda.generateAndExecuteSql" -}}
-{{- /* define 2 init containers, which run in sequence. First run corda-cli initial-config to generate some SQL, storing in a persistent volume called working-volume. Second is a postgres image which mounts the same persistent volume and executes the SQL. */ -}}
-- name: {{ printf "%02d-create-%s" .sequenceNumber .name }}
-  image: {{ include "corda.bootstrapCliImage" . }}
-  imagePullPolicy: {{ .Values.imagePullPolicy }}
-  {{- include "corda.bootstrapResources" . | nindent 2 }}
-  {{- include "corda.containerSecurityContext" . | nindent 2 }}
-  {{- if eq .name "db" }}
-  args: [ 'database', 'spec', '-g', 'config:{{ .Values.db.cluster.schema }},rbac:{{ .Values.bootstrap.db.rbac.schema }},crypto:{{ .Values.bootstrap.db.crypto.schema }},stateManager:{{ .Values.bootstrap.db.stateManager.schema }}', '-c', '-l', '/tmp', '--jdbc-url', 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}', '-u', $(PGUSER), '-p', $(PGPASSWORD) ]
-  {{- else }}
-  args: [ 'initial-config', '{{ .subCommand | default "create-db-config" }}',{{ " " -}}
-
-         {{- /* request admin access in some cases, only when the optional admin argument to this function (named template) is specified as true */ -}}
-         {{- if eq .admin "true" -}} '-a',{{- end -}}
-
-         {{- if and (not (eq .name "db")) (not (eq .name "crypto-config")) -}}
-           {{- /* specify DB user */ -}}
-           {{- "'-u'" -}}, '$({{ .environmentVariablePrefix -}}_USERNAME)',
-
-           {{- /* specify DB password */ -}}
-           {{- " '-p'" -}}, '$({{ .environmentVariablePrefix -}}_PASSWORD)',
-         {{- end -}}
-
-         {{- if and (not (eq .name "rest")) (not (eq .subCommand "create-crypto-config")) -}}
-             {{- " '--name'" -}}, 'corda-{{ .longName | default .name }}',
-             {{- " '--jdbc-url'" -}}, 'jdbc:{{ include "corda.clusterDbType" . }}://{{ required "A db host is required" .Values.db.cluster.host }}:{{ include "corda.clusterDbPort" . }}/{{ include "corda.clusterDbName" . }}{{- if .schema }}?currentSchema={{.schema }}{{- end -}}',
-             {{- " '--jdbc-pool-max-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxSize | quote }},
-             {{- if not (kindIs "invalid" (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize) -}}
-                {{- " '--jdbc-pool-min-size'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.minSize | quote }},
-             {{- end -}}
-             {{- " '--idle-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.idleTimeoutSeconds | quote }},
-             {{- " '--max-lifetime'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.maxLifetimeSeconds | quote }},
-             {{- " '--keepalive-time'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.keepaliveTimeSeconds | quote }},
-             {{- " '--validation-timeout'" -}}, {{ (index .Values.bootstrap.db (.dbName | default .name)).dbConnectionPool.validationTimeoutSeconds | quote }}, {{- " " -}}
-         {{- end -}}
-
-         {{- if not (eq .name "rest") -}}
-           {{- if and (((.Values).config).vault).url  (not (eq .name "crypto-config")) -}}
-             '-t', 'VAULT', '--vault-path', 'dbsecrets', '--key', {{ (printf "%s-db-password" .name)| quote }},
-           {{- else -}}
-             {{- /* using encryption secrets service, so provide its salt and passphrase */ -}}
-             '--salt', "$(SALT)", '--passphrase', "$(PASSPHRASE)",
-           {{- end -}}
-         {{- end -}}
-
-         {{- if and (eq .name "crypto-config") (((.Values).config).vault).url  -}}
-            {{- /* when configuring the crypto service and using Vault then specify where to find the wrapping key salt and passphrase in Vault */ -}}
-            '-t', 'VAULT', '--vault-path', 'cryptosecrets', '-ks', 'salt', '-kp', 'passphrase',
-         {{- end -}}
-
-         {{- " '-l'" -}}, '/tmp']
-   {{- end }}
-  workingDir: /tmp
-  volumeMounts:
-    - mountPath: /tmp
-      name: temp
-    {{- include "corda.log4jVolumeMount" . | nindent 4 }}
-  env:
-    {{- if eq .name "db" -}}
-      {{- include "corda.bootstrapClusterDbEnv" . | nindent 4 }}
-    {{- end -}}
-    {{- if and (not (eq .name "rest")) (not (eq .name "db")) -}}
-      {{- include "corda.configSaltAndPassphraseEnv" . | nindent 4 -}}
-    {{- end -}}
-    {{- include "corda.bootstrapCliEnv" . | nindent 4 -}}{{- /* set JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
-    {{- if or (eq .name "rbac") (eq .name "vnodes") }}
-    {{- include "corda.rbacDbUserEnv" . | nindent 4 }}
-    {{- end -}}
-    {{- if eq .name "vnodes" -}}
-      {{- include "corda.clusterDbEnv" . | nindent 4 -}}
-    {{- end -}}
-    {{- if eq .name "rest" -}}
-      {{- include "corda.restApiAdminSecretEnv" . | nindent 4 }}
-    {{- end -}}
-    {{- if eq .environmentVariablePrefix "CRYPTO_DB_USER" -}}
-      {{- include "corda.cryptoDbUserEnv" . | nindent 4 -}}
-    {{- end }}
-- name: {{ printf "%02d-apply-%s" (add .sequenceNumber 1) .name }}
-  image: {{ include "corda.bootstrapDbClientImage" . }}
-  imagePullPolicy: {{ .Values.imagePullPolicy }}
-  {{- include "corda.bootstrapResources" . | nindent 2 }}
-  {{- include "corda.containerSecurityContext" . | nindent 2 }}
-  command: [ 'sh', '-c', '-e',{{- if eq .name "db" }} 'for f in /tmp/*.sql; do psql -v ON_ERROR_STOP=1 -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f "$f" --dbname {{ include "corda.clusterDbName" . }}; done'{{- else }} 'psql -v ON_ERROR_STOP=1 -h {{ required "A db host is required" .Values.db.cluster.host }} -p {{ include "corda.clusterDbPort" . }} -f /tmp/{{ .sqlFile | default "db-config.sql" }} --dbname "dbname={{ include "corda.clusterDbName" . }} options=--search_path={{ .searchPath | default .Values.db.cluster.schema }}"' {{- end }} ]
-  volumeMounts:
-    - mountPath: /tmp
-      name: temp
-  env:
-  {{- include "corda.bootstrapClusterDbEnv" . | nindent 4 }}
 {{- end }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -67,12 +67,12 @@ spec:
       labels:
         {{- include "corda.selectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.imagePullSecrets" . | nindent 6 }}
+      {{- include "corda.imagePullSecrets" . | indent 6 }}
       {{- include "corda.tolerations" . | nindent 6 }}
       serviceAccountName: {{ include "corda.bootstrapPreinstallServiceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: preinstall-checks
@@ -132,12 +132,12 @@ spec:
       labels:
         {{- include "corda.selectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.tolerations" $ | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.imagePullSecrets" . | indent 6 }}
+      {{- include "corda.tolerations" $ | indent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | indent 6 }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: fin
@@ -184,8 +184,8 @@ spec:
               name: temp
           env:
           {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
-          {{ include "corda.rbacDbUserEnv" . | nindent 12 }}
-          {{ include "corda.cryptoDbUserEnv" . | nindent 12 }}
+          {{- include "corda.rbacDbUserEnv" . | nindent 12 }}
+          {{- include "corda.cryptoDbUserEnv" . | nindent 12 }}
           {{- include "corda.clusterDbEnv" . | nindent 12 }}
         {{- include "corda.generateAndExecuteSql" ( dict "name" "crypto-config" "subCommand" "create-crypto-config" "Values" .Values "Chart" .Chart "Release" .Release "schema" "CRYPTO" "namePostfix" "worker-config" "sqlFile" "crypto-config.sql" "sequenceNumber" 12) | nindent 8 }}
       volumes:
@@ -220,12 +220,12 @@ spec:
       labels:
         {{- include "corda.selectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.tolerations" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.imagePullSecrets" . | indent 6 }}
+      {{- include "corda.tolerations" . | indent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | indent 6 }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: create-topics
@@ -261,9 +261,9 @@ spec:
               name: certs
               readOnly: true
             {{- end }}
-            {{ include "corda.log4jVolumeMount" . | nindent 12 }}
+            {{- include "corda.log4jVolumeMount" . | nindent 12 }}
           env:
-            {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
+            {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
             {{- if .Values.kafka.sasl.enabled }}
               {{- range $k, $v := .Values.workers }}
             - name: {{ ( printf "KAFKA_SASL_USERNAME_%s" ( include "corda.workerTypeUpperSnakeCase" $k )) | quote }}
@@ -291,8 +291,8 @@ spec:
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
           env:
-          {{- include "corda.bootstrapKafkaSaslUsernameAndPasswordEnv" . | nindent 12 }}
-          {{- include "corda.kafkaTlsPassword" . | nindent 12 }}
+          {{- include "corda.bootstrapKafkaSaslUsernameAndPasswordEnv" . | indent 12 }}
+          {{- include "corda.kafkaTlsPassword" . | indent 12 }}
           command:
             - /bin/bash
             - -c
@@ -339,9 +339,9 @@ spec:
               - key: {{ .Values.kafka.tls.truststore.valueFrom.secretKeyRef.key | quote }}
                 path: ca.crt
         {{- end }}
-        {{ include "corda.log4jVolume" . | nindent 8 }}
+        {{- include "corda.log4jVolume" . | nindent 8 }}
       restartPolicy: Never
-      {{- include "corda.bootstrapNodeSelector" . | nindent 6 }}
+      {{- include "corda.bootstrapNodeSelector" . | indent 6 }}
   backoffLimit: 0
 {{- end }}
 {{- end }}
@@ -366,12 +366,12 @@ spec:
       labels:
         {{- include "corda.selectorLabels" . | nindent 8 }}
     spec:
-      {{- include "corda.imagePullSecrets" . | nindent 6 }}
-      {{- include "corda.tolerations" . | nindent 6 }}
-      {{- include "corda.bootstrapServiceAccount" . | nindent 6 }}
+      {{- include "corda.imagePullSecrets" . | indent 6 }}
+      {{- include "corda.tolerations" . | indent 6 }}
+      {{- include "corda.bootstrapServiceAccount" . | indent 6 }}
       {{- with .Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: create-rbac-role-user-admin
@@ -385,10 +385,10 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: temp
-            {{ include "corda.log4jVolumeMount" . | nindent 12 }}
+            {{- include "corda.log4jVolumeMount" . | nindent 12 }}
           env:
-            {{ include "corda.restApiAdminSecretEnv" . | nindent 12 }}
-            {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
+            {{- include "corda.restApiAdminSecretEnv" . | nindent 12 }}
+            {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
         - name: create-rbac-role-vnode-creator
           image: {{ include "corda.bootstrapCliImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -400,10 +400,10 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: temp
-            {{ include "corda.log4jVolumeMount" . | nindent 12 }}
+            {{- include "corda.log4jVolumeMount" . | nindent 12 }}
           env:
-            {{ include "corda.restApiAdminSecretEnv" . | nindent 12 }}
-            {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
+            {{- include "corda.restApiAdminSecretEnv" . | nindent 12 }}
+            {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
         - name: create-rbac-role-corda-dev
           image: {{ include "corda.bootstrapCliImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -415,15 +415,15 @@ spec:
           volumeMounts:
             - mountPath: /tmp
               name: temp
-            {{ include "corda.log4jVolumeMount" . | nindent 12 }}
+            {{- include "corda.log4jVolumeMount" . | nindent 12 }}
           env:
-            {{ include "corda.restApiAdminSecretEnv" . | nindent 12 }}
-            {{ include "corda.bootstrapCliEnv" . | nindent 12 }}
-      {{- include "corda.bootstrapNodeSelector" . | nindent 6 }}
+            {{- include "corda.restApiAdminSecretEnv" . | nindent 12 }}
+            {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
+      {{- include "corda.bootstrapNodeSelector" . | indent 6 }}
       volumes:
         - name: temp
           emptyDir: {}
-        {{ include "corda.log4jVolume" . | nindent 8 }}
+        {{- include "corda.log4jVolume" . | nindent 8 }}
       restartPolicy: Never
   backoffLimit: 0
 {{- end }}
@@ -446,7 +446,7 @@ Bootstrap DB client image
 {{/*
 Bootstrap resources
 */}}
-{{- define "corda.bootstrapResources" }}
+{{- define "corda.bootstrapResources" -}}
 resources:
   requests:
   {{- with .Values.bootstrap.resources.requests.cpu }}
@@ -467,7 +467,7 @@ resources:
 {{/*
 Bootstrap node selector
 */}}
-{{- define "corda.bootstrapNodeSelector" }}
+{{- define "corda.bootstrapNodeSelector" -}}
 {{- with .Values.bootstrap.nodeSelector | default .Values.nodeSelector }}
 nodeSelector:
   {{- toYaml . | nindent 2 }}
@@ -477,7 +477,7 @@ nodeSelector:
 {{/*
 Bootstrap service account
 */}}
-{{- define "corda.bootstrapServiceAccount" }}
+{{- define "corda.bootstrapServiceAccount" -}}
 {{- with .Values.bootstrap.serviceAccount.name | default .Values.serviceAccount.name }}
 serviceAccountName: {{ . }}
 {{- end }}
@@ -559,29 +559,20 @@ a second init container to execute the output SQL to the relevant database
   volumeMounts:
     - mountPath: /tmp
       name: temp
-    {{ include "corda.log4jVolumeMount" . | nindent 4 }}
+    {{- include "corda.log4jVolumeMount" . | nindent 4 }}
   env:
     {{- if eq .name "db" -}}
       {{- include "corda.bootstrapClusterDbEnv" . | nindent 4 }}
     {{- end -}}
-    {{- if or (eq .name "rest") (eq .name "rbac") (eq .name "vnodes") (eq .name "crypto") -}}
-       {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
-    {{- end -}}
     {{- if and (not (eq .name "rest")) (not (eq .name "db")) -}}
-      {{ include "corda.configSaltAndPassphraseEnv" . | nindent 4 -}}
+      {{- include "corda.configSaltAndPassphraseEnv" . | nindent 4 -}}
     {{- end -}}
-    {{- if or (eq .name "rbac") (eq .name "crypto") (eq .name "vnodes") (eq .name "db") -}}
-       {{- "\n    " -}} {{- /* legacy whitespace compliance */ -}}
-    {{- end -}}
-
     {{- include "corda.bootstrapCliEnv" . | nindent 4 -}}{{- /* set JAVA_TOOL_OPTIONS, CONSOLE_LOG*, CORDA_CLI_HOME_DIR */ -}}
-
     {{- if or (eq .name "rbac") (eq .name "vnodes") }}
-    {{ include "corda.rbacDbUserEnv" . | nindent 4 }}
+    {{- include "corda.rbacDbUserEnv" . | nindent 4 }}
     {{- end -}}
-
     {{- if eq .name "vnodes" -}}
-      {{ include "corda.clusterDbEnv" . | nindent 4 -}}
+      {{- include "corda.clusterDbEnv" . | nindent 4 -}}
     {{- end -}}
     {{- if eq .name "rest" -}}
       {{- include "corda.restApiAdminSecretEnv" . | nindent 4 }}

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -168,8 +168,8 @@ spec:
                 --name "corda-rbac" \
                 --jdbc-url "${JDBC_URL}?currentSchema=${DB_RBAC_SCHEMA}" \
                 --jdbc-pool-max-size {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }} \
-              {{- with .Values.bootstrap.db.rbac.dbConnectionPool.minSize }}
-                --jdbc-pool-min-size {{ . | quote }}
+              {{- if not ( kindIs "invalid" .Values.bootstrap.db.rbac.dbConnectionPool.minSize ) }}
+                --jdbc-pool-min-size {{ .Values.bootstrap.db.rbac.dbConnectionPool.minSize | quote }}
               {{- end }}
                 --idle-timeout {{ .Values.bootstrap.db.rbac.dbConnectionPool.idleTimeoutSeconds | quote }} \
                 --max-lifetime {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxLifetimeSeconds | quote }} \
@@ -189,8 +189,8 @@ spec:
                 --name "corda-virtual-nodes" \
                 --jdbc-url "${JDBC_URL}" \
                 --jdbc-pool-max-size {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }} \
-              {{- with .Values.bootstrap.db.rbac.dbConnectionPool.minSize }}
-                --jdbc-pool-min-size {{ . | quote }}
+              {{- if not ( kindIs "invalid" .Values.bootstrap.db.rbac.dbConnectionPool.minSize ) }}
+                --jdbc-pool-min-size {{ .Values.bootstrap.db.rbac.dbConnectionPool.minSize | quote }}
               {{- end }}
                 --idle-timeout {{ .Values.bootstrap.db.rbac.dbConnectionPool.idleTimeoutSeconds | quote }} \
                 --max-lifetime {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxLifetimeSeconds | quote }} \
@@ -210,8 +210,8 @@ spec:
                 --name "corda-crypto" \
                 --jdbc-url "${JDBC_URL}?currentSchema=${DB_CRYPTO_SCHEMA}" \
                 --jdbc-pool-max-size {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxSize | quote }} \
-              {{- with .Values.bootstrap.db.crypto.dbConnectionPool.minSize }}
-                --jdbc-pool-min-size {{ . | quote }}
+              {{- if not ( kindIs "invalid" .Values.bootstrap.db.crypto.dbConnectionPool.minSize ) }}
+                --jdbc-pool-min-size {{ .Values.bootstrap.db.crypto.dbConnectionPool.minSize | quote }}
               {{- end }}
                 --idle-timeout {{ .Values.bootstrap.db.crypto.dbConnectionPool.idleTimeoutSeconds | quote }} \
                 --max-lifetime {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxLifetimeSeconds | quote }} \

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -71,10 +71,10 @@ imagePullSecrets:
 Container security context
 */}}
 {{- define "corda.containerSecurityContext" -}}
-{{- if not .Values.dumpHostPath }}
-{{- with .Values.containerSecurityContext }}
+{{- if not .Values.dumpHostPath -}}
+{{- with .Values.containerSecurityContext -}}
 securityContext:
-  {{ . | toYaml | nindent 2}}
+  {{- . | toYaml | nindent 2}}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -93,9 +93,9 @@ topologySpreadConstraints:
 tolerations for node taints
 */}}
 {{- define "corda.tolerations" -}}
-{{- if .Values.tolerations }}
+{{- with .Values.tolerations }}
 tolerations:
-{{- range .Values.tolerations }}
+{{- range . }}
 - key: {{ required "Must specify key for toleration" .key }}
   {{- with .operator }}
   operator: {{ . }}

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -59,9 +59,11 @@ metadata:
   {{- range $key, $value := . }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
-  {{- end}}
+  {{- end }}
 spec:
-  type: {{ .type }}
+  {{- with .type }}
+  type: {{ . }}
+  {{- end }}
   {{- if .externalTrafficPolicy }}
   externalTrafficPolicy: {{ .externalTrafficPolicy }}
   {{- else if .loadBalancerSourceRanges }}
@@ -106,16 +108,16 @@ spec:
       {{- if and ( not $.Values.dumpHostPath ) ( not .profiling.enabled ) }}
       {{- with $.Values.podSecurityContext }}
       securityContext:
-        {{ . | toYaml | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- end }}
-      {{- include "corda.imagePullSecrets" $ | nindent 6 }}
-      {{- include "corda.tolerations" $ | nindent 6 }}
+      {{- include "corda.imagePullSecrets" $ | indent 6 }}
+      {{- include "corda.tolerations" $ | indent 6 }}
       {{- with $.Values.serviceAccount.name  }}
       serviceAccountName: {{ . }}
       {{- end }}
       {{- include "corda.topologySpreadConstraints" $ | indent 6 }}
-      {{- include "corda.affinity" (list $ . $worker ) | nindent 6 }}
+      {{- include "corda.affinity" (list $ . $worker ) | indent 6 }}
       containers:
       - name: {{ $workerName | quote }}
         image: {{ include "corda.workerImage" ( list $ . ) }}
@@ -432,8 +434,8 @@ Worker type in upper snake case
 Worker common labels
 */}}
 {{- define "corda.workerLabels" -}}
-{{- $ := index . 0 }}
-{{- $worker := index . 1 }}
+{{- $ := index . 0 -}}
+{{- $worker := index . 1 -}}
 {{ include "corda.labels" $ }}
 {{ include "corda.workerComponentLabel" $worker }}
 {{- end }}
@@ -442,8 +444,8 @@ Worker common labels
 Worker selector labels
 */}}
 {{- define "corda.workerSelectorLabels" -}}
-{{- $ := index . 0 }}
-{{- $worker := index . 1 }}
+{{- $ := index . 0 -}}
+{{- $worker := index . 1 -}}
 {{ include "corda.selectorLabels" $ }}
 {{ include "corda.workerComponentLabel" $worker }}
 {{- end }}


### PR DESCRIPTION
Refactor DB bootstrapping from 14 containers down to 2 so that a) they run faster as Kubernetes is not checking for updated images between every stage and b) it is easier to reason about the logic when making updates.