### PR TITLE
(Proof of Concept) Uniqueness backing store optimisations

### DIFF
--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImplIntegrationTests.kt
@@ -609,8 +609,8 @@ class JPABackingStoreImplIntegrationTests {
                 assertThat(exceptions)
                     .hasSize(numExecutors)
                     .containsOnlyOnce(null)
-                assertThat(exceptions.filterNotNull().map { it.message })
-                    .containsOnly("No states were consumed, this might be an in-flight double spend")
+                assertThat(exceptions.filterNotNull().map { it.message?.subSequence(0, 32) })
+                    .containsOnly("Unable to consume all state refs")
             }
         }
 

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntities.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntities.kt
@@ -95,7 +95,11 @@ internal class UniquenessTxAlgoIdKey(
         name = "UniquenessStateDetailEntity.consumeWithProtection",
         query = "UPDATE UniquenessStateDetailEntity SET " +
             "consumingTxIdAlgo = :consumingTxAlgo, consumingTxId = :consumingTxId " +
-            "WHERE issueTxIdAlgo = :issueTxAlgo AND issueTxId = :issueTxId AND issueTxOutputIndex = :stateIndex " +
+             // FIXME: Encode needs to be "cast(issueTxId as string) in HSQLDB. Might need to switch
+             // on DB type similar to C4 backing store selection.
+             // Note: hex returns lower-case, but Corda uses upper when converting to string, so we
+             // convert to match
+            "WHERE concat(issueTxIdAlgo, ':', upper(encode(issueTxId, 'hex')), ':', cast(issueTxOutputIndex as string)) IN :stateRefs " +
             "AND consumingTxId IS NULL" // In-flight double spend protection
     )
 )

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntities.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreEntities.kt
@@ -83,7 +83,7 @@ internal class UniquenessTxAlgoIdKey(
 
 @Entity
 @Table(name = "uniqueness_state_details")
-
+@Suppress("ForbiddenComment")
 // TODO this query needs refining because this way records are retrieved one-by-one which is extremely slow
 @NamedQueries(
     NamedQuery(

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -381,7 +381,9 @@ open class JPABackingStoreImpl @Activate constructor(
                             result.toCharacterRepresentation()
                         )
                     )
+                }
 
+                transactionDetails.forEach { (request, result) ->
                     if (result is UniquenessCheckResultFailure) {
                         entityManager.persist(
                             UniquenessRejectedTransactionEntity(

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -9,7 +9,6 @@ import net.corda.db.schema.CordaDb
 import net.corda.metrics.CordaMetrics
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.uniqueness.backingstore.BackingStore
-import net.corda.uniqueness.datamodel.common.UniquenessConstants.HIBERNATE_JDBC_BATCH_SIZE
 import net.corda.uniqueness.datamodel.common.UniquenessConstants.RESULT_ACCEPTED_REPRESENTATION
 import net.corda.uniqueness.datamodel.common.UniquenessConstants.RESULT_REJECTED_REPRESENTATION
 import net.corda.uniqueness.datamodel.common.toCharacterRepresentation

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -80,8 +80,6 @@ open class JPABackingStoreImpl @Activate constructor(
         )
 
         val entityManager = entityManagerFactory.createEntityManager()
-        // Enable Hibernate JDBC batch and set the batch size on a per-session basis.
-        entityManager.unwrap(Session::class.java).jdbcBatchSize = HIBERNATE_JDBC_BATCH_SIZE
 
         @Suppress("TooGenericExceptionCaught")
         try {

--- a/libs/db/db-orm-impl/src/main/kotlin/net/corda/orm/impl/EntityManagerFactoryFactoryImpl.kt
+++ b/libs/db/db-orm-impl/src/main/kotlin/net/corda/orm/impl/EntityManagerFactoryFactoryImpl.kt
@@ -84,6 +84,8 @@ class EntityManagerFactoryFactoryImpl(
             // TODO - statistics integration isn't working in OSGi.
             // https://r3-cev.atlassian.net/browse/CORE-7168
             //"hibernate.generate_statistics" to true.toString(),
+            AvailableSettings.STATEMENT_BATCH_SIZE to "50",
+            AvailableSettings.ORDER_INSERTS to "true",
             "javax.persistence.validation.mode" to "none"
         ).toProperties()
         props[AvailableSettings.CLASSLOADERS] = classLoaders


### PR DESCRIPTION
***DO NOT MERGE*** *- this is a proof of concept PR, the changes should be reviewed, limitations addressed, and be thoroughly tested before merging*

This PR makes the following changes to the uniqueness checker backing store implementation to improve performance:

### Rejected transaction write performance

This is achieved by re-ordering the record writes so that all transaction records in a batch are written before the error details records, which greatly improves the ability to batch writes. Two approaches to this are possible; ad33ec9fe05529b60275340614607928689a0fe2 tackles this programmatically by using two loops. 3eea6b4e07c3798d9b960a101f161f0619bcb869 achieves the same thing through Hibernate configuration.

Only one of these two approaches needs to be applied. If using the Hibernate config approach, further work will be needed to allow configuration to be specified when instantiating an Entity Manager Factory (the POC simply hardcodes values that will apply to all databases, which may not be suitable outside of uniqueness)

### State consumption write performance

(Implemented by 22e0c0665203c4203286089062c3a3a2d7b3c711)

This is achieved by modifying the named query such that it can use an `IN` expression by concatenating the components of a state ref together into a string. This allows one query to be performed for all states consumed by a single transaction. Multiple queries will still be performed for each transaction that is consuming states in a batch, therefore the benefits of this change will be limited to transactions consuming multiple states.

Note that currently this optimisation only works with Postgres. Slightly different syntax is needed for HSQLDB, so a production solution will likely need to specialise the implementation of this function by implementing subclasses of `JPABackingStore`.

### (Not implemented) Rejected transaction read performance

It is possible to implement a similar batching approach used for rejected transaction write performance to multi-load all transaction errors in one batch, rather than one at a time. However, the added complexity of doing this did not seem justified given that this scenario should be relatively rare - it would only apply if a client node replayed a previously rejected transaction.

### Results

Tests were conducted by running the following command in `corda-runtime-os`:

`./gradlew :components:uniqueness:backing-store-impl:backingStoreBenchmark -PpostgresPort=5432 -PbsBenchNumOpsPerIteration=50 -PbsBenchNumIterations=1000 -i`
 
50 operations per iteration was picked as this matches the current maximum JDBC batch size used by the uniqueness checker. This was performed 5 times for both a baseline build of 5.1, and the changes made by this PR added. An average was taken, excluding any outliers:

![image](https://github.com/corda/corda-runtime-os/assets/4272763/cbd7fa2b-4587-4f79-aaa3-c2adee0a40d8)

(Note the absolute results shown above are meaningless; only relative performance is relevant)

**In summary:** the changes show around a **9x improvement in rejected transaction write performance** and **5x improvement in consumed state write performance**.