### PR TITLE
CORE-18072 CORE-18263 Fix resolveStateRef logic and call

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
@@ -225,9 +225,9 @@ class CryptoRPCSmokeTests {
         assertEquals(expected.requestId, actual.requestId)
         assertEquals(expected.requestingComponent, actual.requestingComponent)
         assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-        assertThat(actual.responseTimestamp.epochSecond)
-            .isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-            .isLessThanOrEqualTo(now.epochSecond)
+        assertThat(actual.responseTimestamp.toEpochMilli())
+            .isGreaterThanOrEqualTo(expected.requestTimestamp.toEpochMilli())
+            .isLessThanOrEqualTo(now.toEpochMilli())
         assertSoftly { softly ->
             softly.assertThat(actual.other.items.size == expected.other.items.size)
             softly.assertThat(actual.other.items.containsAll(expected.other.items))

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoOpsBusProcessorTests.kt
@@ -165,9 +165,9 @@ class CryptoOpsBusProcessorTests {
         assertEquals(expected.requestId, actual.requestId)
         assertEquals(expected.requestingComponent, actual.requestingComponent)
         assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-        assertThat(actual.responseTimestamp.epochSecond)
-            .isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-            .isLessThanOrEqualTo(now.epochSecond)
+        assertThat(actual.responseTimestamp.toEpochMilli())
+            .isGreaterThanOrEqualTo(expected.requestTimestamp.toEpochMilli())
+            .isLessThanOrEqualTo(now.toEpochMilli())
         assertTrue(
             actual.other.items.size == expected.other.items.size &&
                     actual.other.items.containsAll(expected.other.items) &&

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/HSMRegistrationBusProcessorTests.kt
@@ -72,9 +72,9 @@ class HSMRegistrationBusProcessorTests {
             assertEquals(expected.requestId, actual.requestId)
             assertEquals(expected.requestingComponent, actual.requestingComponent)
             assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-            assertThat(actual.responseTimestamp.epochSecond)
-                .isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-                .isLessThanOrEqualTo(now.epochSecond)
+            assertThat(actual.responseTimestamp.toEpochMilli())
+                .isGreaterThanOrEqualTo(expected.requestTimestamp.toEpochMilli())
+                .isLessThanOrEqualTo(now.toEpochMilli())
             assertTrue(
                 actual.other.items.size == expected.other.items.size &&
                         actual.other.items.containsAll(expected.other.items) &&

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -89,7 +89,9 @@ class UtxoPersistenceServiceImpl(
 
                 val allStateRefs = (transaction.inputStateRefs + transaction.referenceStateRefs).distinct()
 
-                val stateRefsToStateAndRefs = resolveStateRefs(allStateRefs)
+                // Note: calling the `resolveStateRefs` function would result in a new connection being established,
+                // so we call the repository directly instead
+                val stateRefsToStateAndRefs = repository.resolveStateRefs(em, allStateRefs)
                     .associateBy { StateRef(parseSecureHash(it.transactionId), it.leafIndex) }
 
                 val inputStateAndRefs = transaction.inputStateRefs.map {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerStateQueryServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerStateQueryServiceImpl.kt
@@ -65,7 +65,7 @@ class UtxoLedgerStateQueryServiceImpl @Activate constructor(
                     val resolvedStateRefs = wrapWithPersistenceException {
                         externalEventExecutor.execute(
                             ResolveStateRefsExternalEventFactory::class.java,
-                            ResolveStateRefsParameters(stateRefs)
+                            ResolveStateRefsParameters(nonCachedStateRefs)
                         )
                     }.map { it.toStateAndRef<ContractState>(serializationService) }
                     stateAndRefCache.putAll(resolvedStateRefs)

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceProcessorTest.kt
@@ -141,8 +141,8 @@ class MemberOpsServiceProcessorTest {
     private fun assertResponseContext(expected: MembershipRpcRequestContext, actual: MembershipRpcResponseContext) {
         assertEquals(expected.requestId, actual.requestId)
         assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-        assertThat(actual.responseTimestamp.epochSecond).isGreaterThanOrEqualTo(expected.requestTimestamp.epochSecond)
-        assertThat(actual.responseTimestamp.epochSecond).isLessThanOrEqualTo(now.epochSecond)
+        assertThat(actual.responseTimestamp.toEpochMilli()).isGreaterThanOrEqualTo(expected.requestTimestamp.toEpochMilli())
+        assertThat(actual.responseTimestamp.toEpochMilli()).isLessThanOrEqualTo(now.toEpochMilli())
     }
 
 


### PR DESCRIPTION
### **THIS PR IS INTENDED FOR 5.2 | DO NOT MERGE**

### Overview

This PR fixes two issues:
- `findSignedLedgerTransaction` explicitly called the `resolveStateRefs` function which resulted in opening two DB connections at the same time. This has been modified to a direct call to the repository instead.
- The `resolveStateRefs` function in the state query service uses a cache but we always fetch all of the state refs instead of just the non-cached ones.