### PR TITLE
DA5-8 Prerequisites for Serialize Merkle Proof - test base

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/signatureproof/SignatureProofTests.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/signatureproof/SignatureProofTests.kt
@@ -46,7 +46,7 @@ class SignatureProofTests : UtxoLedgerWithBatchSignerTest() {
 
     @Test
     fun `sign() produces a signature without proof`() {
-        val signatures = singingService.sign(signedTransaction, listOf(publicKeyExample))
+        val signatures = signingService.sign(signedTransaction, listOf(publicKeyExample))
         assertEquals(1, signatures.size)
         val signature: DigitalSignatureAndMetadata = signatures.first()
         assertNull(signature.proof)
@@ -54,7 +54,7 @@ class SignatureProofTests : UtxoLedgerWithBatchSignerTest() {
 
     @Test
     fun `signBatch() produces a signature with proof`() {
-        val batchSignatures = singingService.signBatch(listOf(signedTransaction), listOf(publicKeyExample))
+        val batchSignatures = signingService.signBatch(listOf(signedTransaction), listOf(publicKeyExample))
         assertEquals(1, batchSignatures.size)
         val batch: List<DigitalSignatureAndMetadata> = batchSignatures.first()
         assertEquals(1, batch.size)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/signatureproof/SignatureProofTests.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/signatureproof/SignatureProofTests.kt
@@ -1,0 +1,64 @@
+package net.corda.ledger.utxo.flow.impl.transaction.signatureproof
+
+import net.corda.ledger.common.testkit.anotherPublicKeyExample
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderImpl
+import net.corda.ledger.utxo.test.UtxoLedgerWithBatchSignerTest
+import net.corda.ledger.utxo.testkit.UtxoCommandExample
+import net.corda.ledger.utxo.testkit.getUtxoStateExample
+import net.corda.ledger.utxo.testkit.utxoTimeWindowExample
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.membership.NotaryInfo
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+class SignatureProofTests : UtxoLedgerWithBatchSignerTest() {
+    companion object {
+        private lateinit var signedTransaction: UtxoSignedTransactionInternal
+        private val notaryX500Name = MemberX500Name.parse("O=ExampleNotaryService, L=London, C=GB")
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        val notaryInfo = mock<NotaryInfo>().also {
+            whenever(it.name).thenReturn(notaryX500Name)
+            whenever(it.publicKey).thenReturn(publicKeyExample)
+        }
+        whenever(mockNotaryLookup.lookup(notaryX500Name)).thenReturn(notaryInfo)
+        signedTransaction = UtxoTransactionBuilderImpl(
+            utxoSignedTransactionFactory,
+            mockNotaryLookup
+        )
+            .setNotary(notaryX500Name)
+            .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
+            .addOutputState(getUtxoStateExample())
+            .addSignatories(listOf(anotherPublicKeyExample))
+            .addCommand(UtxoCommandExample())
+            .toSignedTransaction() as UtxoSignedTransactionInternal
+    }
+
+    @Test
+    fun `sign() produces a signature without proof`() {
+        val signatures = singingService.sign(signedTransaction, listOf(publicKeyExample))
+        assertEquals(1, signatures.size)
+        val signature: DigitalSignatureAndMetadata = signatures.first()
+        assertNull(signature.proof)
+    }
+
+    @Test
+    fun `signBatch() produces a signature with proof`() {
+        val batchSignatures = singingService.signBatch(listOf(signedTransaction), listOf(publicKeyExample))
+        assertEquals(1, batchSignatures.size)
+        val batch: List<DigitalSignatureAndMetadata> = batchSignatures.first()
+        assertEquals(1, batch.size)
+        val signature: DigitalSignatureAndMetadata = batch.first()
+        assertNotNull(signature.proof)
+    }
+}

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PublicKeyExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PublicKeyExample.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.common.testkit
 
+import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.PublicKey
 import java.security.spec.ECGenParameterSpec
@@ -7,8 +8,9 @@ import java.security.spec.ECGenParameterSpec
 private val kpg = KeyPairGenerator.getInstance("EC")
     .apply { initialize(ECGenParameterSpec("secp256r1")) }
 
-val publicKeyExample: PublicKey = kpg
-    .generateKeyPair().public
+val keyPairExample: KeyPair = kpg.generateKeyPair()
+
+val publicKeyExample: PublicKey = keyPairExample.public
 
 val anotherPublicKeyExample: PublicKey = kpg
     .generateKeyPair().public

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerWithBatchSignerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerWithBatchSignerTest.kt
@@ -23,14 +23,14 @@ import java.security.PrivateKey
 import java.security.Signature
 
 /**
- * Extension of [UtxoLedgerTest] base class with [singingService] service. The service can sign a batch of transactions
+ * Extension of [UtxoLedgerTest] base class with [signingService] service. The service can sign a batch of transactions
  * (including size 1). This allows to have a proof [net.corda.v5.crypto.merkle.MerkleProof] inside the signature
  * [DigitalSignatureAndMetadata].
  * The signing uses [net.corda.crypto.cipher.suite.SignatureSpecs.ECDSA_SHA256] algorithm.
  */
 abstract class UtxoLedgerWithBatchSignerTest : UtxoLedgerTest() {
 
-    val singingService = TransactionSignatureServiceImpl(
+    val signingService = TransactionSignatureServiceImpl(
         serializationServiceWithWireTx,
         signingService = mock<SigningService>().also {
             whenever(it.findMySigningKeys(any())).thenReturn(mapOf(publicKeyExample to publicKeyExample))

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerWithBatchSignerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerWithBatchSignerTest.kt
@@ -1,0 +1,74 @@
+package net.corda.ledger.utxo.test
+
+import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
+import net.corda.crypto.cipher.suite.SignatureSpecs
+import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.core.fullIdHash
+import net.corda.crypto.merkle.impl.MerkleTreeProviderImpl
+import net.corda.flow.application.crypto.SignatureSpecServiceImpl
+import net.corda.ledger.common.flow.impl.transaction.TransactionSignatureServiceImpl
+import net.corda.ledger.common.flow.transaction.TransactionSignatureVerificationServiceInternal
+import net.corda.ledger.common.testkit.FakePlatformInfoProvider
+import net.corda.ledger.common.testkit.keyPairExample
+import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.crypto.SigningService
+import net.corda.v5.application.flows.FlowContextProperties
+import net.corda.v5.application.flows.FlowContextPropertyKeys
+import net.corda.v5.application.flows.FlowEngine
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.security.PrivateKey
+import java.security.Signature
+
+/**
+ * Extension of [UtxoLedgerTest] base class with [singingService] service. The service can sign a batch of transactions
+ * (including size 1). This allows to have a proof [net.corda.v5.crypto.merkle.MerkleProof] inside the signature
+ * [DigitalSignatureAndMetadata].
+ * The signing uses [net.corda.crypto.cipher.suite.SignatureSpecs.ECDSA_SHA256] algorithm.
+ */
+abstract class UtxoLedgerWithBatchSignerTest : UtxoLedgerTest() {
+
+    val singingService = TransactionSignatureServiceImpl(
+        serializationServiceWithWireTx,
+        signingService = mock<SigningService>().also {
+            whenever(it.findMySigningKeys(any())).thenReturn(mapOf(publicKeyExample to publicKeyExample))
+            whenever(
+                it.sign(any(), any(), any())
+            ).thenAnswer {
+                val signableData = it.arguments.first() as ByteArray
+                DigitalSignatureWithKeyId(
+                    publicKeyExample.fullIdHash(),
+                    signData(signableData, keyPairExample.private)
+                )
+            }
+        },
+        signatureSpecService = SignatureSpecServiceImpl(CipherSchemeMetadataImpl()),
+        merkleTreeProvider = MerkleTreeProviderImpl(digestService),
+        platformInfoProvider = FakePlatformInfoProvider(),
+        flowEngine = mock<FlowEngine>().also {
+            whenever(it.flowContextProperties).thenReturn(object : FlowContextProperties {
+                override fun put(key: String, value: String) {
+                    throw NotImplementedError("Not envisioned to be invoked in tests.")
+                }
+
+                override fun get(key: String): String =
+                    when (key) {
+                        FlowContextPropertyKeys.CPI_NAME -> "Cordapp1"
+                        FlowContextPropertyKeys.CPI_VERSION -> "1"
+                        FlowContextPropertyKeys.CPI_SIGNER_SUMMARY_HASH -> "hash1234"
+                        else -> "1213213213" //FlowContextPropertyKeys.CPI_FILE_CHECKSUM
+                    }
+            })
+        },
+        transactionSignatureVerificationServiceInternal = mock<TransactionSignatureVerificationServiceInternal>()
+    )
+
+    private fun signData(data: ByteArray, privateKey: PrivateKey): ByteArray {
+        val signature = Signature.getInstance(SignatureSpecs.ECDSA_SHA256.signatureName)
+        signature.initSign(privateKey)
+        signature.update(data)
+        return signature.sign()
+    }
+}


### PR DESCRIPTION
Test signature proof generation by a notary. Add ability for UtxoLedgerTest to sign a batch transaction in order to generate Merkle Tree Proof. The existing UtxoLedgerTest had hardcoded signatures without calling singing service (or a mock), and there was never a proof produced (as not needed so far).