### PR TITLE
CORE-16320 - temporarily remove flow maintenance which uses state manager factory

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
@@ -4,7 +4,6 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.external.messaging.services.ExternalMessagingRoutingService
-import net.corda.flow.maintenance.FlowMaintenance
 import net.corda.lifecycle.Lifecycle
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -37,8 +36,8 @@ class FlowService @Activate constructor(
     private val flowExecutor: FlowExecutor,
     @Reference(service = ExternalMessagingRoutingService::class)
     private val externalMessagingRoutingService: ExternalMessagingRoutingService,
-    @Reference(service = FlowMaintenance::class)
-    private val flowMaintenance: FlowMaintenance,
+//    @Reference(service = FlowMaintenance::class)
+//    private val flowMaintenance: FlowMaintenance,
     ) : Lifecycle {
 
     companion object {
@@ -61,10 +60,10 @@ class FlowService @Activate constructor(
                             LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>(),
                             LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
                             LifecycleCoordinatorName.forComponent<FlowExecutor>(),
-                            LifecycleCoordinatorName.forComponent<FlowMaintenance>(),
+//                            LifecycleCoordinatorName.forComponent<FlowMaintenance>(),
                         )
                     )
-                flowMaintenance.start()
+//                flowMaintenance.start()
                 flowExecutor.start()
             }
 
@@ -88,14 +87,14 @@ class FlowService @Activate constructor(
                  * is configured before we configure the executor to prevent a race between receiving the first
                  * state events and scheduler creating a publisher.
                  */
-                flowMaintenance.onConfigChange(config)
+//                flowMaintenance.onConfigChange(config)
                 flowExecutor.onConfigChange(config)
                 externalMessagingRoutingService.onConfigChange(config)
                 coordinator.updateStatus(LifecycleStatus.UP)
             }
 
             is StopEvent -> {
-                flowMaintenance.stop()
+//                flowMaintenance.stop()
                 flowExecutor.stop()
                 registration?.close()
                 registration = null

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
@@ -4,7 +4,7 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.external.messaging.services.ExternalMessagingRoutingService
 import net.corda.flow.MINIMUM_SMART_CONFIG
-import net.corda.flow.maintenance.FlowMaintenance
+//import net.corda.flow.maintenance.FlowMaintenance
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.test.impl.LifecycleTest
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
@@ -32,14 +32,14 @@ class FlowServiceTest {
                 Arguments.of(LifecycleCoordinatorName.forComponent<VirtualNodeInfoReadService>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<CpiInfoReadService>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<FlowExecutor>()),
-                Arguments.of(LifecycleCoordinatorName.forComponent<FlowMaintenance>()),
+//                Arguments.of(LifecycleCoordinatorName.forComponent<FlowMaintenance>()),
             )
         }
     }
 
     private val flowExecutor = mock<FlowExecutor>()
     private val externalMessagingRoutingService = mock<ExternalMessagingRoutingService>()
-    private val flowMaintenance = mock<FlowMaintenance>()
+//    private val flowMaintenance = mock<FlowMaintenance>()
 
     private val exampleConfig = mapOf(
         ConfigKeys.BOOT_CONFIG to MINIMUM_SMART_CONFIG,
@@ -148,14 +148,14 @@ class FlowServiceTest {
             addDependency<VirtualNodeInfoReadService>()
             addDependency<CpiInfoReadService>()
             addDependency<FlowExecutor>()
-            addDependency<FlowMaintenance>()
+//            addDependency<FlowMaintenance>()
 
             FlowService(
                 coordinatorFactory,
                 configReadService,
                 flowExecutor,
                 externalMessagingRoutingService,
-                flowMaintenance
+//                flowMaintenance
             )
         }
     }


### PR DESCRIPTION
There is an issue with state manager / state manager schema / configuration resulting in the flow maintenance component throwing an exception when it tries create the state manager.