### PR TITLE
CORE-17966: Implement checkpoint cleanup handler when processing FlowFatalException

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ExternalEventAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/ExternalEventAcceptanceTest.kt
@@ -3,17 +3,19 @@ package net.corda.flow.testing.tests
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.flow.event.external.ExternalEventResponseErrorType
+import net.corda.data.flow.output.FlowStates
 import net.corda.data.persistence.EntityRequest
 import net.corda.data.persistence.EntityResponse
 import net.corda.data.persistence.FindEntities
 import net.corda.flow.external.events.factory.ExternalEventFactory
 import net.corda.flow.external.events.factory.ExternalEventRecord
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.pipeline.exceptions.FlowProcessingExceptionTypes.FLOW_FAILED
 import net.corda.flow.state.FlowCheckpoint
+import net.corda.flow.testing.context.ALICE_FLOW_KEY_MAPPER
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.flow.testing.context.flowResumedWithError
 import net.corda.schema.configuration.FlowConfig
-import net.corda.utilities.seconds
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -400,6 +402,9 @@ class ExternalEventAcceptanceTest : FlowServiceTestBase() {
                 markedForDlq()
                 flowDidNotResume()
                 flowFiberCacheDoesNotContainKey(ALICE_HOLDING_IDENTITY, REQUEST_ID1)
+                scheduleFlowMapperCleanupEvents(ALICE_FLOW_KEY_MAPPER)
+                nullStateRecord()
+                flowStatus(state = FlowStates.FAILED, errorType = FLOW_FAILED, errorMessage = "message")
             }
         }
     }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFailedAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFailedAcceptanceTest.kt
@@ -119,7 +119,7 @@ fun `Given a subFlow contains an initiated and closed session when the subFlow f
     }
 
     @Test
-    fun `Given a subFlow contains only errored sessions when the subFlow fails a wakeup event is scheduled and no session error events are sent`() {
+    fun `Given a subFlow contains only errored sessions when the subFlow fails no session error events are sent`() {
         given {
             startFlow(this)
                 .suspendsWith(FlowIORequest.Receive(setOf(
@@ -217,7 +217,7 @@ fun `Given a subFlow contains an initiated and closed session when the subFlow f
     }
 
     @Test
