### PR TITLE
CORE-16246 Allow topic configuration overrides

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -373,6 +373,9 @@ spec:
             {{- end }}
             '-r', '{{ .Values.bootstrap.kafka.replicas }}',
             '-p', '{{ .Values.bootstrap.kafka.partitions }}',
+            {{- if .Values.bootstrap.kafka.overrides }}
+            '-o', '/tmp/overrides.yaml',
+            {{- end }}
             'connect',
             '-w', '{{ .Values.bootstrap.kafka.timeoutSeconds }}'
           ]
@@ -408,7 +411,7 @@ spec:
               {{- end }}
             {{- end }}
       initContainers:
-        - name: create-trust-store
+        - name: setup
           image: {{ include "corda.bootstrapCliImage" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           {{- include "corda.bootstrapResources" . | nindent 10 }}
@@ -421,6 +424,9 @@ spec:
             - -c
           args:
             - |
+                {{- with .Values.bootstrap.kafka.overrides }}
+                echo -e {{ toYaml . | quote }} > /tmp/overrides.yaml
+                {{- end }}
                 touch /tmp/config.properties
                 {{- if .Values.kafka.tls.enabled }}
                 {{- if .Values.kafka.sasl.enabled }}

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1442,6 +1442,19 @@
                                 3
                             ]
                         },
+                        "overrides": {
+                            "type": "object",
+                            "default": null,
+                            "title": "overrides for Kafka topic configuration",
+                            "examples": [
+                                {
+                                    "topics": [{
+                                        "name": "avro.schema",
+                                        "partitions": 5
+                                    }]
+                                }
+                            ]
+                        },
                         "timeoutSeconds": {
                             "type": "integer",
                             "default": 60,

--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/CreateConnect.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/CreateConnect.kt
@@ -158,14 +158,14 @@ class CreateConnect : Runnable {
 
     fun getTopics(topicConfigs: List<Create.PreviewTopicConfiguration>) =
         topicConfigs.associate { topicConfig: Create.PreviewTopicConfiguration ->
-            topicConfig.name to NewTopic(topicConfig.name, create!!.partitionOverride, create!!.replicaOverride)
+            topicConfig.name to NewTopic(topicConfig.name, topicConfig.partitions, topicConfig.replicas)
                 .configs(topicConfig.config)
         }
 
     fun getGeneratedTopicConfigs(): Create.PreviewTopicConfigurations = if (configFilePath == null) {
         create!!.getTopicConfigsForPreview()
     } else {
-        // Simply read the info from provided file
-        create!!.mapper.readValue(Files.readString(Paths.get(configFilePath!!)))
+        // Simply read the info from provided file, applying any overrides
+        create!!.applyOverrides(create!!.mapper.readValue(Files.readString(Paths.get(configFilePath!!))))
     }
 }

--- a/tools/plugins/topic-config/src/test/resources/override_topic_config.yaml
+++ b/tools/plugins/topic-config/src/test/resources/override_topic_config.yaml
@@ -1,0 +1,16 @@
+topics:
+  - name: avro.schema
+    partitions: 8
+    config:
+      min.cleanable.dirty.ratio: 0.7
+acls:
+  - topic: avro.schema
+    users:
+      - name: Mo
+        operations:
+          - write
+  - topic: certificates.rpc.ops
+    users:
+      - name: George
+        operations:
+          - read

--- a/tools/plugins/topic-config/src/test/resources/preview_config.yaml
+++ b/tools/plugins/topic-config/src/test/resources/preview_config.yaml
@@ -1,9 +1,15 @@
 topics:
   - name: config.management.request
+    partitions: 1
+    replicas: 1
     config: {}
   - name: config.management.request.resp
+    partitions: 1
+    replicas: 1
     config: {}
   - name: config.topic
+    partitions: 1
+    replicas: 1
     config:
       cleanup.policy: compact
       segment.ms: 600000

--- a/tools/plugins/topic-config/src/test/resources/short_generated_topic_config.yaml
+++ b/tools/plugins/topic-config/src/test/resources/short_generated_topic_config.yaml
@@ -1,5 +1,7 @@
 topics:
   - name: avro.schema
+    partitions: 5
+    replicas: 3
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -8,6 +10,8 @@ topics:
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   - name: certificates.rpc.ops
+    partitions: 4
+    replicas: 2
     config: {}
 acls:
   - topic: avro.schema


### PR DESCRIPTION
This PR provides the ability to override topic configuration, including replica and partition counts, on the `topic create` CLI commands and via the Helm chart.

The YAML file output by the `topic create preview` now includes `partitions` and `replicas` fields per topic. These default to the global parameters. These are then consumed by the `topic create connect` command so can be manually modified between preview and use.

The `topic create preview` and `topic create connect` commands also both take an `--overides`/`-o` option, which is the optional path to a file of the same format as the preview file. This file's contents are merged to override those generated/passed in.

The contents of this file can be provided as YAML under `bootstrap.kafka.overrides`. For example, the following Helm chart configuration can be used to override the default part count of 10 for the `avro.schema` topic to 5:

```yaml
bootstrap:
  kafka:
    partitions: 10
    overrides:
      topics:
        - name: "avro.schema"
          partitions: 5
```

