### PR TITLE
CORE-18194 - Revert `fetch.max.wait.ms` default config

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -19,7 +19,7 @@ consumer = ${common} {
     enable.auto.commit = false
     # Retrieve 500 records maximum per poll. Note that poll will return immediately if any records are available, so a
     # batch may contain fewer than 500 records.
-    max.poll.records = 200
+    max.poll.records = 100
     # Time to allow between polls on a consumer before a rebalance occurs that removes this consumer's partitions.
     max.poll.interval.ms = 300000
     # Timeout of heartbeats between the consumer and the broker. If no heartbeat is received in this timeframe, a
@@ -29,7 +29,7 @@ consumer = ${common} {
     heartbeat.interval.ms = 20000
     # The maximum amount of time kafka broker will wait before answering a consumer request if there hasn't been
     # an update to the topic
-    fetch.max.wait.ms = 5
+    fetch.max.wait.ms = 20
 }
 
 # Defaults for all producers.
@@ -78,7 +78,7 @@ roles {
         # within this pattern is transactional by default, and the transaction commit also causes a flush.
         producer = ${producer} {
             # Maximum time to wait for additional messages before sending the current batch.
-            linger.ms = 5
+            linger.ms = 50
             # Maximum amount of memory in bytes (not messages) that will be used for each batch. Can not be higher than
             # the value configured for "message.max.bytes" on the broker side (1mb by default).
             batch.size = 204800

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -29,7 +29,7 @@ consumer = ${common} {
     heartbeat.interval.ms = 20000
     # The maximum amount of time kafka broker will wait before answering a consumer request if there hasn't been
     # an update to the topic
-    fetch.max.wait.ms = 20
+    fetch.max.wait.ms = 500
 }
 
 # Defaults for all producers.

--- a/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
+++ b/libs/messaging/kafka-message-bus-impl/src/main/resources/kafka-messaging-defaults.conf
@@ -19,7 +19,7 @@ consumer = ${common} {
     enable.auto.commit = false
     # Retrieve 500 records maximum per poll. Note that poll will return immediately if any records are available, so a
     # batch may contain fewer than 500 records.
-    max.poll.records = 100
+    max.poll.records = 200
     # Time to allow between polls on a consumer before a rebalance occurs that removes this consumer's partitions.
     max.poll.interval.ms = 300000
     # Timeout of heartbeats between the consumer and the broker. If no heartbeat is received in this timeframe, a
@@ -78,7 +78,7 @@ roles {
         # within this pattern is transactional by default, and the transaction commit also causes a flush.
         producer = ${producer} {
             # Maximum time to wait for additional messages before sending the current batch.
-            linger.ms = 50
+            linger.ms = 5
             # Maximum amount of memory in bytes (not messages) that will be used for each batch. Can not be higher than
             # the value configured for "message.max.bytes" on the broker side (1mb by default).
             batch.size = 204800

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -9,9 +9,9 @@ import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorConsumer
+import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient
-import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MultiSourceEventMediator
 import net.corda.messaging.api.mediator.config.EventMediatorConfig
 import net.corda.messaging.api.mediator.config.MediatorConsumerConfig
@@ -68,7 +68,7 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
     private val running = AtomicBoolean(false)
     // TODO This timeout was set with CORE-17768 (changing configuration value would affect other messaging patterns)
     //  This should be reverted to use configuration value once event mediator polling is refactored (planned for 5.2)
-    private val pollTimeout = Duration.ofMillis(5)
+    private val pollTimeout = Duration.ofMillis(50)
 
     override fun start() {
         log.debug { "Starting multi-source event mediator with config: $config" }


### PR DESCRIPTION
The `fetch.max.wait.ms` config had been reduced aggressively which was causing high CPU load (see ticket CORE-18162) and, in turn, reduced performance in the E2E tests.