### PR TITLE
CORE-17899 Add nginx for token selection sharding

### DIFF
--- a/charts/corda-lib/templates/_nginx.tpl
+++ b/charts/corda-lib/templates/_nginx.tpl
@@ -1,0 +1,286 @@
+{{- define "corda.nginxName" -}}
+{{- printf "%s-nginx" . }}
+{{- end }}
+
+{{- define "corda.nginxComponent" -}}
+{{ printf "%s-nginx" . }}
+{{- end }}
+
+{{- define "corda.nginxLabels" -}}
+{{- $workerName := index . 1 }}
+{{- with ( index . 0 ) }}
+{{- include "corda.labels" . }}
+app.kubernetes.io/component: {{ include "corda.nginxComponent" $workerName }}
+{{- end }}
+{{- end }}
+
+{{- define "corda.nginxSelectorLabels" -}}
+{{- $workerName := index . 1 }}
+{{- with ( index . 0 ) }}
+{{- include "corda.selectorLabels" . }}
+app.kubernetes.io/component: {{ include "corda.nginxComponent" $workerName }}
+{{- end }}
+{{- end }}
+
+{{- define "corda.nginx" }}
+{{- $workerName := index . 1 }}
+{{- $shardingConfig := index . 2 }}
+{{- with ( index . 0 ) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxName" $workerName | quote }}
+spec:
+  selector:
+    matchLabels:
+      {{ include "corda.nginxSelectorLabels" ( list . $workerName ) | nindent 6 }}
+  minAvailable: 1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxName" $workerName | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxName" $workerName | quote }}
+data:
+  allow-snippet-annotations: "false"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxName" $workerName | quote }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - {{ include "corda.nginxName" $workerName }}-leader
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - watch
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxName" $workerName | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "corda.nginxName" $workerName | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "corda.nginxName" $workerName | quote }}
+    namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxName" $workerName | quote }}
+spec:
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: http
+      port: {{ include "corda.workerServicePort" ( list . $workerName ) }}
+      protocol: TCP
+      targetPort: http
+      appProtocol: http
+  selector:
+    {{ include "corda.nginxSelectorLabels" ( list . $workerName ) | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxName" $workerName | quote }}
+spec:
+  selector:
+    matchLabels:
+      {{ include "corda.nginxSelectorLabels" ( list . $workerName ) | nindent 6 }}
+  replicas: {{ $shardingConfig.replicaCount }}
+  revisionHistoryLimit: 10
+  minReadySeconds: 0
+  template:
+    metadata:
+      labels:
+        {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 8 }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      dnsPolicy: ClusterFirst
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- include "corda.imagePullSecrets" . | indent 6 }}
+      {{- include "corda.tolerations" . | indent 6 }}
+      {{- with .Values.serviceAccount.name  }}
+      serviceAccountName: {{ . }}
+      {{- end }}
+      {{- include "corda.topologySpreadConstraints" . | indent 6 }}
+      {{- include "corda.affinity" (list . ( include "corda.nginxComponent" $workerName ) ) | indent 6 }}
+      containers:
+        - name: controller
+          {{- with $shardingConfig.image }}
+          image: {{ ( printf "%s/%s:%s" .registry .repository .tag ) | quote }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+          {{- with .Values.containerSecurityContext -}}
+            {{- . | toYaml | nindent 12}}
+          {{- end }}
+            capabilities:
+              add:
+              - NET_BIND_SERVICE
+            readOnlyRootFilesystem: false
+            runAsUser: 101
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /wait-shutdown
+          args:
+            - /nginx-ingress-controller
+            - --publish-service=$(POD_NAMESPACE)/{{ include "corda.nginxName" $workerName }}
+            - --election-id={{ include "corda.nginxName" $workerName }}-leader
+            - --controller-class=k8s.io/{{ include "corda.nginxName" $workerName }}
+            - --ingress-class={{ include "corda.nginxName" $workerName }}
+            - --configmap=$(POD_NAMESPACE)/{{ include "corda.nginxName" $workerName }}
+            - --watch-namespace=$(POD_NAMESPACE)
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: LD_PRELOAD
+              value: /usr/local/lib/libmimalloc.so
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 90Mi
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "corda.nginxName" $workerName | quote }}
+      terminationGracePeriodSeconds: 300
+{{- end }}
+{{- end }}

