### PR TITLE
CORE-17502 - enable state-manager with local deployment

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@CORE-17951') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@CORE-17951') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/state-manager.yaml
+++ b/state-manager.yaml
@@ -46,6 +46,14 @@ bootstrap:
             secretKeyRef:
               name: "state-manager-db-postgresql"
               key: "postgres-password"
+      tokenSelection:
+        username:
+          value: "postgres"
+        password:
+          valueFrom:
+            secretKeyRef:
+              name: "state-manager-db-postgresql"
+              key: "postgres-password"
 workers:
   flow:
     stateManager:

--- a/state-manager.yaml
+++ b/state-manager.yaml
@@ -2,16 +2,8 @@
 # Helm chart and a state-manager deployed via bitnami postgres helm chart with the overrides from
 # `state-manager-postgres.yaml`.
 #
-# First use `./gradlew publishOSGiImage --parallel` to create local docker images
-#
-# Then deploy the prereqs using:
-# helm upgrade --install prereqs -n corda \
-#   oci://corda-os-docker.software.r3.com/helm-charts/corda-dev-prereqs \
-#   --render-subchart-notes \
-#   --timeout 10m \
-#
 # Then deploy the state manager using the bitnami helm chart
-# helm install state-manager-db oci://docker-remotes.software.r3.com/bitnamicharts/postgresql -n corda --version "12.1.0" \
+# helm install state-manager-db oci://registry-1.docker.io/bitnamicharts/postgresql -n corda --version "12.1.0" \
 # -f ./state-manager-postgres.yaml  \
 # --timeout 10m \
 # --wait


### PR DESCRIPTION
Local developers may use this override when deploying a single state-manager database in their local kubernetes deployment.

This adds bootstrap for token-selection 