### PR TITLE
CORE-17863: Close db connection pool after getOwnedKeyRecord

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -542,10 +542,9 @@ open class SoftCryptoService(
         val keyId = ShortHash.of(requestedFullKeyId)
         val cacheKey = ShortHashCacheKey(tenantId, keyId)
         val signingKeyInfo = shortHashCache.getIfPresent(cacheKey) ?: run {
-            val repo = signingRepositoryFactory.getInstance(tenantId)
-            val result = repo.findKey(publicKey)
-            if (result == null) throw IllegalArgumentException("The public key '${publicKey.publicKeyId()}' was not found")
-            result
+            signingRepositoryFactory.getInstance(tenantId).use { repo ->
+                repo.findKey(publicKey)
+            } ?: throw IllegalArgumentException("The public key '${publicKey.publicKeyId()}' was not found")
         }
 
         return OwnedKeyRecord(publicKey, signingKeyInfo)

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
@@ -435,6 +435,28 @@ class SoftCryptoServiceGeneralTests {
         assertThat(exception.message).contains("was not found")
     }
 
+    @Test
+    fun `Should close the repo after use`() {
+        val repo = mock<SigningRepository> {
+            on { findKey(any<PublicKey>()) } doReturn null
+        }
+        val cryptoService = makeSoftCryptoService(signingRepository = repo)
+        val publicKey = mock<PublicKey> {
+            on { encoded } doReturn UUID.randomUUID().toString().toByteArray()
+        }
+        assertThrows<IllegalArgumentException> {
+            cryptoService.sign(
+                tenantId = tenantId,
+                publicKey = publicKey,
+                signatureSpec = SignatureSpecImpl("NONE"),
+                data = ByteArray(2),
+                context = emptyMap()
+            )
+        }
+
+        verify(repo).close()
+    }
+
     private fun mockDigestService() = mock<PlatformDigestService> {
         on { hash(any<ByteArray>(), any()) } doReturn SecureHashUtils.randomSecureHash()
     }


### PR DESCRIPTION
Close the repo (and hence the connection) when the `getOwnedKeyRecord` is called.

Tested by running the scalability large network test and observing that the maximum number of concurrent open connections per virtual node was reduced from ~20 to 2 (and those two are closed after use).