### PR TITLE
CORE-15064: Rename `-pfv` option in `Verify` CLI plugin

### DIFF
--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/Verify.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/Verify.kt
@@ -23,7 +23,7 @@ class Verify : Runnable {
         description = ["Package type (CPK/CPB/CPI)", "Detected from file name extension if not specified"])
     var type: PackageType? = null
 
-    @CommandLine.Option(names = ["--packageFormatVersion", "-pfv"],
+    @CommandLine.Option(names = ["--packageFormatVersion", "-o"],
         description = ["Package format version", "Detected from Manifest if not specified"])
     var format: String? = null
 

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/Verify.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/Verify.kt
@@ -23,7 +23,7 @@ class Verify : Runnable {
         description = ["Package type (CPK/CPB/CPI)", "Detected from file name extension if not specified"])
     var type: PackageType? = null
 
-    @CommandLine.Option(names = ["--packageFormatVersion", "-o"],
+    @CommandLine.Option(names = ["--package-format-version", "-o"],
         description = ["Package format version", "Detected from Manifest if not specified"])
     var format: String? = null
 


### PR DESCRIPTION
As it can be interpreted as `-p -f -v`.