### PR TITLE
CORE-11942, CORE-11860 - Block blank strings as regex for approval rules

### DIFF
--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -764,6 +764,10 @@ class MGMRestResourceImpl internal constructor(
 
         private fun validateRegex(expression: String) {
             try {
+                if (expression.isBlank()) {
+                    throw BadRequestException("The regular expression was a blank string.")
+                }
+
                 expression.toRegex()
             } catch (e: PatternSyntaxException) {
                 throw BadRequestException("The regular expression's syntax is invalid.\n${e.message}")

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -763,11 +763,11 @@ class MGMRestResourceImpl internal constructor(
         }
 
         private fun validateRegex(expression: String) {
-            try {
-                if (expression.isBlank()) {
-                    throw BadRequestException("The regular expression was a blank string.")
-                }
+            if (expression.isBlank()) {
+                throw BadRequestException("The regular expression was a blank string.")
+            }
 
+            try {
                 expression.toRegex()
             } catch (e: PatternSyntaxException) {
                 throw BadRequestException("The regular expression's syntax is invalid.\n${e.message}")

--- a/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceTest.kt
+++ b/components/membership/membership-rest-impl/src/test/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceTest.kt
@@ -238,6 +238,15 @@ class MGMRestResourceTest {
         }
 
         @Test
+        fun `addGroupApprovalRule throws invalid input for blank string regex`() {
+            startService()
+
+            assertThrows<BadRequestException> {
+                mgmRestResource.addGroupApprovalRule(HOLDING_IDENTITY_ID, ApprovalRuleRequestParams("  ", RULE_LABEL))
+            }
+        }
+
+        @Test
         fun `addGroupApprovalRule throws bad request if short hash is invalid`() {
             startService()
 
@@ -859,6 +868,16 @@ class MGMRestResourceTest {
                 callFunctionUnderTest(
                     HOLDING_IDENTITY_ID,
                     ApprovalRuleRequestParams(INVALID_RULE_REGEX, RULE_LABEL)
+                )
+            }
+        }
+
+        @Test
+        fun `it throws bad request for blank string regex`() {
+            assertThrows<BadRequestException> {
+                callFunctionUnderTest(
+                    HOLDING_IDENTITY_ID,
+                    ApprovalRuleRequestParams("  ", RULE_LABEL)
                 )
             }
         }


### PR DESCRIPTION
## Changes
Returning a 400 when a user tries to provide a blank string as a regex for an approval (or pre-auth) rule.

## Testing
Apart from the added unit testing, also tested e2e with a combined worker and got the following result:
```
{
  "title": "The regular expression was a blank string.",
  "status": 400,
  "details": {}
}
```