### PR TITLE
CORE-18492: register notary with backchain required field

### DIFF
--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/NotaryLookupImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/NotaryLookupImplTest.kt
@@ -89,7 +89,8 @@ class NotaryLookupImplTest {
                 alice,
                 "net.corda.Plugin1",
                 emptyList(),
-                emptyList()
+                emptyList(),
+                true
             )
         )
         whenever(groupReader.lookup(alice)).thenReturn(member)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/PluggableNotaryDetails.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/PluggableNotaryDetails.kt
@@ -1,0 +1,8 @@
+package net.corda.ledger.utxo.flow.impl
+
+import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow
+
+data class PluggableNotaryDetails(
+    val flowClass: Class<PluggableNotaryClientFlow>,
+    val backchainRequired: Boolean
+)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/PluggableNotaryDetails.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/PluggableNotaryDetails.kt
@@ -4,5 +4,5 @@ import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow
 
 data class PluggableNotaryDetails(
     val flowClass: Class<PluggableNotaryClientFlow>,
-    val backchainRequired: Boolean
+    val isBackchainRequired: Boolean
 )

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -214,7 +214,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
     // internally.
     @VisibleForTesting
     @Suppress("ThrowsCount")
-    internal fun getPluggableNotaryClientFlow(notary: MemberX500Name): Class<PluggableNotaryClientFlow> {
+    internal fun getPluggableNotaryClientFlow(notary: MemberX500Name): PluggableNotaryDetails {
 
         val notaryInfo = notaryLookup.notaryServices.firstOrNull { it.name == notary }
             ?: throw CordaRuntimeException(
@@ -239,7 +239,11 @@ class UtxoLedgerServiceImpl @Activate constructor(
             )
         }
 
-        @Suppress("UNCHECKED_CAST") return flowClass as Class<PluggableNotaryClientFlow>
+        @Suppress("UNCHECKED_CAST") return PluggableNotaryDetails(
+            flowClass as Class<PluggableNotaryClientFlow>,
+            notaryInfo.backchainRequired
+        )
+
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -144,7 +144,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
                 UtxoFinalityFlow(
                     signedTransaction as UtxoSignedTransactionInternal,
                     sessions,
-                    getPluggableNotaryClientFlow(signedTransaction.notaryName)
+                    getPluggableNotaryDetails(signedTransaction.notaryName)
                 )
             })
         } catch (e: PrivilegedActionException) {
@@ -214,7 +214,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
     // internally.
     @VisibleForTesting
     @Suppress("ThrowsCount")
-    internal fun getPluggableNotaryClientFlow(notary: MemberX500Name): PluggableNotaryDetails {
+    internal fun getPluggableNotaryDetails(notary: MemberX500Name): PluggableNotaryDetails {
 
         val notaryInfo = notaryLookup.notaryServices.firstOrNull { it.name == notary }
             ?: throw CordaRuntimeException(
@@ -241,7 +241,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
 
         @Suppress("UNCHECKED_CAST") return PluggableNotaryDetails(
             flowClass as Class<PluggableNotaryClientFlow>,
-            notaryInfo.backchainRequired
+            notaryInfo.isBackchainRequired
         )
 
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlow.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.flows.finality
 
 import net.corda.flow.application.services.VersioningService
 import net.corda.flow.application.versioning.VersionedSendFlowFactory
+import net.corda.ledger.utxo.flow.impl.PluggableNotaryDetails
 import net.corda.ledger.utxo.flow.impl.flows.finality.v1.UtxoFinalityFlowV1
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.libs.platform.PlatformVersion.CORDA_5_1
@@ -11,14 +12,13 @@ import net.corda.v5.application.flows.SubFlow
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
-import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 
 @CordaSystemFlow
 class UtxoFinalityFlow(
     private val transaction: UtxoSignedTransactionInternal,
     private val sessions: List<FlowSession>,
-    private val pluggableNotaryClientFlow: Class<PluggableNotaryClientFlow>
+    private val pluggableNotaryDetails: PluggableNotaryDetails
 ) : SubFlow<UtxoSignedTransaction> {
 
     @CordaInject
@@ -27,7 +27,7 @@ class UtxoFinalityFlow(
     @Suspendable
     override fun call(): UtxoSignedTransaction {
         return versioningService.versionedSubFlow(
-            UtxoFinalityFlowVersionedFlowFactory(transaction, pluggableNotaryClientFlow),
+            UtxoFinalityFlowVersionedFlowFactory(transaction, pluggableNotaryDetails),
             sessions
         )
     }
@@ -35,14 +35,14 @@ class UtxoFinalityFlow(
 
 class UtxoFinalityFlowVersionedFlowFactory(
     private val transaction: UtxoSignedTransactionInternal,
-    private val pluggableNotaryClientFlow: Class<PluggableNotaryClientFlow>
+    private val pluggableNotaryDetails: PluggableNotaryDetails
 ) : VersionedSendFlowFactory<UtxoSignedTransaction> {
 
     override val versionedInstanceOf: Class<UtxoFinalityFlow> = UtxoFinalityFlow::class.java
 
     override fun create(version: Int, sessions: List<FlowSession>): SubFlow<UtxoSignedTransaction> {
         return when {
-            version >= CORDA_5_1.value -> UtxoFinalityFlowV1(transaction, sessions, pluggableNotaryClientFlow)
+            version >= CORDA_5_1.value -> UtxoFinalityFlowV1(transaction, sessions, pluggableNotaryDetails)
             version in 1 until CORDA_5_1.value -> throw CordaRuntimeException("Flows cannot be shared between 5.0 and 5.1 vnodes.")
             else -> throw IllegalArgumentException()
         }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -5,6 +5,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
 import net.corda.ledger.notary.worker.selection.NotaryVirtualNodeSelectorService
+import net.corda.ledger.utxo.flow.impl.PluggableNotaryDetails
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
@@ -39,7 +40,7 @@ import java.security.PrivilegedExceptionAction
 class UtxoFinalityFlowV1(
     private val initialTransaction: UtxoSignedTransactionInternal,
     private val sessions: List<FlowSession>,
-    private val pluggableNotaryClientFlow: Class<PluggableNotaryClientFlow>
+    private val pluggableNotaryDetails: PluggableNotaryDetails
 ) : UtxoFinalityBaseV1() {
 
     private companion object {
@@ -293,7 +294,7 @@ class UtxoFinalityFlowV1(
     ): PluggableNotaryClientFlow {
         @Suppress("deprecation", "removal")
         return java.security.AccessController.doPrivileged(PrivilegedExceptionAction {
-            pluggableNotaryClientFlow.getConstructor(UtxoSignedTransaction::class.java, MemberX500Name::class.java).newInstance(
+            pluggableNotaryDetails.flowClass.getConstructor(UtxoSignedTransaction::class.java, MemberX500Name::class.java).newInstance(
                 transaction, virtualNodeSelectorService.selectVirtualNode(transaction.notaryName)
             )
         })

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
@@ -282,6 +282,6 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
             utxoLedgerService.getPluggableNotaryClientFlow(notaryX500Name)
         }
 
-        assertEquals(MyClientFlow::class.java.name, result.name)
+        assertEquals(MyClientFlow::class.java.name, result.flowClass.name)
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
@@ -97,7 +97,7 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
         whenever(mockNotaryLookup.notaryServices).thenReturn(listOf(notaryService))
 
         assertThatThrownBy {
-            utxoLedgerService.getPluggableNotaryClientFlow(MemberX500Name.parse("O=ExampleNotaryService2, L=London, C=GB"))
+            utxoLedgerService.getPluggableNotaryDetails(MemberX500Name.parse("O=ExampleNotaryService2, L=London, C=GB"))
         }
             .isInstanceOf(CordaRuntimeException::class.java)
             .hasMessageContaining("has not been registered on the network")
@@ -140,7 +140,7 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
         whenever(mockFlowSandboxService.get(any(), any())).thenReturn(flowSandboxGroupContext)
 
         assertThatThrownBy {
-            utxoLedgerService.getPluggableNotaryClientFlow(notaryX500Name)
+            utxoLedgerService.getPluggableNotaryDetails(notaryX500Name)
         }
             .isInstanceOf(CordaRuntimeException::class.java)
             .hasMessageContaining("is invalid because it does not inherit from")
@@ -186,7 +186,7 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
         whenever(mockFlowSandboxService.get(any(), any())).thenReturn(flowSandboxGroupContext)
 
         assertThatThrownBy {
-            utxoLedgerService.getPluggableNotaryClientFlow(notaryX500Name)
+            utxoLedgerService.getPluggableNotaryDetails(notaryX500Name)
         }
             .isInstanceOf(CordaRuntimeException::class.java)
             .hasMessageContaining("Flow not found")
@@ -234,7 +234,7 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
         whenever(mockFlowSandboxService.get(any(), any())).thenReturn(flowSandboxGroupContext)
 
         assertThatThrownBy {
-            utxoLedgerService.getPluggableNotaryClientFlow(notaryX500Name)
+            utxoLedgerService.getPluggableNotaryDetails(notaryX500Name)
         }
             .isInstanceOf(CordaRuntimeException::class.java)
             .hasMessageContaining("Protocol version not found")
@@ -279,7 +279,7 @@ class UtxoLedgerServiceImplTest: UtxoLedgerTest() {
         whenever(mockFlowSandboxService.get(any(), any())).thenReturn(flowSandboxGroupContext)
 
         val result = assertDoesNotThrow {
-            utxoLedgerService.getPluggableNotaryClientFlow(notaryX500Name)
+            utxoLedgerService.getPluggableNotaryDetails(notaryX500Name)
         }
 
         assertEquals(MyClientFlow::class.java.name, result.flowClass.name)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowVersionedFlowFactoryTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/UtxoFinalityFlowVersionedFlowFactoryTest.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality
 
+import net.corda.ledger.utxo.flow.impl.PluggableNotaryDetails
 import net.corda.ledger.utxo.flow.impl.flows.finality.v1.UtxoFinalityFlowV1
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.libs.platform.PlatformVersion.CORDA_5_1
@@ -16,7 +17,10 @@ class UtxoFinalityFlowVersionedFlowFactoryTest {
     private val transaction = mock<UtxoSignedTransactionInternal>().apply {
         whenever(this.id).thenReturn(mock())
     }
-    private val factory = UtxoFinalityFlowVersionedFlowFactory(transaction, PluggableNotaryClientFlow::class.java)
+    private val pluggableNotaryDetails = mock<PluggableNotaryDetails>().apply {
+        whenever(this.flowClass).thenReturn(PluggableNotaryClientFlow::class.java)
+    }
+    private val factory = UtxoFinalityFlowVersionedFlowFactory(transaction, pluggableNotaryDetails)
 
     @Test
     fun `with platform version 1 throws a CordaRuntimeException`() {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -13,6 +13,7 @@ import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesExce
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.notary.worker.selection.NotaryVirtualNodeSelectorService
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
+import net.corda.ledger.utxo.flow.impl.PluggableNotaryDetails
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
@@ -126,6 +127,7 @@ class UtxoFinalityFlowV1Test {
     private val updatedTxAllSigs = mock<UtxoSignedTransactionInternal>()
     private val notarizedTx = mock<UtxoSignedTransactionInternal>()
 
+    private val pluggableNotaryDetails = mock<PluggableNotaryDetails>()
     private val pluggableNotaryClientFlow = mock<PluggableNotaryClientFlow>()
     private val ledgerTransaction = mock<UtxoLedgerTransaction>()
 
@@ -192,6 +194,8 @@ class UtxoFinalityFlowV1Test {
         whenever(stateAndRef.state).thenReturn(transactionState)
         whenever(transactionState.contractType).thenReturn(TestContact::class.java)
         whenever(transactionState.contractState).thenReturn(testState)
+
+        whenever(pluggableNotaryDetails.flowClass).thenReturn(pluggableNotaryClientFlow.javaClass)
     }
 
     @Test
@@ -1126,9 +1130,9 @@ class UtxoFinalityFlowV1Test {
         val flow = spy(UtxoFinalityFlowV1(
             signedTransaction,
             sessions,
-            pluggableNotaryClientFlow.javaClass
+            pluggableNotaryDetails
         ))
-
+//        doReturn(pluggableNotaryDetails).whenever(pluggableNotaryClientFlow.javaClass)
         doReturn(pluggableNotaryClientFlow).whenever(flow).newPluggableNotaryClientFlowInstance(any())
 
         flow.memberLookup = memberLookup

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -1132,7 +1132,7 @@ class UtxoFinalityFlowV1Test {
             sessions,
             pluggableNotaryDetails
         ))
-//        doReturn(pluggableNotaryDetails).whenever(pluggableNotaryClientFlow.javaClass)
+
         doReturn(pluggableNotaryClientFlow).whenever(flow).newPluggableNotaryClientFlowInstance(any())
 
         flow.memberLookup = memberLookup

--- a/components/ledger/notary-worker-selection-impl/src/test/kotlin/net/corda/ledger/notary/worker/selection/impl/NotaryVirtualNodeSelectorServiceImplTest.kt
+++ b/components/ledger/notary-worker-selection-impl/src/test/kotlin/net/corda/ledger/notary/worker/selection/impl/NotaryVirtualNodeSelectorServiceImplTest.kt
@@ -37,7 +37,8 @@ class NotaryVirtualNodeSelectorServiceImplTest {
                 notary,
                 null,
                 emptyList(),
-                emptyList()
+                emptyList(),
+                true
             )
             val mockMemberContext: MemberContext = mock {
                 on { entries } doReturn mapOf(

--- a/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/integrationTest/kotlin/net/corda/membership/impl/persistence/service/MembershipPersistenceTest.kt
@@ -56,6 +56,7 @@ import net.corda.membership.impl.persistence.service.dummy.TestVirtualNodeInfoRe
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.EPOCH_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MODIFIED_TIME_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MPV_KEY
+import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_KEYS_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_NAME_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_PROTOCOL_KEY
@@ -873,6 +874,7 @@ class MembershipPersistenceTest {
         val endpointUrl = "https://localhost:8080"
         val notaryServiceName = "O=New Service, L=London, C=GB"
         val notaryServicePlugin = "Notary Plugin"
+        val notaryBackchainRequired = true
         val notaryKey = generator.generateKeyPair().public
         val memberContext = notaryMemberContext(memberx500Name, groupId, endpointUrl, notaryServiceName, notaryServicePlugin, notaryKey)
         val mgmContext = KeyValuePairList(
@@ -895,6 +897,7 @@ class MembershipPersistenceTest {
         val expectedGroupParameters = listOf(
             KeyValuePair(EPOCH_KEY, "51"),
             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), notaryServiceName),
+            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), notaryBackchainRequired.toString()),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), notaryServicePlugin),
             KeyValuePair(String.format(NOTARY_SERVICE_KEYS_KEY, 0, 0), keyEncodingService.encodeAsString(notaryKey)),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
@@ -934,6 +937,7 @@ class MembershipPersistenceTest {
         val endpointUrl = "http://localhost:8080"
         val notaryServiceName = "O=New Service, L=London, C=GB"
         val notaryServicePlugin = "Notary Plugin"
+        val notaryBackchainRequired = true
         val generator = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider())
         val notaryKey = generator.generateKeyPair().public
         val notaryKeyAsString = keyEncodingService.encodeAsString(notaryKey)
@@ -967,6 +971,7 @@ class MembershipPersistenceTest {
                             KeyValuePair(EPOCH_KEY, "100"),
                             KeyValuePair(MODIFIED_TIME_KEY, clock.instant().toString()),
                             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), notaryServiceName),
+                            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), notaryBackchainRequired.toString()),
                             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), notaryServicePlugin),
                             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
                         )
@@ -981,6 +986,7 @@ class MembershipPersistenceTest {
         val expectedGroupParameters = listOf(
             KeyValuePair(EPOCH_KEY, "101"),
             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), notaryServiceName),
+            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), notaryBackchainRequired.toString()),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), notaryServicePlugin),
             KeyValuePair(String.format(NOTARY_SERVICE_KEYS_KEY, 0, 0), notaryKeyAsString),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
@@ -1022,6 +1028,7 @@ class MembershipPersistenceTest {
         val endpointUrl = "http://localhost:8080"
         val notaryServiceName = "O=New Service, L=London, C=GB"
         val notaryServicePlugin = "Notary Plugin"
+        val notaryBackchainRequired = true
         val notaryKey = with(keyGenerator) {
             generateKeyPair().public
         }
@@ -1083,6 +1090,7 @@ class MembershipPersistenceTest {
                             KeyValuePair(EPOCH_KEY, "150"),
                             KeyValuePair(MODIFIED_TIME_KEY, clock.instant().toString()),
                             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), notaryServiceName),
+                            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), notaryBackchainRequired.toString()),
                             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), notaryServicePlugin),
                             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
                             KeyValuePair(String.format(NOTARY_SERVICE_KEYS_KEY, 0, 0), oldNotaryKeyAsString)
@@ -1099,6 +1107,7 @@ class MembershipPersistenceTest {
         val expectedGroupParameters = listOf(
             KeyValuePair(EPOCH_KEY, "151"),
             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), notaryServiceName),
+            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), notaryBackchainRequired.toString()),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), notaryServicePlugin),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
             KeyValuePair(String.format(NOTARY_SERVICE_KEYS_KEY, 0, 0), oldNotaryKeyAsString),
