### PR TITLE
CORE-17622 - Refactor - Clean-up - State and Event Subscription

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.subscription
 
-import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.deadletter.StateAndEventDeadLetterRecord
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -30,9 +29,7 @@ import net.corda.metrics.CordaMetrics
 import net.corda.schema.Schemas.getDLQTopic
 import net.corda.schema.Schemas.getStateAndEventStateTopic
 import net.corda.utilities.debug
-import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
-import java.net.http.HttpClient
 import java.nio.ByteBuffer
 import java.time.Clock
 import java.util.UUID
@@ -46,8 +43,6 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     private val chunkSerializerService: ChunkSerializerService,
     private val stateAndEventListener: StateAndEventListener<K, S>? = null,
-    @Reference(service = CordaAvroSerializationFactory::class)
-    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory,
     private val clock: Clock = Clock.systemUTC(),
 ) : StateAndEventSubscription<K, S, E> {
 
@@ -93,12 +88,6 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
         .withTag(CordaMetrics.Tag.MessagePatternClientId, config.clientId)
         .build()
 
-    private val httpClient: HttpClient = HttpClient.newBuilder()
-        .connectTimeout(java.time.Duration.ofSeconds(10))
-        .build()
-
-    private val avroSerializer = cordaAvroSerializationFactory.createAvroSerializer<Any> { }
-    private val avroDeserializer = cordaAvroSerializationFactory.createAvroDeserializer({}, Any::class.java)
 
     /**
      * Is the subscription running.

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/factory/CordaSubscriptionFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/factory/CordaSubscriptionFactory.kt
@@ -140,8 +140,7 @@ class CordaSubscriptionFactory @Activate constructor(
             serializer,
             lifecycleCoordinatorFactory,
             messagingChunkFactory.createChunkSerializerService(messagingConfig.getLong(MAX_ALLOWED_MSG_SIZE)),
-            stateAndEventListener,
-            cordaAvroSerializationFactory
+            stateAndEventListener
         )
     }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.subscription
 
-import net.corda.avro.serialization.CordaAvroSerializationFactory
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
@@ -50,7 +49,6 @@ class StateAndEventSubscriptionImplTest {
     }
 
     private val config = createResolvedSubscriptionConfig(SubscriptionType.STATE_AND_EVENT)
-    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory = mock()
     private val cordaAvroSerializer: CordaAvroSerializer<Any> = mock()
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory = mock()
     private val chunkSerializerService: ChunkSerializerService = mock()
@@ -145,9 +143,7 @@ class StateAndEventSubscriptionImplTest {
             mock(),
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
-            chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
+            chunkSerializerService
         )
 
         subscription.start()
@@ -195,9 +191,7 @@ class StateAndEventSubscriptionImplTest {
             mock(),
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
-            chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
+            chunkSerializerService
         )
 
         subscription.start()
@@ -248,9 +242,7 @@ class StateAndEventSubscriptionImplTest {
             mock(),
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
-            chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
+            chunkSerializerService
         )
 
         subscription.start()
@@ -271,8 +263,6 @@ class StateAndEventSubscriptionImplTest {
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
             chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
         )
 
         subscription.start()
@@ -324,9 +314,7 @@ class StateAndEventSubscriptionImplTest {
             mock(),
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
-            chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
+            chunkSerializerService
         )
 
         subscription.start()
@@ -378,9 +366,7 @@ class StateAndEventSubscriptionImplTest {
             mock(),
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
-            chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
+            chunkSerializerService
         )
 
         subscription.start()
@@ -432,9 +418,7 @@ class StateAndEventSubscriptionImplTest {
             mock(),
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
-            chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
+            chunkSerializerService
         )
 
         subscription.start()
@@ -496,9 +480,7 @@ class StateAndEventSubscriptionImplTest {
             mock(),
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
-            chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
+            chunkSerializerService
         )
 
         subscription.start()
@@ -555,9 +537,7 @@ class StateAndEventSubscriptionImplTest {
             mock(),
             cordaAvroSerializer,
             lifecycleCoordinatorFactory,
-            chunkSerializerService,
-            null,
-            cordaAvroSerializationFactory
+            chunkSerializerService
         )
 
         subscription.start()


### PR DESCRIPTION
### CONTEXT

Due to dependencies still in development by other teams, some dummy implementations were put in place so we could speed up the development.
This code ended up being merged into the main branch.

### SOLUTION

This PR's removes the unused / unnecessary code from State and Event Subscription Implementation and Tests, and from Subscription Factory.