### PR TITLE
ES-1414 - use Path instead of File to read from file

### DIFF
--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/CreateConnect.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/CreateConnect.kt
@@ -18,7 +18,7 @@ import org.apache.kafka.clients.admin.ConfigEntry
 import org.apache.kafka.common.config.ConfigResource
 import picocli.CommandLine
 import java.nio.file.Files
-import java.nio.file.Path
+import java.nio.file.Paths
 import java.time.LocalDateTime
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -166,6 +166,6 @@ class CreateConnect : Runnable {
         create!!.getTopicConfigsForPreview()
     } else {
         // Simply read the info from provided file
-        create!!.mapper.readValue(Files.readString(Path.of(configFilePath!!)))
+        create!!.mapper.readValue(Files.readString(Paths.get(configFilePath!!)))
     }
 }

--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/CreateConnect.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/CreateConnect.kt
@@ -17,8 +17,8 @@ import org.apache.kafka.clients.admin.AlterConfigOp
 import org.apache.kafka.clients.admin.ConfigEntry
 import org.apache.kafka.common.config.ConfigResource
 import picocli.CommandLine
-import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 import java.time.LocalDateTime
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -166,6 +166,6 @@ class CreateConnect : Runnable {
         create!!.getTopicConfigsForPreview()
     } else {
         // Simply read the info from provided file
-        create!!.mapper.readValue(Files.readString(File(configFilePath!!).toPath()))
+        create!!.mapper.readValue(Files.readString(Path.of(configFilePath!!)))
     }
 }

--- a/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
+++ b/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
@@ -12,9 +12,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.FileDescriptor
 import java.io.FileOutputStream
 import java.io.PrintStream
+import java.nio.file.Paths
 
 class CreateConnectTest {
 
@@ -81,7 +83,13 @@ class CreateConnectTest {
     }
 
     private fun getCommandWithConfigFile() = CreateConnect().apply {
-        configFilePath = this::class.java.classLoader.getResource("short_generated_topic_config.yaml")?.path
+        val configFileURL = this::class.java.classLoader.getResource("short_generated_topic_config.yaml")
+        configFilePath = configFileURL?.path
+        println("URL from getResource $configFileURL")
+        println("URI to path ${configFileURL?.toURI()?.path}")
+        println("URL to path ${configFilePath!!}")
+        println("Paths from URI ${Paths.get(configFileURL?.toURI()!!)}")
+        println("File to Path from URI ${File(configFileURL.toURI()).path}")
         create = Create()
         create!!.topic = TopicPlugin.Topic()
     }

--- a/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
+++ b/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
@@ -12,7 +12,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
-import java.io.File
 import java.io.FileDescriptor
 import java.io.FileOutputStream
 import java.io.PrintStream
@@ -83,13 +82,8 @@ class CreateConnectTest {
     }
 
     private fun getCommandWithConfigFile() = CreateConnect().apply {
-        val configFileURL = this::class.java.classLoader.getResource("short_generated_topic_config.yaml")
-        configFilePath = configFileURL?.path
-        println("URL from getResource $configFileURL")
-        println("URI to path ${configFileURL?.toURI()?.path}")
-        println("URL to path ${configFilePath!!}")
-        println("Paths from URI ${Paths.get(configFileURL?.toURI()!!)}")
-        println("File to Path from URI ${File(configFileURL.toURI()).path}")
+        val configFile = this::class.java.classLoader.getResource("short_generated_topic_config.yaml")!!.toURI()
+        configFilePath = Paths.get(configFile).toString()
         create = Create()
         create!!.topic = TopicPlugin.Topic()
     }


### PR DESCRIPTION
Addition to https://github.com/corda/corda-runtime-os/pull/4752 . We missed a place where failure would occur on Windows Server environments due to usage of `File(string)`.

Tests on Windows now pass https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FNightlys%2FCorda-Runtime-OS%2FWindows/detail/bogdan%2Fnotick-fix-win-build/8/tests