### PR TITLE
CORE-16320 - Remove state-manager schema bootstrap configuration 

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -157,7 +157,7 @@ spec:
               mkdir /tmp/db
               java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar database spec \
                 -s "config,rbac,crypto,statemanager" \
-                -g "config:${DB_CLUSTER_SCHEMA},rbac:${DB_RBAC_SCHEMA},crypto:${DB_CRYPTO_SCHEMA},statemanager:${DB_STATE_MANAGER_SCHEMA}" \
+                -g "config:${DB_CLUSTER_SCHEMA},rbac:${DB_RBAC_SCHEMA},crypto:${DB_CRYPTO_SCHEMA},statemanager:STATE_MANAGER" \
                 -u "${PGUSER}" -p "${PGPASSWORD}" \
                 --jdbc-url "${JDBC_URL}" \
                 -c -l /tmp/db
@@ -249,8 +249,6 @@ spec:
               value: {{ .Values.bootstrap.db.rbac.schema | quote }}
             - name: DB_CRYPTO_SCHEMA
               value: {{ .Values.bootstrap.db.crypto.schema | quote }}
-            - name: DB_STATE_MANAGER_SCHEMA
-              value: {{ .Values.bootstrap.db.stateManager.schema | quote }}
             {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
             {{- include "corda.configSaltAndPassphraseEnv" . | nindent 12 }}
             {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
@@ -291,8 +289,8 @@ spec:
                 DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${CRYPTO_DB_USER_USERNAME}') THEN RAISE NOTICE 'Role "${CRYPTO_DB_USER_USERNAME}" already exists'; ELSE CREATE USER "${CRYPTO_DB_USER_USERNAME}" WITH ENCRYPTED PASSWORD '$CRYPTO_DB_USER_PASSWORD'; END IF; END \$\$;
                 GRANT USAGE ON SCHEMA ${DB_CRYPTO_SCHEMA} TO "${CRYPTO_DB_USER_USERNAME}";
                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_CRYPTO_SCHEMA} TO "${CRYPTO_DB_USER_USERNAME}";
-                GRANT USAGE ON SCHEMA ${DB_STATE_MANAGER_SCHEMA} TO "${DB_CLUSTER_USERNAME}";
-                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_STATE_MANAGER_SCHEMA} TO "${DB_CLUSTER_USERNAME}";
+                GRANT USAGE ON SCHEMA STATE_MANAGER TO "${DB_CLUSTER_USERNAME}";
+                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA STATE_MANAGER TO "${DB_CLUSTER_USERNAME}";
               SQL
 
               echo 'DB Bootstrapped'
@@ -312,8 +310,6 @@ spec:
               value: {{ .Values.bootstrap.db.rbac.schema | quote }}
             - name: DB_CRYPTO_SCHEMA
               value: {{ .Values.bootstrap.db.crypto.schema | quote }}
-            - name: DB_STATE_MANAGER_SCHEMA
-              value: {{ .Values.bootstrap.db.stateManager.schema | quote }}
             {{- include "corda.bootstrapClusterDbEnv" . | nindent 12 }}
             {{- include "corda.rbacDbUserEnv" . | nindent 12 }}
             {{- include "corda.cryptoDbUsernameEnv" . | nindent 12 }}

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -296,7 +296,7 @@ spec:
           - "--stateManager"
           - "database.pass=$(DB_CLUSTER_PASSWORD)"
           - "--stateManager"
-          - "database.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" $.Values.db.cluster.host }}:{{ $.Values.db.cluster.port }}/{{ $.Values.db.cluster.database }}?currentSchema={{ $.Values.bootstrap.db.stateManager.schema }}"
+          - "database.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" $.Values.db.cluster.host }}:{{ $.Values.db.cluster.port }}/{{ $.Values.db.cluster.database }}?currentSchema=STATE_MANAGER"
           - "--stateManager"
           - "database.jdbc.directory=/opt/jdbc-driver"
           - "--stateManager"

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1263,19 +1263,9 @@
                             "default": {},
                             "title": "State Manager db configuration",
                             "required": [
-                                "dbConnectionPool",
-                                "schema"
+                                "dbConnectionPool"
                             ],
                             "properties": {
-                                "schema": {
-                                    "type": "string",
-                                    "default": "STATE_MANAGER",
-                                    "title": "the schema in which the State Manager entities will be stored",
-                                    "examples": [
-                                        "STATE_MANAGER"
-                                    ],
-                                    "minLength": 1
-                                },
                                 "username": {
                                     "$ref": "#/$defs/config"
                                 },
@@ -1346,7 +1336,6 @@
                                 }
                             },
                             "examples": [{
-                                "schema": "STATE_MANAGER",
                                 "password": {
                                     "value": "password"
                                 },

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -366,8 +366,6 @@ bootstrap:
 
     # State Manager DB Bootstrap Configuration
     stateManager:
-      # -- the schema in which the state-manager entities will be stored
-      schema: state_manager
       # JDBC connection pool configuration for state-manager DB
       dbConnectionPool:
         # -- maximum JDBC connection pool size for state-manager DB


### PR DESCRIPTION
**Description**
In several places we are using state manager schema from helm chart values.yaml but the worker itself cannot yet be configured to use a different schema.

**Solution**
Hard-code schema to STATE_MANAGER for now, so we can make this configurable in the future if necessary. Remove configurability of the schema in helm bootstrapping.