### PR TITLE
CORE-18072 CORE-18263 fix resolveStateRef logic and call

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -89,7 +89,9 @@ class UtxoPersistenceServiceImpl(
 
                 val allStateRefs = (transaction.inputStateRefs + transaction.referenceStateRefs).distinct()
 
-                val stateRefsToStateAndRefs = resolveStateRefs(allStateRefs)
+                // Note: calling the `resolveStateRefs` function would result in a new connection being established,
+                // so we call the repository directly instead
+                val stateRefsToStateAndRefs = repository.resolveStateRefs(em, allStateRefs)
                     .associateBy { StateRef(parseSecureHash(it.transactionId), it.leafIndex) }
 
                 val inputStateAndRefs = transaction.inputStateRefs.map {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerStateQueryServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerStateQueryServiceImpl.kt
@@ -65,7 +65,7 @@ class UtxoLedgerStateQueryServiceImpl @Activate constructor(
                     val resolvedStateRefs = wrapWithPersistenceException {
                         externalEventExecutor.execute(
                             ResolveStateRefsExternalEventFactory::class.java,
-                            ResolveStateRefsParameters(stateRefs)
+                            ResolveStateRefsParameters(nonCachedStateRefs)
                         )
                     }.map { it.toStateAndRef<ContractState>(serializationService) }
                     stateAndRefCache.putAll(resolvedStateRefs)


### PR DESCRIPTION
### Overview

This PR fixes two issues:
- `findSignedLedgerTransaction` explicitly called the `resolveStateRefs` function which resulted in opening two DB connections at the same time. This has been modified to a direct call to the repository instead.
- The `resolveStateRefs` function in the state query service uses a cache but we always fetch all of the state refs instead of just the non-cached ones.