### PR TITLE
CORE-17354 Force initial reconciliation to support updating configuration after upgrade

### DIFF
--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -131,9 +131,9 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                     // On config section schema update, because Kafka is already populated and DB and Kafka records' versions
                     // match for that config section it means that config section would not get reconciled.
                     // This means newly added property(ies) to config schema will not get added to config published on Kafka.
-                    // With forcing reconciliation, all DB configs go through reconciliation (version is overlooked) and therefore
-                    // through the defaulting config process which will add the property(ies) and subsequently will publish them
-                    // to Kafka. We only need to force the first reconciliation.
+                    // With forcing reconciliation, all DB configs go through reconciliation again (version is overlooked) and
+                    // therefore through the defaulting config process which will add the property(ies) and subsequently
+                    // will publish them to Kafka. We only need to force the first reconciliation.
                     if (forceInitialReconciliation && firstRun) {
                         dbRecord.version >= matchedKafkaRecord.version // reconcile all db records
                     } else {

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -135,7 +135,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                     // therefore through the defaulting config process which will add the property(ies) and subsequently
                     // will publish them to Kafka. We only need to force the first reconciliation.
                     if (forceInitialReconciliation && firstRun) {
-                        dbRecord.version >= matchedKafkaRecord.version // reconcile all db records again
+                        dbRecord.version >= matchedKafkaRecord.version // reconcile all db records again (forced reconciliation)
                     } else {
                         dbRecord.version > matchedKafkaRecord.version // reconcile db updated records
                     } || dbRecord.isDeleted // reconcile db soft deleted records

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -27,7 +27,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
     keyClass: Class<K>,
     valueClass: Class<V>,
     var reconciliationIntervalMs: Long,
-    private val forceInitialReconciliation: Boolean = false,
+    private val forceInitialReconciliation: Boolean,
 ) : LifecycleEventHandler {
 
     val name = "${ReconcilerEventHandler::class.java.name}<${keyClass.name}, ${valueClass.name}>"
@@ -155,9 +155,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
             }
         }
 
-        if (firstRun) {
-            firstRun = false
-        }
+        firstRun = false
 
         return reconciledCount
     }

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -125,7 +125,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                 val toBeReconciled = if (matchedKafkaRecord == null) {
                     !dbRecord.isDeleted // reconcile db inserts (i.e. db column cpi.is_deleted == false)
                 } else {
-                    // Forced reconciliation is meant to fix CORE-14827
+                    // Forced reconciliation is meant to fix CORE-17354
                     if (forceInitialReconciliation && firstRun) {
                         dbRecord.version >= matchedKafkaRecord.version // force reconcile
                                 || dbRecord.isDeleted // reconcile db deletes

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -135,7 +135,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                     // therefore through the defaulting config process which will add the property(ies) and subsequently
                     // will publish them to Kafka. We only need to force the first reconciliation.
                     if (forceInitialReconciliation && firstRun) {
-                        dbRecord.version >= matchedKafkaRecord.version // reconcile all db records
+                        dbRecord.version >= matchedKafkaRecord.version // reconcile all db records again
                     } else {
                         dbRecord.version > matchedKafkaRecord.version // reconcile db updated records
                     } || dbRecord.isDeleted // reconcile db soft deleted records

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -13,6 +13,7 @@ import net.corda.lifecycle.TimerEvent
 import net.corda.metrics.CordaMetrics
 import net.corda.reconciliation.ReconcilerReader
 import net.corda.reconciliation.ReconcilerWriter
+import net.corda.utilities.VisibleForTesting
 import net.corda.utilities.debug
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.LoggerFactory
@@ -114,7 +115,8 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
      * @throws [ReconciliationException] to notify an error occurred at kafka or db [ReconcilerReader.getAllVersionedRecords].
      */
     @Suppress("ComplexMethod")
-    fun reconcile(): Int {
+    @VisibleForTesting
+    internal fun reconcile(): Int {
         val kafkaRecords =
             kafkaReader.getAllVersionedRecords()?.asSequence()?.associateBy { it.key }
                 ?: throw ReconciliationException("Error occurred while retrieving kafka records")
@@ -153,7 +155,9 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
             }
         }
 
-        firstRun = false
+        if (firstRun) {
+            firstRun = false
+        }
 
         return reconciledCount
     }

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -128,11 +128,9 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                     // Forced reconciliation is meant to fix CORE-17354
                     if (forceInitialReconciliation && firstRun) {
                         dbRecord.version >= matchedKafkaRecord.version // force reconcile
-                                || dbRecord.isDeleted // reconcile db deletes
                     } else {
                         dbRecord.version > matchedKafkaRecord.version // reconcile db updates
-                                || dbRecord.isDeleted // reconcile db deletes
-                    }
+                    } || dbRecord.isDeleted // reconcile db deletes
                 }
 
                 if (toBeReconciled) {

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerFactoryImpl.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerFactoryImpl.kt
@@ -31,6 +31,6 @@ class ReconcilerFactoryImpl @Activate constructor(
             valueClass,
             coordinatorFactory,
             reconciliationIntervalMs,
-            forceInitialReconciliation
+            forceInitialReconciliation,
         )
 }

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerFactoryImpl.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerFactoryImpl.kt
@@ -20,7 +20,17 @@ class ReconcilerFactoryImpl @Activate constructor(
         writer: ReconcilerWriter<K, V>,
         keyClass: Class<K>,
         valueClass: Class<V>,
-        reconciliationIntervalMs: Long
+        reconciliationIntervalMs: Long,
+        forceInitialReconciliation: Boolean,
     ): Reconciler =
