### PR TITLE
CORE-17013 Adding repartition handling to MessageBusConsumer

### DIFF
--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
@@ -1,7 +1,8 @@
 package net.corda.messagebus.api.consumer
 
-import net.corda.messagebus.api.CordaTopicPartition
 import java.time.Duration
+import net.corda.messagebus.api.CordaOffsetAndMetadata
+import net.corda.messagebus.api.CordaTopicPartition
 
 
 /**
@@ -149,7 +150,7 @@ interface CordaConsumer<K : Any, V : Any> : AutoCloseable {
      * Synchronously commit the consumer offsets.
      * @throws CordaMessageAPIFatalException fatal error occurred attempting to commit offsets.
      */
-    fun syncCommitOffsets()
+    fun syncCommitOffsets(offsets: Map<CordaTopicPartition, CordaOffsetAndMetadata>? = null)
 
     /**
      * Synchronously commit the consumer offset for this [event] back to the topic partition.

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusConsumer.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusConsumer.kt
@@ -1,10 +1,13 @@
 package net.corda.messaging.mediator
 
+import java.time.Duration
+import net.corda.messagebus.api.CordaOffsetAndMetadata
+import net.corda.messagebus.api.CordaTopicPartition
 import net.corda.messagebus.api.consumer.CordaConsumer
+import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messagebus.api.consumer.CordaOffsetResetStrategy
 import net.corda.messaging.api.mediator.MediatorConsumer
-import java.time.Duration
 
 /**
  * Message bus consumer that reads messages from configured topic.
@@ -13,11 +16,27 @@ class MessageBusConsumer<K: Any, V: Any>(
     private val topic: String,
     private val consumer: CordaConsumer<K, V>,
 ): MediatorConsumer<K, V> {
-    override fun subscribe() = consumer.subscribe(topic)
+    private val revokedPartitions = mutableSetOf<CordaTopicPartition>()
+
+    override fun subscribe() = consumer.subscribe(topic, object : CordaConsumerRebalanceListener {
+        override fun onPartitionsAssigned(partitions: Collection<CordaTopicPartition>) {
+            revokedPartitions.clear()
+        }
+
+        override fun onPartitionsRevoked(partitions: Collection<CordaTopicPartition>) {
+            revokedPartitions.addAll(partitions)
+        }
+    })
 
     override fun poll(timeout: Duration): List<CordaConsumerRecord<K, V>> = consumer.poll(timeout)
 
-    override fun syncCommitOffsets() = consumer.syncCommitOffsets()
+    override fun syncCommitOffsets() {
+        val offsetsToCommit = consumer.assignment()
+            .filter { it !in revokedPartitions }
+            .associateWith { CordaOffsetAndMetadata(consumer.position(it)) }
+
+        consumer.syncCommitOffsets(offsetsToCommit)
+    }
 
     override fun resetEventOffsetPosition() =
         consumer.resetToLastCommittedPositions(CordaOffsetResetStrategy.EARLIEST)


### PR DESCRIPTION
#### Context:
The `MultiSourceEventMediatorImpl` is calling `poll()` on the `MessageBusConsumer`, processing the polled records, and then calling `syncCommitOffsets()`. If a rebalance occurs while we're protesting the polled records, we'll see errors when trying to commit offsets to any partitions revoked in the rebalance.

#### Fix:
Added a `CordaConsumerRebalanceListener` to the `MessageBusConsumer` which tracks any partitions that have been revoked. In `SyncCommitOffsets()` we now only commit offsets for those partitions which have not previously been revoked.

#### To-do:
Update tests