### PR TITLE
ES-1608: fix various version and branch refrences to point to 5.2

### DIFF
--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -5,8 +5,8 @@
 @Library('corda-shared-build-pipeline-steps@5.2') _
 
 endToEndPipeline(
-    helmVersion: '^5.1.0-beta',
-    helmRepoSuffix: 'release/ent/5.1',
+    helmVersion: '^5.2.0-beta',
+    helmRepoSuffix: 'release/ent/5.2',
     helmRepo: 'corda-ent-docker',
     dailyBuildCron: '',
     enableNotifications: false, 

--- a/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/deploy.sh
@@ -18,7 +18,7 @@ deploy() {
                 --render-subchart-notes  \
                 --timeout 10m  \
                 --wait"
-   corda_args="--install corda -n $namespace oci://corda-os-docker.software.r3.com/helm-charts/release/os/5.1/corda \
+   corda_args="--install corda -n $namespace oci://corda-os-docker.software.r3.com/helm-charts/release/os/5.2/corda \
               --set imagePullSecrets={docker-registry-cred} --set image.tag=$DOCKER_IMAGE_VERSION \
               --set image.registry=corda-os-docker.software.r3.com --values $REPO_TOP_LEVEL_DIR/values.yaml \
               --set bootstrap.kafka.partitions=$KAFKA_PARTITION_COUNT \

--- a/build-benchmark.sh
+++ b/build-benchmark.sh
@@ -2,7 +2,7 @@
 # to Gradle Enterprise so that we can analyse them.
 #
 MAX_WORKERS=4
-TAG_BENCHMARK="build-benchmark-5.1"    # Gradle build scan label prefix - should remain stable
+TAG_BENCHMARK="build-benchmark-5.2"    # Gradle build scan label prefix - should remain stable
 TAG_EXP="${TAG_BENCHMARK}-0002"    # Gradle build scan label suffix - can be incremented in case we want another set of benchmarks, for example to compare a before/after change
 
 TAG_CACHE="cache"

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,7 +45,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
-# Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
+# Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
 cordaApiVersion=5.2.0.1-beta+
 
 disruptorVersion=3.4.4

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@
 imagePullPolicy: "IfNotPresent"
 image:
   registry: "corda-os-docker-dev.software.r3.com"
-  tag: "latest-local-5.1.0"
+  tag: "latest-local-5.2.0"
 
 logging:
   format: "text"


### PR DESCRIPTION
- fix incorrect helm values in Jenkinsfile variables should reference 5.2
- Update various other missed references in supporting files which should reference 5.2 rather than 5.1