### PR TITLE
CORE-18459 Checking for issues with new API changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.4-beta+
+cordaApiVersion=5.2.0.4-alpha-1700591333824
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
This PR is to verify that the changes in https://github.com/corda/corda-api/pull/1357 to make the `topic` field in external events optional isn't affecting any of the current external event usages.