### PR TITLE
CORE-17369: Enable display of version information in CLI plugins

### DIFF
--- a/buildSrc/src/main/groovy/corda.cli-plugin-packager.gradle
+++ b/buildSrc/src/main/groovy/corda.cli-plugin-packager.gradle
@@ -32,6 +32,7 @@ def cliPluginPackager = tasks.register("cliPluginTask", Jar) {
     inputs.property('cliPluginClass', cliPlugin.cliPluginClass)
     inputs.property('cliPluginProvider', cliPlugin.cliPluginProvider)
     inputs.property('cliPluginDescription', cliPlugin.cliPluginDescription)
+    inputs.property('cliPluginGitCommitId', cliPlugin.cliPluginGitCommitId)
 
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     reproducibleFileOrder = true
@@ -52,10 +53,12 @@ def cliPluginPackager = tasks.register("cliPluginTask", Jar) {
     }
     manifest {
         attributes['Plugin-Class'] = cliPlugin.cliPluginClass
+        attributes["Plugin-Name"] = cliPlugin.cliPluginId
         attributes['Plugin-Id'] = cliPlugin.cliPluginId
         attributes['Plugin-Version'] = archiveVersion
         attributes['Plugin-Provider'] = cliPlugin.cliPluginProvider
         attributes['Plugin-Description'] = cliPlugin.cliPluginDescription
+        attributes["Plugin-Git-Commit"] = cliPlugin.cliPluginGitCommitId
     }
 }
 
@@ -71,10 +74,12 @@ class CliPluginPackagerExtension {
         cliPluginClass = objects.property(String)
         cliPluginProvider = objects.property(String).convention("R3 Ltd")
         cliPluginDescription = objects.property(String)
+        cliPluginGitCommitId = objects.property(String)
     }
 
     final Property<String> cliPluginId
     final Property<String> cliPluginClass
     final Property<String> cliPluginProvider
     final Property<String> cliPluginDescription
+    final Property<String> cliPluginGitCommitId
 }

--- a/tools/plugins/build.gradle
+++ b/tools/plugins/build.gradle
@@ -9,6 +9,15 @@ configurations {
     cliHostDist
 }
 
+var commitId = com.gradle.Utils.execAndGetStdOut "git", "rev-parse", "--verify", "HEAD"
+subprojects {
+    pluginManager.withPlugin('corda.cli-plugin-packager') {
+        cliPlugin {
+            cliPluginGitCommitId = "$commitId"
+        }
+    }
+}
+
 dependencies {
     cliHostDist "net.corda.cli.host:corda-cli:${pluginHostVersion}"
 }

--- a/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/DatabaseBootstrapAndUpgrade.kt
+++ b/tools/plugins/db-config/src/main/kotlin/net/corda/cli/plugins/dbconfig/DatabaseBootstrapAndUpgrade.kt
@@ -1,11 +1,14 @@
 package net.corda.cli.plugins.dbconfig
 
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import net.corda.cli.api.CordaCliPlugin
 import org.pf4j.Extension
 import org.pf4j.Plugin
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
+
+class VersionProvider : AbstractCordaCliVersionProvider()
 
 class DatabaseBootstrapAndUpgrade : Plugin() {
 
@@ -27,7 +30,8 @@ class DatabaseBootstrapAndUpgrade : Plugin() {
         name = "database",
         subcommands = [Spec::class],
         mixinStandardHelpOptions = true,
-        description = ["Does Database bootstrapping and upgrade"]
+        description = ["Does Database bootstrapping and upgrade"],
+        versionProvider = VersionProvider::class
     )
     class PluginEntryPoint : CordaCliPlugin
 }

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/InitialConfigPlugin.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/InitialConfigPlugin.kt
@@ -1,9 +1,12 @@
 package net.corda.cli.plugin.initialconfig
 
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import net.corda.cli.api.CordaCliPlugin
 import org.pf4j.Extension
 import org.pf4j.Plugin
 import picocli.CommandLine.Command
