### PR TITLE
CORE-17953: Fix Helm Service Internal Selector

### DIFF
--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -110,6 +110,8 @@ metadata:
 spec:
   type: ClusterIP
   selector:
+    app.kubernetes.io/name: {{ include "corda.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/component: {{ include "corda.workerComponent" $worker }}
   ports:
       - protocol: TCP


### PR DESCRIPTION
Update internal service definition so that all labels uniquely
identifying a worker within a deployment ("app.kubernetes.io/name",
"app.kubernetes.io/instance" and "app.kubernetes.io/component") are
used when selecting pods for the service endpoint slice. Since multiple
Corda instances can be deployed within a single Kubernetes namespace,
failing to configure the internal service so it only references workers
from within its own deployment causes HTTP requests to be wrongly
routed to workers in other deployments.
