### PR TITLE
CORE-17766: config redaction on arrays

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
@@ -2,6 +2,8 @@ package net.corda.crypto.softhsm.impl
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigList
 import com.typesafe.config.ConfigObject
 import com.typesafe.config.ConfigValue
@@ -125,21 +127,30 @@ open class SoftCryptoServiceProviderImpl @Activate constructor(
             val expireAfterAccessMins = cachingConfig.getConfig("expireAfterAccessMins").getLong("default")
             val maximumSize = cachingConfig.getConfig("maximumSize").getLong("default")
             val hsmConfig = config.hsm()
-            val keysList: ConfigList = hsmConfig.wrappingKeys
+            val keysList = try {
+                val hsmConfigObject = config.getConfig("hsm")
+                hsmConfigObject.getConfigList("wrappingKeys")
+            } catch (e: ConfigException) {
+                throw InvalidParameterException("invalid wrappingKeys list: $e")
+            }
             val unmanagedWrappingKeys: Map<String, WrappingKey> =
-                keysList.map { it: ConfigValue ->
-                    when (it) {
-                        is ConfigObject -> {
-                            val alias = it["alias"]?.unwrapped()
-                            if (!(alias is String)) throw InvalidParameterException("alias missing or invalid")
-                            val salt = it["salt"]?.unwrapped()
-                            if (!(salt is String)) throw InvalidParameterException("salt missing or invalid")
-                            val passphrase = it["passphrase"]?.unwrapped()
-                            if (!(passphrase is String)) throw InvalidPropertiesFormatException("passphrase missingo rinalid")
-                            alias to WrappingKeyImpl.derive(schemeMetadata, passphrase, salt)
-                        }
-                        else -> throw InvalidParameterException("unexpected item ")
+                keysList.map {
+                    val alias = try {
+                        it.getString("alias")
+                    } catch (e: ConfigException) {
+                        throw InvalidParameterException("alias missing or invalid: $e")
                     }
+                    val salt = try {
+                        it.getString("salt")
+                    } catch (e: ConfigException) {
+                        throw InvalidParameterException("salt missing or invalid: $e")
+                    }
+                    val passphrase = try {
+                        it.getString("passphrase")
+                    } catch (e: ConfigException) {
+                        throw InvalidParameterException("passphrase missing or invalid: $e")
+                    }
+                    alias to WrappingKeyImpl.derive(schemeMetadata, passphrase, salt)
                 }.toMap()
             val defaultUnmanagedWrappingKeyName = hsmConfig.defaultWrappingKey
             require(unmanagedWrappingKeys.containsKey(defaultUnmanagedWrappingKeyName)) {

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceProviderImpl.kt
@@ -2,17 +2,12 @@ package net.corda.crypto.softhsm.impl
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
-import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
-import com.typesafe.config.ConfigList
-import com.typesafe.config.ConfigObject
-import com.typesafe.config.ConfigValue
 import java.security.InvalidParameterException
 import java.security.KeyPairGenerator
 import java.security.PrivateKey
 import java.security.Provider
 import java.security.PublicKey
-import java.util.InvalidPropertiesFormatException
 import java.util.concurrent.TimeUnit
 import net.corda.cache.caffeine.CacheFactoryImpl
 import net.corda.configuration.read.ConfigChangedEvent

--- a/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/SmartConfigImpl.kt
+++ b/libs/configuration/configuration-core/src/main/kotlin/net/corda/libs/configuration/SmartConfigImpl.kt
@@ -32,7 +32,7 @@ class SmartConfigImpl(
 ) : SmartConfig {
     companion object{
         fun empty(): SmartConfig = SmartConfigFactory.createWithoutSecurityServices()
-                .create(ConfigFactory.empty())
+            .create(ConfigFactory.empty())
         private val maskedSecretsLookupService = MaskedSecretsLookupService()
     }
 
@@ -182,7 +182,8 @@ class SmartConfigImpl(
 
     override fun getObjectList(path: String?): MutableList<out ConfigObject> = typeSafeConfig.getObjectList(path)
 
-    override fun getConfigList(path: String?): MutableList<out Config> = typeSafeConfig.getConfigList(path)
+    override fun getConfigList(path: String?): List<Config> =
+        typeSafeConfig.getConfigList(path).map { SmartConfigImpl(it, factory, secretsLookupService) }
 
     override fun getAnyRefList(path: String?): MutableList<out Any> = typeSafeConfig.getAnyRefList(path)
 

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigTest.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/SmartConfigTest.kt
@@ -34,6 +34,8 @@ class SmartConfigTest {
             a: b,
             c: d,
         },
+        test_array: [{prime:2},{prime:3},{prime:5}]
+        test_int_array: [2,3,5]
         """.trimIndent()
     val config = ConfigFactory.parseString(configString).resolve()
 
@@ -315,6 +317,34 @@ class SmartConfigTest {
 
         assertThat(c.getString("jon")).isEqualTo("fallback-secret")
     }
+
+
+    @Test
+    fun `getObjectList works`() {
+        val r = smartConfig.getObjectList("test_array")
+        assertThat(r.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getList works on int array`() {
+        val r = smartConfig.getList("test_int_array")
+        assertThat(r.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getList works on object array`() {
+        val r = smartConfig.getList("test_array")
+        assertThat(r.size).isEqualTo(3)
+    }
+
+    @Test
+    fun `getConfigList works on object array`() {
+        val r = smartConfig.getConfigList("test_array")
+        assertThat(r.size).isEqualTo(3)
+        assertThat(r[0].getInt("prime")).isEqualTo(2)
+        assertThat(r[0]).isInstanceOf(SmartConfig::class.java)
+    }
+
 
     enum class Snack {
         DONUTS,

--- a/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceTest.kt
+++ b/libs/configuration/configuration-core/src/test/kotlin/net/corda/libs/configuration/secret/EncryptionSecretsServiceTest.kt
@@ -135,4 +135,15 @@ class EncryptionSecretsServiceTest {
         assertThat(secretConfig.getString("configSecret.encryptedSecret")).isNotBlank
         assertThat(service.getValue(secretConfig)).isEqualTo("")
     }
+
+    @Test
+    fun `well known key`() {
+        val service = EncryptionSecretsServiceImpl("soup", "fish")
+        val config = ConfigFactory.parseString("""
+        configSecret {
+            "encryptedSecret":"iUUaENwGC+z0PnVjvYHIZz3AACs0mUz2OpIjCg4ZKcCImvsdacgdX+gy8xAIkoR8BAW3vJ3aXenUmNJLbWdrdDPXc8EfWSbL",
+        }   
+    """.trimIndent())
+        assertThat( service.getValue(config)).isEqualTo("C8DMac5wpGagNSuruAjY/6wbKOLtVL66QAuaN5emA/I=")
+    }
 }

--- a/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelper.kt
+++ b/libs/configuration/configuration-validation/src/main/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelper.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.configuration.validation.impl
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
 import net.corda.libs.configuration.secret.MaskedSecretsLookupService
@@ -14,7 +15,6 @@ class ConfigSecretHelper {
     private companion object {
         const val TMP_SECRET = MaskedSecretsLookupService.MASK_VALUE
         val TMP_SECRET_NODE: JsonNode = TextNode(TMP_SECRET)
-
     }
 
     /**
@@ -27,6 +27,20 @@ class ConfigSecretHelper {
         return hideSecretsRecursive(node, node)
     }
 
+    // Make it easy to walk JSON node structures by returning the names of paths
+    // within a node, paired with the value of each path, at one layer only.
+
+    // e.g. {"a":1, "b":2} returns ["a" to JsonNode("1"), "b" to JsonNode("2")]
+    // and  ["alpha", "beta"] returns ["1" to JsonNode("alpha"), "2" to JsonNode("beta")]
+    // and "foo" returns []
+    //
+    // (except the second half of the pairs are actually JsonNode instances)
+    private fun getFieldValues(node: JsonNode): List<Pair<String, JsonNode>> = when(node) {
+        is ObjectNode -> node.fields().asSequence().toList().map { it.key to it.value }
+        is ArrayNode -> node.toList().withIndex().map { it.index.toString() to it.value }
+        else -> emptyList()
+    }
+
     private fun hideSecretsRecursive(
         parentNode: JsonNode,
         node: JsonNode,
@@ -35,25 +49,15 @@ class ConfigSecretHelper {
         nodeName: String = ""
     ): MutableMap<String, JsonNode> {
         val newPath = if (nodePath == "") nodeName else "$nodePath.$nodeName"
-        if (node.isObject) {
-            for ((fieldName, fieldNode) in node.fields().asSequence().toList()) {
-                if (fieldName == ConfigKeys.SECRET_KEY) {
-                    secrets[newPath] = node
-                    (parentNode as ObjectNode).remove(nodeName)
-                    parentNode.set(nodeName, TMP_SECRET_NODE)
-                } else {
-                    hideSecretsRecursive(node, fieldNode, secrets, newPath, fieldName)
-                }
+        getFieldValues(node).forEach { (fieldName, fieldNode) ->
+            if ( fieldName == ConfigKeys.SECRET_KEY) {
+                secrets[newPath] = node
+                (parentNode as ObjectNode).remove(nodeName)
+                parentNode.set(nodeName, TMP_SECRET_NODE)
+            } else {
+                hideSecretsRecursive(node, fieldNode, secrets, newPath, fieldName)
             }
         }
-        if (node.isArray) {
-            var i = 0
-            for (fieldNode in node.toList()) {
-                hideSecretsRecursive(node, fieldNode, secrets, newPath, i.toString())
-                i++
-            }
-        }
-
         return secrets
     }
 
@@ -71,17 +75,14 @@ class ConfigSecretHelper {
         secretsNode: MutableMap<String, JsonNode>,
         nodeName: String = ""
     ) {
-        if (node.isObject) {
-            for ((name, newNode) in node.fields().asSequence().toList()) {
-                val nodePath = if (nodeName == "") name else "$nodeName.$name"
-                val secret = secretsNode[nodePath]
-                if (secret != null) {
-                    (node as ObjectNode).set<ObjectNode>(name, secret)
-                } else {
-                    insertSecretsRecursive(newNode, secretsNode, nodePath)
-                }
+        getFieldValues(node).forEach { (name, newNode) ->
+            val nodePath = if (nodeName == "") name else "$nodeName.$name"
+            val secret = secretsNode[nodePath]
+            if (secret != null) {
+                (node as ObjectNode).set<ObjectNode>(name, secret)
+            } else {
+                insertSecretsRecursive(newNode, secretsNode, nodePath)
             }
         }
     }
-
 }

--- a/libs/configuration/configuration-validation/src/test/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelperTest.kt
+++ b/libs/configuration/configuration-validation/src/test/kotlin/net/corda/libs/configuration/validation/impl/ConfigSecretHelperTest.kt
@@ -30,6 +30,25 @@ class ConfigSecretHelperTest {
        }
     """.trimIndent()
 
+    private val input2= """
+       {
+            "testString": "hello",
+            "testReference": {
+                "foo": [1, 2, 3.14],
+                "bool": true,
+                "array": [
+                     {
+                        "hidden": {
+                            "configSecret": $passwordsObject
+                        }
+                     },
+                     {"visible":"stuff"}
+                 ]
+           }
+       }
+    """.trimIndent()
+
+
     private val helper = ConfigSecretHelper()
 
     @Test
@@ -45,6 +64,23 @@ class ConfigSecretHelperTest {
         val secretsNode = convertJSONToNode(passwordsObject)!!
 
         assertThat(inputNode["testReference"]["hidden"][ConfigKeys.SECRET_KEY]).isEqualTo(secretsNode)
+        assertThat(inputNode["testString"].textValue()).isEqualTo("hello")
+    }
+
+
+    @Test
+    fun `test secrets including array`() {
+        val inputNode = convertJSONToNode(input2)!!
+        val secrets = helper.hideSecrets(inputNode)
+
+        assertThat(inputNode["testReference"]["array"][0]["hidden"].textValue()).isEqualTo(MaskedSecretsLookupService.MASK_VALUE)
+        assertThat(inputNode["testString"].textValue()).isEqualTo("hello")
+
+        helper.insertSecrets(inputNode, secrets)
+
+        val secretsNode = convertJSONToNode(passwordsObject)!!
+
+        assertThat(inputNode["testReference"]["array"][0]["hidden"][ConfigKeys.SECRET_KEY]).isEqualTo(secretsNode)
         assertThat(inputNode["testString"].textValue()).isEqualTo("hello")
     }
 


### PR DESCRIPTION
Arrange to replace secrets in arrays as well as objects, by pulling out the logic.

Supplement the SmartConfig implementation to implement config lists.

Add some tests.

(cherry picked from commit 1777fc50a96f64b2f027c552048a25de3d7e4c67)