### PR TITLE
CORE-17194 Adding logging around partition rebalancing

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -752,13 +752,18 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
 
 fun CordaConsumerRebalanceListener.toKafkaListener(topicPrefix: String): ConsumerRebalanceListener {
     return object : ConsumerRebalanceListener {
+        private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
         override fun onPartitionsRevoked(partitions: Collection<TopicPartition>) {
+            log.info("Consumer from deployment with topic prefix \"$topicPrefix\" has been assigned partitions: " +
+                    partitions.joinToString("\n"))
             this@toKafkaListener.onPartitionsRevoked(
                 partitions.toCordaTopicPartitions(topicPrefix)
             )
         }
 
         override fun onPartitionsAssigned(partitions: Collection<TopicPartition>) {
+            log.info("Consumer from deployment with topic prefix \"$topicPrefix\" has been revoked partitions: " +
+                    partitions.joinToString("\n"))
             this@toKafkaListener.onPartitionsAssigned(
                 partitions.toCordaTopicPartitions(topicPrefix)
             )


### PR DESCRIPTION
Adding additional logging around Kafka rebalancing as part of the investigation around topic leaking in cross-version compatibility testing.