### PR TITLE
CORE-17448 Configure schedule for plugins smoke tests CI job

### DIFF
--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -31,6 +31,10 @@ pipeline {
         }
     }
 
+    triggers {
+        cron(gitUtils.isReleaseBranch() ? 'H 00 * * *' : '')
+    }
+
     environment {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         BUILD_CACHE_CREDENTIALS = credentials('gradle-ent-cache-credentials')
@@ -130,6 +134,9 @@ pipeline {
             }
             archiveArtifacts artifacts: 'forward.txt, workerLogs.txt, podLogs.txt', allowEmptyArchive: true
             sh 'rm -f forward.txt workerLogs.txt podLogs.txt'
+        }
+        failure {
+            sendSlackNotifications("danger", "BUILD FAILURE - Combined Worker CLI Plugins Smoke Tests", true, "#corda-corda5-build-notifications")
         }
     }
 }

--- a/tools/plugins/README.md
+++ b/tools/plugins/README.md
@@ -11,4 +11,4 @@ corda-api.
 * Corda CLI plugins: Plugins for Corda CLI Plugin Host e.g. package, network.
 
 ## Plugin Smoke Tests
-Smoke tests in individual Corda CLI plugin directories under `pluginSmokeTest` are intended to be run against the Combined Worker. There is a separate Jenkins job that runs these tests, which is currently set up to be triggered manually during development. In the future, it may be run on a schedule and/or included as a PR-gate.
+Smoke tests in individual Corda CLI plugin directories under `pluginSmokeTest` are run against the Combined Worker, intended to be triggered manually during development. There is also a nightly Jenkins job that runs these tests on the release branch. In the future, it may be included as a PR-gate.


### PR DESCRIPTION
Configures CI job for CLI plugins smoke tests to run nightly. Also sets up failure Slack notifications.