### PR TITLE
CORE-17961: Allow Time & Multiple Metadata Filters

### DIFF
--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/ScheduledTaskProcessor.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/service/executor/ScheduledTaskProcessor.kt
@@ -51,15 +51,13 @@ class ScheduledTaskProcessor(
 
     private fun getExpiredStateIds() : List<String> {
         val windowExpiry = clock.instant() - Duration.ofMillis(cleanupWindow)
-        val closingStates = stateManager.findUpdatedBetweenWithMetadataFilter(
+        val states = stateManager.findUpdatedBetweenWithMetadataMatchingAny(
             IntervalFilter(Instant.EPOCH, windowExpiry),
-            MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.CLOSING.toString())
+            listOf(
+                MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.ERROR.toString()),
+                MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.CLOSING.toString()),
+            )
         )
-        val errorStates = stateManager.findUpdatedBetweenWithMetadataFilter(
-            IntervalFilter(Instant.EPOCH, windowExpiry),
-            MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.ERROR.toString())
-        )
-        val states = closingStates + errorStates
 
         return states.map {
             it.key

--- a/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/executor/ScheduledTaskProcessorTest.kt
+++ b/components/flow/flow-mapper-service/src/test/kotlin/net/corda/session/mapper/service/executor/ScheduledTaskProcessorTest.kt
@@ -46,7 +46,7 @@ class ScheduledTaskProcessorTest {
     @Test
     fun `when scheduled task handler generates new records, ID of each retrieved state is present in output events`() {
         val stateManager = mock<StateManager>()
-        whenever(stateManager.findUpdatedBetweenWithMetadataFilter(any(), any())).thenReturn(closingStates+errorStates)
+        whenever(stateManager.findUpdatedBetweenWithMetadataMatchingAny(any(), any())).thenReturn(closingStates+errorStates)
         val scheduledTaskProcessor = ScheduledTaskProcessor(
             stateManager,
             clock,
@@ -55,20 +55,19 @@ class ScheduledTaskProcessorTest {
         val output = scheduledTaskProcessor.onNext(listOf(inputEvent))
         val ids = output.flatMap { (it.value as ExecuteCleanup).ids }
         assertThat(ids).contains("key1", "key4")
-        verify(stateManager).findUpdatedBetweenWithMetadataFilter(
+        verify(stateManager).findUpdatedBetweenWithMetadataMatchingAny(
             IntervalFilter(Instant.EPOCH, clock.instant() - Duration.ofMillis(window)),
-            MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.CLOSING.toString())
-        )
-        verify(stateManager).findUpdatedBetweenWithMetadataFilter(
-            IntervalFilter(Instant.EPOCH, clock.instant() - Duration.ofMillis(window)),
-            MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.ERROR.toString())
+            listOf(
+                MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.ERROR.toString()),
+                MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.CLOSING.toString()),
+            )
         )
     }
 
     @Test
     fun `when batch size is set to one, a record per id is present in output events`() {
         val stateManager = mock<StateManager>()
-        whenever(stateManager.findUpdatedBetweenWithMetadataFilter(any(), any())).thenReturn(closingStates)
+        whenever(stateManager.findUpdatedBetweenWithMetadataMatchingAny(any(), any())).thenReturn(closingStates)
         val scheduledTaskProcessor = ScheduledTaskProcessor(
             stateManager,
             clock,
@@ -82,7 +81,7 @@ class ScheduledTaskProcessorTest {
     @Test
     fun `when the last updated time is far enough in the past, no records are returned`() {
         val stateManager = mock<StateManager>()
-        whenever(stateManager.findUpdatedBetweenWithMetadataFilter(any(), any())).thenReturn(mapOf())
+        whenever(stateManager.findUpdatedBetweenWithMetadataMatchingAny(any(), any())).thenReturn(mapOf())
         val scheduledTaskProcessor = ScheduledTaskProcessor(
             stateManager,
             clock,
@@ -90,9 +89,12 @@ class ScheduledTaskProcessorTest {
         )
         val output = scheduledTaskProcessor.onNext(listOf(inputEvent))
         assertThat(output).isEmpty()
-        verify(stateManager).findUpdatedBetweenWithMetadataFilter(
+        verify(stateManager).findUpdatedBetweenWithMetadataMatchingAny(
             IntervalFilter(Instant.EPOCH, clock.instant() - Duration.ofMillis(window * 5)),
-            MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.CLOSING.toString())
+            listOf(
+                MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.ERROR.toString()),
+                MetadataFilter(FLOW_MAPPER_STATUS, Operation.Equals, FlowMapperStateType.CLOSING.toString()),
+            )
         )
     }
 
@@ -111,7 +113,7 @@ class ScheduledTaskProcessorTest {
         )
         val output = scheduledTaskProcessor.onNext(listOf(input))
         assertThat(output).isEmpty()
-        verify(stateManager, never()).findUpdatedBetweenWithMetadataFilter(any(), any())
+        verify(stateManager, never()).findUpdatedBetweenWithMetadataMatchingAny(any(), any())
     }
 
     private fun createStateEntry(

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/PerformanceClaimStateStoreImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/PerformanceClaimStateStoreImplTest.kt
@@ -233,6 +233,20 @@ class PerformanceClaimStateStoreImplTest {
             TODO("Not yet implemented")
         }
 
+        override fun findUpdatedBetweenWithMetadataMatchingAll(
+            intervalFilter: IntervalFilter,
+            metadataFilters: Collection<MetadataFilter>
+        ): Map<String, State> {
+            TODO("Not yet implemented")
+        }
+
+        override fun findUpdatedBetweenWithMetadataMatchingAny(
+            intervalFilter: IntervalFilter,
+            metadataFilters: Collection<MetadataFilter>
+        ): Map<String, State> {
+            TODO("Not yet implemented")
+        }
+
         override val isRunning: Boolean
             get() = true
 

--- a/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/StateManager.kt
+++ b/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/StateManager.kt
@@ -133,5 +133,39 @@ interface StateManager : Lifecycle {
     fun findUpdatedBetweenWithMetadataFilter(
         intervalFilter: IntervalFilter,
         metadataFilter: MetadataFilter
+    ): Map<String, State> = findUpdatedBetweenWithMetadataMatchingAll(intervalFilter, listOf(metadataFilter))
+
+    /**
+     * Retrieve all states, updated for the last time between [IntervalFilter.start] (inclusive) and
+     * [IntervalFilter.finish] (inclusive), for which all the specified [metadataFilters] exclusively match.
+     * Each [MetadataFilter.value] is evaluated through the [MetadataFilter.operation] against the value stored inside
+     * the [State.metadata] under the [MetadataFilter.key].
+     * Only states that have been successfully committed and distributed within the underlying
+     * persistent storage are returned.
+     *
+     * @param intervalFilter Time filter to use when searching for states.
+     * @param metadataFilters Filter parameters to use when searching for states.
+     * @return states matching the specified filters.
+     */
+    fun findUpdatedBetweenWithMetadataMatchingAll(
+        intervalFilter: IntervalFilter,
+        metadataFilters: Collection<MetadataFilter>
+    ): Map<String, State>
+
+    /**
+     * Retrieve all states, updated for the last time between [IntervalFilter.start] (inclusive) and
+     * [IntervalFilter.finish] (inclusive), for which any of the specified [metadataFilters] match.
+     * Each [MetadataFilter.value] is evaluated through the [MetadataFilter.operation] against the value stored inside
+     * the [State.metadata] under the [MetadataFilter.key].
+     * Only states that have been successfully committed and distributed within the underlying
+     * persistent storage are returned.
+     *
+     * @param intervalFilter Time filter to use when searching for states.
+     * @param metadataFilters Filter parameters to use when searching for states.
+     * @return states matching the specified filters.
+     */
+    fun findUpdatedBetweenWithMetadataMatchingAny(
+        intervalFilter: IntervalFilter,
+        metadataFilters: Collection<MetadataFilter>
     ): Map<String, State>
 }

--- a/libs/state-manager/state-manager-db-impl/src/integrationTest/kotlin/net/corda/libs/statemanager/impl/tests/MultiThreadedTestHelper.kt
+++ b/libs/state-manager/state-manager-db-impl/src/integrationTest/kotlin/net/corda/libs/statemanager/impl/tests/MultiThreadedTestHelper.kt
@@ -16,19 +16,20 @@ object MultiThreadedTestHelper {
          */
         val assignedStates: List<State>,
         /**
-         * The list of States in this group that overlap with the next group. These are states that will have contention with the next
-         * group and can be used for assertions on failed keys.
+         * The list of States in this group that overlap with another group. These are states that will have contention
+         * with other group and can be used for assertions on failed keys.
          */
         val overlappingStates: List<State>
     ) {
         /**
-         * States to test optimistic locking, with some overlapping into the next group's States.
+         * States to test optimistic locking, with some overlapping into other group's States.
          */
         fun getStatesForTest() = assignedStates + overlappingStates
     }
 
     /**
-     * A summary of a thread's assigned state group and keys that failed to update/delete in a multi threaded optimistic locking test.
+     * A summary of a thread's assigned state group and keys that failed to update/delete in a multithreaded optimistic
+     * locking test.
      */
     data class ThreadTestSummary(
         /**
@@ -73,8 +74,9 @@ object MultiThreadedTestHelper {
     }
 
     /**
-     * Divide the given states between the number of threads, such that each group of states has overlapping states with the next
-     * group in round robin fashion. The last group in the list will have overlapping states with the first group.
+     * Divide the given states between the number of threads, such that each group of states has overlapping states
+     * with the next group in round-robin fashion. The last group in the list will have overlapping states with the
+     * first group.
      *
      * Runs the [block] in an executor with the set [numThreads].
      *
@@ -82,8 +84,8 @@ object MultiThreadedTestHelper {
      * @param numThreads the number of threads to test
      * @param sharedStatesPerThread the number of overlapping states per thread to exercise optimistic locking
      * @param block the test code which utilizes StateManager
-     * @return a test summary for each thread, including each thread's assigned States plus its State keys that failed due to optimistic
-     * locking.
+     * @return a test summary for each thread, including each thread's assigned States plus its State keys that failed
+     *  due to optimistic locking.
      */
     fun runMultiThreadedOptimisticLockingTest(
         states: List<State>,
@@ -108,16 +110,16 @@ object MultiThreadedTestHelper {
 
     /**
      * Divide a list of states between threads so that each thread's group of states contains some states from the next
-     * thread's group, in round robin fashion. A thread's group will contain unique states, plus [sharedStatesPerThread] states from the
-     * next group.
+     * thread's group, in round-robin fashion. A thread's group will contain unique states, plus [sharedStatesPerThread]
+     * states from the next group.
      *
      * Example: a list of [a, b, c, d, e, f, g, h, i] split among 3 threads with 1 shared states per thread results in:
      * [[a, b, c, d], [d, e, f, g], [g, h, i, a]]
      *
      * @param states a list of states to be divided
      * @param numThreads the number of thread groups to divide the states among
-     * @param sharedStatesPerThread the number of states to be shared between thread groups, only one thread can successfully
-     *  update a state with a given version.
+     * @param sharedStatesPerThread the number of states to be shared between thread groups, only one thread can
+     *  successfully update a state with a given version.
      */
     private fun divideStatesBetweenThreads(
         states: List<State>,

--- a/libs/state-manager/state-manager-db-impl/src/integrationTest/kotlin/net/corda/libs/statemanager/impl/tests/StateManagerIntegrationTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/integrationTest/kotlin/net/corda/libs/statemanager/impl/tests/StateManagerIntegrationTest.kt
@@ -651,6 +651,141 @@ class StateManagerIntegrationTest {
         ).isEmpty()
     }
 
+    @Test
+    @DisplayName(value = "can filter states using multiple conjunctive comparisons on metadata values and last updated time")
+    fun canFilterStatesUsingMultipleConjunctiveComparisonsOnMetadataValuesAndLastUpdatedTime() {
+        val count = 20
+        val half = count / 2
+        val keyIndexRange = 1..count
+        persistStateEntities(
+            (keyIndexRange),
+            { _, _ -> State.VERSION_INITIAL_VALUE },
+            { i, _ -> "state_$i" },
+            { i, _ -> """{ "number": $i, "boolean": ${i % 2 == 0}, "string": "random_$i" }""" }
+        )
+        val (halfTime, finishTime) = getIntervalBetweenEntities(
+            buildStateKey(keyIndexRange.elementAt(half)),
+            buildStateKey(keyIndexRange.last)
+        )
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAll(
+                IntervalFilter(Instant.EPOCH, halfTime),
+                listOf(
+                    MetadataFilter("number", Operation.GreaterThan, 5),
+                    MetadataFilter("number", Operation.LesserThan, 7),
+                    MetadataFilter("boolean", Operation.Equals, true),
+                    MetadataFilter("string", Operation.Equals, "random_6"),
+                )
+            )
+        ).hasSize(1)
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAll(
+                IntervalFilter(finishTime, finishTime.plusSeconds(60)),
+                listOf(
+                    MetadataFilter("number", Operation.GreaterThan, 5),
+                    MetadataFilter("number", Operation.LesserThan, 7),
+                    MetadataFilter("boolean", Operation.Equals, true),
+                    MetadataFilter("string", Operation.Equals, "random_6"),
+                )
+            )
+        ).isEmpty()
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAll(
+                IntervalFilter(halfTime, finishTime),
+                listOf(
+                    MetadataFilter("number", Operation.GreaterThan, 10),
+                    MetadataFilter("boolean", Operation.Equals, true),
+                )
+            )
+        ).hasSize(half / 2)
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAll(
+                IntervalFilter(Instant.EPOCH, finishTime.plusSeconds(60)),
+                listOf(
+                    MetadataFilter("number", Operation.GreaterThan, 1),
+                    MetadataFilter("boolean", Operation.Equals, true),
+                    MetadataFilter("string", Operation.Equals, "non_existing_value"),
+                )
+            )
+        ).isEmpty()
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAll(
+                IntervalFilter(halfTime, finishTime),
+                listOf(
+                    MetadataFilter("number", Operation.GreaterThan, 10),
+                    MetadataFilter("number", Operation.LesserThan, 50),
+                    MetadataFilter("string", Operation.NotEquals, "non_existing_value"),
+                )
+            )
+        ).hasSize(half)
+    }
+
+    @Test
+    @DisplayName(value = "can filter states using multiple disjunctive comparisons on metadata values and last updated time")
+    fun canFilterStatesUsingMultipleDisjunctiveComparisonsOnMetadataValuesAndLastUpdatedTime() {
+        val count = 20
+        val half = count / 2
+        val keyIndexRange = 1..count
+        persistStateEntities(
+            (keyIndexRange),
+            { _, _ -> State.VERSION_INITIAL_VALUE },
+            { i, _ -> "state_$i" },
+            { i, _ -> """{ "number": $i, "boolean": ${i % 2 == 0}, "string": "random_$i" }""" }
+        )
+        val (halfTime, finishTime) = getIntervalBetweenEntities(
+            buildStateKey(keyIndexRange.elementAt(half)),
+            buildStateKey(keyIndexRange.last)
+        )
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAny(
+                IntervalFilter(Instant.EPOCH, halfTime),
+                listOf(
+                    MetadataFilter("number", Operation.Equals, 5),
+                    MetadataFilter("number", Operation.Equals, 7),
+                    MetadataFilter("string", Operation.Equals, "random_6"),
+                )
+            )
+        ).hasSize(3)
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAny(
+                IntervalFilter(finishTime, finishTime.plusSeconds(60)),
+                listOf(
+                    MetadataFilter("number", Operation.GreaterThan, 5),
+                    MetadataFilter("number", Operation.LesserThan, 7),
+                    MetadataFilter("boolean", Operation.Equals, true),
+                    MetadataFilter("string", Operation.Equals, "random_6"),
+                )
+            )
+        ).hasSize(1)
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAny(
+                IntervalFilter(halfTime, finishTime),
+                listOf(
+                    MetadataFilter("number", Operation.GreaterThan, 1),
+                    MetadataFilter("boolean", Operation.Equals, true),
+                )
+            )
+        ).hasSize(half)
+
+        assertThat(
+            stateManager.findUpdatedBetweenWithMetadataMatchingAny(
+                IntervalFilter(Instant.EPOCH, finishTime.plusSeconds(60)),
+                listOf(
+                    MetadataFilter("number", Operation.Equals, 25),
+                    MetadataFilter("string", Operation.Equals, "non_existing_value"),
+                )
+            )
+        ).isEmpty()
+    }
+
     @AfterEach
     fun tearDown() {
         cleanStates()

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
@@ -147,12 +147,25 @@ class StateManagerImpl(
         }
     }
 
