### PR TITLE
CORE-17367 On `Scheduler` error going `DOWN` prevents k8s replacing the pod

### DIFF
--- a/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
+++ b/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
@@ -69,9 +69,11 @@ class SchedulerEventHandler(
                     publisher.publish(schedule.taskName, schedule.scheduleTriggerTopic)
                     schedulerLock.updateLog(schedulerName)
                 } else {
-                    logger.debug { "Skipping publishing task scheduler for ${schedule.taskName} " +
-                            "because it has only been ${schedulerLock.secondsSinceLastScheduledTrigger} " +
-                            "since the last trigger." }
+                    logger.debug {
+                        "Skipping publishing task scheduler for ${schedule.taskName} " +
+                                "because it has only been ${schedulerLock.secondsSinceLastScheduledTrigger} " +
+                                "since the last trigger."
+                    }
                 }
             }
             scheduleNext(coordinator)

--- a/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
+++ b/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
@@ -75,8 +75,8 @@ class SchedulerEventHandler(
         }
         scheduleNext(coordinator)
     } catch (e: Throwable) {
-        logger.warn("Task scheduling for ${schedule.taskName} failed. Terminating Scheduler", e)
-        coordinator.updateStatus(LifecycleStatus.DOWN)
+        logger.error("Task scheduling for ${schedule.taskName} failed. Terminating Scheduler", e)
+        coordinator.updateStatus(LifecycleStatus.ERROR)
     }
 
     private fun scheduleNext(coordinator: LifecycleCoordinator) {

--- a/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
+++ b/components/scheduler/src/main/kotlin/net/corda/components/scheduler/impl/SchedulerEventHandler.kt
@@ -62,21 +62,23 @@ class SchedulerEventHandler(
         }
     }
 
-    private fun triggerAndScheduleNext(coordinator: LifecycleCoordinator) = try {
-        schedulerLog.getLastTriggerAndLock(schedule.taskName, schedulerName).use { schedulerLock ->
-            if (schedulerLock.secondsSinceLastScheduledTrigger >= schedule.scheduleIntervalInSeconds) {
-                publisher.publish(schedule.taskName, schedule.scheduleTriggerTopic)
-                schedulerLock.updateLog(schedulerName)
-            } else {
-                logger.debug { "Skipping publishing task scheduler for ${schedule.taskName} " +
-                        "because it has only been ${schedulerLock.secondsSinceLastScheduledTrigger} " +
-                        "since the last trigger." }
+    private fun triggerAndScheduleNext(coordinator: LifecycleCoordinator) {
+        try {
+            schedulerLog.getLastTriggerAndLock(schedule.taskName, schedulerName).use { schedulerLock ->
+                if (schedulerLock.secondsSinceLastScheduledTrigger >= schedule.scheduleIntervalInSeconds) {
+                    publisher.publish(schedule.taskName, schedule.scheduleTriggerTopic)
+                    schedulerLock.updateLog(schedulerName)
+                } else {
+                    logger.debug { "Skipping publishing task scheduler for ${schedule.taskName} " +
+                            "because it has only been ${schedulerLock.secondsSinceLastScheduledTrigger} " +
+                            "since the last trigger." }
+                }
             }
+            scheduleNext(coordinator)
+        } catch (e: Throwable) {
+            logger.error("Task scheduling for ${schedule.taskName} failed. Terminating Scheduler", e)
+            coordinator.updateStatus(LifecycleStatus.ERROR)
         }
-        scheduleNext(coordinator)
-    } catch (e: Throwable) {
-        logger.error("Task scheduling for ${schedule.taskName} failed. Terminating Scheduler", e)
-        coordinator.updateStatus(LifecycleStatus.ERROR)
     }
 
     private fun scheduleNext(coordinator: LifecycleCoordinator) {


### PR DESCRIPTION
- on `triggerAndScheduleNext` error take coordinator to `ERROR` since it means a scheduled task is no longer working. Which means this is about the core system so `ERROR` feels justified. It also means k8s will replace the pod.
- remove unneeded try catch as expression 