### PR TITLE
CORE-18229 Set code owners on network team branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @driessamyn @jasonbyrner3 @dimosr @ronanbrowne @rick-r3 @simon-johnson-r3 @blsemo @Omar-awad @aditisdesai @vinir3 @vkolomeyko @thiagoviana @Sakpal
+* @corda/corda-platform-network-team


### PR DESCRIPTION
Set the code owners on the network team feature branch.