### PR TITLE
CORE-17821 Bumping API version from 5.2.0.5 -> 5.2.0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.5-beta+
+cordaApiVersion=5.2.0.6-beta+
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26
 felixVersion=7.0.5


### PR DESCRIPTION
Updating the API version following the changes in this PR: https://github.com/corda/corda-api/pull/1353/files