### PR TITLE
CORE-16320 - add all state manager config parameters into worker deployment

### DIFF
--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -294,6 +294,10 @@ spec:
           - "--stateManager"
           - "database.jdbc.directory=/opt/jdbc-driver"
           - "--stateManager"
+          - "database.jdbc.driver=org.postgresql.Driver"
+          - "--stateManager"
+          - "database.jdbc.persistenceUnitName=corda-state-manager"
+          - "--stateManager"
           - "database.pool.maxSize={{ .stateManagerDbConnectionPool.maxSize }}"
           {{- if .stateManagerDbConnectionPool.minSize }}
           - "--stateManager"


### PR DESCRIPTION
Quick fix to fix deployment via helm charts where a component uses the state manager.

Defaults are not being applied to configuration from [state-manager-db-properties](https://github.com/corda/corda-api/blob/release/os/5.1/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/state-manager-db-properties.json#L29).

As a quick fix workaround for now, we will set these in the helm chart.