### PR TITLE
CORE-17331 Add initial-rbac all-cluster-roles sub-command

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -503,37 +503,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: ['initial-rbac', 'user-admin', '--yield', '300', '--user', "$(REST_API_ADMIN_USERNAME)",
-            '--password', "$(REST_API_ADMIN_PASSWORD)",
-            '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443", '--insecure']
-          volumeMounts:
-            - mountPath: /tmp
-              name: temp
-            {{- include "corda.log4jVolumeMount" . | nindent 12 }}
-          env:
-            {{- include "corda.restApiAdminSecretEnv" . | nindent 12 }}
-            {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
-        - name: create-rbac-role-vnode-creator
-          image: {{ include "corda.bootstrapCliImage" . }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: ['initial-rbac', 'vnode-creator', '--yield', '300', '--user', "$(REST_API_ADMIN_USERNAME)",
-            '--password', "$(REST_API_ADMIN_PASSWORD)",
-            '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443", '--insecure']
-          volumeMounts:
-            - mountPath: /tmp
-              name: temp
-            {{- include "corda.log4jVolumeMount" . | nindent 12 }}
-          env:
-            {{- include "corda.restApiAdminSecretEnv" . | nindent 12 }}
-            {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
-        - name: create-rbac-role-corda-dev
-          image: {{ include "corda.bootstrapCliImage" . }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          {{- include "corda.bootstrapResources" . | nindent 10 }}
-          {{- include "corda.containerSecurityContext" . | nindent 10 }}
-          args: ['initial-rbac', 'corda-developer', '--yield', '300', '--user', "$(REST_API_ADMIN_USERNAME)",
+          args: ['initial-rbac', 'all-cluster-roles', '--yield', '300', '--user', "$(REST_API_ADMIN_USERNAME)",
             '--password', "$(REST_API_ADMIN_PASSWORD)",
             '--target', "https://{{ include "corda.fullname" . }}-rest-worker:443", '--insecure']
           volumeMounts:

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/InitialRbacPlugin.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/InitialRbacPlugin.kt
@@ -1,6 +1,7 @@
 package net.corda.cli.plugin.initialRbac
 
 import net.corda.cli.api.CordaCliPlugin
+import net.corda.cli.plugin.initialRbac.commands.AllClusterRolesSubcommand
 import net.corda.cli.plugin.initialRbac.commands.UserAdminSubcommand
 import net.corda.cli.plugin.initialRbac.commands.CordaDeveloperSubcommand
 import net.corda.cli.plugin.initialRbac.commands.FlowExecutorSubcommand
@@ -22,7 +23,8 @@ class InitialRbacPlugin : Plugin() {
     @CommandLine.Command(
         name = "initial-rbac",
         subcommands = [UserAdminSubcommand::class, VNodeCreatorSubcommand::class,
-            CordaDeveloperSubcommand::class, FlowExecutorSubcommand::class],
+            CordaDeveloperSubcommand::class, FlowExecutorSubcommand::class,
+            AllClusterRolesSubcommand::class],
         description = ["Creates common RBAC roles"]
     )
     class PluginEntryPoint : CordaCliPlugin

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/AllClusterRolesSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/AllClusterRolesSubcommand.kt
@@ -1,0 +1,35 @@
+package net.corda.cli.plugin.initialRbac.commands
+
+import net.corda.cli.plugins.common.RestCommand
+import picocli.CommandLine
+import java.util.concurrent.Callable
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.full.declaredMemberProperties
+
+@CommandLine.Command(
+    name = "all-cluster-roles",
+    description = ["""Creates all of the cluster-scoped roles:
+        - '$CORDA_DEV_ROLE'
+        - '$USER_ADMIN_ROLE'
+        - '$VNODE_CREATOR_ROLE'"""]
+)
+class AllClusterRolesSubcommand : RestCommand(), Callable<Int> {
+
+    override fun call(): Int {
+        // If a subcommand fails with a return code of 5 (role already exists),
+        // continue on to process the other roles. All other failures
+        // (e.g. due to lack of connectivity) result in an exception being propagated.
+        return setProperties(CordaDeveloperSubcommand()).call() +
+                setProperties(UserAdminSubcommand()).call() +
+                setProperties(VNodeCreatorSubcommand()).call()
+    }
+
+    private fun <T : RestCommand> setProperties(other: T): T {
+        RestCommand::class.declaredMemberProperties.forEach { property ->
+            if (property is KMutableProperty<*>) {
+                property.setter.call(other, property.get(this))
+            }
+        }
+        return other
+    }
+}

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/CordaDeveloperSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/CordaDeveloperSubcommand.kt
@@ -7,7 +7,7 @@ import net.corda.rbac.schema.RbacKeys.VNODE_SHORT_HASH_REGEX
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
-private const val CORDA_DEV_ROLE = "CordaDeveloperRole"
+const val CORDA_DEV_ROLE = "CordaDeveloperRole"
 
 @CommandLine.Command(
     name = "corda-developer",

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/UserAdminSubcommand.kt
@@ -8,7 +8,7 @@ import net.corda.rbac.schema.RbacKeys.UUID_REGEX
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
-private const val USER_ADMIN_ROLE = "UserAdminRole"
+const val USER_ADMIN_ROLE = "UserAdminRole"
 
 @CommandLine.Command(
     name = "user-admin",

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/commands/VNodeCreatorSubcommand.kt
@@ -9,7 +9,7 @@ import net.corda.rbac.schema.RbacKeys.VNODE_STATE_REGEX
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
-private const val VNODE_CREATOR_ROLE = "VNodeCreatorRole"
+const val VNODE_CREATOR_ROLE = "VNodeCreatorRole"
 
 @CommandLine.Command(
     name = "vnode-creator",


### PR DESCRIPTION
To reduce the number of containers executed during bootstrap, add a new sub-command to the initial-rbac plugin that creates all three of the cluster-scoped roles. (A single container could have invoked all three sub-commands but the approach taken here avoids starting the JVM three times.)