### PR TITLE
DA5-6 implement persistDraftSignedTransaction, findDraftSignedTransaction

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^((CORDA|EG|ENT|INFRA|CORE|DOC|ES)-\d+)(.*)'
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE|DOC|ES|DA5)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -7,6 +7,9 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
     companion object {
         @JvmField
         val UNVERIFIED = TransactionStatus.UNVERIFIED.value
+
+        @JvmField
+        val DRAFT = TransactionStatus.DRAFT.value
     }
 
     override val findTransactionPrivacySaltAndMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -24,7 +24,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
                 VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash)
             ON CONFLICT(id) DO
                 UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated
-            WHERE utxo_transaction.status = EXCLUDED.status OR utxo_transaction.status = '$UNVERIFIED'"""
+            WHERE utxo_transaction.status in (EXCLUDED.status, '$UNVERIFIED', '$DRAFT')"""
             .trimIndent()
 
     override val persistTransactionMetadata: String

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.data.transaction.TransactionStatus.INVALID
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.common.data.transaction.TransactionStatus.VERIFIED
+import net.corda.ledger.common.data.transaction.TransactionStatus.DRAFT
 import net.corda.ledger.utxo.flow.impl.UtxoLedgerMetricRecorder
 import net.corda.ledger.utxo.flow.impl.flows.backchain.InvalidBackchainException
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TopologicalSort
@@ -245,10 +246,12 @@ class TransactionBackchainReceiverFlowV1(
                             transactionsToRetrieve.remove(transactionId)
                         }
 
-                        INVALID -> {
+                        INVALID, DRAFT -> {
                             // If the status changed from UNVERIFIED -> INVALID we cannot go on with the resolution
+                            // Also transitioning back to Draft is impossible.
+
                             throw InvalidBackchainException(
-                                "Found the following invalid transaction during back-chain resolution: " +
+                                "Found the following $status transaction during back-chain resolution: " +
                                         "$transactionId. Backchain resolution cannot be continued."
                             )
                         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,8 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.7-beta+
+cordaApiVersion=5.2.0.8-beta+
+
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionStatus.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/TransactionStatus.kt
@@ -5,13 +5,15 @@ import java.security.InvalidParameterException
 enum class TransactionStatus(val value: String) {
     INVALID("I"),
     UNVERIFIED("U"),
-    VERIFIED("V");
+    VERIFIED("V"),
+    DRAFT("D");
 
     companion object {
         fun String.toTransactionStatus() = when {
             this.equals(INVALID.value, ignoreCase = true) -> INVALID
             this.equals(UNVERIFIED.value, ignoreCase = true) -> UNVERIFIED
             this.equals(VERIFIED.value, ignoreCase = true) -> VERIFIED
+            this.equals(DRAFT.value, ignoreCase = true) -> DRAFT
             else -> throw InvalidParameterException("TransactionStatus $this is not supported")
         }
     }

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -93,7 +93,8 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
         mockCurrentSandboxGroupContext,
         mockNotaryLookup,
         mockExternalEventExecutor,
-        mockResultSetFactory
+        mockResultSetFactory,
+        mockUtxoLedgerTransactionVerificationService
     )
     val utxoSignedTransactionKryoSerializer = UtxoSignedTransactionKryoSerializer(
         serializationServiceWithWireTx,


### PR DESCRIPTION
DA5-6 implement persistDraftSignedTransaction, findDraftSignedTransaction

API: https://github.com/corda/corda-api/pull/1352