### PR TITLE
CORE-17917 Adding handling to MessageBusClient for async kafka errors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.37-beta+
+cordaApiVersion=5.1.0.37-alpha-1700043137966
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.37-alpha-1700137352553
+cordaApiVersion=5.1.0.37-alpha-1700151714786
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.37-alpha-1700058741660
+cordaApiVersion=5.1.0.37-alpha-1700137352553
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.37-alpha-1700043137966
+cordaApiVersion=5.1.0.37-alpha-1700058741660
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.37-alpha-1700151714786
+cordaApiVersion=5.1.0.37-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
@@ -21,7 +21,7 @@ class MessageBusClient(
     override fun send(message: MediatorMessage<*>): MediatorMessage<*>? {
         producer.send(message.toCordaProducerRecord()) { ex ->
             log.info("Encountered an error while sending a message.", ex)
-            ex?.let {throw ex }
+            ex?.let { throw ex }
         }
         return null
     }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
@@ -19,7 +19,10 @@ class MessageBusClient(
     }
 
     override fun send(message: MediatorMessage<*>): MediatorMessage<*>? {
-        producer.send(message.toCordaProducerRecord(), null)
+        producer.send(message.toCordaProducerRecord()) { ex ->
+            log.info("Encountered an error while sending a message.", ex)
+            ex?.let {throw ex }
+        }
         return null
     }
 

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaPublisherImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaPublisherImpl.kt
@@ -232,7 +232,7 @@ internal class CordaPublisherImpl(
                 if (!config.transactional) {
                     future.complete(Unit)
                 } else {
-                    log.debug { "Asynchronous send completed completed successfully." }
+                    log.debug { "Asynchronous send completed successfully." }
                 }
             }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusClientTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusClientTest.kt
@@ -2,19 +2,27 @@ package net.corda.messaging.mediator
 
 import net.corda.messagebus.api.producer.CordaProducer
 import net.corda.messagebus.api.producer.CordaProducerRecord
+import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import org.mockito.Mockito.any
+import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.times
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.CompletableFuture
 
 class MessageBusClientTest {
     private companion object {
@@ -31,6 +39,12 @@ class MessageBusClientTest {
         MSG_PROP_KEY to TEST_KEY,
     )
     private val message: MediatorMessage<Any> = MediatorMessage("value", messageProps)
+    private val record: CordaProducerRecord<*, *> = CordaProducerRecord(
+        TEST_ENDPOINT,
+        TEST_KEY,
+        message.payload,
+        messageProps.toHeaders(),
+    )
 
 
     @BeforeEach
@@ -39,22 +53,26 @@ class MessageBusClientTest {
         messageBusClient = MessageBusClient("client-id", cordaProducer)
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
-    fun testSend() {
-        messageBusClient.send(message)
+    fun `test send`() {
+        doAnswer {
+            val callback = it.getArgument<CordaProducer.Callback>(1)
+            callback.onCompletion(null)
+        }.whenever(cordaProducer).send(eq(record), any())
 
-        val expected = CordaProducerRecord(
-            TEST_ENDPOINT,
-            TEST_KEY,
-            message.payload,
-            messageProps.toHeaders(),
-        )
+        val result = messageBusClient.send(message) as MediatorMessage<CompletableFuture<Unit>>
 
-        verify(cordaProducer).send(eq(expected), any())
+        verify(cordaProducer).send(eq(record), any())
+        assertNotNull(result.payload)
+        result.payload?.let {
+            assertTrue(it.isDone)
+            assertFalse(it.isCompletedExceptionally)
+        }
     }
 
     @Test
-    fun testSendWithError() {
+    fun `send should handle synchronous error`() {
         val record = CordaProducerRecord(
             TEST_ENDPOINT,
             TEST_KEY,
@@ -68,8 +86,74 @@ class MessageBusClientTest {
         }
     }
 
+    @Suppress("UNCHECKED_CAST")
     @Test
-    fun testClose() {
+    fun `send should handle asynchronous CordaMessageAPIIntermittentException`() {
+        doAnswer {
+            val callback = it.getArgument<CordaProducer.Callback>(1)
+            callback.onCompletion(CordaMessageAPIIntermittentException("test"))
+        }.whenever(cordaProducer).send(eq(record), any())
+
+        val result = messageBusClient.send(message) as MediatorMessage<CompletableFuture<Unit>>
+
+        verify(cordaProducer).send(eq(record), any())
+        assertNotNull(result.payload)
+
+        result.payload?.isCompletedExceptionally?.let { assertTrue(it) }
+
+        result.payload?.handle { _, exception ->
+            assertTrue(exception is CordaMessageAPIIntermittentException)
+            assertEquals("test", exception.message)
+        }?.get()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `send should handle asynchronous CordaMessageAPIFatalException`() {
+        doAnswer {
+            val callback = it.getArgument<CordaProducer.Callback>(1)
+            callback.onCompletion(CordaMessageAPIFatalException("test"))
+        }.whenever(cordaProducer).send(eq(record), any())
+
+        val result = messageBusClient.send(message) as MediatorMessage<CompletableFuture<Unit>>
+
+        verify(cordaProducer).send(eq(record), any())
+        assertNotNull(result.payload)
+
+        result.payload?.isCompletedExceptionally?.let { assertTrue(it) }
+
+        result.payload?.handle { _, exception ->
+            assertTrue(exception is CordaMessageAPIFatalException)
+            assertEquals("test", exception.message)
+        }?.get()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun `send should wrap unknown exceptions`() {
+        doAnswer {
+            val callback = it.getArgument<CordaProducer.Callback>(1)
+            callback.onCompletion(CordaRuntimeException("test"))
+        }.whenever(cordaProducer).send(eq(record), any())
+
+        val result = messageBusClient.send(message) as MediatorMessage<CompletableFuture<Unit>>
+
+        verify(cordaProducer).send(eq(record), any())
+        assertNotNull(result.payload)
+
+        result.payload?.isCompletedExceptionally?.let { assertTrue(it) }
+
+        result.payload?.handle { _, exception ->
+            assertTrue(exception is CordaMessageAPIFatalException)
+            assertEquals(
+                "Producer clientId client-id for topic topic failed to send. Unknown error occurred.",
+                exception.message
+            )
+        }?.get()
+    }
+
+    @Test
+    fun `test close`() {
         messageBusClient.close()
         verify(cordaProducer, times(1)).close()
     }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusClientTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MessageBusClientTest.kt
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
+import org.mockito.Mockito.any
 import org.mockito.Mockito.times
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -50,7 +50,7 @@ class MessageBusClientTest {
             messageProps.toHeaders(),
         )
 
-        verify(cordaProducer).send(eq(expected), isNull())
+        verify(cordaProducer).send(eq(expected), any())
     }
 
     @Test
@@ -62,7 +62,7 @@ class MessageBusClientTest {
             messageProps.toHeaders(),
         )
 
-        Mockito.doThrow(CordaRuntimeException("")).whenever(cordaProducer).send(eq(record), isNull())
+        Mockito.doThrow(CordaRuntimeException("")).whenever(cordaProducer).send(eq(record), any())
         assertThrows<CordaRuntimeException> {
             messageBusClient.send(message)
         }


### PR DESCRIPTION
A bug was observed whereby Kafka producer errors were not being correctly reported back to the `MultiSourceEventMediator`. This is because our Kafka messages are essentially 'fire-and-forget'; when something goes wrong, Kafka will exceptionally close a future in the background, but we never attempted to capture or track this future.

This PR adds logging around this type of issue to make it clear to the user that something has gone wrong, and passes a lambda to the `CordaProducer` allowing reporting back of any Kafka exceptions that occur. This `future` is currently not utilized in the mediator; that will be covered in an upcoming mediator refactor.

Currently, all Kafka exceptions are wrapped in a `CordaMessageAPIFatalException` as Kafka is already configured to retry intermittent/retryable errors internally. In the future, we may choose to wrap some of these as `CordaMessageAPIIntermittentException`s regardless.