### PR TITLE
CORE-17495: Add checks to ensure that CPKs do not share a name

### DIFF
--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2.kt
@@ -95,11 +95,11 @@ class CpiLoaderV2(private val clock: Clock = UTCClock()) : CpiLoader {
                         verifySignature = false,
                         cpkFileName = Paths.get(it.entry.name).fileName.toString()
                     ).also {
-                        val cpkName = it.metadata.cpkId.name
-                        if (cordappCpkNames.contains(cpkName)) {
-                            throw PackagingException("Multiple CPKs share the Corda-CPK-Cordapp-Name $cpkName.")
+                        val cordappCpkName = it.metadata.cpkId.name
+                        if (cordappCpkNames.contains(cordappCpkName)) {
+                            throw PackagingException("Multiple CPKs share the Corda-CPK-Cordapp-Name $cordappCpkName.")
                         }
-                        cordappCpkNames.add(cpkName)
+                        cordappCpkNames.add(cordappCpkName)
                     }
                 }
         }

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2.kt
@@ -94,13 +94,12 @@ class CpiLoaderV2(private val clock: Clock = UTCClock()) : CpiLoader {
                         cpkLocation = cpiLocation.plus("/${it.entry.name}"),
                         verifySignature = false,
                         cpkFileName = Paths.get(it.entry.name).fileName.toString()
-                    ).apply {
-                        metadata.cpkId.name.let {cpkName ->
-                            if (cordappCpkNames.contains(cpkName)) {
-                                throw PackagingException("Multiple CPKs share the Corda-CPK-Cordapp-Name $cpkName.")
-                            }
-                            cordappCpkNames.add(cpkName)
+                    ).also {
+                        val cpkName = it.metadata.cpkId.name
+                        if (cordappCpkNames.contains(cpkName)) {
+                            throw PackagingException("Multiple CPKs share the Corda-CPK-Cordapp-Name $cpkName.")
                         }
+                        cordappCpkNames.add(cpkName)
                     }
                 }
         }

--- a/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2.kt
+++ b/libs/packaging/packaging/src/main/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2.kt
@@ -59,6 +59,16 @@ class CpiLoaderV2(private val clock: Clock = UTCClock()) : CpiLoader {
                 emptyList()
             }
 