@@ -1777,6 +1786,7 @@ class MembershipPersistenceTest {
         val memberX500Name = MemberX500Name.parse("O=Notary, C=GB, L=London")
         val notaryServiceName = "O=New Service, L=London, C=GB"
         val notaryPlugin = "Notary Plugin"
+        val notaryBackchainRequired = true
         val notaryPublicKey = generator.generateKeyPair().public
         val notaryVersions = listOf("1")
         val memberContext = notaryMemberContext(
@@ -1818,6 +1828,7 @@ class MembershipPersistenceTest {
         val updatedEpoch = 51
         val expectedGroupParameters = listOf(KeyValuePair(EPOCH_KEY, updatedEpoch.toString()),
             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), notaryServiceName),
+            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), notaryBackchainRequired.toString()),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), notaryPlugin),
             KeyValuePair(String.format(NOTARY_SERVICE_KEYS_KEY, 0, 0), keyEncodingService.encodeAsString(notaryPublicKey)),
             ) + notaryVersions.mapIndexed { i, version -> KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, i), version) }
@@ -1918,6 +1929,7 @@ class MembershipPersistenceTest {
         val notaryPublicKey = generator.generateKeyPair().public
         val notaryParameters = listOf(
             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), "O=New Service, L=London, C=GB"),
+            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), "true"),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), "Notary Plugin"),
             KeyValuePair(String.format(NOTARY_SERVICE_KEYS_KEY, 0, 0), keyEncodingService.encodeAsString(notaryPublicKey))
         ) + listOf("1").mapIndexed {

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
@@ -20,6 +20,7 @@ import net.corda.membership.datamodel.GroupParametersEntity
 import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.EPOCH_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MODIFIED_TIME_KEY
+import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_KEYS_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_NAME_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_PROTOCOL_KEY
@@ -294,8 +295,9 @@ class AddNotaryToGroupParametersHandlerTest {
                     KeyValuePair(String.format(NOTARY_SERVICE_KEYS_KEY, 0, 0), "test-key"),
                     KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), KNOWN_NOTARY_SERVICE),
                     KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), KNOWN_NOTARY_PROTOCOL),
