### PR TITLE
CORE-16150 - Record metrics for heartbeat messages

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -31,6 +31,7 @@ import net.corda.p2p.linkmanager.membership.NetworkMessagingValidator
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.data.p2p.markers.LinkManagerReceivedMarker
+import net.corda.p2p.linkmanager.metrics.recordInboundHeartbeatMessagesMetric
 import net.corda.p2p.linkmanager.metrics.recordInboundMessagesMetric
 import net.corda.p2p.linkmanager.metrics.recordInboundSessionMessagesMetric
 import net.corda.p2p.linkmanager.metrics.recordOutboundSessionMessagesMetric
@@ -214,7 +215,6 @@ internal class InboundMessageProcessor(
                     "of type ${innerMessage.message.javaClass} from session ${session.sessionId}"
             }
             messages.add(Record(Schemas.P2P.P2P_IN_TOPIC, innerMessage.key, AppMessage(innerMessage.message)))
-            recordInboundMessagesMetric(innerMessage.message)
             makeAckMessageForFlowMessage(innerMessage.message, session)?.let { ack -> messages.add(ack) }
             sessionManager.inboundSessionEstablished(session.sessionId)
         } else if (sessionSource != messageSource.toCorda()) {
@@ -243,9 +243,11 @@ internal class InboundMessageProcessor(
             when (val innerMessage = it.message) {
                 is HeartbeatMessage -> {
                     logger.debug { "Processing heartbeat message from session $sessionId" }
+                    recordInboundHeartbeatMessagesMetric(counterparties.counterpartyId, counterparties.ourId)
                     makeAckMessageForHeartbeatMessage(counterparties, session)?.let { ack -> messages.add(ack) }
                 }
                 is AuthenticatedMessageAndKey -> {
+                    recordInboundMessagesMetric(innerMessage.message)
                     checkIdentityBeforeProcessing(
                         counterparties,
                         innerMessage,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
@@ -67,6 +67,12 @@ fun recordInboundSessionMessagesMetric() {
     recordInboundMessagesMetric(null, null, null, P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
 }
 
+fun recordInboundHeartbeatMessagesMetric(sourceVnode: HoldingIdentity,
+                                         destinationVnode: HoldingIdentity) {
+    recordInboundMessagesMetric(sourceVnode.x500Name.toString(), destinationVnode.x500Name.toString(),
+        destinationVnode.groupId, P2P_SUBSYSTEM, HEARTBEAT_MESSAGE)
+}
+
 private fun recordInboundMessagesMetric(source: String?, dest: String?, group: String?, subsystem: String, messageType: String) {
     val builder = CordaMetrics.Metric.InboundMessageCount.builder()
     listOf(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
@@ -9,6 +9,7 @@ import net.corda.virtualnode.HoldingIdentity
 
 const val P2P_SUBSYSTEM = "p2p"
 const val SESSION_MESSAGE_TYPE = "SessionMessage"
+const val HEARTBEAT_MESSAGE = "HeartbeatMessage"
 
 fun recordOutboundMessagesMetric(message: AuthenticatedMessage) {
     message.header.let {
@@ -27,6 +28,11 @@ fun recordOutboundMessagesMetric(message: OutboundUnauthenticatedMessage) {
 fun recordOutboundSessionMessagesMetric(sourceVnode: HoldingIdentity, destinationVnode: HoldingIdentity) {
     recordOutboundMessagesMetric(sourceVnode.x500Name.toString(), destinationVnode.x500Name.toString(), sourceVnode.groupId,
         P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
+}
+
+fun recordOutboundHeartbeatMessagesMetric(sourceVnode: HoldingIdentity, destinationVnode: HoldingIdentity) {
+    recordOutboundMessagesMetric(sourceVnode.x500Name.toString(), destinationVnode.x500Name.toString(), sourceVnode.groupId,
+        P2P_SUBSYSTEM, HEARTBEAT_MESSAGE)
 }
 
 fun recordOutboundSessionMessagesMetric(sourceVnode: net.corda.data.identity.HoldingIdentity,


### PR DESCRIPTION
## Changes
Record metrics for inbound/outbound heartbeat messages

## Testing
Performed a small multi-cluster test run: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FLarge%20Network%20Tests/detail/PR-69/213/pipeline/
The dashboards seem to be picking up the data without any further changes needed.

<img width="1137" alt="heartbeat_dashboards" src="https://github.com/corda/corda-runtime-os/assets/6065016/38d3e951-4b58-4c3a-80fe-386c8bf970b8">
