### PR TITLE
CORE-17429, CORE-16203 - multi-source event mediator

### DIFF
--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestFlowMessageProcessor.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestFlowMessageProcessor.kt
@@ -3,6 +3,7 @@ package net.corda.session.mapper.service.integration
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import org.junit.jupiter.api.fail
 import java.util.concurrent.CountDownLatch
@@ -18,8 +19,8 @@ class TestFlowMessageProcessor(
     var eventsReceived: MutableList<Record<String, FlowEvent>> = mutableListOf()
 
     override fun onNext(
-        state: Checkpoint?,
-        event: Record<String, FlowEvent>
+        state: State<Checkpoint>?,
+        event: Record<String, FlowEvent>,
     ): StateAndEventProcessor.Response<Checkpoint> {
         eventsReceived.add(event)
 

--- a/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessorTest.kt
+++ b/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/executor/FlowMapperMessageProcessorTest.kt
@@ -13,9 +13,12 @@ import net.corda.flow.mapper.FlowMapperResult
 import net.corda.flow.mapper.executor.FlowMapperEventExecutor
 import net.corda.flow.mapper.factory.FlowMapperEventExecutorFactory
 import net.corda.libs.configuration.SmartConfigImpl
+import net.corda.libs.statemanager.api.Metadata
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.FlowConfig
 import net.corda.test.flow.util.buildSessionEvent
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -35,12 +38,15 @@ class FlowMapperMessageProcessorTest {
     private val config = SmartConfigImpl.empty().withValue(FlowConfig.SESSION_P2P_TTL, ConfigValueFactory.fromAnyRef(10000))
     private val flowMapperMessageProcessor = FlowMapperMessageProcessor(flowMapperEventExecutorFactory, config)
 
-    private fun buildMapperState(status: FlowMapperStateType) : FlowMapperState {
-        return FlowMapperState.newBuilder()
-            .setStatus(status)
-            .setFlowId("flowId")
-            .setExpiryTime(Instant.now().toEpochMilli())
-            .build()
+    private fun buildMapperState(status: FlowMapperStateType, metadata: Metadata = Metadata()) : State<FlowMapperState> {
+        return State(
+            FlowMapperState.newBuilder()
+                .setStatus(status)
+                .setFlowId("flowId")
+                .setExpiryTime(Instant.now().toEpochMilli())
+                .build(),
+            metadata = metadata,
+        )
     }
 
     private fun buildMapperEvent(payload: Any) : Record<String, FlowMapperEvent> {
@@ -69,8 +75,12 @@ class FlowMapperMessageProcessorTest {
 
     @Test
     fun `when state is OPEN new session events are processed`() {
-        flowMapperMessageProcessor.onNext(buildMapperState(FlowMapperStateType.OPEN), buildMapperEvent(buildSessionEvent()))
+        val metadata = Metadata(mapOf("foo" to "bar"))
+        val output = flowMapperMessageProcessor.onNext(
+            buildMapperState(FlowMapperStateType.OPEN, metadata),buildMapperEvent(buildSessionEvent())
+        )
         verify(flowMapperEventExecutorFactory, times(1)).create(any(), any(), anyOrNull(), any(), any())
+        assertThat(output.updatedState?.metadata).isEqualTo(metadata)
     }
 
     @Test

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -54,6 +54,7 @@ import net.corda.libs.packaging.core.CpkManifest
 import net.corda.libs.packaging.core.CpkMetadata
 import net.corda.libs.packaging.core.CpkType
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.sandboxgroupcontext.SandboxGroupType.FLOW
 import net.corda.sandboxgroupcontext.VirtualNodeContext
@@ -445,10 +446,13 @@ class FlowServiceTestContext @Activate constructor(
             log.info("Start test run for input/output set $iteration")
             flowFiberFactory.fiber.reset()
             flowFiberFactory.fiber.setIoRequests(testRun.ioRequests)
-            val response = flowEventProcessor.onNext(lastPublishedState, testRun.event)
+            val response = flowEventProcessor.onNext(
+                State(lastPublishedState, metadata = null),
+                testRun.event
+            )
             testRun.flowContinuation = flowFiberFactory.fiber.flowContinuation
             testRun.response = response
-            lastPublishedState = response.updatedState
+            lastPublishedState = response.updatedState?.value
         }
     }
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -259,13 +259,13 @@ class OutputAssertionsImpl(
 
     override fun hasPendingUserException() {
         asserts.add { testRun ->
-            assertThat(testRun.response?.updatedState?.pipelineState?.pendingPlatformError).isNotNull()
+            assertThat(testRun.response?.updatedState?.value?.pipelineState?.pendingPlatformError).isNotNull()
         }
     }
 
     override fun noPendingUserException() {
         asserts.add { testRun ->
-            assertThat(testRun.response?.updatedState?.pipelineState?.pendingPlatformError).isNull()
+            assertThat(testRun.response?.updatedState?.value?.pipelineState?.pendingPlatformError).isNull()
         }
     }
 
@@ -278,8 +278,8 @@ class OutputAssertionsImpl(
 
     override fun checkpointHasRetry(expectedCount: Int) {
         asserts.add { testRun ->
-            assertThat(testRun.response?.updatedState?.pipelineState?.retryState).isNotNull
-            val retry = testRun.response!!.updatedState!!.pipelineState!!.retryState
+            assertThat(testRun.response?.updatedState?.value?.pipelineState?.retryState).isNotNull
+            val retry = testRun.response!!.updatedState!!.value?.pipelineState!!.retryState
 
             assertThat(retry.retryCount).isEqualTo(expectedCount)
 
@@ -296,7 +296,7 @@ class OutputAssertionsImpl(
 
     override fun checkpointDoesNotHaveRetry() {
         asserts.add { testRun ->
-            assertThat(testRun.response?.updatedState?.pipelineState?.retryState).isNull()
+            assertThat(testRun.response?.updatedState?.value?.pipelineState?.retryState).isNull()
         }
     }
 
@@ -364,7 +364,7 @@ class OutputAssertionsImpl(
 
     override fun nullStateRecord() {
         asserts.add {
-            assertNull(it.response?.updatedState, "Expected to receive NULL for output state")
+            assertNull(it.response?.updatedState?.value, "Expected to receive NULL for output state")
         }
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
@@ -7,6 +7,7 @@ import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
+import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.persistence.EntityRequest
 import net.corda.data.uniqueness.UniquenessCheckRequestAvro
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
@@ -27,6 +28,7 @@ import net.corda.schema.Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_STATUS_TOPIC
 import net.corda.schema.Schemas.Persistence.PERSISTENCE_ENTITY_PROCESSOR_TOPIC
 import net.corda.schema.Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC
+import net.corda.schema.Schemas.Services.TOKEN_CACHE_EVENT
 import net.corda.schema.Schemas.UniquenessChecker.UNIQUENESS_CHECK_TOPIC
 import net.corda.schema.Schemas.Verification.VERIFICATION_LEDGER_PROCESSOR_TOPIC
 import org.osgi.service.component.annotations.Activate
@@ -94,6 +96,7 @@ class FlowEventMediatorFactoryImpl @Activate constructor(
                 is FlowOpsRequest -> routeTo(messageBusClient, FLOW_OPS_MESSAGE_TOPIC)
                 is FlowStatus -> routeTo(messageBusClient, FLOW_STATUS_TOPIC)
                 is LedgerPersistenceRequest -> routeTo(messageBusClient, PERSISTENCE_LEDGER_PROCESSOR_TOPIC)
+                is TokenPoolCacheEvent -> routeTo(messageBusClient, TOKEN_CACHE_EVENT)
                 is TransactionVerificationRequest -> routeTo(messageBusClient, VERIFICATION_LEDGER_PROCESSOR_TOPIC)
                 is UniquenessCheckRequestAvro -> routeTo(messageBusClient, UNIQUENESS_CHECK_TOPIC)
                 else -> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/converters/impl/FlowEventContextConverterImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/converters/impl/FlowEventContextConverterImpl.kt
@@ -4,6 +4,7 @@ import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.converters.FlowEventContextConverter
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import org.osgi.service.component.annotations.Component
 
 @Suppress("Unused")
@@ -11,7 +12,7 @@ import org.osgi.service.component.annotations.Component
 class FlowEventContextConverterImpl : FlowEventContextConverter {
     override fun convert(flowContext: FlowEventContext<*>): StateAndEventProcessor.Response<Checkpoint> {
         return StateAndEventProcessor.Response(
-            flowContext.checkpoint.toAvro(),
+            State(flowContext.checkpoint.toAvro(), metadata = flowContext.metadata),
             flowContext.outputRecords,
             flowContext.sendToDlq
         )

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowEventPipelineFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowEventPipelineFactory.kt
@@ -4,6 +4,7 @@ import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.flow.pipeline.FlowEventPipeline
 import net.corda.libs.configuration.SmartConfig
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.tracing.TraceContext
 
 /**
@@ -15,7 +16,7 @@ interface FlowEventPipelineFactory {
     /**
      * Creates a [FlowEventPipeline] instance.
      *
-     * @param checkpoint The [Checkpoint] passed through the pipeline.
+     * @param state The [Checkpoint] and metadata passed through the pipeline.
      * @param event The [FlowEvent] passed through the pipeline.
      * @param config The [SmartConfig] containing the settings used in the pipeline factory.
      * @param mdcProperties properties to set the flow fibers MDC with.
@@ -25,7 +26,7 @@ interface FlowEventPipelineFactory {
      * @return A new [FlowEventPipeline] instance.
      */
     fun create(
-        checkpoint: Checkpoint?,
+        state: State<Checkpoint>?,
         event: FlowEvent,
         configs: Map<String, SmartConfig>,
         mdcProperties: Map<String, String>,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventPipelineFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowEventPipelineFactoryImpl.kt
@@ -19,6 +19,7 @@ import net.corda.flow.pipeline.runner.FlowRunner
 import net.corda.flow.state.impl.FlowCheckpointFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.helper.getConfig
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.tracing.TraceContext
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -97,7 +98,7 @@ class FlowEventPipelineFactoryImpl(
     )
 
     override fun create(
-        checkpoint: Checkpoint?,
+        state: State<Checkpoint>?,
         event: FlowEvent,
         configs: Map<String, SmartConfig>,
         mdcProperties: Map<String, String>,
@@ -106,7 +107,7 @@ class FlowEventPipelineFactoryImpl(
     ): FlowEventPipeline {
         val flowCheckpoint = flowCheckpointFactory.create(
             event.flowId,
-            checkpoint,
+            state?.value,
             configs.getConfig(FLOW_CONFIG)
         )
 
@@ -121,7 +122,8 @@ class FlowEventPipelineFactoryImpl(
             outputRecords = emptyList(),
             mdcProperties = mdcProperties,
             flowMetrics = metrics,
-            flowTraceContext = traceContext
+            flowTraceContext = traceContext,
+            metadata = state?.metadata
         )
 
         val flowExecutionPipelineStage = FlowExecutionPipelineStage(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutorImpl.kt
@@ -3,7 +3,7 @@ package net.corda.flow.service
 import com.typesafe.config.ConfigValueFactory
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.Checkpoint
-import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
+import net.corda.flow.messaging.mediator.FlowEventMediatorFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.helper.getConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -13,10 +13,7 @@ import net.corda.lifecycle.RegistrationHandle
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
-import net.corda.messaging.api.subscription.StateAndEventSubscription
-import net.corda.messaging.api.subscription.config.SubscriptionConfig
-import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
+import net.corda.messaging.api.mediator.MultiSourceEventMediator
 import net.corda.schema.configuration.BootConfig.CRYPTO_WORKER_REST_ENDPOINT
 import net.corda.schema.configuration.BootConfig.PERSISTENCE_WORKER_REST_ENDPOINT
 import net.corda.schema.configuration.BootConfig.UNIQUENESS_WORKER_REST_ENDPOINT
@@ -36,34 +33,29 @@ import org.slf4j.LoggerFactory
 @Component(service = [FlowExecutor::class])
 class FlowExecutorImpl constructor(
     coordinatorFactory: LifecycleCoordinatorFactory,
-    private val subscriptionFactory: SubscriptionFactory,
-    private val flowEventProcessorFactory: FlowEventProcessorFactory,
-    private val toMessagingConfig: (Map<String, SmartConfig>) -> SmartConfig
+    private val flowEventMediatorFactory: FlowEventMediatorFactory,
+    private val toMessagingConfig: (Map<String, SmartConfig>) -> SmartConfig,
 ) : FlowExecutor {
 
     @Activate
     constructor(
         @Reference(service = LifecycleCoordinatorFactory::class)
         coordinatorFactory: LifecycleCoordinatorFactory,
-        @Reference(service = SubscriptionFactory::class)
-        subscriptionFactory: SubscriptionFactory,
-        @Reference(service = FlowEventProcessorFactory::class)
-        flowEventProcessorFactory: FlowEventProcessorFactory
+        @Reference(service = FlowEventMediatorFactory::class)
+        flowEventMediatorFactory: FlowEventMediatorFactory,
     ) : this(
         coordinatorFactory,
-        subscriptionFactory,
-        flowEventProcessorFactory,
+        flowEventMediatorFactory,
         { cfg -> cfg.getConfig(MESSAGING_CONFIG) }
     )
 
     companion object {
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
-        private const val CONSUMER_GROUP = "FlowEventConsumer"
     }
 
     private val coordinator = coordinatorFactory.createCoordinator<FlowExecutor> { event, _ -> eventHandler(event) }
-    private var subscription: StateAndEventSubscription<String, Checkpoint, FlowEvent>? = null
     private var subscriptionRegistrationHandle: RegistrationHandle? = null
+    private var multiSourceEventMediator: MultiSourceEventMediator<String, Checkpoint, FlowEvent>? = null
 
     override fun onConfigChange(config: Map<String, SmartConfig>) {
         try {
@@ -72,19 +64,18 @@ class FlowExecutorImpl constructor(
 
             // close the lifecycle registration first to prevent down being signaled
             subscriptionRegistrationHandle?.close()
-            subscription?.close()
+            multiSourceEventMediator?.close()
 
-            subscription = subscriptionFactory.createStateAndEventSubscription(
-                SubscriptionConfig(CONSUMER_GROUP, FLOW_EVENT_TOPIC),
-                flowEventProcessorFactory.create(updatedConfigs),
-                messagingConfig
+            multiSourceEventMediator = flowEventMediatorFactory.create(
+                updatedConfigs,
+                messagingConfig,
             )
 
             subscriptionRegistrationHandle = coordinator.followStatusChangesByName(
-                setOf(subscription!!.subscriptionName)
+                setOf(multiSourceEventMediator!!.subscriptionName)
             )
 
-            subscription?.start()
+            multiSourceEventMediator?.start()
         } catch (ex: Exception) {
             val reason = "Failed to configure the flow executor using '${config}'"
             log.error(reason, ex)
@@ -126,10 +117,11 @@ class FlowExecutorImpl constructor(
             is StartEvent -> {
                 coordinator.updateStatus(LifecycleStatus.UP)
             }
+
             is StopEvent -> {
                 log.trace { "Flow executor is stopping..." }
                 subscriptionRegistrationHandle?.close()
-                subscription?.close()
+                multiSourceEventMediator?.close()
                 log.trace { "Flow executor stopped" }
             }
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/RequestHandlerTestContext.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/RequestHandlerTestContext.kt
@@ -70,6 +70,7 @@ class RequestHandlerTestContext<PAYLOAD>(val payload: PAYLOAD) {
         recordList,
         mdcProperties = emptyMap(),
         flowMetrics =  mock(),
-        flowTraceContext = mock()
+        flowTraceContext = mock(),
+        metadata = null
     )
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/converters/FlowEventContextConverterImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/converters/FlowEventContextConverterImplTest.kt
@@ -29,7 +29,7 @@ class FlowEventContextConverterImplTest {
         val result = converter.convert(context)
 
         assertThat(result.markForDLQ).isTrue
-        assertThat(result.updatedState).isSameAs(avroCheckpoint)
+        assertThat(result.updatedState?.value).isSameAs(avroCheckpoint)
         assertThat(result.responseEvents).isSameAs(records)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowEventPipelineFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/factory/FlowEventPipelineFactoryImplTest.kt
@@ -19,6 +19,7 @@ import net.corda.flow.pipeline.runner.FlowRunner
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.state.impl.FlowCheckpointFactory
 import net.corda.flow.test.utils.buildFlowEventContext
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -89,7 +90,13 @@ class FlowEventPipelineFactoryImplTest {
             flowEventContext,
             mock(),
         )
-        val result = factory.create(checkpoint, flowEvent, mapOf(FLOW_CONFIG to config), emptyMap(), flowEventContext.flowTraceContext, 0)
+        val result = factory.create(
+            State(checkpoint, null),
+            flowEvent,
+            mapOf(FLOW_CONFIG to config),
+            emptyMap(),
+            flowEventContext.flowTraceContext,
+            0)
         assertEquals(expected.context, result.context)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
@@ -31,6 +31,7 @@ import net.corda.flow.pipeline.handlers.FlowPostProcessingHandler
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
@@ -84,6 +85,7 @@ class FlowEventProcessorImplTest {
     private val flowKey = "flow id"
     private val flowCheckpoint = mock<FlowCheckpoint>()
     private val checkpoint: Checkpoint = mock()
+    private val state = State(checkpoint, metadata = null)
     private val flowState: FlowState = mock()
     private val flowStartContext: FlowStartContext = mock()
     private val externalEventState: ExternalEventState = mock()
@@ -161,9 +163,9 @@ class FlowEventProcessorImplTest {
     fun `Returns the state unaltered if no flow event supplied`() {
         val inputEvent = getFlowEventRecord(null)
 
-        val response = processor.onNext(checkpoint, inputEvent)
+        val response = processor.onNext(state, inputEvent)
 
-        assertThat(response.updatedState).isSameAs(checkpoint)
+        assertThat(response.updatedState?.value).isSameAs(checkpoint)
         assertThat(response.responseEvents).isEmpty()
         verify(flowMDCService, times(0)).getMDCLogging(anyOrNull(), any(), any())
     }
@@ -172,7 +174,7 @@ class FlowEventProcessorImplTest {
     fun `Returns a checkpoint and events to send`() {
         val inputEvent = getFlowEventRecord(FlowEvent(flowKey, payload))
 
-        val response = processor.onNext(checkpoint, inputEvent)
+        val response = processor.onNext(state, inputEvent)
 
         val expectedRecords = updatedContext.outputRecords
         verify(flowEventContextConverter).convert(argThat { outputRecords == expectedRecords })
@@ -183,7 +185,7 @@ class FlowEventProcessorImplTest {
 
     @Test
     fun `Calls the pipeline steps in order`() {
-        processor.onNext(checkpoint, getFlowEventRecord(FlowEvent(flowKey, payload)))
+        processor.onNext(state, getFlowEventRecord(FlowEvent(flowKey, payload)))
         inOrder(flowEventPipeline) {
             verify(flowEventPipeline).eventPreProcessing()
             verify(flowEventPipeline).virtualNodeFlowOperationalChecks()
@@ -199,7 +201,7 @@ class FlowEventProcessorImplTest {
         whenever(flowEventPipeline.eventPreProcessing()).thenThrow(error)
         whenever(flowEventExceptionProcessor.process(error, flowEventPipeline.context)).thenReturn(errorContext)
 
-        val response = processor.onNext(checkpoint, getFlowEventRecord(FlowEvent(flowKey, payload)))
+        val response = processor.onNext(state, getFlowEventRecord(FlowEvent(flowKey, payload)))
 
         assertThat(response).isEqualTo(errorResponse)
     }
@@ -211,7 +213,7 @@ class FlowEventProcessorImplTest {
         whenever(flowEventPipeline.eventPreProcessing()).thenThrow(error)
         whenever(flowEventExceptionProcessor.process(error, flowEventPipeline.context)).thenReturn(errorContext)
 
-        val response = processor.onNext(checkpoint, getFlowEventRecord(FlowEvent(flowKey, payload)))
+        val response = processor.onNext(state, getFlowEventRecord(FlowEvent(flowKey, payload)))
 
         assertThat(response).isEqualTo(errorResponse)
     }
@@ -223,7 +225,7 @@ class FlowEventProcessorImplTest {
         whenever(flowEventPipeline.eventPreProcessing()).thenThrow(error)
         whenever(flowEventExceptionProcessor.process(error, flowEventPipeline.context)).thenReturn(errorContext)
 
-        val response = processor.onNext(checkpoint, getFlowEventRecord(FlowEvent(flowKey, payload)))
+        val response = processor.onNext(state, getFlowEventRecord(FlowEvent(flowKey, payload)))
 
         assertThat(response).isEqualTo(errorResponse)
     }
@@ -235,7 +237,7 @@ class FlowEventProcessorImplTest {
         whenever(flowEventPipeline.eventPreProcessing()).thenThrow(error)
         whenever(flowEventExceptionProcessor.process(error, flowEventPipeline.context)).thenReturn(errorContext)
 
-        val response = processor.onNext(checkpoint, getFlowEventRecord(FlowEvent(flowKey, payload)))
+        val response = processor.onNext(state, getFlowEventRecord(FlowEvent(flowKey, payload)))
 
         assertThat(response).isEqualTo(errorResponse)
     }
@@ -247,7 +249,7 @@ class FlowEventProcessorImplTest {
         whenever(flowEventPipeline.eventPreProcessing()).thenThrow(error)
         whenever(flowEventExceptionProcessor.process(error, updatedContext)).thenReturn(errorContext)
 
-        val response = processor.onNext(checkpoint, getFlowEventRecord(FlowEvent(flowKey, payload)))
+        val response = processor.onNext(state, getFlowEventRecord(FlowEvent(flowKey, payload)))
 
         assertThat(response).isEqualTo(errorResponse)
     }
@@ -268,7 +270,7 @@ class FlowEventProcessorImplTest {
         whenever(flowEventExceptionProcessor.process(error, updatedContext)).thenReturn(flowKillErrorContext)
         whenever(flowEventContextConverter.convert(eq(flowKillErrorContext))).thenReturn(killErrorResponse)
 
-        val result = processor.onNext(checkpoint, getFlowEventRecord(FlowEvent(flowKey, payload)))
+        val result = processor.onNext(state, getFlowEventRecord(FlowEvent(flowKey, payload)))
 
         assertThat(result).isEqualTo(killErrorResponse)
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/FlowEventContextHelper.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/FlowEventContextHelper.kt
@@ -43,7 +43,8 @@ fun <T> buildFlowEventContext(
         sendToDlq,
         emptyMap(),
         mock(),
-        mock()
+        mock(),
+        null
     )
 }
 
@@ -67,6 +68,7 @@ fun <T> buildFlowEventContext(
         sendToDlq,
         emptyMap(),
         mock(),
-        mock()
+        mock(),
+        null
     )
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenCacheEventProcessor.kt
@@ -12,6 +12,7 @@ import net.corda.ledger.utxo.token.cache.entities.TokenEvent
 import net.corda.ledger.utxo.token.cache.entities.TokenPoolCache
 import net.corda.ledger.utxo.token.cache.handlers.TokenEventHandler
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.tracing.traceStateAndEventExecution
 import net.corda.utilities.debug
@@ -38,15 +39,18 @@ class TokenCacheEventProcessor(
     override val stateValueClass = TokenPoolCacheState::class.java
 
     override fun onNext(
-        state: TokenPoolCacheState?,
-        event: Record<TokenPoolCacheKey, TokenPoolCacheEvent>
+        state: State<TokenPoolCacheState>?,
+        event: Record<TokenPoolCacheKey, TokenPoolCacheEvent>,
     ): StateAndEventProcessor.Response<TokenPoolCacheState> {
 
         val tokenEvent = try {
             eventConverter.convert(event.value)
         } catch (e: Exception) {
             log.error("Unexpected error while processing event '${event}'. The event will be sent to the DLQ.", e)
-            return StateAndEventProcessor.Response(state, listOf(), markForDLQ = true)
+            return StateAndEventProcessor.Response(
+                state,
+                listOf(),
+                markForDLQ = true)
         }
 
         log.debug { "Token event received: $tokenEvent" }
@@ -54,7 +58,7 @@ class TokenCacheEventProcessor(
         return traceStateAndEventExecution(event, "Token Event - ${tokenEvent.javaClass.simpleName}") {
             try {
                 tokenSelectionMetrics.recordProcessingTime(tokenEvent) {
-                    val nonNullableState = state ?: TokenPoolCacheState().apply {
+                    val nonNullableState = state?.value ?: TokenPoolCacheState().apply {
                         this.poolKey = event.key
                         this.availableTokens = listOf()
                         this.tokenClaims = listOf()
@@ -87,10 +91,13 @@ class TokenCacheEventProcessor(
                     log.debug { "sending token response: $result" }
 
                     if (result == null) {
-                        StateAndEventProcessor.Response(poolCacheState.toAvro(), listOf())
+                        StateAndEventProcessor.Response(
+                            State(poolCacheState.toAvro(), metadata = state?.metadata),
+                            listOf()
+                        )
                     } else {
                         StateAndEventProcessor.Response(
-                            poolCacheState.toAvro(),
+                            State(poolCacheState.toAvro(), metadata = state?.metadata),
                             listOf(result)
                         )
                     }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenCacheEventProcessorTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenCacheEventProcessorTest.kt
@@ -17,6 +17,7 @@ import net.corda.ledger.utxo.token.cache.impl.POOL_CACHE_KEY
 import net.corda.ledger.utxo.token.cache.impl.POOL_KEY
 import net.corda.ledger.utxo.token.cache.services.TokenCacheEventProcessor
 import net.corda.ledger.utxo.token.cache.services.TokenSelectionMetricsImpl
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.utilities.time.UTCClock
 import org.assertj.core.api.Assertions.assertThat
@@ -65,10 +66,13 @@ class TokenCacheEventProcessorTest {
         val target = createTokenCacheEventProcessor()
         whenever(eventConverter.convert(any())).thenThrow(IllegalStateException())
 
-        val result = target.onNext(stateIn, eventIn)
+        val result = target.onNext(
+            State(stateIn, metadata = null),
+            eventIn
+        )
 
         assertThat(result.responseEvents).isEmpty()
-        assertThat(result.updatedState).isSameAs(stateIn)
+        assertThat(result.updatedState?.value).isSameAs(stateIn)
         assertThat(result.markForDLQ).isTrue
     }
 
@@ -85,7 +89,10 @@ class TokenCacheEventProcessorTest {
                 tokenSelectionMetrics
             )
 
-        val result = target.onNext(stateIn, eventIn)
+        val result = target.onNext(
+            State(stateIn, metadata = null),
+            eventIn
+        )
 
         verify(externalEventResponseFactory).platformError(
             eq(
@@ -99,7 +106,7 @@ class TokenCacheEventProcessorTest {
         )
 
         assertThat(result.responseEvents).isNotEmpty()
-        assertThat(result.updatedState).isSameAs(stateIn)
+        assertThat(result.updatedState?.value).isSameAs(stateIn)
         assertThat(result.markForDLQ).isFalse()
     }
 
@@ -117,7 +124,10 @@ class TokenCacheEventProcessorTest {
                 tokenSelectionMetrics
             )
 
-        val result = target.onNext(stateIn, eventIn)
+        val result = target.onNext(
+            State(stateIn, metadata = null),
+            eventIn
+        )
 
         verify(externalEventResponseFactory).platformError(
             eq(
@@ -131,7 +141,7 @@ class TokenCacheEventProcessorTest {
         )
 
         assertThat(result.responseEvents).isNotEmpty()
-        assertThat(result.updatedState).isSameAs(stateIn)
+        assertThat(result.updatedState?.value).isSameAs(stateIn)
         assertThat(result.markForDLQ).isFalse()
     }
 
@@ -156,11 +166,14 @@ class TokenCacheEventProcessorTest {
 
         val target = createTokenCacheEventProcessor()
 
-        val result = target.onNext(stateIn, eventIn)
+        val result = target.onNext(
+            State(stateIn, metadata = null),
+            eventIn
+        )
 
         assertThat(result.responseEvents).hasSize(1)
         assertThat(result.responseEvents.first()).isEqualTo(handlerResponse)
-        assertThat(result.updatedState).isSameAs(outputState)
+        assertThat(result.updatedState?.value).isSameAs(outputState)
         assertThat(result.markForDLQ).isFalse
     }
 
@@ -191,7 +204,7 @@ class TokenCacheEventProcessorTest {
 
         assertThat(result.responseEvents).hasSize(1)
         assertThat(result.responseEvents.first()).isEqualTo(handlerResponse)
-        assertThat(result.updatedState).isSameAs(outputState)
+        assertThat(result.updatedState?.value).isSameAs(outputState)
         assertThat(result.markForDLQ).isFalse
     }
 
@@ -216,7 +229,10 @@ class TokenCacheEventProcessorTest {
 
         val target = createTokenCacheEventProcessor()
 
-        target.onNext(stateIn, eventIn)
+        target.onNext(
+            State(stateIn, metadata = null),
+            eventIn
+        )
 
         val inOrder = inOrder(cachePoolState, mockHandler)
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTrackerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTrackerTest.kt
@@ -173,9 +173,9 @@ class DeliveryTrackerTest {
         tracker.stop()
 
         assertEquals(0, response.responseEvents.size)
-        assertNotNull(response.updatedState)
-        assertSame(messageAndKey, response.updatedState!!.message)
-        assertEquals(timeStamp, response.updatedState!!.timestamp)
+        assertNotNull(response.updatedState?.value)
+        assertSame(messageAndKey, response.updatedState!!.value!!.message)
+        assertEquals(timeStamp, response.updatedState!!.value!!.timestamp)
     }
 
     @Test
@@ -188,7 +188,7 @@ class DeliveryTrackerTest {
         tracker.stop()
 
         assertEquals(0, response.responseEvents.size)
-        assertNull(response.updatedState)
+        assertNull(response.updatedState?.value)
     }
 
     @Test

--- a/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncProcessor.kt
+++ b/components/membership/membership-persistence-service-impl/src/main/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncProcessor.kt
@@ -4,6 +4,7 @@ import net.corda.data.membership.db.request.async.MembershipPersistenceAsyncRequ
 import net.corda.data.membership.db.request.async.MembershipPersistenceAsyncRequestState
 import net.corda.membership.impl.persistence.service.handler.HandlerFactories
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -18,10 +19,9 @@ internal class MembershipPersistenceAsyncProcessor(
         const val MAX_RETRIES = 10
     }
     override fun onNext(
-        state: MembershipPersistenceAsyncRequestState?,
+        state: State<MembershipPersistenceAsyncRequestState>?,
         event: Record<String, MembershipPersistenceAsyncRequest>,
     ): StateAndEventProcessor.Response<MembershipPersistenceAsyncRequestState> {
-        val numberOfRetriesSoFar = state?.numberOfRetriesSoFar ?: 0
         val request = event.value
         if (request == null) {
             logger.warn("Empty request for ${event.key}")
@@ -46,21 +46,21 @@ internal class MembershipPersistenceAsyncProcessor(
             retry(
                 event.key,
                 e,
-                numberOfRetriesSoFar,
+                state,
                 request,
             )
         } catch (e: OptimisticLockException) {
             retry(
                 event.key,
                 e,
-                numberOfRetriesSoFar,
+                state,
                 request,
             )
         } catch (e: RecoverableException) {
             retry(
                 event.key,
                 e,
-                numberOfRetriesSoFar,
+                state,
                 request,
             )
         } catch (e: Exception) {
@@ -71,16 +71,20 @@ internal class MembershipPersistenceAsyncProcessor(
     private fun retry(
         key: String,
         e: Exception,
-        numberOfRetriesSoFar: Int,
+        state: State<MembershipPersistenceAsyncRequestState>?,
         request: MembershipPersistenceAsyncRequest
     ): StateAndEventProcessor.Response<MembershipPersistenceAsyncRequestState> {
+        val numberOfRetriesSoFar = state?.value?.numberOfRetriesSoFar ?: 0
         return if (numberOfRetriesSoFar < MAX_RETRIES) {
             logger.warn("Got error while trying to execute $key. Will retry again.", e)
             StateAndEventProcessor.Response(
-                updatedState = MembershipPersistenceAsyncRequestState(
-                    request,
-                    numberOfRetriesSoFar + 1,
-                    handlers.persistenceHandlerServices.clock.instant(),
+                updatedState = State(
+                    MembershipPersistenceAsyncRequestState(
+                        request,
+                        numberOfRetriesSoFar + 1,
+                        handlers.persistenceHandlerServices.clock.instant(),
+                    ),
+                    metadata = state?.metadata,
                 ),
                 responseEvents = emptyList(),
                 markForDLQ = false,

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncProcessorTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceAsyncProcessorTest.kt
@@ -8,6 +8,7 @@ import net.corda.data.membership.db.request.async.MembershipPersistenceAsyncRequ
 import net.corda.membership.impl.persistence.service.handler.HandlerFactories
 import net.corda.membership.impl.persistence.service.handler.PersistenceHandlerServices
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.exceptions.CordaRuntimeException
@@ -59,7 +60,7 @@ class MembershipPersistenceAsyncProcessorTest {
         )
 
         assertThat(reply).isEqualTo(
-            StateAndEventProcessor.Response(
+            StateAndEventProcessor.Response<MembershipPersistenceAsyncRequestState>(
                 null,
                 emptyList(),
                 true,
@@ -75,7 +76,7 @@ class MembershipPersistenceAsyncProcessorTest {
         )
 
         assertThat(reply).isEqualTo(
-            StateAndEventProcessor.Response(
+            StateAndEventProcessor.Response<MembershipPersistenceAsyncRequestState>(
                 null,
                 emptyList(),
                 false,
@@ -103,7 +104,7 @@ class MembershipPersistenceAsyncProcessorTest {
         )
 
         assertThat(reply).isEqualTo(
-            StateAndEventProcessor.Response(
+            StateAndEventProcessor.Response<MembershipPersistenceAsyncRequestState>(
                 null,
                 emptyList(),
                 true,
@@ -122,10 +123,13 @@ class MembershipPersistenceAsyncProcessorTest {
 
         assertThat(reply).isEqualTo(
             StateAndEventProcessor.Response(
-                MembershipPersistenceAsyncRequestState(
-                    envelope,
-                    1,
-                    now,
+                State(
+                    MembershipPersistenceAsyncRequestState(
+                        envelope,
+                        1,
+                        now,
+                    ),
+                    metadata = null
                 ),
                 emptyList(),
                 false,
@@ -138,20 +142,26 @@ class MembershipPersistenceAsyncProcessorTest {
         whenever(handlers.handle(any())).doThrow(OptimisticLockException("Nop"))
 
         val reply = processor.onNext(
-            MembershipPersistenceAsyncRequestState(
-                envelope,
-                1,
-                now,
+            State(
+                MembershipPersistenceAsyncRequestState(
+                    envelope,
+                    1,
+                    now,
+                ),
+                metadata = null
             ),
             Record("topic", "key", envelope)
         )
 
         assertThat(reply).isEqualTo(
             StateAndEventProcessor.Response(
-                MembershipPersistenceAsyncRequestState(
-                    envelope,
-                    2,
-                    now,
+                State(
+                    MembershipPersistenceAsyncRequestState(
+                        envelope,
+                        2,
+                        now,
+                    ),
+                    metadata = null
                 ),
                 emptyList(),
                 false,
@@ -164,16 +174,19 @@ class MembershipPersistenceAsyncProcessorTest {
         whenever(handlers.handle(any())).doThrow(RecoverableException("Nop"))
 
         val reply = processor.onNext(
-            MembershipPersistenceAsyncRequestState(
-                envelope,
-                20,
-                now,
+            State(
+                MembershipPersistenceAsyncRequestState(
+                    envelope,
+                    20,
+                    now,
+                ),
+                metadata = null
             ),
             Record("topic", "key", envelope)
         )
 
         assertThat(reply).isEqualTo(
-            StateAndEventProcessor.Response(
+            StateAndEventProcessor.Response<MembershipPersistenceAsyncRequestState>(
                 null,
                 emptyList(),
                 true,

--- a/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/CommandsRetryManager.kt
+++ b/components/membership/membership-service-impl/src/main/kotlin/net/corda/membership/service/impl/CommandsRetryManager.kt
@@ -8,6 +8,7 @@ import net.corda.data.membership.async.request.SentToMgmWaitingForNetwork
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.Resource
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
@@ -46,11 +47,11 @@ internal class CommandsRetryManager(
     private val timers = ConcurrentHashMap<String, ScheduledFuture<*>>()
 
     override fun onNext(
-        state: MembershipAsyncRequestState?,
+        state: State<MembershipAsyncRequestState>?,
         event: Record<String, MembershipAsyncRequestState>,
     ): StateAndEventProcessor.Response<MembershipAsyncRequestState> {
         return StateAndEventProcessor.Response(
-            updatedState = event.value,
+            updatedState = State(event.value, state?.metadata),
             responseEvents = emptyList(),
             markForDLQ = false,
         )

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
@@ -34,6 +34,7 @@ import net.corda.membership.persistence.client.MembershipPersistenceClient
 import net.corda.membership.persistence.client.MembershipQueryClient
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.utilities.time.Clock
 import org.slf4j.LoggerFactory
@@ -129,61 +130,62 @@ class RegistrationProcessor(
 
     @Suppress("ComplexMethod")
     override fun onNext(
-        state: RegistrationState?,
-        event: Record<String, RegistrationCommand>
+        state: State<RegistrationState>?,
+        event: Record<String, RegistrationCommand>,
     ): StateAndEventProcessor.Response<RegistrationState> {
         logger.info("Processing registration command for registration ID ${event.key}.")
         val result = try {
+            val stateValue = state?.value
             when (val command = event.value?.command) {
                 is QueueRegistration -> {
                     logger.info("Received queue registration command.")
-                    handlers[QueueRegistration::class.java]?.invoke(state, event)
+                    handlers[QueueRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is CheckForPendingRegistration -> {
                     logger.info("Received check for pending registration command.")
-                    handlers[CheckForPendingRegistration::class.java]?.invoke(state, event)
+                    handlers[CheckForPendingRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is StartRegistration -> {
                     logger.info("Received start registration command.")
-                    handlers[StartRegistration::class.java]?.invoke(state, event)
+                    handlers[StartRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is VerifyMember -> {
                     logger.info("Received verify member during registration command.")
-                    handlers[VerifyMember::class.java]?.invoke(state, event)
+                    handlers[VerifyMember::class.java]?.invoke(stateValue, event)
                 }
 
                 is ProcessMemberVerificationResponse -> {
                     logger.info("Received process member verification response during registration command.")
-                    handlers[ProcessMemberVerificationResponse::class.java]?.invoke(state, event)
+                    handlers[ProcessMemberVerificationResponse::class.java]?.invoke(stateValue, event)
                 }
 
                 is ApproveRegistration -> {
                     logger.info("Received approve registration command.")
-                    handlers[ApproveRegistration::class.java]?.invoke(state, event)
+                    handlers[ApproveRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is DeclineRegistration -> {
                     logger.info("Received decline registration command.")
                     logger.warn("Declining registration because: ${command.reason}")
-                    handlers[DeclineRegistration::class.java]?.invoke(state, event)
+                    handlers[DeclineRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is ProcessMemberVerificationRequest -> {
                     logger.info("Received process member verification request during registration command.")
-                    handlers[ProcessMemberVerificationRequest::class.java]?.invoke(state, event)
+                    handlers[ProcessMemberVerificationRequest::class.java]?.invoke(stateValue, event)
                 }
 
                 is PersistMemberRegistrationState -> {
                     logger.info("Received persist member registration state command.")
-                    handlers[PersistMemberRegistrationState::class.java]?.invoke(state, event)
+                    handlers[PersistMemberRegistrationState::class.java]?.invoke(stateValue, event)
                 }
 
                 else -> {
                     logger.warn("Unhandled registration command received.")
-                    createEmptyResult(state)
+                    createEmptyResult(stateValue)
                 }
             }
         } catch (e: MissingRegistrationStateException) {
@@ -194,7 +196,9 @@ class RegistrationProcessor(
             createEmptyResult()
         }
         return StateAndEventProcessor.Response(
-            result?.updatedState,
+            result?.updatedState.let {
+                State(it, state?.metadata)
+            },
             result?.outputStates ?: emptyList()
         )
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessorTest.kt
@@ -42,6 +42,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PLATFORM_VERSION
 import net.corda.membership.lib.SelfSignedMemberInfo
 import net.corda.membership.persistence.client.MembershipPersistenceOperation
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.test.util.time.TestClock
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.membership.EndpointInfo
@@ -281,8 +282,13 @@ class  RegistrationProcessorTest {
             null,
             RegistrationState(registrationId, holdingIdentity, mgmHoldingIdentity, emptyList())
         ).forEach { state ->
-            with(processor.onNext(state, Record(testTopic, testTopicKey, RegistrationCommand(Any())))) {
-                assertThat(updatedState).isEqualTo(state)
+            with(
+                processor.onNext(
+                    State(state, metadata = null),
+                    Record(testTopic, testTopicKey, RegistrationCommand(Any()))
+                )
+            ) {
+                assertThat(updatedState?.value).isEqualTo(state)
                 assertThat(responseEvents).isEmpty()
             }
         }
@@ -291,7 +297,7 @@ class  RegistrationProcessorTest {
     @Test
     fun `queue registration command - onNext can be called`() {
         val result = processor.onNext(null, Record(testTopic, testTopicKey, queueRegistrationCommand))
-        assertThat(result.updatedState).isNull()
+        assertThat(result.updatedState?.value).isNull()
         assertThat(result.responseEvents).isNotEmpty.hasSize(2)
         assertThat(result.responseEvents.firstNotNullOf { it.value as? RegistrationCommand }.command)
             .isNotNull
@@ -301,7 +307,7 @@ class  RegistrationProcessorTest {
     @Test
     fun `check for pending registration command - onNext can be called`() {
         val result = processor.onNext(null, Record(testTopic, testTopicKey, checkForPendingRegistrationCommand))
-        assertThat(result.updatedState).isNotNull()
+        assertThat(result.updatedState?.value).isNotNull()
         assertThat(result.responseEvents).isNotEmpty.hasSize(1)
         assertThat((result.responseEvents.first().value as? RegistrationCommand)?.command)
             .isNotNull
@@ -311,10 +317,13 @@ class  RegistrationProcessorTest {
     @Test
     fun `start registration command - onNext can be called for start registration command`() {
         val result = processor.onNext(
-            RegistrationState(registrationId, holdingIdentity, mgmHoldingIdentity, emptyList()),
+            State(
+                RegistrationState(registrationId, holdingIdentity, mgmHoldingIdentity, emptyList()),
+                metadata = null
+            ),
             Record(testTopic, testTopicKey, startRegistrationCommand)
         )
-        assertThat(result.updatedState).isNotNull
+        assertThat(result.updatedState?.value).isNotNull
         val events = result.responseEvents
         assertThat(events).isNotEmpty.hasSize(2)
         assertThat(events.firstNotNullOf { it.value as? RegistrationCommand }.command)
@@ -325,7 +334,7 @@ class  RegistrationProcessorTest {
     @Test
     fun `process member verification request command - onNext can be called for command`() {
         val result = processor.onNext(null, Record(testTopic, testTopicKey, verificationRequestCommand))
-        assertThat(result.updatedState).isNull()
+        assertThat(result.updatedState?.value).isNull()
         assertThat(result.responseEvents)
             .hasSize(1)
             .anySatisfy {
@@ -348,8 +357,11 @@ class  RegistrationProcessorTest {
 
     @Test
     fun `verify member command - onNext can be called for command`() {
-        val result = processor.onNext(state, Record(testTopic, testTopicKey, verifyMemberCommand))
-        assertThat(result.updatedState).isNotNull
+        val result = processor.onNext(
+            State(state, metadata = null),
+            Record(testTopic, testTopicKey, verifyMemberCommand)
+        )
+        assertThat(result.updatedState?.value).isNotNull
         assertThat(result.responseEvents).isNotEmpty.hasSize(1)
             .allMatch {
                 (result.responseEvents.first().value as? AppMessage)?.message as? AuthenticatedMessage != null
@@ -359,7 +371,7 @@ class  RegistrationProcessorTest {
     @Test
     fun `missing RegistrationState results in empty response`() {
         val result = processor.onNext(null, Record(testTopic, testTopicKey, verifyMemberCommand))
-        assertThat(result.updatedState).isNull()
+        assertThat(result.updatedState?.value).isNull()
         assertThat(result.responseEvents).isEmpty()
     }
 }

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/pipeline/events/FlowEventContext.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/pipeline/events/FlowEventContext.kt
@@ -4,6 +4,7 @@ import net.corda.data.flow.event.FlowEvent
 import net.corda.flow.pipeline.metrics.FlowMetrics
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.statemanager.api.Metadata
 import net.corda.messaging.api.records.Record
 import net.corda.tracing.TraceContext
 
@@ -23,6 +24,7 @@ import net.corda.tracing.TraceContext
  * @param mdcProperties properties to set the flow fibers MDC with.
  * @param flowMetrics The [FlowMetrics] instance associated with the flow event
  * @param flowTraceContext The [TraceContext] instance associated with the flow event
+ * @param metadata Metadata associated with the checkpoint in state storage
  */
 data class FlowEventContext<T>(
     val checkpoint: FlowCheckpoint,
@@ -35,5 +37,6 @@ data class FlowEventContext<T>(
     val sendToDlq: Boolean = false,
     val mdcProperties: Map<String, String>,
     val flowMetrics: FlowMetrics,
-    val flowTraceContext: TraceContext
+    val flowTraceContext: TraceContext,
+    val metadata: Metadata?
 )

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImpl.kt
@@ -203,23 +203,18 @@ internal class DBCordaConsumerImpl<K : Any, V : Any> constructor(
         }
     }
 
-    override fun asyncCommitOffsets(callback: CordaConsumer.Callback?) {
-        try {
-            dbAccess.writeOffsets(
-                lastReadOffset.map { (cordaTopicPartition, offset) ->
-                    CommittedPositionEntry(
-                        cordaTopicPartition.topic,
-                        groupId,
-                        cordaTopicPartition.partition,
-                        offset,
-                        ATOMIC_TRANSACTION,
-                    )
-                }
-            )
-            callback?.onCompletion(lastReadOffset, null)
-        } catch(e: Exception) {
-            callback?.onCompletion(emptyMap(), e)
-        }
+    override fun syncCommitOffsets() {
+        dbAccess.writeOffsets(
+            lastReadOffset.map { (cordaTopicPartition, offset) ->
+                CommittedPositionEntry(
+                    cordaTopicPartition.topic,
+                    groupId,
+                    cordaTopicPartition.partition,
+                    offset,
+                    ATOMIC_TRANSACTION,
+                )
+            }
+        )
     }
 
     override fun syncCommitOffsets(event: CordaConsumerRecord<K, V>, metaData: String?) {

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -78,7 +78,7 @@ roles {
         # within this pattern is transactional by default, and the transaction commit also causes a flush.
         producer = ${producer} {
             # Maximum time to wait for additional messages before sending the current batch.
-            linger.ms = 1000
+            linger.ms = 0
             # Maximum amount of memory in bytes (not messages) that will be used for each batch. Can not be higher than
             # the value configured for "message.max.bytes" on the broker side (1mb by default).
             batch.size = 750000

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -4,7 +4,6 @@ import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics
 import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.ChunkKey
 import net.corda.messagebus.api.CordaTopicPartition
-import net.corda.messagebus.api.consumer.CordaConsumer
 import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messagebus.api.consumer.CordaOffsetResetStrategy
@@ -25,7 +24,6 @@ import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener
 import org.apache.kafka.clients.consumer.MockConsumer
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
-import org.apache.kafka.clients.consumer.OffsetCommitCallback
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.AuthenticationException
@@ -45,7 +43,6 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -180,33 +177,26 @@ class CordaKafkaConsumerImplTest {
     }
 
     @Test
-    fun testAsyncCommitOffsets() {
-        val callback = mock<CordaConsumer.Callback>()
+    fun testSyncCommitOffsets() {
         assertThat(consumer.committed(setOf(partition))).isEmpty()
 
         cordaKafkaConsumer.poll(Duration.ZERO)
-        cordaKafkaConsumer.asyncCommitOffsets(callback)
+        cordaKafkaConsumer.syncCommitOffsets()
 
         val committedPositionAfterPoll = consumer.committed(setOf(partition))
         assertThat(committedPositionAfterPoll.values.first().offset()).isEqualTo(numberOfRecords)
     }
 
     @Test
-    fun testAsyncCommitOffsetsException() {
+    fun testSyncCommitOffsetsException() {
         consumer = mock()
         cordaKafkaConsumer = createConsumer(consumer)
-        val exception = CommitFailedException()
-        doAnswer {
-            val callback = it.arguments[0] as OffsetCommitCallback
-            callback.onComplete(mock(), exception)
-            null
-        }.whenever(consumer).commitAsync(any())
-        val callback = mock<CordaConsumer.Callback>()
 
-        cordaKafkaConsumer.asyncCommitOffsets(callback)
-
-        verify(consumer, times(1)).commitAsync(any())
-        verify(callback, times(1)).onCompletion(any(), eq(exception))
+        doThrow(CommitFailedException()).whenever(consumer).commitSync()
+        assertThatExceptionOfType(CordaMessageAPIFatalException::class.java).isThrownBy {
+            cordaKafkaConsumer.syncCommitOffsets()
+        }
+        verify(consumer, times(1)).commitSync()
     }
 
     @Test

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
@@ -146,10 +146,10 @@ interface CordaConsumer<K : Any, V : Any> : AutoCloseable {
     fun resetToLastCommittedPositions(offsetStrategy: CordaOffsetResetStrategy)
 
     /**
-     * Asynchronously commit the consumer offsets.
+     * Synchronously commit the consumer offsets.
      * @throws CordaMessageAPIFatalException fatal error occurred attempting to commit offsets.
      */
-    fun asyncCommitOffsets(callback: Callback?)
+    fun syncCommitOffsets()
 
     /**
      * Synchronously commit the consumer offset for this [event] back to the topic partition.

--- a/libs/messaging/messaging-impl/build.gradle
+++ b/libs/messaging/messaging-impl/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     implementation project(":libs:chunking:chunking-core")
     implementation project(":libs:crypto:cipher-suite")
     implementation project(":libs:crypto:crypto-core")
-    implementation project(path: ':libs:kotlin-coroutines', configuration: 'bundle')
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:messaging:messaging")
     implementation project(":libs:messaging:message-bus")

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/ClientTask.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/ClientTask.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.mediator
 
-import kotlinx.coroutines.runBlocking
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient
@@ -30,11 +29,9 @@ data class ClientTask<K : Any, S : Any, E : Any>(
         val destination = messageRouter.getDestination(message)
 
         @Suppress("UNCHECKED_CAST")
-        val reply = runBlocking {
-            with(destination) {
-                message.addProperty(MSG_PROP_ENDPOINT, endpoint)
-                client.send(message).await() as MediatorMessage<E>?
-            }
+        val reply = with(destination) {
+            message.addProperty(MSG_PROP_ENDPOINT, endpoint)
+            client.send(message) as MediatorMessage<E>?
         }
         return Result(this, reply)
     }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
@@ -1,7 +1,5 @@
 package net.corda.messaging.mediator
 
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
 import net.corda.messagebus.api.producer.CordaProducer
 import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messaging.api.mediator.MediatorMessage
@@ -20,16 +18,10 @@ class MessageBusClient(
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    override fun send(message: MediatorMessage<*>): Deferred<MediatorMessage<*>?> =
-        CompletableDeferred<MediatorMessage<*>?>().apply {
-            producer.send(message.toCordaProducerRecord()) { ex ->
-                if (ex != null) {
-                    completeExceptionally(ex)
-                } else {
-                    complete(null)
-                }
-            }
-        }
+    override fun send(message: MediatorMessage<*>): MediatorMessage<*>? {
+        producer.send(message.toCordaProducerRecord(), null)
+        return null
+    }
 
     override fun close() {
         try {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusConsumer.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusConsumer.kt
@@ -1,8 +1,5 @@
 package net.corda.messaging.mediator
 
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Deferred
-import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.consumer.CordaConsumer
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messagebus.api.consumer.CordaOffsetResetStrategy
@@ -16,33 +13,14 @@ class MessageBusConsumer<K: Any, V: Any>(
     private val topic: String,
     private val consumer: CordaConsumer<K, V>,
 ): MediatorConsumer<K, V> {
+    override fun subscribe() = consumer.subscribe(topic)
 
-    override fun subscribe() =
-        consumer.subscribe(topic)
+    override fun poll(timeout: Duration): List<CordaConsumerRecord<K, V>> = consumer.poll(timeout)
 
-    override fun poll(timeout: Duration): Deferred<List<CordaConsumerRecord<K, V>>> =
-        CompletableDeferred<List<CordaConsumerRecord<K, V>>>().apply {
-            try {
-                complete(consumer.poll(timeout))
-            } catch (throwable: Throwable) {
-                completeExceptionally(throwable)
-            }
-        }
-
-    override fun asyncCommitOffsets(): Deferred<Map<CordaTopicPartition, Long>> =
-        CompletableDeferred<Map<CordaTopicPartition, Long>>().apply {
-            consumer.asyncCommitOffsets { offsets, exception ->
-                if (exception != null) {
-                    completeExceptionally(exception)
-                } else {
-                    complete(offsets)
-                }
-            }
-        }
+    override fun syncCommitOffsets() = consumer.syncCommitOffsets()
 
     override fun resetEventOffsetPosition() =
         consumer.resetToLastCommittedPositions(CordaOffsetResetStrategy.EARLIEST)
 
-    override fun close() =
-        consumer.close()
+    override fun close() = consumer.close()
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/ProcessorTask.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/ProcessorTask.kt
@@ -28,18 +28,23 @@ data class ProcessorTask<K : Any, S : Any, E : Any>(
     }
 
     override fun call(): Result<K, S, E> {
-        var stateValue = stateManagerHelper.deserializeValue(persistedState)
+        var state = stateManagerHelper.deserializeValue(persistedState)?.let { stateValue ->
+            StateAndEventProcessor.State(
+                stateValue,
+                persistedState?.metadata
+            )
+        }
 
         val outputEvents = events.map { event ->
-            val response = processor.onNext(stateValue, event)
-            stateValue = response.updatedState
+            val response = processor.onNext(state, event)
+            state = response.updatedState
             response.responseEvents
         }.flatten()
 
         val updatedState = stateManagerHelper.createOrUpdateState(
             key.toString(),
             persistedState,
-            stateValue
+            state,
         )
 
         return Result(this, outputEvents, updatedState)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/StateManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/StateManagerHelper.kt
@@ -5,6 +5,7 @@ import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.libs.statemanager.api.Metadata
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
+import net.corda.messaging.api.processor.StateAndEventProcessor
 
 /**
  * Helper for working with [StateManager], used by [MultiSourceEventMediatorImpl].
@@ -20,18 +21,18 @@ class StateManagerHelper<K : Any, S : Any, E : Any>(
      *
      * @param key Event's key.
      * @param persistedState State being updated.
-     * @param newValue Updated state value.
+     * @param newState Updated state.
      */
     fun createOrUpdateState(
         key: String,
         persistedState: State?,
-        newValue: S?,
-    ) = serialize(newValue)?.let { serializedValue ->
+        newState: StateAndEventProcessor.State<S>?,
+    ) = serialize(newState?.value)?.let { serializedValue ->
         State(
             key,
             serializedValue,
             persistedState?.version ?: State.VERSION_INITIAL_VALUE,
-            persistedState?.metadata ?: Metadata()
+            newState?.metadata ?: Metadata(),
         )
     }
 

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/taskmanager/TaskManagerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/taskmanager/TaskManagerImpl.kt
@@ -4,6 +4,7 @@ import net.corda.messaging.api.mediator.taskmanager.TaskManager
 import net.corda.messaging.api.mediator.taskmanager.TaskType
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
@@ -12,6 +13,9 @@ import kotlin.concurrent.thread
 // TODO This is used temporarily until Task Manager implementation is finished
 @Component(service = [TaskManager::class])
 class TaskManagerImpl  @Activate constructor() : TaskManager {
+    companion object {
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
     private var executorService = Executors.newSingleThreadExecutor()
 
     override fun <T> execute(type: TaskType, command: () -> T) =
@@ -21,11 +25,20 @@ class TaskManagerImpl  @Activate constructor() : TaskManager {
         }
 
     private fun <T> executeShortRunning(command: () -> T): CompletableFuture<T> {
-        val result = CompletableFuture<T>()
-        executorService.execute {
-            result.complete(command())
+        val resultFuture = CompletableFuture<T>()
+        try {
+            executorService.execute {
+                try {
+                    resultFuture.complete(command())
+                } catch (t: Throwable) {
+                    log.error("Task error", t)
+                    resultFuture.completeExceptionally(t)
+                }
+            }
+        } catch (t: Throwable) {
+            log.error("Executor error", t)
         }
-        return result
+        return resultFuture
     }
 
     private fun <T> executeLongRunning(command: () -> T): CompletableFuture<T> {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -13,6 +13,7 @@ import net.corda.messaging.api.chunking.ChunkSerializerService
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.StateAndEventSubscription
 import net.corda.messaging.api.subscription.listener.StateAndEventListener
@@ -276,7 +277,7 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
         val state = updatedStates[event.partition]?.get(event.key)
         val partitionId = event.partition
         val thisEventUpdates = getUpdatesForEvent(state, event)
-        val updatedState = thisEventUpdates?.updatedState
+        val updatedState = thisEventUpdates?.updatedState?.value
 
 
         when {
@@ -329,7 +330,12 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
 
     private fun getUpdatesForEvent(state: S?, event: CordaConsumerRecord<K, E>): StateAndEventProcessor.Response<S>? {
         val future = stateAndEventConsumer.waitForFunctionToFinish(
-            { processor.onNext(state, event.toRecord()) }, config.processorTimeout.toMillis(),
+            {
+                processor.onNext(
+                    State(state, metadata = null),
+                    event.toRecord()
+                )
+            }, config.processorTimeout.toMillis(),
             "Failed to finish within the time limit for state: $state and event: $event"
         )
         @Suppress("unchecked_cast")

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/ClientTaskTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/ClientTaskTest.kt
@@ -1,7 +1,5 @@
 package net.corda.messaging.mediator
 
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.runBlocking
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient
@@ -25,7 +23,6 @@ class ClientTaskTest {
     private val messageRouter = mock<MessageRouter>()
     private val routingDestination = mock<RoutingDestination>()
     private val messagingClient = mock<MessagingClient>()
-    private val clientDeferredReply = mock<Deferred<MediatorMessage<*>>>()
     private val clientReply = mock<MediatorMessage<*>>()
 
     @BeforeEach
@@ -37,13 +34,8 @@ class ClientTaskTest {
             messagingClient
         )
         `when`(messagingClient.send(any())).thenReturn(
-            clientDeferredReply
+            clientReply
         )
-        runBlocking {
-            `when`(clientDeferredReply.await()).thenReturn(
-                clientReply
-            )
-        }
     }
 
     @Test

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusClientTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusClientTest.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.mediator
 
-import kotlinx.coroutines.runBlocking
 import net.corda.messagebus.api.producer.CordaProducer
 import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messaging.api.mediator.MediatorMessage
@@ -9,9 +8,10 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
 import org.mockito.Mockito.times
-import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -50,7 +50,7 @@ class MessageBusClientTest {
             messageProps.toHeaders(),
         )
 
-        verify(cordaProducer).send(eq(expected), any())
+        verify(cordaProducer).send(eq(expected), isNull())
     }
 
     @Test
@@ -62,14 +62,9 @@ class MessageBusClientTest {
             messageProps.toHeaders(),
         )
 
-        whenever(cordaProducer.send(eq(record), any<CordaProducer.Callback>())).thenAnswer { invocation ->
-            val callback = invocation.getArgument<CordaProducer.Callback>(1)
-            callback.onCompletion(CordaRuntimeException(""))
-        }
+        Mockito.doThrow(CordaRuntimeException("")).whenever(cordaProducer).send(eq(record), isNull())
         assertThrows<CordaRuntimeException> {
-            runBlocking {
-                messageBusClient.send(message).await()
-            }
+            messageBusClient.send(message)
         }
     }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusConsumerTest.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.mediator
 
-import kotlinx.coroutines.runBlocking
 import net.corda.messagebus.api.consumer.CordaConsumer
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.BeforeEach
@@ -51,30 +50,23 @@ class MessageBusConsumerTest {
         doThrow(CordaRuntimeException("")).whenever(cordaConsumer).poll(any())
 
         assertThrows<CordaRuntimeException> {
-            runBlocking {
-                mediatorConsumer.poll(timeout).await()
-            }
+            mediatorConsumer.poll(timeout)
         }
     }
 
     @Test
-    fun testCommitAsyncOffsets() {
-        mediatorConsumer.asyncCommitOffsets()
+    fun testSyncCommitOffsets() {
+        mediatorConsumer.syncCommitOffsets()
 
-        verify(cordaConsumer).asyncCommitOffsets(any())
+        verify(cordaConsumer).syncCommitOffsets()
     }
 
     @Test
-    fun testCommitAsyncOffsetsWithError() {
-        whenever(cordaConsumer.asyncCommitOffsets(any<CordaConsumer.Callback>())).thenAnswer { invocation ->
-            val callback = invocation.getArgument<CordaConsumer.Callback>(0)
-            callback.onCompletion(mock(), CordaRuntimeException(""))
-        }
+    fun testSyncCommitOffsetsWithError() {
+        doThrow(CordaRuntimeException("")).whenever(cordaConsumer).syncCommitOffsets()
 
         assertThrows<CordaRuntimeException> {
-            runBlocking {
-                mediatorConsumer.asyncCommitOffsets().await()
-            }
+            mediatorConsumer.syncCommitOffsets()
         }
     }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.mediator
 
-import kotlinx.coroutines.CompletableDeferred
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.libs.statemanager.api.StateManager
@@ -8,7 +7,6 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messaging.api.mediator.MediatorConsumer
-import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient
 import net.corda.messaging.api.mediator.MultiSourceEventMediator
@@ -63,7 +61,7 @@ class MultiSourceEventMediatorImplTest {
         whenever(mediatorConsumerFactory.create(any<MediatorConsumerConfig<Any, Any>>())).thenReturn(consumer)
 
         whenever(messagingClient.send(any())).thenAnswer {
-            CompletableDeferred(null as MediatorMessage<Any>?)
+            null
         }
 
         whenever(messagingClientFactory.create(any<MessagingClientConfig>())).thenReturn(messagingClient)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
@@ -4,7 +4,6 @@ import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messaging.api.mediator.MediatorConsumer
 import net.corda.messaging.api.mediator.MessageRouter
@@ -24,7 +23,6 @@ import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.test.util.waitWhile
 import org.junit.jupiter.api.BeforeEach
-// import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.atLeast
@@ -117,7 +115,7 @@ class MultiSourceEventMediatorImplTest {
         )
     }
 
-    //@Test
+    // @Test
     // TODO Test temporarily disabled as it seems to be flaky
     fun `mediator processes multiples events by key`() {
         val events = (1..6).map { "event$it" }
@@ -134,18 +132,13 @@ class MultiSourceEventMediatorImplTest {
             ),
         )
         var batchNumber = 0
-        whenever(consumer.asyncCommitOffsets()).thenAnswer {
-            CompletableDeferred(mock<Map<CordaTopicPartition, Long>>())
-        }
         whenever(consumer.poll(any())).thenAnswer {
-            CompletableDeferred(
-                if (batchNumber < eventBatches.size) {
-                    eventBatches[batchNumber++]
-                } else {
-                    Thread.sleep(10)
-                    emptyList()
-                }
-            )
+            if (batchNumber < eventBatches.size) {
+                eventBatches[batchNumber++]
+            } else {
+                Thread.sleep(10)
+                emptyList()
+            }
         }
 
         mediator.start()
@@ -159,7 +152,7 @@ class MultiSourceEventMediatorImplTest {
         verify(stateManager, times(eventBatches.size)).get(any())
         verify(stateManager, times(eventBatches.size)).create(any())
         verify(consumer, atLeast(eventBatches.size)).poll(any())
-        verify(consumer, times(eventBatches.size)).asyncCommitOffsets()
+        verify(consumer, times(eventBatches.size)).syncCommitOffsets()
         verify(messagingClient, times(events.size)).send(any())
     }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
@@ -76,7 +76,7 @@ class MultiSourceEventMediatorImplTest {
                 any()
             )
         ).thenAnswer {
-            StateAndEventProcessor.Response(
+            StateAndEventProcessor.Response<Any>(
                 updatedState = mock(),
                 responseEvents = listOf(
                     Record(

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/StateManagerHelperTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/StateManagerHelperTest.kt
@@ -5,6 +5,7 @@ import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.libs.statemanager.api.Metadata
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
+import net.corda.messaging.api.processor.StateAndEventProcessor
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -51,7 +52,10 @@ class StateManagerHelperTest {
     fun `successfully creates new state`() {
 
         val persistedState: State? = null
-        val newValue = StateType(1)
+        val newState = StateAndEventProcessor.State(
+            StateType(1),
+            mock<Metadata>(),
+        )
         val stateManagerHelper = StateManagerHelper<String, StateType, EventType>(
             stateManager,
             stateSerializer,
@@ -59,14 +63,14 @@ class StateManagerHelperTest {
         )
 
         val state = stateManagerHelper.createOrUpdateState(
-            TEST_KEY, persistedState, newValue
+            TEST_KEY, persistedState, newState
         )
 
         assertNotNull(state)
         assertEquals(TEST_KEY, state!!.key)
-        assertArrayEquals(serialized(newValue), state.value)
+        assertArrayEquals(serialized(newState.value!!), state.value)
         assertEquals(State.VERSION_INITIAL_VALUE, state.version)
-        assertNotNull(state.metadata)
+        assertEquals(newState.metadata, state.metadata)
     }
 
     @Test
@@ -78,7 +82,10 @@ class StateManagerHelperTest {
             stateVersion,
             mock<Metadata>()
         )
-        val updatedValue = StateType(TEST_STATE_VALUE.id + 1)
+        val updatedState = StateAndEventProcessor.State(
+            StateType(TEST_STATE_VALUE.id + 1),
+            mock<Metadata>(),
+        )
         val stateManagerHelper = StateManagerHelper<String, StateType, EventType>(
             stateManager,
             stateSerializer,
@@ -86,14 +93,14 @@ class StateManagerHelperTest {
         )
 
         val state = stateManagerHelper.createOrUpdateState(
-            TEST_KEY, persistedState, updatedValue
+            TEST_KEY, persistedState, updatedState
         )
 
         assertNotNull(state)
         assertEquals(persistedState.key, state!!.key)
-        assertArrayEquals(serialized(updatedValue), state.value)
+        assertArrayEquals(serialized(updatedState.value!!), state.value)
         assertEquals(persistedState.version, state.version)
-        assertEquals(persistedState.metadata, state.metadata)
+        assertEquals(updatedState.metadata, state.metadata)
     }
 
     @Test

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/TaskManagerHelperTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/TaskManagerHelperTest.kt
@@ -7,13 +7,13 @@ import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_KEY
 import net.corda.messaging.api.mediator.taskmanager.TaskManager
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.records.Record
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
-import net.corda.messaging.api.records.Record
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MediatorComponentFactoryTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MediatorComponentFactoryTest.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.mediator.factory
 
+
 import net.corda.messaging.api.mediator.MediatorConsumer
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient
@@ -10,6 +11,7 @@ import net.corda.messaging.api.mediator.factory.MessageRouterFactory
 import net.corda.messaging.api.mediator.factory.MessagingClientFactory
 import net.corda.messaging.api.mediator.factory.MessagingClientFinder
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -27,9 +29,12 @@ import org.mockito.kotlin.whenever
 class MediatorComponentFactoryTest {
     private lateinit var mediatorComponentFactory: MediatorComponentFactory<String, String, String>
     private val messageProcessor = object : StateAndEventProcessor<String, String, String> {
-        override fun onNext(state: String?, event: Record<String, String>): StateAndEventProcessor.Response<String> {
+        override fun onNext(
+            state: State<String>?, event: Record<String, String>
+        ): StateAndEventProcessor.Response<String> {
             TODO("Not yet implemented")
         }
+
         override val keyClass get() = String::class.java
         override val stateValueClass get() = String::class.java
         override val eventValueClass get() = String::class.java

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
@@ -17,6 +17,7 @@ import net.corda.messaging.api.chunking.ChunkSerializerService
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.constants.SubscriptionType
 import net.corda.messaging.createResolvedSubscriptionConfig
@@ -75,7 +76,7 @@ class StateAndEventSubscriptionImplTest {
         doAnswer {
             CompletableFuture.completedFuture(
                 StateAndEventProcessor.Response(
-                    "newstate",
+                    State("newstate", metadata = null),
                     emptyList()
                 )
             )
@@ -466,7 +467,7 @@ class StateAndEventSubscriptionImplTest {
 
         doAnswer {
             CompletableFuture.completedFuture(
-                StateAndEventProcessor.Response(
+                StateAndEventProcessor.Response<String>(
                     null,
                     listOf(outputRecord),
                     true

--- a/libs/messaging/messaging/build.gradle
+++ b/libs/messaging/messaging/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-config-schema"
     implementation project(":libs:chunking:chunking-core")
-    implementation project(path: ':libs:kotlin-coroutines', configuration: 'bundle')
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:messaging:message-bus")
     implementation project(":libs:configuration:configuration-core")

--- a/libs/messaging/messaging/build.gradle
+++ b/libs/messaging/messaging/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
 
+    api project(":libs:state-manager:state-manager-api")
+
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MediatorConsumer.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MediatorConsumer.kt
@@ -1,7 +1,5 @@
 package net.corda.messaging.api.mediator
 
-import kotlinx.coroutines.Deferred
-import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import java.time.Duration
 
@@ -20,14 +18,12 @@ interface MediatorConsumer<K : Any, V : Any> : AutoCloseable {
      *
      * @param timeout - The maximum time to block if there are no available messages.
      */
-    fun poll(timeout: Duration): Deferred<List<CordaConsumerRecord<K, V>>>
+    fun poll(timeout: Duration): List<CordaConsumerRecord<K, V>>
 
     /**
-     * Asynchronously commit the consumer offsets. This function should be called only after `poll` was called.
-     *
-     * @return [Deferred] with committed offsets.
+     * Synchronously commits the consumer offsets. This function should be called only after `poll` was called.
      */
-    fun asyncCommitOffsets(): Deferred<Map<CordaTopicPartition, Long>>
+    fun syncCommitOffsets()
 
     /**
      * Resets consumer's offsets to the last committed positions. Next poll will read from the last committed positions.

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
@@ -1,7 +1,5 @@
 package net.corda.messaging.api.mediator
 
-import kotlinx.coroutines.Deferred
-
 /**
  * Multi-source event mediator messaging client.
  */
@@ -20,11 +18,10 @@ interface MessagingClient : AutoCloseable {
     val id: String
 
     /**
-     * Asynchronously sends a generic [MediatorMessage], and returns any result/error through a [Deferred] response.
+     * Sends a generic [MediatorMessage] and returns any result/error through a response.
      *
      * @param message The [MediatorMessage] to send.
-     * @return [Deferred] instance representing the asynchronous computation result, or null if the destination doesn't
-     * provide a response.
+     * @return Computation result, or null if the destination doesn't provide a response.
      * */
-    fun send(message: MediatorMessage<*>): Deferred<MediatorMessage<*>?>
+    fun send(message: MediatorMessage<*>): MediatorMessage<*>?
 }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/processor/StateAndEventProcessor.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/processor/StateAndEventProcessor.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.api.processor
 
+import net.corda.libs.statemanager.api.Metadata
 import net.corda.messaging.api.records.Record
 
 /**
@@ -17,6 +18,13 @@ import net.corda.messaging.api.records.Record
  * [CordaFatalException] and will cause the subscription to close.
  */
 interface StateAndEventProcessor<K : Any, S : Any, E : Any> {
+    /**
+     * State and metadata stored alongside the state.
+     */
+    data class State<S : Any>(
+        val value: S?,
+        val metadata: Metadata?,
+    )
 
     /**
      * This class encapsulates the responses that will be returned (from [onNext]) to the subscription for
@@ -25,8 +33,12 @@ interface StateAndEventProcessor<K : Any, S : Any, E : Any> {
     data class Response<S : Any>(
         /**
          * The updated state in response to an incoming event from [onNext].
+         *
+         * Both the state and its associated metadata will be overwritten in storage by this new state when provided by
+         * the processor. It is the processor's responsibility to ensure that any required metadata is preserved across
+         * processing.
          */
-        val updatedState: S?,
+        val updatedState: State<S>?,
 
         /**
          * A list of events to be published in response to an incoming event from [onNext].
@@ -38,7 +50,7 @@ interface StateAndEventProcessor<K : Any, S : Any, E : Any> {
         /**
          * Flag to indicate processing failed and the State and Event should be moved to the Dead Letter Queue
          */
-        val markForDLQ: Boolean = false
+        val markForDLQ: Boolean = false,
     )
 
     /**
@@ -55,7 +67,7 @@ interface StateAndEventProcessor<K : Any, S : Any, E : Any> {
      * NOTE: The returned events will be published and the processed events will be consumed atomically as a
      * single transaction.
      */
-    fun onNext(state: S?, event: Record<K, E>): Response<S>
+    fun onNext(state: State<S>?, event: Record<K, E>): Response<S>
 
     /**
      * [keyClass], [stateValueClass] and [eventValueClass] to easily get the class types the processor operates upon.

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestStateEventProcessor.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestStateEventProcessor.kt
@@ -5,6 +5,7 @@ import net.corda.data.demo.DemoStateRecord
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.processor.StateAndEventProcessor.Response
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import org.slf4j.LoggerFactory
 import java.util.concurrent.CountDownLatch
@@ -32,7 +33,9 @@ class TestStateEventProcessor(
         get() = DemoRecord::class.java
 
 
-    override fun onNext(state: DemoStateRecord?, event: Record<String, DemoRecord>): Response<DemoStateRecord> {
+    override fun onNext(
+        state: State<DemoStateRecord>?, event: Record<String, DemoRecord>
+    ): Response<DemoStateRecord> {
         onNextLatch.countDown()
         log.info("Received record, ${onNextLatch.count} remaining")
 
@@ -59,6 +62,9 @@ class TestStateEventProcessor(
             emptyList()
         }
 
-        return Response(newState, outputRecordList)
+        return Response(
+            State(newState, metadata = null),
+            outputRecordList
+        )
     }
 }

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestStateEventProcessorStrings.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/messaging/integration/processors/TestStateEventProcessorStrings.kt
@@ -3,6 +3,7 @@ package net.corda.messaging.integration.processors
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.processor.StateAndEventProcessor.Response
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import java.util.concurrent.CountDownLatch
 
@@ -23,7 +24,9 @@ class TestStateEventProcessorStrings(
     override val eventValueClass: Class<String>
         get() = String::class.java
 
-    override fun onNext(state: String?, event: Record<String, String>): Response<String> {
+    override fun onNext(
+        state: State<String>?, event: Record<String, String>
+    ): Response<String> {
         onNextLatch.countDown()
 
         if (delayProcessorOnFirst != null) {
@@ -48,6 +51,9 @@ class TestStateEventProcessorStrings(
             emptyList()
         }
 
-        return Response(newState, outputRecordList)
+        return Response(
+            State(newState, metadata = null),
+            outputRecordList
+        )
     }
 }

--- a/testing/p2p/inmemory-messaging-impl/src/integrationTest/kotlin/net/corda/messaging/emulation/subscription/stateandevent/InMemoryStateAndEventSubscriptionIntegrationTests.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/integrationTest/kotlin/net/corda/messaging/emulation/subscription/stateandevent/InMemoryStateAndEventSubscriptionIntegrationTests.kt
@@ -63,14 +63,19 @@ class InMemoryStateAndEventSubscriptionIntegrationTests {
                 groupName = "group",
             )
             val processor = object : StateAndEventProcessor<Key, State, Event> {
-                override fun onNext(state: State?, event: Record<Key, Event>): StateAndEventProcessor.Response<State> {
+                override fun onNext(
+                    state: StateAndEventProcessor.State<State>?, event: Record<Key, Event>
+                ): StateAndEventProcessor.Response<State> {
                     if ((state != null) && (event.value == Event.STOP)) {
-                        states[event.key.type] = state.number
+                        states[event.key.type] = state.value!!.number
                         countDown.countDown()
                     }
                     return if (event.value == Event.CREATE_STATE) {
                         StateAndEventProcessor.Response(
-                            State(event.key.type),
+                            StateAndEventProcessor.State(
+                                State(event.key.type),
+                                metadata = null
+                            ),
                             listOf(
                                 Record(
                                     subscriptionConfig.eventTopic,
@@ -80,7 +85,13 @@ class InMemoryStateAndEventSubscriptionIntegrationTests {
                             )
                         )
                     } else {
-                        StateAndEventProcessor.Response(State(event.key.type), emptyList())
+                        StateAndEventProcessor.Response(
+                            StateAndEventProcessor.State(
+                                State(event.key.type),
+                                metadata = null
+                            ),
+                            emptyList()
+                        )
                     }
                 }
 
@@ -132,7 +143,9 @@ class InMemoryStateAndEventSubscriptionIntegrationTests {
             Record(subscriptionConfig.eventTopic, Key(it), Event.SEND_TO_ANOTHER_TOPIC)
         }
         val processor = object : StateAndEventProcessor<Key, State, Event> {
-            override fun onNext(state: State?, event: Record<Key, Event>): StateAndEventProcessor.Response<State> {
+            override fun onNext(
+                state: StateAndEventProcessor.State<State>?, event: Record<Key, Event>
+            ): StateAndEventProcessor.Response<State> {
                 return StateAndEventProcessor.Response(
                     null,
                     (1..increaseBy).map {
@@ -155,7 +168,9 @@ class InMemoryStateAndEventSubscriptionIntegrationTests {
         subscription.start()
 
         val anotherProcessor = object : StateAndEventProcessor<String, String, String> {
-            override fun onNext(state: String?, event: Record<String, String>): StateAndEventProcessor.Response<String> {
+            override fun onNext(
+                state: StateAndEventProcessor.State<String>?, event: Record<String, String>
+            ): StateAndEventProcessor.Response<String> {
                 got.add(event)
                 countDown.countDown()
                 return StateAndEventProcessor.Response(null, emptyList())
@@ -216,15 +231,20 @@ class InMemoryStateAndEventSubscriptionIntegrationTests {
         }
 
         val processor = object : StateAndEventProcessor<Key, State, Event> {
-            override fun onNext(state: State?, event: Record<Key, Event>): StateAndEventProcessor.Response<State> {
+            override fun onNext(
+                state: StateAndEventProcessor.State<State>?, event: Record<Key, Event>
+            ): StateAndEventProcessor.Response<State> {
                 val newState = when (event.value) {
                     Event.CREATE_STATE -> 1
-                    Event.INCREASE_STATE -> (state!!.number + 1)
+                    Event.INCREASE_STATE -> (state?.value!!.number + 1)
                     else -> throw Exception("Unexpected event!")
                 }
                 countDown.countDown()
                 return StateAndEventProcessor.Response(
-                    State(newState),
+                    StateAndEventProcessor.State(
+                        State(newState),
+                        metadata = null
+                    ),
                     emptyList()
                 )
             }
@@ -302,9 +322,14 @@ class InMemoryStateAndEventSubscriptionIntegrationTests {
             }
         }
         val processor = object : StateAndEventProcessor<Key, State, Event> {
-            override fun onNext(state: State?, event: Record<Key, Event>): StateAndEventProcessor.Response<State> {
+            override fun onNext(
+                state: StateAndEventProcessor.State<State>?, event: Record<Key, Event>
+            ): StateAndEventProcessor.Response<State> {
                 return StateAndEventProcessor.Response(
-                    State(state?.number?.inc() ?: -1),
+                    StateAndEventProcessor.State(
+                        State(state?.value?.number?.inc() ?: -1),
+                        metadata = null
+                    ),
                     emptyList()
                 )
             }

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/stateandevent/EventSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/stateandevent/EventSubscription.kt
@@ -1,6 +1,7 @@
 package net.corda.messaging.emulation.subscription.stateandevent
 
 import net.corda.lifecycle.Lifecycle
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.emulation.topic.model.Consumption
 import net.corda.messaging.emulation.topic.model.RecordMetadata
@@ -35,19 +36,22 @@ internal class EventSubscription<K : Any, S : Any, E : Any>(
             )
             if (event != null) {
                 val state = subscription.stateSubscription.getValue(event.key)
-                val response = subscription.processor.onNext(state, event)
-                subscription.setValue(event.key, response.updatedState, eventMetaData.partition)
+                val response = subscription.processor.onNext(
+                    State(state, metadata = null),
+                    event
+                )
+                subscription.setValue(event.key, response.updatedState?.value, eventMetaData.partition)
                 subscription.topicService.addRecords(
                     listOf(
                         Record(
                             subscription.stateSubscriptionConfig.eventTopic,
                             event.key,
-                            response.updatedState
+                            response.updatedState?.value
                         )
                     ) +
                         response.responseEvents
                 )
-                subscription.stateAndEventListener?.onPostCommit(mapOf(event.key to response.updatedState))
+                subscription.stateAndEventListener?.onPostCommit(mapOf(event.key to response.updatedState?.value))
             }
         }
     }

--- a/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/subscription/stateandevent/EventSubscriptionTest.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/subscription/stateandevent/EventSubscriptionTest.kt
@@ -1,6 +1,7 @@
 package net.corda.messaging.emulation.subscription.stateandevent
 
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.listener.StateAndEventListener
@@ -34,9 +35,14 @@ class EventSubscriptionTest {
         on { stateSubscriptionConfig } doReturn SubscriptionConfig("group1", "topic1")
         on { stateSubscription } doReturn stateSubscription
         on { processor } doReturn object : StateAndEventProcessor<String, String, String> {
-            override fun onNext(state: String?, event: Record<String, String>): StateAndEventProcessor.Response<String> {
-                received.add(state to event)
-                return StateAndEventProcessor.Response(newState, response)
+            override fun onNext(
+                state: State<String>?, event: Record<String, String>
+            ): StateAndEventProcessor.Response<String> {
+                received.add(state?.value to event)
+                return StateAndEventProcessor.Response(
+                    State(newState, metadata = null),
+                    response
+                )
             }
 
             override val keyClass = String::class.java

--- a/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/subscription/stateandevent/StateSubscriptionTest.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/test/kotlin/net/corda/messaging/emulation/subscription/stateandevent/StateSubscriptionTest.kt
@@ -1,6 +1,7 @@
 package net.corda.messaging.emulation.subscription.stateandevent
 
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.listener.StateAndEventListener
@@ -35,7 +36,9 @@ class StateSubscriptionTest {
         on { subscriptionConfig } doReturn SubscriptionConfig("group", "topic")
         on { stateSubscriptionConfig } doReturn SubscriptionConfig("group1", "topic1")
         on { processor } doReturn object : StateAndEventProcessor<String, String, String> {
-            override fun onNext(state: String?, event: Record<String, String>): StateAndEventProcessor.Response<String> {
+            override fun onNext(
+                state: State<String>?, event: Record<String, String>
+            ): StateAndEventProcessor.Response<String> {
                 return StateAndEventProcessor.Response(null, emptyList())
             }
 


### PR DESCRIPTION
Merge of the following commits from the perf integration branch:

- CORE-17429 State metadata support in message processor (#4828)
- CORE-16203 Removed coroutine usage from Multi-Source Event Mediator.
- CORE-16203 Replace State and Event pattern with Multi-Source Event Mediator in FlowWorker (#4832)
- CORE-16203 Set linger.ms to 0 for stateAndEvent producer in kafka-messaging-defaults.conf