### PR TITLE
CORE-18088 Race condition registering RPC endpoints in JavalinServer

### DIFF
--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -10,14 +10,15 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
     implementation project(":osgi-framework-api")
 
-    implementation project(":libs:rest:rest")
     implementation project(":libs:lifecycle:lifecycle")
-    implementation project(":libs:utilities")
+    implementation project(':libs:metrics')
+    implementation project(":libs:rest:rest")
     implementation project(":libs:rest:rest-tools")
     implementation project(':libs:rest:rest-security-read')
     implementation project(':libs:rest:json-serialization')
-    implementation project(':libs:metrics')
     implementation project(':libs:tracing')
+    implementation project(":libs:utilities")
+    implementation project(":libs:web:web-impl")
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-base"

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -16,21 +16,20 @@ import net.corda.rest.server.impl.apigen.processing.RouteInfo
 import net.corda.rest.server.impl.apigen.processing.RouteProvider
 import net.corda.rest.server.impl.apigen.processing.openapi.OpenApiInfoProvider
 import net.corda.rest.server.impl.context.ClientHttpRequestContext
-import net.corda.rest.server.impl.security.RestAuthenticationProvider
-import net.corda.rest.server.impl.security.provider.credentials.DefaultCredentialResolver
 import net.corda.rest.server.impl.context.ContextUtils.authenticate
 import net.corda.rest.server.impl.context.ContextUtils.authorize
 import net.corda.rest.server.impl.context.ContextUtils.contentTypeApplicationJson
 import net.corda.rest.server.impl.context.ContextUtils.invokeHttpMethod
+import net.corda.rest.server.impl.security.RestAuthenticationProvider
+import net.corda.rest.server.impl.security.provider.credentials.DefaultCredentialResolver
 import net.corda.rest.server.impl.websocket.WebSocketCloserService
 import net.corda.rest.server.impl.websocket.mapToWsStatusCode
 import net.corda.tracing.configureJavalinForTracing
-import net.corda.utilities.classload.executeWithThreadContextClassLoader
-import net.corda.utilities.classload.OsgiClassLoader
-import net.corda.utilities.executeWithStdErrSuppressed
 import net.corda.utilities.VisibleForTesting
+import net.corda.utilities.classload.executeWithThreadContextClassLoader
 import net.corda.utilities.debug
 import net.corda.utilities.trace
+import net.corda.web.server.JavalinStarter
 import org.eclipse.jetty.http2.HTTP2Cipher
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.HttpConnectionFactory
@@ -39,14 +38,13 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.ServerConnector
 import org.eclipse.jetty.server.SslConnectionFactory
 import org.eclipse.jetty.util.ssl.SslContextFactory
-import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory
 import org.osgi.framework.Bundle
 import org.osgi.framework.FrameworkUtil
 import org.osgi.framework.wiring.BundleWiring
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
-import javax.servlet.MultipartConfigElement
 import java.util.LinkedList
