### PR TITLE
CORE-17882: Add a route for flow events

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
@@ -128,6 +128,7 @@ class FlowEventMediatorFactoryImpl @Activate constructor(
                 is TokenPoolCacheEvent -> routeTo(messageBusClient, TOKEN_CACHE_EVENT)
                 is TransactionVerificationRequest -> routeTo(rpcClient, rpcEndpoint(VERIFICATION_WORKER_REST_ENDPOINT, VERIFICATION_PATH))
                 is UniquenessCheckRequestAvro -> routeTo(rpcClient, rpcEndpoint(UNIQUENESS_WORKER_REST_ENDPOINT, UNIQUENESS_PATH))
+                is FlowEvent -> routeTo(messageBusClient, FLOW_EVENT_TOPIC)
                 else -> {
                     val eventType = event?.let { it::class.java }
                     throw IllegalStateException("No route defined for event type [$eventType]")

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/NewConfigurationReceived.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/NewConfigurationReceived.kt
@@ -1,6 +1,0 @@
-package net.corda.flow.service
-
-import net.corda.libs.configuration.SmartConfig
-import net.corda.lifecycle.LifecycleEvent
-
-data class NewConfigurationReceived(val config: SmartConfig) : LifecycleEvent


### PR DESCRIPTION
### Problem description

The flow worker may post input events back to itself in transient error scenarios. This currently causes errors as there is no route defined for flow events in the flow worker event mediator.

### Solution

Add a route for flow events.

### Additional changes

`NewConfigurationReceived` is an unused lifecycle event, which can be removed.