### PR TITLE
CORE-18147: Fix State Manager Querying

### DIFF
--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
@@ -58,12 +58,16 @@ class StateManagerImpl(
     }
 
     override fun get(keys: Collection<String>): Map<String, State> {
-        return dataSource.connection.transaction { connection ->
-            stateRepository.get(connection, keys)
-        }.map {
-            it.fromPersistentEntity()
-        }.associateBy {
-            it.key
+        return if (keys.isEmpty()) {
+            emptyMap()
+        } else {
+            dataSource.connection.transaction { connection ->
+                stateRepository.get(connection, keys)
+            }.map {
+                it.fromPersistentEntity()
+            }.associateBy {
+                it.key
+            }
         }
     }
 
@@ -116,22 +120,30 @@ class StateManagerImpl(
     }
 
     override fun findByMetadataMatchingAll(filters: Collection<MetadataFilter>): Map<String, State> {
-        return dataSource.connection.transaction { connection ->
-            stateRepository.filterByAll(connection, filters)
-        }.map {
-            it.fromPersistentEntity()
-        }.associateBy {
-            it.key
+        return if (filters.isEmpty()) {
+            emptyMap()
+        } else {
+            dataSource.connection.transaction { connection ->
+                stateRepository.filterByAll(connection, filters)
+            }.map {
+                it.fromPersistentEntity()
+            }.associateBy {
+                it.key
+            }
         }
     }
 
     override fun findByMetadataMatchingAny(filters: Collection<MetadataFilter>): Map<String, State> {
-        return dataSource.connection.transaction { connection ->
-            stateRepository.filterByAny(connection, filters)
-        }.map {
-            it.fromPersistentEntity()
-        }.associateBy {
-            it.key
+        return if (filters.isEmpty()) {
+            emptyMap()
+        } else {
+            dataSource.connection.transaction { connection ->
+                stateRepository.filterByAny(connection, filters)
+            }.map {
+                it.fromPersistentEntity()
+            }.associateBy {
+                it.key
+            }
         }
     }
 

--- a/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
@@ -61,6 +61,14 @@ class StateManagerImplTest {
     }
 
     @Test
+    fun getReturnsEmptyMapAndDoesNotInteractWithTheDatabaseWhenEmptyListOfKeysIsUsedAsInput() {
+        val results = stateManager.get(emptyList())
+
+        assertThat(results).isEmpty()
+        verifyNoInteractions(dataSource)
+    }
+
+    @Test
     fun updateReturnsEmptyMapWhenOptimisticLockingCheckSucceedsForAllStates() {
         whenever(stateRepository.update(any(), any()))
             .thenReturn(StateRepository.StateUpdateSummary(
@@ -92,7 +100,7 @@ class StateManagerImplTest {
     }
 
     @Test
-    fun updateReturnsEmptyAndDoesNotInteractWithTheDatabaseEmptyListOfStatesInput() {
+    fun updateReturnsEmptyMapAndDoesNotInteractWithTheDatabaseWhenEmptyListOfStatesIsUsedAsInput() {
         val failedUpdates = assertDoesNotThrow { stateManager.update(emptyList()) }
 
         assertThat(failedUpdates).isEmpty()
@@ -123,10 +131,26 @@ class StateManagerImplTest {
     }
 
     @Test
-    fun deleteReturnsEmptyAndDoesNotInteractWithTheDatabaseEmptyListOfStatesInput() {
+    fun deleteReturnsEmptyAndDoesNotInteractWithTheDatabaseWhenEmptyListOfStatesIsUsedInput() {
         val failedDeletes = assertDoesNotThrow { stateManager.delete(emptyList()) }
 
         assertThat(failedDeletes).isEmpty()
+        verifyNoInteractions(dataSource)
+    }
+
+    @Test
+    fun findByMetadataMatchingAllReturnsEmptyMapAndDoesNotInteractWithTheDatabaseWhenEmptyListOfFiltersIsUsedInput() {
+        val result = stateManager.findByMetadataMatchingAll(emptyList())
+
+        assertThat(result).isEmpty()
+        verifyNoInteractions(dataSource)
+    }
+
+    @Test
+    fun findByMetadataMatchingAnyReturnsEmptyMapAndDoesNotInteractWithTheDatabaseWhenEmptyListOfFiltersIsUsedInput() {
+        val result = stateManager.findByMetadataMatchingAny(emptyList())
+
+        assertThat(result).isEmpty()
         verifyNoInteractions(dataSource)
     }
 }


### PR DESCRIPTION
Check that the filters used by the calling API is not empty and return
immediately to prevent unnecessary interactions with the database.
