### PR TITLE
CORE-18470: Change key of kafka message to random uuid

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -13,6 +13,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Crypto.REWRAP_MESSAGE_TOPIC
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 /**
  * This processor goes through the databases and find out what keys need re-wrapping.
@@ -23,15 +24,15 @@ class CryptoRekeyBusProcessor(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     private val wrappingRepositoryFactory: WrappingRepositoryFactory,
     private val rekeyPublisher: Publisher
-) : DurableProcessor<String, KeyRotationRequest> {
+) : DurableProcessor<UUID, KeyRotationRequest> {
     companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    override val keyClass: Class<String> = String::class.java
+    override val keyClass: Class<UUID> = UUID::class.java
     override val valueClass = KeyRotationRequest::class.java
     @Suppress("NestedBlockDepth")
-    override fun onNext(events: List<Record<String, KeyRotationRequest>>): List<Record<*, *>> {
+    override fun onNext(events: List<Record<UUID, KeyRotationRequest>>): List<Record<*, *>> {
         logger.debug("received ${events.size} key rotation requests")
         events.mapNotNull { it.value }.forEach { request ->
             logger.debug("processing $request")

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -15,6 +15,7 @@ import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
+
 /**
  * This processor goes through the databases and find out what keys need re-wrapping.
  * It then posts a message to Kafka for each key needing re-wrapping with the tenant ID.
@@ -65,7 +66,7 @@ class CryptoRekeyBusProcessor(
                 targetWrappingKeys.map { (tenantId, wrappingKeyInfo) ->
                     Record(
                         REWRAP_MESSAGE_TOPIC,
-                        request.requestId,
+                        UUID.randomUUID(),
                         IndividualKeyRotationRequest(request.requestId,
                             tenantId,
                             request.oldParentKeyAlias,

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.core.CryptoService
 import net.corda.data.crypto.wire.ops.key.rotation.IndividualKeyRotationRequest
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
+import java.util.UUID
 
 /**
  * This processor does actual re-wrapping of the keys.
@@ -12,11 +13,11 @@ import net.corda.messaging.api.records.Record
 @Suppress("LongParameterList")
 class CryptoRewrapBusProcessor(
     val cryptoService: CryptoService
-) : DurableProcessor<String, IndividualKeyRotationRequest> {
-    override val keyClass: Class<String> = String::class.java
+) : DurableProcessor<UUID, IndividualKeyRotationRequest> {
+    override val keyClass: Class<UUID> = UUID::class.java
     override val valueClass = IndividualKeyRotationRequest::class.java
 
-    override fun onNext(events: List<Record<String, IndividualKeyRotationRequest>>): List<Record<*, *>> {
+    override fun onNext(events: List<Record<UUID, IndividualKeyRotationRequest>>): List<Record<*, *>> {
         events.mapNotNull { it.value }.map { request ->
             cryptoService.rewrapWrappingKey(request.tenantId, request.targetKeyAlias, request.newParentKeyAlias)
         }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
@@ -28,13 +28,13 @@ import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.doReturn
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -224,9 +224,9 @@ class CryptoRekeyBusProcessorTests {
         return virtualNodesInfos
     }
 
-    private fun getKafkaRecord(oldKeyAlias: String): Record<String, KeyRotationRequest> = Record(
+    private fun getKafkaRecord(oldKeyAlias: String): Record<UUID, KeyRotationRequest> = Record(
         "TBC",
-        UUID.randomUUID().toString(),
+        UUID.randomUUID(),
         KeyRotationRequest(
             UUID.randomUUID().toString(),
             KeyType.UNMANAGED,

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
@@ -24,7 +24,7 @@ class CryptoRewrapBusProcessorTests {
             listOf(
                 Record(
                     "TBC",
-                    UUID.randomUUID().toString(),
+                    UUID.randomUUID(),
                     IndividualKeyRotationRequest(UUID.randomUUID().toString(), tenantId, "alias1", "root2", "alias1", KeyType.UNMANAGED)
                 )
             )

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/CordaDBAvroDeserializerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/CordaDBAvroDeserializerImpl.kt
@@ -1,12 +1,13 @@
 package net.corda.messagebus.db.serialization
 
-import java.nio.ByteBuffer
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.ChunkKey
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.util.UUID
 
 class CordaDBAvroDeserializerImpl<T : Any>(
     private val schemaRegistry: AvroSchemaRegistry,
@@ -28,6 +29,9 @@ class CordaDBAvroDeserializerImpl<T : Any>(
             }
             expectedClass == ByteArray::class.java && !isChunkType -> {
                 data
+            }
+            expectedClass == UUID::class.java && !isChunkType -> {
+                UUID.fromString(data.decodeToString()) as T?
             }
             else -> {
                 deserializeAvro(data, allowChunks)

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/CordaDBAvroSerializerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/serialization/CordaDBAvroSerializerImpl.kt
@@ -4,6 +4,7 @@ import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 class CordaDBAvroSerializerImpl<T : Any>(
     private val schemaRegistry: AvroSchemaRegistry,
@@ -20,6 +21,7 @@ class CordaDBAvroSerializerImpl<T : Any>(
             return when (data) {
                 is String -> (data as String).encodeToByteArray()
                 is ByteArray -> data
+                is UUID -> (data.toString()).encodeToByteArray()
                 else -> schemaRegistry.serialize(data).array()
             }
         } catch (ex: Throwable) {

--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/serialization/CordaDBAvroSerializerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/serialization/CordaDBAvroSerializerImplTest.kt
@@ -1,6 +1,5 @@
 package net.corda.messagebus.db.serialization
 
-import java.nio.ByteBuffer
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.assertj.core.api.Assertions.assertThat
@@ -11,6 +10,8 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.nio.ByteBuffer
+import java.util.UUID
 
 class CordaDBAvroSerializerImplTest {
 
@@ -37,6 +38,11 @@ class CordaDBAvroSerializerImplTest {
     @Test
     fun testByteArrayValue() {
         assertThat(cordaDBAvroSerializer.serialize("data".toByteArray()) != null)
+    }
+
+    @Test
+    fun testUUIDValue() {
+        assertThat(cordaDBAvroSerializer.serialize(UUID.randomUUID()) != null)
     }
 
     @Test

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerImpl.kt
@@ -1,7 +1,5 @@
 package net.corda.messagebus.kafka.serialization
 
-import java.nio.ByteBuffer
-import java.util.function.Consumer
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.data.chunking.Chunk
 import net.corda.data.chunking.ChunkKey
@@ -10,6 +8,9 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.apache.kafka.common.serialization.Deserializer
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.util.function.Consumer
+import java.util.UUID
 
 /**
  * Corda avro serializer impl
@@ -40,6 +41,9 @@ class CordaAvroDeserializerImpl<T: Any>(
             }
             expectedClass == ByteArray::class.java && !isChunkType -> {
                 data
+            }
+            expectedClass == UUID::class.java && !isChunkType -> {
+                UUID.fromString(stringDeserializer.deserialize(null, data))
             }
             else -> {
                 deserializeAvro(data, allowChunks)

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroSerializerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroSerializerImpl.kt
@@ -6,6 +6,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.apache.kafka.common.serialization.Serializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 /**
  * Corda avro serializer impl
@@ -38,6 +39,7 @@ class CordaAvroSerializerImpl<T : Any>(
             return when (data) {
                 is String -> stringSerializer.serialize(null, data)
                 is ByteArray -> data
+                is UUID -> stringSerializer.serialize(null, data.toString())
                 else -> {
                     schemaRegistry.serialize(data).array()
                 }

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroDeserializerTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
+import java.util.UUID
 
 internal class CordaAvroDeserializerTest {
 
@@ -41,6 +42,20 @@ internal class CordaAvroDeserializerTest {
         val win = deserializer.deserialize("", "Win!".toByteArray())
 
         assertThat(win).isEqualTo("Win!".toByteArray())
+        verifyNoInteractions(schemaRegistry)
+        verifyNoInteractions(callback)
+    }
+
+    @Test
+    fun `simple UUID deserialize test`() {
+        val schemaRegistry: AvroSchemaRegistry = mock()
+        val callback: (String, ByteArray) -> Unit = mock()
+        val deserializer = CordaAvroDeserializerImpl( mock(),  mock(), UUID::class.java)
+        val value = UUID.randomUUID()
+        // Serializing of the UUID is already tested in the CordaAvroSerializerImplTest, hence using here toString
+        val win = deserializer.deserialize("", kafkaSerializer.serialize("", value.toString()))
+
+        assertThat(win).isEqualTo(value)
         verifyNoInteractions(schemaRegistry)
         verifyNoInteractions(callback)
     }

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroSerializerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/serialization/CordaAvroSerializerImplTest.kt
@@ -1,6 +1,5 @@
 package net.corda.messagebus.kafka.serialization
 
-import java.nio.ByteBuffer
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.assertj.core.api.Assertions.assertThat
@@ -11,6 +10,8 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.nio.ByteBuffer
+import java.util.UUID
 
 class CordaAvroSerializerImplTest {
 
@@ -43,6 +44,11 @@ class CordaAvroSerializerImplTest {
     @Test
     fun testByteArrayValue() {
         assertThat(cordaAvroSerializer.serialize(topic, "bytearray".toByteArray()) != null)
+    }
+
+    @Test
+    fun testUUIDValue() {
+        assertThat(cordaAvroSerializer.serialize(topic, UUID.randomUUID()) != null)
     }
 
     @Test


### PR DESCRIPTION
This ensures the work is evenly spread between Kafka partitions during key rotation.