### PR TITLE
ES-1447: Add ability to run Enterprise smoke tests

### DIFF
--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -3,7 +3,7 @@
 endToEndPipeline(
     helmVersion: '^5.1.0-beta',
     helmRepoSuffix: 'release/ent/5.1',
-    helmRepo: 'corda-ent-docker'
+    helmRepo: 'corda-ent-docker',
     assembleAndCompile: true,
     multiCluster: false,
     gradleTestTargetsToExecute: ['smokeTest'],

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -1,8 +1,9 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@ronanb/ES-1447/enterprise-smoke-tests') _
 
 endToEndPipeline(
     helmVersion: '^5.1.0-beta',
     helmRepoSuffix: 'release/ent/5.1',
+    helmRepo: 'corda-ent-docker'
     assembleAndCompile: true,
     multiCluster: false,
     gradleTestTargetsToExecute: ['smokeTest'],

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -1,3 +1,7 @@
+/**
+ * Pipeline to take a packaged helm chart, deploy it and subsequently run the smoke test target
+ * in this repo against these images - Can be used to exercise the C5 Ent images against smoke tests in corda-runtime-os
+ */
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -1,8 +1,10 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(
+    helmVersion: '^5.1.0-beta',
+    helmRepoSuffix: 'release/ent/5.1',
     assembleAndCompile: true,
-    multiCluster: true,
+    multiCluster: false,
     gradleTestTargetsToExecute: ['smokeTest'],
     usePackagedCordaHelmChart: true,
     gradleAdditionalArgs : '-Dscan.tag.EnterpriseSmokeTest',

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -1,0 +1,12 @@
+@Library('corda-shared-build-pipeline-steps@5.1') _
+
+endToEndPipeline(
+    assembleAndCompile: true,
+    multiCluster: true,
+    gradleTestTargetsToExecute: ['smokeTest'],
+    usePackagedCordaHelmChart: true,
+    gradleAdditionalArgs : '-Dscan.tag.EnterpriseSmokeTest',
+    pipelineTimeoutMinutes: 75,
+    testTimeoutMinutes : 60,
+    javaVersion: '17'
+)

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -4,7 +4,7 @@ endToEndPipeline(
     helmVersion: '^5.1.0-beta',
     helmRepoSuffix: 'release/ent/5.1',
     helmRepo: 'corda-ent-docker',
-    assembleAndCompile: true,
+    assembleAndCompile: false,
     multiCluster: false,
     gradleTestTargetsToExecute: ['smokeTest'],
     usePackagedCordaHelmChart: true,

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@ronanb/ES-1447/enterprise-smoke-tests') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(
     helmVersion: '^5.1.0-beta',


### PR DESCRIPTION
Add the ability to run the C5 Enterprise images against the smoke tests in this repo. 

Tested: https://ci02.dev.r3.com/job/Corda5/job/corda5-enterprise-smoketests/job/ronanb%2FES-1447%2Fenterprise-smoke-tests/14/ 