### PR TITLE
CORE-11214 - Prevent null or blank notary protocol

### DIFF
--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/MemberRoleTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/MemberRoleTest.kt
@@ -67,22 +67,28 @@ class MemberRoleTest {
     }
 
     @Test
-    fun `accept context when notary protocol is missing`() {
-        val roles = extractRolesFromContext(
-            mapOf(
-                "${ROLES_PREFIX}.0" to "notary",
-                NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+    fun `throws exception if notary protocol is missing`() {
+        assertThrows<IllegalArgumentException> {
+            extractRolesFromContext(
+                mapOf(
+                    "${ROLES_PREFIX}.0" to "notary",
+                    NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+                )
             )
-        )
+        }
+    }
 
-        assertThat(roles.toList())
-            .hasSize(1)
-            .allSatisfy {
-                it is MemberRole.Notary
-            }
-            .allSatisfy {
-                assertThat((it as? MemberRole.Notary)?.protocol).isNull()
-            }
+    @Test
+    fun `throws exception if notary protocol is blank string`() {
+        assertThrows<IllegalArgumentException> {
+            extractRolesFromContext(
+                mapOf(
+                    "${ROLES_PREFIX}.0" to "notary",
+                    NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+                    NOTARY_SERVICE_PROTOCOL to "  ",
+                )
+            )
+        }
     }
 
     @Test
@@ -91,6 +97,7 @@ class MemberRoleTest {
             mapOf(
                 "${ROLES_PREFIX}.0" to "notary",
                 NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+                NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService"
             )
         )
 

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -60,6 +60,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_PEM
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS_ID
@@ -1178,6 +1179,7 @@ class DynamicMemberRegistrationServiceTest {
             val newContext = mock<MemberContext> {
                 on { entries } doReturn context.entries + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
+                    NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
                     NOTARY_SERVICE_NAME to "O=ChangedNotaryService, L=London, C=GB",
                     NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 ).entries
@@ -1289,6 +1291,7 @@ class DynamicMemberRegistrationServiceTest {
             }
             val newContextEntries = context.toMutableMap().apply {
                 put(String.format(ROLES_PREFIX, 0), "notary")
+                put(NOTARY_SERVICE_PROTOCOL, "net.corda.notary.MyNotaryService")
                 put(NOTARY_SERVICE_NAME, "O=MyNotaryService, L=London, C=GB")
                 put(NOTARY_KEY_ID_KEY, NOTARY_KEY_ID)
             }.entries
@@ -1449,6 +1452,7 @@ class DynamicMemberRegistrationServiceTest {
             val testProperties =
                 context + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
+                    NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
                     NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
@@ -1480,6 +1484,7 @@ class DynamicMemberRegistrationServiceTest {
             val testProperties =
                 context + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
+                    NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
                     NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
@@ -1538,6 +1543,7 @@ class DynamicMemberRegistrationServiceTest {
             val testProperties =
                 context + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
+                    NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
                     NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )
@@ -1583,6 +1589,7 @@ class DynamicMemberRegistrationServiceTest {
             val testProperties =
                 context.filterNot { it.key.startsWith("corda.ledger") } + mapOf(
                     String.format(ROLES_PREFIX, 0) to "notary",
+                    NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
                     NOTARY_KEY_ID_KEY to NOTARY_KEY_ID,
                 )


### PR DESCRIPTION
## Changes
Reject a registration as INVALID, when the notary protocol is either missing or is a blank string. 

## Testing
Apart from the unit testing added, I also tested manually e2e using the combined worker.
* Before:
```
{
  "registrationId": "5af19b0c-4e02-4f5c-b9e5-13282fa4476d",
  "registrationSent": "2023-09-28T08:43:45.450Z",
  "registrationUpdated": "2023-09-28T08:43:58.037Z",
  "registrationStatus": "DECLINED",
  "memberInfoSubmitted": {
    "data": {
      "registrationProtocolVersion": "1",
      "corda.session.keys.0.id": "8400621C3FDD",
      "corda.session.keys.0.signature.spec": "SHA256withECDSA",
      "corda.ledger.keys.0.id": "C3F7F55B20EA",
      "corda.ledger.keys.0.signature.spec": "SHA256withECDSA",
      "corda.endpoints.0.connectionURL": "https://localhost:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "corda.roles.0": "notary",
      "corda.notary.service.name": "O=NotaryService, L=London, C=GB",
      "corda.notary.service.flow.protocol.name": "  ",
      "corda.notary.service.flow.protocol.version.0": "1",
      "corda.notary.keys.0.id": "0349BD10376D",
      "corda.notary.keys.0.signature.spec": "SHA256withECDSA"
    }
  },
  "reason": "Registering member has specified an invalid notary service plugin type.",
  "serial": 0
}
```
* After:
```
{
  "registrationId": "b14773a6-c4a8-46bd-97d1-6df726523b15",
  "registrationSent": "2023-09-28T09:15:45.491Z",
  "registrationUpdated": "2023-09-28T09:15:46.011Z",
  "registrationStatus": "INVALID",
  "memberInfoSubmitted": {
    "data": {
      "registrationProtocolVersion": "1",
      "corda.session.keys.0.id": "FB2757A97240",
      "corda.session.keys.0.signature.spec": "SHA256withECDSA",
      "corda.ledger.keys.0.id": "91183AF5F7F2",
      "corda.ledger.keys.0.signature.spec": "SHA256withECDSA",
      "corda.endpoints.0.connectionURL": "https://localhost:8080",
      "corda.endpoints.0.protocolVersion": "1",
      "corda.roles.0": "notary",
      "corda.notary.service.name": "O=NotaryService, L=London, C=GB",
      "corda.notary.service.flow.protocol.name": "  ",
      "corda.notary.service.flow.protocol.version.0": "1",
      "corda.notary.keys.0.id": "39FDC9C40C70",
      "corda.notary.keys.0.signature.spec": "SHA256withECDSA"
    }
  },
  "reason": "Registration failed. Reason: Value provided for corda.notary.service.flow.protocol.name was a blank string.",
  "serial": null
}
```