### PR TITLE
CORE-17899: Eliminate use of deprecated annotation for Ingress

### DIFF
--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -62,9 +62,9 @@ metadata:
   {{- with .annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-    kubernetes.io/ingress.class: {{ include "corda.nginxName" $workerName | quote }}
     nginx.ingress.kubernetes.io/upstream-hash-by: "$http_corda_request_key"
 spec:
+  ingressClassName: {{ include "corda.nginxName" $workerName | quote }}
   defaultBackend:
     service:
       name: {{ include "corda.workerInternalServiceName" $workerName | quote }}


### PR DESCRIPTION
Before the change:
```
> helm install corda -n corda charts/corda --values values-prereqs.yaml --wait
W1024 13:39:43.341482   16912 warnings.go:70] annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
```

Tested-by: vkolomeyko
By using local deployment of C5 cluster