### PR TITLE
CORE-18390: Allow old version of SetOwnRegistrationStatus in the command

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/PersistMemberRegistrationStateHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/PersistMemberRegistrationStateHandler.kt
@@ -2,6 +2,10 @@ package net.corda.membership.impl.registration.dynamic.handler.member
 
 import net.corda.data.identity.HoldingIdentity
 import net.corda.data.membership.command.registration.member.PersistMemberRegistrationState
+import net.corda.data.membership.common.RegistrationStatus as RegistrationStatusV1
+import net.corda.data.membership.common.v2.RegistrationStatus as RegistrationStatusV2
+import net.corda.data.membership.p2p.SetOwnRegistrationStatus as SetOwnRegistrationStatusV1
+import net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus as SetOwnRegistrationStatusV2
 import net.corda.data.membership.state.RegistrationState
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
@@ -17,11 +21,12 @@ internal class PersistMemberRegistrationStateHandler(
         command: PersistMemberRegistrationState,
     ): RegistrationHandlerResult {
         val member = command.member.toCorda()
+        val request = command.request()
         val commands = membershipPersistenceClient.setRegistrationRequestStatus(
             member,
-            command.setStatusRequest.registrationId,
-            command.setStatusRequest.newStatus,
-            command.setStatusRequest.reason
+            request.registrationId,
+            request.newStatus,
+            request.reason
         ).createAsyncCommands()
         return RegistrationHandlerResult(
             null,
@@ -35,4 +40,34 @@ internal class PersistMemberRegistrationStateHandler(
         state: RegistrationState?,
         command: PersistMemberRegistrationState
     ): HoldingIdentity = command.member
+
+    private fun PersistMemberRegistrationState.request(): SetOwnRegistrationStatusV2 {
+        val request = this.setStatusRequest
+        return when (request) {
+            is SetOwnRegistrationStatusV2 -> request
+            is SetOwnRegistrationStatusV1 -> SetOwnRegistrationStatusV2(
+                request.registrationId,
+                request.newStatus.toV2(),
+                null
+            )
+            else -> throw IllegalArgumentException("Unknown request status '${request.javaClass}' received.")
+        }
+    }
+
+    private fun RegistrationStatusV1.toV2(): RegistrationStatusV2 {
+        return when(this) {
+            RegistrationStatusV1.NEW -> RegistrationStatusV2.NEW
+            RegistrationStatusV1.SENT_TO_MGM -> RegistrationStatusV2.SENT_TO_MGM
+            RegistrationStatusV1.RECEIVED_BY_MGM -> RegistrationStatusV2.RECEIVED_BY_MGM
+            RegistrationStatusV1.PENDING_MEMBER_VERIFICATION -> RegistrationStatusV2.PENDING_MEMBER_VERIFICATION
+            RegistrationStatusV1.PENDING_MANUAL_APPROVAL -> RegistrationStatusV2.PENDING_MANUAL_APPROVAL
+            RegistrationStatusV1.PENDING_AUTO_APPROVAL -> RegistrationStatusV2.PENDING_AUTO_APPROVAL
+            RegistrationStatusV1.APPROVED -> RegistrationStatusV2.APPROVED
+            RegistrationStatusV1.DECLINED -> RegistrationStatusV2.DECLINED
+            RegistrationStatusV1.INVALID -> RegistrationStatusV2.INVALID
+            RegistrationStatusV1.FAILED -> RegistrationStatusV2.FAILED
+            else -> throw IllegalArgumentException("Unknown status '${this.name}' received.")
+        }
+
+    }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/PersistMemberRegistrationStateHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/member/PersistMemberRegistrationStateHandlerTest.kt
@@ -38,13 +38,14 @@ class PersistMemberRegistrationStateHandlerTest {
         } doReturn operation
     }
     private val reason = "some reason"
-    val command = PersistMemberRegistrationState(
+    private val request = SetOwnRegistrationStatus(
+        UUID(1,2).toString(),
+        RegistrationStatus.DECLINED,
+        reason
+    )
+    private val command = PersistMemberRegistrationState(
         HoldingIdentity("O=Alice, L=London, C=GB", "GroupId"),
-        SetOwnRegistrationStatus(
-            UUID(1,2).toString(),
-            RegistrationStatus.DECLINED,
-            reason
-        )
+        request
     )
 
     private val handler = PersistMemberRegistrationStateHandler(
@@ -66,8 +67,8 @@ class PersistMemberRegistrationStateHandlerTest {
 
         verify(membershipPersistenceClient).setRegistrationRequestStatus(
             command.member.toCorda(),
-            command.setStatusRequest.registrationId,
-            command.setStatusRequest.newStatus,
+            request.registrationId,
+            request.newStatus,
             reason
         )
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.37-beta+
+cordaApiVersion=5.1.0.38-alpha-1700137746834
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.38-alpha-1700137746834
+cordaApiVersion=5.1.0.38-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
This should accept commands from a 5.0 cluster.

See the API pull request at https://github.com/corda/corda-api/pull/1342