### PR TITLE
CORE-16236 - Flow Mapper Worker - Remove 'External Event Responses' (unused) Dependency

### DIFF
--- a/processors/flow-mapper-processor/build.gradle
+++ b/processors/flow-mapper-processor/build.gradle
@@ -51,7 +51,6 @@ dependencies {
     runtimeOnly project(':libs:crypto:crypto-serialization-impl')
     runtimeOnly project(':libs:crypto:merkle-impl')
     runtimeOnly project(':libs:db:db-orm-impl')
-    runtimeOnly project(':libs:flows:external-event-responses-impl')
     runtimeOnly project(':libs:flows:flow-api')
     runtimeOnly project(':libs:flows:session-manager-impl')
     runtimeOnly project(':libs:messaging:messaging-impl')


### PR DESCRIPTION
External Events are not being used by Flow Mapper Worker. This PR is to remove it from Gradle.