### PR TITLE
CORE-16246 Add tags to enable individual properties set on topics during creation

### DIFF
--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Create.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Create.kt
@@ -40,6 +40,15 @@ class Create(
     var partitionOverride: Int = 1
 
     @CommandLine.Option(
+        names = ["-t", "--tag"],
+        description = ["One or more tags associated with topics and their respective number of partitions " +
+                "e.g. -t t01=partitions:3 -t t02=partitions:5"]
+    )
+    // Ideally, this would use a custom converter and a custom data type to provide some future flexibility
+    // Potentially to be implemented as a last step. For now, we'll manually parse the inputs
+    var tagsToPropertiesMap: Map<String, String> = emptyMap()
+
+    @CommandLine.Option(
         names = ["-u", "--user"],
         description = ["One or more Corda workers and their respective Kafka users e.g. -u crypto=Charlie -u rest=Rob"]
     )
@@ -47,6 +56,7 @@ class Create(
 
     data class TopicConfig(
         val name: String,
+        val tag: String?,
         val consumers: List<String>,
         val producers: List<String>,
         val config: Map<String, String> = emptyMap()

--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Create.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Create.kt
@@ -56,7 +56,7 @@ class Create(
 
     data class TopicConfig(
         val name: String,
-        val tag: String?,
+        val tags: List<String> = emptyList(),
         val consumers: List<String>,
         val producers: List<String>,
         val config: Map<String, String> = emptyMap()

--- a/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
+++ b/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
@@ -1,5 +1,6 @@
 package net.corda.cli.plugins.topicconfig
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.common.acl.AccessControlEntry
 import org.apache.kafka.common.acl.AclBinding
@@ -11,10 +12,13 @@ import org.apache.kafka.common.resource.ResourceType
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.FileDescriptor
 import java.io.FileOutputStream
 import java.io.PrintStream
+import java.nio.file.Files
 import java.nio.file.Paths
 
 class CreateConnectTest {
@@ -34,6 +38,71 @@ class CreateConnectTest {
     fun `validate new topic with config`() {
         assertThat(getCommandWithGeneratedConfig().getTopics(listOf(Create.PreviewTopicConfiguration("topic", mapOf("key" to "value")))))
             .containsEntry("topic", NewTopic("topic", 1, 1).configs(mapOf("key" to "value")))
+    }
+
+    @Test
+    fun `validate partition numbers are set correctly`() {
+        val command = CreateConnect().apply {
+            create = Create()
+            create?.topic = TopicPlugin.Topic()
+            create?.partitionOverride = 3 // set a global override
+            create?.tagsToPropertiesMap = mapOf("tag01" to "partitions:5") // set partition number for tagged topics
+        }
+
+        val topicDefinitionsFile = this::class.java.classLoader.getResource("config.yaml")?.toURI()
+        val topicDefinitionsString = Files.readString(File(topicDefinitionsFile!!).toPath())
+        val topicDefinitions: Create.TopicDefinitions = command.create!!.mapper.readValue(topicDefinitionsString)
+        val previewConfig = command.create!!.getTopicConfigsForPreview(topicDefinitions.topics.values.toList())
+
+        var topicsToBeCreated = command.getTopics(previewConfig.topics, Paths.get(topicDefinitionsFile).toString())
+        assertThat(topicsToBeCreated).containsEntry(
+            "config.management.request",
+            NewTopic("config.management.request", 5, 1).configs(emptyMap()))
+        assertThat(topicsToBeCreated).containsEntry(
+            "config.management.request.resp",
+            NewTopic("config.management.request.resp", 3, 1).configs(emptyMap()))
+        assertThat(topicsToBeCreated).containsEntry(
+            "config.topic",
+            NewTopic("config.topic", 3, 1).configs(mapOf(
+                "cleanup.policy" to "compact",
+                "segment.ms" to "600000",
+                "delete.retention.ms" to "300000",
+                "min.compaction.lag.ms" to "60000",
+                "max.compaction.lag.ms" to "604800000",
+                "min.cleanable.dirty.ratio" to "0.5"
+        )))
+
+        // tag arguments do not exist, default will be set
+        command.create?.partitionOverride = 1
+        command.create?.tagsToPropertiesMap = mapOf("tag02" to "partitions:5")
+        topicsToBeCreated = command.getTopics(previewConfig.topics, Paths.get(topicDefinitionsFile).toString())
+        assertThat(topicsToBeCreated).containsEntry(
+            "config.management.request",
+            NewTopic("config.management.request", 1, 1).configs(emptyMap()))
+        assertThat(topicsToBeCreated).containsEntry(
+            "config.management.request.resp",
+            NewTopic("config.management.request.resp", 1, 1).configs(emptyMap()))
+        assertThat(topicsToBeCreated).containsEntry(
+            "config.topic",
+            NewTopic("config.topic", 1, 1).configs(mapOf(
+                "cleanup.policy" to "compact",
+                "segment.ms" to "600000",
+                "delete.retention.ms" to "300000",
+                "min.compaction.lag.ms" to "60000",
+                "max.compaction.lag.ms" to "604800000",
+                "min.cleanable.dirty.ratio" to "0.5"
+        )))
+
+        // tag arguments have invalid format or unsupported values
+        command.create?.tagsToPropertiesMap = mapOf("tag01" to "party:5")
+        assertThrows<IllegalArgumentException> {
+            command.getTopics(previewConfig.topics, Paths.get(topicDefinitionsFile).toString())
+        }
+
+        command.create?.tagsToPropertiesMap = mapOf("tag01" to "partitions:abc")
+        assertThrows<IllegalArgumentException> {
+            command.getTopics(previewConfig.topics, Paths.get(topicDefinitionsFile).toString())
+        }
     }
 
     @Test

--- a/tools/plugins/topic-config/src/test/resources/config.yaml
+++ b/tools/plugins/topic-config/src/test/resources/config.yaml
@@ -1,7 +1,9 @@
 topics:
   ConfigManagementRequestTopic:
     name: config.management.request
-    tag: tag01
+    tags:
+      - tag01
+      - tag03
     consumers:
       - db
     producers:
@@ -9,7 +11,7 @@ topics:
     config:
   ConfigManagementRequestResponseTopic:
     name: config.management.request.resp
-    tag:
+    tags:
     consumers:
       - rest
     producers:

--- a/tools/plugins/topic-config/src/test/resources/config.yaml
+++ b/tools/plugins/topic-config/src/test/resources/config.yaml
@@ -1,6 +1,7 @@
 topics:
   ConfigManagementRequestTopic:
     name: config.management.request
+    tag: tag01
     consumers:
       - db
     producers:
@@ -8,6 +9,7 @@ topics:
     config:
   ConfigManagementRequestResponseTopic:
     name: config.management.request.resp
+    tag:
     consumers:
       - rest
     producers:


### PR DESCRIPTION
Topic schemas can now be edited to contain multiple tags per topic

`topics:
  ConfigManagementRequestTopic:
    name: config.management.request
    tags:
      - tag01
      - tag03`

These tags can then be mapped to custom properties by passing them as arguments to the CLI topic-config tool. Currently only `partitions` is supported to allow users to specify partition numbers per topic.
Users may use the global override (`-p`) in addition to the new option `-t` to set a value for all topics except the tagged ones.

Usage:
`./corda-cli.sh topic -b localhost:9094 -k client.properties create -t tag01=partitions:5 -t tag02=partitions:2 connect`

The above command will set the default partition number 1 for all topics except the ones tagged with `tag01` and `tag02` which will have 5 and 2 respectively.

We currently support tag lists for each topic. If a topic has more than one tag which is used to set partition number, the first tag encountered in the list will be used.