-        ReconcilerImpl(dbReader, kafkaReader, writer, keyClass, valueClass, coordinatorFactory, reconciliationIntervalMs)
+        ReconcilerImpl(
+            dbReader,
+            kafkaReader,
+            writer,
+            keyClass,
+            valueClass,
+            coordinatorFactory,
+            reconciliationIntervalMs,
+            forceInitialReconciliation
+        )
 }

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerImpl.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerImpl.kt
@@ -15,7 +15,7 @@ internal class ReconcilerImpl<K : Any, V : Any>(
     valueClass: Class<V>,
     coordinatorFactory: LifecycleCoordinatorFactory,
     reconciliationIntervalMs: Long,
-    forceInitialReconciliation: Boolean = false,
+    forceInitialReconciliation: Boolean,
 ) : Reconciler {
 
     val name = "${ReconcilerImpl::class.java.name}<${keyClass.name}, ${valueClass.name}>"

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerImpl.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerImpl.kt
@@ -14,7 +14,8 @@ internal class ReconcilerImpl<K : Any, V : Any>(
     keyClass: Class<K>,
     valueClass: Class<V>,
     coordinatorFactory: LifecycleCoordinatorFactory,
-    reconciliationIntervalMs: Long
+    reconciliationIntervalMs: Long,
+    forceInitialReconciliation: Boolean = false,
 ) : Reconciler {
 
     val name = "${ReconcilerImpl::class.java.name}<${keyClass.name}, ${valueClass.name}>"
@@ -28,7 +29,8 @@ internal class ReconcilerImpl<K : Any, V : Any>(
                 writer,
                 keyClass,
                 valueClass,
-                reconciliationIntervalMs
+                reconciliationIntervalMs,
+                forceInitialReconciliation,
             )
         )
 

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -56,30 +56,30 @@ internal class ReconcilerEventHandlerTest {
         assertEquals(updateIntervalEvent.intervalMs, reconcilerEventHandler.reconciliationIntervalMs)
     }
 
+    private val dbRecord = object : VersionedRecord<String, Int> {
+        override val version: Int
+            get() = 1
+        override val isDeleted: Boolean
+            get() = false
+        override val key: String
+            get() = "key1"
+        override val value: Int
+            get() = 1
+    }
+
+    private val kafkaRecord = object : VersionedRecord<String, Int> {
+        override val version: Int
+            get() = 1
+        override val isDeleted: Boolean
+            get() = false
+        override val key: String
+            get() = "key1"
+        override val value: Int
+            get() = 1
+    }
+
     @Test
     fun `on forceInitialReconciliation only the first reconciliation is force reconciled`() {
-        val dbRecord = object : VersionedRecord<String, Int> {
-            override val version: Int
-                get() = 1
-            override val isDeleted: Boolean
-                get() = false
-            override val key: String
-                get() = "key1"
-            override val value: Int
-                get() = 1
-        }
-
-        val kafkaRecord = object : VersionedRecord<String, Int> {
-            override val version: Int
-                get() = 1
-            override val isDeleted: Boolean
-                get() = false
-            override val key: String
-                get() = "key1"
-            override val value: Int
-                get() = 1
-        }
-
         val dbReader = mock<ReconcilerReader<String, Int>>().also {
             whenever(it.getAllVersionedRecords()).doAnswer {
                 listOf<VersionedRecord<String, Int>>(dbRecord).stream()
@@ -111,28 +111,6 @@ internal class ReconcilerEventHandlerTest {
 
     @Test
     fun `on not forceInitialReconciliation the first reconciliation is not forced reconciled`() {
-        val dbRecord = object : VersionedRecord<String, Int> {
-            override val version: Int
-                get() = 1
-            override val isDeleted: Boolean
-                get() = false
-            override val key: String
-                get() = "key1"
-            override val value: Int
-                get() = 1
-        }
-
-        val kafkaRecord = object : VersionedRecord<String, Int> {
-            override val version: Int
-                get() = 1
-            override val isDeleted: Boolean
-                get() = false
-            override val key: String
-                get() = "key1"
-            override val value: Int
-                get() = 1
-        }
-
         val dbReader = mock<ReconcilerReader<String, Int>>().also {
             whenever(it.getAllVersionedRecords()).doAnswer {
                 listOf<VersionedRecord<String, Int>>(dbRecord).stream()

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -1,13 +1,17 @@
 package net.corda.reconciliation.impl
 
 import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.reconciliation.ReconcilerReader
+import net.corda.reconciliation.VersionedRecord
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 internal class ReconcilerEventHandlerTest {
 
@@ -48,5 +52,58 @@ internal class ReconcilerEventHandlerTest {
         reconcilerEventHandler.processEvent(updateIntervalEvent, coordinator)
         verify(coordinator).setTimer(eq(reconcilerEventHandler.name), eq(updateIntervalEvent.intervalMs), any())
         assertEquals(updateIntervalEvent.intervalMs, reconcilerEventHandler.reconciliationIntervalMs)
+    }
+
+    @Test
+    fun `on forceInitialReconciliation only the first reconciliation is force reconciled`() {
+        val dbRecord = object : VersionedRecord<String, Int> {
+            override val version: Int
+                get() = 1
+            override val isDeleted: Boolean
+                get() = false
+            override val key: String
+                get() = "key1"
+            override val value: Int
+                get() = 1
+        }
+
+        val kafkaRecord = object : VersionedRecord<String, Int> {
+            override val version: Int
+                get() = 1
+            override val isDeleted: Boolean
+                get() = false
+            override val key: String
+                get() = "key1"
+            override val value: Int
+                get() = 1
+        }
+
+        val dbReader = mock<ReconcilerReader<String, Int>>().also {
+            whenever(it.getAllVersionedRecords()).doAnswer {
+                listOf<VersionedRecord<String, Int>>(dbRecord).stream()
+            }
+        }
+
+        val kafkaReader = mock<ReconcilerReader<String, Int>>().also {
+            whenever(it.getAllVersionedRecords()).doAnswer {
+                listOf<VersionedRecord<String, Int>>(kafkaRecord).stream()
+            }
+        }
+
+        reconcilerEventHandler =
+            ReconcilerEventHandler(
+                dbReader,
+                kafkaReader,
+                writer = mock(),
+                keyClass = String::class.java,
+                valueClass = Int::class.java,
+                10L,
+                forceInitialReconciliation = true
+            )
+
+        val reconciledInFirstReconciliation =  reconcilerEventHandler.reconcile()
+        val reconciledInSecondReconciliation =  reconcilerEventHandler.reconcile()
+        assertEquals(1, reconciledInFirstReconciliation)
+        assertEquals(0, reconciledInSecondReconciliation)
     }
 }

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -101,9 +101,9 @@ internal class ReconcilerEventHandlerTest {
                 forceInitialReconciliation = true
             )
 
-        val reconciledInFirstReconciliation =  reconcilerEventHandler.reconcile()
-        val reconciledInSecondReconciliation =  reconcilerEventHandler.reconcile()
-        assertEquals(1, reconciledInFirstReconciliation)
-        assertEquals(0, reconciledInSecondReconciliation)
+        val reconciledOnFirstReconciliation =  reconcilerEventHandler.reconcile()
+        val reconciledOnSecondReconciliation =  reconcilerEventHandler.reconcile()
+        assertEquals(1, reconciledOnFirstReconciliation)
+        assertEquals(0, reconciledOnSecondReconciliation)
     }
 }

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -26,7 +26,8 @@ internal class ReconcilerEventHandlerTest {
                 mock(),
                 String::class.java,
                 Int::class.java,
-                1000L
+                1000L,
+                forceInitialReconciliation = false,
             )
         Assertions.assertEquals(
             "${ReconcilerEventHandler::class.java.name}<${String::class.java.name}, ${Int::class.java.name}>",
@@ -43,7 +44,8 @@ internal class ReconcilerEventHandlerTest {
                 mock(),
                 String::class.java,
                 Int::class.java,
-                1000L
+                1000L,
+                forceInitialReconciliation = false,
             )
 
         val updateIntervalEvent = ReconcilerEventHandler.UpdateIntervalEvent(2000L)

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -100,7 +100,7 @@ internal class ReconcilerEventHandlerTest {
                 keyClass = String::class.java,
                 valueClass = Int::class.java,
                 10L,
-                forceInitialReconciliation = true
+                forceInitialReconciliation = true,
             )
 
         val reconciledOnFirstReconciliation = reconcilerEventHandler.reconcile()
@@ -131,7 +131,7 @@ internal class ReconcilerEventHandlerTest {
                 keyClass = String::class.java,
                 valueClass = Int::class.java,
                 10L,
-                forceInitialReconciliation = false
+                forceInitialReconciliation = false,
             )
 
         val reconciledOnFirstReconciliation = reconcilerEventHandler.reconcile()

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -101,8 +101,8 @@ internal class ReconcilerEventHandlerTest {
                 forceInitialReconciliation = true
             )
 
-        val reconciledOnFirstReconciliation =  reconcilerEventHandler.reconcile()
-        val reconciledOnSecondReconciliation =  reconcilerEventHandler.reconcile()
+        val reconciledOnFirstReconciliation = reconcilerEventHandler.reconcile()
+        val reconciledOnSecondReconciliation = reconcilerEventHandler.reconcile()
         assertEquals(1, reconciledOnFirstReconciliation)
         assertEquals(0, reconciledOnSecondReconciliation)
     }

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerImplTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerImplTest.kt
@@ -16,7 +16,8 @@ class ReconcilerImplTest {
                 String::class.java,
                 Int::class.java,
                 mock(),
-                1000L
+                1000L,
+                forceInitialReconciliation = false,
             )
         assertEquals(
             "${ReconcilerImpl::class.java.name}<${String::class.java.name}, ${Int::class.java.name}>",

--- a/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerFactory.kt
+++ b/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerFactory.kt
@@ -11,6 +11,7 @@ interface ReconcilerFactory {
         writer: ReconcilerWriter<K, V>,
         keyClass: Class<K>,
         valueClass: Class<V>,
-        reconciliationIntervalMs: Long
+        reconciliationIntervalMs: Long,
+        forceInitialReconciliation: Boolean = false,
     ): Reconciler
 }

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ConfigReconciler.kt
@@ -63,7 +63,8 @@ class ConfigReconciler(
                 writer = reconcilerWriter,
                 keyClass = String::class.java,
                 valueClass = Configuration::class.java,
-                reconciliationIntervalMs = intervalMillis
+                reconciliationIntervalMs = intervalMillis,
+                forceInitialReconciliation = true,
             ).also { it.start() }
         } else {
             log.info("Updating Config ${Reconciler::class.java.name}")

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/GroupParametersReconcilerTest.kt
@@ -149,7 +149,8 @@ class GroupParametersReconcilerTest {
                 eq(reconcilerWriter),
                 eq(HoldingIdentity::class.java),
                 eq(InternalGroupParameters::class.java),
-                any()
+                any(),
+                any(),
             )
         } doReturn reconciler
     }

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MemberInfoReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MemberInfoReconcilerTest.kt
@@ -120,6 +120,7 @@ class MemberInfoReconcilerTest {
                 eq(String::class.java),
                 eq(PersistentMemberInfo::class.java),
                 any(),
+                any(),
             )
         } doReturn innerReconciler
     }

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/MgmAllowedCertificateSubjectsReconcilerTest.kt
@@ -81,6 +81,7 @@ class MgmAllowedCertificateSubjectsReconcilerTest {
                 eq(MgmAllowedCertificateSubject::class.java),
                 eq(MgmAllowedCertificateSubject::class.java),
                 any(),
+                any(),
             )
         } doReturn reconciler
     }


### PR DESCRIPTION
**Problem Statement**

If we extend the config schema e.g. add a property X,  and we upgrade a cluster we would expect property X to be available to the components that need it. However, that's not the case, property X is not available and the components trying to access it throw on trying to get it from provided config.

What happens is, reconciliation compares DB records to Kafka records (based on version field) and the ones found to be needing updating on Kafka get published to Kafka. But right before getting published, they go through the defaulting process where properties not present in DB config get added with defaulted values. 

In the above scenario, Kafka is already populated (since we upgrade), meaning Kafka config version match DB config version and therefore no update is needed. Meaning we also miss going through the defaulting process and that's where we miss the newly added property X.

**Solution**

Forcing only the initial reconciliation, i.e. doing a full reconciliation even for DB records that are of same version compared to Kafka ones means we will go through the defaulting process and the updated properties will become available to Kafka.

**Testing**

A config update & cluster upgrade was done locally to reproduce issue and witness fix:
 
1. cluster was deployed
2.  new property was added to config schema and then some code trying to access it 
3. image (db-worker) was rebuilt and new pod started. In the logs there was the exception for the missing property
4. force an initial reconciliation code was added, image rebuilt and new pod started, the property was made available