### PR TITLE
CORE-18470: Change key of kafka message to random uuid

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -56,14 +56,13 @@ class KeyRotationRestResourceImpl @Activate constructor(
     override val targetInterface: Class<KeyRotationRestResource> = KeyRotationRestResource::class.java
     override val protocolVersion: Int = platformInfoProvider.localWorkerPlatformVersion
 
-    private val requestId = UUID.randomUUID().toString()
     @VisibleForTesting
     fun initialise(config: Map<String, SmartConfig>) {
         val messagingConfig = config.getConfig(ConfigKeys.MESSAGING_CONFIG)
 
         // Initialise publisher with messaging config
         publisher?.close()
-        val newPublisher = publisherFactory.createPublisher(PublisherConfig(requestId, false), messagingConfig)
+        val newPublisher = publisherFactory.createPublisher(PublisherConfig("KeyRotationRestResource", false), messagingConfig)
         newPublisher.start()
         publisher = newPublisher
     }
@@ -79,6 +78,7 @@ class KeyRotationRestResourceImpl @Activate constructor(
 
         // We need to create a Record that tells Crypto processor to do key rotation
         // Do we need to start the publisher? FlowRestResource is not starting its publisher for some reason
+        val requestId = UUID.randomUUID().toString()
 
         val keyRotationRequest = KeyRotationRequest(
             requestId,

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -13,6 +13,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Crypto.REWRAP_MESSAGE_TOPIC
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 /**
  * This processor goes through the databases and find out what keys need re-wrapping.
@@ -64,7 +65,7 @@ class CryptoRekeyBusProcessor(
                 targetWrappingKeys.map { (tenantId, wrappingKeyInfo) ->
                     Record(
                         REWRAP_MESSAGE_TOPIC,
-                        request.requestId,
+                        UUID.randomUUID().toString(),
                         IndividualKeyRotationRequest(request.requestId,
                             tenantId,
                             request.oldParentKeyAlias,


### PR DESCRIPTION
This ensures the work is evenly spread between Kafka partitions during key rotation.