### PR TITLE
CORE-18209 Adjust the mediator to send asynchronous events directly before saving the state to try to avoid a race condition

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -265,8 +265,7 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
         queue: ArrayDeque<Record<K, E>>,
         event: Record<K, E>
     ) {
-        val output =
-            response.responseEvents.map { taskManagerHelper.convertToMessage(it) }
+        val output = response.responseEvents.map { taskManagerHelper.convertToMessage(it) }
         output.forEach { message ->
             val destination = messageRouter.getDestination(message)
             if (destination.type == RoutingDestination.Type.ASYNCHRONOUS) {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -257,7 +257,7 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
     }
 
     /**
-     * Send any synchronous events immediately, add asynchronous events to the busEvents map to be sent later
+     * Send any synchronous events immediately, add asynchronous events to the busEvents collection to be sent later
      */
     private fun processOutputEvents(
         response: StateAndEventProcessor.Response<S>,

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -229,9 +229,7 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
                     it.join()
                 }
 
-                //Send asynchronous events
                 sendAsynchronousEvents(asynchronousOutputs)
-
                 // Persist states changes
                 val failedToCreateKeys = stateManager.create(newStates.values.mapNotNull { it })
                 val failedToCreate = stateManager.get(failedToCreateKeys.keys)


### PR DESCRIPTION
In the mediator code we poll a batch of events, process each input event, send any output events immediately (HTTP requests & Bus records), and after completing the batch of input events we save the states to the state storage in a batch.
A race condition appears as the output events of an input event can be a SessionEvent output to the bus and subsequently processed by another pod.
This can result in a SessionEvent replied back to our flowId and processed on a different topic by a different pod.
This can all be done while the initial flow worker is still processing its batch of inputs events and before the state has been saved to the state storage.
As a result when the other flow worker pod picks up the SessionEvent it doesn't find the checkpoint and logs the error we saw.

A temporary fix would be to send bus events directly before saving to the state storage. 
If the state storage optimistic locking fails to save the state then duplicate output records would be sent(this is fine) however the race condition will reappear 