### PR TITLE
[CORE-16983] Prerequistites for CORE-16983 Serialize and Send Merkle Proof through Façade 

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/interop/dispatch/FacadeServerDispatcher.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/interop/dispatch/FacadeServerDispatcher.kt
@@ -1,14 +1,11 @@
 package net.corda.flow.application.services.impl.interop.dispatch
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import net.corda.flow.application.services.impl.interop.binding.FacadeInterfaceBinding
 import net.corda.flow.application.services.impl.interop.binding.FacadeMethodBinding
 import net.corda.flow.application.services.impl.interop.binding.FacadeOutParameterBindings
 import net.corda.flow.application.services.impl.interop.binding.creation.FacadeInterfaceBindings
 import net.corda.flow.application.services.impl.interop.parameters.TypeConverter
 import net.corda.flow.application.services.impl.interop.proxies.FacadeMethodDispatchException
-import net.corda.flow.application.services.impl.interop.proxies.JacksonJsonMarshaller
 import net.corda.flow.application.services.impl.interop.proxies.JsonMarshaller
 import net.corda.v5.application.interop.binding.BindsFacade
 import net.corda.v5.application.interop.binding.FacadeVersions
@@ -44,9 +41,6 @@ fun Any.buildDispatcher(facade: Facade, typeConverter: TypeConverter): FacadeSer
 
     return FacadeServerDispatchers.buildDispatcher(facade, targetInterface as Class<Any>, this, typeConverter)
 }
-
-fun Any.buildDispatcher(facade: Facade): FacadeServerDispatcher =
-    buildDispatcher(facade, TypeConverter(JacksonJsonMarshaller(ObjectMapper().registerKotlinModule())))
 
 fun Any.buildDispatcher(facade: Facade, marshaller: JsonMarshaller): FacadeServerDispatcher =
     buildDispatcher(facade, TypeConverter(marshaller))

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/interop/proxies/FacadeClientProxy.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/interop/proxies/FacadeClientProxy.kt
@@ -1,7 +1,5 @@
 package net.corda.flow.application.services.impl.interop.proxies
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import net.corda.flow.application.services.impl.interop.binding.FacadeInterfaceBinding
 import net.corda.flow.application.services.impl.interop.binding.FacadeMethodBinding
 import net.corda.flow.application.services.impl.interop.binding.FacadeOutParameterBindings
@@ -47,14 +45,6 @@ object FacadeProxies {
         }
     }
 }
-
-/**
- * Kotlin convenience method for creating a client proxy with a default [JsonMarshaller].
- */
-inline fun <reified T : Any> Facade.getClientProxy(noinline requestProcessor: (FacadeRequest) -> FacadeResponse) =
-    getClientProxy<T>(
-        JacksonJsonMarshaller(ObjectMapper().registerKotlinModule()),
-        requestProcessor)
 
 /**
  * Kotlin convenience method for creating a client proxy with the provided [JsonMarshaller].

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/InteropTestUtils.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/InteropTestUtils.kt
@@ -1,0 +1,10 @@
+package net.corda.flow.application.services.interop
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import net.corda.flow.application.services.impl.interop.proxies.JacksonJsonMarshaller
+
+/**
+ *  JSON marshaller sufficient for unit testing with ObjectMapper
+ *  without any additional serializers/deserializers like Merkle trees etc.
+ */
+val testJsonMarshaller = JacksonJsonMarshaller(ObjectMapper())

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/dispatchers/FacadeServerDispatcherSpec.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/dispatchers/FacadeServerDispatcherSpec.kt
@@ -4,6 +4,7 @@ import net.corda.flow.application.services.impl.interop.dispatch.buildDispatcher
 import net.corda.flow.application.services.impl.interop.facade.FacadeReaders
 import net.corda.flow.application.services.interop.example.TokenReservation
 import net.corda.flow.application.services.interop.example.TokensFacade
+import net.corda.flow.application.services.interop.testJsonMarshaller
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -27,8 +28,8 @@ class FacadeServerDispatcherSpec {
                 TokenReservation(reservationRef, expirationTimestamp)
     }
 
