### PR TITLE
CORE-17883 RPCClient stability improvements

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -9,6 +9,8 @@ import java.util.concurrent.TimeoutException
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.messaging.api.exception.CordaHTTPClientErrorException
 import net.corda.messaging.api.exception.CordaHTTPServerErrorException
+import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessagingClient
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
@@ -25,7 +27,10 @@ class RPCClient(
     private val httpClient: HttpClient,
     private val retryConfig: HTTPRetryConfig =
         HTTPRetryConfig.Builder()
-            .retryOn(IOException::class.java, TimeoutException::class.java)
+            .retryOn(IOException::class.java,
+                TimeoutException::class.java,
+                CordaHTTPClientErrorException::class.java,
+                CordaHTTPServerErrorException::class.java)
             .build()
 ) : MessagingClient {
     private val deserializer = cordaAvroSerializerFactory.createAvroDeserializer({}, Any::class.java)
@@ -40,15 +45,12 @@ class RPCClient(
             processMessage(message)
         } catch (e: Exception) {
             handleExceptions(e)
-            null
         }
     }
 
     private fun processMessage(message: MediatorMessage<*>): MediatorMessage<*> {
         val request = buildHttpRequest(message)
         val response = sendWithRetry(request)
-
-        checkResponseStatus(response.statusCode())
 
         val deserializedResponse = deserializePayload(response.body())
         return MediatorMessage(deserializedResponse, mutableMapOf("statusCode" to response.statusCode()))
@@ -79,27 +81,30 @@ class RPCClient(
         }
     }
 
