### PR TITLE
CORE-10180: Escape string parameters when creating json to prevent possible injection attacks

### DIFF
--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     kapt "info.picocli:picocli:$picocliVersion"
 
     implementation 'net.corda:corda-config-schema'
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
 
     implementation project(':libs:permissions:permission-common')

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     kapt "info.picocli:picocli:$picocliVersion"
 
     implementation 'net.corda:corda-config-schema'
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
 
     implementation project(':libs:permissions:permission-common')
     implementation project(':libs:permissions:permission-datamodel')

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/DbConfigSubcommand.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/DbConfigSubcommand.kt
@@ -1,5 +1,6 @@
 package net.corda.cli.plugin.initialconfig
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.typesafe.config.ConfigRenderOptions
 import net.corda.db.core.DbPrivilege
 import net.corda.libs.configuration.datamodel.DbConnectionConfig
@@ -10,7 +11,6 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.io.File
 import java.io.FileWriter
-import java.lang.IllegalArgumentException
 import java.time.Instant
 import java.util.UUID
 
@@ -206,12 +206,18 @@ class DbConfigSubcommand : Runnable {
 /**
  * Generate a JSON config string for the config database.
  *
- * @param jdbcUrl URL for the database
- * @param usernmae
+ * @param jdbcUrl URL for the database.
+ * @param username Username for the database connection.
  * @param value
- * @param jdcbPoolMaxSize
- * @param secretsService a factory that can produce representations of secrets
- * @return a string containing a JSON config
+ * @param key Vault key for the secrets service. Used only by VAULT type secrets service.
+ * @param jdbcPoolMaxSize The maximum size for the JDBC connection pool.
+ * @param jdbcPoolMinSize The minimum size for the JDBC connection pool.
+ * @param idleTimeout The maximum time (in seconds) a connection can stay idle in the pool.
+ * @param maxLifetime The maximum time (in seconds) a connection can stay in the pool.
+ * @param keepaliveTime The interval time (in seconds) in which connections will be tested for aliveness.
+ * @param validationTimeout The maximum time (in seconds) that the pool will wait for a connection to be validated as alive.
+ * @param secretsService A factory that can produce representations of secrets.
+ * @return A string containing a JSON config.
  *
  */
 @Suppress("LongParameterList")
@@ -230,9 +236,9 @@ private fun createConfigDbConfig(
 ): String {
     return "{\"database\":{" +
             "\"jdbc\":" +
-            "{\"url\":\"$jdbcUrl\"}," +
+            "{\"url\":${jacksonObjectMapper().writeValueAsString(jdbcUrl)}}," +
             "\"pass\":${createSecureConfig(secretsService, value, key)}," +
-            "\"user\":\"$username\"," +
+            "\"user\":${jacksonObjectMapper().writeValueAsString(username)}," +
             "\"pool\":" +
             "{\"max_size\":$jdbcPoolMaxSize," +
             if (jdbcPoolMinSize != null) { "\"min_size\":$jdbcPoolMinSize," } else { "" } +

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/DbConfigSubcommand.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/DbConfigSubcommand.kt
@@ -221,7 +221,7 @@ class DbConfigSubcommand : Runnable {
  *
  */
 @Suppress("LongParameterList")
-private fun createConfigDbConfig(
+fun createConfigDbConfig(
     jdbcUrl: String,
     username: String,
     value: String,

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/SqlFormatters.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/SqlFormatters.kt
@@ -74,14 +74,17 @@ private fun <T : Annotation> KProperty1<*, *>.getVarAnnotation(type: Class<T>): 
 
 private fun String.simpleSqlEscaping(): String {
     val output = StringBuilder()
+    var i = 0
     for (c in this) {
         output.append(
             when (c) {
                 '\'' -> "\\'"
-                '\\' -> "\\\\"
+                // This prevents escaping backslash if it is part of already escaped double quotes
+                '\\' -> if (this.length > i+1 && this[i+1] == '\"') {"\\"} else {"\\\\"}
                 else -> c
             }
         )
+        i++
     }
     return output.toString()
 }

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
@@ -152,7 +152,6 @@ class TestInitialConfigPluginDb {
         val outText = createConfigDbConfig(jdbcUrl, username, password, vaultKey, jdbcPoolMaxSize, jdbcPoolMinSize,
             idleTimeout, maxLifetime, keepaliveTime, validationTimeout, secretsService)
 
-        println(outText)
         assertThat(outText).contains("\"user\":\"test\\\"user\"")
     }
 
@@ -179,7 +178,6 @@ class TestInitialConfigPluginDb {
                 "-s", "not so secure",
                 "-e", "not so secret")
         }
-        println(outText)
         assertThat(outText).contains("\"user\":\"test\\\"user\"")
     }
 }

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
@@ -1,6 +1,8 @@
 package net.corda.cli.plugin.initialconfig
 
 import com.github.stefanbirkner.systemlambda.SystemLambda
+import net.corda.libs.configuration.secret.EncryptionSecretsServiceImpl
+import net.corda.libs.configuration.secret.SecretsCreateService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import picocli.CommandLine
@@ -129,5 +131,53 @@ class TestInitialConfigPluginDb {
                     " 'DML'," +
                     " 'Setup Script',"
         ).endsWith("Z', 0)\n")
+    }
+
+    @Test
+    fun `test DbConfig creation directly with escaped string`() {
+        val jdbcUrl = ""
+        val jdbcPoolMaxSize = 10
+        val jdbcPoolMinSize: Int? = null
+        val idleTimeout: Int = 120
+        val maxLifetime: Int = 1800
+        val keepaliveTime: Int = 0
+        val validationTimeout: Int = 5
+        val username = "test\"user"
+        val password = ""
+        val salt = "123"
+        val passphrase = "123"
+        val vaultKey = "corda-config-database-password"
+        val secretsService: SecretsCreateService = EncryptionSecretsServiceImpl(passphrase, salt)
+
+        val outText = createConfigDbConfig(jdbcUrl, username, password, vaultKey, jdbcPoolMaxSize, jdbcPoolMinSize, idleTimeout, maxLifetime, keepaliveTime, validationTimeout, secretsService)
+
+        println(outText)
+        assertThat(outText).contains("\"user\":\"test\\\"user\"")
+    }
+
+    @Test
+    fun `test DbConfig creation via command line with escaped string`() {
+        val app = InitialConfigPlugin.PluginEntryPoint()
+
+        val outText = SystemLambda.tapSystemOutNormalized {
+            CommandLine(
+                app
+            ).execute(
+                "create-db-config",
+                "-n", "connection name",
+                "-j", "jdbd:postgres://test\"url",
+                "--jdbc-pool-max-size", "3",
+                "--jdbc-pool-min-size", "1",
+                "--idle-timeout", "121",
+                "--max-lifetime", "1801",
+                "--keepalive-time", "1",
+                "--validation-timeout", "6",
+                "-u", "test\"user",
+                "-p", "password",
+                "-s", "not so secure",
+                "-e", "not so secret")
+        }
+        println(outText)
+        assertThat(outText).contains("\"user\":\"test\\\"user\"")
     }
 }

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
@@ -149,12 +149,14 @@ class TestInitialConfigPluginDb {
         val vaultKey = "corda-config-database-password"
         val secretsService: SecretsCreateService = EncryptionSecretsServiceImpl(passphrase, salt)
 
-        val outText = createConfigDbConfig(jdbcUrl, username, password, vaultKey, jdbcPoolMaxSize, jdbcPoolMinSize, idleTimeout, maxLifetime, keepaliveTime, validationTimeout, secretsService)
+        val outText = createConfigDbConfig(jdbcUrl, username, password, vaultKey, jdbcPoolMaxSize, jdbcPoolMinSize,
+            idleTimeout, maxLifetime, keepaliveTime, validationTimeout, secretsService)
 
         println(outText)
         assertThat(outText).contains("\"user\":\"test\\\"user\"")
     }
 
+    // Running the command via command line applies additional escaping
     @Test
     fun `test DbConfig creation via command line with escaped string`() {
         val app = InitialConfigPlugin.PluginEntryPoint()


### PR DESCRIPTION
Changes:
* Escape string parameters
* Fix most of the kdoc parameters
* Add tests