### PR TITLE
DA5-8 Unit tests for MerkleProof JSON serialization

### DIFF
--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     testImplementation project(':libs:serialization:serialization-kryo')
     testImplementation project(':testing:ledger:ledger-utxo-base-test')
 
+    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project(':testing:sandboxes-testkit')
     integrationTestImplementation project(':libs:messaging:messaging')

--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -60,8 +60,10 @@ dependencies {
     testImplementation project(':libs:serialization:serialization-kryo')
     testImplementation project(':testing:ledger:ledger-utxo-base-test')
 
+    // Dependencies for ProofOfActionSerializationTests:
     testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    testImplementation project(':libs:crypto:merkle-impl')
 
     integrationTestImplementation project(':testing:sandboxes')
     integrationTestImplementation project(':testing:sandboxes-testkit')

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/serialization/DigitalSignatureAndMetadataSerializationTests.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/serialization/DigitalSignatureAndMetadataSerializationTests.kt
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import net.corda.application.impl.services.json.ProofOfActionSerialisationModule
+import net.corda.application.impl.services.json.DigitalSignatureAndMetadataSerialisationModule
 import net.corda.common.json.serializers.standardTypesModule
 import net.corda.crypto.core.parseSecureHash
 import net.corda.crypto.merkle.impl.MerkleProofProviderImpl
@@ -41,7 +41,7 @@ import java.util.*
 import kotlin.test.assertContains
 
 
-class ProofOfActionSerializationTests : UtxoLedgerTest() {
+class DigitalSignatureAndMetadataSerializationTests : UtxoLedgerTest() {
 
     private val signedTransaction: UtxoSignedTransactionInternal =
         UtxoTransactionBuilderImpl(utxoSignedTransactionFactory, mockNotaryLookup)
@@ -77,15 +77,13 @@ class ProofOfActionSerializationTests : UtxoLedgerTest() {
                 setTimeZone(TimeZone.getTimeZone("UTC"))
                 disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 registerModule(standardTypesModule())
-                // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 // Here is a partial System under test (SUT):
                 registerModule(serializersFromJsonMarshallingService)
             }
 
         private val mapper = mapperWithoutProofOfActionModule.copy().apply {
-            // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
             // Here is System under test 'ProofOfActionSerialisationModule.module':
-            registerModule(ProofOfActionSerialisationModule(MerkleProofProviderImpl()).module)
+            registerModule(DigitalSignatureAndMetadataSerialisationModule(MerkleProofProviderImpl()).module)
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/serialization/ProofOfActionSerializationTests.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/serialization/ProofOfActionSerializationTests.kt
@@ -1,0 +1,157 @@
+package net.corda.ledger.utxo.serialization
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import net.corda.application.impl.services.json.ProofOfActionSerialisationModule
+import net.corda.common.json.serializers.standardTypesModule
+import net.corda.crypto.cipher.suite.merkle.MerkleProofProvider
+import net.corda.ledger.common.testkit.anotherPublicKeyExample
+import net.corda.ledger.common.testkit.getSignatureWithMetadataExample
+import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderImpl
+import net.corda.ledger.utxo.test.UtxoLedgerTest
+import net.corda.ledger.utxo.testkit.UtxoCommandExample
+import net.corda.ledger.utxo.testkit.getUtxoStateExample
+import net.corda.ledger.utxo.testkit.utxoTimeWindowExample
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.merkle.IndexedMerkleLeaf
+import net.corda.v5.crypto.merkle.MerkleProof
+import net.corda.v5.crypto.merkle.MerkleProofType
+import net.corda.v5.membership.NotaryInfo
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.security.KeyPairGenerator
+import java.security.spec.ECGenParameterSpec
+import java.util.*
+
+class ProofOfActionSerializationTests : UtxoLedgerTest() {
+
+    companion object {
+
+        private lateinit var signedTransaction: UtxoSignedTransactionInternal
+
+        private val kpg: KeyPairGenerator = KeyPairGenerator.getInstance("EC").apply {
+            initialize(ECGenParameterSpec("secp256r1"))
+        }
+        private val notaryNode1PublicKey = kpg.generateKeyPair().public
+
+        private val notaryX500Name = MemberX500Name.parse("O=ExampleNotaryService, L=London, C=GB")
+        private val notary = notaryX500Name
+
+        private val jsonMapper =
+            JsonMapper.builder().enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build().apply {
+                registerModule(KotlinModule.Builder().build())
+                registerModule(JavaTimeModule())
+                enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+                setTimeZone(TimeZone.getTimeZone("UTC"))
+                disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                registerModule(standardTypesModule())
+                /* !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! */
+                /* Here is System under the test : ProofOfActionSerialisationModule.module */
+                registerModule(ProofOfActionSerialisationModule(object : MerkleProofProvider {
+                    override fun createMerkleProof(
+                        proofType: MerkleProofType,
+                        treeSize: Int,
+                        leaves: List<IndexedMerkleLeaf>,
+                        hashes: List<SecureHash>
+                    ): MerkleProof {
+                        TODO("Not yet implemented")
+                    }
+
+                    override fun createIndexedMerkleLeaf(
+                        index: Int,
+                        nonce: ByteArray?,
+                        leafData: ByteArray
+                    ): IndexedMerkleLeaf {
+                        TODO("Not yet implemented")
+                    }
+                }).module)
+            }
+    }
+
+    @BeforeEach
+    fun beforeEach() {
+        val notaryInfo = mock<NotaryInfo>().also {
+            whenever(it.name).thenReturn(notaryX500Name)
+            whenever(it.publicKey).thenReturn(publicKeyExample)
+        }
+        whenever(mockNotaryLookup.lookup(notaryX500Name)).thenReturn(notaryInfo)
+        signedTransaction = UtxoTransactionBuilderImpl(
+            utxoSignedTransactionFactory,
+            mockNotaryLookup
+        )
+            .setNotary(notary)
+            .setTimeWindowBetween(utxoTimeWindowExample.from, utxoTimeWindowExample.until)
+            .addOutputState(getUtxoStateExample())
+            .addSignatories(listOf(anotherPublicKeyExample))
+            .addCommand(UtxoCommandExample())
+            .toSignedTransaction() as UtxoSignedTransactionInternal
+    }
+
+    @Test
+    fun secureHash() {
+        val by: SecureHash = getSignatureWithMetadataExample(notaryNode1PublicKey).by
+        val json = jsonMapper.writeValueAsString(by)
+        val deserializeObject = jsonMapper.readValue(json, SecureHash::class.java)
+        Assertions.assertEquals(by, deserializeObject)
+    }
+
+    @Test
+    fun digitalSignatureWithKeyId() {
+        val signature: DigitalSignature.WithKeyId = getSignatureWithMetadataExample(notaryNode1PublicKey).signature
+        val json = jsonMapper.writeValueAsString(signature)
+        val deserializeObject = jsonMapper.readValue(json, DigitalSignature.WithKeyId::class.java)
+        Assertions.assertEquals(signature, deserializeObject)
+    }
+
+    @Test
+    fun digitalSignatureAndMetadataWithoutProof() {
+        val signature: DigitalSignatureAndMetadata = getSignatureWithMetadataExample(notaryNode1PublicKey)
+        Assertions.assertNull(signature.proof)
+        val json = jsonMapper.writeValueAsString(signature)
+        val deserializeObject = jsonMapper.readValue(json, DigitalSignatureAndMetadata::class.java)
+        Assertions.assertEquals(signature, deserializeObject)
+    }
+
+    @Test
+    fun digitalSignatureAndMetadata() {
+        val batchSignatures = transactionSignatureService.signBatch(listOf(signedTransaction), listOf(publicKeyExample))
+        val signature: DigitalSignatureAndMetadata = batchSignatures.first().first()
+        Assertions.assertNotNull(signature.proof)
+        val json = jsonMapper.writeValueAsString(signature)
+        val deserializedObject = jsonMapper.readValue(json, DigitalSignatureAndMetadata::class.java)
+        Assertions.assertEquals(signature, deserializedObject)
+    }
+
+    @Test
+    fun testWithoutProofOfActionModule() {
+        // Mapper without ProofOfActionSerialisationModule.module
+        val jsonMapper = JsonMapper.builder().enable(MapperFeature.BLOCK_UNSAFE_POLYMORPHIC_BASE_TYPES).build().apply {
+            registerModule(KotlinModule.Builder().build())
+            registerModule(JavaTimeModule())
+            enable(DeserializationFeature.FAIL_ON_READING_DUP_TREE_KEY)
+            setTimeZone(TimeZone.getTimeZone("UTC"))
+            disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            registerModule(standardTypesModule())
+        }
+        val batchSignatures = transactionSignatureService.signBatch(listOf(signedTransaction), listOf(publicKeyExample))
+        val signature: DigitalSignatureAndMetadata = batchSignatures.first().first()
+        Assertions.assertNotNull(signature.proof)
+        val json = jsonMapper.writeValueAsString(signature)
+        Assertions.assertThrowsExactly(InvalidDefinitionException::class.java) {
+            jsonMapper.readValue(json, DigitalSignatureAndMetadata::class.java)
+        }
+    }
+}

--- a/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/DigitalSignatureAndMetadataSerializers.kt
+++ b/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/DigitalSignatureAndMetadataSerializers.kt
@@ -21,7 +21,7 @@ import net.corda.v5.crypto.merkle.MerkleProof
 import net.corda.v5.crypto.merkle.MerkleProofType
 import java.time.Instant
 
-class ProofOfActionSerialisationModule(private val merkleProofProvider: MerkleProofProvider) {
+class DigitalSignatureAndMetadataSerialisationModule(private val merkleProofProvider: MerkleProofProvider) {
     val module = SimpleModule().apply {
         addSerializer(DigitalSignatureAndMetadata::class.java, DigitalSignatureAndMetadataSerializer())
         addDeserializer(DigitalSignatureAndMetadata::class.java, DigitalSignatureAndMetadataDeserializer())

--- a/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/InteropJsonMarshallingServiceImpl.kt
+++ b/libs/application/application-impl/src/main/kotlin/net/corda/application/impl/services/json/InteropJsonMarshallingServiceImpl.kt
@@ -52,7 +52,7 @@ class InteropJsonMarshallingServiceImpl
         module.addDeserializer(SecureHash::class.java, SecureHashDeserializer)
 
         // Interoperability
-        registerModule(ProofOfActionSerialisationModule(merkleProofProvider).module)
+        registerModule(DigitalSignatureAndMetadataSerialisationModule(merkleProofProvider).module)
         registerModule(JavaTimeModule())
 
         // Register Kotlin after resetting the AnnotationIntrospector.


### PR DESCRIPTION
Added test for `DigitalSignatureAndMetadataSerialisationModule` (renamed now from `ProofOfActionSerialisationModule`) which was created in https://github.com/corda/corda-runtime-os/commit/aa29e223177de22823146cf3950ec988698403ac. 
The test requires a transaction signature with a `MerkleProof`. This type of signature can be produced by the base test class `UtxoLedgerTest` available for use in `components/ledger/ledger-utxo-flow` module where the test is placed.
The test requires a service implementation of `MerkleProofProvider` which is injected into the SUT, the implementation is in `libs/crypto/merkle-impl` hence with Gradle dependency `testImplementation project(':libs:crypto:merkle-impl')`.
The actual test the class `DigitalSignatureAndMetadataSerialisationModule` is from `libs/application/application-impl`, so the test is not placed in the same module as the class.
There are 2 reasons: `application-impl` module has no test dependencies on either `testing/ledger/ledger-utxo-base-test` or `libs/crypto/merkle-impl`,  while adding it to `components/ledger/ledger-utxo-flow` requires addtion of the second latter dependency only.
The second reason is that if the test is run from withing a module other than `components/ledger` then it throws an exception that Sandbox cannot be mocked.
The other placing of the test could me moved later, however putting it inside `components/ledger/ledger-utxo-flow` looked as reasonable compromise.
