### PR TITLE
CORE-18025 Tactical fix for uniqueness checker state errors

### DIFF
--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
@@ -311,7 +311,7 @@ class JPABackingStoreImplIntegrationTests {
 
             UniquenessAssertions.assertContainingTxId(txnDetails, txIds.single())
             UniquenessAssertions.assertInputStateConflictResult(
-                txnDetails.entries.single().value.result, txId, consumingTxId, 1, testClock
+                txnDetails.entries.single().value.result, txId, consumingTxId, 0, testClock
             )
         }
 

--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
@@ -280,6 +280,42 @@ class JPABackingStoreImplIntegrationTests {
         }
 
         @Test
+        // Temporary test for tactical fix delivered in CORE-18025. Should be removed / replaced when
+        // CORE-17155 (strategic fix) is implemented.
+        fun `Persisting rejected transaction with multiple input state conflicts only stores first failure`() {
+            val txId = SecureHashUtils.randomSecureHash()
+            val txIds = listOf(txId)
+            val consumingTxId = SecureHashUtils.randomSecureHash()
+            val txns = listOf(
+                Pair(
+                    generateRequestInternal(txId), UniquenessCheckResultFailureImpl(
+                        testClock.instant(), UniquenessCheckErrorInputStateConflictImpl(
+                            List(2) {
+                                UniquenessCheckStateDetailsImpl(
+                                    UniquenessCheckStateRefImpl(txId, it), consumingTxId
+                                )
+                            }
+                        )
+                    )
+                )
+            )
+
+            backingStoreImpl.session(notaryVNodeIdentity) { session ->
+                session.executeTransaction { _, txnOps -> txnOps.commitTransactions(txns) }
+            }
+
+            val txnDetails = mutableMapOf<SecureHash, UniquenessCheckTransactionDetailsInternal>()
+            backingStoreImpl.session(notaryVNodeIdentity) { session ->
+                txnDetails.putAll(session.getTransactionDetails(txIds))
+            }
+
+            UniquenessAssertions.assertContainingTxId(txnDetails, txIds.single())
+            UniquenessAssertions.assertInputStateConflictResult(
+                txnDetails.entries.single().value.result, txId, consumingTxId, 1, testClock
+            )
+        }
+
+        @Test
         fun `Persisting rejected transaction due to reference state conflict succeeds`() {
             val txId = SecureHashUtils.randomSecureHash()
             val txIds = listOf(txId)

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
@@ -285,33 +285,45 @@ class BatchedUniquenessCheckerImpl(
 
                     val result = when {
                         // Unknown input state -> Immediate failure
-                        unknownInputStates.isNotEmpty() ->
+                        unknownInputStates.isNotEmpty() -> {
+                            log.info("Request for transaction ${request.txId} failed due to unknown " +
+                                    "input states $unknownInputStates")
                             handleRejectedRequest(
                                 request,
                                 UniquenessCheckErrorInputStateUnknownImpl(unknownInputStates)
                             )
+                        }
                         // Unknown reference state -> Immediate failure
-                        unknownReferenceStates.isNotEmpty() ->
+                        unknownReferenceStates.isNotEmpty() -> {
+                            log.info("Request for transaction ${request.txId} failed due to unknown " +
+                                    "reference states $unknownReferenceStates")
                             handleRejectedRequest(
                                 request,
                                 UniquenessCheckErrorReferenceStateUnknownImpl(unknownReferenceStates)
                             )
+                        }
                         // Input state conflict check
-                        inputStateConflicts.isNotEmpty() ->
+                        inputStateConflicts.isNotEmpty() -> {
+                            log.info("Request for transaction ${request.txId} failed due to conflicting " +
+                                    "input states $inputStateConflicts")
                             handleRejectedRequest(
                                 request,
                                 UniquenessCheckErrorInputStateConflictImpl(
                                     inputStateConflicts.map { stateDetailsCache[it]!! }
                                 )
                             )
+                        }
                         // Reference state conflict check
-                        referenceStateConflicts.isNotEmpty() ->
+                        referenceStateConflicts.isNotEmpty() -> {
+                            log.info("Request for transaction ${request.txId} failed due to conflicting " +
+                                    "reference states $referenceStateConflicts")
                             handleRejectedRequest(
                                 request,
                                 UniquenessCheckErrorReferenceStateConflictImpl(
                                     referenceStateConflicts.map { stateDetailsCache[it]!! }
                                 )
                             )
+                        }
                         // Time window check
                         !isTimeWindowValid(
                             timeWindowEvaluationTime,

--- a/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckErrorsImpl.kt
+++ b/libs/uniqueness/common/src/main/kotlin/net/corda/uniqueness/datamodel/impl/UniquenessCheckErrorsImpl.kt
@@ -12,28 +12,35 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
 import java.time.Instant
 import java.util.Collections.unmodifiableList
 
+// NOTE: All state based errors are currently capped to only return the details of the first state,
+// since the size of each one in the DB is large and more than one conflicting state exceeds the
+// 1024 storage limit. This will be fixed properly by CORE-17155
 data class UniquenessCheckErrorInputStateConflictImpl(
     private val conflictingStates: List<UniquenessCheckStateDetails>
 ) : UniquenessCheckErrorInputStateConflict {
-    override fun getConflictingStates() = conflictingStates
+    override fun getConflictingStates() : List<UniquenessCheckStateDetails> =
+        unmodifiableList(listOf(conflictingStates.first()))
 }
 
 data class UniquenessCheckErrorInputStateUnknownImpl(
     private val unknownStates: List<UniquenessCheckStateRef>
 ) : UniquenessCheckErrorInputStateUnknown {
-    override fun getUnknownStates() = unknownStates
+    override fun getUnknownStates() : List<UniquenessCheckStateRef> =
+        unmodifiableList(listOf(unknownStates.first()))
 }
 
 data class UniquenessCheckErrorReferenceStateConflictImpl(
     private val conflictingStates: List<UniquenessCheckStateDetails>
 ) : UniquenessCheckErrorReferenceStateConflict {
-    override fun getConflictingStates(): List<UniquenessCheckStateDetails> = unmodifiableList(conflictingStates)
+    override fun getConflictingStates(): List<UniquenessCheckStateDetails> =
+        unmodifiableList(listOf(conflictingStates.first()))
 }
 
 data class UniquenessCheckErrorReferenceStateUnknownImpl(
     private val unknownStates: List<UniquenessCheckStateRef>
 ) : UniquenessCheckErrorReferenceStateUnknown {
-    override fun getUnknownStates(): List<UniquenessCheckStateRef> = unmodifiableList(unknownStates)
+    override fun getUnknownStates(): List<UniquenessCheckStateRef> =
+        unmodifiableList(listOf(unknownStates.first()))
 }
 
 data class UniquenessCheckErrorTimeWindowOutOfBoundsImpl(

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -11,6 +11,7 @@ import net.corda.uniqueness.datamodel.impl.UniquenessCheckErrorReferenceStateUnk
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckErrorUnhandledExceptionImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultFailureImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultSuccessImpl
+import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateRefImpl
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.uniqueness.model.UniquenessCheckError
@@ -136,14 +137,17 @@ class NonValidatingNotaryServerFlowImplTest {
 
     @Test
     fun `Non-validating notary plugin server should respond with error if the uniqueness check fails`() {
-        createAndCallServer(mockErrorUniquenessClientService(UniquenessCheckErrorReferenceStateUnknownImpl(emptyList()))) {
-            assertThat(responseFromServer).hasSize(1)
+        val unknownStateRef = UniquenessCheckStateRefImpl(randomSecureHash(), 0)
 
+        createAndCallServer(mockErrorUniquenessClientService(
+            UniquenessCheckErrorReferenceStateUnknownImpl(listOf(unknownStateRef)))) {
+
+            assertThat(responseFromServer).hasSize(1)
             val responseError = responseFromServer.first().error
             assertThat(responseError).isNotNull
             assertThat(responseFromServer.first().signatures).isEmpty()
             assertThat(responseError).isInstanceOf(NotaryExceptionReferenceStateUnknown::class.java)
-            assertThat((responseError as NotaryExceptionReferenceStateUnknown).unknownStates).isEmpty()
+            assertThat((responseError as NotaryExceptionReferenceStateUnknown).unknownStates).containsExactly(unknownStateRef)
         }
     }
 

--- a/testing/uniqueness/uniqueness-utilities/src/main/kotlin/net/corda/uniqueness/utils/UniquenessAssertions.kt
+++ b/testing/uniqueness/uniqueness-utilities/src/main/kotlin/net/corda/uniqueness/utils/UniquenessAssertions.kt
@@ -69,7 +69,10 @@ object UniquenessAssertions {
     ) {
         getResultOfType<UniquenessCheckResultInputStateUnknownAvro>(response).run {
             assertThat(unknownStates)
-                .containsExactlyInAnyOrder(*expectedUnknownStates.toTypedArray())
+                // This is necessary due to tactical fix CORE-18025 only storing a single failing
+                // state. This should be restored to containsExactlyInAnyOrder when strategic fix
+                // CORE-17155 is implemented.
+                .containsAnyOf(*expectedUnknownStates.toTypedArray())
         }
     }
 
@@ -83,7 +86,10 @@ object UniquenessAssertions {
     ) {
         getResultOfType<UniquenessCheckResultInputStateConflictAvro>(response).run {
             assertThat(conflictingStates)
-                .containsExactlyInAnyOrder(*expectedConflictingStates.toTypedArray())
+                // This is necessary due to tactical fix CORE-18025 only storing a single failing
+                // state. This should be restored to containsExactlyInAnyOrder when strategic fix
+                // CORE-17155 is implemented.
+                .containsAnyOf(*expectedConflictingStates.toTypedArray())
         }
     }
 
@@ -97,7 +103,10 @@ object UniquenessAssertions {
     ) {
         getResultOfType<UniquenessCheckResultReferenceStateUnknownAvro>(response).run {
             assertThat(unknownStates)
-                .containsExactlyInAnyOrder(*expectedUnknownStates.toTypedArray())
+                // This is necessary due to tactical fix CORE-18025 only storing a single failing
+                // state. This should be restored to containsExactlyInAnyOrder when strategic fix
+                // CORE-17155 is implemented.
+                .containsAnyOf(*expectedUnknownStates.toTypedArray())
         }
     }
 
@@ -111,7 +120,10 @@ object UniquenessAssertions {
     ) {
         getResultOfType<UniquenessCheckResultReferenceStateConflictAvro>(response).run {
             assertThat(conflictingStates)
-                .containsExactlyInAnyOrder(*expectedConflictingStates.toTypedArray())
+                // This is necessary due to tactical fix CORE-18025 only storing a single failing
+                // state. This should be restored to containsExactlyInAnyOrder when strategic fix
+                // CORE-17155 is implemented.
+                .containsAnyOf(*expectedConflictingStates.toTypedArray())
         }
     }
 


### PR DESCRIPTION
### Summary

The uniqueness checker stores full error message details in the database to guarantee idempotency so that on replay of a request, the exact original error message can be returned to the client. The underlying database field is capped at 1024 bytes, and will throw an exception if this is exceeded as a failsafe mechanism.

State reference based errors are currently unbounded in size, as the capture each state that is unknown or in conflict. Further, these states are currently encoded inefficiently, which means we can currently only store details of a single conflicting state before hitting this issue.

This PR provides a tactical fix to this issue by limiting these errors to the first conflicting / unknown state that caused the error. The full set of states are written to the uniqueness processor log, so these can be interrogated by a notary operator for further information.

A strategic solution will follow this change in a later release (CORE-17155), looking at better encoding of the error message and subsequently increasing the number of states that can be reported.

### Testing

The common uniqueness assertion test library has been modified to check that only one of the conflicting states is present in any uniqueness checker state based error. This should be reverted when the strategic fix is made. Also added a new test case to prove only a single error is returned when multiple conflicting states exist in a single transaction.