### PR TITLE
CORE-18003 Validate connection URLs are unique on dynamic member registration

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/verifiers/P2pEndpointVerifier.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/verifiers/P2pEndpointVerifier.kt
@@ -18,9 +18,11 @@ internal class P2pEndpointVerifier(
             require(isNotEmpty()) { "No endpoint protocol was provided." }
             require(orderVerifier.isOrdered(this, 2)) { "Provided endpoint protocols are incorrectly numbered." }
         }
-        urlEntries.map { it.value }.forEach {
+        val urls = urlEntries.map { it.value }
+        urls.forEach {
             verifyP2pUrl(it)
         }
+        verifyUniqueUrls(urls)
     }
 
     private fun verifyP2pUrl(url: String) {
@@ -34,5 +36,17 @@ internal class P2pEndpointVerifier(
         require(uri.host != null) { "The host of the endpoint URL ('$url') was not specified or had an invalid value." }
         require(uri.port > 0) { "The port of the endpoint URL ('$url') was not specified or had an invalid value." }
         require(uri.userInfo == null) { "Endpoint URL ('$url') had user info specified, which must not be specified." }
+    }
+
+    private fun verifyUniqueUrls(urls: List<String>) {
+        val nonUniqueUrls = urls.map { URI.create(it) }
+            .groupingBy { it }
+            .eachCount()
+            .filter { it.value > 1 }
+            .keys
+
+        require(nonUniqueUrls.isEmpty()) {
+            "Duplicate connection URLs found: $nonUniqueUrls"
+        }
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/verifiers/P2pEndpointVerifierTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/verifiers/P2pEndpointVerifierTest.kt
@@ -173,4 +173,28 @@ class P2pEndpointVerifierTest {
          .hasMessageContaining("Endpoint URL ('https://username:password@www.corda.net:8888') " +
                  "had user info specified, which must not be specified.")
     }
+
+    @Test
+    fun `duplicate URLs will fail validation`() {
+        val url1 = "https://www.r3.com:8080"
+        val url2 = "https://www.corda.net:8888"
+
+        val context = mapOf(
+            "corda.endpoints.0.connectionURL" to url1,
+            "corda.endpoints.0.protocolVersion" to "1",
+            "corda.endpoints.1.connectionURL" to url1,
+            "corda.endpoints.1.protocolVersion" to "1",
+            "corda.endpoints.2.connectionURL" to url2,
+            "corda.endpoints.2.protocolVersion" to "1",
+            "corda.endpoints.3.connectionURL" to url2,
+            "corda.endpoints.3.protocolVersion" to "1",
+        )
+
+        assertThatThrownBy {
+            p2pEndpointVerifier.verifyContext(context)
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Duplicate connection URLs found")
+            .hasMessageContaining(url1)
+            .hasMessageContaining(url2)
+    }
 }


### PR DESCRIPTION
Added additional client side validation during dynamic network registration which checks for duplicate URLs submitted in the registration context.

Registration API response after submitting duplicate URLs:
```json
{ 
    "registrationId":"561a5f7e-e3d8-43a0-be4a-a6b3f8b202ab",
    "registrationSent":"2023-10-27T15:39:23.651Z",
    "registrationUpdated":"2023-10-27T15:39:23.810Z",
    "registrationStatus":"INVALID",
    "memberInfoSubmitted": {
        "data": {
            "registrationProtocolVersion":"1",
            "corda.session.keys.0.id":"7E6196D0C5C5",
            "corda.session.keys.0.signature.spec":"SHA256withECDSA",
            "corda.endpoints.0.connectionURL":"https://localhost:8080",
            "corda.endpoints.0.protocolVersion":"1",
            "corda.ledger.keys.0.id":"69408DDD4BEF",
            "corda.ledger.keys.0.signature.spec":"SHA256withECDSA",
            "corda.endpoints.1.connectionURL":"https://www.corda.net:8888",
            "corda.endpoints.1.protocolVersion":"1",
            "corda.endpoints.2.connectionURL":"https://www.corda.net:8888",
            "corda.endpoints.2.protocolVersion":"1"
        }
    },
    "reason":"Registration failed. The registration context is invalid: Duplicate connection URLs found: [https://www.corda.net:8888]",
    "serial":null
}
```