### PR TITLE
CORE-17626: Add integration test for flow mapper cleanup

### DIFF
--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/FlowMapperServiceIntegrationTest.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/FlowMapperServiceIntegrationTest.kt
@@ -18,11 +18,16 @@ import net.corda.data.flow.event.session.SessionCounterpartyInfoRequest
 import net.corda.data.flow.event.session.SessionData
 import net.corda.data.flow.event.session.SessionError
 import net.corda.data.flow.event.session.SessionInit
+import net.corda.data.flow.state.mapper.FlowMapperStateType
 import net.corda.data.identity.HoldingIdentity
+import net.corda.data.scheduler.ScheduledTaskTrigger
 import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.flow.utils.emptyKeyValuePairList
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigImpl
+import net.corda.libs.statemanager.api.Metadata
+import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.StateManagerFactory
 import net.corda.membership.locally.hosted.identities.IdentityInfo
 import net.corda.membership.locally.hosted.identities.LocallyHostedIdentitiesService
 import net.corda.messaging.api.publisher.Publisher
@@ -35,6 +40,7 @@ import net.corda.schema.Schemas.Config.CONFIG_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC
 import net.corda.schema.Schemas.P2P.P2P_OUT_TOPIC
+import net.corda.schema.Schemas.ScheduledTask
 import net.corda.schema.configuration.BootConfig.BOOT_MAX_ALLOWED_MSG_SIZE
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
@@ -44,7 +50,9 @@ import net.corda.schema.configuration.ConfigKeys.STATE_MANAGER_CONFIG
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import net.corda.session.mapper.service.FlowMapperService
+import net.corda.session.mapper.service.state.StateMetadataKeys
 import net.corda.test.flow.util.buildSessionEvent
+import net.corda.test.util.eventually
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -58,6 +66,7 @@ import org.osgi.test.junit5.service.ServiceExtension
 import java.lang.System.currentTimeMillis
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -89,6 +98,9 @@ class FlowMapperServiceIntegrationTest {
 
     @InjectService(timeout = 4000)
     lateinit var locallyHostedIdentityService: LocallyHostedIdentitiesService
+
+    @InjectService(timeout = 4000)
+    lateinit var stateManagerFactory: StateManagerFactory
 
     private val messagingConfig = SmartConfigImpl.empty()
         .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(1))
@@ -402,6 +414,39 @@ class FlowMapperServiceIntegrationTest {
         assertThat(event.messageDirection).isEqualTo(MessageDirection.INBOUND)
         assertThat(event.sessionId).isEqualTo("$testId-INITIATED")
         assertThat(event.payload).isInstanceOf(SessionError::class.java)
+    }
+
+    @Test
+    fun `mapper state cleanup correctly cleans up old states`() {
+
+        // Create a state in the state manager. Note the modified time has to be further in the past than the configured
+        // flow processing time.
+        val stateKey = "foo"
+        val config = SmartConfigImpl.empty()
+        val stateManager = stateManagerFactory.create(config)
+        stateManager.create(listOf(
+            State(
+                stateKey,
+                byteArrayOf(),
+                metadata = Metadata(mapOf(StateMetadataKeys.FLOW_MAPPER_STATUS to FlowMapperStateType.CLOSING.toString())),
+                modifiedTime = Instant.now().minusSeconds(20)
+            )
+        ))
+
+        // Publish a scheduled task trigger.
+        val testId = "test6"
+        val publisher = publisherFactory.createPublisher(PublisherConfig(testId), messagingConfig)
+        publisher.publish(listOf(
+            Record(
+                ScheduledTask.SCHEDULED_TASK_TOPIC_MAPPER_PROCESSOR,
+                "foo",
+                ScheduledTaskTrigger(ScheduledTask.SCHEDULED_TASK_NAME_MAPPER_CLEANUP, Instant.now()))
+        ))
+
+        eventually(duration = Duration.ofMinutes(1)) {
+            val states = stateManager.get(listOf(stateKey))
+            assertThat(states[stateKey]).isNull()
+        }
     }
 
     private fun setupConfig(publisher: Publisher) {

--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestStateManagerFactoryImpl.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestStateManagerFactoryImpl.kt
@@ -19,9 +19,10 @@ import java.util.concurrent.ConcurrentHashMap
 @Component
 class TestStateManagerFactoryImpl : StateManagerFactory {
 
+    private val storage = ConcurrentHashMap<String, State>()
+
     override fun create(config: SmartConfig): StateManager {
         return object : StateManager {
-            private val storage = ConcurrentHashMap<String, State>()
             override fun close() {
             }
 
@@ -51,7 +52,18 @@ class TestStateManagerFactoryImpl : StateManagerFactory {
             }
 
             override fun delete(states: Collection<State>): Map<String, State> {
-                TODO("Not yet implemented")
+                return states.mapNotNull {
+                    var output: State? = null
+                    storage.compute(it.key) { _, existingState ->
+                        if (existingState?.version == it.version) {
+                            null
+                        } else {
+                            output = it
+                            existingState
+                        }
+                    }
+                    output
+                }.associateBy { it.key }
             }
 
             override fun updatedBetween(interval: IntervalFilter): Map<String, State> {
@@ -66,11 +78,16 @@ class TestStateManagerFactoryImpl : StateManagerFactory {
                 TODO("Not yet implemented")
             }
 
+            // Only supporting equals for now.
             override fun findUpdatedBetweenWithMetadataFilter(
                 intervalFilter: IntervalFilter,
                 metadataFilter: MetadataFilter
             ): Map<String, State> {
-                TODO("Not yet implemented")
+                return storage.filter { (_, state) ->
+                    state.modifiedTime >= intervalFilter.start && state.modifiedTime <= intervalFilter.finish
+                }.filter { (_, state) ->
+                    state.metadata.containsKey(metadataFilter.key) && state.metadata[metadataFilter.key] == metadataFilter.value
+                }
             }
         }
     }

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/ScheduledTaskProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/ScheduledTaskProcessor.kt
@@ -33,7 +33,7 @@ class ScheduledTaskProcessor(
     override fun onNext(events: List<Record<String, ScheduledTaskTrigger>>): List<Record<*, *>> {
         return if (events.any { it.value?.name == Schemas.ScheduledTask.SCHEDULED_TASK_NAME_MAPPER_CLEANUP }) {
             process().map {
-                Record(Schemas.Flow.FLOW_MAPPER_CLEANUP_TOPIC, UUID.randomUUID(), it)
+                Record(Schemas.Flow.FLOW_MAPPER_CLEANUP_TOPIC, UUID.randomUUID().toString(), it)
             }
         } else {
             listOf()


### PR DESCRIPTION
### Problem description

The mapper cleanup code did not have an integration test verifying that mapper states are removed from state storage after some time has passed.

### Solution

Add an integration test.

A small bug was found in setting the key for the cleanup event, as the UUID here should have been converted to a string.

This has also been verified manually against the combined worker.