### PR TITLE
CORE-17411: Fix MGM info not getting updated after upgrading the same vNode multiple times

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -224,7 +224,7 @@ internal class VirtualNodeUpgradeOperationHandler(
                     try {
                         val registrationRequestDetails = registrationRequest.payload.first()
 
-                        val updatedSerial = registrationRequestDetails.serial + 1
+                        val updatedSerial = membershipGroupReaderProvider.getGroupReader(holdingIdentity).lookup(x500Name)!!.serial
                         val registrationContext = registrationRequestDetails
                             .memberProvidedContext.data.array()
                             .deserializeContext(keyValuePairListDeserializer)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -223,9 +223,7 @@ internal class VirtualNodeUpgradeOperationHandler(
                 is MembershipQueryResult.Success ->
                     try {
                         // Get the latest registration request
-                        val registrationRequestDetails = registrationRequest.payload.sortedByDescending {
-                            it.registrationLastModified
-                        }.first()
+                        val registrationRequestDetails = registrationRequest.payload.last()
 
                         val updatedSerial = registrationRequestDetails.serial + 1
                         val registrationContext = registrationRequestDetails

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -217,14 +217,17 @@ internal class VirtualNodeUpgradeOperationHandler(
         ) {
             val x500Name = membershipGroupReaderProvider.getGroupReader(holdingIdentity).owningMember
             val registrationRequest = membershipQueryClient
-                .queryRegistrationRequests(holdingIdentity, x500Name, listOf(APPROVED), 1)
+                .queryRegistrationRequests(holdingIdentity, x500Name, listOf(APPROVED))
 
             when (registrationRequest) {
                 is MembershipQueryResult.Success ->
                     try {
-                        val registrationRequestDetails = registrationRequest.payload.first()
+                        // Get the latest registration request
+                        val registrationRequestDetails = registrationRequest.payload.sortedByDescending {
+                            it.registrationLastModified
+                        }.first()
 
-                        val updatedSerial = membershipGroupReaderProvider.getGroupReader(holdingIdentity).lookup(x500Name)!!.serial
+                        val updatedSerial = registrationRequestDetails.serial + 1
                         val registrationContext = registrationRequestDetails
                             .memberProvidedContext.data.array()
                             .deserializeContext(keyValuePairListDeserializer)


### PR DESCRIPTION
- Serial field getting incorrect serial,  to fix this we query for all APPROVED registration requests and sort to get the latest request

E2E test: [CORE-17411: Add test to upgrade the same vNode multiple times with correct serial and version #260](https://github.com/corda/corda-e2e-tests/pull/260)