### PR TITLE
CORE-16150 - Add message rate metrics for session messages

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -32,6 +32,7 @@ import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.data.p2p.markers.LinkManagerReceivedMarker
 import net.corda.p2p.linkmanager.metrics.recordInboundMessagesMetric
+import net.corda.p2p.linkmanager.metrics.recordInboundSessionMessagesMetric
 import net.corda.schema.Schemas
 import net.corda.tracing.traceEventProcessing
 import net.corda.utilities.debug
@@ -104,6 +105,7 @@ internal class InboundMessageProcessor(
     private fun processSessionMessage(message: LinkInMessage): List<Record<String, *>> {
         val response = sessionManager.processSessionMessage(message)
         return if (response != null) {
+            recordInboundSessionMessagesMetric(response.header.sourceIdentity, response.header.destinationIdentity)
             when (val payload = message.payload) {
                 is InitiatorHelloMessage -> {
                     val partitionsAssigned =

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -104,6 +104,7 @@ internal class InboundMessageProcessor(
     }
 
     private fun processSessionMessage(message: LinkInMessage): List<Record<String, *>> {
+        recordInboundSessionMessagesMetric()
         val response = sessionManager.processSessionMessage(message)
         return if (response != null) {
             val records = when (val payload = message.payload) {
@@ -136,7 +137,6 @@ internal class InboundMessageProcessor(
                 }
             }
             if (records.isNotEmpty()) {
-                recordInboundSessionMessagesMetric(response.header.destinationIdentity, response.header.sourceIdentity)
                 recordOutboundSessionMessagesMetric(response.header.sourceIdentity, response.header.destinationIdentity)
             }
             records

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
@@ -57,10 +57,8 @@ fun recordInboundMessagesMetric(message: InboundUnauthenticatedMessage) {
         message.header.subsystem, message::class.java.simpleName)
 }
 
-fun recordInboundSessionMessagesMetric(sourceVnode: net.corda.data.identity.HoldingIdentity,
-                                       destinationVnode: net.corda.data.identity.HoldingIdentity) {
-    recordInboundMessagesMetric(sourceVnode.x500Name, destinationVnode.x500Name, sourceVnode.groupId,
-        P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
+fun recordInboundSessionMessagesMetric() {
+    recordInboundMessagesMetric(null, null, null, P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
 }
 
 private fun recordInboundMessagesMetric(source: String?, dest: String?, group: String?, subsystem: String, messageType: String) {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
@@ -29,6 +29,12 @@ fun recordOutboundSessionMessagesMetric(sourceVnode: HoldingIdentity, destinatio
         P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
 }
 
+fun recordOutboundSessionMessagesMetric(sourceVnode: net.corda.data.identity.HoldingIdentity,
+                                        destinationVnode: net.corda.data.identity.HoldingIdentity) {
+    recordOutboundMessagesMetric(sourceVnode.x500Name, destinationVnode.x500Name, sourceVnode.groupId,
+        P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
+}
+
 fun recordOutboundMessagesMetric(source: String, dest: String, group: String, subsystem: String, messageType: String) {
     CordaMetrics.Metric.OutboundMessageCount.builder()
         .withTag(CordaMetrics.Tag.SourceVirtualNode, source)

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
@@ -2,8 +2,42 @@ package net.corda.p2p.linkmanager.metrics
 
 import net.corda.data.p2p.app.AuthenticatedMessage
 import net.corda.data.p2p.app.InboundUnauthenticatedMessage
+import net.corda.data.p2p.app.OutboundUnauthenticatedMessage
 import net.corda.metrics.CordaMetrics
 import net.corda.metrics.CordaMetrics.NOT_APPLICABLE_TAG_VALUE
+import net.corda.virtualnode.HoldingIdentity
+
+const val P2P_SUBSYSTEM = "p2p"
+const val SESSION_MESSAGE_TYPE = "SessionMessage"
+
+fun recordOutboundMessagesMetric(message: AuthenticatedMessage) {
+    message.header.let {
+        recordOutboundMessagesMetric(it.source.x500Name, it.destination.x500Name, it.source.groupId,
+            it.subsystem, message::class.java.simpleName)
+    }
+}
+
+fun recordOutboundMessagesMetric(message: OutboundUnauthenticatedMessage) {
+    message.header.let {
+        recordOutboundMessagesMetric(it.source.x500Name, it.destination.x500Name, it.source.groupId,
+            it.subsystem, message::class.java.simpleName)
+    }
+}
+
+fun recordOutboundSessionMessagesMetric(sourceVnode: HoldingIdentity, destinationVnode: HoldingIdentity) {
+    recordOutboundMessagesMetric(sourceVnode.x500Name.toString(), destinationVnode.x500Name.toString(), sourceVnode.groupId,
+        P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
+}
+
+fun recordOutboundMessagesMetric(source: String, dest: String, group: String, subsystem: String, messageType: String) {
+    CordaMetrics.Metric.OutboundMessageCount.builder()
+        .withTag(CordaMetrics.Tag.SourceVirtualNode, source)
+        .withTag(CordaMetrics.Tag.DestinationVirtualNode, dest)
+        .withTag(CordaMetrics.Tag.MembershipGroup, group)
+        .withTag(CordaMetrics.Tag.MessagingSubsystem, subsystem)
+        .withTag(CordaMetrics.Tag.MessageType, messageType)
+        .build().increment()
+}
 
 fun recordInboundMessagesMetric(message: AuthenticatedMessage) {
     message.header.let {
@@ -15,6 +49,12 @@ fun recordInboundMessagesMetric(message: AuthenticatedMessage) {
 fun recordInboundMessagesMetric(message: InboundUnauthenticatedMessage) {
     recordInboundMessagesMetric(null, null, null,
         message.header.subsystem, message::class.java.simpleName)
+}
+
+fun recordInboundSessionMessagesMetric(sourceVnode: net.corda.data.identity.HoldingIdentity,
+                                       destinationVnode: net.corda.data.identity.HoldingIdentity) {
+    recordInboundMessagesMetric(sourceVnode.x500Name, destinationVnode.x500Name, sourceVnode.groupId,
+        P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
 }
 
 private fun recordInboundMessagesMetric(source: String?, dest: String?, group: String?, subsystem: String, messageType: String) {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -77,7 +77,9 @@ internal class OutboundMessageProcessor(
                 )
                 emptyList()
             } else {
-                state.messages.forEach { recordOutboundSessionMessagesMetric(state.sessionCounterparties.ourId, state.sessionCounterparties.counterpartyId) }
+                state.messages.forEach {
+                    recordOutboundSessionMessagesMetric(state.sessionCounterparties.ourId, state.sessionCounterparties.counterpartyId)
+                }
                 state.messages.flatMap {
                     listOf(
                         Record(Schemas.P2P.LINK_OUT_TOPIC, LinkManager.generateKey(), it.second),

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -77,7 +77,7 @@ internal class OutboundMessageProcessor(
                 )
                 emptyList()
             } else {
-                recordOutboundSessionMessagesMetric(state.sessionCounterparties.ourId, state.sessionCounterparties.counterpartyId)
+                state.messages.forEach { recordOutboundSessionMessagesMetric(state.sessionCounterparties.ourId, state.sessionCounterparties.counterpartyId) }
                 state.messages.flatMap {
                     listOf(
                         Record(Schemas.P2P.LINK_OUT_TOPIC, LinkManager.generateKey(), it.second),

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
@@ -9,6 +9,7 @@ import net.corda.data.p2p.LinkInMessage
 import net.corda.data.p2p.LinkOutHeader
 import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.MessageAck
+import net.corda.data.p2p.NetworkType
 import net.corda.data.p2p.SessionPartitions
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.AuthenticatedMessage
@@ -823,7 +824,8 @@ class InboundMessageProcessorTest {
         fun `non null responses from sessionManager will produce link out message`() {
             val handshake = ResponderHandshakeMessage()
             val message = LinkInMessage(handshake)
-            val response = LinkOutMessage(LinkOutHeader(), handshake)
+            val header = LinkOutHeader(myIdentity.toAvro(), remoteIdentity.toAvro(), NetworkType.CORDA_5, "https://example.com")
+            val response = LinkOutMessage(header, handshake)
             whenever(sessionManager.processSessionMessage(message)).thenReturn(response)
 
             val records = processor.onNext(
@@ -844,7 +846,8 @@ class InboundMessageProcessorTest {
                 on { header } doReturn commonHeader
             }
             val message = LinkInMessage(hello)
-            val response = LinkOutMessage(LinkOutHeader(), hello)
+            val header = LinkOutHeader(myIdentity.toAvro(), remoteIdentity.toAvro(), NetworkType.CORDA_5, "https://example.com")
+            val response = LinkOutMessage(header, hello)
             whenever(sessionManager.processSessionMessage(message)).thenReturn(response)
             whenever(assignedListener.getCurrentlyAssignedPartitions()).thenReturn(emptySet())
 
@@ -868,7 +871,8 @@ class InboundMessageProcessorTest {
                 on { header } doReturn commonHeader
             }
             val message = LinkInMessage(hello)
-            val response = LinkOutMessage(LinkOutHeader(), hello)
+            val header = LinkOutHeader(myIdentity.toAvro(), remoteIdentity.toAvro(), NetworkType.CORDA_5, "https://example.com")
+            val response = LinkOutMessage(header, hello)
             whenever(sessionManager.processSessionMessage(message)).thenReturn(response)
             whenever(assignedListener.getCurrentlyAssignedPartitions()).thenReturn(setOf(4, 5, 8))
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
@@ -75,6 +75,8 @@ class OutboundMessageProcessorTest {
     }
     private val serialNumber = 1L
     private val sessionCounterparties = mock<SessionManager.SessionCounterparties> {
+        on { ourId } doReturn myIdentity
+        on { counterpartyId } doReturn remoteIdentity
         on { serial } doReturn serialNumber
     }
 


### PR DESCRIPTION
## Changes
Adding inbound/outbound message rate metrics for session messages.

## Testing
Performed a small multi-cluster test run: https://ci02.dev.r3.com/job/Corda5/job/Large%20Network%20Tests/job/PR-69/196/
The dashboards seem to be picking up the data without any further changes needed.

<img width="1138" alt="session_dashboards_2" src="https://github.com/corda/corda-runtime-os/assets/6065016/5abc591b-b049-4289-bdd8-c04e04994ed1">