-    val v1Dispatcher = mockServer.buildDispatcher(facadeV1)
-    val v2Dispatcher = mockServer.buildDispatcher(facadeV2)
+    val v1Dispatcher = mockServer.buildDispatcher(facadeV1, testJsonMarshaller)
+    val v2Dispatcher = mockServer.buildDispatcher(facadeV2, testJsonMarshaller)
 
     @Test
     fun `should dispatch a request to the matching method on the server object`() {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/proxies/FacadeClientProxySpec.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/proxies/FacadeClientProxySpec.kt
@@ -4,6 +4,7 @@ import net.corda.flow.application.services.impl.interop.facade.FacadeReaders
 import net.corda.flow.application.services.impl.interop.proxies.getClientProxy
 import net.corda.flow.application.services.interop.example.TokenReservation
 import net.corda.flow.application.services.interop.example.TokensFacade
+import net.corda.flow.application.services.interop.testJsonMarshaller
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
@@ -19,7 +20,7 @@ class FacadeClientProxySpec {
         val denomination = getBalance.inParameter("denomination", String::class.java)
         val balance = getBalance.outParameter("balance", BigDecimal::class.java)
 
-        val proxy = facade.getClientProxy<TokensFacade> { request ->
+        val proxy = facade.getClientProxy<TokensFacade>(testJsonMarshaller) { request ->
             assertEquals(facade.facadeId, request.facadeId)
             assertEquals(getBalance.name, request.methodName)
             assertEquals("USD", request[denomination])
@@ -43,7 +44,7 @@ class FacadeClientProxySpec {
         val ref = UUID.randomUUID()
         val expiration = ZonedDateTime.now()
 
-        val proxy = facade.getClientProxy<TokensFacade> { request ->
+        val proxy = facade.getClientProxy<TokensFacade>(testJsonMarshaller) { request ->
             assertEquals(facade.facadeId, request.facadeId)
             assertEquals(reserveTokens.name, request.methodName)
             assertEquals("USD", request[denomination])

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/roundtrip/RoundTripTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/roundtrip/RoundTripTest.kt
@@ -4,6 +4,7 @@ import net.corda.flow.application.services.impl.interop.dispatch.buildDispatcher
 import net.corda.flow.application.services.impl.interop.facade.FacadeReaders
 import net.corda.flow.application.services.impl.interop.proxies.getClientProxy
 import net.corda.flow.application.services.interop.example.TokensFacade
+import net.corda.flow.application.services.interop.testJsonMarshaller
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -14,16 +15,13 @@ import java.util.*
 
 class RoundTripTest {
     val facadeV1 = FacadeReaders.JSON.read(this::class.java.getResourceAsStream("/sampleFacades/tokens-facade.json")!!)
-    val facadeV2 =
-        FacadeReaders.JSON.read(this::class.java.getResourceAsStream("/sampleFacades/tokens-facade_v2.json")!!)
 
     val currentTime = ZonedDateTime.now()
     val server = TestTokenServer(mapOf("USD" to BigDecimal(1000000), "GBP" to BigDecimal("1000000"))) { currentTime }
 
-    val v1Dispatcher = server.buildDispatcher(facadeV1)
-    val v2Dispatcher = server.buildDispatcher(facadeV2)
+    val v1Dispatcher = server.buildDispatcher(facadeV1, testJsonMarshaller)
 
-    val v1Client = facadeV1.getClientProxy<TokensFacade>(v1Dispatcher)
+    val v1Client = facadeV1.getClientProxy<TokensFacade>(testJsonMarshaller, v1Dispatcher)
 
     @Test
     fun roundtripClientProxyToServerDispatcher() {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/roundtrip/TestTokenServer.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/interop/roundtrip/TestTokenServer.kt
@@ -22,7 +22,7 @@ class TestTokenServer(initialBalances: Map<String, BigDecimal>, private val time
 
     override fun getBalance(denomination: String): Double {
         val totalBalance = balances[denomination] ?: BigDecimal(0)
-        var now = timeserver()
+        val now = timeserver()
 
         val reserved = reservations.values.filter {
             it.denomination == denomination && it.expires.isAfter(now)


### PR DESCRIPTION
_Code changes copied from https://github.com/corda/corda-runtime-os/pull/4691 to simplify that PR._

- Remove convenience methods for creating a client proxy with a default Json Mappers
`Any.buildDispatcher`and `Facade.getClientProxy`. These methods are used for testing only. In the following code change (the next PR) we add new serializes and deserializes with e.g. Merkle Tree Proof. For unit testing new serializes will be not needed and the core Facade module doesn't create them, however using a default JSON serialize add confusion - should I replaced the existing "default"  JSON Mapper with a new one, or should I leave it as it is. By removing any defaults we delegate this problem when the proxy is actually created, for production code it was always like that, now it's also this way for test code.

- As a cleanup - remove an unused Facade Proxy instance in a test.