### PR TITLE
CORE-17516 Series of backchain code fixes

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -34,7 +34,7 @@ interface UtxoPersistenceService {
      *
      * @return A map of the transaction IDs found and their statuses.
      */
-    fun findTransactionIdsAndStatuses(transactionIds: List<String>): Map<SecureHash, TransactionStatus>
+    fun findTransactionIdsAndStatuses(transactionIds: List<String>): Map<SecureHash, String>
 
     /**
      * Find a signed ledger transaction in the persistence context given it's [id] and return it with the status it is stored with. This

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -18,7 +18,7 @@ interface UtxoRepository {
     fun findTransactionIdsAndStatuses(
         entityManager: EntityManager,
         transactionIds: List<String>
-    ): Map<SecureHash, TransactionStatus>
+    ): Map<SecureHash, String>
 
     /** Retrieves transaction by [id] */
     fun findTransaction(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -70,7 +70,7 @@ class UtxoPersistenceServiceImpl(
 
     override fun findTransactionIdsAndStatuses(
         transactionIds: List<String>
-    ): Map<SecureHash, TransactionStatus> {
+    ): Map<SecureHash, String> {
         return entityManagerFactory.transaction { em ->
             repository.findTransactionIdsAndStatuses(em, transactionIds)
         }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -74,7 +74,7 @@ class UtxoRepositoryImpl @Activate constructor(
     override fun findTransactionIdsAndStatuses(
         entityManager: EntityManager,
         transactionIds: List<String>
-    ): Map<SecureHash, TransactionStatus> {
+    ): Map<SecureHash, String> {
         return entityManager.createNativeQuery(
             """
                 SELECT transaction_id, status 
@@ -84,9 +84,7 @@ class UtxoRepositoryImpl @Activate constructor(
         )
             .setParameter("transactionIds", transactionIds)
             .resultListAsTuples()
-            .associate {
-                    r -> parseSecureHash(r.get(0) as String) to TransactionStatus.valueOf(r.get(1) as String)
-            }
+            .associate { r -> parseSecureHash(r.get(0) as String) to r.get(1) as String }
     }
 
     private fun findTransactionPrivacySalt(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -77,7 +77,7 @@ class UtxoRepositoryImpl @Activate constructor(
     ): Map<SecureHash, TransactionStatus> {
         return entityManager.createNativeQuery(
             """
-                SELECT transaction_id, status, 
+                SELECT transaction_id, status 
                 FROM {h-schema}utxo_transaction_status 
                 WHERE transaction_id IN (:transactionIds)""",
             Tuple::class.java

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindTransactionIdsAndStatusesRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindTransactionIdsAndStatusesRequestHandler.kt
@@ -25,7 +25,7 @@ class UtxoFindTransactionIdsAndStatusesRequestHandler(
             externalEventResponseFactory.success(
                 externalEventContext,
                 EntityResponse(
-                    existingTransactions.map { ByteBuffer.wrap(serializationService.serialize(it).bytes) },
+                    listOf(ByteBuffer.wrap(serializationService.serialize(existingTransactions).bytes)),
                     KeyValuePairList(emptyList()),
                     null
                 )

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
@@ -72,9 +72,8 @@ class TransactionBackchainReceiverFlowV1(
 
         val sortedTransactionIds = TopologicalSort()
 
-        val ledgerConfig = flowConfigService.getConfig(UTXO_LEDGER_CONFIG)
+        val batchSize = flowConfigService.getConfig(UTXO_LEDGER_CONFIG).getInt(BACKCHAIN_BATCH_CONFIG_PATH)
 
-        val batchSize = ledgerConfig.getInt(BACKCHAIN_BATCH_CONFIG_PATH)
         val existingTransactionIdsInDb = mutableMapOf<SecureHash, TransactionStatus>()
 
         while (transactionsToRetrieve.isNotEmpty()) {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
@@ -194,6 +194,7 @@ class TransactionBackchainReceiverFlowV1(
     }
 
     @Suppress("NestedBlockDepth")
+    @Suspendable
     private fun handleExistingTransactionsAndTheirDependencies(
         existingTransactionIdsInDb: MutableMap<SecureHash, TransactionStatus>,
         transactionsToRetrieve: LinkedHashSet<SecureHash>,
@@ -282,6 +283,7 @@ class TransactionBackchainReceiverFlowV1(
         }
     }
 
+    @Suspendable
     private fun fetchGroupParametersAndHashForTransaction(
         transaction: UtxoSignedTransaction
     ): Pair<SecureHash, SignedGroupParameters?> {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -98,9 +98,8 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
                 )
             }
         }.firstOrNull()?.let {
-            serializationService.deserialize<Map<String, TransactionStatus>>(it.array()).mapKeys { entry ->
-                parseSecureHash(entry.key)
-            }
+            serializationService.deserialize<Map<SecureHash, String>>(it.array())
+                .mapValues { (_, status) -> status.toTransactionStatus() }
         } ?: emptyMap()
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -1,7 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
 import io.micrometer.core.instrument.Timer
-import net.corda.crypto.core.parseSecureHash
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.fiber.metrics.recordSuspendable
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
@@ -14,11 +13,11 @@ import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperat
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.PersistTransaction
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.PersistTransactionIfDoesNotExist
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.UpdateTransactionStatus
-import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionIdsAndStatusesExternalEventFactory
-import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionIdsAndStatusesParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionIdsAndStatusesExternalEventFactory
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionIdsAndStatusesParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionIfDoesNotExistExternalEventFactory


### PR DESCRIPTION
Fix several issues in the backchain code:

- Missing `@Suspendable` annotations in `TransactionBackchainReceiverFlowV1`.
- Don't store `SmartConfig` as a variable in `TransactionBackchainReceiverFlowV1` to prevent a Kryo serialization error.
- Remove comma from SQL statement that was causing an error.
- Correct `String` to `TransactionStatus` conversion.
- Correctly match types between flow and persistence code.