### PR TITLE
CORE-17542 Remove unused token ledger event messages.

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -119,7 +119,6 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
             }
             is PersistTransaction -> {
                 UtxoPersistTransactionRequestHandler(
-                    sandbox.virtualNodeContext.holdingIdentity,
                     UtxoTransactionReaderImpl(sandbox, externalEventContext, req),
                     UtxoTokenObserverMapImpl(sandbox),
                     externalEventContext,


### PR DESCRIPTION
This change removes unused token selection ledger event messages. These events are redundant now token selection queries the DB directly.  