### PR TITLE
CORE-17837 Add `UtxoSignedLedgerTransactionKryoSerializer`

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/tests/UtxoFilteredTransactionTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/tests/UtxoFilteredTransactionTest.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.core.parseSecureHash
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
 import net.corda.ledger.utxo.flow.impl.timewindow.TimeWindowBetweenImpl
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.testkit.UtxoLedgerIntegrationTest
 import net.corda.ledger.utxo.testkit.UtxoStateClassExample
 import net.corda.ledger.utxo.testkit.createExample
@@ -11,7 +12,6 @@ import net.corda.ledger.utxo.testkit.notaryX500Name
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredData
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
@@ -408,7 +408,7 @@ class UtxoFilteredTransactionTest : UtxoLedgerIntegrationTest() {
         assertThatCode { utxoFilteredTransaction.verify() }.doesNotThrowAnyException()
     }
     
-    private fun createSignedTransaction(numberOfInputStates: Int = 2, numberOfOutputStates: Int = 2): UtxoSignedTransaction {
+    private fun createSignedTransaction(numberOfInputStates: Int = 2, numberOfOutputStates: Int = 2): UtxoSignedTransactionInternal {
         val inputHash = parseSecureHash("SHA256:1234567890abcdef")
         val outputInfo = UtxoOutputInfoComponent(
             encumbrance = null,

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoLedgerTransactionKryoSerializationTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoLedgerTransactionKryoSerializationTest.kt
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.Test
 
 class UtxoLedgerTransactionKryoSerializationTest : UtxoLedgerIntegrationTest() {
     @Test
-    @Suppress("FunctionName")
-    fun `correct serialization of a utxo Signed Transaction`() {
+    fun `correct serialization of a UtxoLedgerTransaction`() {
         val bytes = kryoSerializer.serialize(utxoLedgerTransaction)
         val deserialized = kryoSerializer.deserialize(bytes, UtxoLedgerTransactionInternal::class.java)
 

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoLedgerTransactionKryoSerializationTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoLedgerTransactionKryoSerializationTest.kt
@@ -1,0 +1,21 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.tests
+
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
+import net.corda.ledger.utxo.testkit.UtxoLedgerIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+class UtxoLedgerTransactionKryoSerializationTest : UtxoLedgerIntegrationTest() {
+    @Test
+    @Suppress("FunctionName")
+    fun `correct serialization of a utxo Signed Transaction`() {
+        val bytes = kryoSerializer.serialize(utxoLedgerTransaction)
+        val deserialized = kryoSerializer.deserialize(bytes, UtxoLedgerTransactionInternal::class.java)
+
+        assertThat(deserialized).isEqualTo(utxoLedgerTransaction)
+        assertDoesNotThrow { deserialized.id }
+        assertThat(deserialized.id).isEqualTo(utxoLedgerTransaction.id)
+        assertThat(deserialized.wireTransaction).isEqualTo(utxoLedgerTransaction.wireTransaction)
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoSignedLedgerTransactionKryoSerializationTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoSignedLedgerTransactionKryoSerializationTest.kt
@@ -9,8 +9,7 @@ import org.junit.jupiter.api.Test
 
 class UtxoSignedLedgerTransactionKryoSerializationTest : UtxoLedgerIntegrationTest() {
     @Test
-    @Suppress("FunctionName")
-    fun `correct serialization of a utxo Signed Transaction`() {
+    fun `correct serialization of a UtxoSignedLedgerTransaction`() {
         val utxoSignedLedgerTransaction = UtxoSignedLedgerTransactionImpl(utxoLedgerTransaction, utxoSignedTransaction)
         val bytes = kryoSerializer.serialize(utxoSignedLedgerTransaction)
         val deserialized = kryoSerializer.deserialize(bytes, UtxoSignedLedgerTransaction::class.java)

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoSignedLedgerTransactionKryoSerializationTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoSignedLedgerTransactionKryoSerializationTest.kt
@@ -1,0 +1,24 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.tests
+
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedLedgerTransaction
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedLedgerTransactionImpl
+import net.corda.ledger.utxo.testkit.UtxoLedgerIntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Test
+
+class UtxoSignedLedgerTransactionKryoSerializationTest : UtxoLedgerIntegrationTest() {
+    @Test
+    @Suppress("FunctionName")
+    fun `correct serialization of a utxo Signed Transaction`() {
+        val utxoSignedLedgerTransaction = UtxoSignedLedgerTransactionImpl(utxoLedgerTransaction, utxoSignedTransaction)
+        val bytes = kryoSerializer.serialize(utxoSignedLedgerTransaction)
+        val deserialized = kryoSerializer.deserialize(bytes, UtxoSignedLedgerTransaction::class.java)
+
+        assertThat(deserialized).isEqualTo(utxoSignedLedgerTransaction)
+        assertDoesNotThrow { deserialized.id }
+        assertThat(deserialized.id).isEqualTo(utxoSignedLedgerTransaction.id)
+        assertThat(deserialized.ledgerTransaction).isEqualTo(utxoSignedLedgerTransaction.ledgerTransaction)
+        assertThat(deserialized.signedTransaction).isEqualTo(utxoSignedLedgerTransaction.signedTransaction)
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoSignedTransactionKryoSerializationTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoSignedTransactionKryoSerializationTest.kt
@@ -1,7 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.transaction.serializer.tests
 
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.testkit.UtxoLedgerIntegrationTest
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -12,10 +12,11 @@ class UtxoSignedTransactionKryoSerializationTest: UtxoLedgerIntegrationTest() {
     fun `correct serialization of a utxo Signed Transaction`() {
 
         val bytes = kryoSerializer.serialize(utxoSignedTransaction)
-        val deserialized = kryoSerializer.deserialize(bytes, UtxoSignedTransaction::class.java)
+        val deserialized = kryoSerializer.deserialize(bytes, UtxoSignedTransactionInternal::class.java)
 
         assertThat(deserialized).isEqualTo(utxoSignedTransaction)
         Assertions.assertDoesNotThrow { deserialized.id }
-        Assertions.assertEquals(utxoSignedTransaction.id, deserialized.id)
+        Assertions.assertEquals(deserialized.id, utxoSignedTransaction.id)
+        assertThat(deserialized.wireTransaction).isEqualTo(utxoSignedTransaction.wireTransaction)
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoSignedTransactionKryoSerializationTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/integrationTest/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/tests/UtxoSignedTransactionKryoSerializationTest.kt
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class UtxoSignedTransactionKryoSerializationTest: UtxoLedgerIntegrationTest() {
+
     @Test
-    @Suppress("FunctionName")
-    fun `correct serialization of a utxo Signed Transaction`() {
+    fun `correct serialization of a UtxoSignedTransaction`() {
 
         val bytes = kryoSerializer.serialize(utxoSignedTransaction)
         val deserialized = kryoSerializer.deserialize(bytes, UtxoSignedTransactionInternal::class.java)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransaction.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransaction.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.transaction
 
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
+import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 
 /**
  * [UtxoSignedLedgerTransaction] is a wrapper that combines the functionality of [UtxoLedgerTransactionInternal] and
@@ -13,4 +14,9 @@ interface UtxoSignedLedgerTransaction : UtxoLedgerTransactionInternal, UtxoSigne
      * Gets the delegate [UtxoLedgerTransaction] from the [UtxoSignedLedgerTransaction] instance.
      */
     val ledgerTransaction: UtxoLedgerTransaction
+
+    /**
+     * Gets the delegate [UtxoSignedTransaction] from the [UtxoSignedLedgerTransaction] instance.
+     */
+    val signedTransaction: UtxoSignedTransaction
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedLedgerTransactionImpl.kt
@@ -21,7 +21,7 @@ import java.security.PublicKey
  */
 data class UtxoSignedLedgerTransactionImpl(
     override val ledgerTransaction: UtxoLedgerTransactionInternal,
-    private val signedTransaction: UtxoSignedTransactionInternal
+    override val signedTransaction: UtxoSignedTransactionInternal
 ) : UtxoSignedLedgerTransaction, UtxoLedgerTransaction by ledgerTransaction, UtxoSignedTransactionInternal by signedTransaction {
 
     override fun getId(): SecureHash {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/UtxoLedgerTransactionFactory.kt
@@ -20,7 +20,7 @@ interface UtxoLedgerTransactionFactory {
     @Suspendable
     fun create(
         wireTransaction: WireTransaction
-    ): UtxoLedgerTransaction
+    ): UtxoLedgerTransactionInternal
 
     fun create(
         wireTransaction: WireTransaction,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
@@ -1,13 +1,13 @@
 package net.corda.ledger.utxo.flow.impl.transaction.factory.impl
 
 import net.corda.crypto.core.parseSecureHash
+import net.corda.flow.application.GroupParametersLookupInternal
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.WireTransaction
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
 import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
-import net.corda.flow.application.GroupParametersLookupInternal
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerStateQueryService
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
@@ -16,7 +16,6 @@ import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.utxo.ContractState
-import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.membership.GroupParameters
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
@@ -39,7 +39,7 @@ class UtxoLedgerTransactionFactoryImpl @Activate constructor(
     @Suspendable
     override fun create(
         wireTransaction: WireTransaction
-    ): UtxoLedgerTransaction {
+    ): UtxoLedgerTransactionInternal {
         val wrappedUtxoWireTransaction = WrappedUtxoWireTransaction(wireTransaction, serializationService)
         val allStateRefs =
             (wrappedUtxoWireTransaction.inputStateRefs + wrappedUtxoWireTransaction.referenceStateRefs)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedLedgerTransactionKryoSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedLedgerTransactionKryoSerializer.kt
@@ -11,7 +11,6 @@ import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
 import net.corda.serialization.checkpoint.CheckpointOutput
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
-import org.slf4j.LoggerFactory
 
 @Component(
     service = [ CheckpointInternalCustomSerializer::class, UsedByFlow::class ],
@@ -27,7 +26,6 @@ class UtxoSignedLedgerTransactionKryoSerializer : CheckpointInternalCustomSerial
     }
 
     override fun read(input: CheckpointInput, type: Class<out UtxoSignedLedgerTransaction>): UtxoSignedLedgerTransaction {
-        LoggerFactory.getLogger(UtxoSignedLedgerTransactionKryoSerializer::class.java).error("TRYING TO KRYO DESERIALIZE WITH THE CORRECT SERIALIZER")
         val ledgerTransaction = input.readClassAndObject() as UtxoLedgerTransactionInternal
         val signedTransaction = input.readClassAndObject() as UtxoSignedTransactionInternal
         return UtxoSignedLedgerTransactionImpl(ledgerTransaction, signedTransaction)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedLedgerTransactionKryoSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedLedgerTransactionKryoSerializer.kt
@@ -1,0 +1,35 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.kryo
+
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedLedgerTransaction
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedLedgerTransactionImpl
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.serialization.checkpoint.CheckpointInput
+import net.corda.serialization.checkpoint.CheckpointInternalCustomSerializer
+import net.corda.serialization.checkpoint.CheckpointOutput
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import org.slf4j.LoggerFactory
+
+@Component(
+    service = [ CheckpointInternalCustomSerializer::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
+class UtxoSignedLedgerTransactionKryoSerializer : CheckpointInternalCustomSerializer<UtxoSignedLedgerTransaction>, UsedByFlow {
+    override val type: Class<UtxoSignedLedgerTransaction> get() = UtxoSignedLedgerTransaction::class.java
+
+    override fun write(output: CheckpointOutput, obj: UtxoSignedLedgerTransaction) {
+        output.writeClassAndObject(obj.ledgerTransaction)
+        output.writeClassAndObject(obj.signedTransaction)
+    }
+
+    override fun read(input: CheckpointInput, type: Class<out UtxoSignedLedgerTransaction>): UtxoSignedLedgerTransaction {
+        LoggerFactory.getLogger(UtxoSignedLedgerTransactionKryoSerializer::class.java).error("TRYING TO KRYO DESERIALIZE WITH THE CORRECT SERIALIZER")
+        val ledgerTransaction = input.readClassAndObject() as UtxoLedgerTransactionInternal
+        val signedTransaction = input.readClassAndObject() as UtxoSignedTransactionInternal
+        return UtxoSignedLedgerTransactionImpl(ledgerTransaction, signedTransaction)
+    }
+}

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/WrappedUtxoWireTransaction.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/WrappedUtxoWireTransaction.kt
@@ -89,4 +89,21 @@ class WrappedUtxoWireTransaction(
         val serializedBytes = wireTransaction.getComponentGroupList(group.ordinal)[index]
         return serializationService.deserialize(serializedBytes)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as WrappedUtxoWireTransaction
+
+        return wireTransaction == other.wireTransaction
+    }
+
+    override fun hashCode(): Int {
+        return wireTransaction.hashCode()
+    }
+
+    override fun toString(): String {
+        return "WrappedUtxoWireTransaction(wireTransaction=$wireTransaction)"
+    }
 }

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoLedgerIntegrationTest.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoLedgerIntegrationTest.kt
@@ -1,22 +1,26 @@
 package net.corda.ledger.utxo.testkit
 
 import net.corda.ledger.common.integration.test.CommonLedgerIntegrationTest
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
+import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
 import net.corda.sandboxgroupcontext.getSandboxSingletonService
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.v5.ledger.utxo.UtxoLedgerService
-import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 
-abstract class UtxoLedgerIntegrationTest: CommonLedgerIntegrationTest() {
+abstract class UtxoLedgerIntegrationTest : CommonLedgerIntegrationTest() {
     override val testingCpb = "/META-INF/ledger-utxo-state-app.cpb"
 
     lateinit var utxoSignedTransactionFactory: UtxoSignedTransactionFactory
     lateinit var utxoLedgerService: UtxoLedgerService
     lateinit var utxoLedgerPersistenceService: UtxoLedgerPersistenceService
-    lateinit var utxoSignedTransaction: UtxoSignedTransaction
+    lateinit var utxoSignedTransaction: UtxoSignedTransactionInternal
+    lateinit var utxoLedgerTransaction: UtxoLedgerTransactionInternal
 
-    override fun initialize(setup: SandboxSetup){
+    override fun initialize(setup: SandboxSetup) {
         super.initialize(setup)
 
         utxoSignedTransactionFactory = sandboxGroupContext.getSandboxSingletonService()
@@ -26,6 +30,12 @@ abstract class UtxoLedgerIntegrationTest: CommonLedgerIntegrationTest() {
             jsonMarshallingService,
             jsonValidator,
             wireTransactionFactory
+        )
+        utxoLedgerTransaction = UtxoLedgerTransactionImpl(
+            WrappedUtxoWireTransaction(utxoSignedTransaction.wireTransaction, serializationService),
+            emptyList(),
+            emptyList(),
+            null
         )
     }
 }

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
@@ -11,6 +11,7 @@ import net.corda.ledger.common.testkit.getWireTransactionExample
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
 import net.corda.v5.application.crypto.DigestService
@@ -24,7 +25,7 @@ fun UtxoSignedTransactionFactory.createExample(
     wireTransactionFactory: WireTransactionFactory,
     componentGroups: List<List<ByteArray>> = defaultComponentGroups +
             List(UtxoComponentGroup.values().size - defaultComponentGroups.size - 1) { emptyList() }
-):UtxoSignedTransaction {
+): UtxoSignedTransactionInternal {
     val wireTransaction = wireTransactionFactory.createExample(
         jsonMarshallingService,
         jsonValidator,


### PR DESCRIPTION
Add a Kryo serializer for `UtxoSignedLedgerTransaction`.

This fixes a bug where `UtxoSignedLedgerTransaction` was being serialized with the Kryo serializer for `UtxoSignedTransaction`, due to it implementing the same interface; however, the serializer can only correct serialize `UtxoSignedTransactionImpl`s.

Adding a specific serializer means Kryo picks up the correct one to serialize and deserialize with.