### PR TITLE
CORE-15100: Migrate FlowStatusFeedSmokeTest to E2E repo

### DIFF
--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     upgradeTestingCpiV2 project(path: ':testing:cpbs:test-cordapp-for-vnode-upgrade-testing-v2', configuration: 'cordaCPB')
 
     smokeTestImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    smokeTestImplementation "org.eclipse.jetty.websocket:websocket-client:$jettyVersion"
     smokeTestImplementation "org.slf4j:slf4j-api:$slf4jVersion"
 
     smokeTestImplementation project(':components:flow:flow-rest-resource-service')

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -2,27 +2,19 @@ package net.corda.applications.workers.smoketest.websocket
 
 import net.corda.applications.workers.smoketest.utils.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.utils.TEST_CPI_NAME
-import net.corda.applications.workers.smoketest.websocket.client.MessageQueueWebSocketHandler
-import net.corda.applications.workers.smoketest.websocket.client.SmokeTestWebsocketClient
 import net.corda.applications.workers.smoketest.websocket.client.useWebsocketConnection
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT_ALIAS
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT_USAGE
 import net.corda.e2etest.utilities.RpcSmokeTestInput
-import net.corda.e2etest.utilities.SMOKE_TEST_CLASS_NAME
-import net.corda.e2etest.utilities.assertWithRetry
 import net.corda.e2etest.utilities.assertWithRetryIgnoringExceptions
-import net.corda.e2etest.utilities.awaitRpcFlowFinished
 import net.corda.e2etest.utilities.cluster
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
-import net.corda.e2etest.utilities.getFlowClasses
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.startRpcFlow
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
@@ -77,26 +69,6 @@ class FlowStatusFeedSmokeTest {
         return "$identifyingTest-${UUID.randomUUID()}"
     }
 
