### PR TITLE
CORE-18579: Provide types as class parameters

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/rpc/CryptoFlowOpsProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/rpc/CryptoFlowOpsProcessor.kt
@@ -41,10 +41,12 @@ class CryptoFlowOpsProcessor(
     private val cryptoService: CryptoService,
     private val externalEventResponseFactory: ExternalEventResponseFactory,
     config: RetryingConfig,
-    private val keyEncodingService: KeyEncodingService,
-    override val requestClass: Class<FlowOpsRequest>,
-    override val responseClass: Class<FlowEvent>,
+    private val keyEncodingService: KeyEncodingService
 ) : SyncRPCProcessor<FlowOpsRequest, FlowEvent> {
+
+    override val requestClass = FlowOpsRequest::class.java
+    override val responseClass = FlowEvent::class.java
+
     companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/rpc/CryptoFlowOpsProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/rpc/CryptoFlowOpsProcessorTests.kt
@@ -189,9 +189,7 @@ class CryptoFlowOpsProcessorTests {
             cryptoService,
             externalEventResponseFactory,
             retryingConfig,
-            keyEncodingService,
-            FlowOpsRequest::class.java,
-            FlowEvent::class.java
+            keyEncodingService
         )
         digestService = mock<DigestService>().also {
             fun capture() {

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -150,9 +150,7 @@ class ConsensualLedgerMessageProcessorTests {
             currentSandboxGroupContext,
             virtualNode.entitySandboxService,
             delegatedRequestHandlerSelector,
-            responseFactory,
-            requestClass,
-            responseClass
+            responseFactory
         )
 
         // Process the messages (this should persist transaction to the DB)

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/consensual/tests/ConsensualLedgerMessageProcessorTests.kt
@@ -5,7 +5,6 @@ import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.FindTransaction
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
@@ -97,9 +96,6 @@ class ConsensualLedgerMessageProcessorTests {
 
     @InjectService(timeout = TIMEOUT_MILLIS)
     lateinit var currentSandboxGroupContext: CurrentSandboxGroupContext
-
-    private val requestClass = LedgerPersistenceRequest::class.java
-    private val responseClass = FlowEvent::class.java
 
     @BeforeAll
     fun setup(

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -154,9 +154,7 @@ class UtxoLedgerMessageProcessorTests {
             currentSandboxGroupContext,
             virtualNode.entitySandboxService,
             delegatedRequestHandlerSelector,
-            responseFactory,
-            requestClass,
-            responseClass
+            responseFactory
         )
 
         // Process the messages (this should persist transaction to the DB)

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoLedgerMessageProcessorTests.kt
@@ -5,7 +5,6 @@ import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.FindTransaction
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
@@ -102,9 +101,6 @@ class UtxoLedgerMessageProcessorTests {
 
     @InjectService(timeout = TIMEOUT_MILLIS)
     lateinit var currentSandboxGroupContext: CurrentSandboxGroupContext
-
-    private val requestClass = LedgerPersistenceRequest::class.java
-    private val responseClass = FlowEvent::class.java
 
     @BeforeAll
     fun setup(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/LedgerPersistenceRequestProcessor.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/LedgerPersistenceRequestProcessor.kt
@@ -30,10 +30,11 @@ class LedgerPersistenceRequestProcessor(
     private val currentSandboxGroupContext: CurrentSandboxGroupContext,
     private val entitySandboxService: EntitySandboxService,
     private val delegatedRequestHandlerSelector: DelegatedRequestHandlerSelector,
-    private val responseFactory: ResponseFactory,
-    override val requestClass: Class<LedgerPersistenceRequest>,
-    override val responseClass: Class<FlowEvent>,
+    private val responseFactory: ResponseFactory
 ) : SyncRPCProcessor<LedgerPersistenceRequest, FlowEvent> {
+
+    override val requestClass = LedgerPersistenceRequest::class.java
+    override val responseClass = FlowEvent::class.java
 
     private companion object {
         val log: Logger = LoggerFactory.getLogger(LedgerPersistenceRequestProcessor::class.java)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestSubscriptionFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestSubscriptionFactoryImpl.kt
@@ -3,8 +3,8 @@ package net.corda.ledger.persistence.processor.impl
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.ledger.persistence.processor.DelegatedRequestHandlerSelector
-import net.corda.ledger.persistence.processor.LedgerPersistenceRequestSubscriptionFactory
 import net.corda.ledger.persistence.processor.LedgerPersistenceRequestProcessor
+import net.corda.ledger.persistence.processor.LedgerPersistenceRequestSubscriptionFactory
 import net.corda.messaging.api.constants.WorkerRPCPaths.LEDGER_PATH
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.api.subscription.config.SyncRPCConfig
@@ -39,9 +39,7 @@ class LedgerPersistenceRequestSubscriptionFactoryImpl @Activate constructor(
             currentSandboxGroupContext,
             entitySandboxService,
             delegatedRequestHandlerSelector,
-            responseFactory,
-            LedgerPersistenceRequest::class.java,
-            FlowEvent::class.java
+            responseFactory
         )
         val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, LEDGER_PATH)
         return subscriptionFactory.createHttpRPCSubscription(rpcConfig, processor)

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestProcessorTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestProcessorTest.kt
@@ -38,16 +38,12 @@ class LedgerPersistenceRequestProcessorTest {
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
 
     private val flowEvent = mock<FlowEvent>()
-    private val requestClass = LedgerPersistenceRequest::class.java
-    private val responseClass = FlowEvent::class.java
 
     private val target = LedgerPersistenceRequestProcessor(
         currentSandboxGroupContext,
         entitySandboxService,
         delegatedRequestHandlerSelector,
-        responseFactory,
-        requestClass,
-        responseClass
+        responseFactory
     )
 
     private fun createRequest(requestId: String): LedgerPersistenceRequest {

--- a/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/integrationTest/kotlin/net/corda/ledger/verification/tests/VerificationRequestProcessorTest.kt
@@ -1,16 +1,15 @@
 package net.corda.ledger.verification.tests
 
-import net.corda.common.json.validation.JsonValidator
-import net.corda.cpiinfo.read.CpiInfoReadService
-import net.corda.crypto.core.parseSecureHash
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
+import net.corda.common.json.validation.JsonValidator
+import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.DigitalSignatureWithKey
+import net.corda.crypto.core.parseSecureHash
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.flow.event.external.ExternalEventResponse
 import net.corda.data.flow.event.external.ExternalEventResponseErrorType
@@ -158,9 +157,7 @@ class VerificationRequestProcessorTest {
             currentSandboxGroupContext,
             verificationSandboxService,
             VerificationRequestHandlerImpl(externalEventResponseFactory),
-            externalEventResponseFactory,
-            TransactionVerificationRequest::class.java,
-            FlowEvent::class.java
+            externalEventResponseFactory
         )
 
         // Send request to message processor
@@ -192,9 +189,7 @@ class VerificationRequestProcessorTest {
             currentSandboxGroupContext,
             verificationSandboxService,
             VerificationRequestHandlerImpl(externalEventResponseFactory),
-            externalEventResponseFactory,
-            TransactionVerificationRequest::class.java,
-            FlowEvent::class.java
+            externalEventResponseFactory
         )
 
         // Send request to message processor
@@ -229,9 +224,7 @@ class VerificationRequestProcessorTest {
             currentSandboxGroupContext,
             verificationSandboxService,
             VerificationRequestHandlerImpl(externalEventResponseFactory),
-            externalEventResponseFactory,
-            TransactionVerificationRequest::class.java,
-            FlowEvent::class.java
+            externalEventResponseFactory
         )
 
         // Send request to message processor (there were max number of redeliveries)

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessor.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessor.kt
@@ -29,10 +29,11 @@ class VerificationRequestProcessor(
     private val currentSandboxGroupContext: CurrentSandboxGroupContext,
     private val verificationSandboxService: VerificationSandboxService,
     private val requestHandler: VerificationRequestHandler,
-    private val responseFactory: ExternalEventResponseFactory,
-    override val requestClass: Class<TransactionVerificationRequest>,
-    override val responseClass: Class<FlowEvent>,
+    private val responseFactory: ExternalEventResponseFactory
 ) : SyncRPCProcessor<TransactionVerificationRequest, FlowEvent> {
+
+    override val requestClass = TransactionVerificationRequest::class.java
+    override val responseClass = FlowEvent::class.java
 
     private companion object {
         val log = LoggerFactory.getLogger(this::class.java.enclosingClass)

--- a/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationSubscriptionFactoryImpl.kt
+++ b/components/ledger/ledger-verification/src/main/kotlin/net/corda/ledger/verification/processor/impl/VerificationSubscriptionFactoryImpl.kt
@@ -34,9 +34,7 @@ class VerificationSubscriptionFactoryImpl @Activate constructor(
             currentSandboxGroupContext,
             verificationSandboxService,
             VerificationRequestHandlerImpl(responseFactory),
-            responseFactory,
-            TransactionVerificationRequest::class.java,
-            FlowEvent::class.java
+            responseFactory
         )
         val rpcConfig = SyncRPCConfig(SUBSCRIPTION_NAME, VERIFICATION_PATH)
         return subscriptionFactory.createHttpRPCSubscription(rpcConfig, processor)

--- a/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
@@ -41,16 +41,12 @@ class VerificationRequestProcessorTest {
     private val virtualNodeContext = mock<VirtualNodeContext>()
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     private val flowEvent = mock<FlowEvent>()
-    private val requestClass = TransactionVerificationRequest::class.java
-    private val responseClass = FlowEvent::class.java
 
     private val verificationRequestProcessor = VerificationRequestProcessor(
         currentSandboxGroupContext,
         verificationSandboxService,
         verificationRequestHandler,
-        responseFactory,
-        requestClass,
-        responseClass
+        responseFactory
     )
 
     private fun createRequest(requestId: String) =

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -7,7 +7,6 @@ import net.corda.cpk.read.CpkReadService
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.flow.event.external.ExternalEventResponse
 import net.corda.data.flow.event.external.ExternalEventResponseErrorType
@@ -115,9 +114,6 @@ class PersistenceExceptionTests {
     private lateinit var deserializer: CordaAvroDeserializer<EntityResponse>
 
     private var dbCounter = 0
-
-    private val requestClass = EntityRequest::class.java
-    private val responseClass = FlowEvent::class.java
 
     @BeforeAll
     fun setup(

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceServiceInternalTests.kt
@@ -134,9 +134,6 @@ class PersistenceServiceInternalTests {
     @InjectService(timeout = TIMEOUT_MILLIS)
     lateinit var currentSandboxGroupContext: CurrentSandboxGroupContext
 
-    private val requestClass = EntityRequest::class.java
-    private val responseClass = FlowEvent::class.java
-
     @BeforeAll
     fun setup(
         @InjectService(timeout = TIMEOUT_MILLIS)

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -43,10 +43,8 @@ import net.corda.crypto.softhsm.impl.SoftCryptoService
 import net.corda.crypto.softhsm.impl.WrappingRepositoryImpl
 import net.corda.data.crypto.wire.hsm.registration.HSMRegistrationRequest
 import net.corda.data.crypto.wire.hsm.registration.HSMRegistrationResponse
-import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
 import net.corda.data.crypto.wire.ops.rpc.RpcOpsRequest
 import net.corda.data.crypto.wire.ops.rpc.RpcOpsResponse
-import net.corda.data.flow.event.FlowEvent
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.schema.CordaDb
 import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
@@ -396,9 +394,8 @@ class CryptoProcessorImpl @Activate constructor(
         val flowOpsProcessor = CryptoFlowOpsProcessor(
             cryptoService,
             externalEventResponseFactory,
-            retryingConfig, keyEncodingService,
-            FlowOpsRequest::class.java,
-            FlowEvent::class.java
+            retryingConfig,
+            keyEncodingService
         )
 
         coordinator.createManagedResource(FLOW_OPS_SUBSCRIPTION) {


### PR DESCRIPTION
The processor implementation in workers have requestClass and responseClass included in their constructors. This was changed in the Entity Persistence processor to be provided as class parameters. This PR is to change other workers - Persistence (of type Ledger), Verification and Crypto - for consistency in the pattern.
_Note_ - _Uniqueness was changed in a uniqueness refactoring PR that was already in-flight https://github.com/corda/corda-runtime-os/pull/5184_ 