+                    KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED, 0), "false"),
                     KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
-                    KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 1), "3"),
+                    KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 1), "3")
                 )
             )
         )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
@@ -297,7 +297,7 @@ class AddNotaryToGroupParametersHandlerTest {
                     KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), KNOWN_NOTARY_PROTOCOL),
                     KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), "false"),
                     KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
-                    KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 1), "3")
+                    KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 1), "3"),
                 )
             )
         )

--- a/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
+++ b/components/membership/membership-persistence-service-impl/src/test/kotlin/net/corda/membership/impl/persistence/service/handler/AddNotaryToGroupParametersHandlerTest.kt
@@ -20,7 +20,7 @@ import net.corda.membership.datamodel.GroupParametersEntity
 import net.corda.membership.datamodel.MemberInfoEntity
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.EPOCH_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MODIFIED_TIME_KEY
-import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
+import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_KEYS_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_NAME_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_PROTOCOL_KEY
@@ -295,7 +295,7 @@ class AddNotaryToGroupParametersHandlerTest {
                     KeyValuePair(String.format(NOTARY_SERVICE_KEYS_KEY, 0, 0), "test-key"),
                     KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, 0), KNOWN_NOTARY_SERVICE),
                     KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), KNOWN_NOTARY_PROTOCOL),
-                    KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED, 0), "false"),
+                    KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, 0), "false"),
                     KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
                     KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 1), "3")
                 )

--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/actions/ActionsTestUtils.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/actions/ActionsTestUtils.kt
@@ -94,7 +94,8 @@ private fun mockMemberContext(
             holdingIdentity.x500Name,
             "Notary Plugin A",
             listOf(1, 2),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         whenever(mock.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
     } else {

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/MemberRole.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/MemberRole.kt
@@ -4,6 +4,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_PEM
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_ROLE
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS
@@ -65,7 +66,8 @@ internal sealed class MemberRole {
             return Notary(
                 serviceName = MemberX500Name.parse(serviceName),
                 protocol = protocol,
-                protocolVersions = protocolVersions
+                protocolVersions = protocolVersions,
+                backchainRequired =  context[NOTARY_SERVICE_BACKCHAIN_REQUIRED].toBoolean()
             )
         }
     }
@@ -79,6 +81,7 @@ internal sealed class MemberRole {
         val serviceName: MemberX500Name,
         val protocol: String,
         val protocolVersions: Collection<Int>,
+        val backchainRequired: Boolean
     ) : MemberRole() {
         override fun toMemberInfo(
             notariesKeysFactory: () -> List<KeyDetails>,
@@ -99,7 +102,8 @@ internal sealed class MemberRole {
             return keys + versions + listOf(
                 "$ROLES_PREFIX.$index" to NOTARY_ROLE,
                 NOTARY_SERVICE_NAME to serviceName.toString(),
-                NOTARY_SERVICE_PROTOCOL to protocol
+                NOTARY_SERVICE_PROTOCOL to protocol,
+                NOTARY_SERVICE_BACKCHAIN_REQUIRED to backchainRequired.toString()
             )
         }
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/MemberRole.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/MemberRole.kt
@@ -63,13 +63,13 @@ internal sealed class MemberRole {
             val protocolVersions = NOTARY_SERVICE_PROTOCOL_VERSIONS.format("([0-9]+)").toRegex().let { regex ->
                 context.filter { it.key.matches(regex) }.mapTo(mutableSetOf()) { it.value.toInt() }
             }
-            val backchainRequired = context[NOTARY_SERVICE_BACKCHAIN_REQUIRED]?.toBoolean() ?: true
+            val isBackchainRequired = context[NOTARY_SERVICE_BACKCHAIN_REQUIRED]?.toBoolean() ?: true
 
             return Notary(
                 serviceName = MemberX500Name.parse(serviceName),
                 protocol = protocol,
                 protocolVersions = protocolVersions,
-                backchainRequired =  backchainRequired
+                isBackchainRequired =  isBackchainRequired
             )
         }
     }
@@ -83,7 +83,7 @@ internal sealed class MemberRole {
         val serviceName: MemberX500Name,
         val protocol: String,
         val protocolVersions: Collection<Int>,
-        val backchainRequired: Boolean
+        val isBackchainRequired: Boolean
     ) : MemberRole() {
         override fun toMemberInfo(
             notariesKeysFactory: () -> List<KeyDetails>,
@@ -105,7 +105,7 @@ internal sealed class MemberRole {
                 "$ROLES_PREFIX.$index" to NOTARY_ROLE,
                 NOTARY_SERVICE_NAME to serviceName.toString(),
                 NOTARY_SERVICE_PROTOCOL to protocol,
-                NOTARY_SERVICE_BACKCHAIN_REQUIRED to backchainRequired.toString()
+                NOTARY_SERVICE_BACKCHAIN_REQUIRED to isBackchainRequired.toString()
             )
         }
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/MemberRole.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/MemberRole.kt
@@ -63,11 +63,13 @@ internal sealed class MemberRole {
             val protocolVersions = NOTARY_SERVICE_PROTOCOL_VERSIONS.format("([0-9]+)").toRegex().let { regex ->
                 context.filter { it.key.matches(regex) }.mapTo(mutableSetOf()) { it.value.toInt() }
             }
+            val backchainRequired = context[NOTARY_SERVICE_BACKCHAIN_REQUIRED]?.toBoolean() ?: true
+
             return Notary(
                 serviceName = MemberX500Name.parse(serviceName),
                 protocol = protocol,
                 protocolVersions = protocolVersions,
-                backchainRequired =  context[NOTARY_SERVICE_BACKCHAIN_REQUIRED].toBoolean()
+                backchainRequired =  backchainRequired
             )
         }
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/MemberRoleTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/MemberRoleTest.kt
@@ -46,6 +46,7 @@ class MemberRoleTest {
                     MemberX500Name.parse("O=MyNotaryService, L=London, C=GB"),
                     "net.corda.notary.MyNotaryService",
                     setOf(1, 2),
+                    true
                 )
             }
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/MemberRoleTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/MemberRoleTest.kt
@@ -8,6 +8,7 @@ import net.corda.membership.impl.registration.MemberRole.Companion.toMemberInfo
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_HASH
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_PEM
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_SPEC
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS
@@ -34,6 +35,7 @@ class MemberRoleTest {
                 mapOf(
                     "${ROLES_PREFIX}.0" to "notary",
                     NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+                    NOTARY_SERVICE_BACKCHAIN_REQUIRED to "true",
                     NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
                     String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS, 0) to "1",
                     String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS, 1) to "2",
@@ -177,6 +179,7 @@ class MemberRoleTest {
             mapOf(
                 "${ROLES_PREFIX}.0" to "notary",
                 NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+                NOTARY_SERVICE_BACKCHAIN_REQUIRED to "true",
                 NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
                 String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS, 0) to "1",
                 String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS, 1) to "2",
@@ -191,6 +194,7 @@ class MemberRoleTest {
             .containsExactlyInAnyOrder(
                 "${ROLES_PREFIX}.0" to "notary",
                 NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+                NOTARY_SERVICE_BACKCHAIN_REQUIRED to "true",
                 NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
                 String.format(NOTARY_KEY_PEM, 0) to "pem1",
                 String.format(NOTARY_KEY_HASH, 0) to key1Hash.toString(),
@@ -199,7 +203,7 @@ class MemberRoleTest {
                 String.format(NOTARY_KEY_HASH, 1) to key2Hash.toString(),
                 String.format(NOTARY_KEY_SPEC, 1) to "SHA512withECDSA",
                 String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS, 0) to "1",
-                String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS, 1) to "2",
+                String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS, 1) to "2"
             )
     }
 }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/TestUtils.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/TestUtils.kt
