### PR TITLE
CORE-18357 back port CORE-17514 into release/os/5.0

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
@@ -8,6 +8,7 @@ import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
 import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
@@ -140,7 +141,14 @@ internal class InMemorySessionReplayer(
             return
         }
 
-        val networkType = groupPolicyProvider.getGroupPolicy(messageReplay.sessionCounterparties.ourId)?.networkType
+        val networkType = try {
+            groupPolicyProvider.getGroupPolicy(messageReplay.sessionCounterparties.ourId)?.networkType
+        } catch (except: BadGroupPolicyException) {
+            logger.warn("Attempted to replay a session negotiation message (type ${messageReplay.message::class.java.simpleName}) but" +
+                " the group policy data is unavailable or cannot be parsed for ${messageReplay.sessionCounterparties.ourId}. Error:" +
+                " ${except.message}. The message was not replayed.")
+            return
+        }
         if (networkType == null) {
             logger.warn("Attempted to replay a session negotiation message (type ${messageReplay.message::class.java.simpleName}) but" +
                 " could not find the network type in the GroupPolicyProvider for ${messageReplay.sessionCounterparties.ourId}." +

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -40,6 +40,7 @@ import net.corda.virtualnode.toCorda
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Instant
+import net.corda.membership.lib.exceptions.BadGroupPolicyException
 
 @Suppress("LongParameterList", "TooManyFunctions")
 internal class OutboundMessageProcessor(
@@ -211,6 +212,13 @@ internal class OutboundMessageProcessor(
                     "Could not find the group information in the GroupPolicyProvider for $source. " +
                     "The message ${message.header.messageId} was discarded."
                 )
+                return emptyList()
+            }
+            try {
+                groupPolicy.p2pParameters
+            } catch (except: BadGroupPolicyException) {
+                logger.warn("The group policy data is unavailable or cannot be parsed for $source. Error: ${except.message}. The message" +
+                            " ${message.header.messageId} was discarded.")
                 return emptyList()
             }
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerWarnings.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerWarnings.kt
@@ -50,6 +50,10 @@ internal object SessionManagerWarnings {
                 " The message was discarded."
         )
     }
+    internal fun Logger.badGroupPolicy(messageName: String, sessionId: String, holdingIdentity: HoldingIdentity, message: String?) {
+        this.warn("The group policy data is unavailable or cannot be parsed for identity $holdingIdentity. Error: $message. The " +
+            "$messageName for sessionId $sessionId was discarded.")
+    }
 
     internal fun Logger.couldNotFindGroupInfo(messageName: String, sessionId: String, holdingIdentity: HoldingIdentity) {
         this.warn(

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/MessageConverterTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/MessageConverterTest.kt
@@ -30,6 +30,9 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import java.nio.ByteBuffer
+import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.lib.exceptions.BadGroupPolicyException
+import net.corda.membership.lib.grouppolicy.GroupPolicy
 
 class MessageConverterTest {
 
@@ -100,7 +103,7 @@ class MessageConverterTest {
     }
 
     @Test
-    fun `createLinkOutMessageFromFlowMessage returns null (with appropriate logging) if the destination is not in the network map`() {
+    fun `linkOutMessageFromAuthenticatedMessageAndKey returns null if the destination is not in the network map`() {
         val mac = mock<AuthenticationResult> {
             on { header } doReturn mockHeader
             on { mac } doReturn byteArrayOf()
@@ -127,7 +130,7 @@ class MessageConverterTest {
     }
 
     @Test
-    fun `createLinkOutMessageFromFlowMessage returns null if the destination does not have the expected serial`() {
+    fun `linkOutMessageFromAuthenticatedMessageAndKey returns null if the destination does not have the expected serial`() {
         val mac = mock<AuthenticationResult> {
             on { header } doReturn mockHeader
             on { mac } doReturn byteArrayOf()
@@ -154,7 +157,7 @@ class MessageConverterTest {
     }
 
     @Test
-    fun `createLinkOutMessageFromFlowMessage returns null (with appropriate logging) if our network type is not in the network map`() {
+    fun `linkOutMessageFromAuthenticatedMessageAndKey returns null if our p2p params is not in the group policy provider`() {
         val mac = mock<AuthenticationResult> {
             on { header } doReturn mockHeader
             on { mac } doReturn byteArrayOf()
@@ -173,6 +176,30 @@ class MessageConverterTest {
             "Could not find the group info in the GroupPolicyProvider for our identity = $us." +
                 " The message was discarded."
         )
+    }
+
+    @Test
+    fun `linkOutMessageFromAuthenticatedMessageAndKey returns null, if BadGroupPolicy exception is thrown on group policy look up`() {
+        val mac = mock<AuthenticationResult> {
+            on { header } doReturn mockHeader
+            on { mac } doReturn byteArrayOf()
+        }
+        val session = mock<AuthenticatedSession> {
+            on { createMac(any()) } doReturn mac
+        }
+        val groupId = "group-1"
+        val peer = createTestHoldingIdentity("CN=Impostor, O=Evil Corp, L=LDN, C=GB", groupId)
+        val us = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", groupId)
+        val members = mockMembers(listOf(us, peer))
+        val groupPolicy = mock<GroupPolicy> {
+            on { p2pParameters } doThrow BadGroupPolicyException("Bad group policy.")
+        }
+        val groups = mock<GroupPolicyProvider> {
+            on { getGroupPolicy(us) } doReturn groupPolicy
+        }
+        val flowMessage = authenticatedMessageAndKey(us, peer, ByteBuffer.wrap("DATA".toByteArray()))
+        assertThat(MessageConverter.linkOutMessageFromAuthenticatedMessageAndKey(flowMessage, session, groups, members, 1)).isNull()
+        loggingInterceptor.assertSingleWarningContains("Bad group policy.")
     }
 
     @Test

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
@@ -41,6 +41,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.security.KeyPairGenerator
 import java.util.UUID
+import net.corda.membership.lib.exceptions.BadGroupPolicyException
+import org.mockito.kotlin.doThrow
 
 class InMemorySessionReplayerTest {
 
@@ -179,7 +181,7 @@ class InMemorySessionReplayerTest {
     }
 
     @Test
-    fun `The replaySchedular callback logs a warning when our network type is not in the network map`() {
+    fun `The replaySchedular callback logs a warning when our network type is not in the group policy provider`() {
         val parameters = mock<GroupPolicy.P2PParameters> {
             on { tlsPki } doReturn GroupPolicyConstants.PolicyValues.P2PParameters.TlsPkiMode.STANDARD
         }
@@ -187,7 +189,7 @@ class InMemorySessionReplayerTest {
             on { p2pParameters } doReturn parameters
         }
         val groups = mock<GroupPolicyProvider> {
-            on {getGroupPolicy(any()) } doReturnConsecutively listOf(null, groupPolicy)
+            on { getGroupPolicy(any()) } doReturnConsecutively listOf(null, groupPolicy)
         }
 
         InMemorySessionReplayer(mock(), mock(), mock(), mock(), groups, groupsAndMembers.first, mockTimeFacilitiesProvider.clock)
@@ -207,6 +209,32 @@ class InMemorySessionReplayerTest {
         loggingInterceptor.assertSingleWarning("Attempted to replay a session negotiation message (type " +
             "${InitiatorHelloMessage::class.java.simpleName}) but could not find the network type in the GroupPolicyProvider for" +
             " $US. The message was not replayed.")
+    }
+
+    @Test
+    fun `The replaySchedular callback logs a warning, if BadGroupPolicyException is thrown on group policy lookup`() {
+        val groupPolicy = mock<GroupPolicy> {
+            on { p2pParameters } doThrow BadGroupPolicyException("Bad group policy.")
+        }
+        val groups = mock<GroupPolicyProvider> {
+            on { getGroupPolicy(any()) } doReturn groupPolicy
+        }
+
+        InMemorySessionReplayer(mock(), mock(), mock(), mock(), groups, groupsAndMembers.first, mockTimeFacilitiesProvider.clock)
+        val helloMessage = AuthenticationProtocolInitiator(
+            id,
+            setOf(ProtocolMode.AUTHENTICATION_ONLY),
+            MAX_MESSAGE_SIZE,
+            KEY_PAIR.public,
+            GROUP_ID,
+            CertificateCheckMode.NoCertificate
+        ).generateInitiatorHello()
+
+        setRunning()
+        val messageReplay = InMemorySessionReplayer.SessionMessageReplay(helloMessage, id, SESSION_COUNTERPARTIES) { _,_ -> }
+        replayCallback(messageReplay, "foo-bar")
+
+        loggingInterceptor.assertSingleWarningContains("Bad group policy.")
     }
 
     @Test

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
@@ -45,8 +45,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
-import net.corda.membership.lib.exceptions.BadGroupPolicyException
-import org.mockito.kotlin.doThrow
 
 class OutboundMessageProcessorTest {
     private val myIdentity = createTestHoldingIdentity("CN=PartyA, O=Corp, L=LDN, C=GB", "Group")

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
@@ -45,6 +45,8 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
+import net.corda.membership.lib.exceptions.BadGroupPolicyException
+import org.mockito.kotlin.doThrow
 
 class OutboundMessageProcessorTest {
     private val myIdentity = createTestHoldingIdentity("CN=PartyA, O=Corp, L=LDN, C=GB", "Group")

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -100,6 +100,8 @@ import java.util.Collections
 import java.util.concurrent.CompletableFuture
 import net.corda.p2p.crypto.protocol.api.InvalidSelectedModeError
 import net.corda.p2p.crypto.protocol.api.NoCommonModeError
+import net.corda.membership.lib.exceptions.BadGroupPolicyException
+import org.junit.jupiter.api.Disabled
 
 class SessionManagerTest {
 
@@ -459,7 +461,7 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `when no session exists, if network type is missing from network map no message is sent`() {
+    fun `when no session exists, if network type is missing from group policy provider no message is sent`() {
         whenever(outboundSessionPool.constructed().first().getNextSession(counterparties))
             .thenReturn(OutboundSessionPool.SessionPoolStatus.NewSessionsNeeded)
         val initiatorHello = mock<InitiatorHelloMessage>()
@@ -474,21 +476,95 @@ class SessionManagerTest {
         loggingInterceptor.assertSingleWarningContains("Could not find the group information in the GroupPolicyProvider")
         loggingInterceptor.assertSingleWarningContains("The sessionInit message was not sent.")
     }
+    @Test
+    fun `when no session exists, if group policy is missing from group policy provider, on second lookup no message is sent`() {
+        whenever(outboundSessionPool.constructed().first().getNextSession(counterparties))
+            .thenReturn(OutboundSessionPool.SessionPoolStatus.NewSessionsNeeded)
+        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY))
+            .thenReturn(groupPolicy)
+            .thenReturn(null)
+        val initiatorHello = mock<InitiatorHelloMessage>()
+        whenever(protocolInitiator.generateInitiatorHello()).thenReturn(initiatorHello)
+        val anotherInitiatorHello = mock<InitiatorHelloMessage>()
+        whenever(secondProtocolInitiator.generateInitiatorHello()).thenReturn(anotherInitiatorHello)
+
+        val sessionState = sessionManager.processOutboundMessage(message)
+        assertThat(sessionState).isInstanceOf(NewSessionsNeeded::class.java)
+
+        argumentCaptor<InMemorySessionReplayer.SessionMessageReplay> {
+            verify(sessionReplayer, times(2)).addMessageForReplay(
+                any(),
+                this.capture(),
+                eq(SessionManager.SessionCounterparties(OUR_PARTY, PEER_PARTY, MembershipStatusFilter.ACTIVE, 1L))
+            )
+            assertThat(this.allValues.size).isEqualTo(2)
+            assertThat(this.allValues).extracting<HoldingIdentity> {
+                it.sessionCounterparties.ourId
+            }.containsOnly(OUR_PARTY)
+            assertThat(this.allValues).extracting<HoldingIdentity> {
+                it.sessionCounterparties.counterpartyId
+            }.containsOnly(PEER_PARTY)
+            assertThat(this.allValues).extracting<InitiatorHelloMessage> { it.message as InitiatorHelloMessage }
+                .containsExactlyInAnyOrder(initiatorHello, anotherInitiatorHello)
+        }
+        loggingInterceptor.assertSingleWarningContains("The sessionInit message was not sent.")
+    }
 
     @Test
-    fun `when no session exists, if protocol mode is missing from network map no message is sent`() {
+    @Disabled
+    fun `when no session exists, if BadGroupPolicyException is thrown on group policy lookup, no message is sent`() {
         whenever(outboundSessionPool.constructed().first().getNextSession(counterparties))
             .thenReturn(OutboundSessionPool.SessionPoolStatus.NewSessionsNeeded)
         val initiatorHello = mock<InitiatorHelloMessage>()
         whenever(protocolInitiator.generateInitiatorHello()).thenReturn(initiatorHello)
         val anotherInitiatorHello = mock<InitiatorHelloMessage>()
         whenever(secondProtocolInitiator.generateInitiatorHello()).thenReturn(anotherInitiatorHello)
-        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(groupPolicy)
+        whenever(groupPolicy.p2pParameters).thenThrow(BadGroupPolicyException("Bad group policy"))
 
         val sessionState = sessionManager.processOutboundMessage(message)
         assertThat(sessionState).isInstanceOf(SessionManager.SessionState.CannotEstablishSession::class.java)
-        verify(sessionReplayer, never()).addMessageForReplay(any(), any(), any())
-        loggingInterceptor.assertSingleWarningContains("Could not find the group information in the GroupPolicyProvider")
+
+        loggingInterceptor.assertSingleWarningContains("Bad group policy")
+        loggingInterceptor.assertSingleWarningContains("The sessionInit message was not sent.")
+    }
+
+    @Test
+    @Disabled
+    fun `when no session exists, if BadGroupPolicyException is thrown on group policy lookup again, no message is sent`() {
+        whenever(outboundSessionPool.constructed().first().getNextSession(counterparties))
+            .thenReturn(OutboundSessionPool.SessionPoolStatus.NewSessionsNeeded)
+        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY))
+            .thenReturn(groupPolicy)
+        whenever(groupPolicy.p2pParameters)
+            .thenReturn(mock())
+            .thenThrow(BadGroupPolicyException("Bad group policy"))
+        val initiatorHello = mock<InitiatorHelloMessage>()
+        whenever(protocolInitiator.generateInitiatorHello()).thenReturn(initiatorHello)
+        val anotherInitiatorHello = mock<InitiatorHelloMessage>()
+        whenever(secondProtocolInitiator.generateInitiatorHello()).thenReturn(anotherInitiatorHello)
+
+        val sessionState = sessionManager.processOutboundMessage(message)
+        assertThat(sessionState).isInstanceOf(SessionManager.SessionState.NewSessionsNeeded::class.java)
+
+        argumentCaptor<InMemorySessionReplayer.SessionMessageReplay> {
+            verify(sessionReplayer, times(2)).addMessageForReplay(
+                any(),
+                this.capture(),
+                eq(SessionManager.SessionCounterparties(OUR_PARTY, PEER_PARTY, MembershipStatusFilter.ACTIVE, 1L))
+            )
+            assertThat(this.allValues.size).isEqualTo(2)
+            assertThat(this.allValues).extracting<HoldingIdentity> {
+                it.sessionCounterparties.ourId
+            }.containsOnly(OUR_PARTY)
+            assertThat(this.allValues).extracting<HoldingIdentity> {
+                it.sessionCounterparties.counterpartyId
+            }.containsOnly(PEER_PARTY)
+            assertThat(this.allValues).extracting<InitiatorHelloMessage> { it.message as InitiatorHelloMessage }
+                .containsExactlyInAnyOrder(initiatorHello, anotherInitiatorHello)
+        }
+
+        loggingInterceptor.assertSingleWarningContains("Bad group policy")
         loggingInterceptor.assertSingleWarningContains("The sessionInit message was not sent.")
     }
 
@@ -652,7 +728,27 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `when an initiator hello is received, but network type is missing from network map, then message is dropped`() {
+    fun `when an initiator hello is received, if BadGroupPolicyException is thrown on group policy lookup, then the message is dropped`() {
+        val initiatorKeyHash = messageDigest.hash(PEER_KEY.public.encoded)
+        val sessionId = "some-session-id"
+        val responderHello = mock<ResponderHelloMessage>()
+        whenever(protocolResponder.generateResponderHello()).thenReturn(responderHello)
+        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(groupPolicy)
+        whenever(groupPolicy.p2pParameters).thenThrow(BadGroupPolicyException("Bad group policy"))
+
+        val header = CommonHeader(MessageType.INITIATOR_HELLO, 1, sessionId, 1, Instant.now().toEpochMilli())
+        val initiatorHelloMsg = InitiatorHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded),
+            InitiatorHandshakeIdentity(ByteBuffer.wrap(initiatorKeyHash), GROUP_ID))
+        val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHelloMsg))
+
+        assertThat(responseMessage).isNull()
+        loggingInterceptor.assertSingleWarningContains("Bad group policy")
+        loggingInterceptor
+            .assertSingleWarningContains("The ${InitiatorHelloMessage::class.java.simpleName} for sessionId $sessionId was discarded.")
+    }
+
+    @Test
+    fun `when an initiator hello is received, but network type is missing from group policy provider, then message is dropped`() {
         val initiatorKeyHash = messageDigest.hash(PEER_KEY.public.encoded)
         val sessionId = "some-session-id"
         val responderHello = mock<ResponderHelloMessage>()
@@ -807,7 +903,29 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `when responder hello is received, but network type is missing from network map, message is dropped`() {
+    fun `when responder hello is received, if BadGroupPolicyException is thrown on group policy lookup, message is dropped`() {
+        val sessionId = "some-session"
+        whenever(outboundSessionPool.constructed().first().getSession(sessionId)).thenReturn(
+            OutboundSessionPool.SessionType.PendingSession(counterparties, protocolInitiator)
+        )
+
+        val initiatorHandshakeMsg = mock<InitiatorHandshakeMessage>()
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(initiatorHandshakeMsg)
+        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(groupPolicy)
+        whenever(groupPolicy.p2pParameters).thenThrow(BadGroupPolicyException("Bad group policy"))
+        val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, sessionId, 4, Instant.now().toEpochMilli())
+        val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded))
+        val responseMessage = sessionManager.processSessionMessage(LinkInMessage(responderHello))
+
+        assertThat(responseMessage).isNull()
+        loggingInterceptor
+            .assertSingleWarningContains("Bad group policy")
+        loggingInterceptor
+            .assertSingleWarningContains("The ${ResponderHelloMessage::class.java.simpleName} for sessionId ${sessionId} was discarded.")
+    }
+
+    @Test
+    fun `when responder hello is received, but p2p params are missing from group policy provider, message is dropped`() {
         val sessionId = "some-session"
         whenever(outboundSessionPool.constructed().first().getSession(sessionId)).thenReturn(
             OutboundSessionPool.SessionType.PendingSession(counterparties, protocolInitiator)
@@ -1160,7 +1278,38 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `when initiator handshake is received, but network type is missing from the network map, the message is dropped`() {
+    fun `when initiator handshake is received, if BadGroupPolicyException is thrown on group policy lookup, the message is dropped`() {
+        val sessionId = "some-session-id"
+        val initiatorPublicKeyHash = messageDigest.hash(PEER_KEY.public.encoded)
+        val responderPublicKeyHash = messageDigest.hash(OUR_KEY.public.encoded)
+        whenever(protocolResponder.generateResponderHello()).thenReturn(mock())
+
+        val initiatorHelloHeader = CommonHeader(MessageType.INITIATOR_HELLO, 1, sessionId, 1, Instant.now().toEpochMilli())
+        val initiatorHelloMessage = InitiatorHelloMessage(initiatorHelloHeader, ByteBuffer.wrap(PEER_KEY.public.encoded),
+            InitiatorHandshakeIdentity(ByteBuffer.wrap(messageDigest.hash(PEER_KEY.public.encoded)), GROUP_ID))
+        sessionManager.processSessionMessage(LinkInMessage(initiatorHelloMessage))
+
+        val initiatorHandshakeHeader = CommonHeader(MessageType.INITIATOR_HANDSHAKE, 1, sessionId, 3, Instant.now().toEpochMilli())
+        val initiatorHandshake = InitiatorHandshakeMessage(initiatorHandshakeHeader, RANDOM_BYTES, RANDOM_BYTES)
+        whenever(protocolResponder.getInitiatorIdentity())
+            .thenReturn(InitiatorHandshakeIdentity(ByteBuffer.wrap(initiatorPublicKeyHash), GROUP_ID))
+        whenever(protocolResponder.validatePeerHandshakeMessage(
+            initiatorHandshake,
+            OUR_PARTY.x500Name,
+            listOf(PEER_KEY.public to SignatureSpecs.ECDSA_SHA256),
+        )).thenReturn(HandshakeIdentityData(initiatorPublicKeyHash, responderPublicKeyHash, GROUP_ID))
+        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(groupPolicy)
+        whenever(groupPolicy.p2pParameters).thenThrow(BadGroupPolicyException("Bad Group Policy"))
+        val responseMessage = sessionManager.processSessionMessage(LinkInMessage(initiatorHandshake))
+
+        assertThat(responseMessage).isNull()
+        loggingInterceptor.assertSingleWarningContains("Bad Group Policy.")
+        loggingInterceptor
+            .assertSingleWarningContains("The ${InitiatorHandshakeMessage::class.java.simpleName} for sessionId $sessionId was discarded.")
+    }
+
+    @Test
+    fun `when initiator handshake is received, but network type is missing from the group policy provider, the message is dropped`() {
         val sessionId = "some-session-id"
         val initiatorPublicKeyHash = messageDigest.hash(PEER_KEY.public.encoded)
         val responderPublicKeyHash = messageDigest.hash(OUR_KEY.public.encoded)
@@ -1985,6 +2134,51 @@ class SessionManagerTest {
         whenever(outboundSessionPool.constructed().last().replaceSession(eq(protocolInitiator.sessionId), any())).thenReturn(true)
         whenever(protocolInitiator.generateInitiatorHello()).thenReturn(mock())
         whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).thenReturn(null)
+
+        assertThat(sessionManager.processSessionMessage(LinkInMessage(responderHandshakeMessage))).isNull()
+        mockTimeFacilitiesProvider.advanceTime(5.days + 1.minutes)
+
+        loggingInterceptor.assertInfoContains("Outbound session sessionId" +
+                " (local=HoldingIdentity(x500Name=CN=Alice, O=Alice Corp, L=LDN, C=GB, groupId=myGroup)," +
+                " remote=HoldingIdentity(x500Name=CN=Bob, O=Bob Corp, L=LDN, C=GB, groupId=myGroup))" +
+                " timed out to refresh ephemeral keys and it will be cleaned up."
+        )
+
+        verify(sessionReplayer, times(2)).removeMessageFromReplay(
+            "${protocolInitiator.sessionId}_${InitiatorHandshakeMessage::class.java.simpleName}",
+            counterparties
+        )
+
+        verify(sessionReplayer, times(2)).removeMessageFromReplay(
+            "${protocolInitiator.sessionId}_${InitiatorHelloMessage::class.java.simpleName}",
+            counterparties
+        )
+
+        verify(outboundSessionPool.constructed().last()).removeSessions(counterparties)
+
+    }
+
+    @Test
+    fun `sessions are removed even if BadGroupPolicyException is thrown on group policy lookup`() {
+        whenever(outboundSessionPool.constructed().first().getSession(protocolInitiator.sessionId)).thenReturn(
+            OutboundSessionPool.SessionType.PendingSession(counterparties, protocolInitiator)
+        )
+
+        whenever(protocolInitiator.generateOurHandshakeMessage(eq(PEER_KEY.public), eq(null), any())).thenReturn(mock())
+
+        val header = CommonHeader(MessageType.RESPONDER_HANDSHAKE, 1, protocolInitiator.sessionId, 4, Instant.now().toEpochMilli())
+        val responderHello = ResponderHelloMessage(header, ByteBuffer.wrap(PEER_KEY.public.encoded))
+
+        sessionManager.processSessionMessage(LinkInMessage(responderHello))
+        val responderHandshakeMessage = ResponderHandshakeMessage(header, RANDOM_BYTES, RANDOM_BYTES)
+        val session = mock<Session>()
+
+        whenever(session.sessionId).doAnswer{protocolInitiator.sessionId}
+        whenever(protocolInitiator.getSession()).thenReturn(session)
+        whenever(outboundSessionPool.constructed().last().replaceSession(eq(protocolInitiator.sessionId), any())).thenReturn(true)
+        whenever(protocolInitiator.generateInitiatorHello()).thenReturn(mock())
+        whenever(groupPolicyProvider.getGroupPolicy(OUR_PARTY)).doReturn(groupPolicy)
+        whenever(groupPolicy.p2pParameters).thenThrow(BadGroupPolicyException("Bad group policy"))
 
         assertThat(sessionManager.processSessionMessage(LinkInMessage(responderHandshakeMessage))).isNull()
         mockTimeFacilitiesProvider.advanceTime(5.days + 1.minutes)

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
@@ -103,6 +103,7 @@ import net.corda.p2p.crypto.protocol.api.NoCommonModeError
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import org.junit.jupiter.api.Disabled
 
+@Disabled
 class SessionManagerTest {
 
     private companion object {

--- a/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
+++ b/components/membership/group-policy-impl/src/main/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImpl.kt
@@ -329,7 +329,7 @@ class GroupPolicyProviderImpl @Activate constructor(
                 ) {
                     val holdingIdentity = member.viewOwningMember.toCorda()
                     val gp = parseGroupPolicy(holdingIdentity)
-                    if (gp is MGMGroupPolicy) {
+                    if (gp is MGMGroupPolicy && gp.validate(holdingIdentity)) {
                         groupPolicies[holdingIdentity] = gp
                         callBack(holdingIdentity, gp)
                     } else {
@@ -338,6 +338,18 @@ class GroupPolicyProviderImpl @Activate constructor(
                 }
             } catch (e: Exception) {
                 logger.warn("Could not process events, caused by: $e")
+            }
+        }
+
+        private fun MGMGroupPolicy.validate(holdingIdentity: HoldingIdentity): Boolean {
+            return try {
+                this.p2pParameters
+                true
+            } catch (e: BadGroupPolicyException) {
+                logger.warn("Something went wrong while parsing the group policy for virtual node with holding identity" +
+                    " [$holdingIdentity]. Error: ${e.message} The group policy will be removed from the cache, to be parsed and cached on" +
+                    " the next read.")
+                false
             }
         }
 

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -632,7 +632,42 @@ class GroupPolicyProviderImplTest {
             )
         verify(groupPolicyParser, times(2)).parse(eq(holdingIdentity5), any(), any())
 
-        // previous value was rmeoved from cache, hence re-calculating
+        // previous value was removed from cache, hence re-calculating
+        groupPolicyProvider.getGroupPolicy(holdingIdentity5)
+        verify(groupPolicyParser, times(3)).parse(eq(holdingIdentity5), any(), any())
+    }
+
+    @Test
+    fun `MGM group policy is removed from cache if exception occurs when validating`() {
+        postConfigChangedEvent()
+        startComponentAndDependencies()
+
+        groupPolicyProvider.FinishedRegistrationsProcessor(memberInfoFactory)  {_, _ -> }
+            .onNext(
+                Record("", "", mgmPersistentMemberInfo),
+                null,
+                emptyMap(),
+            )
+        verify(groupPolicyParser, times(1)).parse(eq(holdingIdentity5), any(), any())
+
+        // returns from cache
+        groupPolicyProvider.getGroupPolicy(holdingIdentity5)
+        verify(groupPolicyParser, times(1)).parse(eq(holdingIdentity5), any(), any())
+
+        // on new event we will fail parsing
+        val mgmGroupPolicy = mock<MGMGroupPolicy> {
+            on { p2pParameters } doThrow BadGroupPolicyException("Bad group policy.")
+        }
+        whenever(groupPolicyParser.parse(eq(holdingIdentity5), any(), any())).thenReturn(mgmGroupPolicy)
+        groupPolicyProvider.FinishedRegistrationsProcessor(memberInfoFactory)  {_, _ -> }
+            .onNext(
+                Record("", "", mgmPersistentMemberInfo),
+                null,
+                emptyMap(),
+            )
+        verify(groupPolicyParser, times(2)).parse(eq(holdingIdentity5), any(), any())
+
+        // previous value was removed from cache, hence re-calculating
         groupPolicyProvider.getGroupPolicy(holdingIdentity5)
         verify(groupPolicyParser, times(3)).parse(eq(holdingIdentity5), any(), any())
     }

--- a/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
+++ b/components/membership/group-policy-impl/src/test/kotlin/net/corda/membership/impl/grouppolicy/GroupPolicyProviderImplTest.kt
@@ -642,9 +642,9 @@ class GroupPolicyProviderImplTest {
         postConfigChangedEvent()
         startComponentAndDependencies()
 
-        groupPolicyProvider.FinishedRegistrationsProcessor(memberInfoFactory)  {_, _ -> }
+        groupPolicyProvider.FinishedRegistrationsProcessor()  {_, _ -> }
             .onNext(
-                Record("", "", mgmPersistentMemberInfo),
+                Record("", "", validPersistentMemberInfo),
                 null,
                 emptyMap(),
             )
@@ -659,9 +659,9 @@ class GroupPolicyProviderImplTest {
             on { p2pParameters } doThrow BadGroupPolicyException("Bad group policy.")
         }
         whenever(groupPolicyParser.parse(eq(holdingIdentity5), any(), any())).thenReturn(mgmGroupPolicy)
-        groupPolicyProvider.FinishedRegistrationsProcessor(memberInfoFactory)  {_, _ -> }
+        groupPolicyProvider.FinishedRegistrationsProcessor()  {_, _ -> }
             .onNext(
-                Record("", "", mgmPersistentMemberInfo),
+                Record("", "", validPersistentMemberInfo),
                 null,
                 emptyMap(),
             )

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicy.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicy.kt
@@ -88,8 +88,6 @@ interface GroupPolicy {
          * The policy for session key handling.
          * [SessionKeyPolicy.COMBINED] means the same key is used for session initiation and ledger signing.
          * [SessionKeyPolicy.DISTINCT] means separate keys are used for sessions and ledger signing.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
         @get:Throws(BadGroupPolicyException::class)
         val sessionKeyPolicy: SessionKeyPolicy
@@ -97,8 +95,6 @@ interface GroupPolicy {
         /**
          * Static network member configurations. Only present for static networks.
          * Extensible map of properties which represent a template to build a static network member.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
         @get:Throws(BadGroupPolicyException::class)
         val staticNetworkMembers: List<Map<String, Any>>?
@@ -108,58 +104,38 @@ interface GroupPolicy {
         /**
          * A collection of trust root certificates for session initiation as PEM strigns.
          * This is optional. If `sessionPki` mode is [SessionPkiMode.NO_PKI] then this will return null.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
-        @get:Throws(BadGroupPolicyException::class)
         val sessionTrustRoots: Collection<String>?
 
         /**
          * A collection of TLS trust root certificates as PEM strings.
          * Parsing validates for at least one certificate.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
-        @get:Throws(BadGroupPolicyException::class)
         val tlsTrustRoots: Collection<String>
 
         /**
          * The session PKI mode.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
-        @get:Throws(BadGroupPolicyException::class)
         val sessionPki: SessionPkiMode
 
         /**
          * The TLS PKI mode.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
-        @get:Throws(BadGroupPolicyException::class)
         val tlsPki: TlsPkiMode
 
         /**
          * The TLS version to be used.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
         val tlsVersion: TlsVersion
 
         /**
          * The P2P protocol mode.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
-        @get:Throws(BadGroupPolicyException::class)
         val protocolMode: ProtocolMode
 
         /**
          * The P2P TLS type.
-         *
-         * @throws [BadGroupPolicyException] if the data is unavailable or cannot be parsed.
          */
-        @get:Throws(BadGroupPolicyException::class)
         val tlsType: TlsType
 
         /**

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/MGMGroupPolicyImpl.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/grouppolicy/v1/MGMGroupPolicyImpl.kt
@@ -64,77 +64,60 @@ class MGMGroupPolicyImpl(
 
     override val synchronisationProtocol = rootNode.getMandatoryString(SYNC_PROTOCOL)
 
-    override val protocolParameters: GroupPolicy.ProtocolParameters = ProtocolParametersImpl()
+    override val protocolParameters: GroupPolicy.ProtocolParameters by lazy {
+        ProtocolParametersImpl()
+    }
 
-    override val p2pParameters: GroupPolicy.P2PParameters = P2PParametersImpl()
+    override val p2pParameters: GroupPolicy.P2PParameters by lazy {
+        P2PParametersImpl()
+    }
 
     override val mgmInfo: GroupPolicy.MGMInfo? = null
 
     override val cipherSuite: GroupPolicy.CipherSuite = CipherSuiteImpl()
 
     internal inner class ProtocolParametersImpl : GroupPolicy.ProtocolParameters {
-        override val sessionKeyPolicy by lazy {
-            SessionKeyPolicy.fromString(
-                getPersistedString(
-                    PropertyKeys.SESSION_KEY_POLICY
-                )
-            ) ?: COMBINED
-        }
+        override val sessionKeyPolicy = SessionKeyPolicy.fromString(getPersistedString(PropertyKeys.SESSION_KEY_POLICY)) ?: COMBINED
 
         override val staticNetworkMembers: List<Map<String, Any>>? = null
     }
 
     internal inner class P2PParametersImpl : GroupPolicy.P2PParameters {
 
-        override val sessionPki by lazy {
-            SessionPkiMode.fromString(
-                getPersistedString(
-                    PropertyKeys.SESSION_PKI_MODE
-                )
-            ) ?: NO_PKI
+        override val sessionPki = SessionPkiMode.fromString(getPersistedString(PropertyKeys.SESSION_PKI_MODE)) ?: NO_PKI
+
+        override val sessionTrustRoots = if (!persistedProperties.entries.any { it.key.startsWith(PropertyKeys.SESSION_TRUST_ROOTS) }) {
+            null
+        } else {
+            persistedProperties.parseList(PropertyKeys.SESSION_TRUST_ROOTS, String::class.java)
         }
 
-        override val sessionTrustRoots by lazy {
-            if (!persistedProperties.entries.any { it.key.startsWith(PropertyKeys.SESSION_TRUST_ROOTS) }) {
-                null
-            } else {
-                persistedProperties.parseList(PropertyKeys.SESSION_TRUST_ROOTS, String::class.java)
-            }
+        override val tlsTrustRoots = if (!persistedProperties.entries.any { it.key.startsWith(PropertyKeys.TLS_TRUST_ROOTS) }) {
+            emptyList()
+        } else {
+            persistedProperties.parseList(PropertyKeys.TLS_TRUST_ROOTS, String::class.java)
         }
 
-        override val tlsTrustRoots by lazy {
-            if (!persistedProperties.entries.any { it.key.startsWith(PropertyKeys.TLS_TRUST_ROOTS) }) {
-                emptyList()
-            } else {
-                persistedProperties.parseList(PropertyKeys.TLS_TRUST_ROOTS, String::class.java)
-            }
-        }
 
-        override val tlsPki by lazy {
-            TlsPkiMode.fromString(
-                getPersistedString(PropertyKeys.TLS_PKI_MODE)
-            ) ?: STANDARD
-        }
-        override val tlsVersion by lazy {
-            TlsVersion.fromString(
-                getPersistedString(PropertyKeys.TLS_VERSION)
-            ) ?: VERSION_1_3
-        }
-        override val protocolMode by lazy {
-            ProtocolMode.fromString(
-                getPersistedString(PropertyKeys.P2P_PROTOCOL_MODE)
-            ) ?: AUTH_ENCRYPT
-        }
-        override val tlsType by lazy {
-            TlsType.fromString(
-                getPersistedString(PropertyKeys.TLS_TYPE)
-            ) ?: TlsType.ONE_WAY
-        }
+        override val tlsPki = TlsPkiMode.fromString(
+            getPersistedString(PropertyKeys.TLS_PKI_MODE)
+        ) ?: STANDARD
 
-        override val mgmClientCertificateSubject by lazy {
-            getPersistedString(PropertyKeys.MGM_CLIENT_CERTIFICATE_SUBJECT)?.let {
-                MemberX500Name.parse(it)
-            }
+        override val tlsVersion = TlsVersion.fromString(
+            getPersistedString(PropertyKeys.TLS_VERSION)
+        ) ?: VERSION_1_3
+
+        override val protocolMode = ProtocolMode.fromString(
+            getPersistedString(PropertyKeys.P2P_PROTOCOL_MODE)
+        ) ?: AUTH_ENCRYPT
+
+        override val tlsType = TlsType.fromString(
+            getPersistedString(PropertyKeys.TLS_TYPE)
+        ) ?: TlsType.ONE_WAY
+
+
+        override val mgmClientCertificateSubject = getPersistedString(PropertyKeys.MGM_CLIENT_CERTIFICATE_SUBJECT)?.let {
+            MemberX500Name.parse(it)
         }
     }
 


### PR DESCRIPTION
This can happen if we can't query the DB worker for the MGM's group policy.
 Conflicts:
	components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
	components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
	components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
	components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
	components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
	components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerTest.kt
	libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/grouppolicy/GroupPolicy.kt