### PR TITLE
CORE-17782 Suppress deprecation warning on `findUnconsumedStatesByType`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.36-beta+
+cordaApiVersion=5.1.0.37-alpha-1697451666245
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.37-alpha-1697451666245
+cordaApiVersion=5.1.0.37-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/testing/cpbs/packaging-verification-app-v1/src/main/kotlin/com/r3/corda/testing/packagingverification/ReportStatesFlow.kt
+++ b/testing/cpbs/packaging-verification-app-v1/src/main/kotlin/com/r3/corda/testing/packagingverification/ReportStatesFlow.kt
@@ -13,6 +13,7 @@ class ReportStatesFlow : ClientStartableFlow {
 
     @Suspendable
     override fun call(requestBody: ClientRequestBody): String {
+        @Suppress("Deprecation") // Call to be replaced in CORE-17745
         val unconsumedStates = utxoLedgerService.findUnconsumedStatesByType(SimpleState::class.java)
         val result = unconsumedStates.fold(0L) { acc, stateAndRef ->
             acc + stateAndRef.state.contractState.value


### PR DESCRIPTION
Temporary suppression to account for changes in https://github.com/corda/corda-api/pull/1300.