### PR TITLE
CORE-18194 - smoke test concurrency

### DIFF
--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -153,4 +153,11 @@ tasks.register('smokeTest', Test) {
     systemProperty "uniquenessWorkerUrl", uniquenessWorkerUrl
 
     jvmArgs '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED'
+
+    systemProperties([
+            // Configuration parameters to execute top-level classes in parallel but methods in same thread
+            'junit.jupiter.execution.parallel.enabled'                 : 'true',
+            'junit.jupiter.execution.parallel.mode.default'            : 'same_thread',
+            'junit.jupiter.execution.parallel.mode.classes.default'    : 'concurrent',
+    ])
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/ConfigurationChangeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/ConfigurationChangeTest.kt
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import java.util.UUID
 
 @Suppress("Unused", "FunctionName")
@@ -32,6 +34,7 @@ import java.util.UUID
 // their patterns are DOWN - CORE-8015
 @Order(Int.MAX_VALUE)
 @TestInstance(Lifecycle.PER_CLASS)
+@Execution(ExecutionMode.SAME_THREAD)
 class ConfigurationChangeTest {
 
     companion object {

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/network/SingleClusterDynamicNetworkTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/network/SingleClusterDynamicNetworkTest.kt
@@ -10,8 +10,11 @@ import net.corda.e2etest.utilities.onboardNotaryMember
 import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import java.util.UUID
 
+@Execution(ExecutionMode.SAME_THREAD)
 class SingleClusterDynamicNetworkTest {
     private val testUniqueId = UUID.randomUUID()
 

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/network/StaticNetworkTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/network/StaticNetworkTest.kt
@@ -11,8 +11,11 @@ import net.corda.e2etest.utilities.containsExactlyInAnyOrderActiveMembers
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 import java.util.*
 
+@Execution(ExecutionMode.SAME_THREAD)
 class StaticNetworkTest {
 
     private val testRunUniqueId = UUID.randomUUID()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/AssertWithRetryBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/AssertWithRetryBuilder.kt
@@ -8,6 +8,7 @@ import java.time.Duration
 class AssertWithRetryArgs {
     var timeout: Duration = Duration.ofSeconds(10)
     var interval: Duration = Duration.ofMillis(500)
+    var startDelay: Duration = Duration.ofMillis(10)
     var command: (() -> SimpleResponse)? = null
     var condition: ((SimpleResponse) -> Boolean)? = null
     var immediateFailCondition: ((SimpleResponse) -> Boolean)? = null
@@ -63,8 +64,8 @@ fun assertWithRetry(initialize: AssertWithRetryBuilder.() -> Unit): SimpleRespon
 
         var retry = 0
         var timeTried: Long
+        Thread.sleep(args.startDelay.toMillis())
         do {
-            Thread.sleep(args.interval.toMillis())
             response = args.command!!.invoke()
             if(null != args.immediateFailCondition && args.immediateFailCondition!!.invoke(response)) {
                 fail("Failed without retry with status code = ${response.code} and body =\n${response.body}")
@@ -73,6 +74,7 @@ fun assertWithRetry(initialize: AssertWithRetryBuilder.() -> Unit): SimpleRespon
             retry++
             timeTried = args.interval.toMillis() * retry
             println("Failed after $retry retry ($timeTried ms): $response")
+            Thread.sleep(args.interval.toMillis())
         } while (timeTried < args.timeout.toMillis())
 
         assertThat(args.condition!!.invoke(response!!))
@@ -110,9 +112,8 @@ fun assertWithRetryIgnoringExceptions(initialize: AssertWithRetryBuilder.() -> U
         var result: Any?
         var timeTried: Long
 
+        Thread.sleep(args.startDelay.toMillis())
         do {
-            Thread.sleep(args.interval.toMillis())
-
             result = try {
                 args.command!!.invoke()
             } catch (exception: Exception) {
@@ -130,6 +131,7 @@ fun assertWithRetryIgnoringExceptions(initialize: AssertWithRetryBuilder.() -> U
             retry++
             timeTried = args.interval.toMillis() * retry
             println("Failed after $retry retry ($timeTried ms): $result")
+            Thread.sleep(args.interval.toMillis())
         } while (timeTried < args.timeout.toMillis())
 
         when (result) {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -1,12 +1,15 @@
 package net.corda.e2etest.utilities
 
 import com.fasterxml.jackson.module.kotlin.contains
-import java.time.Duration
 import net.corda.rest.ResponseCode
 import net.corda.test.util.eventually
 import net.corda.utilities.seconds
 import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThat
+import java.time.Duration
+import java.util.concurrent.Semaphore
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * Transform a Corda Package Bundle (CPB) into a Corda Package Installer (CPI) by adding a group policy file and upload
@@ -20,24 +23,27 @@ fun ClusterInfo.conditionallyUploadCordaPackage(
     cpiUpload(cpbResourceName, groupPolicy, cpiName)
 }
 
+val signingCertLock = ReentrantLock()
 fun ClusterInfo.conditionallyUploadCpiSigningCertificate() = cluster {
-    val hasCertificateChain = assertWithRetryIgnoringExceptions {
-        interval(1.seconds)
-        command { getCertificateChain(CODE_SIGNER_CERT_USAGE, CODE_SIGNER_CERT_ALIAS) }
-        condition {
-            it.code == ResponseCode.RESOURCE_NOT_FOUND.statusCode ||
-                    it.code == ResponseCode.OK.statusCode
+    signingCertLock.withLock {
+        val hasCertificateChain = assertWithRetryIgnoringExceptions {
+            interval(1.seconds)
+            command { getCertificateChain(CODE_SIGNER_CERT_USAGE, CODE_SIGNER_CERT_ALIAS) }
+            condition {
+                it.code == ResponseCode.RESOURCE_NOT_FOUND.statusCode ||
+                        it.code == ResponseCode.OK.statusCode
+            }
+        }.let {
+            it.code != ResponseCode.RESOURCE_NOT_FOUND.statusCode
         }
-    }.let {
-        it.code != ResponseCode.RESOURCE_NOT_FOUND.statusCode
-    }
-    if (!hasCertificateChain) {
-        assertWithRetryIgnoringExceptions {
-            // Certificate upload can be slow in the combined worker, especially after it has just started up.
-            timeout(30.seconds)
-            interval(2.seconds)
-            command { importCertificate(CODE_SIGNER_CERT, CODE_SIGNER_CERT_USAGE, CODE_SIGNER_CERT_ALIAS) }
-            condition { it.code == ResponseCode.NO_CONTENT.statusCode }
+        if (!hasCertificateChain) {
+            assertWithRetryIgnoringExceptions {
+                // Certificate upload can be slow in the combined worker, especially after it has just started up.
+                timeout(30.seconds)
+                interval(2.seconds)
+                command { importCertificate(CODE_SIGNER_CERT, CODE_SIGNER_CERT_USAGE, CODE_SIGNER_CERT_ALIAS) }
+                condition { it.code == ResponseCode.NO_CONTENT.statusCode }
+            }
         }
     }
 }
@@ -64,24 +70,27 @@ fun ClusterInfo.conditionallyUploadCordaPackage(
     cpiUpload(cpbResourceName, groupId, staticMemberNames, cpiName, customGroupParameters = customGroupParameters)
 }
 
+val packageUploadSemaphore = Semaphore(2)
 fun ClusterInfo.conditionallyUploadCordaPackage(
     name: String,
     cpiUpload: ClusterBuilder.() -> SimpleResponse
-) = cluster {
-    if (getExistingCpi(name) == null) {
-        val responseStatusId = cpiUpload().run {
-            assertThat(code).isEqualTo(ResponseCode.OK.statusCode)
-            assertThat(toJson()["id"].textValue()).isNotEmpty
-            toJson()["id"].textValue()
-        }
+) = packageUploadSemaphore.runWith {
+    cluster {
+        if (getExistingCpi(name) == null) {
+            val responseStatusId = cpiUpload().run {
+                assertThat(code).isEqualTo(ResponseCode.OK.statusCode)
+                assertThat(toJson()["id"].textValue()).isNotEmpty
+                toJson()["id"].textValue()
+            }
 
-        assertWithRetryIgnoringExceptions {
-            timeout(Duration.ofSeconds(100))
-            interval(Duration.ofSeconds(2))
-            command { cpiStatus(responseStatusId) }
-            condition {
-                it.code == ResponseCode.OK.statusCode
-                        && it.toJson()["status"].textValue() == ResponseCode.OK.toString()
+            assertWithRetryIgnoringExceptions {
+                timeout(Duration.ofSeconds(100))
+                interval(Duration.ofSeconds(2))
+                command { cpiStatus(responseStatusId) }
+                condition {
+                    it.code == ResponseCode.OK.statusCode
+                            && it.toJson()["status"].textValue() == ResponseCode.OK.toString()
+                }
             }
         }
     }
@@ -92,6 +101,7 @@ fun getOrCreateVirtualNodeFor(
     cpiName: String
 ) = DEFAULT_CLUSTER.getOrCreateVirtualNodeFor(x500, cpiName)
 
+val vNodeCreationSemaphore = Semaphore(2)
 fun ClusterInfo.getOrCreateVirtualNodeFor(
     x500: String,
     cpiName: String
@@ -106,27 +116,29 @@ fun ClusterInfo.getOrCreateVirtualNodeFor(
     }
     val hash = truncateLongHash(json["cpiFileChecksum"].textValue())
 
-    val vNodesJson = assertWithRetryIgnoringExceptions {
-        command { vNodeList() }
-        condition { it.code == 200 }
-        failMessage("Failed to retrieve virtual nodes")
-    }.toJson()
-
-    val normalizedX500 = MemberX500Name.parse(x500).toString()
-
-    if (vNodesJson.findValuesAsText("x500Name").contains(normalizedX500)) {
-        vNodeList().toJson()["virtualNodes"].toList().first {
-            it["holdingIdentity"]["x500Name"].textValue() == normalizedX500
-        }["holdingIdentity"]["shortHash"].textValue()
-    } else {
-        val createVNodeRequest = assertWithRetry {
-            command { vNodeCreate(hash, x500) }
-            condition { it.code == 202 }
-            failMessage("Failed to create the virtual node for '$x500'")
+    vNodeCreationSemaphore.runWith {
+        val vNodesJson = assertWithRetryIgnoringExceptions {
+            command { vNodeList() }
+            condition { it.code == 200 }
+            failMessage("Failed to retrieve virtual nodes")
         }.toJson()
 
-        val requestId = createVNodeRequest["requestId"].textValue()
-        awaitVirtualNodeOperationStatusCheck(requestId)
+        val normalizedX500 = MemberX500Name.parse(x500).toString()
+
+        if (vNodesJson.findValuesAsText("x500Name").contains(normalizedX500)) {
+            vNodeList().toJson()["virtualNodes"].toList().first {
+                it["holdingIdentity"]["x500Name"].textValue() == normalizedX500
+            }["holdingIdentity"]["shortHash"].textValue()
+        } else {
+            val createVNodeRequest = assertWithRetry {
+                command { vNodeCreate(hash, x500) }
+                condition { it.code == 202 }
+                failMessage("Failed to create the virtual node for '$x500'")
+            }.toJson()
+
+            val requestId = createVNodeRequest["requestId"].textValue()
+            awaitVirtualNodeOperationStatusCheck(requestId)
+        }
     }
 }
 
@@ -195,4 +207,13 @@ fun ClusterInfo.keyExists(
     }
 
     result.code == ResponseCode.OK.statusCode && result.toJson().fieldNames().hasNext()
+}
+
+private fun <T> Semaphore.runWith(block: () -> T): T {
+    this.acquire()
+    try {
+        return block()
+    } finally {
+        this.release()
+    }
 }


### PR DESCRIPTION
Allow limited amount of parallelism in the smoketest:
- Update test utils to limit number of concurrent admin operations.
- Smoketests configuration to allow running classes in parallel.
- Exclude from parallelism tests that fail when doing so.