-    private fun checkResponseStatus(statusCode: Int) {
-        log.trace("Received response with status code $statusCode")
-        when (statusCode) {
-            in 400..499 -> throw CordaHTTPClientErrorException(statusCode, "Server returned status code $statusCode.")
-            in 500..599 -> throw CordaHTTPServerErrorException(statusCode, "Server returned status code $statusCode.")
-        }
-    }
+    private fun handleExceptions(e: Exception): Nothing {
+        val exceptionToThrow = when (e) {
+            is IOException,
+            is InterruptedException,
+            is TimeoutException,
+            is CordaHTTPClientErrorException,
+            is CordaHTTPServerErrorException -> {
+                log.warn("Intermittent error in RPCClient: ", e)
+                CordaMessageAPIIntermittentException(e.message, e)
+            }
 
-    private fun handleExceptions(e: Exception) {
-        when (e) {
-            is IOException -> log.warn("Network or IO operation error in RPCClient: ", e)
-            is InterruptedException -> log.warn("Operation was interrupted in RPCClient: ", e)
-            is IllegalArgumentException -> log.warn("Invalid argument provided in RPCClient call: ", e)
-            is SecurityException -> log.warn("Security violation detected in RPCClient: ", e)
-            is IllegalStateException -> log.warn("Coroutine state error in RPCClient: ", e)
-            is CordaHTTPClientErrorException -> log.warn("Client-side HTTP error in RPCClient: ", e)
-            is CordaHTTPServerErrorException -> log.warn("Server-side HTTP error in RPCClient: ", e)
-            else -> log.warn("Unhandled exception in RPCClient: ", e)
+            is IllegalArgumentException,
+            is SecurityException -> {
+                log.warn("Fatal error in RPCClient: ", e)
+                CordaMessageAPIFatalException(e.message, e)
+            }
+
+            else -> {
+                log.warn("Unhandled exception in RPCClient: ", e)
+                e
+            }
         }
 
-        throw e
+        throw exceptionToThrow
     }
 
     override fun close() {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
@@ -1,6 +1,10 @@
 package net.corda.messaging.utils
 
+import java.net.http.HttpResponse
+import net.corda.messaging.api.exception.CordaHTTPClientErrorException
+import net.corda.messaging.api.exception.CordaHTTPServerErrorException
 import net.corda.utilities.trace
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -8,35 +12,54 @@ class HTTPRetryExecutor {
     companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
-        fun <T> withConfig(config: HTTPRetryConfig, block: () -> T): T {
+        fun <T> withConfig(config: HTTPRetryConfig, block: () -> HttpResponse<T>): HttpResponse<T> {
             var currentDelay = config.initialDelay
-            for (i in 0 until config.times - 1) {
-                try {
-                    log.trace { "HTTPRetryExecutor making attempt #${i + 1}." }
-                    val result = block()
-                    log.trace { "Operation successful after #${i + 1} attempt/s." }
-                    return result
-                } catch (e: Exception) {
-                    if (config.retryOn.none { it.isInstance(e) }) {
-                        log.warn("HTTPRetryExecutor caught a non-retryable exception: ${e.message}", e)
-                        throw e
-                    }
+            for (i in 0 until config.times) {
+                val result = tryAttempt(i, config, block)
+                if (result != null) return result
 
-                    log.trace { "Attempt #${i + 1} failed due to ${e.message}. Retrying in $currentDelay ms..." }
-                    Thread.sleep(currentDelay)
-                    currentDelay = (currentDelay * config.factor).toLong()
-                }
+                log.trace { "Attempt #${i + 1} failed. Retrying in $currentDelay ms..." }
+                Thread.sleep(currentDelay)
+                currentDelay = (currentDelay * config.factor).toLong()
             }
 
-            log.trace("All retry attempts exhausted. Making the final call.")
+            val errorMsg = "Retry logic exhausted all attempts without a valid return or rethrow, though this shouldn't be possible."
+            log.trace { errorMsg }
+            throw CordaRuntimeException(errorMsg)
+        }
 
-            try {
+        private fun <T> tryAttempt(i: Int, config: HTTPRetryConfig, block: () -> HttpResponse<T>): HttpResponse<T>? {
+            return try {
+                log.trace { "HTTPRetryExecutor making attempt #${i + 1}." }
                 val result = block()
-                log.trace { "Operation successful after #${config.times} attempt/s." }
-                return result
+                checkResponseStatus(result.statusCode())
+                log.trace { "Operation successful after #${i + 1} attempt/s." }
+                result
             } catch (e: Exception) {
-                log.trace { "Operation failed after ${config.times} attempt/s." }
+                handleException(i, config, e)
+                null
+            }
+        }
+
+        private fun handleException(attempt: Int, config: HTTPRetryConfig, e: Exception) {
+            val isFinalAttempt = attempt == config.times - 1
+            val isRetryable = config.retryOn.any { it.isInstance(e) }
+
+            if (!isRetryable || isFinalAttempt) {
+                val errorMsg = when {
+                    isFinalAttempt -> "Operation failed after ${config.times} attempts."
+                    else -> "HTTPRetryExecutor caught a non-retryable exception: ${e.message}"
+                }
+                log.trace { errorMsg }
                 throw e
+            }
+        }
+
+        private fun checkResponseStatus(statusCode: Int) {
+            log.trace { "Received response with status code $statusCode" }
+            when (statusCode) {
+                in 400..499 -> throw CordaHTTPClientErrorException(statusCode, "Server returned status code $statusCode.")
+                in 500..599 -> throw CordaHTTPServerErrorException(statusCode, "Server returned status code $statusCode.")
             }
         }
     }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/RPCClientTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/RPCClientTest.kt
@@ -8,8 +8,8 @@ import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.flow.event.FlowEvent
-import net.corda.messaging.api.exception.CordaHTTPClientErrorException
-import net.corda.messaging.api.exception.CordaHTTPServerErrorException
+import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
 import net.corda.messaging.api.records.Record
@@ -116,7 +116,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks)
 
-        assertThrows<CordaHTTPClientErrorException> {
+        assertThrows<CordaMessageAPIIntermittentException> {
             client.send(message)
         }
     }
@@ -128,7 +128,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks)
 
-        assertThrows<CordaHTTPServerErrorException> {
+        assertThrows<CordaMessageAPIIntermittentException> {
             client.send(message)
         }
     }
@@ -144,7 +144,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks, onSerializationError)
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<CordaMessageAPIFatalException> {
             client.send(message)
         }
 
@@ -179,7 +179,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks)
 
-        assertThrows<IOException> {
+        assertThrows<CordaMessageAPIIntermittentException> {
             client.send(message)
         }
     }
@@ -193,7 +193,7 @@ class RPCClientTest {
 
         val client = createClient(environment.mocks)
 
-        assertThrows<IOException> {
+        assertThrows<CordaMessageAPIIntermittentException> {
             client.send(message)
         }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/HTTPRetryExecutorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/HTTPRetryExecutorTest.kt
@@ -1,9 +1,13 @@
 package net.corda.messaging.utils
 
+import java.net.http.HttpResponse
+import net.corda.messaging.api.exception.CordaHTTPClientErrorException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 
 class HTTPRetryExecutorTest {
     private lateinit var retryConfig: HTTPRetryConfig
@@ -20,27 +24,33 @@ class HTTPRetryExecutorTest {
 
     @Test
     fun `successfully returns after first attempt`() {
-        val result = HTTPRetryExecutor.withConfig(retryConfig) {
-            "Success"
+        val mockResponse: HttpResponse<String> = mock()
+        whenever(mockResponse.body()).thenReturn("Success")
+
+        val result: HttpResponse<String> = HTTPRetryExecutor.withConfig(retryConfig) {
+            mockResponse
         }
 
-        assertEquals("Success", result)
+        assertEquals("Success", result.body())
     }
 
     @Suppress("TooGenericExceptionThrown")
     @Test
     fun `should retry until successful`() {
+        val mockResponse: HttpResponse<String> = mock()
+        whenever(mockResponse.body()).thenReturn("Success on attempt 3")
+
         var attempt = 0
 
-        val result = HTTPRetryExecutor.withConfig(retryConfig) {
+        val result: HttpResponse<String> = HTTPRetryExecutor.withConfig(retryConfig) {
             ++attempt
             if (attempt < 3) {
                 throw RuntimeException("Failed on attempt $attempt")
             }
-            "Success on attempt $attempt"
+            mockResponse
         }
 
-        assertEquals("Success on attempt 3", result)
+        assertEquals("Success on attempt 3", result.body())
     }
 
     @Suppress("TooGenericExceptionThrown")
@@ -49,7 +59,7 @@ class HTTPRetryExecutorTest {
         var attempt = 0
 
         assertThrows<RuntimeException> {
-            HTTPRetryExecutor.withConfig(retryConfig) {
+            HTTPRetryExecutor.withConfig<String>(retryConfig) {
                 ++attempt
                 throw RuntimeException("Failed on attempt $attempt")
             }
@@ -67,10 +77,35 @@ class HTTPRetryExecutorTest {
             .build()
 
         assertThrows<RuntimeException> {
-            HTTPRetryExecutor.withConfig(config) {
+            HTTPRetryExecutor.withConfig<String>(config) {
                 throw RuntimeException("I'm not retryable!")
             }
         }
+    }
+
+    @Test
+    fun `should retry on client error status code`() {
+        val mockResponse: HttpResponse<String> = mock()
+        whenever(mockResponse.body()).thenReturn("Success on attempt 3")
+        val config = HTTPRetryConfig.Builder()
+            .times(3)
+            .initialDelay(100)
+            .factor(2.0)
+            .retryOn(SpecificException::class.java)
+            .retryOn(CordaHTTPClientErrorException::class.java)
+            .build()
+
+        var attempt = 0
+
+        val result: HttpResponse<String> = HTTPRetryExecutor.withConfig(config) {
+            ++attempt
+            if (attempt < 3) {
+                throw CordaHTTPClientErrorException(404, "Not Found on attempt $attempt")
+            }
+            mockResponse
+        }
+
+        assertEquals("Success on attempt 3", result.body())
     }
 
     internal class SpecificException(message: String) : Exception(message)


### PR DESCRIPTION
Currently, if the `RPCClient` triggers an exception, that exception will bring down the `MultiSourceEventMediator`.

This change modifies the `RPCClient` so that it will retry on 4XX and 5XX errors from HTTP calls; it also segments any potential exceptions into `intermittent` or `fatal`, where `intermittent` exceptions can be retried at the mediator level without bringing it down.

We may need future work to communicate these errors back to the flow level and fail the flow.