### PR TITLE
CORE-10407: Fix kapt warning

### DIFF
--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -9,16 +9,6 @@ configurations {
     cliHostDist
 }
 
-subprojects {
-    pluginManager.withPlugin('org.jetbrains.kotlin.kapt') {
-        kapt {
-            arguments {
-                arg("project", "${project.group}/${project.name}")
-            }
-        }
-    }
-}
-
 dependencies {
     cliHostDist "net.corda.cli.host:corda-cli:${pluginHostVersion}"
 }


### PR DESCRIPTION
Fixes:

```
warning: The following options were not recognized by any processor: '[project, kapt.kotlin.generated]'
The following options were not recognized by any processor: '[project, kapt.kotlin.generated]'
```