### PR TITLE
CORE-18581 - SM.update() returns null for state keys that don't exist

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -223,13 +223,18 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
                 val failedToCreate = stateManager.get(failedToCreateKeys.keys)
                 val failedToDelete = stateManager.delete(statesToDelete.values.mapNotNull { it })
                 val failedToUpdate = stateManager.update(statesToUpdate.values.mapNotNull { it })
-                states = failedToCreate + failedToDelete + failedToUpdate
+                val failedToUpdateOptimisticLockFailure = failedToUpdate.mapNotNull { (key, value) -> value?.let { key to it } }.toMap()
+                val failedToUpdateStateDoesNotExist = (failedToUpdate - failedToUpdateOptimisticLockFailure).map { it.key }
+
+                states = failedToCreate + failedToDelete + failedToUpdateOptimisticLockFailure
+
                 groups = if (states.isNotEmpty()) {
                     allocateGroups(flowEvents.filterKeys { states.containsKey(it) }.values.flatten())
                 } else {
                     listOf()
                 }
                 states.keys.forEach { asynchronousOutputs.remove(it) }
+                failedToUpdateStateDoesNotExist.forEach { asynchronousOutputs.remove(it) }
                 sendAsynchronousEvents(asynchronousOutputs.values.flatten())
             }
             metrics.commitTimer.recordCallable {

--- a/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/StateManager.kt
+++ b/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/StateManager.kt
@@ -58,9 +58,10 @@ interface StateManager : Lifecycle {
      *
      * @param states Collection of states to be updated.
      * @return Map with the most up-to-date version of the states, associated by key for easier access, that failed
-     *      the optimistic locking check.
+     *      the optimistic locking check. If this state failed to be updated because the key was deleted the key is
+     *      associated with null.
      */
-    fun update(states: Collection<State>): Map<String, State>
+    fun update(states: Collection<State>): Map<String, State?>
 
     /**
      * Delete existing [states].

--- a/libs/state-manager/state-manager-db-impl/src/integrationTest/kotlin/net/corda/libs/statemanager/impl/tests/StateManagerIntegrationTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/integrationTest/kotlin/net/corda/libs/statemanager/impl/tests/StateManagerIntegrationTest.kt
@@ -399,7 +399,7 @@ class StateManagerIntegrationTest {
         val expectedFailedKeys = threadResults.map { it.assignedStateGrouping.overlappingStates }.flatten().map { it.key }
 
         // if a thread tries to update a state that was already deleted, it gets that key back as a "failed key", associated with null.
-        // if a thread tries to delete a thread that was already updated, it gets that key back as a "failed key".
+        // if a thread tries to delete a state that was already updated, it gets that key back as a "failed key".
         // we expect to see a failed key for every overlapping state, because in the race between two threads only
         // one can update or delete it.
         assertThat(allFailedUpdates + allFailedDeletes)

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
@@ -71,7 +71,7 @@ class StateManagerImpl(
         }
     }
 
-    override fun update(states: Collection<State>): Map<String, State> {
+    override fun update(states: Collection<State>): Map<String, State?> {
         if (states.isEmpty()) return emptyMap()
 
         try {
@@ -79,16 +79,31 @@ class StateManagerImpl(
                 stateRepository.update(conn, states.map { it.toPersistentEntity() })
             }
 
-            return if (failedUpdates.isEmpty()) {
-                emptyMap()
-            } else {
-                logger.warn("Optimistic locking check failed while updating States ${failedUpdates.joinToString()}")
-                get(failedUpdates)
-            }
+            if (failedUpdates.isEmpty()) return emptyMap()
+
+            return getFailedUpdates(failedUpdates)
         } catch (e: Exception) {
             logger.warn("Failed to updated batch of states - ${states.joinToString { it.key }}", e)
             throw e
         }
+    }
+
+    private fun getFailedUpdates(failedUpdates: List<String>): Map<String, State?> {
+        val failedByOptimisticLocking = get(failedUpdates)
+        val failedByNotExisting = (failedUpdates - failedByOptimisticLocking.keys)
+
+        var warning = ""
+        if (failedByOptimisticLocking.isNotEmpty())
+            warning += "Optimistic locking prevented updates to the following States: " +
+                    failedByOptimisticLocking.keys.joinToString(postfix = ". ")
+
+        if (failedByNotExisting.isNotEmpty())
+            warning += "Failed to update the following States because they did not exist or were already deleted: " +
+                    failedByNotExisting.joinToString(postfix = ".")
+
+        logger.warn(warning)
+
+        return failedByOptimisticLocking + (failedByNotExisting.associateWith { null })
     }
 
     override fun delete(states: Collection<State>): Map<String, State> {

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
@@ -79,9 +79,11 @@ class StateManagerImpl(
                 stateRepository.update(conn, states.map { it.toPersistentEntity() })
             }
 
-            if (failedUpdates.isEmpty()) return emptyMap()
-
-            return getFailedUpdates(failedUpdates)
+            return if (failedUpdates.isEmpty()) {
+                emptyMap()
+            } else {
+                getFailedUpdates(failedUpdates)
+            }
         } catch (e: Exception) {
             logger.warn("Failed to updated batch of states - ${states.joinToString { it.key }}", e)
             throw e

--- a/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
@@ -100,6 +100,26 @@ class StateManagerImplTest {
     }
 
     @Test
+    fun `update returns null for states that failed because they were already deleted`() {
+        val persistedStateTwo = persistentStateTwo.newVersion()
+        whenever(stateRepository.get(any(), any())).thenReturn(listOf(persistedStateTwo))
+        whenever(stateRepository.update(any(), any()))
+            .thenReturn(StateRepository.StateUpdateSummary(
+                listOf(apiStateTwo.key),
+                listOf(apiStateTwo.key, apiStateThree.key)
+            ))
+
+        val result = stateManager.update(listOf(apiStateOne, apiStateTwo, apiStateThree))
+        assertThat(result).containsExactly(
+            entry(persistedStateTwo.key, persistedStateTwo.toState()),
+            entry(persistentStateThree.key, null)
+        )
+        verify(stateRepository).get(connection, listOf(apiStateTwo.key, apiStateThree.key))
+        verify(stateRepository).update(connection, listOf(persistentStateOne, persistentStateTwo, persistentStateThree))
+        verifyNoMoreInteractions(stateRepository)
+    }
+
+    @Test
     fun updateReturnsEmptyMapAndDoesNotInteractWithTheDatabaseWhenEmptyListOfStatesIsUsedAsInput() {
         val failedUpdates = assertDoesNotThrow { stateManager.update(emptyList()) }
 


### PR DESCRIPTION
Problem:
It's possible when state manager updates states, another thread could have deleted the state. Currently this failure is not recorded, the caller simply doesn't know that it even failed.

Solution:
- `SM.update()` should return null for these keys indicating the State no longer exists.
- Mediator should not try to re-attempt or process any output events for this event.
- Added integration test that utilizes null returned from the API to test update() in multi-threaded test. Deletes are now included in the list of failures.