+            val cordappCpkNames = HashSet<String>()
+
+            cpks.forEach {
+                val name = it.metadata.cpkId.name
+                if (cordappCpkNames.contains(name)) {
+                    throw PackagingException("Multiple CPKs share a Corda-CPK-Cordapp-Name")
+                }
+                cordappCpkNames.add(name)
+            }
+
             val mainAttributes = jarInputStream.manifest.mainAttributes
             return CpiImpl(
                 CpiMetadata(

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2Test.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2Test.kt
@@ -35,15 +35,15 @@ class CpiLoaderV2Test {
 
     @Test
     fun `CPI loading fails with duplicate CPKs`() {
-        val cpkName = "com.test.duplicate"
+        val cordappCpkName = "com.test.duplicate"
 
         val inMemoryCpk1 = TestCpkV2Builder()
             .name("test1.jar")
-            .bundleName(cpkName)
+            .bundleName(cordappCpkName)
 
         val inMemoryCpk2 = TestCpkV2Builder()
             .name("test2.jar")
-            .bundleName(cpkName)
+            .bundleName(cordappCpkName)
 
         val inMemoryCpb = TestCpbV2Builder()
             .cpks(inMemoryCpk1, inMemoryCpk2)
@@ -53,12 +53,8 @@ class CpiLoaderV2Test {
             .cpb(inMemoryCpb)
             .build()
 
-        val e = assertThrows<PackagingException> {
+        assertThrows<PackagingException> {
             CpiLoaderV2().loadCpi(inMemoryCpi.toByteArray(), tmp, "in-memory", false)
-        }
-
-        assertEquals(e.message, "Multiple CPKs share the Corda-CPK-Cordapp-Name $cpkName.") {
-            "Failure should be caused by multiple CPKs sharing a Corda-CPK-Cordapp-Name."
         }
     }
 }

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2Test.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2Test.kt
@@ -35,13 +35,15 @@ class CpiLoaderV2Test {
 
     @Test
     fun `CPI loading fails with duplicate CPKs`() {
+        val cpkName = "com.test.duplicate"
+
         val inMemoryCpk1 = TestCpkV2Builder()
             .name("test1.jar")
-            .bundleName("duplicate.cpk")
+            .bundleName(cpkName)
 
         val inMemoryCpk2 = TestCpkV2Builder()
             .name("test2.jar")
-            .bundleName("duplicate.cpk")
+            .bundleName(cpkName)
 
         val inMemoryCpb = TestCpbV2Builder()
             .cpks(inMemoryCpk1, inMemoryCpk2)
@@ -55,9 +57,8 @@ class CpiLoaderV2Test {
             CpiLoaderV2().loadCpi(inMemoryCpi.toByteArray(), tmp, "in-memory", false)
         }
 
-        assert(e.message!!.contains("Multiple CPKs share the Corda-CPK-Cordapp-Name")) {
+        assertEquals(e.message, "Multiple CPKs share the Corda-CPK-Cordapp-Name $cpkName.") {
             "Failure should be caused by multiple CPKs sharing a Corda-CPK-Cordapp-Name."
         }
     }
 }
-

--- a/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2Test.kt
+++ b/libs/packaging/packaging/src/test/kotlin/net/corda/libs/packaging/internal/v2/CpiLoaderV2Test.kt
@@ -55,7 +55,7 @@ class CpiLoaderV2Test {
             CpiLoaderV2().loadCpi(inMemoryCpi.toByteArray(), tmp, "in-memory", false)
         }
 
-        assert(e.message!!.contains("Multiple CPKs share a Corda-CPK-Cordapp-Name")) {
+        assert(e.message!!.contains("Multiple CPKs share the Corda-CPK-Cordapp-Name")) {
             "Failure should be caused by multiple CPKs sharing a Corda-CPK-Cordapp-Name."
         }
     }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -35,10 +35,21 @@ internal class SandboxGroupImpl(
     private val classTagFactory: ClassTagFactory,
     private val bundleUtils: BundleUtils
 ) : SandboxGroupInternal {
+    private val cpkNames = ConcurrentHashMap.newKeySet<String>()
+    init {
+        cpkSandboxes.forEach {
+            val name = it.cpkMetadata.cpkId.name
+            if (cpkNames.contains(name)) {
+                throw SandboxException("CPK $name is declared twice.")
+            } else {
+                cpkNames.add(it.cpkMetadata.cpkId.name)
+            }
+        }
+    }
 
     private companion object {
-        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private fun Throwable.withSuppressed(exceptions: Iterable<Throwable>): Throwable {
             exceptions.forEach(::addSuppressed)
             return this
@@ -47,7 +58,6 @@ internal class SandboxGroupImpl(
 
     // Marker for a missing class.
     private class NotFound
-
     private val publicBundles = publicSandboxes.flatMap(Sandbox::publicBundles).filterNot { bundle ->
         // The system bundle's classloader is actually the JVM's Application Classloader,
         // which is not constrained by the OSGi framework's resolver hooks. So skip the

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -35,15 +35,9 @@ internal class SandboxGroupImpl(
     private val classTagFactory: ClassTagFactory,
     private val bundleUtils: BundleUtils
 ) : SandboxGroupInternal {
-    private val cpkNames = ConcurrentHashMap.newKeySet<String>()
     init {
-        cpkSandboxes.forEach {
-            val name = it.cpkMetadata.cpkId.name
-            if (cpkNames.contains(name)) {
-                throw SandboxException("CPK $name is declared twice.")
-            } else {
-                cpkNames.add(it.cpkMetadata.cpkId.name)
-            }
+        cpkSandboxes.groupBy { it.cpkMetadata.cpkId.name }.filter { (it.value.size > 1) }.map {
+            throw SandboxException("CPK ${it.key} is declared more than once.")
         }
     }
 

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -39,7 +39,7 @@ internal class SandboxGroupImpl(
         val cordappCpkNames = HashSet<String>()
         cpkSandboxes.forEach {
             if (cordappCpkNames.contains(it.cpkMetadata.cpkId.name)) {
-                throw SandboxException("CPK ${it.cpkMetadata.cpkId.name} is declared more than once.")
+                throw SandboxException("Multiple CPKs share the Corda-CPK-Cordapp-Name ${it.cpkMetadata.cpkId.name}.")
             }
             cordappCpkNames.add(it.cpkMetadata.cpkId.name)
         }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxGroupImpl.kt
@@ -36,8 +36,12 @@ internal class SandboxGroupImpl(
     private val bundleUtils: BundleUtils
 ) : SandboxGroupInternal {
     init {
-        cpkSandboxes.groupBy { it.cpkMetadata.cpkId.name }.filter { (it.value.size > 1) }.map {
-            throw SandboxException("CPK ${it.key} is declared more than once.")
+        val cordappCpkNames = HashSet<String>()
+        cpkSandboxes.forEach {
+            if (cordappCpkNames.contains(it.cpkMetadata.cpkId.name)) {
+                throw SandboxException("CPK ${it.cpkMetadata.cpkId.name} is declared more than once.")
+            }
+            cordappCpkNames.add(it.cpkMetadata.cpkId.name)
         }
     }
 

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
@@ -253,6 +253,23 @@ class SandboxGroupImplTests {
             sandboxGroupImpl.getClass(nonSandboxClass.name, CPK_STATIC_TAG)
         }
     }
+
+    @Test
+    fun `throws if multiple sandboxes with shared CPK name`() {
+        val otherCpkSandbox =
+            CpkSandboxImpl(randomUUID(), mockCpkMeta(), mockCpkMainBundle, setOf(mockCpkLibraryBundle))
+
+        val e = assertThrows<SandboxException> {
+            SandboxGroupImpl(
+                randomUUID(),
+                setOf(cpkSandbox, otherCpkSandbox),
+                setOf(publicSandbox),
+                DummyClassTagFactory(cpkSandbox.cpkMetadata),
+                mockBundleUtils
+            )
+        }
+        assert(e.message!!.contains("declared twice."))
+    }
 }
 
 /** A dummy [StaticTag] implementation. */

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
@@ -259,7 +259,7 @@ class SandboxGroupImplTests {
         val otherCpkSandbox =
             CpkSandboxImpl(randomUUID(), mockCpkMeta(), mockCpkMainBundle, setOf(mockCpkLibraryBundle))
 
-        val e = assertThrows<SandboxException> {
+        assertThrows<SandboxException> {
             SandboxGroupImpl(
                 randomUUID(),
                 setOf(cpkSandbox, otherCpkSandbox),
@@ -268,7 +268,6 @@ class SandboxGroupImplTests {
                 mockBundleUtils
             )
         }
-        assert(e.message!!.contains("declared more than once.")) {e.message!!}
     }
 }
 

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxGroupImplTests.kt
@@ -268,7 +268,7 @@ class SandboxGroupImplTests {
                 mockBundleUtils
             )
         }
-        assert(e.message!!.contains("declared twice."))
+        assert(e.message!!.contains("declared more than once.")) {e.message!!}
     }
 }
 


### PR DESCRIPTION
A Cordapp CPK has a field used to identify it as the same Cordapp across multiple versions. This PR ensures that CPKs do not share a name to prevent confusion in the upgrade process.