### PR TITLE
CORE-16181 Implementing RPC client, routing external events through RPC (#4885)

### DIFF
--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -84,7 +84,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: {{ $workerName }}
+    app.kubernetes.io/component: {{ include "corda.workerComponent" $worker }}
   ports:
       - protocol: TCP
         port: {{ include "corda.workerServicePort" . }}

--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/FlowMapperServiceIntegrationTest.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/FlowMapperServiceIntegrationTest.kt
@@ -18,11 +18,16 @@ import net.corda.data.flow.event.session.SessionCounterpartyInfoRequest
 import net.corda.data.flow.event.session.SessionData
 import net.corda.data.flow.event.session.SessionError
 import net.corda.data.flow.event.session.SessionInit
+import net.corda.data.flow.state.mapper.FlowMapperStateType
 import net.corda.data.identity.HoldingIdentity
+import net.corda.data.scheduler.ScheduledTaskTrigger
 import net.corda.db.messagebus.testkit.DBSetup
 import net.corda.flow.utils.emptyKeyValuePairList
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.configuration.SmartConfigImpl
+import net.corda.libs.statemanager.api.Metadata
+import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.StateManagerFactory
 import net.corda.membership.locally.hosted.identities.IdentityInfo
 import net.corda.membership.locally.hosted.identities.LocallyHostedIdentitiesService
 import net.corda.messaging.api.publisher.Publisher
@@ -35,6 +40,7 @@ import net.corda.schema.Schemas.Config.CONFIG_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC
 import net.corda.schema.Schemas.P2P.P2P_OUT_TOPIC
+import net.corda.schema.Schemas.ScheduledTask
 import net.corda.schema.configuration.BootConfig.BOOT_MAX_ALLOWED_MSG_SIZE
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import net.corda.schema.configuration.BootConfig.TOPIC_PREFIX
@@ -44,7 +50,9 @@ import net.corda.schema.configuration.ConfigKeys.STATE_MANAGER_CONFIG
 import net.corda.schema.configuration.MessagingConfig.Bus.BUS_TYPE
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import net.corda.session.mapper.service.FlowMapperService
+import net.corda.session.mapper.service.state.StateMetadataKeys
 import net.corda.test.flow.util.buildSessionEvent
+import net.corda.test.util.eventually
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -58,6 +66,7 @@ import org.osgi.test.junit5.service.ServiceExtension
 import java.lang.System.currentTimeMillis
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -89,6 +98,9 @@ class FlowMapperServiceIntegrationTest {
 
     @InjectService(timeout = 4000)
     lateinit var locallyHostedIdentityService: LocallyHostedIdentitiesService
+
+    @InjectService(timeout = 4000)
+    lateinit var stateManagerFactory: StateManagerFactory
 
     private val messagingConfig = SmartConfigImpl.empty()
         .withValue(INSTANCE_ID, ConfigValueFactory.fromAnyRef(1))
@@ -402,6 +414,39 @@ class FlowMapperServiceIntegrationTest {
         assertThat(event.messageDirection).isEqualTo(MessageDirection.INBOUND)
         assertThat(event.sessionId).isEqualTo("$testId-INITIATED")
         assertThat(event.payload).isInstanceOf(SessionError::class.java)
+    }
+
+    @Test
+    fun `mapper state cleanup correctly cleans up old states`() {
+
+        // Create a state in the state manager. Note the modified time has to be further in the past than the configured
+        // flow processing time.
+        val stateKey = "foo"
+        val config = SmartConfigImpl.empty()
+        val stateManager = stateManagerFactory.create(config)
+        stateManager.create(listOf(
+            State(
+                stateKey,
+                byteArrayOf(),
+                metadata = Metadata(mapOf(StateMetadataKeys.FLOW_MAPPER_STATUS to FlowMapperStateType.CLOSING.toString())),
+                modifiedTime = Instant.now().minusSeconds(20)
+            )
+        ))
+
+        // Publish a scheduled task trigger.
+        val testId = "test6"
+        val publisher = publisherFactory.createPublisher(PublisherConfig(testId), messagingConfig)
+        publisher.publish(listOf(
+            Record(
+                ScheduledTask.SCHEDULED_TASK_TOPIC_MAPPER_PROCESSOR,
+                "foo",
+                ScheduledTaskTrigger(ScheduledTask.SCHEDULED_TASK_NAME_MAPPER_CLEANUP, Instant.now()))
+        ))
+
+        eventually(duration = Duration.ofMinutes(1)) {
+            val states = stateManager.get(listOf(stateKey))
+            assertThat(states[stateKey]).isNull()
+        }
     }
 
     private fun setupConfig(publisher: Publisher) {

--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestStateManagerFactoryImpl.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestStateManagerFactoryImpl.kt
@@ -19,9 +19,10 @@ import java.util.concurrent.ConcurrentHashMap
 @Component
 class TestStateManagerFactoryImpl : StateManagerFactory {
 
+    private val storage = ConcurrentHashMap<String, State>()
+
     override fun create(config: SmartConfig): StateManager {
         return object : StateManager {
-            private val storage = ConcurrentHashMap<String, State>()
             override fun close() {
             }
 
@@ -51,7 +52,18 @@ class TestStateManagerFactoryImpl : StateManagerFactory {
             }
 
             override fun delete(states: Collection<State>): Map<String, State> {
-                TODO("Not yet implemented")
+                return states.mapNotNull {
+                    var output: State? = null
+                    storage.compute(it.key) { _, existingState ->
+                        if (existingState?.version == it.version) {
+                            null
+                        } else {
+                            output = it
+                            existingState
+                        }
+                    }
+                    output
+                }.associateBy { it.key }
             }
 
             override fun updatedBetween(interval: IntervalFilter): Map<String, State> {
@@ -66,11 +78,16 @@ class TestStateManagerFactoryImpl : StateManagerFactory {
                 TODO("Not yet implemented")
             }
 
+            // Only supporting equals for now.
             override fun findUpdatedBetweenWithMetadataFilter(
                 intervalFilter: IntervalFilter,
                 metadataFilter: MetadataFilter
             ): Map<String, State> {
-                TODO("Not yet implemented")
+                return storage.filter { (_, state) ->
+                    state.modifiedTime >= intervalFilter.start && state.modifiedTime <= intervalFilter.finish
+                }.filter { (_, state) ->
+                    state.metadata.containsKey(metadataFilter.key) && state.metadata[metadataFilter.key] == metadataFilter.value
+                }
             }
         }
     }

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/ScheduledTaskProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/ScheduledTaskProcessor.kt
@@ -33,7 +33,7 @@ class ScheduledTaskProcessor(
     override fun onNext(events: List<Record<String, ScheduledTaskTrigger>>): List<Record<*, *>> {
         return if (events.any { it.value?.name == Schemas.ScheduledTask.SCHEDULED_TASK_NAME_MAPPER_CLEANUP }) {
             process().map {
-                Record(Schemas.Flow.FLOW_MAPPER_CLEANUP_TOPIC, UUID.randomUUID(), it)
+                Record(Schemas.Flow.FLOW_MAPPER_CLEANUP_TOPIC, UUID.randomUUID().toString(), it)
             }
         } else {
             listOf()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
@@ -14,7 +14,13 @@ import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
 import net.corda.ledger.utxo.verification.TransactionVerificationRequest
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.helper.getConfig
+import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.libs.statemanager.api.StateManager
+import net.corda.messaging.api.constants.WorkerRPCPaths.CRYPTO_PATH
+import net.corda.messaging.api.constants.WorkerRPCPaths.LEDGER_PATH
+import net.corda.messaging.api.constants.WorkerRPCPaths.PERSISTENCE_PATH
+import net.corda.messaging.api.constants.WorkerRPCPaths.UNIQUENESS_PATH
+import net.corda.messaging.api.constants.WorkerRPCPaths.VERIFICATION_PATH
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.RoutingDestination.Companion.routeTo
@@ -24,21 +30,21 @@ import net.corda.messaging.api.mediator.factory.MessageRouterFactory
 import net.corda.messaging.api.mediator.factory.MessagingClientFactoryFactory
 import net.corda.messaging.api.mediator.factory.MultiSourceEventMediatorFactory
 import net.corda.messaging.api.processor.StateAndEventProcessor
-import net.corda.schema.Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC
 import net.corda.schema.Schemas.Flow.FLOW_STATUS_TOPIC
-import net.corda.schema.Schemas.Persistence.PERSISTENCE_ENTITY_PROCESSOR_TOPIC
-import net.corda.schema.Schemas.Persistence.PERSISTENCE_LEDGER_PROCESSOR_TOPIC
 import net.corda.schema.Schemas.Services.TOKEN_CACHE_EVENT
-import net.corda.schema.Schemas.UniquenessChecker.UNIQUENESS_CHECK_TOPIC
-import net.corda.schema.Schemas.Verification.VERIFICATION_LEDGER_PROCESSOR_TOPIC
+import net.corda.schema.configuration.BootConfig.CRYPTO_WORKER_REST_ENDPOINT
+import net.corda.schema.configuration.BootConfig.PERSISTENCE_WORKER_REST_ENDPOINT
+import net.corda.schema.configuration.BootConfig.UNIQUENESS_WORKER_REST_ENDPOINT
+import net.corda.schema.configuration.BootConfig.VERIFICATION_WORKER_REST_ENDPOINT
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.FlowConfig
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 
+@Suppress("LongParameterList")
 @Component(service = [FlowEventMediatorFactory::class])
 class FlowEventMediatorFactoryImpl @Activate constructor(
     @Reference(service = FlowEventProcessorFactory::class)
@@ -50,11 +56,14 @@ class FlowEventMediatorFactoryImpl @Activate constructor(
     @Reference(service = MultiSourceEventMediatorFactory::class)
     private val eventMediatorFactory: MultiSourceEventMediatorFactory,
     @Reference(service = CordaAvroSerializationFactory::class)
-    cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    @Reference(service = PlatformInfoProvider::class)
+    val platformInfoProvider: PlatformInfoProvider,
 ) : FlowEventMediatorFactory {
     companion object {
         private const val CONSUMER_GROUP = "FlowEventConsumer"
         private const val MESSAGE_BUS_CLIENT = "MessageBusClient"
+        private const val RPC_CLIENT = "RpcClient"
     }
 
     private val deserializer = cordaAvroSerializationFactory.createAvroDeserializer({}, Any::class.java)
@@ -89,28 +98,36 @@ class FlowEventMediatorFactoryImpl @Activate constructor(
             messagingClientFactoryFactory.createMessageBusClientFactory(
                 MESSAGE_BUS_CLIENT, messagingConfig
             ),
+            messagingClientFactoryFactory.createRPCClientFactory(
+                RPC_CLIENT
+            )
         )
         .messageProcessor(messageProcessor)
-        .messageRouterFactory(createMessageRouterFactory())
+        .messageRouterFactory(createMessageRouterFactory(messagingConfig))
         .threads(configs.getConfig(ConfigKeys.FLOW_CONFIG).getInt(FlowConfig.PROCESSING_THREAD_POOL_SIZE))
         .threadName("flow-event-mediator")
         .stateManager(stateManager)
         .build()
 
-    private fun createMessageRouterFactory() = MessageRouterFactory { clientFinder ->
+    private fun createMessageRouterFactory(messagingConfig: SmartConfig) = MessageRouterFactory { clientFinder ->
         val messageBusClient = clientFinder.find(MESSAGE_BUS_CLIENT)
+        val rpcClient = clientFinder.find(RPC_CLIENT)
+
+        fun rpcEndpoint(endpoint: String, path: String) : String {
+            val platformVersion = platformInfoProvider.localWorkerSoftwareShortVersion
+            return "http://${messagingConfig.getString(endpoint)}/api/${platformVersion}$path"
+        }
 
         MessageRouter { message ->
             when (val event = message.event()) {
-                // TODO Route external events to RPC client after CORE-16181 is done
-                is EntityRequest -> routeTo(messageBusClient, PERSISTENCE_ENTITY_PROCESSOR_TOPIC)
+                is EntityRequest -> routeTo(rpcClient, rpcEndpoint(PERSISTENCE_WORKER_REST_ENDPOINT, PERSISTENCE_PATH))
                 is FlowMapperEvent -> routeTo(messageBusClient, FLOW_MAPPER_EVENT_TOPIC)
-                is FlowOpsRequest -> routeTo(messageBusClient, FLOW_OPS_MESSAGE_TOPIC)
+                is FlowOpsRequest -> routeTo(rpcClient, rpcEndpoint(CRYPTO_WORKER_REST_ENDPOINT, CRYPTO_PATH))
                 is FlowStatus -> routeTo(messageBusClient, FLOW_STATUS_TOPIC)
-                is LedgerPersistenceRequest -> routeTo(messageBusClient, PERSISTENCE_LEDGER_PROCESSOR_TOPIC)
+                is LedgerPersistenceRequest -> routeTo(rpcClient, rpcEndpoint(PERSISTENCE_WORKER_REST_ENDPOINT, LEDGER_PATH))
                 is TokenPoolCacheEvent -> routeTo(messageBusClient, TOKEN_CACHE_EVENT)
-                is TransactionVerificationRequest -> routeTo(messageBusClient, VERIFICATION_LEDGER_PROCESSOR_TOPIC)
-                is UniquenessCheckRequestAvro -> routeTo(messageBusClient, UNIQUENESS_CHECK_TOPIC)
+                is TransactionVerificationRequest -> routeTo(rpcClient, rpcEndpoint(VERIFICATION_WORKER_REST_ENDPOINT, VERIFICATION_PATH))
+                is UniquenessCheckRequestAvro -> routeTo(rpcClient, rpcEndpoint(UNIQUENESS_WORKER_REST_ENDPOINT, UNIQUENESS_PATH))
                 is FlowEvent -> routeTo(messageBusClient, FLOW_EVENT_TOPIC)
                 else -> {
                     val eventType = event?.let { it::class.java }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/FlowEventMediatorFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/FlowEventMediatorFactoryImplTest.kt
@@ -7,6 +7,7 @@ import net.corda.flow.messaging.mediator.FlowEventMediatorFactory
 import net.corda.flow.messaging.mediator.FlowEventMediatorFactoryImpl
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
 import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.messaging.api.mediator.config.EventMediatorConfig
 import net.corda.messaging.api.mediator.factory.MediatorConsumerFactoryFactory
 import net.corda.messaging.api.mediator.factory.MessagingClientFactoryFactory
@@ -27,6 +28,7 @@ class FlowEventMediatorFactoryImplTest {
     private val messagingClientFactoryFactory = mock<MessagingClientFactoryFactory>()
     private val multiSourceEventMediatorFactory = mock<MultiSourceEventMediatorFactory>()
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory>()
+    private val platformInfoProvider = mock<PlatformInfoProvider>()
     private val flowConfig = mock<SmartConfig>()
 
     @BeforeEach
@@ -45,6 +47,7 @@ class FlowEventMediatorFactoryImplTest {
             messagingClientFactoryFactory,
             multiSourceEventMediatorFactory,
             cordaAvroSerializationFactory,
+            platformInfoProvider
         )
     }
 

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -1,0 +1,112 @@
+package net.corda.messaging.mediator
+
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.concurrent.TimeoutException
+import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.messaging.api.exception.CordaHTTPClientErrorException
+import net.corda.messaging.api.exception.CordaHTTPServerErrorException
+import net.corda.messaging.api.mediator.MediatorMessage
+import net.corda.messaging.api.mediator.MessagingClient
+import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
+import net.corda.messaging.utils.HTTPRetryConfig
+import net.corda.messaging.utils.HTTPRetryExecutor
+import net.corda.utilities.trace
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class RPCClient(
+    override val id: String,
+    cordaAvroSerializerFactory: CordaAvroSerializationFactory,
+    private val onSerializationError: ((ByteArray) -> Unit)?,
+    private val httpClient: HttpClient,
+    private val retryConfig: HTTPRetryConfig =
+        HTTPRetryConfig.Builder()
+            .retryOn(IOException::class.java, TimeoutException::class.java)
+            .build()
+) : MessagingClient {
+    private val deserializer = cordaAvroSerializerFactory.createAvroDeserializer({}, Any::class.java)
+
+    private companion object {
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    override fun send(message: MediatorMessage<*>): MediatorMessage<*>? {
+        return try {
+            log.trace { "Received RPC external event send request for endpoint ${message.endpoint()}" }
+            processMessage(message)
+        } catch (e: Exception) {
+            handleExceptions(e)
+            null
+        }
+    }
+
+    private fun processMessage(message: MediatorMessage<*>): MediatorMessage<*> {
+        val request = buildHttpRequest(message)
+        val response = sendWithRetry(request)
+
+        checkResponseStatus(response.statusCode())
+
+        val deserializedResponse = deserializePayload(response.body())
+        return MediatorMessage(deserializedResponse, mutableMapOf("statusCode" to response.statusCode()))
+    }
+
+
+    private fun deserializePayload(payload: ByteArray): Any {
+        return try {
+            deserializer.deserialize(payload)!!
+        } catch (e: Exception) {
+            val errorMsg = "Failed to deserialize payload of size ${payload.size} bytes due to: ${e.message}"
+            log.warn(errorMsg, e)
+            onSerializationError?.invoke(errorMsg.toByteArray())
+            throw e
+        }
+    }
+
+    private fun buildHttpRequest(message: MediatorMessage<*>): HttpRequest {
+        return HttpRequest.newBuilder()
+            .uri(URI(message.endpoint()))
+            .POST(HttpRequest.BodyPublishers.ofByteArray(message.payload as ByteArray))
+            .build()
+    }
+
+    private fun sendWithRetry(request: HttpRequest): HttpResponse<ByteArray> {
+        return HTTPRetryExecutor.withConfig(retryConfig) {
+            httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        }
+    }
+
+    private fun checkResponseStatus(statusCode: Int) {
+        log.trace("Received response with status code $statusCode")
+        when (statusCode) {
+            in 400..499 -> throw CordaHTTPClientErrorException(statusCode, "Server returned status code $statusCode.")
+            in 500..599 -> throw CordaHTTPServerErrorException(statusCode, "Server returned status code $statusCode.")
+        }
+    }
+
+    private fun handleExceptions(e: Exception) {
+        when (e) {
+            is IOException -> log.warn("Network or IO operation error in RPCClient: ", e)
+            is InterruptedException -> log.warn("Operation was interrupted in RPCClient: ", e)
+            is IllegalArgumentException -> log.warn("Invalid argument provided in RPCClient call: ", e)
+            is SecurityException -> log.warn("Security violation detected in RPCClient: ", e)
+            is IllegalStateException -> log.warn("Coroutine state error in RPCClient: ", e)
+            is CordaHTTPClientErrorException -> log.warn("Client-side HTTP error in RPCClient: ", e)
+            is CordaHTTPServerErrorException -> log.warn("Server-side HTTP error in RPCClient: ", e)
+            else -> log.warn("Unhandled exception in RPCClient: ", e)
+        }
+
+        throw e
+    }
+
+    override fun close() {
+        // Nothing to do here
+    }
+
+    private fun MediatorMessage<*>.endpoint(): String {
+        return getProperty<String>(MSG_PROP_ENDPOINT)
+    }
+}

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
@@ -64,8 +64,9 @@ internal class TaskManagerHelper<K : Any, S : Any, E : Any>(
                 val groupedEvents = clientTaskResults.map { it.toRecord() }
                 with(clientTaskResults.first()) {
                     val persistedState = processorTaskResult.updatedState!!
+                    val incrementVersion = if (processorTaskResult.processorTask.persistedState == null) 0 else 1
                     processorTask.copy(
-                        persistedState = persistedState.copy(version = persistedState.version + 1),
+                        persistedState = persistedState.copy(version = persistedState.version + incrementVersion),
                         events = groupedEvents
                     )
                 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessagingClientFactoryFactoryImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessagingClientFactoryFactoryImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.mediator.factory
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messagebus.api.producer.builder.CordaProducerBuilder
 import net.corda.messaging.api.mediator.factory.MessagingClientFactoryFactory
@@ -14,6 +15,8 @@ import org.osgi.service.component.annotations.Reference
 class MessagingClientFactoryFactoryImpl @Activate constructor(
     @Reference(service = CordaProducerBuilder::class)
     private val cordaProducerBuilder: CordaProducerBuilder,
+    @Reference(service = CordaAvroSerializationFactory::class)
+    private val cordaSerializationFactory: CordaAvroSerializationFactory
 ): MessagingClientFactoryFactory {
     override fun createMessageBusClientFactory(
         id: String,
@@ -22,5 +25,12 @@ class MessagingClientFactoryFactoryImpl @Activate constructor(
         id,
         messageBusConfig,
         cordaProducerBuilder,
+    )
+
+    override fun createRPCClientFactory(
+        id: String
+    ) = RPCClientFactory(
+        id,
+        cordaSerializationFactory
     )
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/RPCClientFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/RPCClientFactory.kt
@@ -1,0 +1,29 @@
+package net.corda.messaging.mediator.factory
+
+import java.net.http.HttpClient
+import java.time.Duration
+import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.messaging.api.mediator.MessagingClient
+import net.corda.messaging.api.mediator.config.MessagingClientConfig
+import net.corda.messaging.api.mediator.factory.MessagingClientFactory
+import net.corda.messaging.mediator.RPCClient
+
+class RPCClientFactory(
+    private val id: String,
+    private val cordaSerializationFactory: CordaAvroSerializationFactory
+): MessagingClientFactory {
+    private val httpClient: HttpClient by lazy {
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(30))
+            .build()
+    }
+
+    override fun create(config: MessagingClientConfig): MessagingClient {
+        return RPCClient(
+            id,
+            cordaSerializationFactory,
+            config.onSerializationError,
+            httpClient
+        )
+    }
+}

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryConfig.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryConfig.kt
@@ -1,0 +1,34 @@
+package net.corda.messaging.utils
+
+/**
+ * Configuration class for HTTP retry parameters.
+ *
+ * @property times The number of a times a retry will be attempted. Default is 3
+ * @property initialDelay The initial delay (in milliseconds) before the first retry. Default is 100ms
+ * @property factor The multiplier used to increase the delay for each subsequent retry. Default is 2.0
+ * @property retryOn A set of exception classes that should trigger a retry when caught.
+ *                   If an exception not in this list is caught, it will be propagated immediately without retrying.
+ *                   Default is the generic [Exception] class, meaning all exceptions will trigger a retry.
+ */
+data class HTTPRetryConfig(
+    val times: Int = 3,
+    val initialDelay: Long = 100,
+    val factor: Double = 2.0,
+    val retryOn: Set<Class<out Exception>> = setOf(Exception::class.java)
+) {
+    class Builder {
+        private var times: Int = 3
+        private var initialDelay: Long = 100
+        private var factor: Double = 2.0
+        private var retryOn: Set<Class<out Exception>> = setOf(Exception::class.java)
+
+        fun times(times: Int) = apply { this.times = times }
+        fun initialDelay(delay: Long) = apply { this.initialDelay = delay }
+        fun factor(factor: Double) = apply { this.factor = factor }
+        fun retryOn(vararg exceptions: Class<out Exception>) = apply { this.retryOn = exceptions.toSet() }
+
+        fun build(): HTTPRetryConfig {
+            return HTTPRetryConfig(times, initialDelay, factor, retryOn)
+        }
+    }
+}

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
@@ -1,0 +1,43 @@
+package net.corda.messaging.utils
+
+import net.corda.utilities.trace
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class HTTPRetryExecutor {
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+
+        fun <T> withConfig(config: HTTPRetryConfig, block: () -> T): T {
+            var currentDelay = config.initialDelay
+            for (i in 0 until config.times - 1) {
+                try {
+                    log.trace { "HTTPRetryExecutor making attempt #${i + 1}." }
+                    val result = block()
+                    log.trace { "Operation successful after #${i + 1} attempt/s." }
+                    return result
+                } catch (e: Exception) {
+                    if (config.retryOn.none { it.isInstance(e) }) {
+                        log.warn("HTTPRetryExecutor caught a non-retryable exception: ${e.message}", e)
+                        throw e
+                    }
+
+                    log.trace { "Attempt #${i + 1} failed due to ${e.message}. Retrying in $currentDelay ms..." }
+                    Thread.sleep(currentDelay)
+                    currentDelay = (currentDelay * config.factor).toLong()
+                }
+            }
+
+            log.trace("All retry attempts exhausted. Making the final call.")
+
+            try {
+                val result = block()
+                log.trace { "Operation successful after #${config.times} attempt/s." }
+                return result
+            } catch (e: Exception) {
+                log.trace { "Operation failed after ${config.times} attempt/s." }
+                throw e
+            }
+        }
+    }
+}

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/RPCClientTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/RPCClientTest.kt
@@ -1,0 +1,203 @@
+package net.corda.messaging.mediator
+
+import java.io.IOException
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import net.corda.avro.serialization.CordaAvroDeserializer
+import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.avro.serialization.CordaAvroSerializer
+import net.corda.data.flow.event.FlowEvent
+import net.corda.messaging.api.exception.CordaHTTPClientErrorException
+import net.corda.messaging.api.exception.CordaHTTPServerErrorException
+import net.corda.messaging.api.mediator.MediatorMessage
+import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
+import net.corda.messaging.api.records.Record
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.times
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RPCClientTest {
+
+    private lateinit var client: RPCClient
+    private val payload = "testPayload".toByteArray()
+    private val message = MediatorMessage(
+        payload,
+        mutableMapOf(MSG_PROP_ENDPOINT to "http://test-endpoint/api/5.1/test")
+    )
+
+    data class Mocks(
+        val serializer: CordaAvroSerializer<Any>,
+        val deserializer: CordaAvroDeserializer<Any>,
+        val httpClient: HttpClient,
+        val httpResponse: HttpResponse<ByteArray>
+    )
+
+    private inner class MockEnvironment(
+        val mockSerializer: CordaAvroSerializer<Any> = mock(),
+        val mockDeserializer: CordaAvroDeserializer<Any> = mock(),
+        val mockHttpClient: HttpClient = mock(),
+        val mockHttpResponse: HttpResponse<ByteArray> = mock()
+    ) {
+        init {
+            whenever(mockSerializer.serialize(any<Record<*,*>>()))
+                .thenReturn("testPayload".toByteArray())
+
+            whenever(mockDeserializer.deserialize(any()))
+                .thenReturn(FlowEvent())
+
+            whenever(mockHttpResponse.statusCode())
+                .thenReturn(200)
+
+            whenever(mockHttpResponse.body())
+                .thenReturn("responsePayload".toByteArray())
+
+            whenever(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<*>>()))
+                .thenReturn(mockHttpResponse)
+        }
+
+        fun withHttpStatus(status: Int) = apply {
+            whenever(mockHttpResponse.statusCode()).thenReturn(status)
+        }
+
+        val mocks: Mocks
+            get() = Mocks(mockSerializer, mockDeserializer, mockHttpClient, mockHttpResponse)
+    }
+
+
+    private fun createClient(
+        mocks: Mocks,
+        onSerializationError: (ByteArray) -> Unit = mock(),
+    ): RPCClient {
+        val mockSerializationFactory: CordaAvroSerializationFactory = mock()
+
+        whenever(mockSerializationFactory.createAvroSerializer<Any>(any()))
+            .thenReturn(mocks.serializer)
+
+        whenever(mockSerializationFactory.createAvroDeserializer(any(), eq(Any::class.java)))
+            .thenReturn(mocks.deserializer)
+
+        return RPCClient(
+            "TestRPCClient1",
+            mockSerializationFactory,
+            onSerializationError,
+            mocks.httpClient
+        )
+    }
+
+    @BeforeEach
+    fun setup() {
+        val environment = MockEnvironment()
+        client = createClient(environment.mocks)
+    }
+
+    @Test
+    fun `send() processes message and returns result`() {
+        val result = client.send(message)
+        assertNotNull(result?.payload)
+        assertEquals(
+            FlowEvent(),
+            result!!.payload
+        )
+    }
+
+    @Test
+    fun `send() handles 4XX error`() {
+        val environment = MockEnvironment()
+            .withHttpStatus(404)
+
+        val client = createClient(environment.mocks)
+
+        assertThrows<CordaHTTPClientErrorException> {
+            client.send(message)
+        }
+    }
+
+    @Test
+    fun `send() handles 5XX error`() {
+        val environment = MockEnvironment()
+            .withHttpStatus(500)
+
+        val client = createClient(environment.mocks)
+
+        assertThrows<CordaHTTPServerErrorException> {
+            client.send(message)
+        }
+    }
+
+    @Test
+    fun `send() handles deserialization error`() {
+        val onSerializationError: (ByteArray) -> Unit = mock()
+
+        val environment = MockEnvironment().apply {
+            whenever(mockDeserializer.deserialize(any()))
+                .thenThrow(IllegalArgumentException("Deserialization error"))
+        }
+
+        val client = createClient(environment.mocks, onSerializationError)
+
+        assertThrows<IllegalArgumentException> {
+            client.send(message)
+        }
+
+        verify(onSerializationError).invoke(any())
+    }
+
+    @Test
+    fun `send retries on IOException and eventually succeeds`() {
+        val environment = MockEnvironment().apply {
+            whenever(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<*>>()))
+                .thenThrow(IOException("Simulated IO exception"))
+                .thenThrow(IOException("Simulated IO exception"))
+                .thenReturn(mockHttpResponse)
+        }
+
+        val client = createClient(environment.mocks)
+        val result = client.send(message)
+
+        assertNotNull(result?.payload)
+        assertEquals(
+            FlowEvent(),
+            result!!.payload
+        )
+    }
+
+    @Test
+    fun `send fails after exhausting all retries`() {
+        val environment = MockEnvironment().apply {
+            whenever(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<*>>()))
+                .thenThrow(IOException("Simulated IO exception"))
+        }
+
+        val client = createClient(environment.mocks)
+
+        assertThrows<IOException> {
+            client.send(message)
+        }
+    }
+
+    @Test
+    fun `send retries the correct number of times before failing`() {
+        val environment = MockEnvironment().apply {
+            whenever(mockHttpClient.send(any<HttpRequest>(), any<HttpResponse.BodyHandler<*>>()))
+                .thenThrow(IOException("Simulated IO exception"))
+        }
+
+        val client = createClient(environment.mocks)
+
+        assertThrows<IOException> {
+            client.send(message)
+        }
+
+        verify(environment.mockHttpClient, times(3))
+            .send(any<HttpRequest>(), any<HttpResponse.BodyHandler<*>>())
+    }
+}

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/TaskManagerHelperTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/TaskManagerHelperTest.kt
@@ -110,7 +110,7 @@ class TaskManagerHelperTest {
         val expectedProcessorTasks = listOf(
             ProcessorTask(
                 KEY2,
-                updateState.copy(version = updateState.version + 1),
+                updateState.copy(version = updateState.version),
                 listOf(replyMessage.payload!!).toRecords(KEY2),
                 messageProcessor,
                 stateManagerHelper

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MessagingClientFactoryFactoryTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MessagingClientFactoryFactoryTest.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.mediator.factory
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messagebus.api.producer.builder.CordaProducerBuilder
 import org.junit.jupiter.api.Assertions
@@ -10,12 +11,14 @@ import org.mockito.kotlin.mock
 class MessagingClientFactoryFactoryTest {
     private lateinit var messagingClientFactoryFactory: MessagingClientFactoryFactoryImpl
     private val cordaProducerBuilder = mock<CordaProducerBuilder>()
+    private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory>()
     private val messageBusConfig = mock<SmartConfig>()
 
     @BeforeEach
     fun beforeEach() {
         messagingClientFactoryFactory = MessagingClientFactoryFactoryImpl(
             cordaProducerBuilder,
+            cordaAvroSerializationFactory
         )
     }
 
@@ -27,5 +30,14 @@ class MessagingClientFactoryFactoryTest {
         )
 
         Assertions.assertNotNull(messageBusClientFactory)
+    }
+
+    @Test
+    fun testCreateRPCClientFactory() {
+        val rpcClientFactory = messagingClientFactoryFactory.createRPCClientFactory(
+            "rpcClient1"
+        )
+
+        Assertions.assertNotNull(rpcClientFactory)
     }
 }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/RPCClientFactoryTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/RPCClientFactoryTest.kt
@@ -1,0 +1,29 @@
+package net.corda.messaging.mediator.factory
+
+import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.messaging.api.mediator.config.MessagingClientConfig
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+
+class RPCClientFactoryTest {
+    private lateinit var cordaSerializationFactory: CordaAvroSerializationFactory
+    private lateinit var rpcClientFactory: RPCClientFactory
+
+    @BeforeEach
+    fun beforeEach() {
+        cordaSerializationFactory = mock(CordaAvroSerializationFactory::class.java)
+        rpcClientFactory = RPCClientFactory(
+            "RPCClient1",
+            mock(CordaAvroSerializationFactory::class.java)
+        )
+    }
+
+    @Test
+    fun testCreateRPCClient() {
+        val config = MessagingClientConfig {}
+        val rpcClient = rpcClientFactory.create(config)
+        Assertions.assertNotNull(rpcClient)
+    }
+}

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/HTTPRetryExecutorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/HTTPRetryExecutorTest.kt
@@ -1,0 +1,77 @@
+package net.corda.messaging.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class HTTPRetryExecutorTest {
+    private lateinit var retryConfig: HTTPRetryConfig
+
+    @BeforeEach
+    fun setUp() {
+        retryConfig = HTTPRetryConfig.Builder()
+            .times(3)
+            .initialDelay(100)
+            .factor(2.0)
+            .retryOn(RuntimeException::class.java)
+            .build()
+    }
+
+    @Test
+    fun `successfully returns after first attempt`() {
+        val result = HTTPRetryExecutor.withConfig(retryConfig) {
+            "Success"
+        }
+
+        assertEquals("Success", result)
+    }
+
+    @Suppress("TooGenericExceptionThrown")
+    @Test
+    fun `should retry until successful`() {
+        var attempt = 0
+
+        val result = HTTPRetryExecutor.withConfig(retryConfig) {
+            ++attempt
+            if (attempt < 3) {
+                throw RuntimeException("Failed on attempt $attempt")
+            }
+            "Success on attempt $attempt"
+        }
+
+        assertEquals("Success on attempt 3", result)
+    }
+
+    @Suppress("TooGenericExceptionThrown")
+    @Test
+    fun `should throw exception after max attempts`() {
+        var attempt = 0
+
+        assertThrows<RuntimeException> {
+            HTTPRetryExecutor.withConfig(retryConfig) {
+                ++attempt
+                throw RuntimeException("Failed on attempt $attempt")
+            }
+        }
+    }
+
+    @Suppress("TooGenericExceptionThrown")
+    @Test
+    fun `should not retry on non-retryable exception`() {
+        val config = HTTPRetryConfig.Builder()
+            .times(3)
+            .initialDelay(100)
+            .factor(2.0)
+            .retryOn(SpecificException::class.java)
+            .build()
+
+        assertThrows<RuntimeException> {
+            HTTPRetryExecutor.withConfig(config) {
+                throw RuntimeException("I'm not retryable!")
+            }
+        }
+    }
+
+    internal class SpecificException(message: String) : Exception(message)
+}

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/exception/CordaRestAPIExceptions.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/exception/CordaRestAPIExceptions.kt
@@ -19,3 +19,15 @@ class CordaRPCAPIPartitionException(message: String?, exception: Throwable? = nu
  */
 class CordaRPCAPIResponderException(val errorType: String, message: String?, exception: Throwable? = null) :
     CordaRuntimeException(message, exception)
+
+/**
+ * Exception representing a 4XX response from the HTTP server
+ */
+class CordaHTTPClientErrorException(val statusCode: Int, message: String?, exception: Throwable? = null) :
+    CordaRuntimeException(message, exception)
+
+/**
+ * Exception representing a 5XX response from the HTTP server
+ */
+class CordaHTTPServerErrorException(val statusCode: Int, message: String?, exception: Throwable? = null) :
+    CordaRuntimeException(message, exception)

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/factory/MessagingClientFactoryFactory.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/factory/MessagingClientFactoryFactory.kt
@@ -16,4 +16,13 @@ interface MessagingClientFactoryFactory {
         id: String,
         messageBusConfig: SmartConfig,
     ) : MessagingClientFactory
+
+    /**
+     * Creates an RPC messaging client factory.
+     *
+     * @param id RPC client ID.
+     */
+    fun createRPCClientFactory(
+        id: String
+    ) : MessagingClientFactory
 }


### PR DESCRIPTION
This PR adds a new implementation of MessagingClient, RPCClient, handling synchronous calls to the Corda workers via RPC/HTTP with configurable retries.

Includes also a small bug-fix for the task manager.

Previously reviewed: https://github.com/corda/corda-runtime-os/pull/4885