### PR TITLE
CORE-17299: Remove nullability from `EventConverter` for tokens

### DIFF
--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EventConverter.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EventConverter.kt
@@ -15,6 +15,6 @@ interface EventConverter {
      *
      * @return A new instance of [TokenEvent]
      */
-    fun convert(tokenPoolCacheEvent: TokenPoolCacheEvent?): TokenEvent
+    fun convert(tokenPoolCacheEvent: TokenPoolCacheEvent): TokenEvent
 }
 

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EventConverterImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/converters/EventConverterImpl.kt
@@ -10,12 +10,11 @@ import net.corda.ledger.utxo.token.cache.entities.TokenEvent
 
 class EventConverterImpl(private val entityConverter: EntityConverter) : EventConverter {
 
-    override fun convert(tokenPoolCacheEvent: TokenPoolCacheEvent?): TokenEvent {
-        val event = checkNotNull(tokenPoolCacheEvent) { "The received TokenPoolCacheEvent is null." }
-        val key = event.poolKey
+    override fun convert(tokenPoolCacheEvent: TokenPoolCacheEvent): TokenEvent {
+        val key = tokenPoolCacheEvent.poolKey
 
         return when (val payload =
-            checkNotNull(event.payload) { "The received TokenPoolCacheEvent payload is null." }) {
+            checkNotNull(tokenPoolCacheEvent.payload) { "The received TokenPoolCacheEvent payload is null." }) {
             is TokenClaimQuery -> {
                 entityConverter.toClaimQuery(key, payload)
             }

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EventConverterImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/converters/EventConverterImplTest.kt
@@ -87,13 +87,6 @@ class EventConverterImplTest {
     }
 
     @Test
-    fun `convert throws if the input event is null`() {
-        assertThatIllegalStateException().isThrownBy {
-            EventConverterImpl(entityConverter).convert(null)
-        }
-    }
-
-    @Test
     fun `convert throws if the payload is null`() {
         val inputEvent = TokenPoolCacheEvent().apply {
             poolKey = POOL_CACHE_KEY


### PR DESCRIPTION
In the production code `TokenPoolCacheEvent` can never be `null`.