-    fun `Given an initiated top level flow with an errored session when it finishes and calls SubFlowFailed a wakeup event is scheduled and no session error event is sent`() {
+    fun `Given an initiated top level flow with an errored session when it finishes and calls SubFlowFailed, schedules cleanup and does not send a session error event`() {
         given {
             membershipGroupFor(BOB_HOLDING_IDENTITY)
             initiatingToInitiatedFlow(PROTOCOL_2, FLOW_NAME, FLOW_NAME_2)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFailedAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/SubFlowFailedAcceptanceTest.kt
@@ -1,7 +1,9 @@
 package net.corda.flow.testing.tests
 
+import net.corda.data.flow.output.FlowStates
 import net.corda.flow.application.sessions.SessionInfo
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.pipeline.exceptions.FlowProcessingExceptionTypes.FLOW_FAILED
 import net.corda.flow.testing.context.ALICE_FLOW_KEY_MAPPER
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.flow.testing.context.startFlow
@@ -33,15 +35,19 @@ class SubFlowFailedAcceptanceTest : FlowServiceTestBase() {
             initiatingToInitiatedFlow(PROTOCOL, FAKE_FLOW_NAME, FAKE_FLOW_NAME)
         }
     }
+
     @Test
     fun `Given a subFlow contains sessions when the subFlow fails, session error events are sent and session cleanup is scheduled`() {
         `when` {
             startFlow(this)
-                .suspendsWith(FlowIORequest.Send(
-                    mapOf(
-                        SessionInfo(SESSION_ID_1, initiatedIdentityMemberName) to  DATA_MESSAGE_1,
-                        SessionInfo(SESSION_ID_2, initiatedIdentityMemberName) to  DATA_MESSAGE_2,
-                    )))
+                .suspendsWith(
+                    FlowIORequest.Send(
+                        mapOf(
+                            SessionInfo(SESSION_ID_1, initiatedIdentityMemberName) to DATA_MESSAGE_1,
+                            SessionInfo(SESSION_ID_2, initiatedIdentityMemberName) to DATA_MESSAGE_2,
+                        )
+                    )
+                )
                 .suspendsWith(
                     FlowIORequest.SubFlowFailed(
                         RuntimeException(),
@@ -58,50 +64,56 @@ class SubFlowFailedAcceptanceTest : FlowServiceTestBase() {
             }
         }
     }
-@Test
-fun `Given a subFlow contains an initiated and closed session when the subFlow fails a single session error event is sent to the initiated session and session cleanup is scheduled`() {
-    `when` {
-        startFlow(this)
-            .suspendsWith(FlowIORequest.Send(
-                mapOf(
-                    SessionInfo(SESSION_ID_1, initiatedIdentityMemberName) to  DATA_MESSAGE_1,
-                    SessionInfo(SESSION_ID_2, initiatedIdentityMemberName) to  DATA_MESSAGE_2,
-                )))
-            .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1)))
 
-       sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, 1, ALICE_HOLDING_IDENTITY, BOB_HOLDING_IDENTITY)
-            .suspendsWith(
-                FlowIORequest.SubFlowFailed(
-                    RuntimeException(),
-                    listOf(SESSION_ID_1, SESSION_ID_2)
+    @Test
+    fun `Given a subFlow contains an initiated and closed session when the subFlow fails a single session error event is sent to the initiated session and session cleanup is scheduled`() {
+        `when` {
+            startFlow(this)
+                .suspendsWith(
+                    FlowIORequest.Send(
+                        mapOf(
+                            SessionInfo(SESSION_ID_1, initiatedIdentityMemberName) to DATA_MESSAGE_1,
+                            SessionInfo(SESSION_ID_2, initiatedIdentityMemberName) to DATA_MESSAGE_2,
+                        )
+                    )
                 )
-            )
-            .completedWithError(CordaRuntimeException("error"))
-    }
+                .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1)))
 
-    then {
-        expectOutputForFlow(FLOW_ID1) {
-            noOutputEvent()
+            sessionCloseEventReceived(FLOW_ID1, SESSION_ID_1, 1, ALICE_HOLDING_IDENTITY, BOB_HOLDING_IDENTITY)
+                .suspendsWith(
+                    FlowIORequest.SubFlowFailed(
+                        RuntimeException(),
+                        listOf(SESSION_ID_1, SESSION_ID_2)
+                    )
+                )
+                .completedWithError(CordaRuntimeException("error"))
         }
 
-        expectOutputForFlow(FLOW_ID1) {
-            sessionErrorEvents(SESSION_ID_2)
-            scheduleFlowMapperCleanupEvents(ALICE_FLOW_KEY_MAPPER, SESSION_ID_1, SESSION_ID_2)
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                noOutputEvent()
+            }
+
+            expectOutputForFlow(FLOW_ID1) {
+                sessionErrorEvents(SESSION_ID_2)
+                scheduleFlowMapperCleanupEvents(ALICE_FLOW_KEY_MAPPER, SESSION_ID_1, SESSION_ID_2)
+            }
         }
     }