@@ -40,7 +40,8 @@ object TestUtils {
                     holdingIdentity.x500Name,
                     "Notary Plugin A",
                     listOf(1, 2),
-                    listOf(mock())
+                    listOf(mock()),
+                    true
                 )
                 whenever(mock.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
             } else {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -665,7 +665,8 @@ class StartRegistrationHandlerTest {
             notaryServiceName,
             "Notary Plugin A",
             listOf(1),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
         whenever(
@@ -687,7 +688,8 @@ class StartRegistrationHandlerTest {
             notaryServiceName,
             null,
             emptyList(),
-            emptyList()
+            emptyList(),
+            true
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
 
@@ -704,7 +706,8 @@ class StartRegistrationHandlerTest {
             notaryServiceName,
             "Notary Plugin A",
             listOf(1),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
         whenever(
@@ -726,7 +729,8 @@ class StartRegistrationHandlerTest {
             notaryServiceName,
             " ",
             listOf(1),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
 
@@ -742,7 +746,8 @@ class StartRegistrationHandlerTest {
             notaryX500Name,
             "pluginType",
             listOf(1),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
 
@@ -758,7 +763,8 @@ class StartRegistrationHandlerTest {
             notaryX500Name,
             "Notary Protocol A",
             listOf(1),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
         val existingNotaryContext = mock<MemberContext> {
@@ -784,7 +790,8 @@ class StartRegistrationHandlerTest {
             notaryServiceName,
             "Notary Plugin A",
             listOf(1),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
         whenever(groupReader.groupParameters).thenReturn(null)
@@ -800,7 +807,8 @@ class StartRegistrationHandlerTest {
             aliceX500Name,
             "pluginType",
             listOf(1),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         val bobInfo: SelfSignedMemberInfo = mock {
             on { name } doReturn bobX500Name
@@ -1106,7 +1114,8 @@ class StartRegistrationHandlerTest {
             notaryServiceName,
             "Notary Protocol A",
             listOf(1),
-            listOf(mock())
+            listOf(mock()),
+            true
         )
         whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
         val existingNotaryContext = mock<MemberContext> {

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationServiceTest.kt
@@ -552,7 +552,8 @@ class StaticMemberRegistrationServiceTest {
                 notary,
                 null,
                 emptyList(),
-                emptyList()
+                emptyList(),
+                true
             )
             val mockMemberContext: MemberContext = mock {
                 on { entries } doReturn mapOf(
@@ -744,7 +745,8 @@ class StaticMemberRegistrationServiceTest {
                 notary,
                 null,
                 emptyList(),
-                emptyList()
+                emptyList(),
+                true
             )
             val mockMemberContext: MemberContext = mock {
                 on { entries } doReturn mapOf(

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.8-beta+
+cordaApiVersion=5.2.0.9-alpha-1700840877682
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.9-alpha-1700840877682
+cordaApiVersion=5.2.0.9-alpha-1701181436539
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.9-alpha-1701181436539
+cordaApiVersion=5.2.0.9-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
@@ -17,6 +17,7 @@ class GroupParametersNotaryUpdater(
         const val NOTARIES_KEY = "corda.notary.service."
         private const val NOTARY_SERVICE_KEY_PREFIX = "corda.notary.service.%s"
         const val NOTARY_SERVICE_NAME_KEY = "$NOTARY_SERVICE_KEY_PREFIX.name"
+        const val NOTARY_SERVICE_BACKCHAIN_REQUIRED = "$NOTARY_SERVICE_KEY_PREFIX.backchain.required"
         const val NOTARY_SERVICE_PROTOCOL_KEY = "$NOTARY_SERVICE_KEY_PREFIX.flow.protocol.name"
         const val NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY = "$NOTARY_SERVICE_KEY_PREFIX.flow.protocol.version.%s"
         const val NOTARY_SERVICE_KEYS_PREFIX = "$NOTARY_SERVICE_KEY_PREFIX.keys"
@@ -58,7 +59,11 @@ class GroupParametersNotaryUpdater(
                 )
             } + listOf(
             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, newNotaryServiceNumber), notaryServiceName),
-            KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, newNotaryServiceNumber), notaryDetails.serviceProtocol)
+            KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, newNotaryServiceNumber), notaryDetails.serviceProtocol),
+            KeyValuePair(
+                String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED, newNotaryServiceNumber),
+                notaryDetails.backchainRequired.toString()
+            )
         ) + protocolVersions
         val newEpoch = currentParameters[EPOCH_KEY]!!.toInt() + 1
         val parametersWithUpdatedEpoch = with(currentParameters) {

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
@@ -35,7 +35,7 @@ class GroupParametersNotaryUpdater(
         notaryDetails: MemberNotaryDetails,
     ): Pair<Int, KeyValuePairList> {
         val notaryServiceName = notaryDetails.serviceName.toString()
-        val notaryBackchainRequired = notaryDetails.backchainRequired ?: true
+        val notaryBackchainRequired = notaryDetails.backchainRequired
         logger.info("Adding notary to group parameters under new notary service '$notaryServiceName'.")
         requireNotNull(notaryDetails.serviceProtocol) {
             throw InvalidGroupParametersUpdateException("Cannot add notary to group parameters - notary protocol must be" +

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
@@ -17,7 +17,7 @@ class GroupParametersNotaryUpdater(
         const val NOTARIES_KEY = "corda.notary.service."
         private const val NOTARY_SERVICE_KEY_PREFIX = "corda.notary.service.%s"
         const val NOTARY_SERVICE_NAME_KEY = "$NOTARY_SERVICE_KEY_PREFIX.name"
-        const val NOTARY_SERVICE_BACKCHAIN_REQUIRED = "$NOTARY_SERVICE_KEY_PREFIX.backchain.required"
+        const val NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY = "$NOTARY_SERVICE_KEY_PREFIX.backchain.required"
         const val NOTARY_SERVICE_PROTOCOL_KEY = "$NOTARY_SERVICE_KEY_PREFIX.flow.protocol.name"
         const val NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY = "$NOTARY_SERVICE_KEY_PREFIX.flow.protocol.version.%s"
         const val NOTARY_SERVICE_KEYS_PREFIX = "$NOTARY_SERVICE_KEY_PREFIX.keys"
@@ -35,6 +35,7 @@ class GroupParametersNotaryUpdater(
         notaryDetails: MemberNotaryDetails,
     ): Pair<Int, KeyValuePairList> {
         val notaryServiceName = notaryDetails.serviceName.toString()
+        val notaryBackchainRequired = notaryDetails.backchainRequired ?: true
         logger.info("Adding notary to group parameters under new notary service '$notaryServiceName'.")
         requireNotNull(notaryDetails.serviceProtocol) {
             throw InvalidGroupParametersUpdateException("Cannot add notary to group parameters - notary protocol must be" +
@@ -61,8 +62,8 @@ class GroupParametersNotaryUpdater(
             KeyValuePair(String.format(NOTARY_SERVICE_NAME_KEY, newNotaryServiceNumber), notaryServiceName),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, newNotaryServiceNumber), notaryDetails.serviceProtocol),
             KeyValuePair(
-                String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED, newNotaryServiceNumber),
-                notaryDetails.backchainRequired.toString()
+                String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY, newNotaryServiceNumber),
+                notaryBackchainRequired.toString()
             )
         ) + protocolVersions
         val newEpoch = currentParameters[EPOCH_KEY]!!.toInt() + 1

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdater.kt
@@ -35,7 +35,7 @@ class GroupParametersNotaryUpdater(
         notaryDetails: MemberNotaryDetails,
     ): Pair<Int, KeyValuePairList> {
         val notaryServiceName = notaryDetails.serviceName.toString()
-        val notaryBackchainRequired = notaryDetails.backchainRequired
+        val notaryBackchainRequired = notaryDetails.isBackchainRequired
         logger.info("Adding notary to group parameters under new notary service '$notaryServiceName'.")
         requireNotNull(notaryDetails.serviceProtocol) {
             throw InvalidGroupParametersUpdateException("Cannot add notary to group parameters - notary protocol must be" +

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/MemberInfoExtension.kt
@@ -141,6 +141,7 @@ class MemberInfoExtension {
          */
         const val NOTARY_KEYS = "corda.notary.keys"
         const val NOTARY_SERVICE_NAME = "corda.notary.service.name"
+        const val NOTARY_SERVICE_BACKCHAIN_REQUIRED = "corda.notary.service.backchain.required"
         const val NOTARY_SERVICE_PROTOCOL = "corda.notary.service.flow.protocol.name"
         const val NOTARY_SERVICE_PROTOCOL_VERSIONS = "corda.notary.service.flow.protocol.version.%s"
         const val NOTARY_KEYS_ID = "corda.notary.keys.%s.id"

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/notary/MemberNotaryDetails.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/notary/MemberNotaryDetails.kt
@@ -6,5 +6,6 @@ data class MemberNotaryDetails(
     val serviceName: MemberX500Name,
     val serviceProtocol: String?,
     val serviceProtocolVersions: Collection<Int>,
-    val keys: Collection<MemberNotaryKey>
+    val keys: Collection<MemberNotaryKey>,
+    val backchainRequired: Boolean
 )

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/notary/MemberNotaryDetails.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/notary/MemberNotaryDetails.kt
@@ -7,5 +7,5 @@ data class MemberNotaryDetails(
     val serviceProtocol: String?,
     val serviceProtocolVersions: Collection<Int>,
     val keys: Collection<MemberNotaryKey>,
-    val backchainRequired: Boolean?
+    val backchainRequired: Boolean
 )

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/notary/MemberNotaryDetails.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/notary/MemberNotaryDetails.kt
@@ -7,5 +7,5 @@ data class MemberNotaryDetails(
     val serviceProtocol: String?,
     val serviceProtocolVersions: Collection<Int>,
     val keys: Collection<MemberNotaryKey>,
-    val backchainRequired: Boolean
+    val backchainRequired: Boolean?
 )

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/notary/MemberNotaryDetails.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/notary/MemberNotaryDetails.kt
@@ -7,5 +7,5 @@ data class MemberNotaryDetails(
     val serviceProtocol: String?,
     val serviceProtocolVersions: Collection<Int>,
     val keys: Collection<MemberNotaryKey>,
-    val backchainRequired: Boolean
+    val isBackchainRequired: Boolean
 )

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdaterTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdaterTest.kt
@@ -58,7 +58,7 @@ class GroupParametersNotaryUpdaterTest {
     fun `can add new notary service to group parameters`() {
         val publicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
-        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 3), listOf(notaryKey))
+        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 3), listOf(notaryKey), true)
         val (epoch, updatedGroupParameters) = notaryUpdater.addNewNotaryService(originalGroupParameters, notaryDetails)
 
         verify(keyEncodingService).encodeAsString(publicKey)
@@ -78,7 +78,7 @@ class GroupParametersNotaryUpdaterTest {
     fun `notary protocol must be specified to add new notary service`() {
         val publicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
-        val notaryToAdd = MemberNotaryDetails(notaryAx500Name, null, setOf(1, 3), listOf(notaryKey))
+        val notaryToAdd = MemberNotaryDetails(notaryAx500Name, null, setOf(1, 3), listOf(notaryKey), true)
 
         val ex = assertThrows<InvalidGroupParametersUpdateException> {
             notaryUpdater.addNewNotaryService(originalGroupParameters, notaryToAdd)
@@ -90,7 +90,7 @@ class GroupParametersNotaryUpdaterTest {
     fun `exception is thrown when adding new notary if notary protocol is specified but versions are missing`() {
         val publicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
-        val notaryToAdd = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, emptySet(), listOf(notaryKey))
+        val notaryToAdd = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, emptySet(), listOf(notaryKey), true)
 
         val ex = assertThrows<InvalidGroupParametersUpdateException> {
             notaryUpdater.addNewNotaryService(originalGroupParameters, notaryToAdd)
@@ -109,7 +109,7 @@ class GroupParametersNotaryUpdaterTest {
         )
         val publicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
-        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 3), listOf(notaryKey))
+        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 3), listOf(notaryKey), true)
 
         val (epoch, updatedGroupParameters) = notaryUpdater.updateExistingNotaryService(
             currentGroupParameters,
@@ -143,7 +143,7 @@ class GroupParametersNotaryUpdaterTest {
         )
         val publicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
-        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 3, 4), listOf(notaryKey))
+        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 3, 4), listOf(notaryKey), true)
 
         val (epoch, updatedGroupParameters) = notaryUpdater.updateExistingNotaryService(
             currentGroupParameters,
@@ -177,7 +177,7 @@ class GroupParametersNotaryUpdaterTest {
         )
         val publicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
-        val notaryDetails = MemberNotaryDetails(notaryAx500Name, "incorrect.plugin.type", emptySet(), listOf(notaryKey))
+        val notaryDetails = MemberNotaryDetails(notaryAx500Name, "incorrect.plugin.type", emptySet(), listOf(notaryKey), true)
 
         val ex = assertThrows<InvalidGroupParametersUpdateException> { notaryUpdater.updateExistingNotaryService(
             currentGroupParameters,
@@ -199,7 +199,7 @@ class GroupParametersNotaryUpdaterTest {
         )
         val publicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(publicKey, mock(), mock())
-        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, emptySet(), listOf(notaryKey))
+        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, emptySet(), listOf(notaryKey), true)
 
         val ex = assertThrows<InvalidGroupParametersUpdateException> { notaryUpdater.updateExistingNotaryService(
             currentGroupParameters,
@@ -219,7 +219,7 @@ class GroupParametersNotaryUpdaterTest {
             String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 5, 0) to "1",
             String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 5, 1) to "3",
         )
-        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 2, 3), emptyList())
+        val notaryDetails = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 2, 3), emptyList(), true)
 
         val (epoch, updatedGroupParameters) = notaryUpdater.updateExistingNotaryService(
             currentGroupParameters,
@@ -314,9 +314,9 @@ class GroupParametersNotaryUpdaterTest {
         val notaryToRemoveKey = MemberNotaryKey(notaryToRemovePublicKey, mock(), mock())
         val otherPublicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(otherPublicKey, mock(), mock())
-        val notaryToRemove = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 3), listOf(notaryToRemoveKey))
-        val otherNotary1 = MemberNotaryDetails(notaryBx500Name, NOTARY_PROTOCOL_A, setOf(1, 2, 3, 4, 5), listOf(notaryKey))
-        val otherNotary2 = MemberNotaryDetails(notaryCx500Name, NOTARY_PROTOCOL_A, setOf(1, 2, 3, 6, 7), listOf(notaryKey))
+        val notaryToRemove = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, setOf(1, 3), listOf(notaryToRemoveKey), true)
+        val otherNotary1 = MemberNotaryDetails(notaryBx500Name, NOTARY_PROTOCOL_A, setOf(1, 2, 3, 4, 5), listOf(notaryKey), true)
+        val otherNotary2 = MemberNotaryDetails(notaryCx500Name, NOTARY_PROTOCOL_A, setOf(1, 2, 3, 6, 7), listOf(notaryKey), true)
 
         val (epoch, updatedGroupParameters) = notaryUpdater.removeNotaryFromExistingNotaryService(
             currentGroupParameters,
@@ -352,9 +352,9 @@ class GroupParametersNotaryUpdaterTest {
         val notaryToRemoveKey = MemberNotaryKey(notaryToRemovePublicKey, mock(), mock())
         val otherPublicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(otherPublicKey, mock(), mock())
-        val notaryToRemove = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_B, setOf(1, 3), listOf(notaryToRemoveKey))
-        val otherNotary1 = MemberNotaryDetails(notaryBx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey))
-        val otherNotary2 = MemberNotaryDetails(notaryCx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey))
+        val notaryToRemove = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_B, setOf(1, 3), listOf(notaryToRemoveKey), true)
+        val otherNotary1 = MemberNotaryDetails(notaryBx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey), true)
+        val otherNotary2 = MemberNotaryDetails(notaryCx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey), true)
 
         val ex = assertThrows<InvalidGroupParametersUpdateException> { notaryUpdater.removeNotaryFromExistingNotaryService(
             currentGroupParameters,
@@ -376,9 +376,9 @@ class GroupParametersNotaryUpdaterTest {
         val notaryToRemoveKey = MemberNotaryKey(notaryToRemovePublicKey, mock(), mock())
         val otherPublicKey = mock<PublicKey>()
         val notaryKey = MemberNotaryKey(otherPublicKey, mock(), mock())
-        val notaryToRemove = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, emptySet(), listOf(notaryToRemoveKey))
-        val otherNotary1 = MemberNotaryDetails(notaryBx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey))
-        val otherNotary2 = MemberNotaryDetails(notaryCx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey))
+        val notaryToRemove = MemberNotaryDetails(notaryAx500Name, NOTARY_PROTOCOL_A, emptySet(), listOf(notaryToRemoveKey), true)
+        val otherNotary1 = MemberNotaryDetails(notaryBx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey), true)
+        val otherNotary2 = MemberNotaryDetails(notaryCx500Name, NOTARY_PROTOCOL_A, setOf(1), listOf(notaryKey), true)
 
         val ex = assertThrows<InvalidGroupParametersUpdateException> { notaryUpdater.removeNotaryFromExistingNotaryService(
             currentGroupParameters,

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdaterTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdaterTest.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.data.KeyValuePair
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.EPOCH_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MODIFIED_TIME_KEY
+import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_KEYS_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_NAME_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_PROTOCOL_KEY
@@ -71,6 +72,7 @@ class GroupParametersNotaryUpdaterTest {
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), NOTARY_PROTOCOL_A),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 1), "3"),
+            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED,  0), true.toString())
         )
     }
 

