### PR TITLE
CORE-17509 Fix MGM platform version after platform upgrade

### DIFF
--- a/components/membership/membership-service-impl/build.gradle
+++ b/components/membership/membership-service-impl/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation "net.corda:corda-topic-schema"
 
     implementation project(":libs:messaging:messaging")
+    implementation project(':libs:platform-info')
     implementation project(":libs:utilities")
 
     implementation project(":components:configuration:configuration-read-service")

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceImpl.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/MemberOpsServiceImpl.kt
@@ -11,6 +11,7 @@ import net.corda.data.membership.rpc.request.MembershipRpcRequest
 import net.corda.data.membership.rpc.response.MembershipRpcResponse
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.helper.getConfig
+import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -78,6 +79,8 @@ class MemberOpsServiceImpl @Activate constructor(
     private val merkleTreeProvider: MerkleTreeProvider,
     @Reference(service = LocallyHostedIdentitiesService::class)
     private val locallyHostedIdentitiesService: LocallyHostedIdentitiesService,
+    @Reference(service = PlatformInfoProvider::class)
+    private val platformInfoProvider: PlatformInfoProvider,
 ) : MemberOpsService {
     private companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
@@ -202,6 +205,7 @@ class MemberOpsServiceImpl @Activate constructor(
                     virtualNodeInfoReadService,
                     membershipGroupReaderProvider,
                     membershipQueryClient,
+                    platformInfoProvider,
                 ),
                 messagingConfig = messagingConfig
             ).also { it.start() }

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
@@ -134,6 +134,7 @@ class MemberOpsServiceProcessorTest {
         virtualNodeInfoReadService,
         membershipGroupReaderProvider,
         membershipQueryClient,
+        mock(),
         clock,
     )
 

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceTest.kt
@@ -220,6 +220,7 @@ class MemberOpsServiceTest {
                 mock(),
                 mock(),
                 mock(),
+                mock(),
             )
         }
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterFactory.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeWriterFactory.kt
@@ -143,6 +143,8 @@ internal class VirtualNodeWriterFactory(
                 membershipQueryClient,
                 externalMessagingRouteConfigGenerator,
                 cordaAvroSerializationFactory,
+                recordFactory,
+                groupPolicyParser,
             ),
 
             VirtualNodeCreateRequest::class.java to CreateVirtualNodeOperationHandler(

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -242,13 +242,13 @@ internal class VirtualNodeUpgradeOperationHandler(
             viewOwningIdentity = holdingIdentity,
             requestSubjectX500Name = holdingIdentity.x500Name,
             statuses = listOf(APPROVED),
-            limit = 1
         )
         when (registrationRequest) {
             is MembershipQueryResult.Success -> {
                 if (registrationRequest.payload.isNotEmpty()) {
                     try {
-                        val registrationRequestDetails = registrationRequest.payload.first()
+                        // Get the latest registration request
+                        val registrationRequestDetails = registrationRequest.payload.last()
 
                         val updatedSerial = registrationRequestDetails.serial + 1
                         val registrationContext = registrationRequestDetails

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandler.kt
@@ -42,6 +42,7 @@ import net.corda.membership.lib.deserializeContext
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.persistence.client.MembershipQueryResult
 import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.virtualnode.write.db.impl.writer.asyncoperation.factories.RecordFactory
 
 @Suppress("LongParameterList")
 internal class VirtualNodeUpgradeOperationHandler(
@@ -54,6 +55,8 @@ internal class VirtualNodeUpgradeOperationHandler(
     private val membershipQueryClient: MembershipQueryClient,
     private val externalMessagingRouteConfigGenerator: ExternalMessagingRouteConfigGenerator,
     private val cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    private val recordFactory: RecordFactory,
+    private val policyParser: GroupPolicyParser,
     private val cpkDbChangeLogRepository: CpkDbChangeLogRepository = CpiCpkRepositoryFactory().createCpkDbChangeLogRepository(),
     private val virtualNodeRepository: VirtualNodeRepository = VirtualNodeRepositoryImpl(),
 ) : VirtualNodeAsyncOperationHandler<VirtualNodeUpgradeRequest> {
@@ -80,9 +83,9 @@ internal class VirtualNodeUpgradeOperationHandler(
         request.validateMandatoryFields()
 
         try {
-            val (upgradedVNodeInfo, cpkChangelogs) = upgradeVirtualNodeEntityTransaction(requestTimestamp, requestId, request)
+            val (upgradedVNodeInfo, cpkChangelogs, targetCpi) = upgradeVirtualNodeEntityTransaction(requestTimestamp, requestId, request)
             upgradeVirtualNodeCpi(requestId, request, upgradedVNodeInfo, cpkChangelogs)
-            reRegisterMember(upgradedVNodeInfo)
+            reRegisterMember(upgradedVNodeInfo, targetCpi)
         } catch (e: Exception) {
             handleUpgradeException(e, requestId, request, requestTimestamp)
         }
@@ -206,51 +209,68 @@ internal class VirtualNodeUpgradeOperationHandler(
         return Pair(currentVirtualNode, targetCpiMetadata)
     }
 
-    // Re-register the member if the member already exists
-    // after the virtual node has been upgraded, so that the member CPI version is up-to-date
-    private fun reRegisterMember(upgradedVNodeInfo: VirtualNodeInfo) {
+    /**
+     * Re-register the member if the member already exists
+     * after the virtual node has been upgraded, so that the member CPI version is up-to-date.
+     * Republishes the MGM's Member Info, if the Group Policy was changed.
+     */
+    private fun reRegisterMember(upgradedVNodeInfo: VirtualNodeInfo, cpiMetadata: CpiMetadata) {
         val holdingIdentity = upgradedVNodeInfo.holdingIdentity
-        val registrationRequestsCheck = membershipQueryClient.queryRegistrationRequests(holdingIdentity)
-        if (
-            registrationRequestsCheck is MembershipQueryResult.Success
-            && registrationRequestsCheck.payload.isNotEmpty()
-        ) {
-            val x500Name = membershipGroupReaderProvider.getGroupReader(holdingIdentity).owningMember
-            val registrationRequest = membershipQueryClient
-                .queryRegistrationRequests(holdingIdentity, x500Name, listOf(APPROVED))
+        val membershipGroupReader = membershipGroupReaderProvider.getGroupReader(holdingIdentity)
 
-            when (registrationRequest) {
-                is MembershipQueryResult.Success ->
-                    try {
-                        // Get the latest registration request
-                        val registrationRequestDetails = registrationRequest.payload.last()
+        val mgmInfo = if (!GroupPolicyParser.isStaticNetwork(cpiMetadata.groupPolicy!!)) {
+            policyParser.getMgmInfo(holdingIdentity, cpiMetadata.groupPolicy!!)
+        } else {
+            //If it's a static network there is no MGM to re-register with.
+            return
+        }
 
-                        val updatedSerial = registrationRequestDetails.serial + 1
-                        val registrationContext = registrationRequestDetails
-                            .memberProvidedContext.data.array()
-                            .deserializeContext(keyValuePairListDeserializer)
-                            .toMutableMap()
-
-                        registrationContext[MemberInfoExtension.SERIAL] = updatedSerial.toString()
-
-                        memberResourceClient.startRegistration(
-                            holdingIdentity.shortHash,
-                            registrationContext,
-                        )
-                    } catch (e: ContextDeserializationException) {
-                        logger.warn(
-                            "Could not deserialize previous registration context for ${holdingIdentity.shortHash}. " +
-                                    "Re-registration will not be attempted."
-                        )
-                    }
-
-                is MembershipQueryResult.Failure ->
-                    logger.warn(
-                        "Failed to query for an APPROVED previous registration request for ${holdingIdentity.shortHash}: " +
-                                "${registrationRequest.errorMsg}. " +
-                                "Re-registration will not be attempted."
-                    )
+        val records = if (mgmInfo == null) {
+            logger.info("No MGM information found in group policy. MGM member info not published.")
+            mutableListOf()
+        } else {
+            val oldMgmMemberInfo = membershipGroupReader.lookup(mgmInfo.name)
+            if (mgmInfo != oldMgmMemberInfo) {
+                mutableListOf(recordFactory.createMgmInfoRecord(holdingIdentity, mgmInfo))
+            } else {
+                emptyList()
             }
+        }
+        virtualNodeInfoPublisher.publish(records)
+
+        val registrationRequest = membershipQueryClient.queryRegistrationRequests(
+            viewOwningIdentity = holdingIdentity,
+            requestSubjectX500Name = holdingIdentity.x500Name,
+            statuses = listOf(APPROVED),
+            limit = 1
+        )
+        if (registrationRequest is MembershipQueryResult.Success && registrationRequest.payload.isNotEmpty()) {
+            try {
+                val registrationRequestDetails = registrationRequest.payload.first()
+
+                val updatedSerial = registrationRequestDetails.serial + 1
+                val registrationContext = registrationRequestDetails
+                    .memberProvidedContext.data.array()
+                    .deserializeContext(keyValuePairListDeserializer)
+                    .toMutableMap()
+
+                registrationContext[MemberInfoExtension.SERIAL] = updatedSerial.toString()
+
+                memberResourceClient.startRegistration(
+                    holdingIdentity.shortHash,
+                    registrationContext,
+                )
+            } catch (e: ContextDeserializationException) {
+                logger.warn(
+                    "Could not deserialize previous registration context for ${holdingIdentity.shortHash}. " +
+                            "Re-registration will not be attempted."
+                )
+            }
+        } else if (registrationRequest is MembershipQueryResult.Failure) {
+            logger.warn("Failed to query for an APPROVED previous registration request for ${holdingIdentity.shortHash}: " +
+                    "${registrationRequest.errorMsg}. Re-registration will not be attempted.")
+        } else {
+            // TODO
         }
     }
 
@@ -258,8 +278,8 @@ internal class VirtualNodeUpgradeOperationHandler(
         requestTimestamp: Instant,
         requestId: String,
         request: VirtualNodeUpgradeRequest
-    ): Pair<VirtualNodeInfo, List<CpkDbChangeLog>> {
-        val (upgradedVNodeInfo, cpkChangelogs) = entityManagerFactory.createEntityManager().transaction { em ->
+    ): Triple<VirtualNodeInfo, List<CpkDbChangeLog>, CpiMetadata> {
+        val (upgradedVNodeInfo, cpkChangelogs, targetCpi) = entityManagerFactory.createEntityManager().transaction { em ->
             val (virtualNode, targetCpi) = validateUpgradeRequest(em, request, requestId, request.forceUpgrade)
 
             val externalMessagingRouteConfig = externalMessagingRouteConfigGenerator.generateUpgradeConfig(
@@ -270,7 +290,7 @@ internal class VirtualNodeUpgradeOperationHandler(
 
             upgradeVirtualNodeEntity(em, request, requestId, requestTimestamp, targetCpi, externalMessagingRouteConfig)
         }
-        return Pair(upgradedVNodeInfo, cpkChangelogs)
+        return Triple(upgradedVNodeInfo, cpkChangelogs, targetCpi)
     }
 
     private fun upgradeVirtualNodeEntity(
@@ -298,7 +318,8 @@ internal class VirtualNodeUpgradeOperationHandler(
 
         return UpgradeTransactionCompleted(
             upgradedVnodeInfo,
-            migrationChangelogs
+            migrationChangelogs,
+            targetCpiMetadata,
         )
     }
 
@@ -404,7 +425,8 @@ internal class VirtualNodeUpgradeOperationHandler(
 
     data class UpgradeTransactionCompleted(
         val upgradedVirtualNodeInfo: VirtualNodeInfo,
-        val cpkChangelogs: List<CpkDbChangeLog>
+        val cpkChangelogs: List<CpkDbChangeLog>,
+        val cpiMetadata: CpiMetadata,
     )
 
     private fun VirtualNodeUpgradeRequest.validateMandatoryFields() {

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandlerTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/writer/asyncoperation/handlers/VirtualNodeUpgradeOperationHandlerTest.kt
@@ -21,17 +21,20 @@ import net.corda.membership.lib.grouppolicy.GroupPolicyConstants
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.persistence.client.MembershipQueryResult
+import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.publisher.Publisher
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.VirtualNode.VIRTUAL_NODE_INFO_TOPIC
 import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.membership.MemberInfo
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeEntityRepository
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.MigrationUtility
+import net.corda.virtualnode.write.db.impl.writer.asyncoperation.factories.RecordFactory
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.handlers.VirtualNodeUpgradeOperationHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -62,7 +65,6 @@ class VirtualNodeUpgradeOperationHandlerTest {
     private val migrationUtility = mock<MigrationUtility> {
         whenever(it.areChangesetsDeployedOnVault(any(), any(), any())).thenReturn(false)
     }
-    private val membershipGroupReaderProvider = mock<MembershipGroupReaderProvider>()
     private val memberResourceClient = mock<MemberResourceClient>()
     private val membershipQueryClient = mock<MembershipQueryClient>().apply {
         whenever(queryRegistrationRequests(any(), anyOrNull(), any(), anyOrNull())).thenReturn(MembershipQueryResult.Success(emptyList()))
@@ -100,9 +102,26 @@ class VirtualNodeUpgradeOperationHandlerTest {
         whenever(it.findByCpiId(any(), any())).thenReturn(cpkDbChangelogs)
     }
 
-    private val deserializer= mock<CordaAvroDeserializer<KeyValuePairList>>()
-    private val cordaAvroSerializationFactory= mock<CordaAvroSerializationFactory> {
+    private val deserializer = mock<CordaAvroDeserializer<KeyValuePairList>>()
+    private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
         on { createAvroDeserializer(any(), eq(KeyValuePairList::class.java)) } doReturn deserializer
+    }
+    private val recordFactory = mock<RecordFactory>()
+
+    private val mgmX500Name = MemberX500Name.parse("CN=MGM, O=MGM Corp, L=LDN, C=GB")
+    private val newMgmInfo = mock<MemberInfo> {
+        on { name } doReturn mgmX500Name
+    }
+    private val groupPolicyParser = mock<GroupPolicyParser> {
+        on { getMgmInfo(any(), any()) } doReturn newMgmInfo
+    }
+
+    private val oldMgmInfo = mock<MemberInfo>()
+    private val membershipGroupReader = mock<MembershipGroupReader> {
+        on { lookup(eq(mgmX500Name), any()) } doReturn oldMgmInfo
+    }
+    private val membershipGroupReaderProvider = mock<MembershipGroupReaderProvider> {
+        on { getGroupReader(any()) } doReturn membershipGroupReader
     }
 
     private val handler = VirtualNodeUpgradeOperationHandler(
@@ -115,6 +134,8 @@ class VirtualNodeUpgradeOperationHandlerTest {
         membershipQueryClient,
         externalMessagingRouteConfigGenerator,
         cordaAvroSerializationFactory,
+        recordFactory,
+        groupPolicyParser,
         mockCpkDbChangeLogRepository,
         virtualNodeRepository,
     )
@@ -142,8 +163,9 @@ class VirtualNodeUpgradeOperationHandlerTest {
         externalMessagingRouteConfig = externalMessagingRouteConfig,
         timestamp = Instant.now()
     )
-    private val groupPolicy = genGroupPolicy(UUID.randomUUID().toString())
-    private val groupId = GroupPolicyParser.groupIdFromJson(groupPolicy)
+    private val staticGroupPolicy = genGroupPolicy(UUID.randomUUID().toString())
+    private val dynamicGroupPolicy = genDynamicGroupPolicy(UUID.randomUUID().toString())
+    private val groupId = GroupPolicyParser.groupIdFromJson(staticGroupPolicy)
 
     private fun genGroupPolicy(groupId: String): String {
         return """
@@ -156,13 +178,25 @@ class VirtualNodeUpgradeOperationHandlerTest {
                 """.trimIndent()
     }
 
+    private fun genDynamicGroupPolicy(groupId: String): String {
+        return """
+                {
+                    "${GroupPolicyConstants.PolicyKeys.Root.GROUP_ID}": "$groupId"
+                }
+                """.trimIndent()
+    }
+
     private val targetCpiChecksum = "targetCpi"
     private val currentCpiMetadata = mock<CpiMetadata> {
-        whenever(it.groupPolicy).thenReturn(groupPolicy)
+        whenever(it.groupPolicy).thenReturn(staticGroupPolicy)
     }
     private val targetCpiId = CpiIdentifier(cpiName, "v2", ssh)
     private val targetCpiMetadata = mock<CpiMetadata> {
-        whenever(it.groupPolicy).thenReturn(groupPolicy)
+        whenever(it.groupPolicy).thenReturn(staticGroupPolicy)
+        whenever(it.cpiId).thenReturn(targetCpiId)
+    }
+    private val nonStaticTargetCpiMetadata = mock<CpiMetadata> {
+        whenever(it.groupPolicy).thenReturn(dynamicGroupPolicy)
         whenever(it.cpiId).thenReturn(targetCpiId)
     }
 
@@ -505,6 +539,37 @@ class VirtualNodeUpgradeOperationHandlerTest {
     }
 
     @Test
+    fun `upgrade handler re-publishes updated mgm information when group policy changed`() {
+        val requestTimestamp = Instant.now()
+
+        whenever(virtualNodeRepository.find(em, ShortHash.of(vnodeId))).thenReturn(vNode)
+        whenever(oldVirtualNodeEntityRepository.getCpiMetadataByChecksum(targetCpiChecksum)).thenReturn(
+            nonStaticTargetCpiMetadata
+        )
+        whenever(oldVirtualNodeEntityRepository.getCPIMetadataById(eq(em), eq(cpiId)))
+            .thenReturn(nonStaticTargetCpiMetadata)
+        whenever(
+            virtualNodeRepository.upgradeVirtualNodeCpi(
+                eq(em),
+                eq(vnodeId),
+                eq(cpiName),
+                eq("v2"),
+                eq(sshString),
+                eq(newExternalMessagingRouteConfig),
+                eq(requestId),
+                eq(requestTimestamp),
+                eq(request.toString())
+            )
+        ).thenReturn(inProgressVnodeInfoWithoutVaultDdl)
+        val mgmRecord = mock<Record<*, *>>()
+        whenever(recordFactory.createMgmInfoRecord(any(), eq(newMgmInfo))).thenReturn(mgmRecord)
+
+        handler.handle(requestTimestamp, requestId, request)
+
+        verify(virtualNodeInfoPublisher).publish(eq(listOf(mgmRecord)))
+    }
+
+    @Test
     fun `migrations thrown an exception, operation is written with the details`() {
         val requestTimestamp = Instant.now()
 
@@ -701,7 +766,7 @@ class VirtualNodeUpgradeOperationHandlerTest {
         assertThat(publishedRecord.topic).isEqualTo(VIRTUAL_NODE_INFO_TOPIC)
 
         val holdingIdentity = publishedRecord.key
-        assertThat(holdingIdentity.groupId).isEqualTo(GroupPolicyParser.groupIdFromJson(groupPolicy))
+        assertThat(holdingIdentity.groupId).isEqualTo(GroupPolicyParser.groupIdFromJson(staticGroupPolicy))
         assertThat(holdingIdentity.x500Name).isEqualTo(x500Name.toString())
 
         assertThat(publishedRecord.value).isNotNull


### PR DESCRIPTION
Fixes an issue where the platform version in the exported group policy would continue to be the older version after performing a platform upgrade. While exporting the group policy, the platform version is now retrieved from `PlatformInfoProvider` instead of the MGM's `MemberInfo`. 
This change also republishes the MGM's `MemberInfo` before re-registering a member (after the virtual node has been upgraded), if the Group Policy was changed.