### PR TITLE
CORE-17778 Use the query provider instead of raw SQL in findTransactionIdsAndStatuses

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -9,6 +9,13 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
         val UNVERIFIED = TransactionStatus.UNVERIFIED.value
     }
 
+    override val findTransactionIdsAndStatuses: String
+        get() = """
+            SELECT id, status 
+            FROM {h-schema}utxo_transaction 
+            WHERE id IN (:transactionIds)"""
+            .trimIndent()
+
     override val findTransactionPrivacySaltAndMetadata: String
         get() = """
             SELECT privacy_salt,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -91,4 +91,9 @@ interface UtxoQueryProvider {
      * @property persistSignedGroupParameters SQL text for [UtxoRepositoryImpl.persistSignedGroupParameters].
      */
     val persistSignedGroupParameters: String
+
+    /**
+     * @property findTransactionIdsAndStatuses SQL text for [UtxoRepositoryImpl.findTransactionIdsAndStatuses].
+     */
+    val findTransactionIdsAndStatuses: String
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -75,13 +75,7 @@ class UtxoRepositoryImpl @Activate constructor(
         entityManager: EntityManager,
         transactionIds: List<String>
     ): Map<SecureHash, String> {
-        return entityManager.createNativeQuery(
-            """
-                SELECT id, status 
-                FROM {h-schema}utxo_transaction 
-                WHERE id IN (:transactionIds)""",
-            Tuple::class.java
-        )
+        return entityManager.createNativeQuery(queryProvider.findTransactionIdsAndStatuses, Tuple::class.java)
             .setParameter("transactionIds", transactionIds)
             .resultListAsTuples()
             .associate { r -> parseSecureHash(r.get(0) as String) to r.get(1) as String }


### PR DESCRIPTION
### Overview
Currently, we use a raw SQL in the findTransactionIdsAndStatuses function in UtxoRepositoryImpl. 
We should change this to use the QueryProvider instead. 

**This is not going to change functionality** just a nice to have thing to avoid confusion in the future.

### Test plan
Make sure that the current integration / e2e tests run.
