### PR TITLE
CORE-17502 - Helm changes to support token selection + state manager

### DIFF
--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 import groovy.transform.Field
 import com.r3.build.utils.PipelineUtils

--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 import groovy.transform.Field
 import com.r3.build.utils.PipelineUtils

--- a/.ci/JenkinsfileSnykDelta
+++ b/.ci/JenkinsfileSnykDelta
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 snykDelta(
   snykOrgId: 'corda5-snyk-org-id',

--- a/.ci/JenkinsfileSnykDelta
+++ b/.ci/JenkinsfileSnykDelta
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 snykDelta(
   snykOrgId: 'corda5-snyk-org-id',

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -1,5 +1,5 @@
 #! groovy
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 import com.r3.build.agents.KubernetesAgent
 import com.r3.build.enums.BuildEnvironment

--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -1,5 +1,5 @@
 #! groovy
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 import com.r3.build.agents.KubernetesAgent
 import com.r3.build.enums.BuildEnvironment

--- a/.ci/dev/forward-merge/JenkinsInteropMerge
+++ b/.ci/dev/forward-merge/JenkinsInteropMerge
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 /*
  * Forward merge any changes in current branch to the branch with following version.

--- a/.ci/dev/forward-merge/JenkinsInteropMerge
+++ b/.ci/dev/forward-merge/JenkinsInteropMerge
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 /*
  * Forward merge any changes in current branch to the branch with following version.

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 import groovy.transform.Field
 import com.r3.build.utils.PipelineUtils

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 import groovy.transform.Field
 import com.r3.build.utils.PipelineUtils

--- a/.ci/e2eTests/JenkinsfileCombinedWorkerLinux
+++ b/.ci/e2eTests/JenkinsfileCombinedWorkerLinux
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 combinedWorkerPipeline(
     agentOs : 'linux'

--- a/.ci/e2eTests/JenkinsfileCombinedWorkerLinux
+++ b/.ci/e2eTests/JenkinsfileCombinedWorkerLinux
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 combinedWorkerPipeline(
     agentOs : 'linux'

--- a/.ci/e2eTests/JenkinsfileCombinedWorkerWindows
+++ b/.ci/e2eTests/JenkinsfileCombinedWorkerWindows
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 combinedWorkerPipeline(
     agentOs : 'windows'

--- a/.ci/e2eTests/JenkinsfileCombinedWorkerWindows
+++ b/.ci/e2eTests/JenkinsfileCombinedWorkerWindows
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 combinedWorkerPipeline(
     agentOs : 'windows'

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -2,7 +2,7 @@
  * Pipeline to take a packaged helm chart, deploy it and subsequently run the smoke test target
  * in this repo against these images - Can be used to exercise the C5 Ent images against smoke tests in corda-runtime-os
  */
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 endToEndPipeline(
     helmVersion: '^5.1.0-beta',

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -2,7 +2,7 @@
  * Pipeline to take a packaged helm chart, deploy it and subsequently run the smoke test target
  * in this repo against these images - Can be used to exercise the C5 Ent images against smoke tests in corda-runtime-os
  */
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 endToEndPipeline(
     helmVersion: '^5.1.0-beta',

--- a/.ci/e2eTests/JenkinsfileUnstableTest
+++ b/.ci/e2eTests/JenkinsfileUnstableTest
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 endToEndPipeline(
     assembleAndCompile: true,

--- a/.ci/e2eTests/JenkinsfileUnstableTest
+++ b/.ci/e2eTests/JenkinsfileUnstableTest
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 endToEndPipeline(
     assembleAndCompile: true,

--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -22,6 +22,13 @@ bootstrap:
           valueFrom:
             secretKeyRef:
               key: "password"
+      tokenSelection:
+        username:
+          value: "state-manager-user"
+        password:
+          valueFrom:
+            secretKeyRef:
+              key: "password"
   kafka:
     sasl:
       username:

--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -183,6 +183,15 @@ workers:
             secretKeyRef:
               name: "kafka-credentials"
               key: "tokenSelection"
+    stateManager:
+      db:
+        name: state-manager
+        username:
+          value: "state-manager-user"
+        password:
+          valueFrom:
+            secretKeyRef:
+              key: "password"
   rest:
     kafka:
       sasl:

--- a/.ci/e2eTests/ethereum/Jenkinsfile
+++ b/.ci/e2eTests/ethereum/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 ethereumInterop(
     deployEthereum: true,

--- a/.ci/e2eTests/ethereum/Jenkinsfile
+++ b/.ci/e2eTests/ethereum/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 ethereumInterop(
     deployEthereum: true,

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H 03 * * *',

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H 03 * * *',

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5',

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5',

--- a/.ci/nightly/JenkinsfileUnstableTests
+++ b/.ci/nightly/JenkinsfileUnstableTests
@@ -1,5 +1,5 @@
 //catch all job for flaky tests
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 cordaPipelineKubernetesAgent(
     runIntegrationTests: true,

--- a/.ci/nightly/JenkinsfileUnstableTests
+++ b/.ci/nightly/JenkinsfileUnstableTests
@@ -1,5 +1,5 @@
 //catch all job for flaky tests
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 cordaPipelineKubernetesAgent(
     runIntegrationTests: true,

--- a/.ci/nightly/JenkinsfileWindowsCompatibility
+++ b/.ci/nightly/JenkinsfileWindowsCompatibility
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 windowsCompatibility(
     runIntegrationTests: true,

--- a/.ci/nightly/JenkinsfileWindowsCompatibility
+++ b/.ci/nightly/JenkinsfileWindowsCompatibility
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 windowsCompatibility(
     runIntegrationTests: true,

--- a/.ci/versionCompatibility/Jenkinsfile
+++ b/.ci/versionCompatibility/Jenkinsfile
@@ -1,3 +1,3 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 cordaCompatibilityCheckPipeline(javaVersion: '17')

--- a/.ci/versionCompatibility/Jenkinsfile
+++ b/.ci/versionCompatibility/Jenkinsfile
@@ -1,3 +1,3 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 cordaCompatibilityCheckPipeline(javaVersion: '17')

--- a/.ci/versionCompatibility/latest-version.Jenkinsfile
+++ b/.ci/versionCompatibility/latest-version.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 // This build forces using the "very latest" version of the dependencies, regardless of which revision was chosen
 //  This is useful as it gives early indication of a downstream change that may introduce a breaking change

--- a/.ci/versionCompatibility/latest-version.Jenkinsfile
+++ b/.ci/versionCompatibility/latest-version.Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 // This build forces using the "very latest" version of the dependencies, regardless of which revision was chosen
 //  This is useful as it gives early indication of a downstream change that may introduce a breaking change

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@owen/CORE-17502-Token-selection-helm-changes') _
+@Library('corda-shared-build-pipeline-steps@owen/CORE-17957-Add-state-manager-support') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',

--- a/charts/corda/templates/workers.yaml
+++ b/charts/corda/templates/workers.yaml
@@ -20,7 +20,7 @@
     ( dict "clusterDbAccess" true )
 ) }}
 {{- include "corda.worker" ( list $ .Values.workers.tokenSelection "tokenSelection"
-      ( dict "clusterDbAccess" true )
+      ( dict "clusterDbAccess" true "stateManagerDbAccess" true )
 ) }}
 {{- include "corda.worker" ( list $ .Values.workers.rest "rest"
   ( dict "httpPort" 8888 "tlsSecretName" ( include "corda.restTlsSecretName" $ ) "additionalWorkerArgs" ( list "-rtls.crt.path=/tls/tls.crt" "-rtls.key.path=/tls/tls.key" "-rtls.ca.crt.path=/tls/ca.crt"  ) )

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -1282,6 +1282,13 @@
                                         "$ref": "#/$defs/basicAuthConfig"
                                     }
                                 ]
+                            },
+                            "tokenSelection": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/$defs/basicAuthConfig"
+                                    }
+                                ]
                             }
                         },
                         "clientImage": {
@@ -2580,6 +2587,9 @@
                                 "logging": {},
                                 "profiling": {},
                                 "resources": {},
+                                "stateManager": {
+                                    "$ref": "#/$defs/stateManager"
+                                },
                                 "kafka": {},
                                 "sharding": {
                                     "type": "object",

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -423,7 +423,31 @@ bootstrap:
               name: ""
               # -- the password secret key
               key: ""
-
+      tokenSelection:
+        # the username configuration
+        username:
+          # -- the username, defaults to this value
+          value: ""
+          # the username secret configuration; used in preference to value if name is set
+          valueFrom:
+            # the username secret key reference
+            secretKeyRef:
+              # -- the username secret name
+              name: ""
+              # -- the username secret key
+              key: ""
+        # password configuration
+        password:
+          # -- the password, defaults to a value randomly-generated on install
+          value: ""
+          # the password secret configuration
+          valueFrom:
+            # the password secret key reference
+            secretKeyRef:
+              # -- the password secret name
+              name: ""
+              # -- the password secret key
+              key: ""
     # Image containing DB client, used to set up the DB
     clientImage:
       # -- registry for image containing a db client, used to set up the db
@@ -1445,6 +1469,59 @@ workers:
       keepaliveTimeSeconds: 0
       # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
       validationTimeoutSeconds: 5
+
+    stateManager:
+      # Type of State Manager
+      type: DATABASE
+      # State Manager database configuration
+      db:
+        # -- the State Manager database host
+        host: null
+        # -- the State Manager database type
+        type: "postgresql"
+        # -- the State Manager database port
+        port: 5432
+        # -- the State Manager database name
+        name: token_selection_state_manager
+        # the State Manager database user configuration
+        username:
+          # -- the State Manager database user
+          value: "token_selection_state_manager_user"
+          # the State Manager database user secret configuration; used in preference to value if name is set
+          valueFrom:
+            # the State Manager database user secret key reference
+            secretKeyRef:
+              # -- the State Manager database user secret name
+              name: ""
+              # -- the State Manager database user secret key
+              key: ""
+        # the State Manager database password configuration
+        password:
+          # -- the State Manager database password
+          value: ""
+          # the State Manager database password secret configuration; used in preference to value if name is set
+          valueFrom:
+            # the State Manager database password secret key reference
+            secretKeyRef:
+              # -- the State Manager database password secret name
+              name: ""
+              # -- the State Manager database password secret key
+              key: ""
+        # flow worker JDBC connection pool configuration for State Manager DB
+        connectionPool:
+          # -- flow worker maximum JDBC connection pool size for state manager DB
+          maxSize: 5
+          # -- flow worker minimum JDBC connection pool size for state manager DB; null value means pool's min size will default to pool's max size value
+          minSize: null
+          # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
+          idleTimeoutSeconds: 120
+          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+          maxLifetimeSeconds: 1800
+          # -- interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled
+          keepAliveTimeSeconds: 0
+          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+          validationTimeoutSeconds: 5
+
     # token selection worker Kafka configuration
     kafka:
       # if kafka.sasl.enabled, the credentials to connect to Kafka with for the token selection worker

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -1507,11 +1507,11 @@ workers:
               name: ""
               # -- the State Manager database password secret key
               key: ""
-        # flow worker JDBC connection pool configuration for State Manager DB
+        # token selection worker JDBC connection pool configuration for State Manager DB
         connectionPool:
-          # -- flow worker maximum JDBC connection pool size for state manager DB
+          # -- token selection maximum JDBC connection pool size for state manager DB
           maxSize: 5
-          # -- flow worker minimum JDBC connection pool size for state manager DB; null value means pool's min size will default to pool's max size value
+          # -- token selection minimum JDBC connection pool size for state manager DB; null value means pool's min size will default to pool's max size value
           minSize: null
           # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
           idleTimeoutSeconds: 120

--- a/state-manager.yaml
+++ b/state-manager.yaml
@@ -69,3 +69,15 @@ workers:
             secretKeyRef:
               name: "state-manager-db-postgresql"
               key: "password"
+
+  tokenSelection:
+    stateManager:
+      db:
+        host: "state-manager-db-postgresql"
+        username:
+          value: "statemanager-user"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "state-manager-db-postgresql"
+              key: "password"


### PR DESCRIPTION
Adding the helm changes required to pass the state manager DB configuration to the token selection worker. This PR contains just the config changes, the code changes to use it are in a related PR here:
https://github.com/corda/corda-runtime-os/pull/4910
