### PR TITLE
CORE-18099 -  Fix Fiber Cache

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -72,7 +72,17 @@ class FlowFiberCacheImpl @Activate constructor(
     }
 
     override fun get(key: FlowKey, suspendCount: Int): FlowFiber? {
-        return cache.getIfPresent(key)?.takeIf { it.suspendCount == suspendCount }?.fiber
+        val fiber = cache.getIfPresent(key)
+        return if(null == fiber) {
+            logger.info("Fiber not found in cache: ${key.id}")
+            null
+        } else if (fiber.suspendCount == suspendCount) {
+            logger.debug { "Fiber found in cache: ${key.id}" }
+            fiber.fiber
+        } else {
+            logger.info("Fiber found in cache but at wrong suspendCount (${fiber.suspendCount} <-> $suspendCount): ${key.id}")
+            null
+        }
     }
 
     override fun remove(key: FlowKey) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -80,7 +80,7 @@ class FlowFiberCacheImpl @Activate constructor(
             logger.debug { "Fiber found in cache: ${key.id}" }
             fiber.fiber
         } else {
-            logger.info("Fiber found in cache but at wrong suspendCount (${fiber.suspendCount} <-> $suspendCount): ${key.id}")
+            logger.warn("Fiber found in cache but at wrong suspendCount (${fiber.suspendCount} <-> $suspendCount): ${key.id}")
             null
         }
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStage.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowExecutionPipelineStage.kt
@@ -111,10 +111,10 @@ internal class FlowExecutionPipelineStage(
             }
 
             is FlowIORequest.FlowSuspended<*> -> {
+                context.checkpoint.serializedFiber = fiberResult.fiber
                 fiberResult.cacheableFiber?.let {
                     fiberCache.put(context.checkpoint.flowKey, context.checkpoint.suspendCount, it)
                 }
-                context.checkpoint.serializedFiber = fiberResult.fiber
                 context.flowMetrics.flowFiberExitedWithSuspension(
                     flowIORequestTypeConverter.convertToActionName(fiberResult.output)
                 )

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowStateManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowStateManager.kt
@@ -30,7 +30,7 @@ class FlowStateManager(private val initialState: FlowState) {
 
     val holdingIdentity: HoldingIdentity = state.flowStartContext.identity.toCorda()
 
-    val suspendCount: Int = state.suspendCount
+    val suspendCount: Int get() = state.suspendCount
 
     val fiber: ByteBuffer
         get() = state.fiber ?: ByteBuffer.wrap(byteArrayOf())
@@ -42,7 +42,7 @@ class FlowStateManager(private val initialState: FlowState) {
 
     fun updateSuspendedFiber(fiber: ByteBuffer) {
         state.fiber = fiber
-        state.suspendCount++
+        state.suspendCount += 1
     }
 
     fun getSessionState(sessionId: String): SessionState? {


### PR DESCRIPTION
The suspend count in the current implementation of the Fiber cache does not work correctly meaning that all checkpoints end up being deserialised.
This changes fixes this issue by ensuring the suspension count is always updated before the cache is updated, and that the correct suspension count is added to the cache value.