### PR TITLE
CORE-18109 unfollow the state storage coordinator before recreating it to avoid infinite loop

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowMaintenanceImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowMaintenanceImpl.kt
@@ -83,7 +83,7 @@ class FlowMaintenanceImpl @Activate constructor(
                 )
             }.start()
 
-            coordinator.followStatusChangesByName(setOf(stateManager!!.name))
+            subscriptionRegistrationHandle = coordinator.followStatusChangesByName(setOf(stateManager!!.name))
         }
     }
 


### PR DESCRIPTION
if the state storage is not unfollowed before recreating it then flow maintenance coordinator can get stuck in an infinite loop of recreating its components.

Without this PR in 5.1 flow session timeout will not work