### PR TITLE
CORE-17397: Turn off tracing logs in kubernetes

### DIFF
--- a/charts/corda/log4j2.xml
+++ b/charts/corda/log4j2.xml
@@ -34,6 +34,8 @@
             <AppenderRef ref="${env:CONSOLE_LOG_FORMAT:-json}" level="info"/>
         </logger>
 
+        <logger name="net.corda.tracing.brave.BraveTracingService$LogReporter" additivity="false" level="off"/>
+
         <!-- log warn only for these 3rd party libs -->
         <Logger name="com.zaxxer.hikari" level="warn"/>
         <Logger name="io.javalin.Javalin" level="warn"/>

--- a/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2-console.xml
@@ -10,6 +10,8 @@
             <AppenderRef ref="Console" level="info"/>
         </logger>
 
+        <logger name="net.corda.tracing.brave.BraveTracingService$LogReporter" additivity="false" level="off"/>
+
         <!-- log warn only for these 3rd party libs -->
         <Logger name="org.apache.aries.spifly" level="warn" />
         <Logger name="org.apache.kafka" level="warn" />

--- a/osgi-framework-bootstrap/src/main/resources/log4j2.xml
+++ b/osgi-framework-bootstrap/src/main/resources/log4j2.xml
@@ -85,7 +85,7 @@
         </logger>
 
         <!-- set logger level to trace to enable -->
-        <logger name="net.corda.tracing" additivity="false" level="off">
+        <logger name="net.corda.tracing.brave.BraveTracingService$LogReporter" additivity="false" level="off">
             <AppenderRef ref="Trace-Spans"/>
         </logger>
 


### PR DESCRIPTION
This PR turns off logging trace spans in both the console and helm chart log4j configuration. These trace spans are intended to go into a log file and they should be switched off by default.

It also changes the existing configuration to be very specific about which class we want to send to the `corda-trace-spans` log file. So we don't sweep logs related to the operation of tracing into that file.