--- a/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdaterTest.kt
+++ b/libs/membership/membership-common/src/test/kotlin/net/corda/membership/lib/GroupParametersNotaryUpdaterTest.kt
@@ -4,7 +4,7 @@ import net.corda.crypto.cipher.suite.KeyEncodingService
 import net.corda.data.KeyValuePair
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.EPOCH_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.MODIFIED_TIME_KEY
-import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
+import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_KEYS_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_NAME_KEY
 import net.corda.membership.lib.GroupParametersNotaryUpdater.Companion.NOTARY_SERVICE_PROTOCOL_KEY
@@ -72,7 +72,7 @@ class GroupParametersNotaryUpdaterTest {
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_KEY, 0), NOTARY_PROTOCOL_A),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 0), "1"),
             KeyValuePair(String.format(NOTARY_SERVICE_PROTOCOL_VERSIONS_KEY, 0, 1), "3"),
-            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED,  0), true.toString())
+            KeyValuePair(String.format(NOTARY_SERVICE_BACKCHAIN_REQUIRED_KEY,  0), true.toString())
         )
     }
 

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverter.kt
@@ -23,6 +23,7 @@ class MemberNotaryDetailsConverter @Activate constructor(
 ) : CustomPropertyConverter<MemberNotaryDetails> {
     private companion object {
         const val SERVICE_NAME = "service.name"
+        const val SERVICE_BACKCHAIN_REQUIRED = "service.backchain.required"
         const val SERVICE_PROTOCOL = "service.flow.protocol.name"
         const val PROTOCOL_VERSIONS_PREFIX = "service.flow.protocol.version."
         const val KEYS_PREFIX = "keys."
@@ -36,6 +37,7 @@ class MemberNotaryDetailsConverter @Activate constructor(
 
     override fun convert(context: ConversionContext): MemberNotaryDetails {
         val serviceName = context.value(SERVICE_NAME) ?: throw ValueNotFoundException("'$SERVICE_NAME' is null or absent.")
+        val serviceBackchainRequired = context.value(SERVICE_BACKCHAIN_REQUIRED).toBoolean()
         val serviceProtocol = context.value(SERVICE_PROTOCOL)
         val serviceProtocolVersions = generateSequence(0) {
             it + 1
@@ -70,7 +72,8 @@ class MemberNotaryDetailsConverter @Activate constructor(
             serviceName = MemberX500Name.parse(serviceName),
             serviceProtocol = serviceProtocol,
             serviceProtocolVersions = serviceProtocolVersions,
-            keys = keys
+            keys = keys,
+            backchainRequired = serviceBackchainRequired
         )
     }
 }

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverter.kt
@@ -73,7 +73,7 @@ class MemberNotaryDetailsConverter @Activate constructor(
             serviceProtocol = serviceProtocol,
             serviceProtocolVersions = serviceProtocolVersions,
             keys = keys,
-            backchainRequired = serviceBackchainRequired
+            isBackchainRequired = serviceBackchainRequired
         )
     }
 }

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/MemberNotaryDetailsConverter.kt
@@ -37,7 +37,7 @@ class MemberNotaryDetailsConverter @Activate constructor(
 
     override fun convert(context: ConversionContext): MemberNotaryDetails {
         val serviceName = context.value(SERVICE_NAME) ?: throw ValueNotFoundException("'$SERVICE_NAME' is null or absent.")
-        val serviceBackchainRequired = context.value(SERVICE_BACKCHAIN_REQUIRED).toBoolean()
+        val serviceBackchainRequired = context.value(SERVICE_BACKCHAIN_REQUIRED)?.toBoolean() ?: true
         val serviceProtocol = context.value(SERVICE_PROTOCOL)
         val serviceProtocolVersions = generateSequence(0) {
             it + 1

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverter.kt
@@ -31,6 +31,7 @@ class NotaryInfoConverter @Activate constructor(
         const val PROTOCOL = "flow.protocol.name"
         const val PROTOCOL_VERSIONS_PREFIX = "flow.protocol.version"
         const val KEYS_PREFIX = "keys"
+        const val BACKCHAIN_REQUIRED = "backchain.required"
     }
 
     override val type = NotaryInfo::class.java
@@ -44,11 +45,14 @@ class NotaryInfoConverter @Activate constructor(
         val keysWithWeight = context.map.parseList(KEYS_PREFIX, PublicKey::class.java).map {
             CompositeKeyNodeAndWeight(it, 1)
         }
+        val backchainRequired = context.map.parseOrNull(BACKCHAIN_REQUIRED, Boolean::class.java)
+
         return NotaryInfoImpl(
             name,
             protocol,
             protocolVersions,
-            compositeKeyProvider.create(keysWithWeight, 1)
+            compositeKeyProvider.create(keysWithWeight, 1),
+            backchainRequired ?: true
         )
     }
 }
@@ -58,9 +62,11 @@ private data class NotaryInfoImpl(
     private val protocol: String,
     private val protocolVersions: Collection<Int>,
     private val publicKey: PublicKey,
+    private val backchainRequired: Boolean
 ) : NotaryInfo {
     override fun getName() = name
     override fun getProtocol() = protocol
     override fun getProtocolVersions() = protocolVersions
     override fun getPublicKey() = publicKey
+    override fun getBackchainRequired() = backchainRequired
 }

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverter.kt
@@ -45,14 +45,14 @@ class NotaryInfoConverter @Activate constructor(
         val keysWithWeight = context.map.parseList(KEYS_PREFIX, PublicKey::class.java).map {
             CompositeKeyNodeAndWeight(it, 1)
         }
-        val backchainRequired = context.map.parseOrNull(BACKCHAIN_REQUIRED, Boolean::class.java)
+        val backchainRequired = context.map[BACKCHAIN_REQUIRED]?.toBoolean() ?: true
 
         return NotaryInfoImpl(
             name,
             protocol,
             protocolVersions,
             compositeKeyProvider.create(keysWithWeight, 1),
-            backchainRequired ?: true
+            backchainRequired
         )
     }
 }

--- a/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverter.kt
+++ b/libs/membership/membership-impl/src/main/kotlin/net/corda/membership/lib/impl/converter/NotaryInfoConverter.kt
@@ -45,14 +45,14 @@ class NotaryInfoConverter @Activate constructor(
         val keysWithWeight = context.map.parseList(KEYS_PREFIX, PublicKey::class.java).map {
             CompositeKeyNodeAndWeight(it, 1)
         }
-        val backchainRequired = context.map[BACKCHAIN_REQUIRED]?.toBoolean() ?: true
+        val isBackchainRequired = context.map[BACKCHAIN_REQUIRED]?.toBoolean() ?: true
 
         return NotaryInfoImpl(
             name,
             protocol,
             protocolVersions,
             compositeKeyProvider.create(keysWithWeight, 1),
-            backchainRequired
+            isBackchainRequired
         )
     }
 }
@@ -62,11 +62,11 @@ private data class NotaryInfoImpl(
     private val protocol: String,
     private val protocolVersions: Collection<Int>,
     private val publicKey: PublicKey,
-    private val backchainRequired: Boolean
+    private val isBackchainRequired: Boolean
 ) : NotaryInfo {
     override fun getName() = name
     override fun getProtocol() = protocol
     override fun getProtocolVersions() = protocolVersions
     override fun getPublicKey() = publicKey
-    override fun getBackchainRequired() = backchainRequired
+    override fun isBackchainRequired() = isBackchainRequired
 }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -142,7 +142,7 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
         }
 
         require(currentNotaryBackchainRequired) {
-            "Non-validating notary can't switch bachchain verification off."
+            "Non-validating notary can't switch backchain verification off."
         }
     }
 

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -47,6 +47,8 @@ class NonValidatingNotaryServerFlowImplTest {
 
     private companion object {
         const val NOTARY_SERVICE_NAME = "corda.notary.service.name"
+        const val NOTARY_SERVICE_BACKCHAIN_REQUIRED = "corda.notary.service.backchain.required"
+
 
         /* Cache for storing response from server */
         val responseFromServer = mutableListOf<NotarizationResponse>()
@@ -337,6 +339,7 @@ class NonValidatingNotaryServerFlowImplTest {
         whenever(mockMemberLookup.myInfo()).thenReturn(notaryInfo)
         whenever(notaryInfo.memberProvidedContext).thenReturn(memberProvidedContext)
         whenever(memberProvidedContext.parse(NOTARY_SERVICE_NAME, MemberX500Name::class.java)).thenReturn(notaryServiceName)
+        whenever(memberProvidedContext.parse(NOTARY_SERVICE_BACKCHAIN_REQUIRED, Boolean::class.java)).thenReturn(true)
 
         // 3. Check if any filtered transaction data should be overwritten
         val filteredTx = mock<UtxoFilteredTransaction> {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -269,6 +269,7 @@ class ClusterBuilder {
     private fun registerNotaryBody(
         notaryServiceName: String,
         customMetadata: Map<String, String>,
+        isBackchainRequiredNotary: Boolean
     ): String {
         val context = (mapOf(
             "corda.key.scheme" to "CORDA.ECDSA.SECP256R1",
@@ -276,6 +277,7 @@ class ClusterBuilder {
             "corda.notary.service.name" to "$notaryServiceName",
             "corda.notary.service.flow.protocol.name" to "com.r3.corda.notary.plugin.nonvalidating",
             "corda.notary.service.flow.protocol.version.0" to "1",
+            "corda.notary.service.backchain.required" to "$isBackchainRequiredNotary"
         ) + customMetadata)
             .map { "\"${it.key}\" : \"${it.value}\"" }
             .joinToString()
@@ -399,9 +401,14 @@ class ClusterBuilder {
         holdingIdShortHash: String,
         notaryServiceName: String? = null,
         customMetadata: Map<String, String> = emptyMap(),
+        isBackchainRequiredNotary: Boolean = true
     ) = register(
         holdingIdShortHash,
-        if (notaryServiceName != null) registerNotaryBody(notaryServiceName, customMetadata) else registerMemberBody(
+        if (notaryServiceName != null) registerNotaryBody(
+            notaryServiceName,
+            customMetadata,
+            isBackchainRequiredNotary
+        ) else registerMemberBody(
             customMetadata
         )
     )

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -269,7 +269,7 @@ class ClusterBuilder {
     private fun registerNotaryBody(
         notaryServiceName: String,
         customMetadata: Map<String, String>,
-        isBackchainRequiredNotary: Boolean? = null
+        isBackchainRequiredNotary: Boolean? = true
     ): String {
         val context = (mapOf(
             "corda.key.scheme" to "CORDA.ECDSA.SECP256R1",

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -269,7 +269,7 @@ class ClusterBuilder {
     private fun registerNotaryBody(
         notaryServiceName: String,
         customMetadata: Map<String, String>,
-        isBackchainRequiredNotary: Boolean
+        isBackchainRequiredNotary: Boolean? = null
     ): String {
         val context = (mapOf(
             "corda.key.scheme" to "CORDA.ECDSA.SECP256R1",
@@ -401,7 +401,7 @@ class ClusterBuilder {
         holdingIdShortHash: String,
         notaryServiceName: String? = null,
         customMetadata: Map<String, String> = emptyMap(),
-        isBackchainRequiredNotary: Boolean = true
+        isBackchainRequiredNotary: Boolean? = null
     ) = register(
         holdingIdShortHash,
         if (notaryServiceName != null) registerNotaryBody(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -269,7 +269,7 @@ class ClusterBuilder {
     private fun registerNotaryBody(
         notaryServiceName: String,
         customMetadata: Map<String, String>,
-        isBackchainRequiredNotary: Boolean? = true
+        isBackchainRequiredNotary: Boolean = true
     ): String {
         val context = (mapOf(
             "corda.key.scheme" to "CORDA.ECDSA.SECP256R1",
@@ -401,7 +401,7 @@ class ClusterBuilder {
         holdingIdShortHash: String,
         notaryServiceName: String? = null,
         customMetadata: Map<String, String> = emptyMap(),
-        isBackchainRequiredNotary: Boolean? = null
+        isBackchainRequiredNotary: Boolean = true
     ) = register(
         holdingIdShortHash,
         if (notaryServiceName != null) registerNotaryBody(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -155,7 +155,8 @@ fun ClusterInfo.onboardNotaryMember(
     wait: Boolean = true,
     getAdditionalContext: ((holdingId: String) -> Map<String, String>)? = null,
     tlsCertificateUploadedCallback: (String) -> Unit = {},
-    notaryServiceName: String = DEFAULT_NOTARY_SERVICE
+    notaryServiceName: String = DEFAULT_NOTARY_SERVICE,
+    backchainRequired: Boolean = true
 ) = onboardMember(
     resourceName,
     cpiName,
@@ -169,6 +170,7 @@ fun ClusterInfo.onboardNotaryMember(
         mapOf(
             "corda.roles.0" to "notary",
             "corda.notary.service.name" to MemberX500Name.parse(notaryServiceName).toString(),
+            "corda.notary.service.backchain.required" to "$backchainRequired",
             "corda.notary.service.flow.protocol.name" to "com.r3.corda.notary.plugin.nonvalidating",
             "corda.notary.service.flow.protocol.version.0" to "1",
             "corda.notary.keys.0.id" to notaryKeyId,

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -291,20 +291,22 @@ fun registerStaticMember(
     holdingIdentityShortHash: String,
     notaryServiceName: String? = null,
     customMetadata: Map<String, String> = emptyMap(),
-) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata)
+    backchainRequired: Boolean?
+) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata, backchainRequired)
 
 val memberRegisterLock = ReentrantLock()
 fun ClusterInfo.registerStaticMember(
     holdingIdentityShortHash: String,
     notaryServiceName: String? = null,
     customMetadata: Map<String, String> = emptyMap(),
+    backchainRequired: Boolean?
 ) {
     cluster {
         memberRegisterLock.withLock {
             assertWithRetry {
                 interval(1.seconds)
                 timeout(10.seconds)
-                command { registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata) }
+                command { registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata, backchainRequired) }
                 condition {
                     it.code == ResponseCode.OK.statusCode
                             && it.toJson()["registrationStatus"].textValue() == REGISTRATION_SUBMITTED

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -156,7 +156,7 @@ fun ClusterInfo.onboardNotaryMember(
     getAdditionalContext: ((holdingId: String) -> Map<String, String>)? = null,
     tlsCertificateUploadedCallback: (String) -> Unit = {},
     notaryServiceName: String = DEFAULT_NOTARY_SERVICE,
-    backchainRequired: Boolean = true
+    isBackchainRequired: Boolean = true
 ) = onboardMember(
     resourceName,
     cpiName,
@@ -170,7 +170,7 @@ fun ClusterInfo.onboardNotaryMember(
         mapOf(
             "corda.roles.0" to "notary",
             "corda.notary.service.name" to MemberX500Name.parse(notaryServiceName).toString(),
-            "corda.notary.service.backchain.required" to "$backchainRequired",
+            "corda.notary.service.backchain.required" to "$isBackchainRequired",
             "corda.notary.service.flow.protocol.name" to "com.r3.corda.notary.plugin.nonvalidating",
             "corda.notary.service.flow.protocol.version.0" to "1",
             "corda.notary.keys.0.id" to notaryKeyId,
@@ -291,22 +291,22 @@ fun registerStaticMember(
     holdingIdentityShortHash: String,
     notaryServiceName: String? = null,
     customMetadata: Map<String, String> = emptyMap(),
-    backchainRequired: Boolean = true
-) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata, backchainRequired)
+    isBackchainRequired: Boolean = true
+) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata, isBackchainRequired)
 
 val memberRegisterLock = ReentrantLock()
 fun ClusterInfo.registerStaticMember(
     holdingIdentityShortHash: String,
     notaryServiceName: String? = null,
     customMetadata: Map<String, String> = emptyMap(),
-    backchainRequired: Boolean = true
+    isBackchainRequired: Boolean = true
 ) {
     cluster {
         memberRegisterLock.withLock {
             assertWithRetry {
                 interval(1.seconds)
                 timeout(10.seconds)
-                command { registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata, backchainRequired) }
+                command { registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata, isBackchainRequired) }
                 condition {
                     it.code == ResponseCode.OK.statusCode
                             && it.toJson()["registrationStatus"].textValue() == REGISTRATION_SUBMITTED

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -291,7 +291,7 @@ fun registerStaticMember(
     holdingIdentityShortHash: String,
     notaryServiceName: String? = null,
     customMetadata: Map<String, String> = emptyMap(),
-    backchainRequired: Boolean?
+    backchainRequired: Boolean = true
 ) = DEFAULT_CLUSTER.registerStaticMember(holdingIdentityShortHash, notaryServiceName, customMetadata, backchainRequired)
 
 val memberRegisterLock = ReentrantLock()
@@ -299,7 +299,7 @@ fun ClusterInfo.registerStaticMember(
     holdingIdentityShortHash: String,
     notaryServiceName: String? = null,
     customMetadata: Map<String, String> = emptyMap(),
-    backchainRequired: Boolean?
+    backchainRequired: Boolean = true
 ) {
     cluster {
         memberRegisterLock.withLock {

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
@@ -11,6 +11,7 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEY_SIGNATURE_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEYS_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_SPEC
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS
@@ -170,9 +171,12 @@ class OnboardMember : Runnable, BaseOnboard() {
             val notaryServiceName = customProperties[NOTARY_SERVICE_NAME] ?:
                 throw IllegalArgumentException("When specifying a NOTARY role, " +
                         "you also need to specify a custom property for its name under $NOTARY_SERVICE_NAME.")
+            val backchainRequired = customProperties[NOTARY_SERVICE_BACKCHAIN_REQUIRED] ?: true
+            val notaryProtocol = customProperties[NOTARY_SERVICE_PROTOCOL] ?: "com.r3.corda.notary.plugin.nonvalidating"
             mapOf(
                 NOTARY_SERVICE_NAME to notaryServiceName,
-                NOTARY_SERVICE_PROTOCOL to "com.r3.corda.notary.plugin.nonvalidating",
+                NOTARY_SERVICE_BACKCHAIN_REQUIRED to "$backchainRequired",
+                NOTARY_SERVICE_PROTOCOL to notaryProtocol,
                 NOTARY_SERVICE_PROTOCOL_VERSIONS.format("0") to "1",
                 NOTARY_KEYS_ID.format("0") to notaryKeyId,
                 NOTARY_KEY_SPEC.format("0") to "SHA256withECDSA"

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
@@ -171,11 +171,11 @@ class OnboardMember : Runnable, BaseOnboard() {
             val notaryServiceName = customProperties[NOTARY_SERVICE_NAME] ?:
                 throw IllegalArgumentException("When specifying a NOTARY role, " +
                         "you also need to specify a custom property for its name under $NOTARY_SERVICE_NAME.")
-            val backchainRequired = customProperties[NOTARY_SERVICE_BACKCHAIN_REQUIRED] ?: true
+            val isBackchainRequired = customProperties[NOTARY_SERVICE_BACKCHAIN_REQUIRED] ?: true
             val notaryProtocol = customProperties[NOTARY_SERVICE_PROTOCOL] ?: "com.r3.corda.notary.plugin.nonvalidating"
             mapOf(
                 NOTARY_SERVICE_NAME to notaryServiceName,
-                NOTARY_SERVICE_BACKCHAIN_REQUIRED to "$backchainRequired",
+                NOTARY_SERVICE_BACKCHAIN_REQUIRED to "$isBackchainRequired",
                 NOTARY_SERVICE_PROTOCOL to notaryProtocol,
                 NOTARY_SERVICE_PROTOCOL_VERSIONS.format("0") to "1",
                 NOTARY_KEYS_ID.format("0") to notaryKeyId,


### PR DESCRIPTION
To be able to implement a contract verifying notary which allows skipping backchain and does contract verification within notary, we need to have a `backchainRequired` flag and register the notary with this flag. This PR added the flag in membership registration and cascaded the field with respect to it.

The `backchainRequired` field is `true` in default, considering a non-validating notary to be the default notary, which requires backchain resolution.

API repo: https://github.com/corda/corda-api/pull/1362