-    @Order(10)
-    @Test
-    fun `websocket connection can be opened to listen for updates for flow clientRequestid`() {
-        val flowStatusFeedPath = "/flow/$bobHoldingId/${generateRequestId("test10")}"
-
-        val wsHandler = MessageQueueWebSocketHandler()
-
-        val client = SmokeTestWebsocketClient()
-        client.start()
-        client.connect(flowStatusFeedPath, wsHandler)
-        eventually {
-            assertTrue(wsHandler.isConnected)
-        }
-
-        client.close()
-        eventually {
-            assertTrue(wsHandler.isNotConnected)
-        }
-    }
-
     @Order(20)
     @Test
     fun `flow status update feed receives updates for the basic lifecycle of a flow`() {
@@ -113,218 +85,6 @@ class FlowStatusFeedSmokeTest {
             assertThat(messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
             assertThat(messageQueue[1]).contains(FlowStates.RUNNING.name)
             assertThat(messageQueue[2]).contains(FlowStates.COMPLETED.name)
-        }
-    }
-
-    @Order(30)
-    @Test
-    fun `multiple websocket connections can be open for one flow from one holding identity and request id`() {
-        val clientRequestId = generateRequestId("test30")
-        val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
-
-        useWebsocketConnection(flowStatusFeedPath) { wsHandler1 ->
-            useWebsocketConnection(flowStatusFeedPath) { wsHandler2 ->
-                startFlow(clientRequestId)
-
-                eventually(Duration.ofSeconds(300)) {
-                    assertThat(wsHandler1.messageQueueSnapshot).hasSize(3)
-                    assertThat(wsHandler2.messageQueueSnapshot).hasSize(3)
-                }
-                val messageQueue1 = wsHandler1.messageQueueSnapshot
-                val messageQueue2 = wsHandler2.messageQueueSnapshot
-                assertThat(messageQueue1[0]).contains(FlowStates.START_REQUESTED.name)
-                assertThat(messageQueue1[1]).contains(FlowStates.RUNNING.name)
-                assertThat(messageQueue1[2]).contains(FlowStates.COMPLETED.name)
-                assertThat(messageQueue2[0]).contains(FlowStates.START_REQUESTED.name)
-                assertThat(messageQueue2[1]).contains(FlowStates.RUNNING.name)
-                assertThat(messageQueue2[2]).contains(FlowStates.COMPLETED.name)
-            }
-        }
-    }
-
-    @Order(31)
-    @Test
-    fun `multiple websocket connections can be open for two flows and receive the correct statuses`() {
-        val clientRequestId1 = generateRequestId("test31-req1")
-        val clientRequestId2 = generateRequestId("test31-req2")
-        val flowStatusFeedPath1 = "/flow/$bobHoldingId/$clientRequestId1"
-        val flowStatusFeedPath2 = "/flow/$bobHoldingId/$clientRequestId2"
-
-        fun assertNormalFlowStatusesForRequest(messageQueue: List<String>, clientRequestId1: String) {
-            assertThat(messageQueue[0]).contains(FlowStates.START_REQUESTED.name)
-            assertThat(messageQueue[0]).contains(clientRequestId1)
-            assertThat(messageQueue[1]).contains(FlowStates.RUNNING.name)
-            assertThat(messageQueue[1]).contains(clientRequestId1)
-            assertThat(messageQueue[2]).contains(FlowStates.COMPLETED.name)
-            assertThat(messageQueue[2]).contains(clientRequestId1)
-        }
-
-        useWebsocketConnection(flowStatusFeedPath1) { wsHandler1 ->
-            useWebsocketConnection(flowStatusFeedPath2) { wsHandler2 ->
-                startFlow(clientRequestId1)
-                startFlow(clientRequestId2)
-
-                eventually(Duration.ofSeconds(300)) {
-                    assertThat(wsHandler1.messageQueueSnapshot).hasSize(3)
-                    assertThat(wsHandler2.messageQueueSnapshot).hasSize(3)
-                }
-
-                assertNormalFlowStatusesForRequest(wsHandler1.messageQueueSnapshot, clientRequestId1)
-                assertNormalFlowStatusesForRequest(wsHandler2.messageQueueSnapshot, clientRequestId2)
-            }
-        }
-    }
-
-    @Order(40)
-    @Test
-    fun `registering for flow status feed when flow is already finished sends the finished status and terminates connection`() {
-        val clientRequestId = generateRequestId("test40")
-        val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
-
-        startFlow(clientRequestId)
-        awaitRpcFlowFinished(bobHoldingId, clientRequestId)
-
-        val wsHandler = MessageQueueWebSocketHandler()
-        val client = SmokeTestWebsocketClient()
-
-        client.start()
-        client.connect(flowStatusFeedPath, wsHandler)
-        // The websocket channel is terminated too quickly to use eventually to assert wsHandler.isConnected
-
-        client.use {
-            eventually {
-                assertThat(wsHandler.messageQueueSnapshot).hasSize(1)
-            }
-            assertThat(wsHandler.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
-
-            eventually {
-                assertFalse(wsHandler.isConnected)
-            }
-        }
-
-        // Check HTTP RPC Server is still functioning
-        assertThat(getFlowClasses(bobHoldingId)).contains(SMOKE_TEST_CLASS_NAME)
-    }
-
-    @Order(41)
-    @Test
-    fun `two test clients can function after first reports completed flow during registration`() {
-        val clientRequestId = generateRequestId("test41")
-        val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
-
-        startFlow(clientRequestId)
-        awaitRpcFlowFinished(bobHoldingId, clientRequestId)
-
-        val wsHandler1 = MessageQueueWebSocketHandler()
-        val client1 = SmokeTestWebsocketClient()
-
-        client1.start()
-        val session1 = client1.connect(flowStatusFeedPath, wsHandler1)
-        // The websocket channel is terminated too quickly to use eventually to assert wsHandler.isConnected
-
-        eventually {
-            assertThat(wsHandler1.messageQueueSnapshot).hasSize(1)
-        }
-        assertThat(wsHandler1.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
-
-        eventually {
-            assertFalse(wsHandler1.isConnected)
-        }
-
-        session1.close(1000, "Smoke test closing session 1.")
-        client1.close()
-
-        val wsHandler2 = MessageQueueWebSocketHandler()
-        val client2 = SmokeTestWebsocketClient()
-
-        client2.start()
-        val session2 = client2.connect(flowStatusFeedPath, wsHandler2)
-        // The websocket channel is terminated too quickly to use eventually to assert wsHandler.isConnected
-
-        eventually {
-            assertThat(wsHandler2.messageQueueSnapshot).hasSize(1)
-        }
-        assertThat(wsHandler2.messageQueueSnapshot[0]).contains(FlowStates.COMPLETED.name)
-
-        eventually {
-            assertFalse(wsHandler2.isConnected)
-        }
-
-        session2.close(1000, "Smoke test closing session 2.")
-        client2.close()
-    }
-
-    @Order(50)
-    @Test
-    fun `websocket connection terminated when client sends server a message`() {
-        val clientRequestId = generateRequestId("test50")
-        val flowStatusFeedPath = "/flow/$bobHoldingId/$clientRequestId"
-
-        useWebsocketConnection(flowStatusFeedPath) { wsHandler ->
-            wsHandler.send("malicious message!")
-            eventually {
-                assertFalse(wsHandler.isConnected())
-            }
-        }
-    }
-
-    @Order(51)
-    @Test
-    fun `two websocket connections correct one terminated when it sends server a message`() {
-        val clientRequestId1 = generateRequestId("test51-req1")
-        val clientRequestId2 = generateRequestId("test51-req2")
-        val flowStatusFeedPath1 = "/flow/$bobHoldingId/$clientRequestId1"
-        val flowStatusFeedPath2 = "/flow/$bobHoldingId/$clientRequestId2"
-
-        val wsHandler1 = MessageQueueWebSocketHandler()
-        val client1 = SmokeTestWebsocketClient()
-        client1.start()
-        val session1 = client1.connect(flowStatusFeedPath1, wsHandler1)
-
-        val wsHandler2 = MessageQueueWebSocketHandler()
-        val client2 = SmokeTestWebsocketClient()
-        client2.start()
-        val session2 = client2.connect(flowStatusFeedPath2, wsHandler2)
-
-        wsHandler1.send("malicious message for client 1 ($clientRequestId1)")
-
-        eventually {
-            assertFalse(wsHandler1.isConnected)
-        }
-
-        session1.close()
-        session2.close()
-        client1.close()
-        client2.close()
-    }
-
-    @Order(60)
-    @Test
-    fun `websocket connection terminated when client registers for holding identity with invalid holding identity hex string`() {
-        val clientRequestId = generateRequestId("test60")
-        val flowStatusFeedPath = "/flow/THIS_HOLDING_ID_IS_NOT_HEX/$clientRequestId"
-
-        val wsHandler = MessageQueueWebSocketHandler()
-        val client = SmokeTestWebsocketClient()
-        client.start()
-        client.connect(flowStatusFeedPath, wsHandler)
-        eventually {
-            assertFalse(wsHandler.isConnected)
-        }
-    }
-
-    @Order(61)
-    @Test
-    fun `websocket connection terminated when client registers for non existing holding identity`() {
-        val clientRequestId = generateRequestId("test61")
-        val flowStatusFeedPath = "/flow/544849535f484f4c44494e475f49445f49535f4e4f545f484558/$clientRequestId"
-
-        val wsHandler = MessageQueueWebSocketHandler()
-        val client = SmokeTestWebsocketClient()
-        client.start()
-        client.connect(flowStatusFeedPath, wsHandler)
-        eventually {
-            assertFalse(wsHandler.isConnected)
         }
     }
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -2,7 +2,7 @@ package net.corda.applications.workers.smoketest.websocket
 
 import net.corda.applications.workers.smoketest.utils.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.utils.TEST_CPI_NAME
-import net.corda.applications.workers.smoketest.websocket.client.useWebsocketConnection
+import net.corda.e2etest.utilities.websocket.client.useWebsocketConnection
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT_ALIAS
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT_USAGE

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         }
     }
 
-    implementation "org.eclipse.jetty.websocket:websocket-client:$jettyVersion"
+    api "org.eclipse.jetty.websocket:websocket-client:$jettyVersion"
     implementation "net.corda:corda-config-schema:$cordaApiVersion"
 
     implementation "com.konghq:unirest-java:$unirestVersion"

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -14,6 +14,7 @@ dependencies {
         }
     }
 
