### PR TITLE
CORE-17476 Modifying helm charts to create ClusterIP services for workers, passing to FlowWorker

### DIFF
--- a/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
+++ b/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
@@ -94,6 +94,6 @@ private class FlowWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()
 
-    @Option(names = ["--endpoint"], description = ["Internal RPC endpoints for Corda workers"], required = true)
+    @Option(names = ["--endpoint"], description = ["Internal REST endpoints for Corda workers"], required = true)
     val workerEndpoints: Map<String, String> = emptyMap()
 }

--- a/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
+++ b/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
 import picocli.CommandLine.Mixin
+import picocli.CommandLine.Option
 
 /** The worker for handling flows. */
 @Suppress("Unused", "LongParameterList")
@@ -92,4 +93,7 @@ class FlowWorker @Activate constructor(
 private class FlowWorkerParams {
     @Mixin
     var defaultParams = DefaultWorkerParams()
+
+    @Option(names = ["--endpoint"], description = ["Internal RPC endpoints for Corda workers"], required = true)
+    val workerEndpoints: Map<String, String> = emptyMap()
 }

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/Constants.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/Constants.kt
@@ -5,5 +5,5 @@ internal const val HTTP_SERVICE_UNAVAILABLE_CODE = 503
 internal const val HTTP_HEALTH_ROUTE = "/isHealthy"
 internal const val HTTP_METRICS_ROUTE = "/metrics"
 internal const val HTTP_STATUS_ROUTE = "/status"
-internal const val WORKER_SERVER_PORT = 7000
+internal const val WORKER_SERVER_PORT = 7000 // Note: This variable is defined in charts/corda-lib/templates/_helpers.kt:622
 internal const val NO_CACHE = "no-cache"

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/Constants.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/Constants.kt
@@ -5,5 +5,5 @@ internal const val HTTP_SERVICE_UNAVAILABLE_CODE = 503
 internal const val HTTP_HEALTH_ROUTE = "/isHealthy"
 internal const val HTTP_METRICS_ROUTE = "/metrics"
 internal const val HTTP_STATUS_ROUTE = "/status"
-internal const val WORKER_SERVER_PORT = 7000 // Note: This variable is defined in charts/corda-lib/templates/_helpers.kt:622
+internal const val WORKER_SERVER_PORT = 7000
 internal const val NO_CACHE = "no-cache"

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -614,3 +614,28 @@ data:
   {{ $keySecretKey }}: {{ $keySecretValue }}
   {{ $caSecretKey }}: {{ $caSecretValue }}
 {{- end }}
+
+{{/*
+The port which should be used to connect to Corda worker instances
+*/}}
+{{- define "worker.port" -}}
+7000
+{{- end -}}
+
+{{/*
+Cluster IP service name
+*/}}
+{{- define "corda.workerInternalServiceName" -}}
+{{- printf "%s-internal-service" . -}}
+{{- end -}}
+
+{{/*
+Get the endpoint argument for a given worker
+*/}}
+{{- define "corda.getWorkerEndpoint" }}
+{{- $context := .context }}
+{{- $worker := .worker }}
+{{- $workerName := printf "%s-%s-worker" (include "corda.fullname" $context) (include "corda.workerTypeKebabCase" $worker) }}
+{{- $workerServiceName := include "corda.workerInternalServiceName" $workerName }}
+{{- printf "%s-worker-endpoint=%s:7000" $worker $workerServiceName }}
+{{- end }}

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -637,5 +637,5 @@ Get the endpoint argument for a given worker
 {{- $worker := .worker }}
 {{- $workerName := printf "%s-%s-worker" (include "corda.fullname" $context) (include "corda.workerTypeKebabCase" $worker) }}
 {{- $workerServiceName := include "corda.workerInternalServiceName" $workerName }}
-{{- printf "%s-worker-endpoint=%s:7000" $worker $workerServiceName }}
+{{- printf "worker.rpc.endpoint.%s=%s:%s" $worker $workerServiceName (include "worker.port" $) }}
 {{- end }}

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -618,7 +618,7 @@ data:
 {{/*
 The port which should be used to connect to Corda worker instances
 */}}
-{{- define "worker.port" -}}
+{{- define "corda.workerServicePort" -}}
 7000
 {{- end -}}
 
@@ -637,5 +637,5 @@ Get the endpoint argument for a given worker
 {{- $worker := .worker }}
 {{- $workerName := printf "%s-%s-worker" (include "corda.fullname" $context) (include "corda.workerTypeKebabCase" $worker) }}
 {{- $workerServiceName := include "corda.workerInternalServiceName" $workerName }}
-{{- printf "worker.rpc.endpoint.%s=%s:%s" $worker $workerServiceName (include "worker.port" $) }}
+{{- printf "worker.http.endpoint.%s=%s:%s" $worker $workerServiceName (include "corda.workerServicePort" $) }}
 {{- end }}

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -77,6 +77,19 @@ spec:
     targetPort: http
 {{- end }}
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "corda.workerInternalServiceName" $workerName }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ $workerName }}
+  ports:
+      - protocol: TCP
+        port: {{ include "worker.port" . }}
+        targetPort: {{ include "worker.port" . }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -354,8 +367,8 @@ spec:
           - name: http
             containerPort: {{ $optionalArgs.httpPort }}
         {{- end }}
-          - name: monitor
-            containerPort: 7000
+          - name: worker
+            containerPort: {{ include "worker.port" . }}
         {{- if .profiling.enabled }}
           - name: profiling
             containerPort: 10045

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -88,7 +88,7 @@ spec:
   ports:
       - protocol: TCP
         port: {{ include "corda.workerServicePort" . }}
-        targetPort: "worker"
+        targetPort: "monitor"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -373,7 +373,7 @@ spec:
           - name: http
             containerPort: {{ $optionalArgs.httpPort }}
         {{- end }}
-          - name: worker
+          - name: monitor
             containerPort: 7000
         {{- if .profiling.enabled }}
           - name: profiling

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -87,8 +87,8 @@ spec:
     app: {{ $workerName }}
   ports:
       - protocol: TCP
-        port: {{ include "worker.port" . }}
-        targetPort: {{ include "worker.port" . }}
+        port: {{ include "corda.workerServicePort" . }}
+        targetPort: "worker"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -331,6 +331,12 @@ spec:
           {{- if $.Values.tracing.samplesPerSecond }}
           - "--trace-samples-per-second={{ $.Values.tracing.samplesPerSecond }}"
           {{- end }}
+          {{- if $optionalArgs.servicesAccessed }}
+          {{- range $worker := $optionalArgs.servicesAccessed }}
+          {{- $endpoint := include "corda.getWorkerEndpoint" (dict "context" $ "worker" $worker) }}
+          - --endpoint={{ $endpoint }}
+          {{- end }}
+          {{- end }}
           {{- range $i, $arg := $optionalArgs.additionalWorkerArgs }}
           - {{ $arg | quote }}
           {{- end }}
@@ -368,7 +374,7 @@ spec:
             containerPort: {{ $optionalArgs.httpPort }}
         {{- end }}
           - name: worker
-            containerPort: {{ include "worker.port" . }}
+            containerPort: 7000
         {{- if .profiling.enabled }}
           - name: profiling
             containerPort: 10045

--- a/charts/corda/templates/workers.yaml
+++ b/charts/corda/templates/workers.yaml
@@ -4,16 +4,8 @@
 {{- include "corda.worker" ( list $ .Values.workers.db "db"
   ( dict "clusterDbAccess" true )
 ) }}
-
-{{- $args := list }}
-{{- $servicesAccessed := list "crypto" "verification" "uniqueness" "persistence" }}
-{{- range $worker := $servicesAccessed }}
-{{- $endpoint := include "corda.getWorkerEndpoint" (dict "context" $ "worker" $worker) }}
-{{- $args = append $args (printf "--endpoint=%s" $endpoint) }}
-{{- end }}
-
 {{- include "corda.worker" ( list $ .Values.workers.flow "flow"
-  ( dict "stateManagerDbAccess" true "additionalWorkerArgs" $args )
+  ( dict "stateManagerDbAccess" true "servicesAccessed" (list "crypto" "verification" "uniqueness" "persistence") )
 ) }}
 {{- include "corda.worker" ( list $ .Values.workers.flowMapper "flowMapper" ) }}
 {{- include "corda.worker" ( list $ .Values.workers.verification "verification" ) }}

--- a/charts/corda/templates/workers.yaml
+++ b/charts/corda/templates/workers.yaml
@@ -4,8 +4,16 @@
 {{- include "corda.worker" ( list $ .Values.workers.db "db"
   ( dict "clusterDbAccess" true )
 ) }}
+
+{{- $args := list }}
+{{- $servicesAccessed := list "crypto" "verification" "uniqueness" "persistence" }}
+{{- range $worker := $servicesAccessed }}
+{{- $endpoint := include "corda.getWorkerEndpoint" (dict "context" $ "worker" $worker) }}
+{{- $args = append $args (printf "--endpoint=%s" $endpoint) }}
+{{- end }}
+
 {{- include "corda.worker" ( list $ .Values.workers.flow "flow"
-  ( dict "stateManagerDbAccess" true )
+  ( dict "stateManagerDbAccess" true "additionalWorkerArgs" $args )
 ) }}
 {{- include "corda.worker" ( list $ .Values.workers.flowMapper "flowMapper" ) }}
 {{- include "corda.worker" ( list $ .Values.workers.verification "verification" ) }}


### PR DESCRIPTION
As part of the Corda topology redesign, communication between the flow engine and Corda workers is moving from a Kafka message bus to synchronous RPC calls. In order to support this, we're adding a load balancing layer (Here, a `ClusterIP` service per worker) which will expose a single endpoint which distributes calls across all worker instances. 

The endpoint for this ClusterIP service is now being passed into the additional startup args of the `FlowWorker`; a future PR will use these to define a routing component for external messages.

#### Related PRs:
- https://github.com/corda/corda-api/pull/1276 (Adding endpoint IDs to API)