### PR TITLE
CORE-17966: Implement checkpoint cleanup handler when processing FlowMarkedForKillException

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
@@ -4,6 +4,7 @@ import net.corda.data.flow.output.FlowStates
 import net.corda.flow.application.sessions.SessionInfo
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.flow.testing.context.ALICE_FLOW_KEY_MAPPER
+import net.corda.flow.testing.context.BOB_FLOW_KEY_MAPPER
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.virtualnode.OperationalStatus
 import org.junit.jupiter.api.BeforeEach
@@ -44,6 +45,7 @@ class FlowKilledAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 nullStateRecord()
                 flowKilledStatus(flowTerminatedReason = "Flow operational status is INACTIVE")
+                scheduleFlowMapperCleanupEvents(BOB_FLOW_KEY_MAPPER)
                 flowFiberCacheDoesNotContainKey(BOB_HOLDING_IDENTITY, REQUEST_ID1)
             }
         }

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
@@ -43,6 +43,7 @@ class FlowKilledAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
+                sessionErrorEvents()
                 nullStateRecord()
                 flowKilledStatus(flowTerminatedReason = "Flow operational status is INACTIVE")
                 scheduleFlowMapperCleanupEvents(BOB_FLOW_KEY_MAPPER)
@@ -97,6 +98,7 @@ class FlowKilledAcceptanceTest : FlowServiceTestBase() {
 
         then {
             expectOutputForFlow(FLOW_ID1) {
+                sessionErrorEvents(SESSION_ID_1)
                 nullStateRecord()
                 flowKilledStatus(flowTerminatedReason = "Flow operational status is INACTIVE")
                 scheduleFlowMapperCleanupEvents(SESSION_ID_1, ALICE_FLOW_KEY_MAPPER)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/tests/FlowKilledAcceptanceTest.kt
@@ -3,6 +3,7 @@ package net.corda.flow.testing.tests
 import net.corda.data.flow.output.FlowStates
 import net.corda.flow.application.sessions.SessionInfo
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.testing.context.ALICE_FLOW_KEY_MAPPER
 import net.corda.flow.testing.context.FlowServiceTestBase
 import net.corda.virtualnode.OperationalStatus
 import org.junit.jupiter.api.BeforeEach
@@ -96,6 +97,7 @@ class FlowKilledAcceptanceTest : FlowServiceTestBase() {
             expectOutputForFlow(FLOW_ID1) {
                 nullStateRecord()
                 flowKilledStatus(flowTerminatedReason = "Flow operational status is INACTIVE")
+                scheduleFlowMapperCleanupEvents(SESSION_ID_1, ALICE_FLOW_KEY_MAPPER)
                 flowFiberCacheDoesNotContainKey(ALICE_HOLDING_IDENTITY, REQUEST_ID1)
             }
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImplTest.kt
@@ -12,6 +12,7 @@ import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.fiber.cache.FlowFiberCache
+import net.corda.flow.maintenance.CheckpointCleanupHandler
 import net.corda.flow.pipeline.converters.FlowEventContextConverter
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowEventException
@@ -60,6 +61,8 @@ class FlowEventExceptionProcessorImplTest {
     private val flowFiberCache = mock<FlowFiberCache>()
     private val serializedFiber = ByteBuffer.wrap("mock fiber".toByteArray())
 
+    private val checkpointCleanupHandler = mock<CheckpointCleanupHandler>()
+
     private val sessionIdOpen = "sesh-id"
     private val sessionIdClosed = "sesh-id-closed"
     private val flowActiveSessionState = SessionState().apply {
@@ -74,7 +77,8 @@ class FlowEventExceptionProcessorImplTest {
         flowMessageFactory,
         flowRecordFactory,
         flowSessionManager,
-        flowFiberCache
+        flowFiberCache,
+        checkpointCleanupHandler
     )
 
     @BeforeEach

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
@@ -8,8 +8,6 @@ import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.output.FlowStatus
-import net.corda.data.flow.state.session.SessionState
-import net.corda.data.flow.state.session.SessionStateType
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.cache.FlowFiberCache
 import net.corda.flow.maintenance.CheckpointCleanupHandler
@@ -27,19 +25,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class FlowToBeKilledExceptionProcessingTest {
-
     private companion object {
-        const val SESSION_ID_1 = "s1"
-        const val SESSION_ID_2 = "s2"
-        const val SESSION_ID_3 = "s3"
-        const val SESSION_ID_4 = "s4"
-        const val SESSION_ID_5 = "s5"
         const val FLOW_ID = "flowId"
     }
 
@@ -50,32 +40,6 @@ class FlowToBeKilledExceptionProcessingTest {
         FlowConfig.PROCESSING_MAX_RETRY_WINDOW_DURATION, ConfigValueFactory.fromAnyRef(20000L)
     )
     private val smartFlowConfig = SmartConfigFactory.createWithoutSecurityServices().create(flowConfig)
-
-    // starting session states
-    private val sessionState1 = createSessionState(SESSION_ID_1, true, SessionStateType.CLOSING)
-    private val sessionState2 = createSessionState(SESSION_ID_2, true, SessionStateType.ERROR)
-    private val sessionState3 = createSessionState(SESSION_ID_3, true, SessionStateType.CLOSED)
-    private val sessionState4 = createSessionState(SESSION_ID_4, false, SessionStateType.CONFIRMED)
-    private val sessionState5 = createSessionState(SESSION_ID_5, false, SessionStateType.CREATED)
-
-    // session states which have had their state updated to ERROR
-    private val erroredSessionState1 = createSessionState(SESSION_ID_1, false, SessionStateType.ERROR)
-    private val erroredSessionState4 = createSessionState(SESSION_ID_4, false, SessionStateType.ERROR)
-    private val erroredSessionState5 = createSessionState(SESSION_ID_5, false, SessionStateType.ERROR)
-
-    private val allFlowSessions = listOf(sessionState1, sessionState2, sessionState3, sessionState4, sessionState5)
-    private val activeFlowSessionIds = listOf(SESSION_ID_1, SESSION_ID_4, SESSION_ID_5)
-    private val allFlowSessionsAfterErrorsSent = listOf(
-        erroredSessionState1, sessionState2, sessionState3, erroredSessionState4, erroredSessionState5
-    )
-
-    private fun createSessionState(sessionId: String, hasScheduledCleanup: Boolean, status: SessionStateType): SessionState =
-        SessionState().apply {
-            this.sessionId = sessionId
-            this.hasScheduledCleanup = hasScheduledCleanup
-            this.status = status
-        }
-
     private val flowKey = FlowKey("id", HoldingIdentity("x500", "grp1"))
     private val checkpoint = mock<FlowCheckpoint> {
         whenever(it.flowKey).thenReturn(flowKey)
@@ -89,13 +53,8 @@ class FlowToBeKilledExceptionProcessingTest {
     private val flowKilledStatusRecord = Record("s", flowKey, flowKilledStatus)
     private val flowFiberCache = mock<FlowFiberCache>()
     private val checkpointCleanupHandler = mock<CheckpointCleanupHandler>()
-
     private val target = FlowEventExceptionProcessorImpl(
-        flowMessageFactory,
-        flowRecordFactory,
-        flowSessionManager,
-        flowFiberCache,
-        checkpointCleanupHandler
+        flowMessageFactory, flowRecordFactory, flowSessionManager, flowFiberCache, checkpointCleanupHandler
     )
 
     @BeforeEach
@@ -108,58 +67,46 @@ class FlowToBeKilledExceptionProcessingTest {
     fun `processing FlowMarkedForKillException calls checkpoint cleanup handler and copies cleanup records to context`() {
         val testContext = buildFlowEventContext(checkpoint, Any())
         val exception = FlowMarkedForKillException("reasoning")
-
         whenever(checkpoint.doesExist).thenReturn(true)
-
         val flowMapperEvent = mock<FlowMapperEvent>()
         val cleanupRecord = Record(Schemas.Flow.FLOW_MAPPER_SESSION_OUT, "key", flowMapperEvent)
-        val cleanupRecords = listOf (cleanupRecord)
+        val cleanupRecords = listOf(cleanupRecord)
         whenever(checkpointCleanupHandler.cleanupCheckpoint(any(), any(), any())).thenReturn(cleanupRecords)
 
         val response = target.process(exception, testContext)
 
-        assertThat(response.outputRecords)
-            .contains(cleanupRecord)
+        assertThat(response.outputRecords).contains(cleanupRecord)
     }
 
     @Test
     fun `processing FlowMarkedForKillException when checkpoint does not exist only outputs flow killed status record`() {
         whenever(checkpoint.doesExist).thenReturn(false)
-
-        val inputEventPayload = StartFlow(FlowStartContext().apply {statusKey = flowKey}, "")
-
+        val inputEventPayload = StartFlow(FlowStartContext().apply { statusKey = flowKey }, "")
         val testContext = buildFlowEventContext(checkpoint, inputEventPayload)
         val exception = FlowMarkedForKillException("reasoning")
-
         whenever(flowRecordFactory.createFlowStatusRecord(any())).thenReturn(flowKilledStatusRecord)
 
         val response = target.process(exception, testContext)
 
-        assertThat(response.outputRecords)
-            .hasSize(1)
-            .contains(flowKilledStatusRecord)
+        assertThat(response.outputRecords).hasSize(1).contains(flowKilledStatusRecord)
     }
 
     @Test
     fun `error processing FlowMarkedForKillException falls back to null state record, empty response events and marked for DLQ`() {
         val testContext = buildFlowEventContext(checkpoint, Any())
         val exception = FlowMarkedForKillException("reasoning")
-
-
         whenever(checkpoint.doesExist).thenReturn(true)
-
-        // The first call returns all sessions.
-        whenever(checkpoint.sessions)
-            .thenReturn(allFlowSessions)
-            .thenReturn(allFlowSessionsAfterErrorsSent)
-
-        // simulating exception thrown during processing of the flow session
-        whenever(flowSessionManager.sendErrorMessages(eq(checkpoint), eq(activeFlowSessionIds), eq(exception), any()))
-            .thenThrow(IllegalArgumentException("some error message while sending errors to peers"))
+        // simulating exception thrown during processing
+        whenever(
+            checkpointCleanupHandler.cleanupCheckpoint(
+                any(),
+                any(),
+                any()
+            )
+        ).thenThrow(IllegalArgumentException("some error message while sending errors to peers"))
 
         val response = target.process(exception, testContext)
 
-        verify(response.checkpoint).markDeleted()
         assertThat(response.outputRecords).isEmpty()
         assertThat(response.sendToDlq).isTrue
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
@@ -6,16 +6,13 @@ import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
 import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.event.mapper.FlowMapperEvent
-import net.corda.data.flow.event.mapper.ScheduleCleanup
 import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.output.FlowStatus
-import net.corda.data.flow.state.checkpoint.Checkpoint
-import net.corda.data.flow.state.external.ExternalEventState
 import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.data.identity.HoldingIdentity
 import net.corda.flow.fiber.cache.FlowFiberCache
-import net.corda.flow.pipeline.converters.FlowEventContextConverter
+import net.corda.flow.maintenance.CheckpointCleanupHandler
 import net.corda.flow.pipeline.exceptions.FlowMarkedForKillException
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
@@ -23,8 +20,8 @@ import net.corda.flow.pipeline.sessions.FlowSessionManager
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.libs.configuration.SmartConfigFactory
-import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas
 import net.corda.schema.configuration.FlowConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -32,7 +29,6 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -49,7 +45,6 @@ class FlowToBeKilledExceptionProcessingTest {
 
     private val flowRecordFactory = mock<FlowRecordFactory>()
     private val flowMessageFactory = mock<FlowMessageFactory>()
-    private val flowEventContextConverter = mock<FlowEventContextConverter>()
     private val flowSessionManager = mock<FlowSessionManager>()
     private val flowConfig = ConfigFactory.empty().withValue(
         FlowConfig.PROCESSING_MAX_RETRY_WINDOW_DURATION, ConfigValueFactory.fromAnyRef(20000L)
@@ -70,7 +65,6 @@ class FlowToBeKilledExceptionProcessingTest {
 
     private val allFlowSessions = listOf(sessionState1, sessionState2, sessionState3, sessionState4, sessionState5)
     private val activeFlowSessionIds = listOf(SESSION_ID_1, SESSION_ID_4, SESSION_ID_5)
-    private val erroredFlowSessions = listOf(erroredSessionState1, erroredSessionState4, erroredSessionState5)
     private val allFlowSessionsAfterErrorsSent = listOf(
         erroredSessionState1, sessionState2, sessionState3, erroredSessionState4, erroredSessionState5
     )
@@ -82,8 +76,6 @@ class FlowToBeKilledExceptionProcessingTest {
             this.status = status
         }
 
-    private val scheduleCleanupRecord4 = Record("t", SESSION_ID_4, FlowMapperEvent(ScheduleCleanup(1000)))
-    private val scheduleCleanupRecord5 = Record("t", SESSION_ID_5, FlowMapperEvent(ScheduleCleanup(1000)))
     private val flowKey = FlowKey("id", HoldingIdentity("x500", "grp1"))
     private val checkpoint = mock<FlowCheckpoint> {
         whenever(it.flowKey).thenReturn(flowKey)
@@ -95,14 +87,15 @@ class FlowToBeKilledExceptionProcessingTest {
         processingTerminatedReason = "reason"
     }
     private val flowKilledStatusRecord = Record("s", flowKey, flowKilledStatus)
-    private val mockResponse = mock<StateAndEventProcessor.Response<Checkpoint>>()
     private val flowFiberCache = mock<FlowFiberCache>()
+    private val checkpointCleanupHandler = mock<CheckpointCleanupHandler>()
 
     private val target = FlowEventExceptionProcessorImpl(
         flowMessageFactory,
         flowRecordFactory,
         flowSessionManager,
-        flowFiberCache
+        flowFiberCache,
+        checkpointCleanupHandler
     )
 
     @BeforeEach
@@ -112,87 +105,25 @@ class FlowToBeKilledExceptionProcessingTest {
     }
 
     @Test
-    fun `processing MarkedForKillException sends error events to all sessions then schedules cleanup for any not yet scheduled`() {
+    fun `processing FlowMarkedForKillException calls checkpoint cleanup handler and copies cleanup records to context`() {
         val testContext = buildFlowEventContext(checkpoint, Any())
         val exception = FlowMarkedForKillException("reasoning")
 
         whenever(checkpoint.doesExist).thenReturn(true)
 
-        // The first call returns all sessions.
-        whenever(checkpoint.sessions)
-            .thenReturn(allFlowSessions)
-            .thenReturn(allFlowSessionsAfterErrorsSent)
-
-        // we send error messages for all active flow sessions, returning the flow sessions with state updated to ERROR
-        whenever(flowSessionManager.sendErrorMessages(eq(checkpoint), eq(activeFlowSessionIds), eq(exception), any()))
-            .thenReturn(erroredFlowSessions)
-
-        // we clean up all flow sessions that have not already been cleaned up
-        whenever(flowRecordFactory.createFlowMapperEventRecord(eq(SESSION_ID_4), any())).thenReturn(scheduleCleanupRecord4)
-        whenever(flowRecordFactory.createFlowMapperEventRecord(eq(SESSION_ID_5), any())).thenReturn(scheduleCleanupRecord5)
-
-        // callouts to factories to create flow killed status record
-        whenever(flowMessageFactory.createFlowKilledStatusMessage(any(), any())).thenReturn(flowKilledStatus)
-        whenever(flowRecordFactory.createFlowStatusRecord(flowKilledStatus)).thenReturn(flowKilledStatusRecord)
+        val flowMapperEvent = mock<FlowMapperEvent>()
+        val cleanupRecord = Record(Schemas.Flow.FLOW_MAPPER_SESSION_OUT, "key", flowMapperEvent)
+        val cleanupRecords = listOf (cleanupRecord)
+        whenever(checkpointCleanupHandler.cleanupCheckpoint(any(), any(), any())).thenReturn(cleanupRecords)
 
         val response = target.process(exception, testContext)
 
-        verify(checkpoint, times(1)).putSessionStates(erroredFlowSessions)
-        verify(checkpoint, times(1)).markDeleted()
-
         assertThat(response.outputRecords)
-            .withFailMessage("Output records should contain cleanup records for sessions that aren't already scheduled")
-            .contains(scheduleCleanupRecord4, scheduleCleanupRecord5)
-
-        assertThat(response.outputRecords)
-            .withFailMessage("Output records should contain the flow killed status record")
-            .contains(flowKilledStatusRecord)
-
-        val updatedFlowSessions = response.checkpoint.sessions.associateBy { it.sessionId }
-        assertThat(updatedFlowSessions.values.all { it.hasScheduledCleanup })
-            .withFailMessage("All flow sessions should now be marked as scheduled for cleanup")
-            .isTrue
-        assertThat(updatedFlowSessions[SESSION_ID_1]?.status).isEqualTo(SessionStateType.ERROR)
-        assertThat(updatedFlowSessions[SESSION_ID_2]?.status).isEqualTo(SessionStateType.ERROR)
-        assertThat(updatedFlowSessions[SESSION_ID_3]?.status).isEqualTo(SessionStateType.CLOSED)
-        assertThat(updatedFlowSessions[SESSION_ID_4]?.status).isEqualTo(SessionStateType.ERROR)
-        assertThat(updatedFlowSessions[SESSION_ID_5]?.status).isEqualTo(SessionStateType.ERROR)
+            .contains(cleanupRecord)
     }
 
     @Test
-    fun `processing MarkedForKillException removes retries and external events from output records`() {
-        whenever(checkpoint.doesExist).thenReturn(true)
-
-        val externalEventState = ExternalEventState()
-        whenever(checkpoint.externalEventState).thenReturn(externalEventState)
-        whenever(checkpoint.inRetryState).thenReturn(true)
-
-        val testContext = buildFlowEventContext(checkpoint, Any())
-        val exception = FlowMarkedForKillException("reasoning")
-
-        whenever(checkpoint.sessions)
-            .thenReturn(emptyList())
-            .thenReturn(emptyList())
-
-        // callouts to factories to create flow killed status record
-        whenever(flowMessageFactory.createFlowKilledStatusMessage(any(), any())).thenReturn(flowKilledStatus)
-        whenever(flowRecordFactory.createFlowStatusRecord(flowKilledStatus)).thenReturn(flowKilledStatusRecord)
-
-        val response = target.process(exception, testContext)
-
-        verify(checkpoint, times(1)).markDeleted()
-
-        assertThat(response.outputRecords)
-            .withFailMessage("Output records should only have flow status record")
-            .hasSize(1)
-
-        assertThat(response.outputRecords)
-            .withFailMessage("Output records should contain the flow killed status record")
-            .contains(flowKilledStatusRecord)
-    }
-
-    @Test
-    fun `processing MarkedForKillException when checkpoint does not exist only outputs flow killed status record`() {
+    fun `processing FlowMarkedForKillException when checkpoint does not exist only outputs flow killed status record`() {
         whenever(checkpoint.doesExist).thenReturn(false)
 
         val inputEventPayload = StartFlow(FlowStartContext().apply {statusKey = flowKey}, "")
@@ -205,16 +136,12 @@ class FlowToBeKilledExceptionProcessingTest {
         val response = target.process(exception, testContext)
 
         assertThat(response.outputRecords)
-            .withFailMessage("Output records should only have flow status record")
             .hasSize(1)
-
-        assertThat(response.outputRecords)
-            .withFailMessage("Output records should contain the flow killed status record")
             .contains(flowKilledStatusRecord)
     }
 
     @Test
-    fun `error processing MarkedForKillException falls back to null state record, empty response events and marked for DLQ`() {
+    fun `error processing FlowMarkedForKillException falls back to null state record, empty response events and marked for DLQ`() {
         val testContext = buildFlowEventContext(checkpoint, Any())
         val exception = FlowMarkedForKillException("reasoning")
 


### PR DESCRIPTION
### Change:
This PR will implement checkpoint cleanup handler when processing **FlowMarkedForKillException**.

### Reasoning:
In order to address CORE-17966: _When exceptions such as FlowFatalException are thrown in the Flow Engine the exception handlers cleanup the checkpoints and schedule cleanup of the session states. However they currently do not cleanup the StartFlow Flow Mapper state for RPC started flows_ the checkpoint cleanup handler will be integrated in a series of small PRs.