### PR TITLE
DA5-5 persist and find draft transaction

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^((CORDA|EG|ENT|INFRA|CORE|DOC|ES)-\d+)(.*)'
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE|DOC|ES|DA5)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -7,6 +7,9 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
     companion object {
         @JvmField
         val UNVERIFIED = TransactionStatus.UNVERIFIED.value
+
+        @JvmField
+        val DRAFT = TransactionStatus.DRAFT.value
     }
 
     override val findTransactionPrivacySaltAndMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -23,7 +23,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
                 VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash)
             ON CONFLICT(id) DO
                 UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated
-            WHERE utxo_transaction.status = EXCLUDED.status OR utxo_transaction.status in ('$UNVERIFIED', '$DRAFT')"""
+            WHERE utxo_transaction.status in (EXCLUDED.status, '$UNVERIFIED', '$DRAFT')"""
             .trimIndent()
 
     override val persistTransactionMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -23,7 +23,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
                 VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash)
             ON CONFLICT(id) DO
                 UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated
-            WHERE utxo_transaction.status = EXCLUDED.status OR utxo_transaction.status = '$UNVERIFIED'"""
+            WHERE utxo_transaction.status = EXCLUDED.status OR utxo_transaction.status in ('$UNVERIFIED', '$DRAFT')"""
             .trimIndent()
 
     override val persistTransactionMetadata: String

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -18,6 +18,7 @@ import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInterna
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.filtered.UtxoFilteredTransactionBuilderImpl
 import net.corda.ledger.utxo.flow.impl.transaction.filtered.factory.UtxoFilteredTransactionFactory
+import net.corda.ledger.utxo.flow.impl.transaction.verifier.UtxoLedgerTransactionVerificationService
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.getObjectByKey
@@ -63,7 +64,9 @@ class UtxoLedgerServiceImpl @Activate constructor(
     @Reference(service = CurrentSandboxGroupContext::class) private val currentSandboxGroupContext: CurrentSandboxGroupContext,
     @Reference(service = NotaryLookup::class) private val notaryLookup: NotaryLookup,
     @Reference(service = ExternalEventExecutor::class) private val externalEventExecutor: ExternalEventExecutor,
-    @Reference(service = ResultSetFactory::class) private val resultSetFactory: ResultSetFactory
+    @Reference(service = ResultSetFactory::class) private val resultSetFactory: ResultSetFactory,
+    @Reference(service = UtxoLedgerTransactionVerificationService::class)
+    private val transactionVerificationService: UtxoLedgerTransactionVerificationService
 ) : UtxoLedgerService, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
@@ -174,6 +177,32 @@ class UtxoLedgerServiceImpl @Activate constructor(
             resultClass,
             clock
         )
+    }
+
+    @Suspendable
+    override fun persistDraftSignedTransaction(utxoSignedTransaction: UtxoSignedTransaction) {
+        // Verifications need to be at least as strong as what
+        // net.corda.ledger.utxo.flow.impl.flows.finality.v1.UtxoFinalityFlowV1.call
+        // does before the initial persist()
+
+        utxoSignedTransaction as UtxoSignedTransactionInternal
+        // verifyExistingSignatures
+        check(utxoSignedTransaction.signatures.isNotEmpty()) {
+            "Received draft transaction without signatures."
+        }
+        utxoSignedTransaction.signatures.forEach {
+            utxoSignedTransaction.verifySignatorySignature(it)
+        }
+        //verifyTransaction
+        transactionVerificationService.verify(utxoSignedTransaction.toLedgerTransaction())
+
+        // Initial verifications passed, the transaction can be saved in the database.
+        utxoLedgerPersistenceService.persist(utxoSignedTransaction, TransactionStatus.DRAFT)
+    }
+
+    @Suspendable
+    override fun findDraftSignedTransaction(id: SecureHash): UtxoSignedTransaction? {
+        return utxoLedgerPersistenceService.findSignedTransaction(id, TransactionStatus.DRAFT)
     }
 
     // Retrieve notary client plugin class for specified notary service identity. This is done in

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.INVALID
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.common.data.transaction.TransactionStatus.VERIFIED
+import net.corda.ledger.common.data.transaction.TransactionStatus.DRAFT
 import net.corda.ledger.utxo.flow.impl.UtxoLedgerMetricRecorder
 import net.corda.ledger.utxo.flow.impl.flows.backchain.InvalidBackchainException
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TopologicalSort
@@ -245,10 +246,12 @@ class TransactionBackchainReceiverFlowV1(
                             transactionsToRetrieve.remove(transactionId)
                         }
 
-                        INVALID -> {
+                        INVALID, DRAFT -> {
                             // If the status changed from UNVERIFIED -> INVALID we cannot go on with the resolution
+                            // Also transitioning back to Draft is impossible.
+
                             throw InvalidBackchainException(
-                                "Found the following invalid transaction during back-chain resolution: " +
+                                "Found the following $status transaction during back-chain resolution: " +
                                         "$transactionId. Backchain resolution cannot be continued."
                             )
                         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,8 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.37-beta+
+#cordaApiVersion=5.1.0.38-beta+
+cordaApiVersion=5.1.0.38-alpha-1698409890656
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionStatus.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionStatus.kt
@@ -5,13 +5,15 @@ import java.security.InvalidParameterException
 enum class TransactionStatus(val value: String) {
     INVALID("I"),
     UNVERIFIED("U"),
-    VERIFIED("V");
+    VERIFIED("V"),
+    DRAFT("D");
 
     companion object {
         fun String.toTransactionStatus() = when {
             this.equals(INVALID.value, ignoreCase = true) -> INVALID
             this.equals(UNVERIFIED.value, ignoreCase = true) -> UNVERIFIED
             this.equals(VERIFIED.value, ignoreCase = true) -> VERIFIED
+            this.equals(DRAFT.value, ignoreCase = true) -> DRAFT
             else -> throw InvalidParameterException("TransactionStatus $this is not supported")
         }
     }

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -93,7 +93,8 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
         mockCurrentSandboxGroupContext,
         mockNotaryLookup,
         mockExternalEventExecutor,
-        mockResultSetFactory
+        mockResultSetFactory,
+        mockUtxoLedgerTransactionVerificationService
     )
     val utxoSignedTransactionKryoSerializer = UtxoSignedTransactionKryoSerializer(
         serializationServiceWithWireTx,


### PR DESCRIPTION
Implement UtxoLedgerService.persistDraftSignedTransaction and UtxoLedgerService.findDraftSignedTransaction

API: https://github.com/corda/corda-api/pull/1314