### PR TITLE
ES-1414 Update PreviewTest.kt to use toURI() call

### DIFF
--- a/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/PreviewTest.kt
+++ b/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/PreviewTest.kt
@@ -12,12 +12,12 @@ class PreviewTest {
     fun `validate topic configuration is generated correctly`() {
         val command = command()
 
-        val expectedConfigYamlFile = this::class.java.classLoader.getResource("preview_config.yaml")?.file
+        val expectedConfigYamlFile = this::class.java.classLoader.getResource("preview_config.yaml")?.toURI()
         val expectedConfigString = Files.readString(File(expectedConfigYamlFile!!).toPath())
         val expectedConfig: Create.PreviewTopicConfigurations = command.create!!.mapper.readValue(expectedConfigString)
 
 
-        val topicDefinitionsFile = this::class.java.classLoader.getResource("config.yaml")?.file
+        val topicDefinitionsFile = this::class.java.classLoader.getResource("config.yaml")?.toURI()
         val topicDefinitionsString = Files.readString(File(topicDefinitionsFile!!).toPath())
         val topicDefinitions: Create.TopicDefinitions = command.create!!.mapper.readValue(topicDefinitionsString)
         val actualConfig = command.create!!.getTopicConfigsForPreview(topicDefinitions.topics.values.toList())


### PR DESCRIPTION
Calling `.file` fails in a Windows CI environment, where as `toURI()` seems to be more forgiving regardless of OS / environment 

Passing windows CI test:  https://ci02.dev.r3.com/job/Corda5/view/Full%20Health%205.1/job/Nightlys/job/Corda-Runtime-OS/job/Windows/view/change-requests/job/PR-4752/