-}
-
 
 
     @Test
     fun `Given a subFlow contains only closed sessions when the subFlow fails no session error events are sent`() {
         `when` {
             startFlow(this)
-                .suspendsWith(FlowIORequest.Send(
-                    mapOf(
-                        SessionInfo(SESSION_ID_1, initiatedIdentityMemberName) to  DATA_MESSAGE_1,
-                        SessionInfo(SESSION_ID_2, initiatedIdentityMemberName) to  DATA_MESSAGE_2,
-                    )))
+                .suspendsWith(
+                    FlowIORequest.Send(
+                        mapOf(
+                            SessionInfo(SESSION_ID_1, initiatedIdentityMemberName) to DATA_MESSAGE_1,
+                            SessionInfo(SESSION_ID_2, initiatedIdentityMemberName) to DATA_MESSAGE_2,
+                        )
+                    )
+                )
                 .suspendsWith(FlowIORequest.CloseSessions(setOf(SESSION_ID_1, SESSION_ID_2)))
                 .suspendsWith(
                     FlowIORequest.SubFlowFailed(
@@ -122,10 +134,14 @@ fun `Given a subFlow contains an initiated and closed session when the subFlow f
     fun `Given a subFlow contains only errored sessions when the subFlow fails no session error events are sent`() {
         given {
             startFlow(this)
-                .suspendsWith(FlowIORequest.Receive(setOf(
-                    SessionInfo(SESSION_ID_1, initiatedIdentityMemberName),
-                    SessionInfo(SESSION_ID_2, initiatedIdentityMemberName),
-                )))
+                .suspendsWith(
+                    FlowIORequest.Receive(
+                        setOf(
+                            SessionInfo(SESSION_ID_1, initiatedIdentityMemberName),
+                            SessionInfo(SESSION_ID_2, initiatedIdentityMemberName),
+                        )
+                    )
+                )
 
             sessionErrorEventReceived(FLOW_ID1, SESSION_ID_1)
         }
@@ -151,7 +167,7 @@ fun `Given a subFlow contains an initiated and closed session when the subFlow f
     fun `Given a subFlow contains no sessions when the subFlow fails and flow finishes, requestid is cleaned up and no session errors are sent`() {
         `when` {
             startFlow(this)
-                     .suspendsWith(FlowIORequest.SubFlowFailed(RuntimeException(), emptyList()))
+                .suspendsWith(FlowIORequest.SubFlowFailed(RuntimeException(), emptyList()))
                 .completedWithError(CordaRuntimeException("Error"))
         }
 
@@ -223,9 +239,13 @@ fun `Given a subFlow contains an initiated and closed session when the subFlow f
             initiatingToInitiatedFlow(PROTOCOL_2, FLOW_NAME, FLOW_NAME_2)
 
             sessionCounterpartyInfoRequestReceived(FLOW_ID1, INITIATED_SESSION_ID_1, CPI1, PROTOCOL_2)
-                .suspendsWith(FlowIORequest.Receive(setOf(
-                    SessionInfo(INITIATED_SESSION_ID_1, initiatedIdentityMemberName),
-                )))
+                .suspendsWith(
+                    FlowIORequest.Receive(
+                        setOf(
+                            SessionInfo(INITIATED_SESSION_ID_1, initiatedIdentityMemberName),
+                        )
+                    )
+                )
         }
 
         `when` {
@@ -246,4 +266,34 @@ fun `Given a subFlow contains an initiated and closed session when the subFlow f
             }
         }
     }
+
+    @Test
+    fun `Given a subFlow contains sessions when the subFlow fails, and session is not found, FlowFatalException is thrown`() {
+        `when` {
+            startFlow(this)
+                .suspendsWith(
+                    FlowIORequest.Send(
+                        mapOf(
+                            SessionInfo(SESSION_ID_1, initiatedIdentityMemberName) to DATA_MESSAGE_1,
+                        )
+                    )
+                )
+                .suspendsWith(
+                    FlowIORequest.SubFlowFailed(
+                        RuntimeException(),
+                        listOf(SESSION_ID_1, "BrokenSession")
+                    )
+                )
+        }
+
+        then {
+            expectOutputForFlow(FLOW_ID1) {
+                sessionErrorEvents(SESSION_ID_1)
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1, ALICE_FLOW_KEY_MAPPER)
+                nullStateRecord()
+                flowStatus(state = FlowStates.FAILED,  errorType = FLOW_FAILED, errorMessage = "Session: BrokenSession does not exist when executing session operation that requires an existing session")
+            }
+        }
+    }
+
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/CheckpointCleanupHandlerImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/CheckpointCleanupHandlerImpl.kt
@@ -37,7 +37,7 @@ class CheckpointCleanupHandlerImpl @Activate constructor(
         val records = errorActiveSessions(checkpoint, config, exception, time) +
                 cleanupSessions(checkpoint, config, time) +
                 generateStatus(checkpoint, exception) +
-                cleanupInitiatingFlow(checkpoint, config, time)
+                cleanupRpcFlowMapperState(checkpoint, config, time)
         checkpoint.markDeleted()
         return records
     }
@@ -100,7 +100,7 @@ class CheckpointCleanupHandlerImpl @Activate constructor(
         }
     }
 