+
+class VersionProvider : AbstractCordaCliVersionProvider()
 
 class InitialConfigPlugin : Plugin() {
     override fun start() {
@@ -17,7 +20,8 @@ class InitialConfigPlugin : Plugin() {
         name = "initial-config",
         subcommands = [RbacConfigSubcommand::class, DbConfigSubcommand::class, CryptoConfigSubcommand::class],
         mixinStandardHelpOptions = true,
-        description = ["Create SQL files to write the initial config to a new cluster"]
+        description = ["Create SQL files to write the initial config to a new cluster"],
+        versionProvider = VersionProvider::class
     )
     class PluginEntryPoint : CordaCliPlugin
 }

--- a/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/InitialRbacPlugin.kt
+++ b/tools/plugins/initial-rbac/src/main/kotlin/net/corda/cli/plugin/initialRbac/InitialRbacPlugin.kt
@@ -1,5 +1,6 @@
 package net.corda.cli.plugin.initialRbac
 
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import net.corda.cli.api.CordaCliPlugin
 import net.corda.cli.plugin.initialRbac.commands.AllClusterRolesSubcommand
 import net.corda.cli.plugin.initialRbac.commands.UserAdminSubcommand
@@ -9,6 +10,8 @@ import net.corda.cli.plugin.initialRbac.commands.VNodeCreatorSubcommand
 import org.pf4j.Extension
 import org.pf4j.Plugin
 import picocli.CommandLine
+
+class VersionProvider : AbstractCordaCliVersionProvider()
 
 @Suppress("unused")
 class InitialRbacPlugin : Plugin() {
@@ -26,7 +29,8 @@ class InitialRbacPlugin : Plugin() {
             CordaDeveloperSubcommand::class, FlowExecutorSubcommand::class,
             AllClusterRolesSubcommand::class],
         mixinStandardHelpOptions = true,
-        description = ["Creates common RBAC roles"]
+        description = ["Creates common RBAC roles"],
+        versionProvider = VersionProvider::class
     )
     class PluginEntryPoint : CordaCliPlugin
 }

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/NetworkPluginWrapper.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/NetworkPluginWrapper.kt
@@ -1,11 +1,14 @@
 package net.corda.cli.plugins.network
 
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import net.corda.cli.api.CordaCliPlugin
 import org.pf4j.Extension
 import org.pf4j.Plugin
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
+
+class VersionProvider : AbstractCordaCliVersionProvider()
 
 @Suppress("unused")
 class NetworkPluginWrapper : Plugin() {
@@ -33,7 +36,8 @@ class NetworkPluginWrapper : Plugin() {
         ],
         hidden = true,
         mixinStandardHelpOptions = true,
-        description = ["Plugin for interacting with a network."]
+        description = ["Plugin for interacting with a network."],
+        versionProvider = VersionProvider::class
     )
     class NetworkPlugin : CordaCliPlugin
 
@@ -44,7 +48,8 @@ class NetworkPluginWrapper : Plugin() {
             GenerateGroupPolicy::class,
         ],
         mixinStandardHelpOptions = true,
-        description = ["Plugin for membership operations."]
+        description = ["Plugin for membership operations."],
+        versionProvider = VersionProvider::class
     )
     class MgmPlugin : CordaCliPlugin
 }

--- a/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/PackagePluginWrapper.kt
+++ b/tools/plugins/package/src/main/kotlin/net/corda/cli/plugins/packaging/PackagePluginWrapper.kt
@@ -1,9 +1,12 @@
 package net.corda.cli.plugins.packaging
 
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import net.corda.cli.api.CordaCliPlugin
 import org.pf4j.Extension
 import org.pf4j.Plugin
 import picocli.CommandLine
+
+class VersionProvider : AbstractCordaCliVersionProvider()
 
 @Suppress("unused")
 class PackagePluginWrapper : Plugin() {
@@ -12,7 +15,8 @@ class PackagePluginWrapper : Plugin() {
         name = "package",
         subcommands = [CreateCpiV2::class, Verify::class, CreateCpb::class, SignCpx::class],
         mixinStandardHelpOptions = true,
-        description = ["Plugin for CPB, CPI operations."]
+        description = ["Plugin for CPB, CPI operations."],
+        versionProvider = VersionProvider::class
     )
     class PackagePlugin : CordaCliPlugin
 }

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/PreInstallPlugin.kt
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Secret
 import io.fabric8.kubernetes.client.KubernetesClient
 import io.fabric8.kubernetes.client.KubernetesClientBuilder
 import io.fabric8.kubernetes.client.KubernetesClientException
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import java.io.File
 import java.io.FileNotFoundException
 import java.util.Base64
