### PR TITLE
CORE-18352 Fix app-simulator optional database parameters 

### DIFF
--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/AppSimulator.kt
@@ -146,6 +146,7 @@ class AppSimulator @Activate constructor(
 
     private fun runSink(commonConfig: CommonConfig) {
         val connectionDetails = DBParams.read(commonConfig)
+            ?: throw IllegalArgumentException("Database parameters must be specified on the command line, or in a config file.")
         val sink = Sink(subscriptionFactory, configMerger, commonConfig, connectionDetails)
         sink.start()
         resources.add(sink)
@@ -297,11 +298,15 @@ data class TopicCreationParams(val numPartitions: Int, val replicationFactor: In
 
 data class DBParams(val username: String, val password: String, val host: String, val db: String) {
     companion object {
-        fun read(commonConfig: CommonConfig): DBParams {
+        fun read(commonConfig: CommonConfig): DBParams? {
             val username = getDbParameter("username", commonConfig.configFromFile, commonConfig.parameters)
+                ?: return null
             val password = getDbParameter("password", commonConfig.configFromFile, commonConfig.parameters)
+                ?: return null
             val host = getDbParameter("host", commonConfig.configFromFile, commonConfig.parameters)
+                ?: return null
             val db = getDbParameter("db", commonConfig.configFromFile, commonConfig.parameters)
+                ?: return null
             return DBParams(username, password, host, db)
         }
     }

--- a/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/ArgParsingUtils.kt
+++ b/applications/tools/p2p-test/app-simulator/src/main/kotlin/net/corda/p2p/app/simulator/ArgParsingUtils.kt
@@ -16,13 +16,12 @@ class ArgParsingUtils {
          * Get a database parameter from the command line or the config file. Command line options override options in
          * the config file.
          */
-        fun getDbParameter(path: String, configFromFile: Config, parameters: CliParameters): String {
+        fun getDbParameter(path: String, configFromFile: Config, parameters: CliParameters): String? {
             return getParameter(
                 path,
                 configFromFile.getConfigOrEmpty(AppSimulator.DB_PARAMS_PREFIX),
                 parameters.databaseParams
-            ) ?: throw InvalidArgumentException("Database parameter $path must be specified on the command line, using -d$path, or in a " +
-                    "config file.")
+            )
         }
 
         /***


### PR DESCRIPTION
The app-simulator’s database parameters are optional when running in SENDER mode. This change fixes an issue where the Sender fails to start if these are not provided.