### PR TITLE
CORE-17766: config redaction on arrays

### DIFF
--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/SmartConfigImpl.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/SmartConfigImpl.kt
@@ -32,7 +32,7 @@ class SmartConfigImpl(
 ) : SmartConfig {
     companion object{
         fun empty(): SmartConfig = SmartConfigFactory.createWithoutSecurityServices()
-                .create(ConfigFactory.empty())
+            .create(ConfigFactory.empty())
         private val maskedSecretsLookupService = MaskedSecretsLookupService()
     }
 

--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/SmartConfigImpl.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/SmartConfigImpl.kt
@@ -182,7 +182,8 @@ class SmartConfigImpl(
 
     override fun getObjectList(path: String?): MutableList<out ConfigObject> = typeSafeConfig.getObjectList(path)
 
-    override fun getConfigList(path: String?): MutableList<out Config> = typeSafeConfig.getConfigList(path)
+    override fun getConfigList(path: String?): List<Config> =
+        typeSafeConfig.getConfigList(path).map { SmartConfigImpl(it, factory, secretsLookupService) }
 
     override fun getAnyRefList(path: String?): MutableList<out Any> = typeSafeConfig.getAnyRefList(path)
 

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigTest.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigTest.kt
@@ -342,7 +342,7 @@ class SmartConfigTest {
         val r = smartConfig.getConfigList("test_array")
         assertThat(r.size).isEqualTo(3)
         assertThat(r[0].getInt("prime")).isEqualTo(2)
-        assertThat(r[0]).isInstanceOf(SmartConfig)
+        assertThat(r[0]).isInstanceOf(SmartConfig::class.java)
     }
 
 

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigTest.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigTest.kt
@@ -34,6 +34,8 @@ class SmartConfigTest {
             a: b,
             c: d,
         },
+        test_array: [{prime:2},{prime:3},{prime:5}]
+        test_int_array: [2,3,5]
         """.trimIndent()
     val config = ConfigFactory.parseString(configString).resolve()
 
@@ -315,6 +317,33 @@ class SmartConfigTest {
 
         assertThat(c.getString("jon")).isEqualTo("fallback-secret")
     }
+
+
+    @Test
+    fun `getObjectList works`() {
+        val r = smartConfig.getObjectList("test_array")
+        assertThat(r.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getList works on int array`() {
+        val r = smartConfig.getList("test_int_array")
+        assertThat(r.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getList works on object array`() {
+        val r = smartConfig.getList("test_array")
+        assertThat(r.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getConfigList works on object array`() {
+        val r = smartConfig.getConfigList("test_array")
+        assertThat(r.size).isEqualTo(3)
+        assertThat(r[0].getInt("prime")).isEqualTo(2)
+    }
+
 
     enum class Snack {
         DONUTS,

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigTest.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigTest.kt
@@ -342,6 +342,7 @@ class SmartConfigTest {
         val r = smartConfig.getConfigList("test_array")
         assertThat(r.size).isEqualTo(3)
         assertThat(r[0].getInt("prime")).isEqualTo(2)
+        assertThat(r[0]).isInstanceOf(SmartConfig)
     }
 
 

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceTest.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceTest.kt
@@ -1,6 +1,5 @@
 package net.corda.libs.configuration.secret
 
-import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import net.corda.schema.configuration.ConfigKeys
 import org.assertj.core.api.Assertions.assertThat

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceTest.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceTest.kt
@@ -1,5 +1,6 @@
 package net.corda.libs.configuration.secret
 
+import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import net.corda.schema.configuration.ConfigKeys
 import org.assertj.core.api.Assertions.assertThat
@@ -134,5 +135,16 @@ class EncryptionSecretsServiceTest {
 
         assertThat(secretConfig.getString("configSecret.encryptedSecret")).isNotBlank
         assertThat(service.getValue(secretConfig)).isEqualTo("")
+    }
+
+    @Test
+    fun `well known key`() {
+        val service = EncryptionSecretsServiceImpl("soup", "fish")
+        val config = ConfigFactory.parseString("""
+        configSecret {
+            "encryptedSecret":"iUUaENwGC+z0PnVjvYHIZz3AACs0mUz2OpIjCg4ZKcCImvsdacgdX+gy8xAIkoR8BAW3vJ3aXenUmNJLbWdrdDPXc8EfWSbL",
+        }   
+    """.trimIndent())
+        assertThat( service.getValue(config)).isEqualTo("C8DMac5wpGagNSuruAjY/6wbKOLtVL66QAuaN5emA/I=")
     }
 }

--- a/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelper.kt
+++ b/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelper.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.configuration.validation.impl
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
 import net.corda.libs.configuration.secret.MaskedSecretsLookupService
@@ -37,16 +38,11 @@ class ConfigSecretHelper {
     // and "foo" returns []
     //
     // (except the second half of the pairs are actually JsonNode instances)
-    private fun getFieldValues(node: JsonNode): List<Pair<String, JsonNode>> =
-        if (node.isObject) {
-            node.fields().asSequence().toList().map { it.key to it.value }
-        } else {
-            if (node.isArray) {
-                node.toList().withIndex().map { it.index.toString() to it.value }
-            } else {
-                emptyList()
-            }
-        }
+    private fun getFieldValues(node: JsonNode): List<Pair<String, JsonNode>> = when(node) {
+        is ObjectNode -> node.fields().asSequence().toList().map { it.key to it.value }
+        is ArrayNode -> node.toList().withIndex().map { it.index.toString() to it.value }
+        else -> emptyList()
+    }
 
     private fun hideSecretsRecursive(
         parentNode: JsonNode,

--- a/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelper.kt
+++ b/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelper.kt
@@ -16,8 +16,6 @@ class ConfigSecretHelper {
     private companion object {
         const val TMP_SECRET = MaskedSecretsLookupService.MASK_VALUE
         val TMP_SECRET_NODE: JsonNode = TextNode(TMP_SECRET)
-        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
-
     }
 
     /**
@@ -81,7 +79,6 @@ class ConfigSecretHelper {
         getFieldValues(node).forEach { (name, newNode) ->
             val nodePath = if (nodeName == "") name else "$nodeName.$name"
             val secret = secretsNode[nodePath]
-            logger.info("insertSecretsRecursive node name $name newNode $newNode, secret $secret")
             if (secret != null) {
                 (node as ObjectNode).set<ObjectNode>(name, secret)
             } else {

--- a/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelper.kt
+++ b/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelper.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
 import net.corda.libs.configuration.secret.MaskedSecretsLookupService
 import net.corda.schema.configuration.ConfigKeys
-import org.slf4j.LoggerFactory
 
 /**
  *

--- a/libs/configuration/configuration-validation/src/test/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelperTest.kt
+++ b/libs/configuration/configuration-validation/src/test/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelperTest.kt
@@ -30,6 +30,25 @@ class ConfigSecretHelperTest {
        }
     """.trimIndent()
 
+    private val input2= """
+       {
+            "testString": "hello",
+            "testReference": {
+                "foo": [1, 2, 3.14],
+                "bool": true,
+                "array": [
+                     {
+                        "hidden": {
+                            "configSecret": $passwordsObject
+                        }
+                     },
+                     {"visible":"stuff"}
+                 ]
+           }
+       }
+    """.trimIndent()
+
+
     private val helper = ConfigSecretHelper()
 
     @Test
@@ -45,6 +64,23 @@ class ConfigSecretHelperTest {
         val secretsNode = convertJSONToNode(passwordsObject)!!
 
         assertThat(inputNode["testReference"]["hidden"][ConfigKeys.SECRET_KEY]).isEqualTo(secretsNode)
+        assertThat(inputNode["testString"].textValue()).isEqualTo("hello")
+    }
+
+
+    @Test
+    fun `test secrets including array`() {
+        val inputNode = convertJSONToNode(input2)!!
+        val secrets = helper.hideSecrets(inputNode)
+
+        assertThat(inputNode["testReference"]["array"][0]["hidden"].textValue()).isEqualTo(MaskedSecretsLookupService.MASK_VALUE)
+        assertThat(inputNode["testString"].textValue()).isEqualTo("hello")
+
+        helper.insertSecrets(inputNode, secrets)
+
+        val secretsNode = convertJSONToNode(passwordsObject)!!
+
+        assertThat(inputNode["testReference"]["array"][0]["hidden"][ConfigKeys.SECRET_KEY]).isEqualTo(secretsNode)
         assertThat(inputNode["testString"].textValue()).isEqualTo("hello")
     }
 


### PR DESCRIPTION
Arrange to replace secrets in arrays as well as objects, by pulling out the logic.

Supplement the SmartConfig implementation to implement config lists.

Add some tests.