### PR TITLE
CORE-17688: Fix sandbox level cache

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -426,12 +426,7 @@ class FlowServiceTestContext @Activate constructor(
     override fun resetFlowFiberCache() {
     ALL_TEST_VIRTUAL_NODES.forEach {
         flowFiberCache.remove(
-            VirtualNodeContext(
-                it.toCorda(),
-                setOf(CPK1_CHECKSUM),
-                FLOW,
-                null
-            )
+            VirtualNodeContext(it.toCorda(), setOf(CPK1_CHECKSUM), FLOW, null)
         )
     }
 }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -37,6 +37,7 @@ import net.corda.flow.testing.fakes.FakeFlowFiberFactory
 import net.corda.flow.testing.fakes.FakeMembershipGroupReaderProvider
 import net.corda.flow.testing.fakes.FakeSandboxGroupContextComponent
 import net.corda.flow.testing.tests.ALL_TEST_VIRTUAL_NODES
+import net.corda.flow.testing.tests.CPK1_CHECKSUM
 import net.corda.flow.testing.tests.FLOW_NAME
 import net.corda.flow.testing.tests.SESSION_PROPERTIES
 import net.corda.flow.utils.KeyValueStore
@@ -55,6 +56,8 @@ import net.corda.libs.packaging.core.CpkType
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
+import net.corda.sandboxgroupcontext.SandboxGroupType.FLOW
+import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.schema.configuration.FlowConfig
@@ -421,8 +424,17 @@ class FlowServiceTestContext @Activate constructor(
     }
 
     override fun resetFlowFiberCache() {
-        ALL_TEST_VIRTUAL_NODES.forEach { flowFiberCache.remove(it.toCorda()) }
+    ALL_TEST_VIRTUAL_NODES.forEach {
+        flowFiberCache.remove(
+            VirtualNodeContext(
+                it.toCorda(),
+                setOf(CPK1_CHECKSUM),
+                FLOW,
+                null
+            )
+        )
     }
+}
 
     fun clearTestRuns() {
         testRuns.clear()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImpl.kt
@@ -10,7 +10,6 @@ import net.corda.sandboxgroupcontext.SandboxedCache.CacheKey
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheEviction
 import net.corda.utilities.debug
-import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
@@ -58,10 +57,10 @@ class MySigningKeysCacheImpl @Activate constructor(
 
     private fun onEviction(vnc: VirtualNodeContext) {
         log.debug {
-            "Evicting cached items from ${cache::class.java} with holding identity: ${vnc.holdingIdentity} and sandbox type: " +
-                    SandboxGroupType.FLOW
+            "Evicting cached items from ${cache::class.java} with holding identity: ${vnc.holdingIdentity}, " +
+                    "cpkFileChecksums: ${vnc.cpkFileChecksums} and sandbox type: ${SandboxGroupType.FLOW}"
         }
-        remove(vnc.holdingIdentity)
+        remove(vnc)
     }
 
     override fun get(keys: Set<PublicKey>): Map<PublicKey, PublicKey?> {
@@ -82,8 +81,8 @@ class MySigningKeysCacheImpl @Activate constructor(
         }
     }
 
-    override fun remove(holdingIdentity: HoldingIdentity) {
-        cache.invalidateAll(cache.asMap().keys.filter { it.holdingIdentity == holdingIdentity })
+    override fun remove(virtualNodeContext: VirtualNodeContext) {
+        cache.invalidateAll(cache.asMap().keys.filter { it.virtualNodeContext == virtualNodeContext })
         cache.cleanUp()
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImplTest.kt
@@ -86,10 +86,12 @@ class MySigningKeysCacheImplTest {
 
     @Test
     fun `removes keys by virtual node context`() {
-        // return vnode in this order in consecutive calls of the function
-       whenever(sandbox.virtualNodeContext).thenReturn(
+        // return vnode in this order in consecutive calls of the function (alice, bob, alice, bob)
+        whenever(sandbox.virtualNodeContext).thenReturn(
             aliceVirtualNodeContext,
-            bobVirtualNodeContext
+            bobVirtualNodeContext,
+            aliceVirtualNodeContext,
+            bobVirtualNodeContext,
         )
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
 
@@ -98,6 +100,11 @@ class MySigningKeysCacheImplTest {
         // bob put cache
         mySigningKeysCache.putAll(mapOf(KEY_C to KEY_C, KEY_D to null))
         mySigningKeysCache.remove(aliceVirtualNodeContext)
+
+        // alice's cache should be empty
+        assertThat(mySigningKeysCache.get(setOf(KEY_A, KEY_B, KEY_C, KEY_D))).containsExactlyInAnyOrderEntriesOf(
+            emptyMap()
+        )
 
         // there should bob's cache only
         assertThat(mySigningKeysCache.get(setOf(KEY_A, KEY_B, KEY_C, KEY_D))).containsExactlyInAnyOrderEntriesOf(

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImplTest.kt
@@ -89,7 +89,7 @@ class MySigningKeysCacheImplTest {
         // return vnode in this order in consecutive calls of the function
        whenever(sandbox.virtualNodeContext).thenReturn(
             aliceVirtualNodeContext,
-            bobVirtualNodeContext,
+            bobVirtualNodeContext
         )
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImplTest.kt
@@ -90,8 +90,6 @@ class MySigningKeysCacheImplTest {
        whenever(sandbox.virtualNodeContext).thenReturn(
             aliceVirtualNodeContext,
             bobVirtualNodeContext,
-            bobVirtualNodeContext,
-           aliceVirtualNodeContext
         )
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
 
@@ -101,15 +99,12 @@ class MySigningKeysCacheImplTest {
         mySigningKeysCache.putAll(mapOf(KEY_C to KEY_C, KEY_D to null))
         mySigningKeysCache.remove(aliceVirtualNodeContext)
 
-        // check bob's cache
+        // there should bob's cache only
         assertThat(mySigningKeysCache.get(setOf(KEY_A, KEY_B, KEY_C, KEY_D))).containsExactlyInAnyOrderEntriesOf(
             mapOf(
                 KEY_C to KEY_C,
                 KEY_D to null
             )
-        )
-        assertThat(mySigningKeysCache.get(setOf(KEY_A, KEY_B, KEY_C, KEY_D))).containsExactlyInAnyOrderEntriesOf(
-            emptyMap()
         )
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/crypto/MySigningKeysCacheImplTest.kt
@@ -1,10 +1,11 @@
 package net.corda.flow.application.crypto
 
+import net.corda.crypto.core.SecureHashImpl
 import net.corda.flow.ALICE_X500_HOLDING_IDENTITY
 import net.corda.flow.BOB_X500_HOLDING_IDENTITY
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.SandboxGroupType
+import net.corda.sandboxgroupcontext.SandboxGroupType.FLOW
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheEviction
 import net.corda.virtualnode.toCorda
@@ -22,10 +23,24 @@ class MySigningKeysCacheImplTest {
         val KEY_B = mock<PublicKey>()
         val KEY_C = mock<PublicKey>()
         val KEY_D = mock<PublicKey>()
+        val CPK1_CHECKSUM = SecureHashImpl("ALG", byteArrayOf(0, 0, 0, 0))
     }
 
     private val sandbox = mock<SandboxGroupContext>()
     private val virtualNodeContext = mock<VirtualNodeContext>()
+    private val aliceVirtualNodeContext = VirtualNodeContext(
+        ALICE_X500_HOLDING_IDENTITY.toCorda(),
+        setOf(CPK1_CHECKSUM),
+        FLOW,
+        null
+    )
+    private val bobVirtualNodeContext = VirtualNodeContext(
+        BOB_X500_HOLDING_IDENTITY.toCorda(),
+        setOf(CPK1_CHECKSUM),
+        FLOW,
+        null
+    )
+
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     private val cacheEviction = mock<CacheEviction>()
     private val mySigningKeysCache = MySigningKeysCacheImpl(currentSandboxGroupContext, cacheEviction)
@@ -33,7 +48,7 @@ class MySigningKeysCacheImplTest {
     @BeforeEach
     fun beforeEach() {
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
-        whenever(virtualNodeContext.sandboxGroupType).thenReturn(SandboxGroupType.FLOW)
+        whenever(virtualNodeContext.sandboxGroupType).thenReturn(FLOW)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
     }
@@ -70,21 +85,31 @@ class MySigningKeysCacheImplTest {
     }
 
     @Test
-    fun `removes keys by holding identity`() {
-        whenever(virtualNodeContext.holdingIdentity).thenReturn(
-            ALICE_X500_HOLDING_IDENTITY.toCorda(),
-            ALICE_X500_HOLDING_IDENTITY.toCorda(),
-            BOB_X500_HOLDING_IDENTITY.toCorda(),
-            BOB_X500_HOLDING_IDENTITY.toCorda()
+    fun `removes keys by virtual node context`() {
+        // return vnode in this order in consecutive calls of the function
+       whenever(sandbox.virtualNodeContext).thenReturn(
+            aliceVirtualNodeContext,
+            bobVirtualNodeContext,
+            bobVirtualNodeContext,
+           aliceVirtualNodeContext
         )
-        mySigningKeysCache.putAll(mapOf(KEY_A to KEY_A, KEY_B to null, KEY_C to KEY_C, KEY_D to null))
-        mySigningKeysCache.remove(ALICE_X500_HOLDING_IDENTITY.toCorda())
+        whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
 
+        // alice put cache
+        mySigningKeysCache.putAll(mapOf(KEY_A to KEY_A, KEY_B to null))
+        // bob put cache
+        mySigningKeysCache.putAll(mapOf(KEY_C to KEY_C, KEY_D to null))
+        mySigningKeysCache.remove(aliceVirtualNodeContext)
+
+        // check bob's cache
         assertThat(mySigningKeysCache.get(setOf(KEY_A, KEY_B, KEY_C, KEY_D))).containsExactlyInAnyOrderEntriesOf(
             mapOf(
                 KEY_C to KEY_C,
                 KEY_D to null
             )
+        )
+        assertThat(mySigningKeysCache.get(setOf(KEY_A, KEY_B, KEY_C, KEY_D))).containsExactlyInAnyOrderEntriesOf(
+            emptyMap()
         )
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImpl.kt
@@ -12,7 +12,6 @@ import net.corda.sandboxgroupcontext.service.CacheEviction
 import net.corda.utilities.debug
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
-import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
@@ -68,8 +67,8 @@ class StateAndRefCacheImpl @Activate constructor(
         }
     }
 
-    override fun remove(holdingIdentity: HoldingIdentity) {
-        cache.invalidateAll(cache.asMap().keys.filter { it.holdingIdentity == holdingIdentity })
+    override fun remove(virtualNodeContext: VirtualNodeContext) {
+        cache.invalidateAll(cache.asMap().keys.filter { it.virtualNodeContext == virtualNodeContext })
         cache.cleanUp()
     }
 
@@ -86,6 +85,6 @@ class StateAndRefCacheImpl @Activate constructor(
             "Evicting cached items from ${cache::class.java} with holding identity: ${vnc.holdingIdentity} and sandbox type: " +
                     SandboxGroupType.FLOW
         }
-        remove(vnc.holdingIdentity)
+        remove(vnc)
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/GroupParametersCacheImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/GroupParametersCacheImpl.kt
@@ -12,7 +12,6 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheEviction
 import net.corda.utilities.debug
 import net.corda.v5.crypto.SecureHash
-import net.corda.virtualnode.HoldingIdentity
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Deactivate
@@ -58,10 +57,10 @@ class GroupParametersCacheImpl @Activate constructor(
 
     private fun onEviction(vnc: VirtualNodeContext) {
         log.debug {
-            "Evicting cached items from ${cache::class.java} with holding identity: ${vnc.holdingIdentity} and sandbox type: " +
-                    SandboxGroupType.FLOW
+            "Evicting cached items from ${cache::class.java} with holding identity: ${vnc.holdingIdentity}, " +
+                    "cpkFileChecksums: ${vnc.cpkFileChecksums} and sandbox type: ${SandboxGroupType.FLOW}"
         }
-        remove(vnc.holdingIdentity)
+        remove(vnc)
     }
 
     override fun get(hash: SecureHash): SignedGroupParameters? {
@@ -74,8 +73,8 @@ class GroupParametersCacheImpl @Activate constructor(
         cache.put(CacheKey(virtualNodeContext, groupParameters.hash), groupParameters)
     }
 
-    override fun remove(holdingIdentity: HoldingIdentity) {
-        cache.invalidateAll(cache.asMap().keys.filter { it.holdingIdentity == holdingIdentity })
+    override fun remove(virtualNodeContext: VirtualNodeContext) {
+        cache.invalidateAll(cache.asMap().keys.filter { it.virtualNodeContext == virtualNodeContext })
         cache.cleanUp()
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImplTest.kt
@@ -94,7 +94,7 @@ class StateAndRefCacheImplTest {
         )
         stateAndRefCache.putAll(listOf(STATE_AND_REF_1, STATE_AND_REF_2))
 
-        stateAndRefCache.remove(ALICE_X500_HOLDING_IDENTITY.toCorda())
+        stateAndRefCache.remove(virtualNodeContext)
 
         assertThat(stateAndRefCache.get(setOf(STATE_REF_1, STATE_REF_2)).values).containsExactly(STATE_AND_REF_2)
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImplTest.kt
@@ -108,8 +108,13 @@ class StateAndRefCacheImplTest {
 
     @Test
     fun `removes keys by virtual node context`() {
-        // subsequent calls of sandbox.virtualNodeContext return in order of alice, bob
-        whenever(sandbox.virtualNodeContext).thenReturn(aliceVirtualNodeContext, bobVirtualNodeContext)
+        // subsequent calls of the function call return in the order of alice, bob, alice, bob
+        whenever(sandbox.virtualNodeContext).thenReturn(
+            aliceVirtualNodeContext,
+            bobVirtualNodeContext,
+            aliceVirtualNodeContext,
+            bobVirtualNodeContext
+        )
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
 
         whenever(STATE_AND_REF_1.ref).thenReturn(STATE_REF_1)
@@ -119,15 +124,13 @@ class StateAndRefCacheImplTest {
         stateAndRefCache.putAll(listOf(STATE_AND_REF_3, STATE_AND_REF_4))
         stateAndRefCache.remove(aliceVirtualNodeContext)
 
+        // alice's cache should be empty
         assertThat(
-            stateAndRefCache.get(
-                setOf(
-                    STATE_REF_1,
-                    STATE_REF_2,
-                    STATE_REF_3,
-                    STATE_REF_4
-                )
-            ).values
+            stateAndRefCache.get(setOf(STATE_REF_1, STATE_REF_2, STATE_REF_3, STATE_REF_4)).values
+        ).containsExactlyElementsOf(emptyList())
+        // bob's cache should exist
+        assertThat(
+            stateAndRefCache.get(setOf(STATE_REF_1, STATE_REF_2, STATE_REF_3, STATE_REF_4)).values
         ).containsExactlyElementsOf(listOf(STATE_AND_REF_3, STATE_AND_REF_4))
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/cache/impl/StateAndRefCacheImplTest.kt
@@ -1,9 +1,10 @@
 package net.corda.ledger.utxo.flow.impl.cache.impl
 
+import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.identity.HoldingIdentity
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.SandboxGroupType
+import net.corda.sandboxgroupcontext.SandboxGroupType.FLOW
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheEviction
 import net.corda.v5.ledger.utxo.ContractState
@@ -21,16 +22,33 @@ class StateAndRefCacheImplTest {
     private companion object {
         val STATE_REF_1 = StateRef(mock(), 0)
         val STATE_REF_2 = StateRef(mock(), 0)
+        val STATE_REF_3 = StateRef(mock(), 0)
+        val STATE_REF_4 = StateRef(mock(), 0)
 
         val STATE_AND_REF_1 = mock<StateAndRef<ContractState>>()
         val STATE_AND_REF_2 = mock<StateAndRef<ContractState>>()
+        val STATE_AND_REF_3 = mock<StateAndRef<ContractState>>()
+        val STATE_AND_REF_4 = mock<StateAndRef<ContractState>>()
 
         val ALICE_X500_HOLDING_IDENTITY = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group1")
         val BOB_X500_HOLDING_IDENTITY = HoldingIdentity("CN=Bob, O=Alice Corp, L=LDN, C=GB", "group1")
+        val CPK1_CHECKSUM = SecureHashImpl("ALG", byteArrayOf(0, 0, 0, 0))
     }
 
     private val sandbox = mock<SandboxGroupContext>()
     private val virtualNodeContext = mock<VirtualNodeContext>()
+    private val aliceVirtualNodeContext = VirtualNodeContext(
+        ALICE_X500_HOLDING_IDENTITY.toCorda(),
+        setOf(CPK1_CHECKSUM),
+        FLOW,
+        null
+    )
+    private val bobVirtualNodeContext = VirtualNodeContext(
+        BOB_X500_HOLDING_IDENTITY.toCorda(),
+        setOf(CPK1_CHECKSUM),
+        FLOW,
+        null
+    )
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     private val cacheEviction = mock<CacheEviction>()
     private val stateAndRefCache = StateAndRefCacheImpl(currentSandboxGroupContext, cacheEviction)
@@ -38,12 +56,14 @@ class StateAndRefCacheImplTest {
     @BeforeEach
     fun beforeEach() {
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
-        whenever(virtualNodeContext.sandboxGroupType).thenReturn(SandboxGroupType.FLOW)
+        whenever(virtualNodeContext.sandboxGroupType).thenReturn(FLOW)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
 
         whenever(STATE_AND_REF_1.ref).thenReturn(STATE_REF_1)
         whenever(STATE_AND_REF_2.ref).thenReturn(STATE_REF_2)
+        whenever(STATE_AND_REF_3.ref).thenReturn(STATE_REF_3)
+        whenever(STATE_AND_REF_4.ref).thenReturn(STATE_REF_4)
     }
 
     @Test
@@ -87,15 +107,27 @@ class StateAndRefCacheImplTest {
     }
 
     @Test
-    fun `removes keys by holding identity`() {
-        whenever(virtualNodeContext.holdingIdentity).thenReturn(
-            ALICE_X500_HOLDING_IDENTITY.toCorda(),
-            BOB_X500_HOLDING_IDENTITY.toCorda()
-        )
+    fun `removes keys by virtual node context`() {
+        // subsequent calls of sandbox.virtualNodeContext return in order of alice, bob
+        whenever(sandbox.virtualNodeContext).thenReturn(aliceVirtualNodeContext, bobVirtualNodeContext)
+        whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
+
+        whenever(STATE_AND_REF_1.ref).thenReturn(STATE_REF_1)
+        whenever(STATE_AND_REF_2.ref).thenReturn(STATE_REF_2)
+
         stateAndRefCache.putAll(listOf(STATE_AND_REF_1, STATE_AND_REF_2))
+        stateAndRefCache.putAll(listOf(STATE_AND_REF_3, STATE_AND_REF_4))
+        stateAndRefCache.remove(aliceVirtualNodeContext)
 
-        stateAndRefCache.remove(virtualNodeContext)
-
-        assertThat(stateAndRefCache.get(setOf(STATE_REF_1, STATE_REF_2)).values).containsExactly(STATE_AND_REF_2)
+        assertThat(
+            stateAndRefCache.get(
+                setOf(
+                    STATE_REF_1,
+                    STATE_REF_2,
+                    STATE_REF_3,
+                    STATE_REF_4
+                )
+            ).values
+        ).containsExactlyElementsOf(listOf(STATE_AND_REF_3, STATE_AND_REF_4))
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/GroupParametersCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/GroupParametersCacheImplTest.kt
@@ -1,10 +1,11 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
+import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.identity.HoldingIdentity
 import net.corda.membership.lib.SignedGroupParameters
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
-import net.corda.sandboxgroupcontext.SandboxGroupType
+import net.corda.sandboxgroupcontext.SandboxGroupType.FLOW
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.CacheEviction
 import net.corda.v5.crypto.SecureHash
@@ -25,10 +26,24 @@ class GroupParametersCacheImplTest {
 
         val ALICE_X500_HOLDING_IDENTITY = HoldingIdentity("CN=Alice, O=Alice Corp, L=LDN, C=GB", "group1")
         val BOB_X500_HOLDING_IDENTITY = HoldingIdentity("CN=Bob, O=Alice Corp, L=LDN, C=GB", "group1")
+
+        val CPK1_CHECKSUM = SecureHashImpl("ALG", byteArrayOf(0, 0, 0, 0))
     }
 
     private val sandbox = mock<SandboxGroupContext>()
     private val virtualNodeContext = mock<VirtualNodeContext>()
+    private val aliceVirtualNodeContext = VirtualNodeContext(
+        ALICE_X500_HOLDING_IDENTITY.toCorda(),
+        setOf(CPK1_CHECKSUM),
+        FLOW,
+        null
+    )
+    private val bobVirtualNodeContext = VirtualNodeContext(
+        BOB_X500_HOLDING_IDENTITY.toCorda(),
+        setOf(CPK1_CHECKSUM),
+        FLOW,
+        null
+    )
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     private val cacheEviction = mock<CacheEviction>()
     private val groupParametersCache = GroupParametersCacheImpl(currentSandboxGroupContext, cacheEviction)
@@ -36,7 +51,7 @@ class GroupParametersCacheImplTest {
     @BeforeEach
     fun beforeEach() {
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
-        whenever(virtualNodeContext.sandboxGroupType).thenReturn(SandboxGroupType.FLOW)
+        whenever(virtualNodeContext.sandboxGroupType).thenReturn(FLOW)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
         whenever(GROUP_PARAMS_1.hash).thenReturn(KEY_1)
@@ -57,16 +72,27 @@ class GroupParametersCacheImplTest {
     }
 
     @Test
-    fun `removes keys by holding identity`() {
-        whenever(virtualNodeContext.holdingIdentity).thenReturn(
-            ALICE_X500_HOLDING_IDENTITY.toCorda(),
-            BOB_X500_HOLDING_IDENTITY.toCorda()
+    fun `removes keys by virtual node context`() {
+        // return vnode in this order in consecutive calls of the function
+        whenever(sandbox.virtualNodeContext).thenReturn(
+            aliceVirtualNodeContext,
+            bobVirtualNodeContext,
+            aliceVirtualNodeContext,
+            bobVirtualNodeContext
         )
-        groupParametersCache.put(GROUP_PARAMS_1)
-        groupParametersCache.put(GROUP_PARAMS_2)
-        groupParametersCache.remove(ALICE_X500_HOLDING_IDENTITY.toCorda())
+        whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
+        whenever(GROUP_PARAMS_1.hash).thenReturn(KEY_1)
+        whenever(GROUP_PARAMS_2.hash).thenReturn(KEY_2)
 
+        // alice puts cache
+        groupParametersCache.put(GROUP_PARAMS_1)
+        // bob puts cache
+        groupParametersCache.put(GROUP_PARAMS_2)
+        groupParametersCache.remove(aliceVirtualNodeContext)
+
+        // alice gets cache and it's null
         assertThat(groupParametersCache.get(KEY_1)).isNull()
+        // bob gets cache and it's group param 2
         assertThat(groupParametersCache.get(KEY_2)).isEqualTo(GROUP_PARAMS_2)
     }
 }

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxedCache.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxedCache.kt
@@ -5,11 +5,11 @@ package net.corda.sandboxgroupcontext
  *
  * These caches should exist as global OSGi singletons.
  *
- * [SandboxedCache]s have invalidate keys related to a sandbox when that sandbox is evicted from the worker's sandbox cache. [remove] is
- * called when this occurs.
+ * [SandboxedCache]s have invalidate keys related to a sandbox when that sandbox is evicted from
+ * the worker's sandbox cache. [remove] is called when this occurs.
  *
- * All [SandboxedCache]s should contain an internal cache that contains _at least_ the [VirtualNodeContext] of the sandbox that put key-value
- * pairs into the cache.
+ * All [SandboxedCache]s should contain an internal cache that contains _at least_ the [VirtualNodeContext] of
+ * the sandbox that put key-value pairs into the cache.
  *
  * Ideally [CacheKey] should be used by a [SandboxedCache]'s internal cache.
  */

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxedCache.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxedCache.kt
@@ -1,7 +1,5 @@
 package net.corda.sandboxgroupcontext
 
-import net.corda.virtualnode.HoldingIdentity
-
 /**
  * Instances of [SandboxedCache] are "sandbox-level" caches.
  *
@@ -10,7 +8,7 @@ import net.corda.virtualnode.HoldingIdentity
  * [SandboxedCache]s have invalidate keys related to a sandbox when that sandbox is evicted from the worker's sandbox cache. [remove] is
  * called when this occurs.
  *
- * All [SandboxedCache]s should contain an internal cache that contains _at least_ the [HoldingIdentity] of the sandbox that put key-value
+ * All [SandboxedCache]s should contain an internal cache that contains _at least_ the [VirtualNodeContext] of the sandbox that put key-value
  * pairs into the cache.
  *
  * Ideally [CacheKey] should be used by a [SandboxedCache]'s internal cache.

--- a/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxedCache.kt
+++ b/libs/virtual-node/sandbox-group-context/src/main/kotlin/net/corda/sandboxgroupcontext/SandboxedCache.kt
@@ -20,25 +20,18 @@ interface SandboxedCache {
     /**
      * A cache key holding sandbox information and the _real_ key to the cache.
      *
-     * @property holdingIdentity The [HoldingIdentity] of the sandbox that added the key-value pair.
+     * @property virtualNodeContext The [VirtualNodeContext] of the sandbox that added the key-value pair.
      * @property key The real key of the cache.
      */
-    data class CacheKey<T>(val holdingIdentity: HoldingIdentity, val key: T) {
-
-        /**
-         * @param virtualNodeContext The [VirtualNodeContext] of the sandbox that added the key-value pair.
-         * @param key The real key of the cache.
-         */
-        constructor(virtualNodeContext: VirtualNodeContext, key: T) : this(virtualNodeContext.holdingIdentity, key)
-    }
+    data class CacheKey<T>(val virtualNodeContext: VirtualNodeContext, val key: T)
 
     /**
-     * Removes key-value pairs from the cache based on [HoldingIdentity].
+     * Removes key-value pairs from the cache based on [VirtualNodeContext].
      *
-     * Implementations of this method should iterate over the keys to remove the ones that match the [holdingIdentity].
+     * Implementations of this method should iterate over the keys to remove the ones that match the [virtualNodeContext].
      *
-     * @param holdingIdentity The [HoldingIdentity] of the keys to remove from the cache.
+     * @param virtualNodeContext The [VirtualNodeContext] of the keys to remove from the cache.
      */
-    fun remove(holdingIdentity: HoldingIdentity)
+    fun remove(virtualNodeContext: VirtualNodeContext)
 
 }


### PR DESCRIPTION
## Why this PR?
We have `CacheKey` data class with holidingIdentity in sandbox. When CPI is upgraded with the same bundle name, holding Identity doesn't change, hence it picks up previous version cached with the same holding identity. This caused failure in CPI upgrade so this PR fixes the issue.