### PR TITLE
CORE-17147: Bump Jetty version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -125,7 +125,7 @@ jcipAnnotationsVersion = 1.0_2
 unirestVersion = 3.14.2
 # This version of Jetty must be the same major version as used by Javalin, please see above.
 # Once Javalin version is upgraded to the latest, this override may be removed.
-jettyVersion = 9.4.51.v20230217
+jettyVersion = 9.4.52.v20230823
 
 # Enables the substitution of binaries for source code if it exists in expected location
 # Default behaviour is false.


### PR DESCRIPTION
To address Snyk vulnerability: https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-5902998