### PR TITLE
CORE-18080 Fix CI pipeline for CLI plugin smoke tests

### DIFF
--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -94,7 +94,7 @@ pipeline {
                 REST_TLS_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/tls/rest/rest_worker.pfx"
                 VM_PARAMETERS = "-Dco.paralleluniverse.fibers.verifyInstrumentation=true"
                 LOG4J_PARAMETERS = "-Dlog4j.configurationFile=log4j2-console.xml"
-                PROGRAM_PARAMETERS = "--instance-id=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -ddatabase.user=u${postgresDb} -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://${postgresHost}:${postgresPort}/${postgresDb} -ddatabase.jdbc.directory=${JDBC_PATH} -rtls.keystore.path=${REST_TLS_PATH} -rtls.keystore.password=mySecretPassword --serviceEndpoint=endpoints.crypto=localhost:7004 --serviceEndpoint=endpoints.verification=localhost:7004 --serviceEndpoint=endpoints.uniqueness=localhost:7004 --serviceEndpoint=endpoints.persistence=localhost:7004"
+                PROGRAM_PARAMETERS = "--instance-id=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -ddatabase.user=u${postgresDb} -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://${postgresHost}:${postgresPort}/${postgresDb} -ddatabase.jdbc.directory=${JDBC_PATH} -rtls.keystore.path=${REST_TLS_PATH} -rtls.keystore.password=mySecretPassword --serviceEndpoint=endpoints.crypto=localhost:7004 --serviceEndpoint=endpoints.verification=localhost:7004 --serviceEndpoint=endpoints.uniqueness=localhost:7004 --serviceEndpoint=endpoints.persistence=localhost:7004 --serviceEndpoint=endpoints.tokenSelection=localhost:7004"
                 WORKING_DIRECTORY = "${env.WORKSPACE}"
             }
             steps {


### PR DESCRIPTION
Fixes the broken CI pipeline for CLI plugin smoke tests by updating the Combined Worker startup parameters.

Pipeline [URL](https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-combined-worker-plugins-smoke-tests/job/PR-yash%2FCORE-18080/)