### PR TITLE
CORE-16149 Add inbound session timeout metric

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManager.kt
@@ -15,8 +15,8 @@ internal interface SessionManager : LifecycleWithDominoTile {
     fun processSessionMessage(message: LinkInMessage): LinkOutMessage?
     fun inboundSessionEstablished(sessionId: String)
     fun messageAcknowledged(sessionId: String)
-    fun sessionMessageReceived(sessionId: String)
-    fun dataMessageReceived(sessionId: String)
+    fun sessionMessageReceived(sessionId: String, source: HoldingIdentity, destination: HoldingIdentity?)
+    fun dataMessageReceived(sessionId: String, source: HoldingIdentity, destination: HoldingIdentity)
 
     fun recordsForSessionEstablished(
         session: Session,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManager.kt
@@ -15,7 +15,6 @@ internal interface SessionManager : LifecycleWithDominoTile {
     fun processSessionMessage(message: LinkInMessage): LinkOutMessage?
     fun inboundSessionEstablished(sessionId: String)
     fun messageAcknowledged(sessionId: String)
-    fun sessionMessageReceived(sessionId: String, source: HoldingIdentity, destination: HoldingIdentity?)
     fun dataMessageReceived(sessionId: String, source: HoldingIdentity, destination: HoldingIdentity)
 
     fun recordsForSessionEstablished(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -339,7 +339,7 @@ internal class SessionManagerImpl(
         }
     }
 
-    override fun sessionMessageReceived(sessionId: String, source: HoldingIdentity, destination: HoldingIdentity?) {
+    fun sessionMessageReceived(sessionId: String, source: HoldingIdentity, destination: HoldingIdentity?) {
         dominoTile.withLifecycleLock {
             heartbeatManager.sessionMessageReceived(sessionId, source, destination)
         }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -1181,7 +1181,7 @@ internal class SessionManagerImpl(
                 )
                 destroyOutboundSession(counterparties, sessionId)
                 trackedOutboundSessions.remove(sessionId)
-                recordSessionTimeoutMetric(counterparties.ourId, counterparties.counterpartyId)
+                recordOutboundSessionTimeoutMetric(counterparties.ourId, counterparties.counterpartyId)
             } else {
                 executorService.schedule(
                     { outboundSessionTimeout(counterparties, sessionId) },
@@ -1202,6 +1202,7 @@ internal class SessionManagerImpl(
                 )
                 destroyInboundSession(sessionId)
                 trackedInboundSessions.remove(sessionId)
+                recordInboundSessionTimeoutMetric()
             } else {
                 executorService.schedule(
                     { inboundSessionTimeout(sessionId) },
@@ -1286,12 +1287,16 @@ internal class SessionManagerImpl(
             return clock.instant().toEpochMilli()
         }
 
-        private fun recordSessionTimeoutMetric(source: HoldingIdentity, destination: HoldingIdentity) {
+        private fun recordOutboundSessionTimeoutMetric(source: HoldingIdentity, destination: HoldingIdentity) {
             CordaMetrics.Metric.OutboundSessionTimeoutCount.builder()
                 .withTag(CordaMetrics.Tag.SourceVirtualNode, source.x500Name.toString())
                 .withTag(CordaMetrics.Tag.DestinationVirtualNode, destination.x500Name.toString())
                 .withTag(CordaMetrics.Tag.MembershipGroup, source.groupId)
                 .build().increment()
+        }
+
+        private fun recordInboundSessionTimeoutMetric() {
+            CordaMetrics.Metric.InboundSessionTimeoutCount.builder().build().increment()
         }
     }
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -96,6 +96,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
+import net.corda.metrics.CordaMetrics.NOT_APPLICABLE_TAG_VALUE
 import net.corda.p2p.crypto.protocol.api.InvalidSelectedModeError
 import net.corda.p2p.crypto.protocol.api.NoCommonModeError
 import net.corda.p2p.linkmanager.sessions.SessionManagerWarnings.badGroupPolicy
@@ -1300,7 +1301,7 @@ internal class SessionManagerImpl(
         private fun recordInboundSessionTimeoutMetric(source: HoldingIdentity, destination: HoldingIdentity?) {
             CordaMetrics.Metric.InboundSessionTimeoutCount.builder()
                 .withTag(CordaMetrics.Tag.SourceVirtualNode, source.x500Name.toString())
-                .withTag(CordaMetrics.Tag.DestinationVirtualNode, destination?.x500Name?.toString() ?: "not_available")
+                .withTag(CordaMetrics.Tag.DestinationVirtualNode, destination?.x500Name?.toString() ?: NOT_APPLICABLE_TAG_VALUE)
                 .withTag(CordaMetrics.Tag.MembershipGroup, source.groupId)
                 .build().increment()
         }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
@@ -202,7 +202,7 @@ class InboundMessageProcessorTest {
                 }
                 false
             }
-            verify(sessionManager).dataMessageReceived(SESSION_ID)
+            verify(sessionManager).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -240,7 +240,7 @@ class InboundMessageProcessorTest {
                     value.marker is LinkManagerReceivedMarker && value.timestamp == 1000000L
             }
             verify(sessionManager).messageAcknowledged(SESSION_ID)
-            verify(sessionManager, never()).dataMessageReceived(SESSION_ID)
+            verify(sessionManager, never()).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -271,7 +271,7 @@ class InboundMessageProcessorTest {
 
             assertThat(records).hasSize(0)
             verify(sessionManager).messageAcknowledged(SESSION_ID)
-            verify(sessionManager, never()).dataMessageReceived(SESSION_ID)
+            verify(sessionManager, never()).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -302,7 +302,7 @@ class InboundMessageProcessorTest {
             assertThat(loggingInterceptor.errors).allSatisfy {
                 assertThat(it).matches("Could not deserialize message for session Session.* The message was discarded\\.")
             }
-            verify(sessionManager, never()).dataMessageReceived(SESSION_ID)
+            verify(sessionManager, never()).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -339,7 +339,7 @@ class InboundMessageProcessorTest {
                 .anySatisfy {
                     assertThat(it).matches("Could not deserialize message for session Session\\..* Cannot resolve schema for fingerprint.*")
                 }
-            verify(sessionManager).dataMessageReceived(SESSION_ID)
+            verify(sessionManager).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -375,7 +375,7 @@ class InboundMessageProcessorTest {
             assertThat(loggingInterceptor.warnings)
                 .hasSize(1)
                 .contains("Received message with SessionId = Session for which there is no active session. The message was discarded.")
-            verify(sessionManager, never()).dataMessageReceived(SESSION_ID)
+            verify(sessionManager, never()).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -404,7 +404,7 @@ class InboundMessageProcessorTest {
 
             assertThat(records).isEmpty()
             verify(networkMessagingValidator).invokeIfValidInbound<Unit>(eq(myIdentity), eq(remoteIdentity), any())
-            verify(sessionManager).dataMessageReceived(SESSION_ID)
+            verify(sessionManager).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -434,7 +434,7 @@ class InboundMessageProcessorTest {
             assertThat(records).isEmpty()
             verify(sessionManager, never()).messageAcknowledged(any())
             verify(networkMessagingValidator).invokeIfValidInbound<Unit>(eq(myIdentity), eq(remoteIdentity), any())
-            verify(sessionManager, never()).dataMessageReceived(SESSION_ID)
+            verify(sessionManager, never()).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
     }
 
@@ -507,7 +507,7 @@ class InboundMessageProcessorTest {
                 false
             }
             verify(sessionManager).inboundSessionEstablished(anyOrNull())
-            verify(sessionManager).dataMessageReceived(SESSION_ID)
+            verify(sessionManager).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -568,7 +568,7 @@ class InboundMessageProcessorTest {
                             " which indicates a spoofing attempt! The message was discarded\\."
                     )
                 }
-            verify(sessionManager).dataMessageReceived(SESSION_ID)
+            verify(sessionManager).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -629,7 +629,7 @@ class InboundMessageProcessorTest {
                             " which indicates a spoofing attempt! The message was discarded"
                     )
                 }
-            verify(sessionManager).dataMessageReceived(SESSION_ID)
+            verify(sessionManager).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -681,7 +681,7 @@ class InboundMessageProcessorTest {
                 }
                 false
             }
-            verify(sessionManager).dataMessageReceived(SESSION_ID)
+            verify(sessionManager).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -712,7 +712,7 @@ class InboundMessageProcessorTest {
             assertThat(records).isEmpty()
             verify(sessionManager, never()).inboundSessionEstablished(anyOrNull())
             verify(networkMessagingValidator).invokeIfValidInbound<Unit>(eq(myIdentity), eq(remoteIdentity), any())
-            verify(sessionManager).dataMessageReceived(SESSION_ID)
+            verify(sessionManager).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
 
         @Test
@@ -744,7 +744,7 @@ class InboundMessageProcessorTest {
             verify(sessionManager, never()).inboundSessionEstablished(anyOrNull())
             verify(sessionManager, never()).messageAcknowledged(any())
             verify(networkMessagingValidator).invokeIfValidInbound<Unit>(eq(myIdentity), eq(remoteIdentity), any())
-            verify(sessionManager, never()).dataMessageReceived(SESSION_ID)
+            verify(sessionManager, never()).dataMessageReceived(eq(SESSION_ID), any(), any())
         }
     }
 
@@ -762,7 +762,6 @@ class InboundMessageProcessorTest {
             )
 
             verify(sessionManager).processSessionMessage(message)
-            verify(sessionManager, never()).sessionMessageReceived(any())
         }
         @Test
         fun `ResponderHandshakeMessage calls to processSessionMessage`() {
@@ -776,7 +775,6 @@ class InboundMessageProcessorTest {
             )
 
             verify(sessionManager).processSessionMessage(message)
-            verify(sessionManager, never()).sessionMessageReceived(any())
         }
         @Test
         fun `InitiatorHandshakeMessage calls to processSessionMessage`() {
@@ -863,7 +861,6 @@ class InboundMessageProcessorTest {
                     "No partitions from topic link.in are currently assigned to the inbound message processor. " +
                             "Not going to reply to session initiation for session Session."
                 )
-            verify(sessionManager).sessionMessageReceived(SESSION_ID)
         }
         @Test
         fun `InitiatorHelloMessage responses from sessionManager with partitions will produce records to the correct topics`() {
@@ -889,7 +886,6 @@ class InboundMessageProcessorTest {
                 assertThat(it.key).isSameAs(SESSION_ID)
                 assertThat(it.value).isEqualTo(SessionPartitions(listOf(4, 5, 8)))
             }
-            verify(sessionManager).sessionMessageReceived(SESSION_ID)
         }
     }
 

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -208,6 +208,11 @@ object CordaMetrics {
         object OutboundSessionTimeoutCount : Metric<Counter>("p2p.session.outbound.timeout", Metrics::counter)
 
         /**
+         * Number of inbound peer-to-peer sessions that timed out (indicating communication issues with peers).
+         */
+        object InboundSessionTimeoutCount : Metric<Counter>("p2p.session.inbound.timeout", Metrics::counter)
+
+        /**
          * Number of outbound peer-to-peer sessions.
          */
         class OutboundSessionCount(computation: Supplier<Number>): ComputedValue<Nothing>("p2p.session.outbound", computation)


### PR DESCRIPTION
Add additional metric to capture the rate of inbound session timeouts.

_**NOTE: This currently targets the 5.1 branch but the change will not be merged to that branch. Waiting for the 5.2 branch but this can be reviewed against 5.1 in the meantime.**_ 