### PR TITLE
CORE-17379 UTXO transaction builder and composite keys

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/test/UtxoLedgerServiceTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/test/UtxoLedgerServiceTest.kt
@@ -1,15 +1,42 @@
 package net.corda.ledger.utxo.flow.impl.test
 
+import net.corda.ledger.common.testkit.anotherPublicKeyExample
+import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.testkit.UtxoLedgerIntegrationTest
+import net.corda.sandboxgroupcontext.getSandboxSingletonService
+import net.corda.testing.sandboxes.SandboxSetup
+import net.corda.v5.application.crypto.CompositeKeyGenerator
+import net.corda.v5.crypto.CompositeKeyNodeAndWeight
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class UtxoLedgerServiceTest: UtxoLedgerIntegrationTest() {
-    @Test
+
+    lateinit var compositeKeyGenerator: CompositeKeyGenerator
+    override fun initialize(setup: SandboxSetup) {
+        super.initialize(setup)
+        compositeKeyGenerator = sandboxGroupContext.getSandboxSingletonService()
+    }
+        @Test
     @Suppress("FunctionName")
     fun `createTransactionBuilder should return a Transaction Builder`() {
         val transactionBuilder = utxoLedgerService.createTransactionBuilder()
         assertThat(transactionBuilder).isInstanceOf(UtxoTransactionBuilder::class.java)
     }
+
+    @Test
+    fun `Can use composite Keys`(){
+        val transactionBuilder = utxoLedgerService.createTransactionBuilder()
+        val aliceKey = publicKeyExample
+        val bobKey = anotherPublicKeyExample
+        val compositeKey = compositeKeyGenerator.create(listOf(
+            CompositeKeyNodeAndWeight(aliceKey, 1),
+            CompositeKeyNodeAndWeight(bobKey, 1),
+        ),1 )
+        transactionBuilder
+            .addSignatories(listOf(aliceKey, bobKey))
+            .addSignatories(compositeKey)
+    }
 }
+

--- a/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/CompositeKeyImplTests.kt
+++ b/libs/crypto/crypto-impl/src/test/kotlin/net/corda/crypto/impl/CompositeKeyImplTests.kt
@@ -75,6 +75,17 @@ class CompositeKeyImplTests {
         assertFalse { KeyUtils.isKeyFulfilledBy(aliceOrBob, charlieSignature.by) }
     }
 
+    @Test
+    fun `Composite keys are distinct from their components`(){
+        val aliceOrBob = target.createFromKeys(alicePublicKey, bobPublicKey)
+        val aliceOrBobList = listOf(aliceOrBob)
+        assertEquals(1, aliceOrBobList.count())
+        assertEquals(1, aliceOrBobList.distinct().size)
+        val aliceBobList = listOf(alicePublicKey, bobPublicKey)
+        assertEquals(2, aliceBobList.count())
+        assertEquals(2, aliceBobList.distinct().size)
+        assertTrue(aliceBobList.intersect(aliceOrBobList.toSet()).isEmpty())
+    }
 
     @Test
     fun `(Alice and Bob) fulfilled by Alice, Bob signatures`() {


### PR DESCRIPTION
Add tests for adding keys and a composite key containing them to the UTXO transaction builder.