### PR TITLE
CORE-18016 rebalance in progress exception should be a transient issue not a fatal one

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -34,6 +34,7 @@ import org.apache.kafka.common.errors.AuthorizationException
 import org.apache.kafka.common.errors.FencedInstanceIdException
 import org.apache.kafka.common.errors.InconsistentGroupProtocolException
 import org.apache.kafka.common.errors.InterruptException
+import org.apache.kafka.common.errors.RebalanceInProgressException
 import org.apache.kafka.common.errors.TimeoutException
 import org.apache.kafka.common.errors.WakeupException
 import org.slf4j.LoggerFactory
@@ -77,7 +78,8 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
             WakeupException::class.java,
             InterruptException::class.java,
             KafkaException::class.java,
-            ConcurrentModificationException::class.java
+            ConcurrentModificationException::class.java,
+            RebalanceInProgressException::class.java
         )
     }
 


### PR DESCRIPTION
currently we are not handling this exception so it is treated as fatal. We should allow the consumer to call poll() to complete the rebalance