### PR TITLE
CORE-17955 - Changes to `ClaimStateStore` implementation class.

### DIFF
--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheEventProcessorFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheEventProcessorFactoryImpl.kt
@@ -54,7 +54,7 @@ class TokenCacheEventProcessorFactoryImpl(
             eventConverter,
             entityConverter,
             tokenPoolCacheManager,
-            ClaimStateStoreCacheImpl(stateManager, serialization, claimStateStoreFactory, clock),
+            ClaimStateStoreCacheImpl(claimStateStoreFactory),
             externalEventResponseFactory,
             tokenSelectionMetrics
         )

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreCacheImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreCacheImpl.kt
@@ -1,17 +1,10 @@
 package net.corda.ledger.utxo.token.cache.services
 
-import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
 import net.corda.ledger.utxo.token.cache.entities.TokenPoolKey
-import net.corda.libs.statemanager.api.State
-import net.corda.libs.statemanager.api.StateManager
-import net.corda.utilities.time.Clock
 import java.util.concurrent.ConcurrentHashMap
 
 class ClaimStateStoreCacheImpl(
-    private val stateManager: StateManager,
-    private val serialization: TokenPoolCacheStateSerialization,
     private val claimStateStoreFactory: ClaimStateStoreFactory,
-    private val clock: Clock
 ) : ClaimStateStoreCache {
 
     private val stateStoreCache = ConcurrentHashMap<TokenPoolKey, ClaimStateStore>()
@@ -23,53 +16,6 @@ class ClaimStateStoreCacheImpl(
     }
 
     private fun createClaimStateStore(key: TokenPoolKey): ClaimStateStore {
-        // No existing Store for this key, we need to create one
-        // Try and get the existing state from storage
-        val stateRecord = stateManager.get(listOf(key.toString()))
-            .map { it.value }
-            .firstOrNull()
-
-        val claimState = if (stateRecord == null) {
-            createClaimStateFromDefaults(key)
-        } else {
-            createClaimStateFromExisting(key, stateRecord)
-        }
-
-        return claimStateStoreFactory.create(key, claimState)
-    }
-
-    private fun createClaimStateFromDefaults(key: TokenPoolKey): StoredPoolClaimState {
-        val tokenPoolCacheState = getDefaultTokenPoolCacheState(key)
-        val stateBytes = serialization.serialize(tokenPoolCacheState)
-        val newStoredState = State(
-            key = key.toString(),
-            value = stateBytes,
-            modifiedTime = clock.instant()
-        )
-
-        stateManager.create(listOf(newStoredState))
-
-        return StoredPoolClaimState(
-            State.VERSION_INITIAL_VALUE,
-            key,
-            tokenPoolCacheState
-        )
-    }
-
-    private fun createClaimStateFromExisting(key: TokenPoolKey, existing: State): StoredPoolClaimState {
-        return StoredPoolClaimState(
-            existing.version,
-            key,
-            serialization.deserialize(existing.value)
-        )
-    }
-
-    private fun getDefaultTokenPoolCacheState(key: TokenPoolKey): TokenPoolCacheState {
-        return TokenPoolCacheState.newBuilder()
-            .setPoolKey(key.toAvro())
-            .setAvailableTokens(listOf())
-            .setTokenClaims(listOf())
-            .build()
+        return claimStateStoreFactory.create(key)
     }
 }
