### PR TITLE
CORE-16752 - Unclear error message after failed signature verification

### DIFF
--- a/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactory.kt
+++ b/components/membership/certificates-client-impl/src/main/kotlin/net/corda/membership/certificate/client/impl/HostedIdentityEntryFactory.kt
@@ -281,7 +281,7 @@ internal class HostedIdentityEntryFactory(
                 } catch (e: SignatureException) {
                     false
                 }
-            }.firstOrNull() ?: throw CordaRuntimeException(
+            }.firstOrNull() ?: throw BadRequestException(
             "The ${certificateType.type.label} certificate was not signed by the correct certificate authority"
         )
     }

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/NetworkRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/NetworkRestResourceImpl.kt
@@ -72,11 +72,8 @@ class NetworkRestResourceImpl @Activate constructor(
         } catch (e: CertificatesResourceNotFoundException) {
             throw ResourceNotFoundException(e.message)
         } catch (e: BadRequestException) {
-            logger.warn(e.message)
-            throw e
-        } catch (e: SignatureException) {
             logger.warn("Could not $operation", e)
-            throw BadRequestException("The certificate was not signed by the correct certificate authority. ${e.message}")
+            throw e
         } catch (e: CordaRPCAPIPartitionException) {
             logger.warn("Could not $operation", e)
             throw ServiceUnavailableException("Could not $operation: Repartition Event!")

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/NetworkRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/NetworkRestResourceImpl.kt
@@ -24,7 +24,6 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
-import java.security.SignatureException
 
 @Component(service = [PluggableRestResource::class])
 class NetworkRestResourceImpl @Activate constructor(


### PR DESCRIPTION
Original scope was: The below conversation shows that if certificate validation fails, it’s unclear which certificate the error refers to. In this case it must refer to the TLS certificate because the session certificate is not used, but the error message should be clearer regardless. 

However, we lately merged in a fix where we specify which type of certificate was wrong, so the message should be okay. This change resulted in Internal Server Error 500, which is wrong so modified it to 400.

**Testing:**
1) Created 2 certificates with fake CA tool.
2) Used one of the to create the TLS cert.
3) The other one was used to register MGM with.
<img width="909" alt="Screenshot 2023-10-12 at 15 57 28" src="https://github.com/corda/corda-runtime-os/assets/61757742/d3f15efd-66ce-496e-b0b5-8289ea870808">
4) Registered MGM.
5) When configuring vnode as network participant we get the following:
<img width="1500" alt="Screenshot 2023-10-12 at 15 57 28" src="https://github.com/corda/corda-runtime-os/assets/61757742/88cc07af-6cd3-447b-b553-73cd139d0a0d">



