### PR TITLE
CORE-17624: Fail "Create CPI" operations when the CLI reports failure

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CpiLoader.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/CpiLoader.kt
@@ -4,6 +4,7 @@ import net.corda.cli.plugins.packaging.CreateCpiV2
 import net.corda.cli.plugins.packaging.signing.SigningOptions
 import net.corda.utilities.deleteRecursively
 import net.corda.utilities.readAll
+import org.junit.jupiter.api.Assertions.assertEquals
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.nio.file.Files
@@ -67,7 +68,7 @@ object CpiLoader {
 
             // Create CPI
             val cpiPath = tempDirectory.resolve("cpi")
-            CreateCpiV2().apply {
+            val exitCode = CreateCpiV2().apply {
                 cpbPath?.let {
                     cpbFileName = it.toString()
                 }
@@ -81,7 +82,9 @@ object CpiLoader {
                     keyStorePass = signOptions.keyStorePassword
                     keyAlias = signOptions.keyAlias
                 }
-            }.run()
+            }.call()
+
+            assertEquals(0, exitCode, "Create CPI returned non-zero exit code")
 
             // Read CPI
             return cpiPath.readAll().inputStream()

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
@@ -7,6 +7,7 @@ import net.corda.cli.plugins.network.utils.InvariantUtils.checkInvariant
 import net.corda.cli.plugins.network.utils.PrintUtils.verifyAndPrintError
 import net.corda.crypto.test.certificates.generation.toPem
 import net.corda.membership.rest.v1.MGMRestResource
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.ByteArrayOutputStream
@@ -141,7 +142,10 @@ class OnboardMgm : Runnable, BaseOnboard() {
         creator.cpiUpgrade = false
         creator.outputFileName = cpiFile.absolutePath
         creator.signingOptions = createDefaultSingingOptions()
-        creator.run()
+        val exitCode = creator.call()
+        if (exitCode != 0) {
+            throw CordaRuntimeException("Create CPI returned non-zero exit code")
+        }
         uploadSigningCertificates()
         cpiFile
     }


### PR DESCRIPTION
Our E2E tests showed an error where an attempt to create a CPI had failed, but they continued further into the test instead of exiting at the first sign of failure.

This change turns `CreateCpiV2` into a `Callable<Int>`, where the `Int` return type is the exit code of the command line process. This allows us to communicate failures using the exit code as well as console output. That makes it easy for code calling `CreateCpiV2` to test for failures and act appropriately.

Changes in this PR:
- Change `CreateCpiV2` to return an exit code (zero on success, non-zero on error)
- Update all usages to check the exit code and stop what they are doing when an error happens
