### PR TITLE
CORE-15810: Allow null or empty DDL connection string

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
@@ -46,28 +46,24 @@ internal class VirtualNodeDbImpl(
             for (privilege in listOf(DDL, DML)) {
                 dbConnections[privilege]!!.let { connection ->
                     val user = connection.getUser()
+                        ?: throw DBConfigurationException("DB user not known for connection ${connection.description}")
                     val password = connection.getPassword()
-                    if (privilege == DML) {
-                        user ?: throw DBConfigurationException("DB user not known for connection ${connection.description}")
-                        password ?: throw DBConfigurationException("DB password not known for connection ${connection.description}")
-                    }
-                    if (!user.isNullOrEmpty() && !password.isNullOrEmpty()) {
-                        val dbSchema = dbType.getSchemaName(holdingIdentityShortHash)
-                        // This covers scenario when previous virtual node on-boarding request failed after user was created
-                        // Since connections are persisted at later point, user's password is lost, so user is re-created
-                        if (virtualNodesDbAdmin.userExists(user)) {
-                            if (privilege == DDL) {
-                                log.info("User for connection ${connection.description} already exists in DB, schema will be deleted")
-                                virtualNodesDbAdmin.deleteSchema(dbSchema)
-                            }
-                            log.info("User for connection ${connection.description} already exists in DB, it will be re-created")
-                            virtualNodesDbAdmin.deleteUser(user)
+                        ?: throw DBConfigurationException("DB password not known for connection ${connection.description}")
+                    val dbSchema = dbType.getSchemaName(holdingIdentityShortHash)
+                    // This covers scenario when previous virtual node on-boarding request failed after user was created
+                    // Since connections are persisted at later point, user's password is lost, so user is re-created
+                    if (virtualNodesDbAdmin.userExists(user)) {
+                        if (privilege == DDL) {
+                            log.info("User for connection ${connection.description} already exists in DB, schema will be deleted")
+                            virtualNodesDbAdmin.deleteSchema(dbSchema)
                         }
-                        // When DML user is created, it is granted with privileges related to DB objects created by DDL user
-                        // (therefore DDL user has to be provided as grantee)
-                        val grantee = if (privilege == DML) dbConnections[DDL]!!.getUser() else null
-                        virtualNodesDbAdmin.createDbAndUser(dbSchema, user, password, privilege, grantee)
+                        log.info("User for connection ${connection.description} already exists in DB, it will be re-created")
+                        virtualNodesDbAdmin.deleteUser(user)
                     }
+                    // When DML user is created, it is granted with privileges related to DB objects created by DDL user
+                    // (therefore DDL user has to be provided as grantee)
+                    val grantee = if (privilege == DML) dbConnections[DDL]!!.getUser() else null
+                    virtualNodesDbAdmin.createDbAndUser(dbSchema, user, password, privilege, grantee)
                 }
             }
         }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
@@ -75,6 +75,7 @@ internal class VirtualNodeDbImpl(
      * @param migrationTagToApply [string?] is an optional tag to be added to the liquibase migration.
      *  See: https://docs.liquibase.com/change-types/tag-database.html
      */
+    @Suppress("NestedBlockDepth")
     override fun runDbMigration(migrationTagToApply: String?) {
         val dbConnection = dbConnections[DDL]
         if (dbConnection != null) {

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -59,12 +59,12 @@ class VirtualNodeDbImplTest {
     }
 
     @Test
-    fun `create schema and users for platform managed DBs - throws if DDL user is missing`() {
+    fun `create schema and users for platform managed DBs - does nothing if DDL user is missing`() {
         val target = createVirtualNodeDb(isPlatformManagedDb = true)
 
         whenever(ddlConnection.getUser()).thenReturn(null)
 
-        assertThrows<DBConfigurationException> { target.createSchemasAndUsers() }
+        assertDoesNotThrow { target.createSchemasAndUsers() }
     }
 
     @Test
@@ -77,12 +77,12 @@ class VirtualNodeDbImplTest {
     }
 
     @Test
-    fun `create schema and users for platform managed DBs - throws if DDL password is missing`() {
+    fun `create schema and users for platform managed DBs - does nothing if DDL password is missing`() {
         val target = createVirtualNodeDb(isPlatformManagedDb = true)
 
         whenever(ddlConnection.getPassword()).thenReturn(null)
 
-        assertThrows<DBConfigurationException> { target.createSchemasAndUsers() }
+        assertDoesNotThrow { target.createSchemasAndUsers() }
     }
 
     @Test

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -154,7 +154,7 @@ class VirtualNodeDbImplTest {
     }
 
     @Test
-    fun `run cpi migrations throws if no DDL connection present`() {
+    fun `run cpi migrations does nothing if no DDL connection present`() {
         val target = createVirtualNodeDb(
             isPlatformManagedDb = true,
             dbConnections = mapOf(
@@ -181,7 +181,7 @@ class VirtualNodeDbImplTest {
     }
 
     @Test
-    fun `run DB migration throws if no DDL connection set`() {
+    fun `run DB migration does nothing if no DDL connection set`() {
         val target = createVirtualNodeDb(
             isPlatformManagedDb = true,
             dbConnections = mapOf(

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -59,12 +59,12 @@ class VirtualNodeDbImplTest {
     }
 
     @Test
-    fun `create schema and users for platform managed DBs - does nothing if DDL user is missing`() {
+    fun `create schema and users for platform managed DBs - throws if DDL user is missing`() {
         val target = createVirtualNodeDb(isPlatformManagedDb = true)
 
         whenever(ddlConnection.getUser()).thenReturn(null)
 
-        assertDoesNotThrow { target.createSchemasAndUsers() }
+        assertThrows<DBConfigurationException> { target.createSchemasAndUsers() }
     }
 
     @Test
@@ -77,12 +77,12 @@ class VirtualNodeDbImplTest {
     }
 
     @Test
-    fun `create schema and users for platform managed DBs - does nothing if DDL password is missing`() {
+    fun `create schema and users for platform managed DBs - throws if DDL password is missing`() {
         val target = createVirtualNodeDb(isPlatformManagedDb = true)
 
         whenever(ddlConnection.getPassword()).thenReturn(null)
 
-        assertDoesNotThrow { target.createSchemasAndUsers() }
+        assertThrows<DBConfigurationException> { target.createSchemasAndUsers() }
     }
 
     @Test

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -11,9 +11,9 @@ import net.corda.db.core.DbPrivilege
 import net.corda.libs.configuration.SmartConfig
 import net.corda.virtualnode.write.db.impl.VirtualNodesDbAdmin
 import net.corda.virtualnode.write.db.impl.writer.DbConnection
-import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbException
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbImpl
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -142,6 +142,18 @@ class VirtualNodeDbImplTest {
     }
 
     @Test
+    fun `create schema and users for platform managed DBs - does nothing if DDL connection missing`() {
+        val target = createVirtualNodeDb(
+            isPlatformManagedDb = true,
+            dbConnections = mapOf(
+                DbPrivilege.DML to dmlConnection,
+            )
+        )
+
+        assertDoesNotThrow { target.createSchemasAndUsers() }
+    }
+
+    @Test
     fun `run cpi migrations throws if no DDL connection present`() {
         val target = createVirtualNodeDb(
             isPlatformManagedDb = true,
@@ -150,7 +162,7 @@ class VirtualNodeDbImplTest {
             )
         )
 
-        assertThrows<VirtualNodeDbException> { target.runCpiMigrations(mock(), "tag") }
+        assertDoesNotThrow { target.runCpiMigrations(mock(), "tag") }
     }
 
     @Test
@@ -177,7 +189,7 @@ class VirtualNodeDbImplTest {
             )
         )
 
-        assertThrows<VirtualNodeDbException> { target.runDbMigration("tag") }
+        assertDoesNotThrow { target.runDbMigration("tag") }
     }
 
     @Test


### PR DESCRIPTION
- Allows null or empty DDL string instead of throwing a `VirtualNodeDbException`

E2E test: [CORE-15810: Add test for creating vNode with empty DDL string](https://github.com/corda/corda-e2e-tests/pull/303)