### PR TITLE
CORE-15267 Make MemberInfo serializable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.39-alpha-1700162971190
+cordaApiVersion=5.1.0.39-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.1.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.1.0.38-beta+
+cordaApiVersion=5.1.0.39-alpha-1700162971190
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/membership/membership-impl/build.gradle
+++ b/libs/membership/membership-impl/build.gradle
@@ -17,7 +17,9 @@ dependencies {
     implementation project(':libs:crypto:crypto-core')
     implementation project(":libs:membership:membership-common")
     implementation project(":libs:utilities")
+    implementation project(':libs:sandbox-types')
     implementation project(":libs:serialization:serialization-avro")
+    implementation project(':libs:serialization:serialization-internal')
 
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-base"

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/serializer/amqp/MGMContextSerializer.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/serializer/amqp/MGMContextSerializer.kt
@@ -1,0 +1,72 @@
+package net.corda.membership.lib.impl.serializer.amqp
+
+import net.corda.layeredpropertymap.LayeredPropertyMapFactory
+import net.corda.membership.lib.impl.MGMContextImpl
+import net.corda.sandbox.type.SandboxConstants
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandbox.type.UsedByPersistence
+import net.corda.sandbox.type.UsedByVerification
+import net.corda.serialization.BaseProxySerializer
+import net.corda.serialization.InternalCustomSerializer
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.types.LayeredPropertyMap
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ServiceScope
+
+@Component(
+    service = [ InternalCustomSerializer::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
+    property = [SandboxConstants.CORDA_UNINJECTABLE_SERVICE],
+    scope = ServiceScope.PROTOTYPE
+)
+class MGMContextSerializer @Activate constructor(
+    @Reference(service = LayeredPropertyMapFactory::class)
+    private val layeredPropertyMapFactory: LayeredPropertyMapFactory,
+) : BaseProxySerializer<MGMContextImpl, MGMContextProxy>(), UsedByFlow, UsedByPersistence, UsedByVerification {
+    private companion object {
+        private const val VERSION_1 = 1
+    }
+
+    override fun toProxy(obj: MGMContextImpl): MGMContextProxy {
+        return MGMContextProxy(
+            VERSION_1,
+            obj.toMap()
+        )
+    }
+
+    override fun fromProxy(proxy: MGMContextProxy): MGMContextImpl {
+        return when(proxy.version) {
+            VERSION_1 ->
+                MGMContextImpl(layeredPropertyMapFactory.createMap(proxy.map))
+            else ->
+                throw CordaRuntimeException("Unable to create MGMContextImpl with Version='${proxy.version}'")
+        }
+    }
+
+    override val proxyType: Class<MGMContextProxy>
+        get() = MGMContextProxy::class.java
+
+    override val type: Class<MGMContextImpl>
+        get() = MGMContextImpl::class.java
+
+    override val withInheritance: Boolean
+        get() = false
+
+    private fun LayeredPropertyMap.toMap() = this.entries.associate { it.key to it.value }
+
+}
+
+/**
+ * The class that actually gets serialized on the wire.
+ */
+data class MGMContextProxy(
+    /**
+     * Version of container.
+     */
+    val version: Int,
+    /**
+     * Properties for [MGMContextImpl] serialization.
+     */
+    val map: Map<String, String?>
+)

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/serializer/amqp/MemberContextSerializer.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/serializer/amqp/MemberContextSerializer.kt
@@ -1,0 +1,72 @@
+package net.corda.membership.lib.impl.serializer.amqp
+
+import net.corda.layeredpropertymap.LayeredPropertyMapFactory
+import net.corda.membership.lib.impl.MemberContextImpl
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandbox.type.UsedByPersistence
+import net.corda.sandbox.type.UsedByVerification
+import net.corda.serialization.BaseProxySerializer
+import net.corda.serialization.InternalCustomSerializer
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.base.types.LayeredPropertyMap
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ServiceScope
+
+@Component(
+    service = [ InternalCustomSerializer::class, UsedByFlow::class, UsedByPersistence::class, UsedByVerification::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = ServiceScope.PROTOTYPE
+)
+class MemberContextSerializer @Activate constructor(
+    @Reference(service = LayeredPropertyMapFactory::class)
+    private val layeredPropertyMapFactory: LayeredPropertyMapFactory,
+) : BaseProxySerializer<MemberContextImpl, MemberContextProxy>(), UsedByFlow, UsedByPersistence, UsedByVerification {
+    private companion object {
+        private const val VERSION_1 = 1
+    }
+
+    override fun toProxy(obj: MemberContextImpl): MemberContextProxy {
+        return MemberContextProxy(
+            VERSION_1,
+            obj.toMap()
+        )
+    }
+
+    override fun fromProxy(proxy: MemberContextProxy): MemberContextImpl {
+        return when(proxy.version) {
+            VERSION_1 ->
+                MemberContextImpl(layeredPropertyMapFactory.createMap(proxy.map))
+            else ->
+                throw CordaRuntimeException("Unable to create MemberContextImpl with Version='${proxy.version}'")
+        }
+    }
+
+    override val proxyType: Class<MemberContextProxy>
+        get() = MemberContextProxy::class.java
+
+    override val type: Class<MemberContextImpl>
+        get() = MemberContextImpl::class.java
+
+    override val withInheritance: Boolean
+        get() = false
+
+    private fun LayeredPropertyMap.toMap() = this.entries.associate { it.key to it.value }
+
+}
+
+/**
+ * The class that actually gets serialized on the wire.
+ */
+data class MemberContextProxy(
+    /**
+     * Version of container.
+     */
+    val version: Int,
+    /**
+     * Properties for [MemberContextImpl] serialization.
+     */
+    val map: Map<String, String?>
+)


### PR DESCRIPTION
Makes `MemberInfo` serializable by registering custom serializers for `MemberContext` and `MGMContext`. The corresponding corda-api change marks these interfaces as `@CordaSerializable` - https://github.com/corda/corda-api/pull/1341

This change was tested manually using a modified version of the combined worker smoke tests, by including `MemberInfo` in one of the flow states used by the tests. [[build](https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-combined-worker-e2e-tests/job/PR-yash%2Fserialization-fix%2Ftest/)]
It was also manually confirmed that this change does not break ABI compatibility, by running a modified version of the end-to-end flow tests against a combined worker compiled with the newer corda-api version.