### PR TITLE
CORE-17883 Moving status code check to HTTPRetryExecutor, retrying on 404

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
@@ -64,4 +64,3 @@ class HTTPRetryExecutor {
         }
     }
 }
-

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/RPCClientTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/RPCClientTest.kt
@@ -8,8 +8,8 @@ import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.flow.event.FlowEvent
-import net.corda.messaging.api.exception.CordaHTTPClientErrorException
-import net.corda.messaging.api.exception.CordaHTTPServerErrorException
+import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
 import net.corda.messaging.api.records.Record
@@ -116,7 +116,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks)
 
-        assertThrows<CordaHTTPClientErrorException> {
+        assertThrows<CordaMessageAPIIntermittentException> {
             client.send(message)
         }
     }
@@ -128,7 +128,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks)
 
-        assertThrows<CordaHTTPServerErrorException> {
+        assertThrows<CordaMessageAPIIntermittentException> {
             client.send(message)
         }
     }
@@ -144,7 +144,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks, onSerializationError)
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<CordaMessageAPIFatalException> {
             client.send(message)
         }
 
@@ -179,7 +179,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks)
 
-        assertThrows<IOException> {
+        assertThrows<CordaMessageAPIIntermittentException> {
             client.send(message)
         }
     }
@@ -193,7 +193,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks)
 
-        assertThrows<IOException> {
+        assertThrows<CordaMessageAPIIntermittentException> {
             client.send(message)
         }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/HTTPRetryExecutorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/HTTPRetryExecutorTest.kt
@@ -1,9 +1,13 @@
 package net.corda.messaging.utils
 
+import java.net.http.HttpResponse
+import net.corda.messaging.api.exception.CordaHTTPClientErrorException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 
 class HTTPRetryExecutorTest {
     private lateinit var retryConfig: HTTPRetryConfig
@@ -20,27 +24,33 @@ class HTTPRetryExecutorTest {
 
     @Test
     fun `successfully returns after first attempt`() {
-        val result = HTTPRetryExecutor.withConfig(retryConfig) {
-            "Success"
+        val mockResponse: HttpResponse<String> = mock()
+        whenever(mockResponse.body()).thenReturn("Success")
+
+        val result: HttpResponse<String> = HTTPRetryExecutor.withConfig(retryConfig) {
+            mockResponse
         }
 
-        assertEquals("Success", result)
+        assertEquals("Success", result.body())
     }
 
     @Suppress("TooGenericExceptionThrown")
     @Test
     fun `should retry until successful`() {
+        val mockResponse: HttpResponse<String> = mock()
+        whenever(mockResponse.body()).thenReturn("Success on attempt 3")
+
         var attempt = 0
 
-        val result = HTTPRetryExecutor.withConfig(retryConfig) {
+        val result: HttpResponse<String> = HTTPRetryExecutor.withConfig(retryConfig) {
             ++attempt
             if (attempt < 3) {
                 throw RuntimeException("Failed on attempt $attempt")
             }
-            "Success on attempt $attempt"
+            mockResponse
         }
 
-        assertEquals("Success on attempt 3", result)
+        assertEquals("Success on attempt 3", result.body())
     }
 
     @Suppress("TooGenericExceptionThrown")
@@ -49,7 +59,7 @@ class HTTPRetryExecutorTest {
         var attempt = 0
 
         assertThrows<RuntimeException> {
-            HTTPRetryExecutor.withConfig(retryConfig) {
+            HTTPRetryExecutor.withConfig<String>(retryConfig) {
                 ++attempt
                 throw RuntimeException("Failed on attempt $attempt")
             }
@@ -67,10 +77,35 @@ class HTTPRetryExecutorTest {
             .build()
 
         assertThrows<RuntimeException> {
-            HTTPRetryExecutor.withConfig(config) {
+            HTTPRetryExecutor.withConfig<String>(config) {
                 throw RuntimeException("I'm not retryable!")
             }
         }
+    }
+
+    @Test
+    fun `should retry on client error status code`() {
+        val mockResponse: HttpResponse<String> = mock()
+        whenever(mockResponse.body()).thenReturn("Success on attempt 3")
+        val config = HTTPRetryConfig.Builder()
+            .times(3)
+            .initialDelay(100)
+            .factor(2.0)
+            .retryOn(SpecificException::class.java)
+            .retryOn(CordaHTTPClientErrorException::class.java)
+            .build()
+
+        var attempt = 0
+
+        val result: HttpResponse<String> = HTTPRetryExecutor.withConfig(config) {
+            ++attempt
+            if (attempt < 3) {
+                throw CordaHTTPClientErrorException(404, "Not Found on attempt $attempt")
+            }
+            mockResponse
+        }
+
+        assertEquals("Success on attempt 3", result.body())
     }
 
     internal class SpecificException(message: String) : Exception(message)


### PR DESCRIPTION
This change modifies the `RPCClient` so that it will retry on 4XX and 5XX errors from HTTP calls; it also segments any potential exceptions into `intermittent` or `fatal`, where `intermittent` exceptions can be retried at the mediator level without bringing it down.

We may need future work to communicate these errors back to the flow level and fail the flow.