### PR TITLE
CORE-18463: Reduce logging in assertWithRetry

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/AssertWithRetryBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/AssertWithRetryBuilder.kt
@@ -49,14 +49,14 @@ class AssertWithRetryBuilder(private val args: AssertWithRetryArgs) {
 private data class Attempt(val attemptNumber: Int, val timeTried: Duration, val response: String)
 
 private fun Iterable<Attempt>.prettyPrint(): String =
-    attempts.joinToString("\n") { "${it.attemptNumber} (${it.timeTried}): ${it.response}" }
+    joinToString("\n") { "${it.attemptNumber} (${it.timeTried}): ${it.response}" }
 
 private fun <T> trackRetryAttempts(block: ((Attempt) -> Unit) -> T): T {
     val attempts = mutableListOf<Attempt>()
     try {
         return block { attempts.add(it) }
     } catch (t: Throwable) {
-        println("\nAttempts:\n${formatAttempts(attempts)}")
+        println("\nAttempts:\n${attempts.prettyPrint()}")
         throw t
     }
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/AssertWithRetryBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/AssertWithRetryBuilder.kt
@@ -46,6 +46,21 @@ class AssertWithRetryBuilder(private val args: AssertWithRetryArgs) {
     }
 }
 
+private data class Attempt(val attemptNumber: Int, val timeTried: Duration, val response: String)
+
+private fun formatAttempts(attempts: Iterable<Attempt>): String =
+    attempts.joinToString("\n") { "${it.attemptNumber} (${it.timeTried}): ${it.response}" }
+
+private fun <T> trackRetryAttempts(block: ((Attempt) -> Unit) -> T): T {
+    val attempts = mutableListOf<Attempt>()
+    try {
+        return block { attempts.add(it) }
+    } catch (t: Throwable) {
+        println("\nAttempts:\n${formatAttempts(attempts)}")
+        throw t
+    }
+}
+
 /**
  * Sort-of-DSL.  Asserts a command and retries if it doesn't initially succeed.
  *
@@ -62,34 +77,42 @@ class AssertWithRetryBuilder(private val args: AssertWithRetryArgs) {
  */
 fun assertWithRetry(initialize: AssertWithRetryBuilder.() -> Unit): SimpleResponse {
     val args = AssertWithRetryArgs()
-    AssertWithRetryBuilder(args).apply(initialize).also {
+
+    return trackRetryAttempts { addAttempt ->
+        AssertWithRetryBuilder(args).apply(initialize).also {
         args.validate()
     }.run {
-        var response: SimpleResponse?
+            var response: SimpleResponse?
 
-        var retry = 0
-        var timeTried: Long
-        Thread.sleep(args.startDelay.toMillis())
-        do {
-            response = args.command!!.invoke()
-            if(null != args.immediateFailCondition && args.immediateFailCondition!!.invoke(response)) {
-                fail("Failed without retry with status code = ${response.code} and body =\n${response.body}")
-            }
-            if (args.condition.invoke(response)) break
-            retry++
-            timeTried = args.interval.toMillis() * retry
-            println("Failed after $retry retry ($timeTried ms): $response")
-            Thread.sleep(args.interval.toMillis())
-        } while (timeTried < args.timeout.toMillis())
+            var retry = 0
+            var timeTried: Long
+            Thread.sleep(args.startDelay.toMillis())
+            do {
+                response = args.command!!.invoke()
+                if (retry == 0) {
+                    println(response.url)
+                }
+                unbufferedPrint('.')
+                if (null != args.immediateFailCondition && args.immediateFailCondition!!.invoke(response)) {
+                    fail("Failed without retry with status code = ${response.code} and body =\n${response.body}")
+                }
+                if (args.condition.invoke(response)) break
+                retry++
+                timeTried = args.interval.toMillis() * retry
+                addAttempt(Attempt(retry, Duration.ofMillis(timeTried), response.toString()))
+                Thread.sleep(args.interval.toMillis())
+            } while (timeTried < args.timeout.toMillis())
+            println()
 
-        assertThat(args.condition.invoke(response!!))
-            .withFailMessage(
-                "${args.failMessage}Retried ${response.url} and " +
-                        "failed with status code = ${response.code} and body =\n${response.body}"
-            )
-            .isTrue
+            assertThat(args.condition.invoke(response!!))
+                .withFailMessage(
+                    "${args.failMessage}Retried ${response.url} and " +
+                            "failed with status code = ${response.code} and body =\n${response.body}"
+                )
+                .isTrue
 
-        return response
+            response
+        }
     }
 }
 
@@ -111,48 +134,62 @@ fun assertWithRetry(initialize: AssertWithRetryBuilder.() -> Unit): SimpleRespon
 @Suppress("ComplexMethod", "NestedBlockDepth")
 fun assertWithRetryIgnoringExceptions(initialize: AssertWithRetryBuilder.() -> Unit): SimpleResponse {
     val args = AssertWithRetryArgs()
-    AssertWithRetryBuilder(args).apply(initialize).also {
-        args.validate()
-    }.run {
-        var retry = 0
-        var result: Any?
-        var timeTried: Long
 
-        Thread.sleep(args.startDelay.toMillis())
-        do {
-            result = try {
-                args.command!!.invoke()
-            } catch (exception: Exception) {
-                exception
-            }
+    return trackRetryAttempts { addAttempt ->
+        AssertWithRetryBuilder(args).apply(initialize).also {
+            args.validate()
+        }.run {
+            var retry = 0
+            var result: Any?
+            var timeTried: Long
 
-            if (result is SimpleResponse) {
-                if (null != args.immediateFailCondition && args.immediateFailCondition!!.invoke(result)) {
-                    fail("Failed without retry with status code = ${result.code} and body =\n${result.body}")
+            Thread.sleep(args.startDelay.toMillis())
+            do {
+                result = try {
+                    args.command!!.invoke()
+                } catch (exception: Exception) {
+                    exception
                 }
 
-                if (args.condition.invoke(result)) break
+                if (retry == 0 && result is SimpleResponse) {
+                    println(result.url)
+                }
+                unbufferedPrint('.')
+
+                retry++
+                timeTried = args.interval.toMillis() * retry
+                addAttempt(Attempt(retry, Duration.ofMillis(timeTried),
+                        if (result is Exception) result.stackTraceToString() else result.toString()))
+
+                if (result is SimpleResponse) {
+                    if (null != args.immediateFailCondition && args.immediateFailCondition!!.invoke(result)) {
+                        fail("Failed without retry with status code = ${result.code} and body =\n${result.body}")
+                    }
+                    if (args.condition.invoke(result)) break
+                }
+                Thread.sleep(args.interval.toMillis())
+            } while (timeTried < args.timeout.toMillis())
+            println()
+
+            when (result) {
+                is SimpleResponse -> {
+                    assertThat(args.condition.invoke(result))
+                        .withFailMessage(
+                            "${args.failMessage}Retried ${result.url} and " +
+                                    "failed with status code = ${result.code} and body =\n${result.body}"
+                        )
+                        .isTrue
+
+                    result
+                }
+
+                else -> fail("${args.failMessage} Retried $retry times and failed with $result")
             }
-
-            retry++
-            timeTried = args.interval.toMillis() * retry
-            println("Failed after $retry retry ($timeTried ms): $result")
-            Thread.sleep(args.interval.toMillis())
-        } while (timeTried < args.timeout.toMillis())
-
-        when (result) {
-            is SimpleResponse -> {
-                assertThat(args.condition.invoke(result))
-                    .withFailMessage(
-                        "${args.failMessage}Retried ${result.url} and " +
-                                "failed with status code = ${result.code} and body =\n${result.body}"
-                    )
-                    .isTrue
-
-                return result
-            }
-
-            else -> fail("${args.failMessage} Retried $retry times and failed with $result")
         }
     }
+}
+
+private fun unbufferedPrint(c: Char) {
+    print(c)
+    System.out.flush()
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/AssertWithRetryBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/AssertWithRetryBuilder.kt
@@ -48,7 +48,7 @@ class AssertWithRetryBuilder(private val args: AssertWithRetryArgs) {
 
 private data class Attempt(val attemptNumber: Int, val timeTried: Duration, val response: String)
 
-private fun formatAttempts(attempts: Iterable<Attempt>): String =
+private fun Iterable<Attempt>.prettyPrint(): String =
     attempts.joinToString("\n") { "${it.attemptNumber} (${it.timeTried}): ${it.response}" }
 
 private fun <T> trackRetryAttempts(block: ((Attempt) -> Unit) -> T): T {


### PR DESCRIPTION
- Remove the retry log on successful runs because it will greatly reduce log output
- Avoid saying "Failed" in the context of retry attempts because "Failed" is a useful keyword when looking for assertion failures
- But do output the URL once, and a full stop for each retry because it is useful to see some activity when watching a test run
- Keep the response for each retry in a list and output the list on failure so we still have the logs on failure
- Output the log of attempts on assertion failure or any unexpected exception