### PR TITLE
Monitor non-cluster database connections

### DIFF
--- a/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/LateInitDbConnectionOps.kt
+++ b/components/db/db-connection-manager-impl/src/main/kotlin/net/corda/db/connection/manager/impl/LateInitDbConnectionOps.kt
@@ -70,4 +70,6 @@ class LateInitDbConnectionOps: DbConnectionOps {
         entitiesSet: JpaEntitiesSet
     ): EntityManagerFactory =
         delegate.getOrCreateEntityManagerFactory(connectionId, entitiesSet)
+
+    override fun getIssuedDataSources(): Collection<DataSource> = delegate.getIssuedDataSources()
 }

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionOps.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionOps.kt
@@ -142,4 +142,10 @@ interface DbConnectionOps {
     fun createEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet): EntityManagerFactory
 
     fun getOrCreateEntityManagerFactory(connectionId: UUID, entitiesSet: JpaEntitiesSet): EntityManagerFactory
+    
+    /*
+     * Return all data sources that have been isssued by the previous methods
+     * 
+     */
+    fun getIssuedDataSources() : Collection<DataSource>
 }

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/components/impl/DbConnectionManagerImpl.kt
@@ -171,4 +171,8 @@ class DbConnectionManagerImpl @Activate constructor(
     ): CloseableDataSource {
         TODO("Not yet implemented")
     }
+
+    override fun getIssuedDataSources(): Collection<DataSource> {
+        TODO("Not yet implemented")
+    }
 }

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -165,4 +165,5 @@ class FakeDbConnectionManager(
         TODO("Not yet implemented")
     }
 
+    override fun getIssuedDataSources(): Collection<DataSource> = emptySet()
 }


### PR DESCRIPTION
Previousy we only monitored the cluster database connection internal to the DbConnectionManager. If passwords changed on the other connections we will keep trying the old values and not go unhealthy.

This means that the lifecycle will go down in all cases if the database password is rotated, which gives us a chance to reread it, via Kubernetes restarting the whole worker.

A better solution which picks up passwords dynamically seems to require a bigger change.

Add docstrings and improve the clarity of some code.