### PR TITLE
CORE-17604 Moving worker RPC endpoint paths to consts file

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestSubscriptionFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestSubscriptionFactoryImpl.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.persistence.processor.LedgerPersistenceRequestProcessor
 import net.corda.ledger.persistence.processor.LedgerPersistenceRequestSubscriptionFactory
 import net.corda.ledger.persistence.processor.LedgerPersistenceRpcRequestProcessor
 import net.corda.libs.configuration.SmartConfig
+import net.corda.messaging.api.constants.WorkerRPCPaths.LEDGER_PATH
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
@@ -37,7 +38,6 @@ class LedgerPersistenceRequestSubscriptionFactoryImpl @Activate constructor(
     companion object {
         internal const val GROUP_NAME = "persistence.ledger.processor"
         const val SUBSCRIPTION_NAME = "Ledger"
-        const val PATH = "/ledger"
     }
 
     override fun create(config: SmartConfig): Subscription<String, LedgerPersistenceRequest> {
@@ -67,7 +67,7 @@ class LedgerPersistenceRequestSubscriptionFactoryImpl @Activate constructor(
             LedgerPersistenceRequest::class.java,
             FlowEvent::class.java
         )
-        val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, PATH)
+        val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, LEDGER_PATH)
         return subscriptionFactory.createHttpRPCSubscription(rpcConfig, processor)
     }
 }

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationSubscriptionFactoryImpl.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationSubscriptionFactoryImpl.kt
@@ -6,6 +6,7 @@ import net.corda.ledger.utxo.verification.TransactionVerificationRequest
 import net.corda.ledger.verification.processor.VerificationSubscriptionFactory
 import net.corda.ledger.verification.sandbox.VerificationSandboxService
 import net.corda.libs.configuration.SmartConfig
+import net.corda.messaging.api.constants.WorkerRPCPaths.VERIFICATION_PATH
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
@@ -31,7 +32,6 @@ class VerificationSubscriptionFactoryImpl @Activate constructor(
     companion object {
         internal const val GROUP_NAME = "verification.ledger.processor"
         const val SUBSCRIPTION_NAME = "Verification"
-        const val PATH = "/verification"
     }
 
     override fun create(config: SmartConfig): Subscription<String, TransactionVerificationRequest> {
@@ -61,7 +61,7 @@ class VerificationSubscriptionFactoryImpl @Activate constructor(
             TransactionVerificationRequest::class.java,
             FlowEvent::class.java
         )
-        val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, PATH)
+        val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, VERIFICATION_PATH)
         return subscriptionFactory.createHttpRPCSubscription(rpcConfig, processor)
     }
 

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/EntityRequestSubscriptionFactoryImpl.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/EntityRequestSubscriptionFactoryImpl.kt
@@ -6,6 +6,7 @@ import net.corda.entityprocessor.EntityRequestSubscriptionFactory
 import net.corda.entityprocessor.impl.internal.EntityRequestProcessor
 import net.corda.entityprocessor.impl.internal.EntityRpcRequestProcessor
 import net.corda.libs.configuration.SmartConfig
+import net.corda.messaging.api.constants.WorkerRPCPaths.PERSISTENCE_PATH
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
@@ -35,7 +36,6 @@ class EntityRequestSubscriptionFactoryImpl @Activate constructor(
     companion object {
         internal const val GROUP_NAME = "persistence.entity.processor"
         const val SUBSCRIPTION_NAME = "Persistence"
-        const val PATH = "/persistence"
     }
 
     override fun create(config: SmartConfig): Subscription<String, EntityRequest> {
@@ -64,7 +64,7 @@ class EntityRequestSubscriptionFactoryImpl @Activate constructor(
             EntityRequest::class.java,
             FlowEvent::class.java
         )
-        val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, PATH)
+        val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, PERSISTENCE_PATH)
         return subscriptionFactory.createHttpRPCSubscription(rpcConfig, processor)
     }
 }

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerLifecycleImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerLifecycleImpl.kt
@@ -16,6 +16,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.messaging.api.constants.WorkerRPCPaths.UNIQUENESS_PATH
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.config.SyncRPCConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
@@ -52,7 +53,6 @@ class BatchedUniquenessCheckerLifecycleImpl @Activate constructor(
         const val GROUP_NAME = "uniqueness.checker"
         const val CONFIG_HANDLE = "CONFIG_HANDLE"
         const val SUBSCRIPTION_NAME = "Uniqueness Check"
-        const val PATH = "/uniqueness-checker"
         const val SUBSCRIPTION = "SUBSCRIPTION"
         const val RPC_SUBSCRIPTION = "RPC_SUBSCRIPTION"
 
@@ -141,7 +141,7 @@ class BatchedUniquenessCheckerLifecycleImpl @Activate constructor(
             FlowEvent::class.java
         )
         lifecycleCoordinator.createManagedResource(RPC_SUBSCRIPTION) {
-            val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, PATH)
+            val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, UNIQUENESS_PATH)
             subscriptionFactory.createHttpRPCSubscription(rpcConfig, processor).also {
                 it.start()
             }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/constants/WorkerRPCPaths.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/constants/WorkerRPCPaths.kt
@@ -1,0 +1,14 @@
+package net.corda.messaging.api.constants
+
+/**
+ * These are the paths which should be appended to the Corda worker service endpoints to create the
+ * full RPC endpoint URI. E.g.: "${messagingConfig.getString(CRYPTO_WORKER_REST_ENDPOINT)}$CRYPTO_PATH"
+ *
+ */
+object WorkerRPCPaths {
+    const val CRYPTO_PATH = "/crypto"
+    const val LEDGER_PATH = "/ledger"
+    const val PERSISTENCE_PATH = "/persistence"
+    const val UNIQUENESS_PATH = "/uniqueness-checker"
+    const val VERIFICATION_PATH = "/verification"
+}


### PR DESCRIPTION
The 4 workers which will communicate over RPC now have endpoints defined (E.g., `/persistence`, `/ledger`, etc.). Currently these are hardcoded strings, but this PR moves these to a consts file so they can be re-used between client and server implementations.