### PR TITLE
CORE-17360: Update execute cleanup event to match new avro object

### DIFF
--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperListener.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperListener.kt
@@ -81,7 +81,7 @@ class FlowMapperListener(
             executorService.schedule(
                 {
                     log.debug { "Clearing up mapper state for key $eventKey" }
-                    publisher?.publish(listOf(Record(FLOW_MAPPER_EVENT_TOPIC, eventKey, FlowMapperEvent(ExecuteCleanup()))))
+                    publisher?.publish(listOf(Record(FLOW_MAPPER_EVENT_TOPIC, eventKey, FlowMapperEvent(ExecuteCleanup(listOf())))))
                 },
                 expiryTime - clock.millis(),
                 TimeUnit.MILLISECONDS

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperListener.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperListener.kt
@@ -39,7 +39,7 @@ class FlowMapperListener(
                         listOf(
                             Record(
                                 FLOW_MAPPER_EVENT_TOPIC, key, FlowMapperEvent(
-                                    ExecuteCleanup()
+                                    ExecuteCleanup(listOf())
                                 )
                             )
                         )

--- a/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/FlowMapperServiceTest.kt
+++ b/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/FlowMapperServiceTest.kt
@@ -31,8 +31,7 @@ internal class FlowMapperServiceTest {
 
     private val messagingConfig = configFactory.create(
         ConfigFactory.parseString(
-            """
-                    """.trimIndent()
+            ""
         )
     )
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.25-SNAPSHOT
+cordaApiVersion=5.1.0.25-alpha-1695819131422
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.24-beta+
+cordaApiVersion=5.1.0.25-SNAPSHOT
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.73
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.0.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.25-alpha-1695819131422
+cordaApiVersion=5.1.0.25-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
### Problem statement

The flow mapper currently uses an in-process scheduler to execute cleanups of the mapper states. This mechanism will cease to work when moving to the new state storage mechanism, and so it must be replaced with the new scheduler implementation built into the DB worker. Doing this requires some small topic schema and Avro changes. A corresponding small change is required in the runtime code to keep things compiling.

### Solution

The new Avro object contains a list of ids to clean up, rather than using one message per key. When the new mechanism is fully implemented this will be populated. At present the old mechanism is still in place, so this just needs to be populated with an empty list.