### PR TITLE
CORE-15064: Set `mixinStandardHelpOptions = true`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,9 @@ CODEOWNERS         @corda/blt @corda/corda5-team-leads
 /libs/rest/                                     @corda/rest
 /libs/permissions/                              @corda/rest
 /processors/rest-processor/                     @corda/rest
+/tools/plugins/initial-rbac/                    @corda/rest
+/tools/plugins/plugins-rest/                    @corda/rest
+/tools/plugins/virtual-node/                    @corda/rest
 
 # Corda Helm chart for cluster management team
 /charts/corda/                                @corda/cluster-management

--- a/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/DatabaseBootstrapAndUpgrade.kt
+++ b/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/DatabaseBootstrapAndUpgrade.kt
@@ -23,6 +23,11 @@ class DatabaseBootstrapAndUpgrade : Plugin() {
     }
 
     @Extension
-    @CommandLine.Command(name = "database", subcommands = [Spec::class], description = ["Does Database bootstrapping and upgrade"])
+    @CommandLine.Command(
+        name = "database",
+        subcommands = [Spec::class],
+        mixinStandardHelpOptions = true,
+        description = ["Does Database bootstrapping and upgrade"]
+    )
     class PluginEntryPoint : CordaCliPlugin
 }

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/InitialConfigPlugin.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/InitialConfigPlugin.kt
@@ -16,6 +16,7 @@ class InitialConfigPlugin : Plugin() {
     @Command(
         name = "initial-config",
         subcommands = [RbacConfigSubcommand::class, DbConfigSubcommand::class, CryptoConfigSubcommand::class],
+        mixinStandardHelpOptions = true,
         description = ["Create SQL files to write the initial config to a new cluster"]
     )
     class PluginEntryPoint : CordaCliPlugin

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/InitialRbacPlugin.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/InitialRbacPlugin.kt
@@ -25,6 +25,7 @@ class InitialRbacPlugin : Plugin() {
         subcommands = [UserAdminSubcommand::class, VNodeCreatorSubcommand::class,
             CordaDeveloperSubcommand::class, FlowExecutorSubcommand::class,
             AllClusterRolesSubcommand::class],
+        mixinStandardHelpOptions = true,
         description = ["Creates common RBAC roles"]
     )
     class PluginEntryPoint : CordaCliPlugin

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/Dynamic.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/Dynamic.kt
@@ -8,6 +8,7 @@ import picocli.CommandLine.Command
         OnboardMgm::class,
         OnBoardMember::class,
     ],
+    mixinStandardHelpOptions = true,
     description = ["For Onboarding Member and MGM"]
 )
 class Dynamic

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/Lookup.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/Lookup.kt
@@ -8,6 +8,7 @@ import picocli.CommandLine.Command
         MemberLookup::class,
         GroupParametersLookup::class,
     ],
+    mixinStandardHelpOptions = true,
     description = ["Lookup members or group parameters."]
 )
 class Lookup

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/Operate.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/Operate.kt
@@ -10,6 +10,7 @@ import picocli.CommandLine.Command
     subcommands = [
         AllowClientCertificate::class,
         ExportGroupPolicy::class
-    ]
+    ],
+    mixinStandardHelpOptions = true
 )
 class Operate

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/PackagePluginWrapper.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/PackagePluginWrapper.kt
@@ -11,6 +11,7 @@ class PackagePluginWrapper : Plugin() {
     @CommandLine.Command(
         name = "package",
         subcommands = [CreateCpiV2::class, Verify::class, CreateCpb::class, SignCpx::class],
+        mixinStandardHelpOptions = true,
         description = ["Plugin for CPB, CPI operations."]
     )
     class PackagePlugin : CordaCliPlugin

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
@@ -35,6 +35,7 @@ class PreInstallPlugin : Plugin() {
     @Extension
     @CommandLine.Command(name = "preinstall",
         subcommands = [CheckLimits::class, CheckPostgres::class, CheckKafka::class, RunAll::class],
+        mixinStandardHelpOptions = true,
         description = ["Preinstall checks for Corda."])
     class PreInstallPluginEntry : CordaCliPlugin
 

--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Create.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Create.kt
@@ -12,7 +12,12 @@ import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import picocli.CommandLine
 
-@CommandLine.Command(name = "create", description = ["Create Kafka topics"], subcommands = [CreateScript::class, CreateConnect::class])
+@CommandLine.Command(
+    name = "create",
+    description = ["Create Kafka topics"],
+    subcommands = [CreateScript::class, CreateConnect::class],
+    mixinStandardHelpOptions = true
+)
 class Create(
     private val cl: ClassLoader = TopicPlugin.classLoader,
     private val resourceGetter: (String) -> List<URL> = { path -> cl.getResources(path).toList().filterNotNull() }

--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Delete.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Delete.kt
@@ -2,7 +2,12 @@ package net.corda.cli.plugins.topicconfig
 
 import picocli.CommandLine
 
-@CommandLine.Command(name = "delete", description = ["Delete Kafka topics"], subcommands = [DeleteScript::class, DeleteConnect::class])
+@CommandLine.Command(
+    name = "delete",
+    description = ["Delete Kafka topics"],
+    subcommands = [DeleteScript::class, DeleteConnect::class],
+    mixinStandardHelpOptions = true
+)
 class Delete {
 
     @CommandLine.ParentCommand

--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/TopicPlugin.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/TopicPlugin.kt
@@ -26,7 +26,12 @@ class TopicPlugin : Plugin() {
     }
 
     @Extension
-    @CommandLine.Command(name = "topic", subcommands = [Create::class, Delete::class], description = ["Plugin for Kafka topic operations."])
+    @CommandLine.Command(
+        name = "topic",
+        subcommands = [Create::class, Delete::class],
+        description = ["Plugin for Kafka topic operations."],
+        mixinStandardHelpOptions = true
+    )
     class Topic : CordaCliPlugin {
 
         @CommandLine.Option(

--- a/tools/plugins/virtual-node/src/main/kotlin/net/corda/cli/plugins/vnode/VirtualNodeCliPlugin.kt
+++ b/tools/plugins/virtual-node/src/main/kotlin/net/corda/cli/plugins/vnode/VirtualNodeCliPlugin.kt
@@ -28,6 +28,7 @@ class VirtualNodeCliPlugin : Plugin() {
     @CommandLine.Command(
         name = "vnode",
         subcommands = [ResetCommand::class, PlatformMigration::class],
+        mixinStandardHelpOptions = true,
         description = ["Manages a virtual node"]
     )
     class PluginEntryPoint : CordaCliPlugin


### PR DESCRIPTION
For all the CLI plugins where `subcommands` are used. This would enable to pass `-h` argument and properly receive help into StdOut rather than to StdErr like it is currently.