+    implementation "org.eclipse.jetty.websocket:websocket-client:$jettyVersion"
     implementation "net.corda:corda-config-schema:$cordaApiVersion"
 
     implementation "com.konghq:unirest-java:$unirestVersion"

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/BasicAuthUpgradeListener.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/BasicAuthUpgradeListener.kt
@@ -1,4 +1,4 @@
-package net.corda.applications.workers.smoketest.websocket.client
+package net.corda.e2etest.utilities.websocket.client
 
 import org.eclipse.jetty.websocket.api.UpgradeRequest
 import org.eclipse.jetty.websocket.api.UpgradeResponse

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/InternalWebsocketHandler.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/InternalWebsocketHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.applications.workers.smoketest.websocket.client
+package net.corda.e2etest.utilities.websocket.client
 
 interface InternalWebsocketHandler {
     val messageQueueSnapshot: List<String>

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/MessageQueueWebSocketHandler.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/MessageQueueWebSocketHandler.kt
@@ -1,4 +1,4 @@
-package net.corda.applications.workers.smoketest.websocket.client
+package net.corda.e2etest.utilities.websocket.client
 
 import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.client.NoOpEndpoint

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/SmokeTestWebsocketClient.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/SmokeTestWebsocketClient.kt
@@ -1,4 +1,4 @@
-package net.corda.applications.workers.smoketest.websocket.client
+package net.corda.e2etest.utilities.websocket.client
 
 import net.corda.e2etest.utilities.DEFAULT_CLUSTER
 import net.corda.e2etest.utilities.PASSWORD

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/SmokeTestWebsocketException.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/websocket/client/SmokeTestWebsocketException.kt
@@ -1,3 +1,3 @@
-package net.corda.applications.workers.smoketest.websocket.client
+package net.corda.e2etest.utilities.websocket.client
 
 class SmokeTestWebsocketException(message: String, e: Exception? = null) : Exception(message, e)


### PR DESCRIPTION
This PR is one half of moving error path `FlowStatusFeedSmokeTest` tests to the E2E test repo.

* Delete all tests being moved to the E2E test repo
* Move `websocket.client` to e2e-test-utilities for reuse in the E2E test repo

E2E test PR: https://github.com/corda/corda-e2e-tests/pull/253