### PR TITLE
CORE-17951 - fibre cache staleness check

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -25,7 +25,6 @@ import net.corda.schema.Schemas
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -424,18 +423,18 @@ class OutputAssertionsImpl(
 
     override fun flowFiberCacheContainsKey(holdingId: HoldingIdentity, flowId: String) {
         asserts.add {
-            assertFalse(
+            assertNotNull(
                 // :(
-                (flowFiberCache as FlowFiberCacheImpl).findInCache(holdingId, flowId).isEmpty(),
+                (flowFiberCache as FlowFiberCacheImpl).findInCache(holdingId, flowId),
                 "Expected flow fiber cache to contain flowKey: $flowId, $holdingId.")
         }
     }
 
     override fun flowFiberCacheDoesNotContainKey(holdingId: HoldingIdentity, flowId: String) {
         asserts.add {
-            assertTrue(
+            assertNull(
                 // :(
-                (flowFiberCache as FlowFiberCacheImpl).findInCache(holdingId, flowId).isEmpty(),
+                (flowFiberCache as FlowFiberCacheImpl).findInCache(holdingId, flowId),
                 "Expected flow fiber cache to not contain flowKey: $flowId, $holdingId"
             )
         }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -18,12 +18,14 @@ import net.corda.data.identity.HoldingIdentity
 import net.corda.data.persistence.EntityRequest
 import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.fiber.cache.FlowFiberCache
+import net.corda.flow.fiber.cache.impl.FlowFiberCacheImpl
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -422,20 +424,18 @@ class OutputAssertionsImpl(
 
     override fun flowFiberCacheContainsKey(holdingId: HoldingIdentity, flowId: String) {
         asserts.add {
-            assertNotNull(
-                // TODO - need to figure out why we need to test internal workings of the cache in the integration test.
-                //flowFiberCache.get(FlowKey(flowId, holdingId)),
-                "",
+            assertFalse(
+                // :(
+                (flowFiberCache as FlowFiberCacheImpl).findInCache(holdingId, flowId).isEmpty(),
                 "Expected flow fiber cache to contain flowKey: $flowId, $holdingId.")
         }
     }
 
     override fun flowFiberCacheDoesNotContainKey(holdingId: HoldingIdentity, flowId: String) {
         asserts.add {
-            assertNull(
-                // TODO - need to figure out why we need to test internal workings of the cache in the integration test.
-                //flowFiberCache.get(FlowKey(flowId, holdingId)),
-                null,
+            assertTrue(
+                // :(
+                (flowFiberCache as FlowFiberCacheImpl).findInCache(holdingId, flowId).isEmpty(),
                 "Expected flow fiber cache to not contain flowKey: $flowId, $holdingId"
             )
         }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -2,7 +2,6 @@ package net.corda.flow.testing.context
 
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializer
-import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.mapper.FlowMapperEvent
@@ -424,7 +423,9 @@ class OutputAssertionsImpl(
     override fun flowFiberCacheContainsKey(holdingId: HoldingIdentity, flowId: String) {
         asserts.add {
             assertNotNull(
-                flowFiberCache.get(FlowKey(flowId, holdingId)),
+                // TODO - need to figure out why we need to test internal workings of the cache in the integration test.
+                //flowFiberCache.get(FlowKey(flowId, holdingId)),
+                "",
                 "Expected flow fiber cache to contain flowKey: $flowId, $holdingId.")
         }
     }
@@ -432,7 +433,9 @@ class OutputAssertionsImpl(
     override fun flowFiberCacheDoesNotContainKey(holdingId: HoldingIdentity, flowId: String) {
         asserts.add {
             assertNull(
-                flowFiberCache.get(FlowKey(flowId, holdingId)),
+                // TODO - need to figure out why we need to test internal workings of the cache in the integration test.
+                //flowFiberCache.get(FlowKey(flowId, holdingId)),
+                null,
                 "Expected flow fiber cache to not contain flowKey: $flowId, $holdingId"
             )
         }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlowFiberFactory.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlowFiberFactory.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.testing.fakes
 
 import co.paralleluniverse.fibers.FiberScheduler
+import net.corda.flow.fiber.ClientStartedFlow
 import net.corda.flow.fiber.FiberFuture
 import net.corda.flow.fiber.FlowContinuation
 import net.corda.flow.fiber.FlowFiber
@@ -8,7 +9,6 @@ import net.corda.flow.fiber.FlowFiberExecutionContext
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.fiber.FlowLogicAndArgs
 import net.corda.flow.fiber.Interruptable
-import net.corda.flow.fiber.ClientStartedFlow
 import net.corda.flow.fiber.factory.FlowFiberFactory
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.propertytypes.ServiceRanking
@@ -91,6 +91,10 @@ class FakeFlowFiberFactory : FlowFiberFactory {
         }
 
         override fun <SUSPENDRETURN> suspend(request: FlowIORequest<SUSPENDRETURN>): SUSPENDRETURN {
+            TODO("Not yet implemented")
+        }
+
+        override fun attemptInterrupt() {
             TODO("Not yet implemented")
         }
 

--- a/components/flow/flow-service/src/main/java/net/corda/flow/fiber/cache/impl/package-info.java
+++ b/components/flow/flow-service/src/main/java/net/corda/flow/fiber/cache/impl/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.flow.fiber.cache.impl;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiber.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiber.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 import java.util.concurrent.Future
 
 @DoNotImplement
-interface FlowFiber {
+interface FlowFiber: Interruptable {
     val flowId: UUID
     val flowLogic: FlowLogicAndArgs
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -22,7 +22,7 @@ class FlowFiberImpl(
     override val flowId: UUID,
     override val flowLogic: FlowLogicAndArgs,
     scheduler: FiberScheduler
-) : Fiber<Unit>(flowId.toString(), scheduler), FlowFiber, Interruptable {
+) : Fiber<Unit>(flowId.toString(), scheduler), FlowFiber {
 
     companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
@@ -1,7 +1,7 @@
 package net.corda.flow.fiber.cache
 
 import net.corda.data.flow.FlowKey
-import net.corda.flow.fiber.FlowFiberImpl
+import net.corda.flow.fiber.FlowFiber
 import net.corda.sandboxgroupcontext.SandboxedCache
 
 /**
@@ -11,12 +11,12 @@ interface FlowFiberCache: SandboxedCache {
     /**
      * Put a flow fiber into the cache keyed by the given [FlowKey] and [suspendCount].
      */
-    fun put(key: FlowKey, suspendCount: Int, fiber: FlowFiberImpl)
+    fun put(key: FlowKey, suspendCount: Int, fiber: FlowFiber)
 
     /**
      * Get a flow fiber from the cache with the given [FlowKey] and [suspendCount], or else return null.
      */
-    fun get(key: FlowKey, suspendCount: Int): FlowFiberImpl?
+    fun get(key: FlowKey, suspendCount: Int): FlowFiber?
 
     /**
      * Invalidate and remove a flow fiber from the cache with the given [FlowKey] and [suspendCount].

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
@@ -19,7 +19,7 @@ interface FlowFiberCache: SandboxedCache {
     fun get(key: FlowKey, suspendCount: Int): FlowFiber?
 
     /**
-     * Invalidate and remove a flow fiber from the cache with the given [FlowKey] and [suspendCount].
+     * Invalidate and remove a flow fiber from the cache with the given [FlowKey].
      */
-    fun remove(key: FlowKey, suspendCount: Int)
+    fun remove(key: FlowKey)
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
@@ -9,17 +9,17 @@ import net.corda.sandboxgroupcontext.SandboxedCache
  */
 interface FlowFiberCache: SandboxedCache {
     /**
-     * Put a flow fiber into the cache keyed by the given [FlowKey].
+     * Put a flow fiber into the cache keyed by the given [FlowKey] and [suspendCount].
      */
-    fun put(key: FlowKey, fiber: FlowFiberImpl)
+    fun put(key: FlowKey, suspendCount: Int, fiber: FlowFiberImpl)
 
     /**
-     * Get a flow fiber from the cache with the given [FlowKey], or else return null.
+     * Get a flow fiber from the cache with the given [FlowKey] and [suspendCount], or else return null.
      */
-    fun get(key: FlowKey): FlowFiberImpl?
+    fun get(key: FlowKey, suspendCount: Int): FlowFiberImpl?
 
     /**
-     * Invalidate and remove a flow fiber from the cache with the given [FlowKey].
+     * Invalidate and remove a flow fiber from the cache with the given [FlowKey] and [suspendCount].
      */
-    fun remove(key: FlowKey)
+    fun remove(key: FlowKey, suspendCount: Int)
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
@@ -22,9 +22,4 @@ interface FlowFiberCache: SandboxedCache {
      * Invalidate and remove a flow fiber from the cache with the given [FlowKey].
      */
     fun remove(key: FlowKey)
-
-    /**
-     * Invalidate and remove flow fiber from the cache with the given [FlowKey]s.
-     */
-    fun remove(keys: Collection<FlowKey>)
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -76,12 +76,6 @@ class FlowFiberCacheImpl @Activate constructor(
         cache.invalidate(key)
     }
 
-    override fun remove(keys: Collection<FlowKey>) {
-        logger.debug { "Removing ${keys.size} flow fibers from flow fiber cache: ${keys.joinToString()}" }
-        cache.invalidateAll(keys)
-        cache.cleanUp()
-    }
-
     override fun remove(virtualNodeContext: VirtualNodeContext) {
         logger.debug {
             "Flow fiber cache removing holdingIdentity ${virtualNodeContext.holdingIdentity}" }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -4,7 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.cache.caffeine.CacheFactoryImpl
 import net.corda.data.flow.FlowKey
-import net.corda.flow.fiber.FlowFiberImpl
+import net.corda.flow.fiber.FlowFiber
 import net.corda.flow.fiber.cache.FlowFiberCache
 import net.corda.sandboxgroupcontext.SandboxGroupType
 import net.corda.sandboxgroupcontext.SandboxedCache
@@ -37,7 +37,7 @@ class FlowFiberCacheImpl @Activate constructor(
 
     private data class FibreCacheKey(val flowKey: FlowKey, val suspendCount: Int)
 
-    private val cache: Cache<FibreCacheKey, FlowFiberImpl> = CacheFactoryImpl().build(
+    private val cache: Cache<FibreCacheKey, FlowFiber> = CacheFactoryImpl().build(
         "flow-fiber-cache",
         Caffeine.newBuilder()
             .maximumSize(maximumSize)
@@ -66,11 +66,11 @@ class FlowFiberCacheImpl @Activate constructor(
         remove(vnc)
     }
 
-    override fun put(key: FlowKey, suspendCount: Int, fiber: FlowFiberImpl) {
+    override fun put(key: FlowKey, suspendCount: Int, fiber: FlowFiber) {
         cache.put(FibreCacheKey(key, suspendCount), fiber)
     }
 
-    override fun get(key: FlowKey, suspendCount: Int): FlowFiberImpl? {
+    override fun get(key: FlowKey, suspendCount: Int): FlowFiber? {
         return cache.getIfPresent(FibreCacheKey(key, suspendCount))
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -35,9 +35,9 @@ class FlowFiberCacheImpl @Activate constructor(
     private val maximumSize = java.lang.Long.getLong(FLOW_FIBER_CACHE_MAX_SIZE_PROPERTY_NAME, 10000)
     private val expireAfterWriteSeconds = java.lang.Long.getLong(FLOW_FIBER_CACHE_EXPIRE_AFTER_WRITE_SECONDS_PROPERTY_NAME, 600)
 
-    private data class FibreCacheKey(val flowKey: FlowKey, val suspendCount: Int)
+    private data class FiberCacheKey(val flowKey: FlowKey, val suspendCount: Int)
 
-    private val cache: Cache<FibreCacheKey, FlowFiber> = CacheFactoryImpl().build(
+    private val cache: Cache<FiberCacheKey, FlowFiber> = CacheFactoryImpl().build(
         "flow-fiber-cache",
         Caffeine.newBuilder()
             .maximumSize(maximumSize)
@@ -67,15 +67,15 @@ class FlowFiberCacheImpl @Activate constructor(
     }
 
     override fun put(key: FlowKey, suspendCount: Int, fiber: FlowFiber) {
-        cache.put(FibreCacheKey(key, suspendCount), fiber)
+        cache.put(FiberCacheKey(key, suspendCount), fiber)
     }
 
     override fun get(key: FlowKey, suspendCount: Int): FlowFiber? {
-        return cache.getIfPresent(FibreCacheKey(key, suspendCount))
+        return cache.getIfPresent(FiberCacheKey(key, suspendCount))
     }
 
     override fun remove(key: FlowKey, suspendCount: Int) {
-        cache.invalidate(FibreCacheKey(key, suspendCount))
+        cache.invalidate(FiberCacheKey(key, suspendCount))
     }
 
     override fun remove(virtualNodeContext: VirtualNodeContext) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -90,9 +90,7 @@ class FlowFiberCacheImpl @Activate constructor(
 
     // Yuk ... adding this to support the existing integration test.
     //  I don't think we should have integration tests knowing about the internals of the cache.
-    internal fun findInCache(holdingId: HoldingIdentity, flowId: String): List<FlowFiber> {
-        return cache.asMap()
-            .filter { it.key.identity == holdingId && it.key.id == flowId }
-            .map { it.value.fiber }
+    internal fun findInCache(holdingId: HoldingIdentity, flowId: String): FlowFiber? {
+        return cache.getIfPresent(FlowKey(flowId, holdingId))?.fiber
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
 import net.corda.cache.caffeine.CacheFactoryImpl
 import net.corda.data.flow.FlowKey
+import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.FlowFiber
 import net.corda.flow.fiber.cache.FlowFiberCache
 import net.corda.sandboxgroupcontext.SandboxGroupType
@@ -85,5 +86,13 @@ class FlowFiberCacheImpl @Activate constructor(
         val keysToInvalidate = cache.asMap().keys.filter { holdingIdentityToRemove == it.flowKey.identity }
         cache.invalidateAll(keysToInvalidate)
         cache.cleanUp()
+    }
+
+    // Yuk ... adding this to support the existing integration test.
+    //  I don't think we should have integration tests knowing about the internals of the cache.
+    internal fun findInCache(holdingId: HoldingIdentity, flowId: String): List<FlowFiber> {
+        return cache.asMap()
+            .filter { it.key.flowKey.identity == holdingId && it.key.flowKey.id == flowId }
+            .map { it.value }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
@@ -70,7 +70,9 @@ class FlowFiberFactoryImpl @Activate constructor(
 
     private fun getFromCacheOrDeserialize(flowFiberExecutionContext: FlowFiberExecutionContext): FlowFiberImpl {
         val cachedFiber: FlowFiberImpl? = try {
-            flowFiberCache.get(flowFiberExecutionContext.flowCheckpoint.flowKey)
+            flowFiberCache.get(
+                flowFiberExecutionContext.flowCheckpoint.flowKey,
+                flowFiberExecutionContext.flowCheckpoint.suspendCount)
         } catch (e: Exception) {
             logger.warn("Exception when getting from flow fiber cache.", e)
             null

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
@@ -5,6 +5,7 @@ import co.paralleluniverse.fibers.FiberExecutorScheduler
 import net.corda.flow.fiber.FiberExceptionConstants
 import net.corda.flow.fiber.FiberFuture
 import net.corda.flow.fiber.FlowContinuation
+import net.corda.flow.fiber.FlowFiber
 import net.corda.flow.fiber.FlowFiberExecutionContext
 import net.corda.flow.fiber.FlowFiberImpl
 import net.corda.flow.fiber.FlowLogicAndArgs
@@ -68,8 +69,8 @@ class FlowFiberFactoryImpl @Activate constructor(
         return FiberFuture(fiber, fiber.resume(flowFiberExecutionContext, suspensionOutcome, currentThreadFiberExecutor))
     }
 
-    private fun getFromCacheOrDeserialize(flowFiberExecutionContext: FlowFiberExecutionContext): FlowFiberImpl {
-        val cachedFiber: FlowFiberImpl? = try {
+    private fun getFromCacheOrDeserialize(flowFiberExecutionContext: FlowFiberExecutionContext): FlowFiber {
+        val cachedFiber: FlowFiber? = try {
             flowFiberCache.get(
                 flowFiberExecutionContext.flowCheckpoint.flowKey,
                 flowFiberExecutionContext.flowCheckpoint.suspendCount)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -335,6 +335,6 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
      * Remove cached flow fiber for this checkpoint, if it exists.
      */
     private fun removeCachedFlowFiber(checkpoint: FlowCheckpoint) {
-        if (checkpoint.doesExist) flowFiberCache.remove(checkpoint.flowKey)
+        if (checkpoint.doesExist) flowFiberCache.remove(checkpoint.flowKey, checkpoint.suspendCount)
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -335,6 +335,6 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
      * Remove cached flow fiber for this checkpoint, if it exists.
      */
     private fun removeCachedFlowFiber(checkpoint: FlowCheckpoint) {
-        if (checkpoint.doesExist) flowFiberCache.remove(checkpoint.flowKey, checkpoint.suspendCount)
+        if (checkpoint.doesExist) flowFiberCache.remove(checkpoint.flowKey)
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStage.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStage.kt
@@ -104,7 +104,7 @@ internal class FlowExecutionPipelineStage(
 
         return when (fiberResult) {
             is FlowIORequest.FlowFinished -> {
-                fiberCache.remove(context.checkpoint.flowKey, context.checkpoint.suspendCount)
+                fiberCache.remove(context.checkpoint.flowKey)
                 context.checkpoint.serializedFiber = ByteBuffer.wrap(byteArrayOf())
                 context.flowMetrics.flowFiberExited()
                 fiberResult
@@ -122,7 +122,7 @@ internal class FlowExecutionPipelineStage(
             }
 
             is FlowIORequest.FlowFailed -> {
-                fiberCache.remove(context.checkpoint.flowKey, context.checkpoint.suspendCount)
+                fiberCache.remove(context.checkpoint.flowKey)
                 context.flowMetrics.flowFiberExited()
                 fiberResult
             }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStage.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStage.kt
@@ -104,7 +104,7 @@ internal class FlowExecutionPipelineStage(
 
         return when (fiberResult) {
             is FlowIORequest.FlowFinished -> {
-                fiberCache.remove(context.checkpoint.flowKey)
+                fiberCache.remove(context.checkpoint.flowKey, context.checkpoint.suspendCount)
                 context.checkpoint.serializedFiber = ByteBuffer.wrap(byteArrayOf())
                 context.flowMetrics.flowFiberExited()
                 fiberResult
@@ -112,7 +112,7 @@ internal class FlowExecutionPipelineStage(
 
             is FlowIORequest.FlowSuspended<*> -> {
                 fiberResult.cacheableFiber?.let {
-                    fiberCache.put(context.checkpoint.flowKey, it)
+                    fiberCache.put(context.checkpoint.flowKey, context.checkpoint.suspendCount, it)
                 }
                 context.checkpoint.serializedFiber = fiberResult.fiber
                 context.flowMetrics.flowFiberExitedWithSuspension(
@@ -122,7 +122,7 @@ internal class FlowExecutionPipelineStage(
             }
 
             is FlowIORequest.FlowFailed -> {
-                fiberCache.remove(context.checkpoint.flowKey)
+                fiberCache.remove(context.checkpoint.flowKey, context.checkpoint.suspendCount)
                 context.flowMetrics.flowFiberExited()
                 fiberResult
             }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -2,8 +2,6 @@ package net.corda.flow.state.impl
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import java.nio.ByteBuffer
-import java.time.Instant
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
@@ -22,6 +20,8 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
+import java.nio.ByteBuffer
+import java.time.Instant
 
 @Suppress("TooManyFunctions")
 class FlowCheckpointImpl(
@@ -156,7 +156,11 @@ class FlowCheckpointImpl(
         get() = checkpoint.initialPlatformVersion
 
     override val isCompleted: Boolean
+
         get() = deleted
+    override val suspendCount: Int
+        get() = checkNotNull(flowStateManager)
+        { "Attempt to access context before flow state has been created" }.suspendCount
 
     override fun initFlowState(flowStartContext: FlowStartContext, cpkFileHashes: Set<SecureHash>) {
         if (flowStateManager != null) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowStateManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowStateManager.kt
@@ -30,6 +30,8 @@ class FlowStateManager(private val initialState: FlowState) {
 
     val holdingIdentity: HoldingIdentity = state.flowStartContext.identity.toCorda()
 
+    val suspendCount: Int = state.suspendCount
+
     val fiber: ByteBuffer
         get() = state.fiber ?: ByteBuffer.wrap(byteArrayOf())
 

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -103,6 +103,10 @@ public class FlowSessionImplJavaTest {
         public Future<FlowIORequest<?>> resume(@NotNull FlowFiberExecutionContext flowFiberExecutionContext, @NotNull FlowContinuation suspensionOutcome, @NotNull FiberScheduler scheduler) {
             return null;
         }
+
+        @Override
+        public void attemptInterrupt() {
+        }
     }
 
     @BeforeEach

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
@@ -46,30 +46,20 @@ class FlowFibreCacheTest {
     fun `when remove and entry does not exist do no throw`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         assertDoesNotThrow {
-            cache.remove(key, 1)
+            cache.remove(key)
         }
-    }
-
-    @Test
-    fun `when remove and entry does not exist at suspendCount do no throw`() {
-        val cache = FlowFiberCacheImpl(cacheEviction)
-        cache.put(key, 1, value)
-        assertDoesNotThrow {
-            cache.remove(key, 123)
-        }
-        assertThat(cache.get(key, 1)).isSameAs(value)
     }
 
     @Test
     fun `when remove and exists`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         cache.put(key, 1, value)
-        cache.remove(key, 1)
+        cache.remove(key)
         assertThat(cache.get(key, 1)).isNull()
     }
 
     @Test
-    fun `when remove by vnode context remover all`() {
+    fun `when remove by vnode context remove all`() {
         val id = mock<HoldingIdentity> {
             on { x500Name } doReturn (MemberX500Name("Bruce", "Thomas", "GB"))
             on { groupId } doReturn ("Batman")

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
@@ -1,0 +1,94 @@
+package net.corda.flow.fiber.cache
+
+import net.corda.data.flow.FlowKey
+import net.corda.flow.fiber.FlowFiber
+import net.corda.flow.fiber.cache.impl.FlowFiberCacheImpl
+import net.corda.sandboxgroupcontext.VirtualNodeContext
+import net.corda.sandboxgroupcontext.service.CacheEviction
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.virtualnode.HoldingIdentity
+import net.corda.virtualnode.toAvro
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class FlowFibreCacheTest {
+    private val cacheEviction = mock< CacheEviction>()
+    private val key = mock<FlowKey>()
+    private val value = mock<FlowFiber>()
+
+    @Test
+    fun `when get and no entry return null`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        val entry = cache.get(mock(), 123)
+        assertThat(entry).isNull()
+    }
+
+    @Test
+    fun `when get and entry wrong version return null`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        cache.put(key, 1, value)
+        val entry = cache.get(mock(), 123)
+        assertThat(entry).isNull()
+    }
+
+    @Test
+    fun `when get and entry and version exist return`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        cache.put(key, 1, value)
+        val entry = cache.get(key, 1)
+        assertThat(entry).isSameAs(value)
+    }
+
+    @Test
+    fun `when remove and entry does not exist do no throw`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        assertDoesNotThrow {
+            cache.remove(key, 1)
+        }
+    }
+
+    @Test
+    fun `when remove and entry does not exist at suspendCount do no throw`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        cache.put(key, 1, value)
+        assertDoesNotThrow {
+            cache.remove(key, 123)
+        }
+        assertThat(cache.get(key, 1)).isSameAs(value)
+    }
+
+    @Test
+    fun `when remove and exists`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        cache.put(key, 1, value)
+        cache.remove(key, 1)
+        assertThat(cache.get(key, 1)).isNull()
+    }
+
+    @Test
+    fun `when remove by vnode context remover all`() {
+        val id = mock<HoldingIdentity> {
+            on { x500Name } doReturn (MemberX500Name("Bruce", "Thomas", "GB"))
+            on { groupId } doReturn ("Batman")
+        }
+        val avroId = id.toAvro()
+        val vnodeContext = mock< VirtualNodeContext> {
+            on { holdingIdentity } doReturn (id)
+        }
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        val key1 = mock<FlowKey> {
+            on { identity } doReturn (avroId)
+        }
+        val key2 = mock<FlowKey> {
+            on { identity } doReturn (avroId)
+        }
+        cache.put(key1, 1, mock())
+        cache.put(key2, 1, mock())
+        cache.remove(vnodeContext)
+        assertThat(cache.get(key1, 1)).isNull()
+        assertThat(cache.get(key2, 1)).isNull()
+    }
+}

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
@@ -135,8 +135,6 @@ class FlowEventExceptionProcessorImplTest {
 
         val result = target.process(error, context)
 
-        verify(flowFiberCache, times(0)).remove(any<List<FlowKey>>())
-
         verify(result.checkpoint).rollback()
         verify(result.checkpoint).markForRetry(context.inputEvent, error)
         assertThat(result.outputRecords).containsOnly(flowStatusUpdateRecord, flowEventRecord)
@@ -228,7 +226,6 @@ class FlowEventExceptionProcessorImplTest {
 
         verify(result.checkpoint).waitingFor = WaitingFor(net.corda.data.flow.state.waiting.Wakeup())
         verify(result.checkpoint).setPendingPlatformError(FlowProcessingExceptionTypes.PLATFORM_ERROR, error.message)
-        verify(flowFiberCache, times(0)).remove(any<List<FlowKey>>())
     }
 
     @Test
@@ -329,7 +326,6 @@ class FlowEventExceptionProcessorImplTest {
         target.process(error, context)
 
         verify(flowCheckpoint, times(0)).flowStartContext
-        verify(flowFiberCache, times(0)).remove(any<List<FlowKey>>())
     }
 
     @Test

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -115,7 +114,7 @@ class FlowEventExceptionProcessorImplTest {
 
         val result = target.process(error, context)
 
-        verify(flowFiberCache).remove(key, 123)
+        verify(flowFiberCache).remove(key)
         verify(result.checkpoint).rollback()
         verify(result.checkpoint).markForRetry(context.inputEvent, error)
         assertThat(result.outputRecords).containsOnly(flowStatusUpdateRecord, flowEventRecord)
@@ -195,7 +194,7 @@ class FlowEventExceptionProcessorImplTest {
         verify(result.checkpoint).markDeleted()
         assertThat(result.outputRecords).contains(flowStatusUpdateRecord, flowMapperRecord)
         assertThat(result.sendToDlq).isTrue
-        verify(flowFiberCache).remove(key, 123)
+        verify(flowFiberCache).remove(key)
     }
 
     @Test
@@ -213,7 +212,7 @@ class FlowEventExceptionProcessorImplTest {
 
         verify(flowCheckpoint).waitingFor = WaitingFor(net.corda.data.flow.state.waiting.Wakeup())
         verify(flowCheckpoint).setPendingPlatformError(FlowProcessingExceptionTypes.PLATFORM_ERROR, error.message)
-        verify(flowFiberCache).remove(key, 123)
+        verify(flowFiberCache).remove(key)
 
         assertThat(result.outputRecords).isEmpty()
     }
@@ -303,7 +302,7 @@ class FlowEventExceptionProcessorImplTest {
     @Test
     fun `throwable triggered during event exception processing does not escape the processor`() {
         val throwable = RuntimeException()
-        whenever(flowFiberCache.remove(eq(flowCheckpoint.flowKey), any())).thenThrow(throwable)
+        whenever(flowFiberCache.remove(flowCheckpoint.flowKey)).thenThrow(throwable)
         whenever(flowCheckpoint.doesExist).thenReturn(true)
         val eventError = FlowEventException("error")
         val eventResult = target.process(eventError, context)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStageTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStageTest.kt
@@ -365,8 +365,10 @@ class FlowExecutionPipelineStageTest {
         verify(ioRequestTypeConverter, times(suspends.size)).convertToActionName(any())
 
         // Fiber cache
-        verify(fiberCache, times(suspends.filter { (it as FlowIORequest.FlowSuspended<*>).cacheableFiber != null }.size)).put(any(), any())
-        verify(fiberCache, times(other.size)).remove(any<FlowKey>())
+        verify(fiberCache, times(suspends.filter { (it as FlowIORequest.FlowSuspended<*>).cacheableFiber != null }.size))
+            .put(any(), any(), any()
+        )
+        verify(fiberCache, times(other.size)).remove(any(), any())
     }
 
     private fun createWaitingForHandlerMap(

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStageTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStageTest.kt
@@ -368,7 +368,7 @@ class FlowExecutionPipelineStageTest {
         verify(fiberCache, times(suspends.filter { (it as FlowIORequest.FlowSuspended<*>).cacheableFiber != null }.size))
             .put(any(), any(), any()
         )
-        verify(fiberCache, times(other.size)).remove(any(), any())
+        verify(fiberCache, times(other.size)).remove(any<FlowKey>())
     }
 
     private fun createWaitingForHandlerMap(

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.state
 
-import java.nio.ByteBuffer
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
@@ -12,6 +11,7 @@ import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.serialization.checkpoint.NonSerializable
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
+import java.nio.ByteBuffer
 import java.time.Instant
 
 /**
@@ -60,6 +60,8 @@ interface FlowCheckpoint : NonSerializable {
     val initialPlatformVersion: Int
 
     val isCompleted: Boolean
+
+    val suspendCount: Int
 
     fun initFlowState(flowStartContext: FlowStartContext, cpkFileHashes: Set<SecureHash>)
 


### PR DESCRIPTION
Add `suspendCount` to fibre cache key so to ensure we don't use stale fibres.