### PR TITLE
CORE-18255 Replacing epochSecond check with epochMilli reducing test flakiness

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
@@ -1,5 +1,12 @@
 package net.corda.applications.workers.smoketest.services
 
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
 import net.corda.applications.workers.smoketest.utils.PLATFORM_VERSION
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.toAvro
@@ -32,13 +39,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.slf4j.LoggerFactory
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.time.Duration
-import java.time.Instant
-import java.util.UUID
 
 /**
  * Tests for the Crypto RPC service
@@ -225,9 +225,9 @@ class CryptoRPCSmokeTests {
         assertEquals(expected.requestId, actual.requestId)
         assertEquals(expected.requestingComponent, actual.requestingComponent)
         assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-        assertThat(actual.responseTimestamp.epochSecond)
-            .isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-            .isLessThanOrEqualTo(now.epochSecond)
+        assertThat(actual.responseTimestamp.toEpochMilli())
+            .isGreaterThanOrEqualTo(expected.requestTimestamp.toEpochMilli())
+            .isLessThanOrEqualTo(now.toEpochMilli())
         assertSoftly { softly ->
             softly.assertThat(actual.other.items.size == expected.other.items.size)
             softly.assertThat(actual.other.items.containsAll(expected.other.items))

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
@@ -1,12 +1,5 @@
 package net.corda.applications.workers.smoketest.services
 
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import java.time.Duration
-import java.time.Instant
-import java.util.UUID
 import net.corda.applications.workers.smoketest.utils.PLATFORM_VERSION
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.toAvro
@@ -39,6 +32,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.slf4j.LoggerFactory
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
 
 /**
  * Tests for the Crypto RPC service

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -1,5 +1,11 @@
 package net.corda.crypto.service.impl.bus
 
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.crypto.config.impl.createDefaultCryptoConfig
 import net.corda.crypto.config.impl.retrying
@@ -23,12 +29,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import java.time.Instant
-import java.util.*
-import java.util.concurrent.CompletableFuture
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 //
 //import net.corda.configuration.read.ConfigChangedEvent
@@ -165,9 +165,9 @@ class CryptoOpsBusProcessorTests {
         assertEquals(expected.requestId, actual.requestId)
         assertEquals(expected.requestingComponent, actual.requestingComponent)
         assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-        assertThat(actual.responseTimestamp.epochSecond)
-            .isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-            .isLessThanOrEqualTo(now.epochSecond)
+        assertThat(actual.responseTimestamp.toEpochMilli())
+            .isGreaterThanOrEqualTo(expected.requestTimestamp.toEpochMilli())
+            .isLessThanOrEqualTo(now.toEpochMilli())
         assertTrue(
             actual.other.items.size == expected.other.items.size &&
                     actual.other.items.containsAll(expected.other.items) &&

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -1,11 +1,5 @@
 package net.corda.crypto.service.impl.bus
 
-import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.CompletableFuture
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.crypto.config.impl.createDefaultCryptoConfig
 import net.corda.crypto.config.impl.retrying
@@ -29,6 +23,12 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 //
 //import net.corda.configuration.read.ConfigChangedEvent

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
@@ -1,13 +1,5 @@
 package net.corda.crypto.service.impl.bus
 
-import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutionException
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.crypto.cipher.suite.sha256Bytes
 import net.corda.crypto.config.impl.createDefaultCryptoConfig
@@ -40,6 +32,14 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class HSMRegistrationBusProcessorTests {
     companion object {

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
@@ -1,5 +1,13 @@
 package net.corda.crypto.service.impl.bus
 
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.crypto.cipher.suite.sha256Bytes
 import net.corda.crypto.config.impl.createDefaultCryptoConfig
@@ -32,14 +40,6 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
-import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutionException
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertSame
-import kotlin.test.assertTrue
 
 class HSMRegistrationBusProcessorTests {
     companion object {
@@ -72,9 +72,9 @@ class HSMRegistrationBusProcessorTests {
             assertEquals(expected.requestId, actual.requestId)
             assertEquals(expected.requestingComponent, actual.requestingComponent)
             assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-            assertThat(actual.responseTimestamp.epochSecond)
-                .isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-                .isLessThanOrEqualTo(now.epochSecond)
+            assertThat(actual.responseTimestamp.toEpochMilli())
+                .isGreaterThanOrEqualTo(expected.requestTimestamp.toEpochMilli())
+                .isLessThanOrEqualTo(now.toEpochMilli())
             assertTrue(
                 actual.other.items.size == expected.other.items.size &&
                         actual.other.items.containsAll(expected.other.items) &&

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
@@ -1,5 +1,11 @@
 package net.corda.membership.service.impl
 
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.membership.rpc.request.MGMGroupPolicyRequest
 import net.corda.data.membership.rpc.request.MembershipRpcRequest
@@ -51,12 +57,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.time.Instant
-import java.util.*
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutionException
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 
 class MemberOpsServiceProcessorTest {
 
@@ -141,8 +141,8 @@ class MemberOpsServiceProcessorTest {
     private fun assertResponseContext(expected: MembershipRpcRequestContext, actual: MembershipRpcResponseContext) {
         assertEquals(expected.requestId, actual.requestId)
         assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-        assertThat(actual.responseTimestamp.epochSecond).isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-        assertThat(actual.responseTimestamp.epochSecond).isLessThanOrEqualTo(now.epochSecond)
+        assertThat(actual.responseTimestamp.toEpochMilli()).isGreaterThanOrEqualTo(expected.requestTimestamp.toEpochMilli())
+        assertThat(actual.responseTimestamp.toEpochMilli()).isLessThanOrEqualTo(now.toEpochMilli())
     }
 
 

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
@@ -1,11 +1,5 @@
 package net.corda.membership.service.impl
 
-import java.time.Instant
-import java.util.UUID
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutionException
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.membership.rpc.request.MGMGroupPolicyRequest
 import net.corda.data.membership.rpc.request.MembershipRpcRequest
@@ -57,6 +51,12 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 class MemberOpsServiceProcessorTest {
 


### PR DESCRIPTION
While running a PR build, I had a test failure for `RPC endpoint accepts a request and returns back a response() -- net.corda.applications.workers.smoketest.services.CryptoRPCSmokeTests` for the following assertion:

```
assertThat(actual.responseTimestamp.epochSecond)
    .isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
    .isLessThanOrEqualTo(now.epochSecond)
```

which failed with:

```
java.lang.AssertionError: 
Expecting actual:
  1699456403L
to be greater than or equal to:
  1699456404L
```

(See failure here: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-runtime-os-e2e-tests/detail/PR-5055/4/tests/)

It appears that tests with this condition can be flaky with very fast response times, and so I propose modifying the timestamp check from epochSecond to epochMilli.