@@ -17,6 +18,8 @@ import org.pf4j.Plugin
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
+
+class VersionProvider : AbstractCordaCliVersionProvider()
 
 class PreInstallPlugin : Plugin() {
 
@@ -36,7 +39,8 @@ class PreInstallPlugin : Plugin() {
     @CommandLine.Command(name = "preinstall",
         subcommands = [CheckLimits::class, CheckPostgres::class, CheckKafka::class, RunAll::class],
         mixinStandardHelpOptions = true,
-        description = ["Preinstall checks for Corda."])
+        description = ["Preinstall checks for Corda."],
+        versionProvider = VersionProvider::class)
     class PreInstallPluginEntry : CordaCliPlugin
 
     // Common class for plugins to inherit methods from

--- a/tools/plugins/secret-config/src/main/kotlin/net/corda/cli/plugin/secretconfig/SecretConfigPlugin.kt
+++ b/tools/plugins/secret-config/src/main/kotlin/net/corda/cli/plugin/secretconfig/SecretConfigPlugin.kt
@@ -1,6 +1,7 @@
 package net.corda.cli.plugin.secretconfig
 
 import com.typesafe.config.ConfigRenderOptions
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import net.corda.cli.api.CordaCliPlugin
 import net.corda.libs.configuration.helper.VaultSecretConfigGenerator
 import net.corda.libs.configuration.secret.EncryptionSecretsServiceImpl
@@ -14,6 +15,8 @@ import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
 import java.lang.IllegalArgumentException
 
+class VersionProvider : AbstractCordaCliVersionProvider()
+
 class SecretConfigPlugin : Plugin() {
     @Extension
     @Command(
@@ -21,7 +24,8 @@ class SecretConfigPlugin : Plugin() {
         description = ["Generate secret Config values which can be inserted into your Corda Config, removing the need to " +
                 "put sensitive values in plain text. The output will depend on the type of secrets service being used. " +
                 "See 'type' for more information."],
-        mixinStandardHelpOptions = true
+        mixinStandardHelpOptions = true,
+        versionProvider = VersionProvider::class
     )
     class PluginEntryPoint : CordaCliPlugin {
         enum class SecretsServiceType {

--- a/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/TopicPlugin.kt
+++ b/tools/plugins/topic-config/src/main/kotlin/net/corda/cli/plugins/topicconfig/TopicPlugin.kt
@@ -1,5 +1,6 @@
 package net.corda.cli.plugins.topicconfig
 
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import net.corda.cli.api.CordaCliPlugin
 import org.apache.kafka.clients.admin.AdminClientConfig
 import org.pf4j.Extension
@@ -9,6 +10,8 @@ import org.slf4j.LoggerFactory
 import picocli.CommandLine
 import java.io.FileInputStream
 import java.util.Properties
+
+class VersionProvider : AbstractCordaCliVersionProvider()
 
 class TopicPlugin : Plugin() {
 
@@ -30,7 +33,8 @@ class TopicPlugin : Plugin() {
         name = "topic",
         subcommands = [Create::class],
         description = ["Plugin for Kafka topic operations."],
-        mixinStandardHelpOptions = true
+        mixinStandardHelpOptions = true,
+        versionProvider = VersionProvider::class
     )
     class Topic : CordaCliPlugin {
 

--- a/tools/plugins/virtual-node/src/main/kotlin/net/corda/cli/plugins/vnode/VirtualNodeCliPlugin.kt
+++ b/tools/plugins/virtual-node/src/main/kotlin/net/corda/cli/plugins/vnode/VirtualNodeCliPlugin.kt
@@ -1,5 +1,6 @@
 package net.corda.cli.plugins.vnode
 
+import net.corda.cli.api.AbstractCordaCliVersionProvider
 import net.corda.cli.api.CordaCliPlugin
 import net.corda.cli.plugins.vnode.commands.PlatformMigration
 import net.corda.cli.plugins.vnode.commands.ResetCommand
@@ -8,6 +9,8 @@ import org.pf4j.Plugin
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import picocli.CommandLine
+
+class VersionProvider : AbstractCordaCliVersionProvider()
 
 @Suppress("unused")
 class VirtualNodeCliPlugin : Plugin() {
@@ -29,7 +32,8 @@ class VirtualNodeCliPlugin : Plugin() {
         name = "vnode",
         subcommands = [ResetCommand::class, PlatformMigration::class],
         mixinStandardHelpOptions = true,
-        description = ["Manages a virtual node"]
+        description = ["Manages a virtual node"],
+        versionProvider = VersionProvider::class
     )
     class PluginEntryPoint : CordaCliPlugin
 }


### PR DESCRIPTION
Example output:

```text
generatedScripts $ ./corda-cli.sh database --version
db-config 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh initial-config --version
initial-config 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh initial-rbac --version
initial-rbac 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh network --version
network 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh mgm --version
network 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh package --version
package 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh secret-config --version
secret-config 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh topic --version
topic-config 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh vnode --version
virtual-node 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

generatedScripts $ ./corda-cli.sh preinstall --version
preinstall 5.2.0.0-SNAPSHOT

Provider: R3 Ltd

Commit ID: edeca54251cc7c7e088d123c1aa913c31e7a8145

```