### PR TITLE
ES-1477 Enable PodMonitor filtering by metric name

### DIFF
--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -561,6 +561,13 @@ metadata:
 spec:
   podMetricsEndpoints:
   - port: monitor
+    {{- with .Values.metrics.podMonitor.keepNames }}
+    metricRelabelings:
+    - sourceLabels:
+      - "__name__"
+      regex: {{ join "|" . | quote }}
+      action: "keep"
+    {{- end }}
   jobLabel: {{ $.Release.Name }}-{{ include "corda.name" . }}
   selector:
     matchLabels:

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -526,6 +526,16 @@
                                 ]
                             },
                             "examples": [{}]
+                        },
+                        "keepNames": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "regex"
+                            },
+                            "default": [],
+                            "title": "A list of regular expressions for the names of metrics that Prometheus should keep; if empty, all metrics are kept",
+                            "examples": [[ "jvm_.*" ]]
                         }
                     },
                     "examples": [

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -78,6 +78,9 @@ metrics:
     enabled: false
     # -- Labels that can be used so PodMonitor is discovered by Prometheus
     labels: {}
+    # -- A list of regular expressions for the names of metrics that Prometheus should keep; if empty, all metrics are kept
+    keepNames: []
+    # - "jvm_.*"
 
 # Distributed tracing configuration
 tracing:


### PR DESCRIPTION
Enables the ability to filter the metrics scraped by Prometheus when using the Prometheus Operator. By default, all metrics are still scraped but the list can be filtered using the `metrics.podMonitor.keepNames` override. For example:

```
metrics:
  podMonitor:
    enabled: true
    labels:
      release: observability
    keepNames:
    - "cache_.*"
    - "jvm_.*"
    - "system_.*"
    - "process_.*"
    - "corda_http_server_request_time_seconds.*"
    - "corda_flow_execution_time_seconds.*"
    - "corda_kafka_.*"
```