### PR TITLE
CORE-17377: Fix create-topics timeout to not depend on kafka.cleanup

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -372,9 +372,10 @@ spec:
             {{- end }}
             '-r', '{{ .Values.bootstrap.kafka.replicas }}',
             '-p', '{{ .Values.bootstrap.kafka.partitions }}',
-            'connect'{{- if .Values.bootstrap.kafka.cleanup }},
-            '-d',
+            'connect',
             '-w', '{{ .Values.bootstrap.kafka.timeoutSeconds }}'
+            {{- if .Values.bootstrap.kafka.cleanup }},
+            '-d'
             {{- end }}
           ]
           volumeMounts:


### PR DESCRIPTION
[CORE-17377](https://r3-cev.atlassian.net/browse/CORE-17377): Unable to install Corda Enterprise helm chart when bootstrap.kafka.cleanup: true

`bootstrap.kafka.timeoutSeconds` should apply outside of `boostrap.kafka.cleanup` condition block.

[CORE-17377]: https://r3-cev.atlassian.net/browse/CORE-17377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