### PR TITLE
ES-1646: Remove redundant badge and fix logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="https://www.corda.net/wp-content/themes/corda/assets/images/crda-logo-big.svg" alt="Corda" width="500">
+  <img src="https://corda.net/wp-content/uploads/2021/11/corda-logo.svg" alt="Corda" width="500">
 </p>
 
 ---
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Build Status](https://ci02.dev.r3.com/buildStatus/icon?job=Corda5%2Fcorda-runtime-os%2Frelease%252Fos%252F5.0)](https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os/job/release%252Fos%252F5.0/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 <h2>Project Overview</h2>
 


### PR DESCRIPTION
- Badge link in redme is redundant as it can not return the correct status without logging in, furthermore an external user can not follow the link, therefore removing
- Fix the logo where the Corda image location had changed.

Rendered changes:
![image](https://github.com/corda/corda-runtime-os/assets/5963044/a1d9ae4d-d2d0-49e8-a43d-06901244a78c)
