### PR TITLE
CORE-16786: Upgrade CLI PF4J to 3.10 and SLF4J to 2.0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -89,6 +89,7 @@ quasarVersion = 0.9.1_r3-SNAPSHOT
 reflectAsmVersion = 1.11.9
 # SLF4J cannot be ugraded to 2.x due to CorDapps requiring the 1.7 <= x < 2.0
 slf4jVersion=1.7.36
+# The CLI uses SLF4J version 2
 slf4jV2Version=2.0.6
 # Snappy version used for serialization
 snappyVersion=0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -89,6 +89,7 @@ quasarVersion = 0.9.1_r3-SNAPSHOT
 reflectAsmVersion = 1.11.9
 # SLF4J cannot be ugraded to 2.x due to CorDapps requiring the 1.7 <= x < 2.0
 slf4jVersion=1.7.36
+slf4jV2Version=2.0.6
 # Snappy version used for serialization
 snappyVersion=0.4
 # Completely different version of Snappy used in Kafka client
@@ -136,7 +137,7 @@ jibCoreVersion=0.23.0
 artifactoryPluginVersion = 4.28.2
 
 # PF4J
-pf4jVersion=3.9.0
+pf4jVersion=3.10.0
 
 # corda-cli plugin host
 pluginHostVersion=5.1.0-beta+

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -6,6 +6,15 @@ plugins {
 description 'E2E test utilities'
 
 dependencies {
+    constraints {
+        implementation('org.slf4j:slf4j-api') {
+            version {
+                strictly slf4jV2Version
+            }
+        }
+
+    }
+
     implementation "net.corda:corda-config-schema:$cordaApiVersion"
 
     implementation "com.konghq:unirest-java:$unirestVersion"

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -12,7 +12,6 @@ dependencies {
                 strictly slf4jV2Version
             }
         }
-
     }
 
     implementation "net.corda:corda-config-schema:$cordaApiVersion"

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     constraints {
         implementation('org.slf4j:slf4j-api') {
             version {
-                strictly slf4jV2Version
+                strictly slf4jVersion
             }
         }
     }

--- a/tools/plugins/db-config/build.gradle
+++ b/tools/plugins/db-config/build.gradle
@@ -26,6 +26,11 @@ dependencies {
         implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
             because "required until liquibase-core updates it's internal version of snakeYaml, currently using 1.33 which has CVE-2022-1471"
         }
+        implementation('org.slf4j:slf4j-api') {
+            version {
+                strictly slf4jV2Version
+            }
+        }
     }
 
     // DO NOT DISTRIBUTE DRIVERS HERE WE ARE NOT LICENSED TO DISTRIBUTE

--- a/tools/plugins/network/build.gradle
+++ b/tools/plugins/network/build.gradle
@@ -13,6 +13,15 @@ ext {
 group 'net.corda.cli.deployment'
 
 dependencies {
+    constraints {
+        implementation('org.slf4j:slf4j-api') {
+            version {
+                strictly slf4jV2Version
+            }
+        }
+
+    }
+
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
 
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"

--- a/tools/plugins/network/build.gradle
+++ b/tools/plugins/network/build.gradle
@@ -19,7 +19,6 @@ dependencies {
                 strictly slf4jV2Version
             }
         }
-
     }
 
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"

--- a/tools/plugins/package/build.gradle
+++ b/tools/plugins/package/build.gradle
@@ -13,6 +13,15 @@ ext {
 group 'net.corda.cli.deployment'
 
 dependencies {
+    constraints {
+        implementation('org.slf4j:slf4j-api') {
+            version {
+                strictly slf4jV2Version
+            }
+        }
+
+    }
+
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
 
     implementation project(':libs:packaging:packaging-verify')

--- a/tools/plugins/package/build.gradle
+++ b/tools/plugins/package/build.gradle
@@ -19,7 +19,6 @@ dependencies {
                 strictly slf4jV2Version
             }
         }
-
     }
 
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
@@ -36,7 +35,7 @@ dependencies {
     testImplementation project(":testing:test-utilities")
     testImplementation project(":testing:packaging-test-utilities")
 
-    testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+    testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion"
 }
 
 cliPlugin {

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -29,6 +29,11 @@ dependencies {
             because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +
                     'This might be resolved in the future versions of Kafka Client.'
         }
+        implementation('org.slf4j:slf4j-api') {
+            version {
+                strictly slf4jV2Version
+            }
+        }
     }
 
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib'

--- a/tools/plugins/virtual-node/build.gradle
+++ b/tools/plugins/virtual-node/build.gradle
@@ -33,6 +33,11 @@ dependencies {
         implementation("org.yaml:snakeyaml:$snakeyamlVersion") {
             because "required until liquibase-core updates it's internal version of snakeYaml, currently using 1.33 which has CVE-2022-1471"
         }
+        implementation('org.slf4j:slf4j-api') {
+            version {
+                strictly slf4jV2Version
+            }
+        }
     }
 
     // DO NOT DISTRIBUTE DRIVERS HERE WE ARE NOT LICENSED TO DISTRIBUTE


### PR DESCRIPTION
This change upgrades PF4J to 3.10, the change log can be viewed here:
https://github.com/pf4j/pf4j/blob/master/CHANGELOG.md#3100---2023-09-06

One of the changes included in PF4J is an upgrade to SLF4J 2. This change uses SLF4J 2 for the CLI and SLF4J 1 for Corda itself.

Related CLI PR: https://github.com/corda/corda-cli-plugin-host/pull/194