### PR TITLE
CORE-15064: Rename `-v` option in `Verify` CLI plugin

### DIFF
--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/Verify.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/Verify.kt
@@ -23,7 +23,7 @@ class Verify : Runnable {
         description = ["Package type (CPK/CPB/CPI)", "Detected from file name extension if not specified"])
     var type: PackageType? = null
 
-    @CommandLine.Option(names = ["--version", "-v"],
+    @CommandLine.Option(names = ["--packageFormatVersion", "-pfv"],
         description = ["Package format version", "Detected from Manifest if not specified"])
     var format: String? = null
 


### PR DESCRIPTION
As it is clashing with standard option to display version information of the CLI.

Strictly speaking it is a backward compatibility braking change as far CLI tool is concerned. But I cannot think of any better way of doing it given that we clashed with standard CLI options which are available in the rest of the CLI commands.