### PR TITLE
CORE-17932 ensure the flow service depends on the membership group reader providers lifecycle

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowService.kt
@@ -16,6 +16,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
 import net.corda.lifecycle.createCoordinator
+import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
@@ -69,6 +70,7 @@ class FlowService @Activate constructor(
                             LifecycleCoordinatorName.forComponent<CpiInfoReadService>(),
                             LifecycleCoordinatorName.forComponent<FlowExecutor>(),
                             LifecycleCoordinatorName.forComponent<FlowMaintenance>(),
+                            LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),
                         )
                     )
                 flowMaintenance.start()

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/service/FlowServiceTest.kt
@@ -7,6 +7,7 @@ import net.corda.flow.MINIMUM_SMART_CONFIG
 import net.corda.flow.maintenance.FlowMaintenance
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.test.impl.LifecycleTest
+import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -33,6 +34,7 @@ class FlowServiceTest {
                 Arguments.of(LifecycleCoordinatorName.forComponent<CpiInfoReadService>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<FlowExecutor>()),
                 Arguments.of(LifecycleCoordinatorName.forComponent<FlowMaintenance>()),
+                Arguments.of(LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>()),
             )
         }
     }
@@ -156,6 +158,7 @@ class FlowServiceTest {
             addDependency<SandboxGroupContextComponent>()
             addDependency<VirtualNodeInfoReadService>()
             addDependency<CpiInfoReadService>()
+            addDependency<MembershipGroupReaderProvider>()
             addDependency<FlowExecutor>()
             addDependency<FlowMaintenance>()
 


### PR DESCRIPTION
Small fix to ensure the flow engine does not try to run without the membership cache populated and ready. This has commonly affected multicluster large network tests