### PR TITLE
CORE-17885: Use explicit conversion of session timeout to long

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessor.kt
@@ -10,6 +10,7 @@ import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Flow.FLOW_TIMEOUT_TOPIC
 import net.corda.schema.Schemas.ScheduledTask
+import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
 import java.time.Instant
 
@@ -39,8 +40,7 @@ class SessionTimeoutTaskProcessor(
                 logger.trace("No flows to time out")
                 emptyList()
             } else {
-                // TODO - take log message out when everything plumbed in.
-                logger.info("Trigger cleanup of $checkpoints")
+                logger.debug { "Trigger cleanup of $checkpoints" }
                 checkpoints.map { kvp ->
                     val instant = (kvp.value.metadata[STATE_META_SESSION_EXPIRY_KEY] as Number).toLong()
                     Record(FLOW_TIMEOUT_TOPIC, kvp.key,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessor.kt
@@ -42,10 +42,12 @@ class SessionTimeoutTaskProcessor(
                 // TODO - take log message out when everything plumbed in.
                 logger.info("Trigger cleanup of $checkpoints")
                 checkpoints.map { kvp ->
+                    val instant = (kvp.value.metadata[STATE_META_SESSION_EXPIRY_KEY] as Number).toLong()
                     Record(FLOW_TIMEOUT_TOPIC, kvp.key,
                         FlowTimeout(
                             kvp.value.key,
-                            Instant.ofEpochSecond(kvp.value.metadata[STATE_META_SESSION_EXPIRY_KEY] as Long))
+                            Instant.ofEpochSecond(instant)
+                        )
                     )
                 }
             }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessorTests.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/maintenance/SessionTimeoutTaskProcessorTests.kt
@@ -26,7 +26,7 @@ class SessionTimeoutTaskProcessorTests {
             "foo",
             randomBytes(),
             0,
-            Metadata(mapOf(STATE_META_SESSION_EXPIRY_KEY to now.minusSeconds(1).epochSecond)))
+            Metadata(mapOf(STATE_META_SESSION_EXPIRY_KEY to now.minusSeconds(1).epochSecond.toInt())))
     private val states = mapOf(
         state1.key to state1,
     )
@@ -65,13 +65,15 @@ class SessionTimeoutTaskProcessorTests {
     fun `when state found return`() {
         val processor = SessionTimeoutTaskProcessor(stateManager) { now }
         val output = processor.onNext(listOf(record1))
+        val outputInstant = (state1.metadata[STATE_META_SESSION_EXPIRY_KEY] as Number).toLong()
         assertThat(output).containsExactly(
             Record(
                 Schemas.Flow.FLOW_TIMEOUT_TOPIC,
                 state1.key,
                 FlowTimeout(
                     state1.key,
-                    Instant.ofEpochSecond(state1.metadata[STATE_META_SESSION_EXPIRY_KEY] as Long))
+                    Instant.ofEpochSecond(outputInstant)
+                )
             )
         )
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/FlowEventMediatorFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/FlowEventMediatorFactoryImplTest.kt
@@ -1,25 +1,47 @@
 package net.corda.flow.messaging
 
 import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.flow.event.FlowEvent
+import net.corda.data.flow.event.mapper.FlowMapperEvent
+import net.corda.data.flow.output.FlowStatus
 import net.corda.data.flow.state.checkpoint.Checkpoint
+import net.corda.data.ledger.persistence.LedgerPersistenceRequest
+import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
+import net.corda.data.persistence.EntityRequest
+import net.corda.data.uniqueness.UniquenessCheckRequestAvro
 import net.corda.flow.messaging.mediator.FlowEventMediatorFactory
 import net.corda.flow.messaging.mediator.FlowEventMediatorFactoryImpl
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
+import net.corda.ledger.utxo.verification.TransactionVerificationRequest
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.platform.PlatformInfoProvider
+import net.corda.messaging.api.constants.WorkerRPCPaths.CRYPTO_PATH
+import net.corda.messaging.api.constants.WorkerRPCPaths.LEDGER_PATH
+import net.corda.messaging.api.constants.WorkerRPCPaths.PERSISTENCE_PATH
+import net.corda.messaging.api.constants.WorkerRPCPaths.UNIQUENESS_PATH
+import net.corda.messaging.api.constants.WorkerRPCPaths.VERIFICATION_PATH
+import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.config.EventMediatorConfig
 import net.corda.messaging.api.mediator.factory.MediatorConsumerFactoryFactory
 import net.corda.messaging.api.mediator.factory.MessagingClientFactoryFactory
+import net.corda.messaging.api.mediator.factory.MessagingClientFinder
 import net.corda.messaging.api.mediator.factory.MultiSourceEventMediatorFactory
+import net.corda.schema.Schemas.Flow.FLOW_EVENT_TOPIC
+import net.corda.schema.Schemas.Flow.FLOW_MAPPER_EVENT_TOPIC
+import net.corda.schema.Schemas.Flow.FLOW_STATUS_TOPIC
+import net.corda.schema.Schemas.Services.TOKEN_CACHE_EVENT
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.FlowConfig
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class FlowEventMediatorFactoryImplTest {
     private lateinit var flowEventMediatorFactory: FlowEventMediatorFactory
@@ -31,12 +53,14 @@ class FlowEventMediatorFactoryImplTest {
     private val platformInfoProvider = mock<PlatformInfoProvider>()
     private val flowConfig = mock<SmartConfig>()
 
+    val captor = argumentCaptor<EventMediatorConfig<String, Checkpoint, FlowEvent>>()
+
     @BeforeEach
     fun beforeEach() {
         `when`(flowEventProcessorFactory.create(any()))
             .thenReturn(mock())
 
-        `when`(multiSourceEventMediatorFactory.create(any<EventMediatorConfig<String, Checkpoint, FlowEvent>>()))
+        `when`(multiSourceEventMediatorFactory.create(captor.capture()))
             .thenReturn(mock())
 
         `when`(flowConfig.getInt(FlowConfig.PROCESSING_THREAD_POOL_SIZE)).thenReturn(10)
@@ -51,14 +75,40 @@ class FlowEventMediatorFactoryImplTest {
         )
     }
 
+    private fun endpoint(suffix: String) : String {
+        // As no config is supplied in these tests, the parameterized parts of the endpoint will be null.
+        return "http://null/api/null$suffix"
+    }
+
     @Test
-    fun `successfully creates event mediator`() {
+    fun `successfully creates event mediator with expected routes`() {
         val mediator = flowEventMediatorFactory.create(
             mapOf(ConfigKeys.FLOW_CONFIG to flowConfig),
             mock(),
             mock(),
         )
-
         assertNotNull(mediator)
+        val clientFinder = mock<MessagingClientFinder>().apply {
+            whenever(this.find(any())).thenReturn(mock())
+        }
+        val config = captor.firstValue
+        val router = config.messageRouterFactory.create(clientFinder)
+        assertThat(router.getDestination(MediatorMessage(FlowEvent())).endpoint).isEqualTo(FLOW_EVENT_TOPIC)
+        assertThat(router.getDestination(MediatorMessage(FlowMapperEvent())).endpoint)
+            .isEqualTo(FLOW_MAPPER_EVENT_TOPIC)
+        assertThat(router.getDestination(MediatorMessage(EntityRequest())).endpoint)
+            .isEqualTo(endpoint(PERSISTENCE_PATH))
+        assertThat(router.getDestination(MediatorMessage(FlowOpsRequest())).endpoint)
+            .isEqualTo(endpoint(CRYPTO_PATH))
+        assertThat(router.getDestination(MediatorMessage(FlowStatus())).endpoint).isEqualTo(FLOW_STATUS_TOPIC)
+        assertThat(router.getDestination(MediatorMessage(LedgerPersistenceRequest())).endpoint)
+            .isEqualTo(endpoint(LEDGER_PATH))
+        assertThat(router.getDestination(MediatorMessage(TokenPoolCacheEvent())).endpoint).isEqualTo(TOKEN_CACHE_EVENT)
+        assertThat(router.getDestination(MediatorMessage(TransactionVerificationRequest())).endpoint).isEqualTo(
+            endpoint(VERIFICATION_PATH)
+        )
+        assertThat(router.getDestination(MediatorMessage(UniquenessCheckRequestAvro())).endpoint).isEqualTo(
+            endpoint(UNIQUENESS_PATH)
+        )
     }
 }


### PR DESCRIPTION
### Problem description

When the metadata associated with the checkpoint goes through a cycle of being written to and read from the state manager, it is converted to and from JSON. As part of this, the fact that the original type of the session timeout metadata is a long is lost. Casting from int to long is not allowed, and so this results in an error when the timeout processor attempts to use this metadata.

### Solution

Cast instead to `Number` and then do an explicit conversion to long.

As `Number` is a supertype of all numeric values, this cast should always succeed. It's then possible to do an explicit conversion via the `toLong` method.

### Additional changes

A previous PR introduced a routing change to allow flow events to be outputted from the flow engine for transient errors. The unit test for the mediator factory has been enhanced to assert that this route (and others) is correct.