### PR TITLE
CORE-18017: do query and add under a DB transaction

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/TenantInfoServiceImpl.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/TenantInfoServiceImpl.kt
@@ -21,18 +21,7 @@ class TenantInfoServiceImpl(
     override fun populate(tenantId: String, category: String, cryptoService: CryptoService): HSMAssociationInfo {
         logger.info("assignSoftHSM(tenant={}, category={})", tenantId, category)
         return hsmRepositoryFactory().use { hsmRepository ->
-            val existing = hsmRepository.findTenantAssociation(tenantId, category)
-            if (existing != null) {
-                logger.warn("Already have tenant information populated for tenant={}, category={}", tenantId, category)
-                ensureWrappingKey(existing, cryptoService)
-                return existing
-            }
-            hsmRepository.associate(
-                tenantId = tenantId,
-                category = category,
-                // Defaulting the below to what it used be in crypto default config - but it probably needs be removed now
-                masterKeyPolicy = MasterKeyPolicy.UNIQUE
-            )
+            hsmRepository.createOrLookupCategoryAssociation(tenantId, category, MasterKeyPolicy.UNIQUE)
         }.also {
             ensureWrappingKey(it, cryptoService)
         }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/HSMRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/HSMRepository.kt
@@ -6,8 +6,10 @@ import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import java.io.Closeable
 
 interface HSMRepository : Closeable {
+
     /**
      * Finds a tenant association with an HSM for the given category.
+     *
      */
     fun findTenantAssociation(tenantId: String, category: String): HSMAssociationInfo?
 
@@ -24,4 +26,18 @@ interface HSMRepository : Closeable {
         category: String,
         masterKeyPolicy: MasterKeyPolicy,
     ): HSMAssociationInfo
+
+    /**
+     * Returns existing association, otherwise creates association with specified masterKeyPolicy
+     *
+     * @param tenantId The tenant ID to consider
+     * @param category The category to consider (acts like a string enum)
+     * @param masterKeyPolicy The master key policy to set if the association does not exist
+     */
+    fun createOrLookupCategoryAssociation(
+        tenantId: String,
+        category: String,
+        masterKeyPolicy: MasterKeyPolicy,
+    ): HSMAssociationInfo
+
 }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
@@ -11,6 +11,7 @@ import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
 import net.corda.v5.base.util.EncodingUtils.toHex
 import org.slf4j.LoggerFactory
+import java.lang.UnsupportedOperationException
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManager
@@ -138,6 +139,7 @@ class HSMRepositoryImpl(
                 }
             }
         }
