### PR TITLE
ES-1485 Begin dry-run roll out on corda-runtime-os

### DIFF
--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -1,0 +1,19 @@
+name: 'Remove stale branches'
+on:
+  schedule:
+    - cron: '0 0 * * 1-5'
+
+jobs:
+  remove-stale-branches:
+    name: Remove stale branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fpicalausa/remove-stale-branches@v1.5.8
+        with:
+          dry-run: true
+          days-before-branch-stale: 30
+          days-before-branch-delete: 14
+          stale-branch-message: "@{author} The branch [{branchName}]({branchUrl}) hasn't been updated in the last 30 days and is marked as stale. It will be removed in 14 days.\r\nIf you want to keep this branch around, delete this comment or add new commits to this branch."
+          exempt-protected-branches: true
+          exempt-branches-regex: "^(release\\/|feature\\/|poc\\/).*"
+          operations-per-run: 30


### PR DESCRIPTION
Dry-run roll out of the stale branch deletion Github Action.

Tested here: https://github.com/corda/Build_team_Test_repo/blob/release/os/5.0/.github/workflows/removeStaleBranches.yml

(test runs can be seen here: https://github.com/corda/Build_team_Test_repo/actions/workflows/removeStaleBranches.yml 
and here: https://github.com/corda/corda-api/actions/workflows/remove-stale-branches.yml)