### PR TITLE
CORE-17297: Fix incompatible responder flow failure handling

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -21,6 +21,7 @@ import net.corda.flow.pipeline.sessions.FlowSessionManager
 import net.corda.flow.pipeline.sessions.protocol.FlowAndProtocolVersion
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.utils.KeyValueStore
+import net.corda.flow.utils.emptyKeyValuePairList
 import net.corda.flow.utils.keyValuePairListOf
 import net.corda.flow.utils.toMap
 import net.corda.session.manager.Constants.Companion.FLOW_PROTOCOL
@@ -231,6 +232,14 @@ class SessionEventHandler @Activate constructor(
         sessionId: String,
         exception: Throwable
     ) {
+        context.checkpoint.putSessionState(sessionManager.generateSessionState(
+            sessionId,
+            emptyKeyValuePairList(),
+            (context.inputEventPayload as SessionEvent).initiatingIdentity,
+            Instant.now(),
+            SessionStateType.CONFIRMED
+        ))
+
         context.checkpoint.putSessionStates(
             flowSessionManager.sendErrorMessages(
                 context.checkpoint,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandler.kt
@@ -237,7 +237,7 @@ class SessionEventHandler @Activate constructor(
             emptyKeyValuePairList(),
             (context.inputEventPayload as SessionEvent).initiatingIdentity,
             Instant.now(),
-            SessionStateType.CONFIRMED
+            SessionStateType.ERROR
         ))
 
         context.checkpoint.putSessionStates(

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/SessionEventHandlerTest.kt
@@ -159,6 +159,7 @@ class SessionEventHandlerTest {
             flowSandboxService, sessionManager, fakeCheckpointInitializerService, flowSessionManager)
 
         sessionEventHandler.preProcess(inputContext)
+        verify(sessionManager, times(1)).generateSessionState(any(), any(), anyOrNull(), any(), any())
         verify(flowSessionManager, times(1)).sendErrorMessages(any(), any(), anyOrNull(), any())
     }
 


### PR DESCRIPTION
This PR addresses the scenario where two vNodes with with incompatible flow protocol versions try to communicate. At the moment, this results in hitting a `FlowSessionStateException` in the responder flow. This gets handled by the generic exception handler in `FlowEventProcessorImpl.getFlowPipelineResponse` and the initiating flow getting left in a RUNNING state indefinitely.

The `FlowSessionStateException` is thrown by the responder flow because we have not created a SessionState when we try to send the Error message.

This PR adds session State creation to `sendErrorMessage `so that it can complete correctly and fail the initiating flow. 
