### PR TITLE
CORE-18212 - default the state manager max connections to 8 

### DIFF
--- a/applications/workers/worker-common/src/main/resources/net/corda/applications/workers/workercommon/boot/corda.boot.json
+++ b/applications/workers/worker-common/src/main/resources/net/corda/applications/workers/workercommon/boot/corda.boot.json
@@ -252,7 +252,7 @@
               "properties": {
                 "maxSize": {
                   "description": "Maximum connection pool size for State Manager DB",
-                  "default": 5,
+                  "default": 8,
                   "type": [
                     "integer",
                     "null"

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -3621,10 +3621,10 @@
                             "properties": {
                                 "maxSize": {
                                     "type": "integer",
-                                    "default": 5,
+                                    "default": 8,
                                     "title": "JDBC connection pool size for State Manager DB",
                                     "examples": [
-                                        5
+                                        8
                                     ]
                                 },
                                 "minSize": {

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -815,7 +815,7 @@ workers:
         # flow worker JDBC connection pool configuration for State Manager DB
         connectionPool:
           # -- flow worker maximum JDBC connection pool size for state manager DB
-          maxSize: 5
+          maxSize: 8
           # -- flow worker minimum JDBC connection pool size for state manager DB; null value means pool's min size will default to pool's max size value
           minSize: null
           # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
@@ -935,7 +935,7 @@ workers:
         # flow mapper worker JDBC connection pool configuration for State Manager DB
         connectionPool:
           # -- flow mapper worker maximum JDBC connection pool size for state manager DB
-          maxSize: 5
+          maxSize: 8
           # -- flow mapper worker minimum JDBC connection pool size for state manager DB; null value means pool's min size will default to pool's max size value
           minSize: null
           # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool
@@ -1531,7 +1531,7 @@ workers:
         # token selection worker JDBC connection pool configuration for State Manager DB
         connectionPool:
           # -- token selection maximum JDBC connection pool size for state manager DB
-          maxSize: 5
+          maxSize: 8
           # -- token selection minimum JDBC connection pool size for state manager DB; null value means pool's min size will default to pool's max size value
           minSize: null
           # -- maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool


### PR DESCRIPTION
**Problem:**

Default SM connections is 5, default taskManager threads is 8. By default, there could be a bottleneck as threads may be waiting for db connections to be released.

**Solution**

Set the default max number of connections to 8 for state manager.

**Ambiguous**

Token selection does not use the TaskManager nor the MultiSourceEventMediator, however I think keeping the max connections consistent for all workers is a better approach.