### PR TITLE
CORE-18071 Quasar ignore net.corda.ledger.common.data.transaction package

### DIFF
--- a/libs/ledger/ledger-common-data/build.gradle
+++ b/libs/ledger/ledger-common-data/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
+    compileOnly "co.paralleluniverse:quasar-osgi-annotations:$quasarVersion"
+
     implementation 'net.corda:corda-ledger-common'
 
     implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"

--- a/libs/ledger/ledger-common-data/src/main/java/net/corda/ledger/common/data/transaction/package-info.java
+++ b/libs/ledger/ledger-common-data/src/main/java/net/corda/ledger/common/data/transaction/package-info.java
@@ -1,4 +1,6 @@
 @Export
+@QuasarIgnoreAllPackages
 package net.corda.ledger.common.data.transaction;
 
+import co.paralleluniverse.quasar.annotations.QuasarIgnoreAllPackages;
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
This fix is related to a bug that came up recently. We've been getting `Cannot read field "merkleTreeProvider" because  "$this" is null` errors in flow worker logs.