-    override fun findUpdatedBetweenWithMetadataFilter(
+    override fun findUpdatedBetweenWithMetadataMatchingAll(
         intervalFilter: IntervalFilter,
-        metadataFilter: MetadataFilter
+        metadataFilters: Collection<MetadataFilter>
     ): Map<String, State> {
         return dataSource.connection.transaction { connection ->
-            stateRepository.filterByUpdatedBetweenAndMetadata(connection, intervalFilter, metadataFilter)
+            stateRepository.filterByUpdatedBetweenWithMetadataMatchingAll(connection, intervalFilter, metadataFilters)
+        }.map {
+            it.fromPersistentEntity()
+        }.associateBy {
+            it.key
+        }
+    }
+
+    override fun findUpdatedBetweenWithMetadataMatchingAny(
+        intervalFilter: IntervalFilter,
+        metadataFilters: Collection<MetadataFilter>
+    ): Map<String, State> {
+        return dataSource.connection.transaction { connection ->
+            stateRepository.filterByUpdatedBetweenWithMetadataMatchingAny(connection, intervalFilter, metadataFilters)
         }.map {
             it.fromPersistentEntity()
         }.associateBy {

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/StateRepository.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/StateRepository.kt
@@ -22,7 +22,7 @@ interface StateRepository {
     )
 
     /**
-     * Create state into the persistence context.
+     * Create state.
      * Transaction should be controlled by the caller.
      *
      * @param connection The JDBC connection used to interact with the database.
@@ -41,9 +41,8 @@ interface StateRepository {
     fun get(connection: Connection, keys: Collection<String>): Collection<StateEntity>
 
     /**
-     * Update a collection of states within the database using JDBC connection.
-     *
-     * Note: Transaction should be controlled by the caller.
+     * Update collection of states.
+     * Transaction should be controlled by the caller.
      *
      * @param connection The JDBC connection used to interact with the database.
      * @param states A collection of states to be updated in the database.
@@ -52,7 +51,7 @@ interface StateRepository {
     fun update(connection: Connection, states: List<StateEntity>): StateUpdateSummary
 
     /**
-     * Delete states with the given keys from the persistence context.
+     * Delete states with the given keys.
      * Transaction should be controlled by the caller.
      *
      * @param connection The JDBC connection used to interact with the database.
@@ -62,7 +61,7 @@ interface StateRepository {
     fun delete(connection: Connection, states: Collection<StateEntity>): Collection<String>
 
     /**
-     * Retrieve entities that were lastly updated between [IntervalFilter.start] and [IntervalFilter.finish].
+     * Retrieve states for which [StateEntity.modifiedTime] is within [interval].
      * Transaction should be controlled by the caller.
      *
      * @param connection The JDBC connection used to interact with the database.
@@ -72,8 +71,8 @@ interface StateRepository {
     fun updatedBetween(connection: Connection, interval: IntervalFilter): Collection<StateEntity>
 
     /**
-     * Filter states based on a list of custom single key filters over the [StateEntity.metadata], only states matching
-     * all [filters] are returned.
+     * Retrieve states exclusively matching all specified [filters] (comparisons are applied against the stored keys
+     * and values within the [StateEntity.metadata]).
      * Transaction should be controlled by the caller.
      *
      * @param connection The JDBC connection used to interact with the database.
@@ -83,8 +82,8 @@ interface StateRepository {
     fun filterByAll(connection: Connection, filters: Collection<MetadataFilter>): Collection<StateEntity>
 
     /**
-     * Filter states based on a list of custom single key filters over the [StateEntity.metadata], states matching
-     * any of the [filters] are returned.
+     * Retrieve states matching any of the specified [filters] (comparisons are applied against the stored keys and
+     * values within the [StateEntity.metadata]).
      * Transaction should be controlled by the caller.
      *
      * @param connection The JDBC connection used to interact with the database.
@@ -94,19 +93,36 @@ interface StateRepository {
     fun filterByAny(connection: Connection, filters: Collection<MetadataFilter>): Collection<StateEntity>
 
     /**
-     * Filter states based on a custom comparison operation to be executed against a single key within the metadata and
-     * the last updated time.
+     * Retrieve states that were lastly updated within [interval] (compared against [StateEntity.modifiedTime]) and
+     * exclusively matching all specified [filters] (comparisons are applied against the stored keys and values within
+     * the [StateEntity.metadata]).
      * Transaction should be controlled by the caller.
      *
      * @param connection The JDBC connection used to interact with the database.
      * @param interval Lower and upper bound to use when filtering by time.
-     * @param filter Filter to use when searching for entities.
+     * @param filters List of filter to use when searching for entities.
      * @return Collection of states found.
      */
-    @Suppress("LongParameterList")
-    fun filterByUpdatedBetweenAndMetadata(
+    fun filterByUpdatedBetweenWithMetadataMatchingAll(
         connection: Connection,
         interval: IntervalFilter,
-        filter: MetadataFilter
+        filters: Collection<MetadataFilter>
+    ): Collection<StateEntity>
+
+    /**
+     * Retrieve states that were lastly updated within [interval] (compared against [StateEntity.modifiedTime]) and
+     * matching any of the specified [filters] (comparisons are applied against the stored keys and values within
+     * the [StateEntity.metadata]).
+     * Transaction should be controlled by the caller.
+     *
+     * @param connection The JDBC connection used to interact with the database.
+     * @param interval Lower and upper bound to use when filtering by time.
+     * @param filters List of filter to use when searching for entities.
+     * @return Collection of states found.
+     */
+    fun filterByUpdatedBetweenWithMetadataMatchingAny(
+        connection: Connection,
+        interval: IntervalFilter,
+        filters: Collection<MetadataFilter>
     ): Collection<StateEntity>
 }

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/PostgresQueryProvider.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/PostgresQueryProvider.kt
@@ -37,21 +37,25 @@ class PostgresQueryProvider : AbstractQueryProvider() {
         """
             SELECT s.$KEY_COLUMN, s.$VALUE_COLUMN, s.$METADATA_COLUMN, s.$VERSION_COLUMN, s.$MODIFIED_TIME_COLUMN 
             FROM $STATE_MANAGER_TABLE s
-            WHERE ${metadataKeyFilters(filters).joinToString(" AND ")}
+            WHERE (${metadataKeyFilters(filters).joinToString(" AND ")})
         """.trimIndent()
 
     override fun findStatesByMetadataMatchingAny(filters: Collection<MetadataFilter>) =
         """
             SELECT s.$KEY_COLUMN, s.$VALUE_COLUMN, s.$METADATA_COLUMN, s.$VERSION_COLUMN, s.$MODIFIED_TIME_COLUMN 
             FROM $STATE_MANAGER_TABLE s
-            WHERE ${metadataKeyFilters(filters).joinToString(" OR ")}
+            WHERE (${metadataKeyFilters(filters).joinToString(" OR ")})
         """.trimIndent()
 
-    override fun findStatesUpdatedBetweenAndFilteredByMetadataKey(filter: MetadataFilter): String {
+    override fun findStatesUpdatedBetweenWithMetadataMatchingAll(filters: Collection<MetadataFilter>): String {
         return """
-            SELECT s.$KEY_COLUMN, s.$VALUE_COLUMN, s.$METADATA_COLUMN, s.$VERSION_COLUMN, s.$MODIFIED_TIME_COLUMN
-            FROM $STATE_MANAGER_TABLE s
-            WHERE (${metadataKeyFilter(filter)}) AND (${updatedBetweenFilter()})
+            ${findStatesByMetadataMatchingAll(filters)} AND (${updatedBetweenFilter()})
+        """.trimIndent()
+    }
+
+    override fun findStatesUpdatedBetweenWithMetadataMatchingAny(filters: Collection<MetadataFilter>): String {
+        return """
+            ${findStatesByMetadataMatchingAny(filters)} AND (${updatedBetweenFilter()})
         """.trimIndent()
     }
 

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/QueryProvider.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/QueryProvider.kt
@@ -24,5 +24,7 @@ interface QueryProvider {
 
     fun findStatesByMetadataMatchingAny(filters: Collection<MetadataFilter>): String
 
-    fun findStatesUpdatedBetweenAndFilteredByMetadataKey(filter: MetadataFilter): String
+    fun findStatesUpdatedBetweenWithMetadataMatchingAll(filters: Collection<MetadataFilter>): String
+
+    fun findStatesUpdatedBetweenWithMetadataMatchingAny(filters: Collection<MetadataFilter>): String
 }

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImpl.kt
@@ -89,11 +89,21 @@ class StateRepositoryImpl(private val queryProvider: QueryProvider) : StateRepos
             it.executeQuery().resultSetAsStateEntityCollection()
         }
 
-    override fun filterByUpdatedBetweenAndMetadata(
+    override fun filterByUpdatedBetweenWithMetadataMatchingAll(
         connection: Connection,
         interval: IntervalFilter,
-        filter: MetadataFilter
-    ) = connection.prepareStatement(queryProvider.findStatesUpdatedBetweenAndFilteredByMetadataKey(filter)).use {
+        filters: Collection<MetadataFilter>
+    ) = connection.prepareStatement(queryProvider.findStatesUpdatedBetweenWithMetadataMatchingAll(filters)).use {
+        it.setTimestamp(1, Timestamp.from(interval.start))
+        it.setTimestamp(2, Timestamp.from(interval.finish))
+        it.executeQuery().resultSetAsStateEntityCollection()
+    }
+
+    override fun filterByUpdatedBetweenWithMetadataMatchingAny(
+        connection: Connection,
+        interval: IntervalFilter,
+        filters: Collection<MetadataFilter>
+    ) = connection.prepareStatement(queryProvider.findStatesUpdatedBetweenWithMetadataMatchingAny(filters)).use {
         it.setTimestamp(1, Timestamp.from(interval.start))
         it.setTimestamp(2, Timestamp.from(interval.finish))
         it.executeQuery().resultSetAsStateEntityCollection()


### PR DESCRIPTION
- Allow filtering states by last updated timestamp and multiple
  metadata filters (both conjunctive and disjunctive operations).
- Update 'ScheduledTaskProcessor' to use the new feature instead of
  manually filtering states.
