### PR TITLE
CORE-17934: Explicitly output when REST endpoints added

### DIFF
--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/RouteProvider.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/RouteProvider.kt
@@ -16,7 +16,6 @@ import net.corda.rest.server.impl.websocket.WebSocketRouteAdaptor
 import net.corda.rest.tools.HttpPathUtils.joinResourceAndEndpointPaths
 import net.corda.rest.tools.isDuplexChannel
 import net.corda.rest.tools.isStaticallyExposedGet
-import net.corda.utilities.debug
 import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
 import java.lang.reflect.InvocationTargetException

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/RouteProvider.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/RouteProvider.kt
@@ -185,7 +185,7 @@ internal class RouteInfo(
                 wsConfig.onError(adaptor)
 
                 adaptors.add(adaptor)
-                log.debug { "Setup for WS call for \"$fullPath\" completed." }
+                log.info("Setup for WS call for \"$fullPath\" completed.")
             } catch (e: Exception) {
                 log.warn("Error setting-up WS call for \"$fullPath\"", e)
                 throw HttpExceptionMapper.mapToResponse(e)

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -209,7 +209,7 @@ internal class RestServerInternal(
     private fun Javalin.registerHandlerForRoute(routeInfo: RouteInfo, handlerType: HandlerType) {
         try {
             addHandler(handlerType, routeInfo.fullPath, routeInfo.invokeHttpMethod())
-            log.debug { "Added \"$handlerType\" handler for \"${routeInfo.fullPath}\"." }
+            log.info("Added \"$handlerType\" handler for \"${routeInfo.fullPath}\".")
         } catch (e: Exception) {
             "Error during adding route. Handler type=$handlerType, Path=\"${routeInfo.fullPath}\"".let {
                 log.error("$it: ${e.message}")


### PR DESCRIPTION
This is only happens once during REST worker start and should provide valuable information as for which endpoint been actually configured and for which versons.