### PR TITLE
ES-1463: config update for automated slack messages

### DIFF
--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -136,7 +136,7 @@ pipeline {
             sh 'rm -f forward.txt workerLogs.txt podLogs.txt'
         }
         failure {
-            sendSlackNotifications("danger", "BUILD FAILURE - Combined Worker CLI Plugins Smoke Tests", true, "#corda-corda5-build-notifications")
+            sendSlackNotifications("danger", "BUILD FAILURE - Combined Worker CLI Plugins Smoke Tests", false, "#corda-corda5-build-notifications")
         }
     }
 }

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -132,7 +132,7 @@ pipeline {
             sh 'rm -f forward.txt workerLogs.txt podLogs.txt'
         }
         failure {
-            sendSlackNotifications("danger", "BUILD FAILURE - Combined Worker E2E Tests", true, "#corda-corda5-build-notifications")
+            sendSlackNotifications("danger", "BUILD FAILURE - Combined Worker E2E Tests", false, "#corda-corda5-build-notifications")
         }
     }
 }


### PR DESCRIPTION
Minor non-functional change to remove the automated tagging on slack notifications for the last committer in case of failure. This leads to excess noise due to Jenkins picking up committers from the shared library, which is also checked out, and a test failure may have nothing to do with the last committer. 
