### PR TITLE
CORE-17371 fix CPI signerSummaryHash and fileChecksum in FlowContextProperties

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/runner/impl/FlowRunnerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/runner/impl/FlowRunnerImpl.kt
@@ -196,8 +196,8 @@ class FlowRunnerImpl @Activate constructor(
                 this[FlowContextPropertyKeys.CPI_NAME] = metadata.cpiId.name
                 this[FlowContextPropertyKeys.CPI_VERSION] = metadata.cpiId.version
                 this[FlowContextPropertyKeys.CPI_SIGNER_SUMMARY_HASH] =
-                    metadata.cpiId.signerSummaryHash.toHexString()
-                this[FlowContextPropertyKeys.CPI_FILE_CHECKSUM] = metadata.fileChecksum.toHexString()
+                    metadata.cpiId.signerSummaryHash.toString()
+                this[FlowContextPropertyKeys.CPI_FILE_CHECKSUM] = metadata.fileChecksum.toString()
 
                 this[FlowContextPropertyKeys.INITIAL_PLATFORM_VERSION] =
                     platformInfoProvider.localWorkerPlatformVersion.toString()


### PR DESCRIPTION
CORE-17371 fix CPI signerSummaryHash and fileChecksum in FlowContextProperties
Using toString() instead of toHexString() prepends them with the used algorithm name.

Related ledger metadata fields before the change:
![image](https://github.com/corda/corda-runtime-os/assets/3994645/39b116c9-3bec-46db-bfef-63564370d1a3)
And after:
![image](https://github.com/corda/corda-runtime-os/assets/3994645/7a6d9d63-7243-409d-9bbe-7055fa504e6d)
