### PR TITLE
CORE-16320 - default the state manager credentials for local deployments

### DIFF
--- a/values-prereqs.yaml
+++ b/values-prereqs.yaml
@@ -30,6 +30,14 @@ bootstrap:
             key: "postgres-password"
       username:
         value: "postgres"
+    stateManager:
+      password:
+        valueFrom:
+          secretKeyRef:
+            name: "prereqs-postgresql"
+            key: "postgres-password"
+      username:
+        value: "postgres"
   kafka:
     replicas: 1
 

--- a/values.yaml
+++ b/values.yaml
@@ -38,6 +38,14 @@ bootstrap:
             key: "postgres-password"
       username:
         value: "postgres"
+    stateManager:
+      password:
+        valueFrom:
+          secretKeyRef:
+            name: "prereqs-postgresql"
+            key: "postgres-password"
+      username:
+        value: "postgres"
   kafka:
     replicas: 1
 


### PR DESCRIPTION
Some developers will run Corda via the following commands:

1 - Install prereqs
```
helm upgrade --install prereqs -n corda \
  oci://corda-os-docker.software.r3.com/helm-charts/corda-dev \
  --render-subchart-notes \
  --timeout 10m \
  --wait
```

2 - Install Corda
```
helm upgrade --install corda -n corda \
oci://corda-os-docker.software.r3.com/helm-charts/corda \
--version "<helm chart version number>" \
--values values.yaml \
--wait
```
or
```
helm install corda -n corda charts/corda --values values-prereqs.yaml --wait
```

The prereqs helm chart does not deploy a state-manager postgres instance. Thus, in order to get developers up and running they should point to the cluster state-manager.