### PR TITLE
CORE-17822 Apply prefix to topic overrides

### DIFF
--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Create.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/Create.kt
@@ -192,8 +192,17 @@ class Create(
         if (overrideFilePath == null) {
             config
         } else {
-            mergeConfigurations(config, mapper.readValue(Files.readString(Paths.get(overrideFilePath!!))))
+            mergeConfigurations(
+                config,
+                applyPrefix(mapper.readValue(Files.readString(Paths.get(overrideFilePath!!))))
+            )
         }
+
+    private fun applyPrefix(overrides: OverrideTopicConfigurations): OverrideTopicConfigurations =
+        OverrideTopicConfigurations(
+            overrides.topics.map { it.copy(name = topic!!.namePrefix + it.name) },
+            overrides.acls.map { it.copy(topic = topic!!.namePrefix + it.topic) }
+        )
 
     fun getTopicConfigsForPreview(topicConfigurations: List<TopicConfig>): PreviewTopicConfigurations {
         val topicConfigs = mutableListOf<PreviewTopicConfiguration>()

--- a/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
+++ b/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/CreateConnectTest.kt
@@ -45,19 +45,19 @@ class CreateConnectTest {
         val acls = cmd.getGeneratedTopicConfigs().acls
         assertThat(cmd.getAclBindings(acls))
             .containsExactly(
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Chris", "*", AclOperation.READ, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Chris", "*", AclOperation.WRITE, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Chris", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Mo", "*", AclOperation.READ, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Mo", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "certificates.rpc.ops", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.certificates.rpc.ops", PatternType.LITERAL),
                     AccessControlEntry("User:Dan", "*", AclOperation.READ, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "certificates.rpc.ops", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.certificates.rpc.ops", PatternType.LITERAL),
                     AccessControlEntry("User:Dan", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW))
 
             )
@@ -69,23 +69,23 @@ class CreateConnectTest {
         val acls = cmd.getGeneratedTopicConfigs().acls
         assertThat(cmd.getAclBindings(acls))
             .containsExactly(
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Chris", "*", AclOperation.READ, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Chris", "*", AclOperation.WRITE, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Chris", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Mo", "*", AclOperation.READ, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Mo", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "avro.schema", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.avro.schema", PatternType.LITERAL),
                     AccessControlEntry("User:Mo", "*", AclOperation.WRITE, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "certificates.rpc.ops", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.certificates.rpc.ops", PatternType.LITERAL),
                     AccessControlEntry("User:Dan", "*", AclOperation.READ, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "certificates.rpc.ops", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.certificates.rpc.ops", PatternType.LITERAL),
                     AccessControlEntry("User:Dan", "*", AclOperation.DESCRIBE, AclPermissionType.ALLOW)),
-                AclBinding(ResourcePattern(ResourceType.TOPIC, "certificates.rpc.ops", PatternType.LITERAL),
+                AclBinding(ResourcePattern(ResourceType.TOPIC, "prefix.certificates.rpc.ops", PatternType.LITERAL),
                     AccessControlEntry("User:George", "*", AclOperation.READ, AclPermissionType.ALLOW))
 
             )
@@ -96,11 +96,11 @@ class CreateConnectTest {
         val cmd = getCommandWithConfigFile()
         val topics = cmd.getGeneratedTopicConfigs().topics
         assertThat(cmd.getTopics(topics))
-            .containsEntry("avro.schema", NewTopic("avro.schema", 5, 3)
+            .containsEntry("prefix.avro.schema", NewTopic("prefix.avro.schema", 5, 3)
                 .configs(mapOf("cleanup.policy" to "compact", "segment.ms" to "600000",
                     "delete.retention.ms" to "300000", "min.compaction.lag.ms" to "60000",
                     "max.compaction.lag.ms" to "604800000", "min.cleanable.dirty.ratio" to "0.5")))
-            .containsEntry("certificates.rpc.ops", NewTopic("certificates.rpc.ops", 4, 2)
+            .containsEntry("prefix.certificates.rpc.ops", NewTopic("prefix.certificates.rpc.ops", 4, 2)
                 .configs(emptyMap()))
     }
 
@@ -109,11 +109,11 @@ class CreateConnectTest {
         val cmd = getCommandWithConfigAndOverrideFiles()
         val topics = cmd.getGeneratedTopicConfigs().topics
         assertThat(cmd.getTopics(topics))
-            .containsEntry("avro.schema", NewTopic("avro.schema", 8, 3)
+            .containsEntry("prefix.avro.schema", NewTopic("prefix.avro.schema", 8, 3)
                 .configs(mapOf("cleanup.policy" to "compact", "segment.ms" to "600000",
                     "delete.retention.ms" to "300000", "min.compaction.lag.ms" to "60000",
                     "max.compaction.lag.ms" to "604800000", "min.cleanable.dirty.ratio" to "0.7")))
-            .containsEntry("certificates.rpc.ops", NewTopic("certificates.rpc.ops", 4, 2)
+            .containsEntry("prefix.certificates.rpc.ops", NewTopic("prefix.certificates.rpc.ops", 4, 2)
                 .configs(emptyMap()))
     }
 
@@ -135,6 +135,7 @@ class CreateConnectTest {
     private fun getCommandWithGeneratedConfig() = CreateConnect().apply {
         create = Create()
         create!!.topic = TopicPlugin.Topic()
+        create!!.topic!!.namePrefix = "prefix."
         create!!.kafkaUsers = mapOf("crypto" to "Chris", "db" to "Dan", "flow" to "Fiona", "membership" to "Mo")
     }
 
@@ -143,6 +144,7 @@ class CreateConnectTest {
         configFilePath = Paths.get(configFile).toString()
         create = Create()
         create!!.topic = TopicPlugin.Topic()
+        create!!.topic!!.namePrefix = "prefix."
     }
 
     private fun getCommandWithConfigAndOverrideFiles() = CreateConnect().apply {
@@ -150,6 +152,7 @@ class CreateConnectTest {
         configFilePath = Paths.get(configFile).toString()
         create = Create()
         create!!.topic = TopicPlugin.Topic()
+        create!!.topic!!.namePrefix = "prefix."
         val overrideFile = this::class.java.classLoader.getResource("override_topic_config.yaml")!!.toURI()
         create!!.overrideFilePath = Paths.get(overrideFile).toString()
     }

--- a/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/PreviewTest.kt
+++ b/tools/plugins/topic-config/src/test/kotlin/net/corda/cli/plugins/topicconfig/PreviewTest.kt
@@ -41,6 +41,7 @@ class PreviewTest {
             "persistence" to "I",
             "rest" to "J",
             "uniqueness" to "K")
+        preview.create!!.topic!!.namePrefix = "prefix."
         return preview
     }
 }

--- a/tools/plugins/topic-config/src/test/resources/preview_config.yaml
+++ b/tools/plugins/topic-config/src/test/resources/preview_config.yaml
@@ -1,13 +1,13 @@
 topics:
-  - name: config.management.request
+  - name: prefix.config.management.request
     partitions: 1
     replicas: 1
     config: {}
-  - name: config.management.request.resp
+  - name: prefix.config.management.request.resp
     partitions: 1
     replicas: 1
     config: {}
-  - name: config.topic
+  - name: prefix.config.topic
     partitions: 1
     replicas: 1
     config:
@@ -18,7 +18,7 @@ topics:
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
 acls:
-  - topic: config.management.request
+  - topic: prefix.config.management.request
     users:
       - name: B
         operations:
@@ -28,7 +28,7 @@ acls:
         operations:
           - write
           - describe
-  - topic: config.management.request.resp
+  - topic: prefix.config.management.request.resp
     users:
       - name: J
         operations:
@@ -38,7 +38,7 @@ acls:
         operations:
           - write
           - describe
-  - topic: config.topic
+  - topic: prefix.config.topic
     users:
       - name: A
         operations:

--- a/tools/plugins/topic-config/src/test/resources/short_generated_topic_config.yaml
+++ b/tools/plugins/topic-config/src/test/resources/short_generated_topic_config.yaml
@@ -1,5 +1,5 @@
 topics:
-  - name: avro.schema
+  - name: prefix.avro.schema
     partitions: 5
     replicas: 3
     config:
@@ -9,12 +9,12 @@ topics:
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
-  - name: certificates.rpc.ops
+  - name: prefix.certificates.rpc.ops
     partitions: 4
     replicas: 2
     config: {}
 acls:
-  - topic: avro.schema
+  - topic: prefix.avro.schema
     users:
       - name: Chris
         operations:
@@ -25,7 +25,7 @@ acls:
         operations:
           - read
           - describe
-  - topic: certificates.rpc.ops
+  - topic: prefix.certificates.rpc.ops
     users:
       - name: Dan
         operations:


### PR DESCRIPTION
Apply the topic prefix to overrides provided to the CLI command. (Most of the changes are to use prefixes in all of the tests to ensure they're being considered everywhere.)