### PR TITLE
CORE-18057: avoid compiler internal error

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt
@@ -413,10 +413,13 @@ class SandboxGroupContextServiceImpl @Activate constructor(
         missingCpks.isEmpty()
     }
 
+    override fun close() = shutdown()
+
     @Deactivate
-    override fun close() = lock.withLock {
+    fun shutdown() = lock.withLock {
         cache.close()
     }
+
 
     /**
      * An [AutoCloseable] associated with an injectable service, i.e. one which


### PR DESCRIPTION
Sometimes, inconsistently, we find this compiler error:

org.jetbrains.kotlin.util.KotlinFrontEndException: Exception while analyzing expression in (411,5) in /Users/dickon.reed/src/corda-runtime-os/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextServiceImpl.kt .
