### PR TITLE
CORE-17506 Removing unused flow topics, making Record.topic field optional

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/RecordExtensions.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/RecordExtensions.kt
@@ -38,7 +38,9 @@ fun <K: Any, V: Any> EventLogRecord<K, V>.toRecord(): Record<K, V> {
 }
 
 fun Record<*, *>.toCordaProducerRecord(): CordaProducerRecord<*, *> {
-    return CordaProducerRecord(this.topic!!, this.key, this.value, this.headers)
+    val topic = this.topic
+    requireNotNull(topic) { "Topic is not allowed to be null for CordaProducerRecords" }
+    return CordaProducerRecord(topic, this.key, this.value, this.headers)
 }
 
 fun List<Record<*, *>>.toCordaProducerRecords(): List<CordaProducerRecord<*, *>> {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/RecordExtensions.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/RecordExtensions.kt
@@ -38,7 +38,7 @@ fun <K: Any, V: Any> EventLogRecord<K, V>.toRecord(): Record<K, V> {
 }
 
 fun Record<*, *>.toCordaProducerRecord(): CordaProducerRecord<*, *> {
-    return CordaProducerRecord(this.topic, this.key, this.value, this.headers)
+    return CordaProducerRecord(this.topic!!, this.key, this.value, this.headers)
 }
 
 fun List<Record<*, *>>.toCordaProducerRecords(): List<CordaProducerRecord<*, *>> {

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/records/Record.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/records/Record.kt
@@ -9,7 +9,7 @@ package net.corda.messaging.api.records
  * @property headers Optional list of headers to added to the message.
  */
 data class Record<K : Any, V : Any>(
-    val topic: String,
+    val topic: String?,
     val key: K,
     val value: V?,
     val timestamp: Long = 0,

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/records/Record.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/records/Record.kt
@@ -2,9 +2,10 @@ package net.corda.messaging.api.records
 
 /**
  * Object to encapsulate the events stored on topics
- * @property topic Defines the id of the topic the record is stored on.
- * @property key Is the unique per topic key for a record
- * @property value The value of the record
+ * @property topic Defines the id of the topic the [Record] is stored on when sending on the message bus.
+ * This field is not required for records being sent via synchronous RPC.
+ * @property key Is the unique per topic key for a [Record].
+ * @property value The value of the [Record].
  * @property timestamp The timestamp of when the message was produced.
  * @property headers Optional list of headers to added to the message.
  */

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topics.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topics.kt
@@ -19,7 +19,7 @@ class Topics(
     internal fun getWriteLock(records: Collection<Record<*, *>>, partitionId: Int): PartitionsWriteLock {
         val partitions = records.map {
             val topic = requireNotNull(it.topic) { "Topic is not allowed to be null for message bus records" }
-            getTopic(topic).getPartition(it)
+            getTopic(topic).getPartition(partitionId)
         }
         return PartitionsWriteLock(partitions)
     }

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topics.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topics.kt
@@ -11,14 +11,14 @@ class Topics(
 
     internal fun getWriteLock(records: Collection<Record<*, *>>): PartitionsWriteLock {
         val partitions = records.map {
-            val topic = getTopic(it.topic)
+            val topic = getTopic(it.topic!!)
             topic.getPartition(it)
         }
         return PartitionsWriteLock(partitions)
     }
     internal fun getWriteLock(records: Collection<Record<*, *>>, partitionId: Int): PartitionsWriteLock {
         val partitions = records.map {
-            val topic = getTopic(it.topic)
+            val topic = getTopic(it.topic!!)
             topic.getPartition(partitionId)
         }
         return PartitionsWriteLock(partitions)

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topics.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topics.kt
@@ -11,15 +11,15 @@ class Topics(
 
     internal fun getWriteLock(records: Collection<Record<*, *>>): PartitionsWriteLock {
         val partitions = records.map {
-            val topic = getTopic(it.topic!!)
-            topic.getPartition(it)
+            val topic = requireNotNull(it.topic) { "Topic is not allowed to be null for message bus records" }
+            getTopic(topic).getPartition(it)
         }
         return PartitionsWriteLock(partitions)
     }
     internal fun getWriteLock(records: Collection<Record<*, *>>, partitionId: Int): PartitionsWriteLock {
         val partitions = records.map {
-            val topic = getTopic(it.topic!!)
-            topic.getPartition(partitionId)
+            val topic = requireNotNull(it.topic) { "Topic is not allowed to be null for message bus records" }
+            getTopic(topic).getPartition(it)
         }
         return PartitionsWriteLock(partitions)
     }


### PR DESCRIPTION
This PR removes the flow-related topics which are no longer in use, and makes the `topic` field in the `Record` object nullable. This nullability is handled for all instances where the `Record.topic` field is read by either filtering out null topics, or by asserting that they're non-null depending on the context.