### PR TITLE
CORE-17834: Allow empty responses from HTTP RPC

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerImpl.kt
@@ -80,9 +80,12 @@ class CordaAvroDeserializerImpl<T: Any>(
         }
     }
 
+    @Suppress("unchecked_cast")
     override fun deserialize(data: ByteArray): T? {
-        @Suppress("unchecked_cast")
-        return deserialize(data, false) as? T
+        return when {
+            data.isEmpty() -> null
+            else -> deserialize(data, false) as? T
+        }
     }
 
     override fun deserialize(topic: String?, data: ByteArray?): Any? {

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerImpl.kt
@@ -80,12 +80,9 @@ class CordaAvroDeserializerImpl<T: Any>(
         }
     }
 
-    @Suppress("unchecked_cast")
     override fun deserialize(data: ByteArray): T? {
-        return when {
-            data.isEmpty() -> null
-            else -> deserialize(data, false) as? T
-        }
+        @Suppress("unchecked_cast")
+        return deserialize(data, false) as? T
     }
 
     override fun deserialize(topic: String?, data: ByteArray?): Any? {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -76,6 +76,7 @@ class RPCClient(
             .flatMap { (key, value) -> listOf(key, value) }
             .toTypedArray()
 
+        @Suppress("SpreadOperator")
         return HttpRequest.newBuilder()
             .uri(URI(message.endpoint()))
             .headers(*headers)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -55,9 +55,9 @@ class RPCClient(
     }
 
 
-    private fun deserializePayload(payload: ByteArray): Any {
+    private fun deserializePayload(payload: ByteArray): Any? {
         return try {
-            deserializer.deserialize(payload)!!
+            deserializer.deserialize(payload)
         } catch (e: Exception) {
             val errorMsg = "Failed to deserialize payload of size ${payload.size} bytes due to: ${e.message}"
             log.warn(errorMsg, e)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -18,6 +18,8 @@ import net.corda.utilities.trace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+typealias HeadersMap = Map<String, String>
+
 class RPCClient(
     override val id: String,
     cordaAvroSerializerFactory: CordaAvroSerializationFactory,
@@ -77,9 +79,10 @@ class RPCClient(
             .POST(HttpRequest.BodyPublishers.ofByteArray(message.payload as ByteArray))
 
         // Add HTTP headers
-        val headers = message.getProperty<Map<String, String>>(HEADERS_PROPERTY)
-        for ((name, value) in headers) {
-            builder.header(name, value)
+        message.getPropertyOrNull<HeadersMap>(HEADERS_PROPERTY)?.let { headers ->
+            for ((name, value) in headers) {
+                builder.header(name, value)
+            }
         }
 
         return builder.build()

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -19,6 +19,8 @@ import net.corda.utilities.trace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+const val CORDA_REQUEST_KEY_HEADER = "corda-request-key"
+
 class RPCClient(
     override val id: String,
     cordaAvroSerializerFactory: CordaAvroSerializationFactory,
@@ -78,7 +80,7 @@ class RPCClient(
 
         // Add key HTTP header
         message.getPropertyOrNull(MSG_PROP_KEY)?.let { value ->
-            builder.header("corda-request-key", value.toString())
+            builder.header(CORDA_REQUEST_KEY_HEADER, value.toString())
         }
 
         return builder.build()

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -12,13 +12,12 @@ import net.corda.messaging.api.exception.CordaHTTPServerErrorException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessagingClient
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
+import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_KEY
 import net.corda.messaging.utils.HTTPRetryConfig
 import net.corda.messaging.utils.HTTPRetryExecutor
 import net.corda.utilities.trace
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-
-typealias HeadersMap = Map<String, String>
 
 class RPCClient(
     override val id: String,
@@ -34,7 +33,6 @@ class RPCClient(
 
     private companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
-        const val HEADERS_PROPERTY = "headers"
     }
 
     override fun send(message: MediatorMessage<*>): MediatorMessage<*>? {
@@ -78,11 +76,9 @@ class RPCClient(
             .uri(URI(message.endpoint()))
             .POST(HttpRequest.BodyPublishers.ofByteArray(message.payload as ByteArray))
 
-        // Add HTTP headers
-        message.getPropertyOrNull<HeadersMap>(HEADERS_PROPERTY)?.let { headers ->
-            for ((name, value) in headers) {
-                builder.header(name, value)
-            }
+        // Add key HTTP header
+        message.getPropertyOrNull(MSG_PROP_KEY)?.let { key ->
+            builder.header("corda-request-key", key.toString())
         }
 
         return builder.build()

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -77,8 +77,8 @@ class RPCClient(
             .POST(HttpRequest.BodyPublishers.ofByteArray(message.payload as ByteArray))
 
         // Add key HTTP header
-        message.getPropertyOrNull(MSG_PROP_KEY)?.let { key ->
-            builder.header("corda-request-key", key.toString())
+        message.getPropertyOrNull(MSG_PROP_KEY)?.let { value ->
+            builder.header("corda-request-key", value.toString())
         }
 
         return builder.build()

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -57,7 +57,10 @@ class RPCClient(
 
     private fun deserializePayload(payload: ByteArray): Any? {
         return try {
-            deserializer.deserialize(payload)
+            when {
+                payload.isEmpty() -> null
+                else -> deserializer.deserialize(payload)
+            }
         } catch (e: Exception) {
             val errorMsg = "Failed to deserialize payload of size ${payload.size} bytes due to: ${e.message}"
             log.warn(errorMsg, e)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -72,16 +72,17 @@ class RPCClient(
 
     private fun buildHttpRequest(message: MediatorMessage<*>): HttpRequest {
 
-        val headers = message.getProperty<Map<String, String>>(HEADERS_PROPERTY)
-            .flatMap { (key, value) -> listOf(key, value) }
-            .toTypedArray()
-
-        @Suppress("SpreadOperator")
-        return HttpRequest.newBuilder()
+        val builder = HttpRequest.newBuilder()
             .uri(URI(message.endpoint()))
-            .headers(*headers)
             .POST(HttpRequest.BodyPublishers.ofByteArray(message.payload as ByteArray))
-            .build()
+
+        // Add HTTP headers
+        val headers = message.getProperty<Map<String, String>>(HEADERS_PROPERTY)
+        for ((name, value) in headers) {
+            builder.header(name, value)
+        }
+
+        return builder.build()
     }
 
     private fun sendWithRetry(request: HttpRequest): HttpResponse<ByteArray> {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -32,6 +32,7 @@ class RPCClient(
 
     private companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        const val HEADERS_PROPERTY = "headers"
     }
 
     override fun send(message: MediatorMessage<*>): MediatorMessage<*>? {
@@ -70,8 +71,14 @@ class RPCClient(
     }
 
     private fun buildHttpRequest(message: MediatorMessage<*>): HttpRequest {
+
+        val headers = message.getProperty<Map<String, String>>(HEADERS_PROPERTY)
+            .flatMap { (key, value) -> listOf(key, value) }
+            .toTypedArray()
+
         return HttpRequest.newBuilder()
             .uri(URI(message.endpoint()))
+            .headers(*headers)
             .POST(HttpRequest.BodyPublishers.ofByteArray(message.payload as ByteArray))
             .build()
     }


### PR DESCRIPTION
Changes to support HTTP RPC in Token Selection:
- Allow `RPCClient.deserializePayload` to return null because we have a "release tokens" request that needs no response
- Send `corda-request-key` HTTP header (read from `MediatorMessage`) because we need to send a consistent identifier for sticky load balancer routing.