+        throw UnsupportedOperationException() // unreachable
     }
 
     private fun findHSMAssociationEntity(

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
@@ -12,13 +12,11 @@ import net.corda.orm.utils.use
 import net.corda.v5.base.util.EncodingUtils.toHex
 import org.slf4j.LoggerFactory
 import java.lang.IllegalStateException
-import java.lang.UnsupportedOperationException
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.PersistenceException
-import javax.persistence.RollbackException
 import javax.persistence.Tuple
 
 /**

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
@@ -11,11 +11,13 @@ import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
 import net.corda.v5.base.util.EncodingUtils.toHex
 import org.slf4j.LoggerFactory
+import java.lang.IllegalStateException
 import java.lang.UnsupportedOperationException
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
+import javax.persistence.PersistenceException
 import javax.persistence.RollbackException
 import javax.persistence.Tuple
 
@@ -101,45 +103,48 @@ class HSMRepositoryImpl(
         tenantId: String,
         category: String,
         masterKeyPolicy: MasterKeyPolicy
-    ): HSMAssociationInfo {
-        entityManagerFactory.createEntityManager().use {
-            while (true) {
-                try {
-                    return it.transaction { em ->
-                        val association =
-                            findHSMAssociationEntity(em, tenantId)
-                                ?: createAndPersistAssociation(em, tenantId, CryptoConsts.SOFT_HSM_ID, masterKeyPolicy)
+    ): HSMAssociationInfo = entityManagerFactory.createEntityManager().use {
+        try {
+            it.transaction { em ->
+                val association =
+                    findHSMAssociationEntity(em, tenantId)
+                        ?: createAndPersistAssociation(em, tenantId, CryptoConsts.SOFT_HSM_ID, masterKeyPolicy)
 
-                        val tenantAssociation = findTenantAssociation(tenantId, category)
-                        if (tenantAssociation == null) {
-                            val newAssociation = HSMCategoryAssociationEntity(
-                                id = UUID.randomUUID().toString(),
-                                tenantId = tenantId,
-                                category = category,
-                                timestamp = Instant.now(),
-                                hsmAssociation = association,
-                                deprecatedAt = 0
-                            )
-                            em.merge(newAssociation).toHSMAssociation().also {
-                                logger.trace(
-                                    "Stored tenant category association $tenantId $category with wrapping key alias " +
-                                            it.masterKeyAlias
-                                )
-                            }
-                        } else {
-                            logger.trace(
-                                "Reusing tenant category association $tenantId $category with wrapping key alias " +
-                                        tenantAssociation.masterKeyAlias
-                            )
-                            tenantAssociation
-                        }
+                val tenantAssociation = findTenantAssociation(tenantId, category)
+                if (tenantAssociation == null) {
+                    val newAssociation = HSMCategoryAssociationEntity(
+                        id = UUID.randomUUID().toString(),
+                        tenantId = tenantId,
+                        category = category,
+                        timestamp = Instant.now(),
+                        hsmAssociation = association,
+                        deprecatedAt = 0
+                    )
+                    em.merge(newAssociation).toHSMAssociation().also {
+                        logger.trace(
+                            "Stored tenant category association $tenantId $category with wrapping key alias " +
+                                    it.masterKeyAlias
+                        )
                     }
-                } catch (_: RollbackException) {
-                    Thread.sleep(1000)
+                } else {
+                    logger.trace(
+                        "Reusing tenant category association $tenantId $category with wrapping key alias " +
+                                tenantAssociation.masterKeyAlias
+                    )
+                    tenantAssociation
                 }
             }
+        } catch(e: PersistenceException) {
+            // NOTE: this is not great, but we must be able to detect a constraint violation in case
+            //  of a race condition, however, the JPA exception type doesn't give us enough info, so we check
+            //  the hibernate generated message.
+            if (e.message?.contains("ConstraintViolationException") == true) {
+                findTenantAssociation(tenantId, category) ?:
+                throw IllegalStateException("unable to find tenant assocation $tenantId:$category after constraint violation")
+            } else {
+                throw e
+            }
         }
-        throw UnsupportedOperationException() // unreachable
     }
 
     private fun findHSMAssociationEntity(

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
@@ -116,10 +116,12 @@ class HSMRepositoryImpl(
                     deprecatedAt = 0
                 )
                 em.merge(newAssociation).toHSMAssociation().also {
-                    logger.trace("Stored tenant category association $tenantId $category with wrapping key alias ${it.masterKeyAlias}")
+                    logger.trace("Stored tenant category association $tenantId $category with wrapping key alias "+
+                            it.masterKeyAlias)
                 }
             } else {
-                logger.trace("Reusing tenant category association $tenantId $category with wrapping key alias ${tenantAssociation.masterKeyAlias}")
+                logger.trace("Reusing tenant category association $tenantId $category with wrapping key alias "+
+                        tenantAssociation.masterKeyAlias)
                 tenantAssociation
             }
         }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImplTest.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImplTest.kt
@@ -7,7 +7,6 @@ import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -21,6 +20,11 @@ import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
 
 class HSMRepositoryImplTest {
+
+    companion object {
+        @JvmStatic
+        private fun masterKeyPolicies() = listOf(MasterKeyPolicy.UNIQUE, MasterKeyPolicy.SHARED, MasterKeyPolicy.NONE)
+    }
 
     @Test
     fun `findTenantAssociation returns null when there are no results`() {
@@ -86,16 +90,13 @@ class HSMRepositoryImplTest {
     }
 
     @Test
-    fun `createOrLookupCategoryAssociation returns existing master key alias`() {
+    fun `createOrLookupCategoryAssociation returns existing associations`() {
         val entityCap = argumentCaptor<HSMCategoryAssociationEntity>()
 
         val hsmAssociation1 = HSMAssociationEntity("2", "tenant", "hsm", Instant.ofEpochMilli(0), "master_key")
         val hsmCategoryAssociation1 = HSMCategoryAssociationEntity("1", "tenant", "category", hsmAssociation1, Instant.ofEpochMilli(0), 0)
-        //val hsmAssociation2 = HSMAssociationEntity("2", "tenant", "hsm", Instant.ofEpochMilli(0), "master_key")
-        //val hsmCategoryAssociation2 = HSMCategoryAssociationEntity("2", "tenant", "category", hsmAssociation2, Instant.ofEpochMilli(0), 0)
 
-        val et = org.mockito.kotlin.mock<EntityTransaction> {
-        }
+        val et = org.mockito.kotlin.mock<EntityTransaction>()
         val em = org.mockito.kotlin.mock<EntityManager> {
             on { createQuery(any(), eq(HSMAssociationEntity::class.java)) } doAnswer {
                 org.mockito.kotlin.mock {
@@ -123,14 +124,9 @@ class HSMRepositoryImplTest {
         }
     }
 
-    companion object {
-        @JvmStatic
-        private fun masterKeyPolicies() = listOf(MasterKeyPolicy.UNIQUE, MasterKeyPolicy.SHARED, MasterKeyPolicy.NONE)
-    }
-
     @ParameterizedTest
     @MethodSource("masterKeyPolicies")
-    fun `createOrLookupCategoryAssociation returns null master key alias`(masterKeyPolicy: MasterKeyPolicy) {
+    fun `createOrLookupCategoryAssociation creates appropriate associations`(masterKeyPolicy: MasterKeyPolicy) {
         val entityCap = argumentCaptor<HSMCategoryAssociationEntity>()
 
         val et = org.mockito.kotlin.mock<EntityTransaction>()

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImplTest.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImplTest.kt
@@ -8,15 +8,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import java.time.Instant
 import java.util.Collections.emptyList
 import javax.persistence.EntityManager
-import javax.persistence.EntityManagerFactory
 import javax.persistence.EntityTransaction
 
 class HSMRepositoryImplTest {
@@ -89,75 +90,56 @@ class HSMRepositoryImplTest {
     fun associate() {
     }
 
-    @Test
-    fun `createOrLookupCategoryAssociation returns existing associations`() {
-        val entityCap = argumentCaptor<HSMCategoryAssociationEntity>()
-
-        val hsmAssociation1 = HSMAssociationEntity("2", "tenant", "hsm", Instant.ofEpochMilli(0), "master_key")
-        val hsmCategoryAssociation1 = HSMCategoryAssociationEntity("1", "tenant", "category", hsmAssociation1, Instant.ofEpochMilli(0), 0)
-
-        val et = org.mockito.kotlin.mock<EntityTransaction>()
-        val em = org.mockito.kotlin.mock<EntityManager> {
-            on { createQuery(any(), eq(HSMAssociationEntity::class.java)) } doAnswer {
-                org.mockito.kotlin.mock {
-                    on { setParameter(any<String>(), any()) } doReturn it
-                    on { resultList } doReturn listOf(hsmAssociation1)
-                }
-            }
-            on { createQuery(any(), eq(HSMCategoryAssociationEntity::class.java)) } doAnswer {
-                org.mockito.kotlin.mock {
-                    on { setParameter(any<String>(), any()) } doReturn it
-                    on { resultList } doReturn listOf(hsmCategoryAssociation1)
-                }
-            }
-            on { transaction } doReturn et
-            on { merge(entityCap.capture()) } doAnswer { entityCap.lastValue }
-        }
-        HSMRepositoryImpl(
-            org.mockito.kotlin.mock {
-                on { createEntityManager() } doReturn em
-            }
-        ).use {
-            val association = it.createOrLookupCategoryAssociation("tenant", "hsm", MasterKeyPolicy.SHARED)
-            assertThat(entityCap.allValues.size).isEqualTo(0)
-            assertThat(association.masterKeyAlias).isEqualTo("master_key")
-        }
+    @ParameterizedTest
+    @MethodSource("masterKeyPolicies")
+    fun `createOrLookupCategoryAssociation returns existing associations`(masterKeyPolicy: MasterKeyPolicy) {
+        val (entityCap, repo) = makeMockedInstance(true)
+        val association = repo.createOrLookupCategoryAssociation("tenant", "hsm", masterKeyPolicy)
+        assertThat(entityCap.allValues.size).isEqualTo(0)
+        assertThat(association.masterKeyAlias).isEqualTo("master_key")
     }
 
     @ParameterizedTest
     @MethodSource("masterKeyPolicies")
     fun `createOrLookupCategoryAssociation creates appropriate associations`(masterKeyPolicy: MasterKeyPolicy) {
+        val (entityCap, repo) = makeMockedInstance(false)
+        val association = repo.createOrLookupCategoryAssociation("tenant", "hsm", masterKeyPolicy)
+        assertThat(entityCap.allValues.size).isEqualTo(1)
+        when (masterKeyPolicy) {
+            MasterKeyPolicy.UNIQUE -> assertThat(association.masterKeyAlias).isNotNull()
+            MasterKeyPolicy.SHARED, MasterKeyPolicy.NONE-> assertThat(association.masterKeyAlias).isNull()
+        }
+    }
+
+    private fun makeMockedInstance(associationsExist: Boolean): Pair<KArgumentCaptor<HSMCategoryAssociationEntity>, HSMRepositoryImpl> {
         val entityCap = argumentCaptor<HSMCategoryAssociationEntity>()
 
-        val et = org.mockito.kotlin.mock<EntityTransaction>()
-        val em = org.mockito.kotlin.mock<EntityManager> {
+        val hsmAssociation1 = HSMAssociationEntity("2", "tenant", "hsm", Instant.ofEpochMilli(0), "master_key")
+        val hsmCategoryAssociation1 =
+            HSMCategoryAssociationEntity("1", "tenant", "category", hsmAssociation1, Instant.ofEpochMilli(0), 0)
+
+        val et = mock<EntityTransaction>()
+        val em = mock<EntityManager> {
             on { createQuery(any(), eq(HSMAssociationEntity::class.java)) } doAnswer {
-                org.mockito.kotlin.mock {
+                mock {
                     on { setParameter(any<String>(), any()) } doReturn it
-                    on { resultList } doReturn listOf<HSMAssociationEntity>()
+                    on { resultList } doReturn (if (associationsExist) listOf(hsmAssociation1)  else listOf())
                 }
             }
             on { createQuery(any(), eq(HSMCategoryAssociationEntity::class.java)) } doAnswer {
-                org.mockito.kotlin.mock {
+                mock {
                     on { setParameter(any<String>(), any()) } doReturn it
-                    on { resultList } doReturn listOf<HSMCategoryAssociationEntity>()
+                    on { resultList } doReturn (if (associationsExist) listOf(hsmCategoryAssociation1) else listOf())
                 }
             }
-
             on { transaction } doReturn et
             on { merge(entityCap.capture()) } doAnswer { entityCap.lastValue }
         }
-        HSMRepositoryImpl(
-            org.mockito.kotlin.mock {
+        val repo = HSMRepositoryImpl(
+            mock {
                 on { createEntityManager() } doReturn em
             }
-        ).use {
-            val association = it.createOrLookupCategoryAssociation("tenant", "hsm", masterKeyPolicy)
-            assertThat(entityCap.allValues.size).isEqualTo(1)
-            when (masterKeyPolicy) {
-                MasterKeyPolicy.UNIQUE -> assertThat(association.masterKeyAlias).isNotNull()
-                MasterKeyPolicy.SHARED, MasterKeyPolicy.NONE-> assertThat(association.masterKeyAlias).isNull()
-            }
-        }
+        )
+        return Pair(entityCap, repo)
     }
 }


### PR DESCRIPTION
We have seen `TenantInfoService.populate` fail with a constraint violation, which is probably a race. The DB operation involves up to two reads and two writes, across two tables, so do it under a transaction and handle the constraint violation.