### PR TITLE
CORE-18239: Delete Correct State Within Mediator

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -220,7 +220,7 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
                             }
 
                             // Delete state
-                            if (state != null && processorState == null) {
+                            if (state != null && processedState == null) {
                                 deleteStates[it.key.toString()] = state
                             }
                         }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -165,12 +165,14 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
         if (messages.isNotEmpty()) {
             var groups = allocateGroups(messages.map { it.toRecord() })
             var states = stateManager.get(messages.map { it.key.toString() }.distinct())
+
             while (groups.isNotEmpty()) {
                 val asynchronousOutputs = mutableListOf<MediatorMessage<Any>>()
-                val newStates = ConcurrentHashMap<String, State?>()
-                val updateStates = ConcurrentHashMap<String, State?>()
-                val deleteStates = ConcurrentHashMap<String, State?>()
+                val statesToCreate = ConcurrentHashMap<String, State?>()
+                val statesToUpdate = ConcurrentHashMap<String, State?>()
+                val statesToDelete = ConcurrentHashMap<String, State?>()
                 val flowEvents = ConcurrentHashMap<String, MutableList<Record<K, E>>>()
+
                 // Process each group on a thread
                 groups.filter {
                     it.isNotEmpty()
@@ -209,20 +211,7 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
                                 processorState,
                             )
 
-                            // New state
-                            if (state == null && processedState != null) {
-                                newStates[it.key.toString()] = processedState
-                            }
-
-                            // Update state
-                            if (state != null && processedState != null) {
-                                updateStates[it.key.toString()] = processedState
-                            }
-
-                            // Delete state
-                            if (state != null && processedState == null) {
-                                deleteStates[it.key.toString()] = state
-                            }
+                            qualifyState(it.key.toString(), state, processedState, statesToCreate, statesToUpdate, statesToDelete)
                         }
                     }
                 }.map {
@@ -231,10 +220,10 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
 
                 sendAsynchronousEvents(asynchronousOutputs)
                 // Persist states changes
-                val failedToCreateKeys = stateManager.create(newStates.values.mapNotNull { it })
+                val failedToCreateKeys = stateManager.create(statesToCreate.values.mapNotNull { it })
                 val failedToCreate = stateManager.get(failedToCreateKeys.keys)
-                val failedToDelete = stateManager.delete(deleteStates.values.mapNotNull { it })
-                val failedToUpdate = stateManager.update(updateStates.values.mapNotNull { it })
+                val failedToDelete = stateManager.delete(statesToDelete.values.mapNotNull { it })
+                val failedToUpdate = stateManager.update(statesToUpdate.values.mapNotNull { it })
                 states = failedToCreate + failedToDelete + failedToUpdate
                 groups = if (states.isNotEmpty()) {
                     allocateGroups(flowEvents.filterKeys { states.containsKey(it) }.values.flatten())
@@ -247,6 +236,34 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
             }
         }
         metrics.processorTimer.record(System.nanoTime() - startTimestamp, TimeUnit.NANOSECONDS)
+    }
+
+    /**
+     * Decide, based on the original and processed state values, whether the state must be deleted, updated or
+     * deleted; and add the relevant state value to the specific Map.
+     */
+    fun qualifyState(
+        groupId: String,
+        original: State?,
+        processed: State?,
+        toCreate : MutableMap<String, State?>,
+        toUpdate : MutableMap<String, State?>,
+        toDelete : MutableMap<String, State?>
+    ) {
+        // New state
+        if (original == null && processed != null) {
+            toCreate[groupId] = processed
+        }
+
+        // Update state
+        if (original != null && processed != null) {
+            toUpdate[groupId] = processed
+        }
+
+        // Delete state
+        if (original != null && processed == null) {
+            toDelete[groupId] = original
+        }
     }
 
     private fun sendAsynchronousEvents(busEvents: MutableList<MediatorMessage<Any>>) {


### PR DESCRIPTION
Update event mediator so it uses the State returned by the processor,
instead of the original one, when making the decision on whether to
delete it from the persistent storage or not. Failing to do so leaves
orphaned States in the persistent storage, which in turn ends up
causing other issues in the system.

 Co-authored-by: James Higgs <james.higgs@r3.com>