### PR TITLE
CORE-18041 Event mediator doesn't properly detect intermittent exception

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -21,6 +21,7 @@ import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
 import java.lang.Thread.sleep
 import java.util.UUID
+import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 @Suppress("LongParameterList")
@@ -145,7 +146,8 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
                 processEvents()
                 keepProcessing = false
             } catch (exception: Exception) {
-                when (exception) {
+                val cause = if (exception is CompletionException) exception.cause else exception
+                when (cause) {
                     is CordaMessageAPIIntermittentException -> {
                         attempts++
                         handleProcessEventRetries(attempts, exception)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
@@ -2,9 +2,11 @@ package net.corda.messaging.mediator
 
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializer
+import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
+import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorConsumer
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient
@@ -20,26 +22,32 @@ import net.corda.messaging.api.mediator.factory.MessagingClientFactory
 import net.corda.messaging.api.mediator.factory.MessagingClientFinder
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
+import net.corda.schema.configuration.MessagingConfig
 import net.corda.taskmanager.TaskManager
 import net.corda.test.util.waitWhile
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.atLeast
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 
 class MultiSourceEventMediatorImplTest {
     companion object {
         private const val TEST_TIMEOUT_SECONDS = 20L
+        private const val TEST_PROCESSOR_RETRIES = 3
         const val KEY1 = "key1"
         const val KEY2 = "key2"
     }
 
+    private val messagingConfig = mock<SmartConfig>()
     private lateinit var config: EventMediatorConfig<Any, Any, Any>
     private lateinit var mediator: MultiSourceEventMediator<Any, Any, Any>
     private val mediatorConsumerFactory = mock<MediatorConsumerFactory>()
@@ -89,20 +97,30 @@ class MultiSourceEventMediatorImplTest {
 
         whenever(stateSerializer.serialize(any())).thenAnswer { ByteArray(0) }
 
-        whenever(taskManager.executeLongRunningTask (any<() -> Any>())).thenAnswer { invocation ->
-            val command = invocation.getArgument<() -> Any>(1)
+        whenever(taskManager.executeLongRunningTask(any<() -> Any>())).thenAnswer { invocation ->
+            val command = invocation.getArgument<() -> Any>(0)
+            CompletableFuture.supplyAsync(command)
+        }
+
+        whenever(taskManager.executeShortRunningTask(any<() -> Any>())).thenAnswer { invocation ->
+            val command = invocation.getArgument<() -> Any>(0)
             CompletableFuture.supplyAsync(command)
         }
 
         whenever(lifecycleCoordinatorFactory.createCoordinator(any(), anyOrNull())).thenReturn(mock())
 
+        whenever(messagingConfig.getInt(eq(MessagingConfig.Subscription.PROCESSOR_RETRIES))).thenReturn(TEST_PROCESSOR_RETRIES)
+
         config = EventMediatorConfigBuilder<Any, Any, Any>()
             .name("Test")
-            .messagingConfig(mock())
+            .messagingConfig(messagingConfig)
             .consumerFactories(mediatorConsumerFactory)
             .clientFactories(messagingClientFactory)
             .messageProcessor(messageProcessor)
             .messageRouterFactory(messageRouterFactory)
+            .threads(1)
+            .threadName("mediator-thread")
+            .stateManager(stateManager)
             .build()
 
         mediator = MultiSourceEventMediatorImpl(
@@ -131,10 +149,10 @@ class MultiSourceEventMediatorImplTest {
                 cordaConsumerRecords(KEY1, events[5]),
             ),
         )
-        var batchNumber = 0
+        val batchNumber = AtomicInteger(0)
         whenever(consumer.poll(any())).thenAnswer {
-            if (batchNumber < eventBatches.size) {
-                eventBatches[batchNumber++]
+            if (batchNumber.get() < eventBatches.size) {
+                eventBatches[batchNumber.getAndIncrement()]
             } else {
                 Thread.sleep(10)
                 emptyList()
@@ -142,7 +160,7 @@ class MultiSourceEventMediatorImplTest {
         }
 
         mediator.start()
-        waitWhile(Duration.ofSeconds(TEST_TIMEOUT_SECONDS)) { batchNumber < eventBatches.size }
+        waitWhile(Duration.ofSeconds(TEST_TIMEOUT_SECONDS)) { batchNumber.get() < eventBatches.size }
         mediator.close()
 
         verify(mediatorConsumerFactory).create(any<MediatorConsumerConfig<Any, Any>>())
@@ -154,6 +172,40 @@ class MultiSourceEventMediatorImplTest {
         verify(consumer, atLeast(eventBatches.size)).poll(any())
         verify(consumer, times(eventBatches.size)).syncCommitOffsets()
         verify(messagingClient, times(events.size)).send(any())
+    }
+
+    @Test
+    fun `mediator retries after intermittent exceptions`() {
+        val event1 = cordaConsumerRecords(KEY1, "event1")
+        val sendCount = AtomicInteger(0)
+        val errorsCount = TEST_PROCESSOR_RETRIES + 1
+        val expectedProcessingCount = errorsCount + 1
+        whenever(consumer.poll(any())).thenAnswer {
+            if (sendCount.get() < expectedProcessingCount) {
+                listOf(event1)
+            } else {
+                Thread.sleep(10)
+                emptyList()
+            }
+        }
+
+        whenever(messagingClient.send(any())).thenAnswer {
+            if (sendCount.getAndIncrement() < errorsCount) {
+                throw CordaMessageAPIIntermittentException("IntermittentException")
+            }
+            null
+        }
+
+        mediator.start()
+        waitWhile(Duration.ofSeconds(TEST_TIMEOUT_SECONDS)) { sendCount.get() < expectedProcessingCount }
+        mediator.close()
+
+        verify(mediatorConsumerFactory, times(2)).create(any<MediatorConsumerConfig<Any, Any>>())
+        verify(messagingClientFactory, times(2)).create(any<MessagingClientConfig>())
+        verify(messageRouterFactory, times(2)).create(any<MessagingClientFinder>())
+        verify(messageProcessor, times(expectedProcessingCount)).onNext(anyOrNull(), any())
+        verify(consumer, atLeast(expectedProcessingCount)).poll(any())
+        verify(messagingClient, times(expectedProcessingCount)).send(any())
     }
 
     private fun cordaConsumerRecords(key: String, event: String) =


### PR DESCRIPTION
Using cause of CompletionException exception when checking for intermittent/fatal exception in event mediator.