-    private fun cleanupInitiatingFlow(
+    private fun cleanupRpcFlowMapperState(
         checkpoint: FlowCheckpoint,
         config: SmartConfig,
         currentTime: Instant

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
@@ -12,6 +12,7 @@ import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.fiber.cache.FlowFiberCache
+import net.corda.flow.maintenance.CheckpointCleanupHandler
 import net.corda.flow.pipeline.converters.FlowEventContextConverter
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowEventException
@@ -60,6 +61,8 @@ class FlowEventExceptionProcessorImplTest {
     private val flowFiberCache = mock<FlowFiberCache>()
     private val serializedFiber = ByteBuffer.wrap("mock fiber".toByteArray())
 
+    private val checkpointCleanupHandler = mock<CheckpointCleanupHandler>()
+
     private val sessionIdOpen = "sesh-id"
     private val sessionIdClosed = "sesh-id-closed"
     private val flowActiveSessionState = SessionState().apply {
@@ -74,7 +77,8 @@ class FlowEventExceptionProcessorImplTest {
         flowMessageFactory,
         flowRecordFactory,
         flowSessionManager,
-        flowFiberCache
+        flowFiberCache,
+        checkpointCleanupHandler
     )
 
     @BeforeEach

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
@@ -164,11 +164,9 @@ class FlowEventExceptionProcessorImplTest {
         ).thenReturn(flowStatusUpdate)
         whenever(flowRecordFactory.createFlowStatusRecord(flowStatusUpdate)).thenReturn(flowStatusUpdateRecord)
 
-        val result = target.process(error, context)
+        target.process(error, context)
 
-        verify(result.checkpoint).markDeleted()
-        assertThat(result.outputRecords).containsOnly(flowStatusUpdateRecord)
-        assertThat(result.sendToDlq).isTrue
+        verify(checkpointCleanupHandler).cleanupCheckpoint(eq(flowCheckpoint), any(), any<FlowFatalException>())
     }
 
     @Test
@@ -293,17 +291,7 @@ class FlowEventExceptionProcessorImplTest {
         val context = buildFlowEventContext<Any>(checkpoint = flowCheckpoint, inputEventPayload = inputEvent)
 
         val error = FlowFatalException("error")
-        val flowStatusUpdate = FlowStatus()
-        val flowStatusUpdateRecord = Record("", FlowKey(), flowStatusUpdate)
 
-        whenever(
-            flowMessageFactory.createFlowFailedStatusMessage(
-                flowCheckpoint,
-                FlowProcessingExceptionTypes.FLOW_FAILED,
-                error.message
-            )
-        ).thenReturn(flowStatusUpdate)
-        whenever(flowRecordFactory.createFlowStatusRecord(flowStatusUpdate)).thenReturn(flowStatusUpdateRecord)
         target.process(error, context)
 
         verify(flowCheckpoint, times(1)).flowStartContext

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
@@ -15,6 +15,7 @@ import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.cache.FlowFiberCache
+import net.corda.flow.maintenance.CheckpointCleanupHandler
 import net.corda.flow.pipeline.converters.FlowEventContextConverter
 import net.corda.flow.pipeline.exceptions.FlowMarkedForKillException
 import net.corda.flow.pipeline.factory.FlowMessageFactory
@@ -97,12 +98,15 @@ class FlowToBeKilledExceptionProcessingTest {
     private val flowKilledStatusRecord = Record("s", flowKey, flowKilledStatus)
     private val mockResponse = mock<StateAndEventProcessor.Response<Checkpoint>>()
     private val flowFiberCache = mock<FlowFiberCache>()
+    private val checkpointCleanupHandler = mock<CheckpointCleanupHandler>()
+
 
     private val target = FlowEventExceptionProcessorImpl(
         flowMessageFactory,
         flowRecordFactory,
         flowSessionManager,
-        flowFiberCache
+        flowFiberCache,
+        checkpointCleanupHandler
     )
 
     @BeforeEach


### PR DESCRIPTION
### Change:
This PR will implement checkpoint cleanup handler when processing **FlowFatalException**.

### Reasoning:
In order to address CORE-17966: _When exceptions such as FlowFatalException are thrown in the Flow Engine the exception handlers cleanup the checkpoints and schedule cleanup of the session states. However they currently do not cleanup the StartFlow Flow Mapper state for RPC started flows_ the checkpoint cleanup handler will be integrated in a series of small PRs.