+import javax.servlet.MultipartConfigElement
 
 @Suppress("TooManyFunctions", "TooGenericExceptionThrown", "LongParameterList")
 internal class RestServerInternal(
@@ -265,41 +263,14 @@ internal class RestServerInternal(
     }
 
     fun start() {
-        val existingSystemErrStream = System.err
-        try {
-            log.trace { "Starting the Javalin server." }
-
-            val bundle = FrameworkUtil.getBundle(WebSocketServletFactory::class.java)
-            if (bundle != null) {
-                val bundleList = listOfNotNull(bundle, getSwaggerUiBundle())
-                val osgiClassLoader = OsgiClassLoader(bundleList)
-                // We need to set thread context classloader at start time as
-                // `org.eclipse.jetty.websocket.servlet.WebSocketServletFactory.Loader.load` relies on it to perform
-                // classloading during `start` method invocation.
-                executeWithThreadContextClassLoader(osgiClassLoader) {
-                    // Required because Javalin prints an error directly to stderr if it cannot find a logging
-                    // implementation via standard class loading mechanism. This mechanism is not appropriate for OSGi.
-                    // The logging implementation is found correctly in practice.
-                    executeWithStdErrSuppressed {
-                        server.start(
-                            configurationsProvider.getHostAndPort().host,
-                            configurationsProvider.getHostAndPort().port
-                        )
-                    }
-                }
-            } else {
-                server.start(configurationsProvider.getHostAndPort().host, configurationsProvider.getHostAndPort().port)
-            }
-            addExceptionHandlers(server)
-            log.trace { "Starting the Javalin server completed." }
-        } catch (e: Exception) {
-            "Error when starting the Javalin server".let {
-                log.error("$it: ${e.message}")
-                throw Exception(it, e)
-            }
-        } finally {
-            System.setErr(existingSystemErrStream)
-        }
+        JavalinStarter.startServer(
+            "REST API",
+            server,
+            configurationsProvider.getHostAndPort().port,
+            configurationsProvider.getHostAndPort().host,
+            getSwaggerUiBundle()?.let { listOf(it) }?: emptyList()
+        )
+        addExceptionHandlers(server)
     }
 
     fun stop() {

--- a/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinServer.kt
+++ b/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinServer.kt
@@ -20,6 +20,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 
 
 @Component(service = [WebServer::class])
@@ -59,7 +60,7 @@ class JavalinServer(
     private var server: Javalin? = null
     private val coordinator = coordinatorFactory.createCoordinator<WebServer> { _, _ -> }
 
-    override val endpoints: MutableSet<Endpoint> = mutableSetOf<Endpoint>()
+    override val endpoints: MutableSet<Endpoint> = ConcurrentHashMap.newKeySet()
 
     override fun start(port: Int) {
         check(null == server) { "The Javalin webserver is already initialized" }

--- a/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinStarter.kt
+++ b/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinStarter.kt
@@ -1,0 +1,83 @@
+package net.corda.web.server
+
+import io.javalin.Javalin
+import net.corda.utilities.classload.OsgiClassLoader
+import net.corda.utilities.classload.executeWithThreadContextClassLoader
+import net.corda.utilities.executeWithStdErrSuppressed
+import net.corda.utilities.trace
+import org.eclipse.jetty.websocket.servlet.WebSocketServletFactory
+import org.osgi.framework.Bundle
+import org.osgi.framework.FrameworkUtil
+import org.slf4j.LoggerFactory
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+object JavalinStarter {
+    // JavalinLogger is shared for all Javalin instances and logs their configuration
+    //  RestServerInternal sets '/META-INF/resources/' which means if another Javalin instance is started
+    //  at the same time, it could be logged by JavalinServer using a different class loader.
+    //  This issue is reported as:
+    //  JavalinException: Static resource directory with path: '/META-INF/resources/' does not exist`
+    //  when another server is started
+    // This helper utility ensures we only start one instance at a time
+    private val logger = LoggerFactory.getLogger(JavalinStarter::class.java)
+    private val serverStartLock = ReentrantLock()
+
+    /**
+     * Start the Javalin server and ensuring only one starts at a time.
+     *
+     * @param name Name of the server (to be used in logging only)
+     * @param server the Javalin server object
+     * @param port the port to start the server on
+     * @param host the host to use (default: localhost)
+     * @param threadLocalClassLoaderBundles any bundles to use in the ThreadLocal class loader
+     */
+    @Suppress("TooGenericExceptionThrown")
+    fun startServer(
+        name: String,
+        server: Javalin,
+        port: Int,
+        host: String? = null,
+        threadLocalClassLoaderBundles: List<Bundle> = emptyList(),
+    ) {
+        serverStartLock.withLock {
+            val existingSystemErrStream = System.err
+            try {
+                logger.trace { "Starting the $name Javalin server." }
+
+                val bundle = FrameworkUtil.getBundle(WebSocketServletFactory::class.java)
+                if (bundle != null) {
+                    val bundleList = threadLocalClassLoaderBundles.plus(bundle)
+                    val osgiClassLoader = OsgiClassLoader(bundleList)
+                    // We need to set thread context classloader at start time as
+                    // `org.eclipse.jetty.websocket.servlet.WebSocketServletFactory.Loader.load` relies on it to perform
+                    // classloading during `start` method invocation.
+                    executeWithThreadContextClassLoader(osgiClassLoader) {
+                        // Required because Javalin prints an error directly to stderr if it cannot find a logging
+                        // implementation via standard class loading mechanism. This mechanism is not appropriate for OSGi.
+                        // The logging implementation is found correctly in practice.
+                        executeWithStdErrSuppressed {
+                            host?.let {
+                                server.start(it, port)
+                                it
+                            }?:server.start(port)
+                        }
+                    }
+                } else {
+                    host?.let {
+                        server.start(it, port)
+                        it
+                    }?:server.start(port)
+                }
+                logger.trace { "Starting the $name Javalin server completed." }
+            } catch (e: Exception) {
+                "Error when starting the $name Javalin server".let {
+                    logger.error("$it: ${e.message}")
+                    throw Exception(it, e)
+                }
+            } finally {
+                System.setErr(existingSystemErrStream)
+            }
+        }
+    }
+}

--- a/libs/web/web-impl/src/test/kotlin/net/corda/web/server/JavalinServerTest.kt
+++ b/libs/web/web-impl/src/test/kotlin/net/corda/web/server/JavalinServerTest.kt
@@ -9,6 +9,8 @@ import net.corda.web.api.HTTPMethod
 import net.corda.web.api.WebHandler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -131,8 +133,8 @@ class JavalinServerTest {
         javalinServer.registerEndpoint(postEndpoint)
 
         assertEquals(2, javalinServer.endpoints.size)
-        assertEquals(getEndpoint, javalinServer.endpoints.elementAt(0))
-        assertEquals(postEndpoint, javalinServer.endpoints.elementAt(1))
+        assertTrue(javalinServer.endpoints.contains(getEndpoint))
+        assertTrue(javalinServer.endpoints.contains(postEndpoint))
     }
 
     @Test
@@ -152,7 +154,8 @@ class JavalinServerTest {
 
         val endpoints = javalinServer.endpoints
         assertEquals(1, endpoints.size)
-        assertEquals(postEndpoint, endpoints.elementAt(0))
+        assertFalse(endpoints.contains(getEndpoint))
+        assertTrue(endpoints.contains(postEndpoint))
     }
 
     @Test
@@ -170,7 +173,8 @@ class JavalinServerTest {
 
         val endpoints = javalinServer.endpoints
         assertEquals(1, endpoints.size)
-        assertEquals(postEndpoint, endpoints.elementAt(0))
+        assertFalse(endpoints.contains(getEndpoint))
+        assertTrue(endpoints.contains(postEndpoint))
     }
 
     @Test
@@ -184,6 +188,7 @@ class JavalinServerTest {
 
         val endpoints = javalinServer.endpoints
         assertEquals(1, endpoints.size)
-        assertEquals(postEndpoint, endpoints.elementAt(0))
+        assertFalse(endpoints.contains(getEndpoint))
+        assertTrue(endpoints.contains(postEndpoint))
     }
 }


### PR DESCRIPTION
Ensuring that JavalinServer is thread-safe by changing the`Set` implementation for registered endpoints in `JavalinServer` to prevent threading issues when multiple clients register endpoint at the same time as well as synchronising Javalin server starts across the process in case of multiple servers.