### PR TITLE
CORE-18192: Handle Exceptions When Scheduling Check

### DIFF
--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/lifecycle/CheckConnectionEventHandler.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/lifecycle/CheckConnectionEventHandler.kt
@@ -56,7 +56,7 @@ class CheckConnectionEventHandler(
         try {
             coordinator.setTimer(CHECK_EVENT_KEY, delay) { key -> CheckConnectionEvent(key) }
         } catch (lifecycleException : LifecycleException) {
-            // Coordinator has been closed, ignore the exception until CORE-XXXX is fixed
+            // Coordinator has been closed, ignore the exception until CORE-18202 is fixed
             logger.warn("Component {} is already closed, ignoring scheduling of {} event", componentName, CHECK_EVENT_KEY)
         }
     }

--- a/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/lifecycle/CheckConnectionEventHandlerTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/lifecycle/CheckConnectionEventHandlerTest.kt
@@ -2,20 +2,33 @@ package net.corda.libs.statemanager.impl.lifecycle
 
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorName
+import net.corda.lifecycle.LifecycleException
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.StopEvent
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
 import java.lang.IllegalStateException
 
 class CheckConnectionEventHandlerTest {
     private val coordinatorName = mock<LifecycleCoordinatorName>()
     private val lifecycleCoordinator = mock<LifecycleCoordinator>()
+
+    @Test
+    fun scheduleConnectionCheckHandleExceptions() {
+        whenever(lifecycleCoordinator.setTimer(any(), any(), any())).thenThrow(LifecycleException("Mock"))
+        val connectionEventHandler = CheckConnectionEventHandler(coordinatorName) {}
+
+        Assertions.assertThatCode {
+            connectionEventHandler.scheduleConnectionCheck(lifecycleCoordinator)
+        }.doesNotThrowAnyException()
+    }
 
     @Test
     fun processStartEventSchedulesConnectionCheck() {


### PR DESCRIPTION
Handle Lifecycle exceptions that might be thrown when scheduling the
next connection check if another thread already closed the coordinator.