### PR TITLE
CORE-15183 - Revert "CORE-15179 - Replaced the operator ~ with an equivalent so the sql query is also supported by `HSQLDB` (#4458)"

### DIFF
--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/queries/impl/SqlQueryProviderTokens.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/queries/impl/SqlQueryProviderTokens.kt
@@ -16,14 +16,14 @@ class SqlQueryProviderTokens : SqlQueryProvider {
     }
 
     override fun getBalanceQuery(includeTagFilter: Boolean, includeOwnerFilter: Boolean): String {
-        val tagFilter = if (includeTagFilter) {
-            "AND REGEXP_LIKE(token_tag, :$SQL_PARAMETER_TAG_FILTER)"
-        } else {
+        val tagFilter = if(includeTagFilter){
+            "AND   token_tag ~ :$SQL_PARAMETER_TAG_FILTER"
+        }else{
             ""
         }
-        val ownerFilter = if (includeOwnerFilter) {
-            "AND token_owner_hash = :$SQL_PARAMETER_OWNER_HASH"
-        } else {
+        val ownerFilter = if(includeOwnerFilter){
+            "AND   token_owner_hash = :$SQL_PARAMETER_OWNER_HASH"
+        }else{
             ""
         }
 
@@ -46,14 +46,14 @@ class SqlQueryProviderTokens : SqlQueryProvider {
     }
 
     override fun getPagedSelectQuery(limit: Int, includeTagFilter: Boolean, includeOwnerFilter: Boolean): String {
-        val tagFilter = if (includeTagFilter) {
-            "AND REGEXP_LIKE(token_tag, :$SQL_PARAMETER_TAG_FILTER)"
-        } else {
+        val tagFilter = if(includeTagFilter){
+            "AND   token_tag ~ :$SQL_PARAMETER_TAG_FILTER"
+        }else{
             ""
         }
-        val ownerFilter = if (includeOwnerFilter) {
-            "AND token_owner_hash = :$SQL_PARAMETER_OWNER_HASH"
-        } else {
+        val ownerFilter = if(includeOwnerFilter){
+            "AND   token_owner_hash = :$SQL_PARAMETER_OWNER_HASH"
+        }else{
             ""
         }
 

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/queries/impl/SqlQueryProviderTokens.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/queries/impl/SqlQueryProviderTokens.kt
@@ -3,7 +3,7 @@ package net.corda.ledger.utxo.token.cache.queries.impl
 import net.corda.ledger.utxo.token.cache.queries.SqlQueryProvider
 import org.osgi.service.component.annotations.Component
 
-@Component(service = [ SqlQueryProvider::class])
+@Component(service = [SqlQueryProvider::class])
 class SqlQueryProviderTokens : SqlQueryProvider {
 
     companion object {
@@ -16,14 +16,14 @@ class SqlQueryProviderTokens : SqlQueryProvider {
     }
 
     override fun getBalanceQuery(includeTagFilter: Boolean, includeOwnerFilter: Boolean): String {
-        val tagFilter = if(includeTagFilter){
-            "AND   token_tag ~ :$SQL_PARAMETER_TAG_FILTER"
-        }else{
+        val tagFilter = if (includeTagFilter) {
+            "AND token_tag ~ :$SQL_PARAMETER_TAG_FILTER"
+        } else {
             ""
         }
-        val ownerFilter = if(includeOwnerFilter){
-            "AND   token_owner_hash = :$SQL_PARAMETER_OWNER_HASH"
-        }else{
+        val ownerFilter = if (includeOwnerFilter) {
+            "AND token_owner_hash = :$SQL_PARAMETER_OWNER_HASH"
+        } else {
             ""
         }
 
@@ -46,14 +46,14 @@ class SqlQueryProviderTokens : SqlQueryProvider {
     }
 
     override fun getPagedSelectQuery(limit: Int, includeTagFilter: Boolean, includeOwnerFilter: Boolean): String {
-        val tagFilter = if(includeTagFilter){
-            "AND   token_tag ~ :$SQL_PARAMETER_TAG_FILTER"
-        }else{
+        val tagFilter = if (includeTagFilter) {
+            "AND token_tag ~ :$SQL_PARAMETER_TAG_FILTER"
+        } else {
             ""
         }
-        val ownerFilter = if(includeOwnerFilter){
-            "AND   token_owner_hash = :$SQL_PARAMETER_OWNER_HASH"
-        }else{
+        val ownerFilter = if (includeOwnerFilter) {
+            "AND token_owner_hash = :$SQL_PARAMETER_OWNER_HASH"
+        } else {
             ""
         }
 


### PR DESCRIPTION
It has been decided that the tilde should be put back since the work which relied on `regexp_like` for compatibility purposes is no longer required. This also means that the token selection feature supports older versions of Postgresql.

This reverts commit b07244a4b8440962f60cfef8b9bb9246b1d6695d.