### PR TITLE
ES-1477 Add default metrics

### DIFF
--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -561,12 +561,16 @@ metadata:
 spec:
   podMetricsEndpoints:
   - port: monitor
-    {{- with .Values.metrics.podMonitor.keepNames }}
     metricRelabelings:
+    {{- with .Values.metrics.podMonitor.keepNames }}
     - sourceLabels:
       - "__name__"
       regex: {{ join "|" . | quote }}
       action: "keep"
+    {{- end }}
+    {{- with .Values.metrics.podMonitor.dropLabels }}
+    - regex: {{ join "|" . | quote }}
+      action: "labeldrop"
     {{- end }}
   jobLabel: {{ $.Release.Name }}-{{ include "corda.name" . }}
   selector:

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -533,9 +533,17 @@
                                 "type": "string",
                                 "format": "regex"
                             },
-                            "default": [],
                             "title": "A list of regular expressions for the names of metrics that Prometheus should keep; if empty, all metrics are kept",
                             "examples": [[ "jvm_.*" ]]
+                        },
+                        "dropLabels": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "regex"
+                            },
+                            "title": "A list of regular expressions for labels that Prometheus should drop across all metrics; if empty, all labels are kept",
+                            "examples": [[ "virtualnode_destination" ]]
                         }
                     },
                     "examples": [

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -79,8 +79,25 @@ metrics:
     # -- Labels that can be used so PodMonitor is discovered by Prometheus
     labels: {}
     # -- A list of regular expressions for the names of metrics that Prometheus should keep; if empty, all metrics are kept
-    keepNames: []
-    # - "jvm_.*"
+    keepNames:
+      - "corda_flow_execution_time_seconds_(count|sum|max)"
+      - "corda_http_server_request_time_seconds_(count|sum|max)"
+      - "corda_p2p_gateway_inbound_request_time_seconds_(count|sum|max)"
+      - "corda_p2p_gateway_outbound_request_time_seconds_(count|sum|max)"
+      - "corda_p2p_gateway_outbound_tls_connections_total"
+      - "corda_p2p_message_outbound_total"
+      - "corda_p2p_message_outbound_replayed_total"
+      - "corda_p2p_message_outbound_latency_seconds_(count|sum|max)"
+      - "corda_p2p_message_inbound_total"
+      - "corda_p2p_session_outbound_total"
+      - "corda_p2p_session_inbound_total"
+      - "corda_membership_actions_handler_time_seconds_(count|sum|max)"
+      - "jvm_.*"
+      - "process_cpu_usage"
+    # -- A list of regular expressions for labels that Prometheus should drop across all metrics; if empty, all labels are kept
+    dropLabels:
+      - "virtualnode_destination"
+      - "virtualnode_source"
 
 # Distributed tracing configuration
 tracing:


### PR DESCRIPTION
Enables the following metrics by default:
- corda_flow_execution_time_seconds_(count|sum|max)
- corda_http_server_request_time_seconds_(count|sum|max)
- corda_p2p_gateway_inbound_request_time_seconds_(count|sum|max)
- corda_p2p_gateway_outbound_request_time_seconds_(count|sum|max)
- corda_p2p_gateway_outbound_tls_connections_total
- corda_p2p_message_outbound_total
- corda_p2p_message_outbound_replayed_total
- corda_p2p_message_outbound_latency_seconds_(count|sum|max)
- corda_p2p_message_inbound_total
- corda_p2p_session_outbound_total
- corda_p2p_session_inbound_total
- corda_membership_actions_handler_time_seconds_(count|sum|max)
- jvm_.*
- process_cpu_usage

Note that `_bucket` metrics are not captured as the number of buckets tends to mean these have higher cardinality.

Adds the ability to drop labels (across all metrics) and, by default, drops the following labels that can lead to high cardinality:
- vitualnode_destination
- virtualnode_source