### PR TITLE
CORE-17388: Add session timeout metadata to store alongside the checkpoint

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessor.kt
@@ -2,6 +2,7 @@ package net.corda.flow.maintenance
 
 import net.corda.data.flow.FlowTimeout
 import net.corda.data.scheduler.ScheduledTaskTrigger
+import net.corda.flow.state.impl.CheckpointMetadataKeys.STATE_META_SESSION_EXPIRY_KEY
 import net.corda.libs.statemanager.api.MetadataFilter
 import net.corda.libs.statemanager.api.Operation
 import net.corda.libs.statemanager.api.StateManager
@@ -18,8 +19,6 @@ class SessionTimeoutTaskProcessor(
 ) : DurableProcessor<String, ScheduledTaskTrigger> {
     companion object {
         private val logger = LoggerFactory.getLogger(SessionTimeoutTaskProcessor::class.java)
-        // TODO - this may need to move out somewhere else.
-        const val STATE_META_SESSION_EXPIRY_KEY = "session.expiry"
     }
     override val keyClass: Class<String>
         get() = String::class.java

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
@@ -12,10 +12,13 @@ import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
+import net.corda.flow.state.impl.CheckpointMetadataKeys.STATE_META_SESSION_EXPIRY_KEY
+import net.corda.libs.statemanager.api.Metadata
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.FlowConfig.EXTERNAL_EVENT_MESSAGE_RESEND_WINDOW
 import net.corda.schema.configuration.FlowConfig.SESSION_FLOW_CLEANUP_TIME
+import net.corda.schema.configuration.FlowConfig.SESSION_TIMEOUT_WINDOW
 import net.corda.session.manager.SessionManager
 import net.corda.utilities.debug
 import net.corda.v5.base.types.MemberX500Name
@@ -55,8 +58,12 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
                 postProcessRetries(context)
 
         context.flowMetrics.flowEventCompleted(context.inputEvent.payload::class.java.name)
+        val metadata = getStateMetadata(context)
 
-        return context.copy(outputRecords = context.outputRecords + outputRecords)
+        return context.copy(
+            outputRecords = context.outputRecords + outputRecords,
+            metadata = metadata
+        )
     }
 
     private fun getSessionEvents(context: FlowEventContext<Any>, now: Instant): List<Record<*, FlowMapperEvent>> {
@@ -195,5 +202,29 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
 
         val status = flowMessageFactory.createFlowStartedStatusMessage(checkpoint)
         return listOf(flowRecordFactory.createFlowStatusRecord(status))
+    }
+
+    private fun getStateMetadata(context: FlowEventContext<Any>): Metadata? {
+        val checkpoint = context.checkpoint
+        // Find the earliest expiry time for any open sessions.
+        val lastReceivedMessageTime = checkpoint.sessions.filter {
+            it.status == SessionStateType.CREATED || it.status == SessionStateType.CONFIRMED
+        }.minByOrNull { it.lastReceivedMessageTime }?.lastReceivedMessageTime
+
+        return if (lastReceivedMessageTime != null) {
+            // Add the metadata key if there are any open sessions.
+            val expiryTime = lastReceivedMessageTime + Duration.ofMillis(
+                context.flowConfig.getLong(SESSION_TIMEOUT_WINDOW)
+            )
+            val newMap = mapOf(STATE_META_SESSION_EXPIRY_KEY to expiryTime.epochSecond)
+            context.metadata?.let {
+                Metadata(it + newMap)
+            } ?: Metadata(newMap)
+        } else {
+            // If there are no open sessions, remove the metadata key.
+            context.metadata?.let {
+                Metadata(it - STATE_META_SESSION_EXPIRY_KEY)
+            }
+        }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/CheckpointMetadataKeys.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/CheckpointMetadataKeys.kt
@@ -1,0 +1,14 @@
+package net.corda.flow.state.impl
+
+/**
+ * Metadata keys for information stored alongside the flow checkpoint.
+ */
+object CheckpointMetadataKeys {
+    /**
+     * Earliest expiry time of any session still active in this checkpoint.
+     *
+     * Note that the time provided here should only take into consideration open sessions. If the checkpoint has no open
+     * sessions, then this metadata key should be removed.
+     */
+    const val STATE_META_SESSION_EXPIRY_KEY = "session.expiry"
+}

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessorTests.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessorTests.kt
@@ -2,7 +2,7 @@ package net.corda.flow.maintenance
 
 import net.corda.data.flow.FlowTimeout
 import net.corda.data.scheduler.ScheduledTaskTrigger
-import net.corda.flow.maintenance.SessionTimeoutTaskProcessor.Companion.STATE_META_SESSION_EXPIRY_KEY
+import net.corda.flow.state.impl.CheckpointMetadataKeys.STATE_META_SESSION_EXPIRY_KEY
 import net.corda.libs.statemanager.api.Metadata
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -19,7 +19,6 @@ import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.flow.state.FlowCheckpoint
-import net.corda.flow.state.impl.CheckpointMetadataKeys
 import net.corda.flow.state.impl.CheckpointMetadataKeys.STATE_META_SESSION_EXPIRY_KEY
 import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.libs.statemanager.api.Metadata

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -19,10 +19,13 @@ import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.flow.state.FlowCheckpoint
+import net.corda.flow.state.impl.CheckpointMetadataKeys
+import net.corda.flow.state.impl.CheckpointMetadataKeys.STATE_META_SESSION_EXPIRY_KEY
 import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.records.Record
+import net.corda.schema.configuration.FlowConfig.SESSION_TIMEOUT_WINDOW
 import net.corda.session.manager.SessionManager
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
@@ -41,6 +44,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Duration
 import java.time.Instant
 
 class FlowGlobalPostProcessorImplTest {
@@ -351,5 +355,23 @@ class FlowGlobalPostProcessorImplTest {
 
         verify(sessionManager, times(1)).errorSession(any())
         verify(checkpoint, times(0)).putSessionState(any())
+    }
+
+    @Test
+    fun `when open session exists session timeout is set in metadata`() {
+        val earliestInstant = Instant.now().minusSeconds(20)
+        sessionState1.apply {
+            lastReceivedMessageTime = earliestInstant
+            status = SessionStateType.CONFIRMED
+        }
+        sessionState2.apply {
+            lastReceivedMessageTime = earliestInstant.plusSeconds(4)
+            status = SessionStateType.CONFIRMED
+        }
+        whenever(checkpoint.sessions).thenReturn(listOf(sessionState1, sessionState2))
+        val output = flowGlobalPostProcessor.postProcess(testContext)
+        val window = Duration.ofMillis(testContext.flowConfig.getLong(SESSION_TIMEOUT_WINDOW))
+        val expectedExpiry = (earliestInstant + window).epochSecond
+        assertThat(output.metadata).containsEntry(STATE_META_SESSION_EXPIRY_KEY, expectedExpiry)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/FlowEventContextHelper.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/test/utils/FlowEventContextHelper.kt
@@ -30,6 +30,7 @@ fun <T> buildFlowEventContext(
         .withValue(FlowConfig.SESSION_FLOW_CLEANUP_TIME, ConfigValueFactory.fromAnyRef(10000))
         .withValue(FlowConfig.PROCESSING_FLOW_CLEANUP_TIME, ConfigValueFactory.fromAnyRef(10000))
         .withValue(FlowConfig.EXTERNAL_EVENT_MESSAGE_RESEND_WINDOW, ConfigValueFactory.fromAnyRef(100))
+        .withValue(FlowConfig.SESSION_TIMEOUT_WINDOW, ConfigValueFactory.fromAnyRef(5000))
     )
 
     return FlowEventContext(


### PR DESCRIPTION
### Problem statement

The new session timeout handling uses a scheduled task to look up flows with open sessions that are about to expire. This is done by looking for a metadata key indicating when the timeout is due. At present, this metadata key is not set, meaning that no session timeout will ever occur.

### Solution

Add the metadata key to the output of the flow processor when the flow has open sessions.

The metadata should be updated every time a session receives a message so that the expiry time is set to the earliest expiry time of any active session. Additionally, if there are no active sessions any more, the metadata key should be unset to indicate that no timeouts are expected.