### PR TITLE
CORE-18268 db-worker restart causes loss of REST API High Availability

### DIFF
--- a/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
+++ b/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
@@ -107,7 +107,7 @@ class ConfigPublishServiceImpl @Activate constructor(
         TODO("Not yet implemented")
     }
 
-    override fun recordValueMisalignmentAfterDefaulted(
+    override fun recordValueMisalignedAfterDefaulted(
         recordKey: String,
         dbRecordValue: Configuration,
         kafkaRecordValue: Configuration

--- a/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
+++ b/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
@@ -139,8 +139,8 @@ class ConfigPublishServiceImpl @Activate constructor(
             }
 
 
-        val configsAreEqual = dbConfigValueDefaulted == kafkaConfigValue
-        if (!configsAreEqual) {
+        val configsAreNotEqual = dbConfigValueDefaulted != kafkaConfigValue
+        if (configsAreNotEqual) {
             logger.info(
                 "Configuration for key $recordKey is misaligned on Kafka after applying defaults (Kafka will be updated).\n" +
                         "DB config value: ${
@@ -154,7 +154,7 @@ class ConfigPublishServiceImpl @Activate constructor(
             )
         }
 
-        return configsAreEqual
+        return configsAreNotEqual
     }
 
     override val isRunning get() = coordinator.isRunning

--- a/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
+++ b/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
@@ -107,7 +107,7 @@ class ConfigPublishServiceImpl @Activate constructor(
         TODO("Not yet implemented")
     }
 
-    override fun recordValueMisalignedAfterDefaulted(
+    override fun recordValueMisalignedAfterDefaults(
         recordKey: String,
         dbRecordValue: Configuration,
         kafkaRecordValue: Configuration
@@ -118,7 +118,7 @@ class ConfigPublishServiceImpl @Activate constructor(
         require(dbRecordValue.schemaVersion.minorVersion == kafkaRecordValue.schemaVersion.minorVersion)
         val schemaMinorVersion = dbRecordValue.schemaVersion.minorVersion
 
-        val dbConfigValueDefaulted =
+        val dbConfigValueWithDefaults =
             smartConfigFactory.create(ConfigFactory.parseString(dbRecordValue.value)).run {
                 validator.validate(
                     recordKey,
@@ -139,12 +139,12 @@ class ConfigPublishServiceImpl @Activate constructor(
             }
 
 
-        val configsAreNotEqual = dbConfigValueDefaulted != kafkaConfigValue
+        val configsAreNotEqual = dbConfigValueWithDefaults != kafkaConfigValue
         if (configsAreNotEqual) {
             logger.info(
                 "Configuration for key $recordKey is misaligned on Kafka after applying defaults (Kafka will be updated).\n" +
                         "DB config value: ${
-                            dbConfigValueDefaulted.toSafeConfig().root()
+                            dbConfigValueWithDefaults.toSafeConfig().root()
                                 .render(ConfigRenderOptions.concise().setFormatted(true))
                         }\n" +
                         "Kafka config value: ${

--- a/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
+++ b/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
@@ -107,7 +107,7 @@ class ConfigPublishServiceImpl @Activate constructor(
         TODO("Not yet implemented")
     }
 
-    override fun recordValueMisalignedAfterDefaults(
+    override fun valuesMisalignedAfterDefaults(
         recordKey: String,
         dbRecordValue: Configuration,
         kafkaRecordValue: Configuration

--- a/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
+++ b/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
@@ -19,6 +19,7 @@ import net.corda.v5.base.versioning.Version
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.LoggerFactory
 
 // This needs to be a `Lifecycle` for reconciliation, maybe not only for that. However it cannot really wait on
 // `ConfigurationReadService`, because it will be used by `ConfigWriteService` which needs to be started before
@@ -35,6 +36,10 @@ class ConfigPublishServiceImpl @Activate constructor(
     @Reference(service = ConfigurationValidatorFactory::class)
     configurationValidatorFactory: ConfigurationValidatorFactory
 ) : ConfigPublishService {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(ConfigPublishServiceImpl::class.java)
+    }
 
     private val handler = ConfigPublishServiceHandler(publisherFactory, configMerger)
 
@@ -100,6 +105,56 @@ class ConfigPublishServiceImpl @Activate constructor(
     @Suppress("parameter_name_changed_on_override")
     override fun remove(configSection: String) {
         TODO("Not yet implemented")
+    }
+
+    override fun recordValueMisalignmentAfterDefaulted(
+        recordKey: String,
+        dbRecordValue: Configuration,
+        kafkaRecordValue: Configuration
+    ): Boolean {
+        require(dbRecordValue.version == kafkaRecordValue.version)
+        require(dbRecordValue.schemaVersion.majorVersion == kafkaRecordValue.schemaVersion.majorVersion)
+        val schemaMajorVersion = dbRecordValue.schemaVersion.majorVersion
+        require(dbRecordValue.schemaVersion.minorVersion == kafkaRecordValue.schemaVersion.minorVersion)
+        val schemaMinorVersion = dbRecordValue.schemaVersion.minorVersion
+
+        val dbConfigValueDefaulted =
+            smartConfigFactory.create(ConfigFactory.parseString(dbRecordValue.value)).run {
+                validator.validate(
+                    recordKey,
+                    Version(schemaMajorVersion, schemaMinorVersion),
+                    this,
+                    applyDefaults = true
+                )
+            }
+
+        val kafkaConfigValue =
+            smartConfigFactory.create(ConfigFactory.parseString(kafkaRecordValue.value)).run {
+                validator.validate(
+                    recordKey,
+                    Version(schemaMajorVersion, schemaMinorVersion),
+                    this,
+                    applyDefaults = false,
+                )
+            }
+
+
+        val configsAreEqual = dbConfigValueDefaulted == kafkaConfigValue
+        if (!configsAreEqual) {
+            logger.info(
+                "Configuration for key $recordKey is misaligned on Kafka after applying defaults (Kafka will be updated).\n" +
+                        "DB config value: ${
+                            dbConfigValueDefaulted.toSafeConfig().root()
+                                .render(ConfigRenderOptions.concise().setFormatted(true))
+                        }\n" +
+                        "Kafka config value: ${
+                            kafkaConfigValue.toSafeConfig().root()
+                                .render(ConfigRenderOptions.concise().setFormatted(true))
+                        }"
+            )
+        }
+
+        return configsAreEqual
     }
 
     override val isRunning get() = coordinator.isRunning

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -137,7 +137,15 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                     // therefore through the defaulting config process which will add the property(ies) and subsequently
                     // will publish them to Kafka. We only need to force the first reconciliation.
                     if (forceInitialReconciliation && firstRun) {
-                        dbRecord.version >= matchedKafkaRecord.version // reconcile all db records again (forced reconciliation)
+                        dbRecord.version > matchedKafkaRecord.version
+                                // reconcile all db records again (forced reconciliation)
+                                || (dbRecord.version == matchedKafkaRecord.version
+                                        && writer.recordValueMisalignmentAfterDefaulted(
+                                                    dbRecord.key,
+                                                    dbRecord.value,
+                                                    matchedKafkaRecord.value
+                                            )
+                                    )
                     } else {
                         dbRecord.version > matchedKafkaRecord.version // reconcile db updated records
                     } || dbRecord.isDeleted // reconcile db soft deleted records

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -140,7 +140,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                         dbRecord.version > matchedKafkaRecord.version
                                 // reconcile all db records again (forced reconciliation)
                                 || (dbRecord.version == matchedKafkaRecord.version
-                                        && writer.recordValueMisalignmentAfterDefaulted(
+                                        && writer.recordValueMisalignedAfterDefaulted(
                                                     dbRecord.key,
                                                     dbRecord.value,
                                                     matchedKafkaRecord.value

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -140,7 +140,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                         dbRecord.version > matchedKafkaRecord.version
                                 // reconcile all db records again (forced reconciliation)
                                 || (dbRecord.version == matchedKafkaRecord.version
-                                        && writer.recordValueMisalignedAfterDefaulted(
+                                        && writer.recordValueMisalignedAfterDefaults(
                                                     dbRecord.key,
                                                     dbRecord.value,
                                                     matchedKafkaRecord.value

--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -140,7 +140,7 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
                         dbRecord.version > matchedKafkaRecord.version
                                 // reconcile all db records again (forced reconciliation)
                                 || (dbRecord.version == matchedKafkaRecord.version
-                                        && writer.recordValueMisalignedAfterDefaults(
+                                        && writer.valuesMisalignedAfterDefaults(
                                                     dbRecord.key,
                                                     dbRecord.value,
                                                     matchedKafkaRecord.value

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -94,7 +94,7 @@ internal class ReconcilerEventHandlerTest {
         }
 
         val writer = mock<ReconcilerWriter<String, Int>>().also {
-            whenever(it.recordValueMisalignedAfterDefaults(any(), any(), any())).thenReturn(true)
+            whenever(it.valuesMisalignedAfterDefaults(any(), any(), any())).thenReturn(true)
         }
 
         reconcilerEventHandler =

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -94,7 +94,7 @@ internal class ReconcilerEventHandlerTest {
         }
 
         val writer = mock<ReconcilerWriter<String, Int>>().also {
-            whenever(it.recordValueMisalignedAfterDefaulted(any(), any(), any())).thenReturn(true)
+            whenever(it.recordValueMisalignedAfterDefaults(any(), any(), any())).thenReturn(true)
         }
 
         reconcilerEventHandler =

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -2,6 +2,7 @@ package net.corda.reconciliation.impl
 
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.reconciliation.ReconcilerReader
+import net.corda.reconciliation.ReconcilerWriter
 import net.corda.reconciliation.VersionedRecord
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -92,11 +93,15 @@ internal class ReconcilerEventHandlerTest {
             }
         }
 
+        val writer = mock<ReconcilerWriter<String, Int>>().also {
+            whenever(it.recordValueMisalignmentAfterDefaulted(any(), any(), any())).thenReturn(true)
+        }
+
         reconcilerEventHandler =
             ReconcilerEventHandler(
                 dbReader,
                 kafkaReader,
-                writer = mock(),
+                writer,
                 keyClass = String::class.java,
                 valueClass = Int::class.java,
                 10L,

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -94,7 +94,7 @@ internal class ReconcilerEventHandlerTest {
         }
 
         val writer = mock<ReconcilerWriter<String, Int>>().also {
-            whenever(it.recordValueMisalignmentAfterDefaulted(any(), any(), any())).thenReturn(true)
+            whenever(it.recordValueMisalignedAfterDefaulted(any(), any(), any())).thenReturn(true)
         }
 
         reconcilerEventHandler =

--- a/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
+++ b/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
@@ -20,8 +20,8 @@ interface ReconcilerWriter<K : Any, V : Any> {
     val lifecycleCoordinatorName: LifecycleCoordinatorName
 
     /**
-     * Some writers allow the checking of records to see if the value content has changed
-     * between the db and Kafka before pushing out a new value.
+     * Compare DB record value to its Kafka respective one to see if after applying defaults
+     * to the DB record, the DB record is different to the Kafka one.
      */
     fun valuesMisalignedAfterDefaults(
         recordKey: K,

--- a/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
+++ b/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
@@ -19,7 +19,7 @@ interface ReconcilerWriter<K : Any, V : Any> {
 
     val lifecycleCoordinatorName: LifecycleCoordinatorName
 
-    fun recordValueMisalignmentAfterDefaulted(
+    fun recordValueMisalignedAfterDefaulted(
         recordKey: K,
         dbRecordValue: V,
         kafkaRecordValue: V

--- a/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
+++ b/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
@@ -19,6 +19,11 @@ interface ReconcilerWriter<K : Any, V : Any> {
 
     val lifecycleCoordinatorName: LifecycleCoordinatorName
 
+    // The below API currently only applies to Config reconciliation in an attempt to address CORE-18268.
+    // It currently seems quite specific to Config reconciliation and therefore, ideally, should be removed.
+    // In which case Config reconciliation should be aligned with the rest of the reconciliations, i.e.
+    // the defaulting process should be done prior to reading the db records (in that case forced reconciliation concept
+    // will also, no longer be needed).
     fun recordValueMisalignedAfterDefaults(
         recordKey: K,
         dbRecordValue: V,

--- a/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
+++ b/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
@@ -19,12 +19,11 @@ interface ReconcilerWriter<K : Any, V : Any> {
 
     val lifecycleCoordinatorName: LifecycleCoordinatorName
 
-    // The below API currently only applies to Config reconciliation in an attempt to address CORE-18268.
-    // It currently seems quite specific to Config reconciliation and therefore, ideally, should be removed.
-    // In which case Config reconciliation should be aligned with the rest of the reconciliations, i.e.
-    // the defaulting process should be done prior to reading the db records (in that case forced reconciliation concept
-    // will also, no longer be needed).
-    fun recordValueMisalignedAfterDefaults(
+    /**
+     * Some writers allow the checking of records to see if the value content has changed
+     * between the db and Kafka before pushing out a new value.
+     */
+    fun valuesMisalignedAfterDefaults(
         recordKey: K,
         dbRecordValue: V,
         kafkaRecordValue: V

--- a/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
+++ b/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
@@ -19,7 +19,7 @@ interface ReconcilerWriter<K : Any, V : Any> {
 
     val lifecycleCoordinatorName: LifecycleCoordinatorName
 
-    fun recordValueMisalignedAfterDefaulted(
+    fun recordValueMisalignedAfterDefaults(
         recordKey: K,
         dbRecordValue: V,
         kafkaRecordValue: V

--- a/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
+++ b/components/reconciliation/reconciliation/src/main/kotlin/net/corda/reconciliation/ReconcilerWriter.kt
@@ -18,4 +18,10 @@ interface ReconcilerWriter<K : Any, V : Any> {
     fun remove(recordKey: K)
 
     val lifecycleCoordinatorName: LifecycleCoordinatorName
+
+    fun recordValueMisalignmentAfterDefaulted(
+        recordKey: K,
+        dbRecordValue: V,
+        kafkaRecordValue: V
+    ): Boolean = false
 }


### PR DESCRIPTION
### Problem description

On forced Config reconciliation we would reconcile all config sections and therefore propagate them across the cluster no matter if their config value actually changed or not as part of the defaulting process. 

This caused a lot of components to restart, one of which is the http server within the rest-worker which causes its unavailability on db-worker restarts (Ideally components consuming configuration should check if the next configuration is changed compared to the previous one and only then restart).

### Solution

Contain the above Config propagation on the db-worker side. On forced reconciliation check if after applying the defaulting process to a config value, it changes compared to its Kafka corresponding one and only then reconcile it.

### Testing

Tested locally to an already deployed corda-cluster by: 
1. adding config properties to sections of the config schema 
2. rebuilding the db-worker against the updated `corda-api/data:config-schema`  and re-deploying the db-worker
3. assert the only config sections getting reconciled are only the extended ones (via the debugger and logs). 