### PR TITLE
CORE-18031 Allow the flow mapper to send OUTBOUND messages when in state ERROR & CLOSING

### DIFF
--- a/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
+++ b/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/executor/SessionEventExecutor.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.mapper.impl.executor
 
 import net.corda.data.ExceptionEnvelope
+import net.corda.data.flow.event.MessageDirection
 import net.corda.data.flow.event.SessionEvent
 import net.corda.data.flow.event.session.SessionCounterpartyInfoRequest
 import net.corda.data.flow.event.session.SessionData
@@ -91,9 +92,15 @@ class SessionEventExecutor(
                 FlowMapperResult(null, listOf())
             }
             FlowMapperStateType.CLOSING, FlowMapperStateType.ERROR -> {
-                log.warn("Attempted to process a message ${sessionEvent.messageDirection} but flow mapper state is " +
-                        "in ${flowMapperState.status}. Session ID: ${sessionEvent.sessionId}. Ignoring Event")
-                FlowMapperResult(flowMapperState, listOf())
+                if (sessionEvent.messageDirection == MessageDirection.OUTBOUND) {
+                    //with the new topic topology changes, the session close/error can arrive to the mapper after the cleanup message
+                    val outputRecord = recordFactory.forwardEvent(sessionEvent, instant, flowConfig, flowMapperState.flowId)
+                    FlowMapperResult(flowMapperState, listOf(outputRecord))
+                } else {
+                    log.info("Attempted to process a message ${sessionEvent.messageDirection} but flow mapper state is " +
+                            "in ${flowMapperState.status}. Session ID: ${sessionEvent.sessionId}. Ignoring Event")
+                    FlowMapperResult(flowMapperState, listOf())
+                }
             }
             FlowMapperStateType.OPEN -> {
                 val outputRecord = recordFactory.forwardEvent(sessionEvent, instant, flowConfig, flowMapperState.flowId)


### PR DESCRIPTION
Final SessionClose/SessionError can potentially be blocked if the ScheduleCleanup message is processed first by the flow mapper