### PR TITLE
CORE-18015 Fixed HTTP RPC message key header

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessagingClientFactoryFactoryImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessagingClientFactoryFactoryImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.messaging.mediator.factory
 
 import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messagebus.api.producer.builder.CordaProducerBuilder
 import net.corda.messaging.api.mediator.factory.MessagingClientFactoryFactory
@@ -16,7 +17,9 @@ class MessagingClientFactoryFactoryImpl @Activate constructor(
     @Reference(service = CordaProducerBuilder::class)
     private val cordaProducerBuilder: CordaProducerBuilder,
     @Reference(service = CordaAvroSerializationFactory::class)
-    private val cordaSerializationFactory: CordaAvroSerializationFactory
+    private val cordaSerializationFactory: CordaAvroSerializationFactory,
+    @Reference(service = PlatformDigestService::class)
+    private val platformDigestService: PlatformDigestService
 ): MessagingClientFactoryFactory {
     override fun createMessageBusClientFactory(
         id: String,
@@ -31,6 +34,7 @@ class MessagingClientFactoryFactoryImpl @Activate constructor(
         id: String
     ) = RPCClientFactory(
         id,
-        cordaSerializationFactory
+        cordaSerializationFactory,
+        platformDigestService
     )
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/RPCClientFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/RPCClientFactory.kt
@@ -3,6 +3,7 @@ package net.corda.messaging.mediator.factory
 import java.net.http.HttpClient
 import java.time.Duration
 import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.messaging.api.mediator.MessagingClient
 import net.corda.messaging.api.mediator.config.MessagingClientConfig
 import net.corda.messaging.api.mediator.factory.MessagingClientFactory
@@ -10,7 +11,8 @@ import net.corda.messaging.mediator.RPCClient
 
 class RPCClientFactory(
     private val id: String,
-    private val cordaSerializationFactory: CordaAvroSerializationFactory
+    private val cordaSerializationFactory: CordaAvroSerializationFactory,
+    private val platformDigestService: PlatformDigestService
 ): MessagingClientFactory {
     private val httpClient: HttpClient by lazy {
         HttpClient.newBuilder()
@@ -22,6 +24,7 @@ class RPCClientFactory(
         return RPCClient(
             id,
             cordaSerializationFactory,
+            platformDigestService,
             config.onSerializationError,
             httpClient
         )

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/RPCClientTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/RPCClientTest.kt
@@ -1,17 +1,16 @@
 package net.corda.messaging.mediator
 
-import java.io.IOException
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
+import net.corda.crypto.cipher.suite.PlatformDigestService
+import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.flow.event.FlowEvent
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
+import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_KEY
 import net.corda.messaging.api.records.Record
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -25,28 +24,38 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.io.IOException
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 class RPCClientTest {
 
     private lateinit var client: RPCClient
+    private val secureHash = SecureHashImpl("alg", "abc".toByteArray())
     private val payload = "testPayload".toByteArray()
     private val message = MediatorMessage(
         payload,
-        mutableMapOf(MSG_PROP_ENDPOINT to "http://test-endpoint/api/5.1/test")
+        mutableMapOf(
+            MSG_PROP_ENDPOINT to "http://test-endpoint/api/5.1/test",
+            MSG_PROP_KEY to "test"
+        )
     )
 
     data class Mocks(
         val serializer: CordaAvroSerializer<Any>,
         val deserializer: CordaAvroDeserializer<Any>,
         val httpClient: HttpClient,
-        val httpResponse: HttpResponse<ByteArray>
+        val httpResponse: HttpResponse<ByteArray>,
+        val digestService: PlatformDigestService
     )
 
     private inner class MockEnvironment(
         val mockSerializer: CordaAvroSerializer<Any> = mock(),
         val mockDeserializer: CordaAvroDeserializer<Any> = mock(),
         val mockHttpClient: HttpClient = mock(),
-        val mockHttpResponse: HttpResponse<ByteArray> = mock()
+        val mockHttpResponse: HttpResponse<ByteArray> = mock(),
+        val mockDigestService: PlatformDigestService = mock()
     ) {
         init {
             whenever(mockSerializer.serialize(any<Record<*, *>>()))
@@ -63,6 +72,8 @@ class RPCClientTest {
 
             whenever(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<*>>()))
                 .thenReturn(mockHttpResponse)
+
+            whenever(mockDigestService.hash(any<ByteArray>(), any())).thenReturn(secureHash)
         }
 
         fun setResponse(bytes: ByteArray) = apply {
@@ -75,7 +86,7 @@ class RPCClientTest {
         }
 
         val mocks: Mocks
-            get() = Mocks(mockSerializer, mockDeserializer, mockHttpClient, mockHttpResponse)
+            get() = Mocks(mockSerializer, mockDeserializer, mockHttpClient, mockHttpResponse, mockDigestService)
     }
 
 
@@ -94,6 +105,7 @@ class RPCClientTest {
         return RPCClient(
             "TestRPCClient1",
             mockSerializationFactory,
+            mocks.digestService,
             onSerializationError,
             mocks.httpClient
         )

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MessagingClientFactoryFactoryTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MessagingClientFactoryFactoryTest.kt
@@ -1,6 +1,7 @@
 package net.corda.messaging.mediator.factory
 
 import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.crypto.cipher.suite.PlatformDigestService
 import net.corda.libs.configuration.SmartConfig
 import net.corda.messagebus.api.producer.builder.CordaProducerBuilder
 import org.junit.jupiter.api.Assertions
@@ -12,13 +13,15 @@ class MessagingClientFactoryFactoryTest {
     private lateinit var messagingClientFactoryFactory: MessagingClientFactoryFactoryImpl
     private val cordaProducerBuilder = mock<CordaProducerBuilder>()
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory>()
+    private val platformDigestService = mock<PlatformDigestService>()
     private val messageBusConfig = mock<SmartConfig>()
 
     @BeforeEach
     fun beforeEach() {
         messagingClientFactoryFactory = MessagingClientFactoryFactoryImpl(
             cordaProducerBuilder,
-            cordaAvroSerializationFactory
+            cordaAvroSerializationFactory,
+            platformDigestService
         )
     }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/RPCClientFactoryTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/RPCClientFactoryTest.kt
@@ -16,7 +16,8 @@ class RPCClientFactoryTest {
         cordaSerializationFactory = mock(CordaAvroSerializationFactory::class.java)
         rpcClientFactory = RPCClientFactory(
             "RPCClient1",
-            mock(CordaAvroSerializationFactory::class.java)
+            mock(),
+            mock()
         )
     }
 


### PR DESCRIPTION
 Fixed issue where byte array message keys were not added to the outgoing HTTP RPC request header correctly.