### PR TITLE
CORE-18370 Fix `findUnconsumedStatesByExactType`

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/registration/impl/VaultNamedQueryFactoryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/registration/impl/VaultNamedQueryFactoryProvider.kt
@@ -48,7 +48,7 @@ class VaultNamedQueryFactoryProvider @Activate constructor(
     private fun registerPlatformQueries(vaultNamedQueryBuilderFactory: VaultNamedQueryBuilderFactory) {
         vaultNamedQueryBuilderFactory
             .create(FIND_UNCONSUMED_STATES_BY_EXACT_TYPE)
-            .whereJson("WHERE visible_states.type = :type")
+            .whereJson("WHERE visible_states.type = :type AND visible_states.consumed IS NULL")
             .register()
     }
 }


### PR DESCRIPTION
The query for `findUnconsumedStatesByExactType` did not actually filter by `consumed IS NULL` so it returned all states regardless of if they were consumed or not.

Added `consumed IS NULL` to fix this.