-

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreFactory.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreFactory.kt
@@ -3,5 +3,5 @@ package net.corda.ledger.utxo.token.cache.services
 import net.corda.ledger.utxo.token.cache.entities.TokenPoolKey
 
 interface ClaimStateStoreFactory {
-    fun create(key: TokenPoolKey, storedPoolClaimState: StoredPoolClaimState): ClaimStateStore
+    fun create(key: TokenPoolKey): ClaimStateStore
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreFactoryImpl.kt
@@ -1,6 +1,8 @@
 package net.corda.ledger.utxo.token.cache.services
 
+import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
 import net.corda.ledger.utxo.token.cache.entities.TokenPoolKey
+import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.utilities.time.Clock
 
@@ -11,14 +13,61 @@ class ClaimStateStoreFactoryImpl(
     private val clock: Clock
 ) : ClaimStateStoreFactory {
 
-    override fun create(key: TokenPoolKey, storedPoolClaimState: StoredPoolClaimState): ClaimStateStore {
+    override fun create(key: TokenPoolKey): ClaimStateStore {
+
+        // No existing Store for this key, we need to create one
+        // Try and get the existing state from storage
+        val stateRecord = stateManager.get(listOf(key.toString()))
+            .map { it.value }
+            .firstOrNull()
+
+        val claimState = if (stateRecord == null) {
+            createClaimStateFromDefaults(key)
+        } else {
+            createClaimStateFromExisting(key, stateRecord)
+        }
+
         return PerformanceClaimStateStoreImpl(
             key,
-            storedPoolClaimState,
+            claimState,
             serialization,
             stateManager,
             tokenPoolCacheManager,
             clock
         )
+    }
+
+    private fun createClaimStateFromDefaults(key: TokenPoolKey): StoredPoolClaimState {
+        val tokenPoolCacheState = getDefaultTokenPoolCacheState(key)
+        val stateBytes = serialization.serialize(tokenPoolCacheState)
+        val newStoredState = State(
+            key = key.toString(),
+            value = stateBytes,
+            modifiedTime = clock.instant()
+        )
+
+        stateManager.create(listOf(newStoredState))
+
+        return StoredPoolClaimState(
+            State.VERSION_INITIAL_VALUE,
+            key,
+            tokenPoolCacheState
+        )
+    }
+
+    private fun createClaimStateFromExisting(key: TokenPoolKey, existing: State): StoredPoolClaimState {
+        return StoredPoolClaimState(
+            existing.version,
+            key,
+            serialization.deserialize(existing.value)
+        )
+    }
+
+    private fun getDefaultTokenPoolCacheState(key: TokenPoolKey): TokenPoolCacheState {
+        return TokenPoolCacheState.newBuilder()
+            .setPoolKey(key.toAvro())
+            .setAvailableTokens(listOf())
+            .setTokenClaims(listOf())
+            .build()
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreFactoryImpl.kt
@@ -1,8 +1,6 @@
 package net.corda.ledger.utxo.token.cache.services
 
-import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
 import net.corda.ledger.utxo.token.cache.entities.TokenPoolKey
-import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.utilities.time.Clock
 

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/ClaimStateStoreFactoryImpl.kt
@@ -14,60 +14,12 @@ class ClaimStateStoreFactoryImpl(
 ) : ClaimStateStoreFactory {
 
     override fun create(key: TokenPoolKey): ClaimStateStore {
-
-        // No existing Store for this key, we need to create one
-        // Try and get the existing state from storage
-        val stateRecord = stateManager.get(listOf(key.toString()))
-            .map { it.value }
-            .firstOrNull()
-
-        val claimState = if (stateRecord == null) {
-            createClaimStateFromDefaults(key)
-        } else {
-            createClaimStateFromExisting(key, stateRecord)
-        }
-
         return PerformanceClaimStateStoreImpl(
             key,
-            claimState,
             serialization,
             stateManager,
             tokenPoolCacheManager,
             clock
         )
-    }
-
-    private fun createClaimStateFromDefaults(key: TokenPoolKey): StoredPoolClaimState {
-        val tokenPoolCacheState = getDefaultTokenPoolCacheState(key)
-        val stateBytes = serialization.serialize(tokenPoolCacheState)
-        val newStoredState = State(
-            key = key.toString(),
-            value = stateBytes,
-            modifiedTime = clock.instant()
-        )
-
-        stateManager.create(listOf(newStoredState))
-
-        return StoredPoolClaimState(
-            State.VERSION_INITIAL_VALUE,
-            key,
-            tokenPoolCacheState
-        )
-    }
-
-    private fun createClaimStateFromExisting(key: TokenPoolKey, existing: State): StoredPoolClaimState {
-        return StoredPoolClaimState(
-            existing.version,
-            key,
-            serialization.deserialize(existing.value)
-        )
-    }
-
-    private fun getDefaultTokenPoolCacheState(key: TokenPoolKey): TokenPoolCacheState {
-        return TokenPoolCacheState.newBuilder()
-            .setPoolKey(key.toAvro())
-            .setAvailableTokens(listOf())
-            .setTokenClaims(listOf())
-            .build()
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/PerformanceClaimStateStoreImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/PerformanceClaimStateStoreImpl.kt
@@ -50,13 +50,13 @@ class PerformanceClaimStateStoreImpl(
     }
 
     private fun drainAndProcessQueue() {
-        var itemsToProcess = drainQueuedRequests()
+        var requests = drainQueuedRequests()
 
-        while (itemsToProcess.isNotEmpty()) {
+        while (requests.isNotEmpty()) {
             // Executing all pending requests against the current state
             var currentPoolState = currentState.poolState
             val unexceptionalRequests = mutableListOf<CompletableFuture<Boolean>>()
-            itemsToProcess.forEach { queuedRequest ->
+            requests.forEach { queuedRequest ->
                 try {
                     currentPoolState = queuedRequest.requestAction(currentPoolState)
                     unexceptionalRequests.add(queuedRequest.requestFuture)
@@ -111,7 +111,7 @@ class PerformanceClaimStateStoreImpl(
             }
 
             // look for more request to process
-            itemsToProcess = drainQueuedRequests()
+            requests = drainQueuedRequests()
         }
     }
 

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/PerformanceClaimStateStoreImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/PerformanceClaimStateStoreImpl.kt
@@ -15,7 +15,6 @@ import java.util.concurrent.TimeUnit
 @Suppress("LongParameterList")
 class PerformanceClaimStateStoreImpl(
     private val tokenPoolKey: TokenPoolKey,
-    storedPoolClaimState: StoredPoolClaimState,
     private val serialization: TokenPoolCacheStateSerialization,
     private val stateManager: StateManager,
     private val tokenPoolCacheManager: TokenPoolCacheManager,
@@ -35,7 +34,7 @@ class PerformanceClaimStateStoreImpl(
         ThreadPoolExecutor.DiscardPolicy()
     )
     private val requestQueue = LinkedBlockingQueue<QueuedRequestItem>()
-    private var currentState = storedPoolClaimState
+    private var currentState = getStoredPoolClaimState()
 
     private data class QueuedRequestItem(
         val requestAction: (TokenPoolCacheState) -> TokenPoolCacheState,
@@ -74,10 +73,10 @@ class PerformanceClaimStateStoreImpl(
             )
 
             val mismatchedState = try {
-               stateManager.update(listOf(stateManagerState))
+                stateManager.update(listOf(stateManagerState))
                     .map { it.value }
                     .firstOrNull()
-            } catch(ex: Exception) {
+            } catch (ex: Exception) {
 
                 logger.warn("Exception during execution of an update", ex)
 
@@ -94,11 +93,7 @@ class PerformanceClaimStateStoreImpl(
             // If we failed to update the state then fail the batch of requests and rollback the state to the DB
             // version
             if (mismatchedState != null) {
-                currentState = StoredPoolClaimState(
-                    dbVersion = mismatchedState.version,
-                    tokenPoolKey,
-                    serialization.deserialize(mismatchedState.value)
-                )
+                currentState = createClaimStateFromExisting(mismatchedState)
 
                 // When fail to save the state we have to assume the available token cache could be invalid
                 // and therefore clear it to force a refresh from the DB on the next request.
@@ -134,6 +129,54 @@ class PerformanceClaimStateStoreImpl(
             .setPoolKey(this.poolKey)
             .setAvailableTokens(this.availableTokens)
             .setTokenClaims(this.tokenClaims)
+            .build()
+    }
+
+    private fun getStoredPoolClaimState(): StoredPoolClaimState {
+        // No existing Store for this key, we need to create one
+        // Try and get the existing state from storage
+        val stateRecord = stateManager.get(listOf(tokenPoolKey.toString()))
+            .map { it.value }
+            .firstOrNull()
+
+        return if (stateRecord == null) {
+            createClaimStateFromDefaults()
+        } else {
+            createClaimStateFromExisting(stateRecord)
+        }
+    }
+
+    private fun createClaimStateFromDefaults(): StoredPoolClaimState {
+        val tokenPoolCacheState = getDefaultTokenPoolCacheState()
+        val stateBytes = serialization.serialize(tokenPoolCacheState)
+        val newStoredState = State(
+            key = tokenPoolKey.toString(),
+            value = stateBytes,
+            modifiedTime = clock.instant()
+        )
+
+        stateManager.create(listOf(newStoredState))
+
+        return StoredPoolClaimState(
+            State.VERSION_INITIAL_VALUE,
+            tokenPoolKey,
+            tokenPoolCacheState
+        )
+    }
+
+    private fun createClaimStateFromExisting(existing: State): StoredPoolClaimState {
+        return StoredPoolClaimState(
+            existing.version,
+            tokenPoolKey,
+            serialization.deserialize(existing.value)
+        )
+    }
+
+    private fun getDefaultTokenPoolCacheState(): TokenPoolCacheState {
+        return TokenPoolCacheState.newBuilder()
+            .setPoolKey(tokenPoolKey.toAvro())
+            .setAvailableTokens(listOf())
+            .setTokenClaims(listOf())
             .build()
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/PerformanceClaimStateStoreImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/PerformanceClaimStateStoreImpl.kt
@@ -34,7 +34,7 @@ class PerformanceClaimStateStoreImpl(
         ThreadPoolExecutor.DiscardPolicy()
     )
     private val requestQueue = LinkedBlockingQueue<QueuedRequestItem>()
-    private var currentState = getStoredPoolClaimState()
+    private var currentState = createClaimState()
 
     private data class QueuedRequestItem(
         val requestAction: (TokenPoolCacheState) -> TokenPoolCacheState,
@@ -132,7 +132,7 @@ class PerformanceClaimStateStoreImpl(
             .build()
     }
 
-    private fun getStoredPoolClaimState(): StoredPoolClaimState {
+    private fun createClaimState(): StoredPoolClaimState {
         // No existing Store for this key, we need to create one
         // Try and get the existing state from storage
         val stateRecord = stateManager.get(listOf(tokenPoolKey.toString()))

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
@@ -34,11 +34,12 @@ class ClaimStateStoreCacheImplTest {
         whenever(claimStateStoreFactory.create(any())).thenReturn(newClaimStateStore)
 
         val result1 = claimStateStoreCache.get(POOL_KEY)
-        assertThat(result1).isEqualTo(newClaimStateStore)
-
         val result2 = claimStateStoreCache.get(POOL_KEY)
-        verify(claimStateStoreFactory, times(1)).create(any())
+
+        assertThat(result1).isEqualTo(newClaimStateStore)
         assertThat(result2).isSameAs(result1)
+
+        // Ensure that the claim state was only created once
         verify(claimStateStoreFactory, times(1)).create(any())
     }
 }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
@@ -29,18 +29,6 @@ class ClaimStateStoreCacheImplTest {
     }
 
     @Test
-    fun `get when existing state then load and use`() {
-        val newClaimStateStore = mock<ClaimStateStore>()
-
-        whenever(claimStateStoreFactory.create(any())).thenReturn(newClaimStateStore)
-
-        val result = claimStateStoreCache.get(POOL_KEY)
-        assertThat(result).isEqualTo(newClaimStateStore)
-
-        verify(claimStateStoreFactory).create(eq(POOL_KEY))
-    }
-
-    @Test
     fun `get when existing cached used cached version`() {
         val newClaimStateStore = mock<ClaimStateStore>()
         whenever(claimStateStoreFactory.create(any())).thenReturn(newClaimStateStore)

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
@@ -1,13 +1,9 @@
 package net.corda.ledger.utxo.token.cache.impl.services
 
 import net.corda.ledger.utxo.token.cache.impl.POOL_KEY
-import net.corda.ledger.utxo.token.cache.impl.TOKEN_POOL_CACHE_STATE
 import net.corda.ledger.utxo.token.cache.services.ClaimStateStore
 import net.corda.ledger.utxo.token.cache.services.ClaimStateStoreCacheImpl
 import net.corda.ledger.utxo.token.cache.services.ClaimStateStoreFactory
-import net.corda.ledger.utxo.token.cache.services.TokenPoolCacheStateSerialization
-import net.corda.libs.statemanager.api.State
-import net.corda.libs.statemanager.api.StateManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -16,63 +12,43 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.time.Instant
 
 class ClaimStateStoreCacheImplTest {
-    private val now = Instant.ofEpochMilli(1)
-    private val stateManager = mock<StateManager>()
-    private val serialization = mock<TokenPoolCacheStateSerialization>()
     private val claimStateStoreFactory = mock<ClaimStateStoreFactory>()
-
-    private val target = ClaimStateStoreCacheImpl(claimStateStoreFactory)
+    private val claimStateStoreCache = ClaimStateStoreCacheImpl(claimStateStoreFactory)
 
     @Test
     fun `get when no existing state in store then create default state`() {
         val newClaimStateStore = mock<ClaimStateStore>()
-        val stateBytes = "data".toByteArray()
-        whenever(stateManager.get(any())).thenReturn(mapOf())
         whenever(claimStateStoreFactory.create(any())).thenReturn(newClaimStateStore)
-        whenever(serialization.serialize(any())).thenReturn(stateBytes)
 
-        val expectedStoredState = State(POOL_KEY.toString(), stateBytes, modifiedTime = now)
-
-        val result = target.get(POOL_KEY)
+        val result = claimStateStoreCache.get(POOL_KEY)
         assertThat(result).isEqualTo(newClaimStateStore)
 
         verify(claimStateStoreFactory).create(eq(POOL_KEY))
-        verify(stateManager).create(eq(listOf(expectedStoredState)))
     }
 
     @Test
     fun `get when existing state then load and use`() {
         val newClaimStateStore = mock<ClaimStateStore>()
-        val stateBytes = "data".toByteArray()
-        val stateRecord = State(POOL_KEY.toString(), stateBytes, 1)
-        val expectedState = TOKEN_POOL_CACHE_STATE
 
-        whenever(stateManager.get(any())).thenReturn(mapOf(POOL_KEY.toString() to stateRecord))
-        whenever(serialization.deserialize(any())).thenReturn(expectedState)
         whenever(claimStateStoreFactory.create(any())).thenReturn(newClaimStateStore)
 
-        val result = target.get(POOL_KEY)
+        val result = claimStateStoreCache.get(POOL_KEY)
         assertThat(result).isEqualTo(newClaimStateStore)
 
-        verify(serialization).deserialize(stateBytes)
         verify(claimStateStoreFactory).create(eq(POOL_KEY))
     }
 
     @Test
     fun `get when existing cached used cached version`() {
         val newClaimStateStore = mock<ClaimStateStore>()
-        val stateBytes = "data".toByteArray()
-        whenever(stateManager.get(any())).thenReturn(mapOf())
-        whenever(serialization.serialize(any())).thenReturn(stateBytes)
         whenever(claimStateStoreFactory.create(any())).thenReturn(newClaimStateStore)
 
-        val result1 = target.get(POOL_KEY)
+        val result1 = claimStateStoreCache.get(POOL_KEY)
         assertThat(result1).isEqualTo(newClaimStateStore)
 
-        val result2 = target.get(POOL_KEY)
+        val result2 = claimStateStoreCache.get(POOL_KEY)
         verify(claimStateStoreFactory, times(1)).create(any())
         assertThat(result2).isSameAs(result1)
         verify(claimStateStoreFactory, times(1)).create(any())

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
@@ -34,7 +34,6 @@ class ClaimStateStoreCacheImplTest {
         whenever(claimStateStoreFactory.create(any())).thenReturn(newClaimStateStore)
         whenever(serialization.serialize(any())).thenReturn(stateBytes)
 
-        val expectedState = TOKEN_POOL_CACHE_STATE
         val expectedStoredState = State(POOL_KEY.toString(), stateBytes, modifiedTime = now)
 
         val result = target.get(POOL_KEY)

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/ClaimStateStoreCacheImplTest.kt
@@ -33,9 +33,12 @@ class ClaimStateStoreCacheImplTest {
         val newClaimStateStore = mock<ClaimStateStore>()
         whenever(claimStateStoreFactory.create(any())).thenReturn(newClaimStateStore)
 
+        // The claim state store is created
         val result1 = claimStateStoreCache.get(POOL_KEY)
+        // The previous created claim state store is retrieved
         val result2 = claimStateStoreCache.get(POOL_KEY)
 
+        // Ensure the claim state store are all the same
         assertThat(result1).isEqualTo(newClaimStateStore)
         assertThat(result2).isSameAs(result1)
 

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/PerformanceClaimStateStoreImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/PerformanceClaimStateStoreImplTest.kt
@@ -57,22 +57,8 @@ class PerformanceClaimStateStoreImplTest {
             this.create(listOf(baseState))
         }
 
-        val initialStoredPoolClaimStateA = StoredPoolClaimState(
-            0, POOL_KEY, TokenPoolCacheState.newBuilder()
-                .setPoolKey(POOL_KEY.toAvro())
-                .setAvailableTokens(listOf())
-                .setTokenClaims(listOf())
-                .build()
-        )
-        val initialStoredPoolClaimStateB = StoredPoolClaimState(
-            0, POOL_KEY, TokenPoolCacheState.newBuilder()
-                .setPoolKey(POOL_KEY.toAvro())
-                .setAvailableTokens(listOf())
-                .setTokenClaims(listOf())
-                .build()
-        )
-        val instanceA = createTarget(initialStoredPoolClaimStateA, slowStateManager)
-        val instanceB = createTarget(initialStoredPoolClaimStateB, slowStateManager)
+        val instanceA = createTarget(slowStateManager)
+        val instanceB = createTarget(slowStateManager)
 
         val claimCount = 100
         var instanceAClaims = (0..claimCount).map { createTokenClaim("A$it") }
@@ -171,7 +157,6 @@ class PerformanceClaimStateStoreImplTest {
     }
 
     private fun createTarget(
-        storedPoolClaimState: StoredPoolClaimState,
         sm: StateManager
     ): PerformanceClaimStateStoreImpl {
         return PerformanceClaimStateStoreImpl(POOL_KEY, serialization, sm, tokenPoolCacheManager, clock)

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/PerformanceClaimStateStoreImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/PerformanceClaimStateStoreImplTest.kt
@@ -1,10 +1,8 @@
 package net.corda.ledger.utxo.token.cache.impl.services
 
 import net.corda.data.ledger.utxo.token.selection.data.TokenClaim
-import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
 import net.corda.ledger.utxo.token.cache.impl.POOL_KEY
 import net.corda.ledger.utxo.token.cache.impl.TOKEN_POOL_CACHE_STATE
-import net.corda.ledger.utxo.token.cache.services.StoredPoolClaimState
 import net.corda.ledger.utxo.token.cache.services.PerformanceClaimStateStoreImpl
 import net.corda.ledger.utxo.token.cache.services.TokenPoolCacheManager
 import net.corda.ledger.utxo.token.cache.services.TokenPoolCacheStateSerializationImpl


### PR DESCRIPTION
The logic that creates a state has been merged with the logic that updates a state in the `ClaimStateStore` implementation class.
The intention was only to move code around to make it tidier. The logic should remain the same.