--- a/charts/corda/templates/workers.yaml
+++ b/charts/corda/templates/workers.yaml
@@ -5,7 +5,7 @@
   ( dict "clusterDbAccess" true )
 ) }}
 {{- include "corda.worker" ( list $ .Values.workers.flow "flow"
-  ( dict "stateManagerDbAccess" true "servicesAccessed" (list "crypto" "verification" "uniqueness" "persistence") )
+  ( dict "stateManagerDbAccess" true "servicesAccessed" ( list "crypto" "verification" "uniqueness" "persistence" "tokenSelection" ) )
 ) }}
 {{- include "corda.worker" ( list $ .Values.workers.flowMapper "flowMapper" 
   ( dict "stateManagerDbAccess" true )

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -2671,6 +2671,88 @@
                                 "profiling": {},
                                 "resources": {},
                                 "kafka": {},
+                                "sharding": {
+                                    "type": "object",
+                                    "default": {
+                                        "enabled":  false,
+                                        "image": {
+                                            "registry": "registry.k8s.io",
+                                            "repository": "ingress-nginx/controller",
+                                            "tag": "v1.9.3@sha256:8fd21d59428507671ce0fb47f818b1d859c92d2ad07bb7c947268d433030ba98"
+                                        },
+                                        "replicaCount": 2
+                                    },
+                                    "title": "token selection sharding configuration",
+                                    "required": [
+                                        "enabled",
+                                        "image",
+                                        "replicaCount"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "default": "false",
+                                            "title": "enable sharding of requests"
+                                        },
+                                        "image": {
+                                            "type": "object",
+                                            "default": {
+                                                "registry": "registry.k8s.io",
+                                                "repository": "ingress-nginx/controller",
+                                                "tag": "v1.9.3@sha256:8fd21d59428507671ce0fb47f818b1d859c92d2ad07bb7c947268d433030ba98"
+                                            },
+                                            "title": "sharding image configuration",
+                                            "required": [
+                                                "registry",
+                                                "repository",
+                                                "tag"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "registry": {
+                                                    "type": "string",
+                                                    "default": "registry.k8s.io",
+                                                    "title": "sharding image registry",
+                                                    "examples": [
+                                                        "registry.k8s.io"
+                                                    ],
+                                                    "minLength": 1
+                                                },
+                                                "repository": {
+                                                    "type": "string",
+                                                    "title": "sharding image repository",
+                                                    "examples": [
+                                                        "ingress-nginx/controller"
+                                                    ],
+                                                    "minLength": 1
+                                                },
+                                                "tag": {
+                                                    "type": "string",
+                                                    "default": "v1.9.3@sha256:8fd21d59428507671ce0fb47f818b1d859c92d2ad07bb7c947268d433030ba98",
+                                                    "title": "sharding image tag",
+                                                    "examples": [
+                                                        "v1.9.3@sha256:8fd21d59428507671ce0fb47f818b1d859c92d2ad07bb7c947268d433030ba98"
+                                                    ],
+                                                    "minLength": 1
+                                                }
+                                            },
+                                            "examples": [{
+                                                "registry": "corda-os-docker.software.r3.com",
+                                                "repository": "corda-os-xxx-worker",
+                                                "tag": ""
+                                            }]
+                                        },
+                                        "replicaCount": {
+                                            "type": "integer",
+                                            "default": 2,
+                                            "title": "sharding replica count",
+                                            "examples": [
+                                                2
+                                            ]
+                                        }
+                                    }
+                                },
                                 "clusterDbConnectionPool": {
                                     "type": "object",
                                     "default": {},

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -1406,6 +1406,20 @@ workers:
               name: ""
               # -- the token selection worker SASL password secret key for client connection to Kafka
               key: ""
+    # token selection sharding configuration
+    sharding:
+      # -- enable sharding of token selection requests
+      enabled: false
+      # token selection sharding image configuration
+      image:
+        # -- token selection sharding image registry
+        registry: "registry.k8s.io"
+        # -- token selection sharding image repository
+        repository: "ingress-nginx/controller"
+        # -- token selection sharding image tag
+        tag: "v1.9.3@sha256:8fd21d59428507671ce0fb47f818b1d859c92d2ad07bb7c947268d433030ba98"
+      # -- token selection replica count
+      replicaCount: 2
 
   # uniqueness worker configuration
   uniqueness:


### PR DESCRIPTION
Setting `workers.tokenSelection.sharding.enabled=true` results in the creation of an nginx ingress controller that is forwarding to the token selection internal service but with affinity to the individual worker instances based on a hash of `CORDA-REQUEST-KEY`.

The nginx configuration is based on the results of running:
```
helm template ingress-nginx ingress-nginx \
  --repo https://kubernetes.github.io/ingress-nginx \
  --set controller.service.type=ClusterIP,controller.replicaCount=2,controller.ingressClassResource.name=corda-internal,controller.scope.enabled=true,controller.admissionWebhooks.enabled=false,rbac.scope=true --skip-crds
  ```
  
Changes made to the `corda` Helm chart will need to be replicated for Corda Enterprise, and the `nginx` image packaged with those delivered to customers. The documentation then needs to cover how to use the packaged image rather than the one from `registry.k8s.io` by overriding the values in `workers.tokenSelection.sharding.image`.