### PR TITLE
CORE-17322 Specify certificate type when verification fails

### DIFF
--- a/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactory.kt
+++ b/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactory.kt
@@ -259,7 +259,7 @@ internal class HostedIdentityEntryFactory(
         if (certificateType.trustRoots.isEmpty()) {
             throw CordaRuntimeException("The group ${holdingIdentity.groupId} P2P parameters ${certificateType.parameterName} is empty")
         }
-        certificateType.trustRoots
+        val trustRoot = certificateType.trustRoots
             .asSequence()
             .map { rootCertificateStr ->
                 CertificateFactory.getInstance("X.509")
@@ -274,8 +274,11 @@ internal class HostedIdentityEntryFactory(
                     false
                 }
             }.firstOrNull()
-            ?: throw CordaRuntimeException(
-                "The ${CertificateType::class.java.simpleName} was not signed by the correct certificate authority"
-            )
+            if (trustRoot == null) {
+                val type = certificateType as? CertificateType.TlsCertificate ?: certificateType as CertificateType.SessionCertificate
+                throw CordaRuntimeException(
+                    "The ${type::class.java.simpleName} was not signed by the correct certificate authority"
+                )
+            }
     }
 }


### PR DESCRIPTION
If TLS or Session certificate verification fails while setting up a locally-hosted identity, the error message now specifies the certificate type which failed verification.

Before:
```
{
    "title": "Could not import certificate: The CertificateType was not signed by the correct certificate authority",
    "status": 500,
    "details": {}
}
```

After this change:

![Screenshot 2023-10-05 at 12 03 58](https://github.com/corda/corda-runtime-os/assets/17948697/19201753-9019-4015-b549-7db730cddf01)

![Screenshot 2023-10-05 at 12 08 47](https://github.com/corda/corda-runtime-os/assets/17948697/9933a7a5-04a2-44f5-bc61-2283de6499ca)

