### PR TITLE
CORE-17627: Add metadata to flow mapper states for mapper status

### DIFF
--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
@@ -62,10 +62,13 @@ class FlowMapperMessageProcessor(
                 if (!isExpiredSessionEvent(value)) {
                     val executor = flowMapperEventExecutorFactory.create(key, value, state?.value, flowConfig)
                     val result = executor.execute()
+                    val newMap = result.flowMapperState?.status?.let {
+                        mapOf(FLOW_MAPPER_STATUS to it.toString())
+                    } ?: mapOf()
                     StateAndEventProcessor.Response(
                         State(result.flowMapperState, state?.metadata?.let {
-                            Metadata(it + mapOf(FLOW_MAPPER_STATUS to result.flowMapperState?.status.toString()))
-                        }),
+                            Metadata(it + newMap)
+                        } ?: Metadata(newMap)),
                         result.outputEvents
                     )
                 } else {

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessor.kt
@@ -6,11 +6,13 @@ import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.state.mapper.FlowMapperState
 import net.corda.flow.mapper.factory.FlowMapperEventExecutorFactory
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.statemanager.api.Metadata
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.metrics.CordaMetrics
 import net.corda.schema.configuration.FlowConfig
+import net.corda.session.mapper.service.state.StateMetadataKeys.FLOW_MAPPER_STATUS
 import net.corda.tracing.traceStateAndEventExecution
 import net.corda.utilities.debug
 import net.corda.utilities.time.UTCClock
@@ -61,7 +63,9 @@ class FlowMapperMessageProcessor(
                     val executor = flowMapperEventExecutorFactory.create(key, value, state?.value, flowConfig)
                     val result = executor.execute()
                     StateAndEventProcessor.Response(
-                        State(result.flowMapperState, state?.metadata),
+                        State(result.flowMapperState, state?.metadata?.let {
+                            Metadata(it + mapOf(FLOW_MAPPER_STATUS to result.flowMapperState?.status.toString()))
+                        }),
                         result.outputEvents
                     )
                 } else {

--- a/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessorTest.kt
+++ b/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessorTest.kt
@@ -145,4 +145,18 @@ class FlowMapperMessageProcessorTest {
         verify(flowMapperEventExecutorFactory, times(0)).create(any(), any(), anyOrNull(), any(), any())
         assertThat(output.updatedState).isEqualTo(state)
     }
+
+    @Test
+    fun `when input metadata is null metadata is still set`() {
+        whenever(flowMapperEventExecutor.execute()).thenReturn(FlowMapperResult(FlowMapperState().apply {
+            status = FlowMapperStateType.OPEN
+        }, listOf()))
+        val output = flowMapperMessageProcessor.onNext(
+            buildMapperState(FlowMapperStateType.OPEN),buildMapperEvent(buildSessionEvent())
+        )
+        verify(flowMapperEventExecutorFactory, times(1)).create(any(), any(), anyOrNull(), any(), any())
+        assertThat(output.updatedState?.metadata).isEqualTo(
+            Metadata(mapOf(FLOW_MAPPER_STATUS to FlowMapperStateType.OPEN.toString()))
+        )
+    }
 }

--- a/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessorTest.kt
+++ b/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessorTest.kt
@@ -17,6 +17,7 @@ import net.corda.libs.statemanager.api.Metadata
 import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.FlowConfig
+import net.corda.session.mapper.service.state.StateMetadataKeys.FLOW_MAPPER_STATUS
 import net.corda.test.flow.util.buildSessionEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -76,11 +77,16 @@ class FlowMapperMessageProcessorTest {
     @Test
     fun `when state is OPEN new session events are processed`() {
         val metadata = Metadata(mapOf("foo" to "bar"))
+        whenever(flowMapperEventExecutor.execute()).thenReturn(FlowMapperResult(FlowMapperState().apply {
+            status = FlowMapperStateType.OPEN
+        }, listOf()))
         val output = flowMapperMessageProcessor.onNext(
             buildMapperState(FlowMapperStateType.OPEN, metadata),buildMapperEvent(buildSessionEvent())
         )
         verify(flowMapperEventExecutorFactory, times(1)).create(any(), any(), anyOrNull(), any(), any())
-        assertThat(output.updatedState?.metadata).isEqualTo(metadata)
+        assertThat(output.updatedState?.metadata).isEqualTo(
+            Metadata(metadata + mapOf(FLOW_MAPPER_STATUS to FlowMapperStateType.OPEN.toString()))
+        )
     }
 
     @Test
@@ -91,9 +97,12 @@ class FlowMapperMessageProcessorTest {
 
     @Test
     fun `when state is OPEN expired session events are not processed`() {
-        flowMapperMessageProcessor.onNext(buildMapperState(FlowMapperStateType.OPEN), buildMapperEvent(buildSessionEvent(Instant.now()
-            .minusSeconds(100000))))
+        val metadata = Metadata(mapOf("foo" to "bar"))
+        val output = flowMapperMessageProcessor.onNext(
+            buildMapperState(FlowMapperStateType.OPEN, metadata = metadata),
+            buildMapperEvent(buildSessionEvent(Instant.now().minusSeconds(100000))))
         verify(flowMapperEventExecutorFactory, times(0)).create(any(), any(), anyOrNull(), any(), any())
+        assertThat(output.updatedState?.metadata).isEqualTo(metadata)
     }
 
     @Test
@@ -126,5 +135,14 @@ class FlowMapperMessageProcessorTest {
     fun `when state is ERROR new session events are processed`() {
         flowMapperMessageProcessor.onNext(buildMapperState(FlowMapperStateType.ERROR), buildMapperEvent(buildSessionEvent(Instant.now())))
         verify(flowMapperEventExecutorFactory, times(1)).create(any(), any(), anyOrNull(), any(), any())
+    }
+
+    @Test
+    fun `when input event has no value the existing state is returned`() {
+        val metadata = Metadata(mapOf("foo" to "bar"))
+        val state = buildMapperState(FlowMapperStateType.OPEN, metadata)
+        val output = flowMapperMessageProcessor.onNext(state, Record("foo", "foo", null))
+        verify(flowMapperEventExecutorFactory, times(0)).create(any(), any(), anyOrNull(), any(), any())
+        assertThat(output.updatedState).isEqualTo(state)
     }
 }


### PR DESCRIPTION
### Problem description

The new flow mapper cleanup mechanism involving the scheduled task trigger and the state manager requires that the state metadata is populated with the current flow mapper status. Currently this is not written, meaning no states will be picked up when attempting mapper cleanup.

### Solution

Add the mapper status as a metadata field to the output state metadata.

The value used is the enum value as a string.