### PR TITLE
CORE-18029: Batch delete states in the state manager

### DIFF
--- a/libs/state-manager/state-manager-db-impl/src/integrationTest/kotlin/net/corda/libs/statemanager/impl/tests/StateManagerIntegrationTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/integrationTest/kotlin/net/corda/libs/statemanager/impl/tests/StateManagerIntegrationTest.kt
@@ -379,6 +379,17 @@ class StateManagerIntegrationTest {
     }
 
     @Test
+    fun `delete returns empty collection of keys if the states were never present`() {
+        val statesToDelete = (1..20).map {
+            State(buildStateKey(it), "".toByteArray(), it)
+        }
+        // Double check that the states we're requesting do not exist.
+        assertThat(stateManager.get(statesToDelete.map { it.key })).isEmpty()
+        val failed = stateManager.delete(statesToDelete)
+        assertThat(failed).isEmpty()
+    }
+
+    @Test
     fun `optimistic locking prevents sequentially deleting states with mismatched versions and does not halt entire batch`() {
         val totalCount = 20
         persistStateEntities(

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
@@ -102,8 +102,12 @@ class StateManagerImpl(
             return if (failedDeletes.isEmpty()) {
                 emptyMap()
             } else {
-                logger.warn("Optimistic locking check failed while deleting States ${failedDeletes.joinToString()}")
-                get(failedDeletes)
+                get(failedDeletes).also {
+                    if (it.isNotEmpty()) {
+                        logger.warn("Optimistic locking check failed while deleting States" +
+                                " ${failedDeletes.joinToString()}")
+                    }
+                }
             }
         } catch (e: Exception) {
             logger.warn("Failed to delete batch of states - ${states.joinToString { it.key }}", e)

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/StateRepository.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/StateRepository.kt
@@ -54,6 +54,9 @@ interface StateRepository {
      * Delete states with the given keys.
      * Transaction should be controlled by the caller.
      *
+     * Note that if the underlying provider isn't sure whether the delete was successful, the repository should behave
+     * as if it failed. The state manager must double-check any failures reported by the repository.
+     *
      * @param connection The JDBC connection used to interact with the database.
      * @param states Collection of states to be deleted.
      * @return Collection of keys for states that could not be deleted due to optimistic locking check failure.

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImpl.kt
@@ -8,7 +8,7 @@ import net.corda.libs.statemanager.impl.repository.StateRepository
 import java.sql.Connection
 import java.sql.Timestamp
 
-// TODO-[CORE-18029 / CORE-18030]: batch delete and create.
+// TODO-[CORE-18030]: batch create.
 class StateRepositoryImpl(private val queryProvider: QueryProvider) : StateRepository {
 
     override fun create(connection: Connection, state: StateEntity) {

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImpl.kt
@@ -65,7 +65,7 @@ class StateRepositoryImpl(private val queryProvider: QueryProvider) : StateRepos
                 statement.addBatch()
             }
             statement.executeBatch().zip(statesOrdered).mapNotNull { (count, state) ->
-                if (count == 0) {
+                if (count <= 0) {
                     state.key
                 } else {
                     null

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImpl.kt
@@ -64,6 +64,9 @@ class StateRepositoryImpl(private val queryProvider: QueryProvider) : StateRepos
                 statement.setInt(2, state.version)
                 statement.addBatch()
             }
+            // For the delete case, it's safe to return anything other than a row update count of 1 as failed. The state
+            // manager must check any returned failed deletes regardless to verify that the call did not request
+            // removal of a state that never existed.
             statement.executeBatch().zip(statesOrdered).mapNotNull { (count, state) ->
                 if (count <= 0) {
                     state.key

--- a/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImplTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/repository/impl/StateRepositoryImplTest.kt
@@ -1,0 +1,47 @@
+package net.corda.libs.statemanager.impl.repository.impl
+
+import net.corda.libs.statemanager.impl.model.v1.StateEntity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.Statement.EXECUTE_FAILED
+import java.sql.Statement.SUCCESS_NO_INFO
+
+class StateRepositoryImplTest {
+
+    private val queryProvider = mock<QueryProvider>()
+    private val connection = mock<Connection>()
+    private val statement = mock<PreparedStatement>()
+
+    @BeforeEach
+    fun setup() {
+        whenever(connection.prepareStatement(any())).thenReturn(statement)
+    }
+
+    @Test
+    fun `delete returns inputs as failed if they hit a JDBC error`() {
+        val states = createStates(4)
+        whenever(statement.executeBatch()).thenReturn(
+            arrayOf(1, 0, SUCCESS_NO_INFO, EXECUTE_FAILED).toIntArray()
+        )
+        whenever(queryProvider.deleteStatesByKey).thenReturn("")
+        val repository = StateRepositoryImpl(queryProvider)
+        val failed = repository.delete(connection, states)
+        assertThat(failed.size).isEqualTo(3)
+    }
+
+    private fun createStates(numStates: Int) : Collection<StateEntity> {
+        return (1..numStates).map {
+            StateEntity(
+                "foo_$it",
+                "".toByteArray(),
+                ""
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Problem description

When the state manager is asked to delete states, it does this one at a time. This means many more database interactions than is required.

### Solution

Delete the full batch of requested states in a single statement executed as a batch.

If an individual state is deleted, the index of that state in the returned array will have a value of 1. A value of 0 or less indicates that either the state was never there, the optimistic lock check failed, or a driver error occurred. The repository treats all these the same and reports the keys as failed. The state manager then does a lookup of any failed keys to see if they exist. The client is only informed of those keys that are still present within the state manager.