### PR TITLE
CORE-18515: Create gateway HTTP RPC client

### DIFF
--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/utils/HttpRpcClientIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/utils/HttpRpcClientIntegrationTest.kt
@@ -1,0 +1,57 @@
+package net.corda.p2p.gateway.utils
+
+import com.sun.net.httpserver.HttpServer
+import net.corda.data.identity.HoldingIdentity
+import net.corda.data.p2p.GatewayTlsCertificates
+import net.corda.data.p2p.GatewayTruststore
+import net.corda.p2p.gateway.TestBase
+import net.corda.schema.registry.impl.AvroSchemaRegistryImpl
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.net.URI
+import java.nio.ByteBuffer
+
+internal class HttpRpcClientIntegrationTest : TestBase() {
+    @Test
+    fun `verify that RPC HTTP client works`() {
+        val port = getOpenPort()
+        val avroSchemaRegistry = AvroSchemaRegistryImpl()
+        val requestMessage = GatewayTlsCertificates(
+            "tenantId",
+            HoldingIdentity("X500-name", "Group ID"),
+            listOf("pems"),
+        )
+        val replyMessage = GatewayTruststore(
+            HoldingIdentity("X500-name", "Group ID"),
+            listOf("more"),
+        )
+        val path = "/test"
+        val uri = URI.create("http://www.alice.net:$port$path")
+        val server = HttpServer.create(InetSocketAddress(port), 0)
+        server.createContext(path) { exchange ->
+            exchange.use {
+                val content = exchange.requestBody.readAllBytes()
+
+                val request = avroSchemaRegistry.deserialize(
+                    ByteBuffer.wrap(content),
+                    GatewayTlsCertificates::class.java,
+                    null,
+                )
+                assertThat(request).isEqualTo(requestMessage)
+                val response = avroSchemaRegistry.serialize(replyMessage).array()
+                exchange.sendResponseHeaders(200, response.size.toLong())
+                exchange.responseBody.write(response)
+            }
+        }
+        try {
+            server.start()
+
+            val client = HttpRpcClient(avroSchemaRegistry)
+            val reply: GatewayTruststore? = client.send(uri, requestMessage)
+            assertThat(reply).isEqualTo(replyMessage)
+        } finally {
+            server.stop(0)
+        }
+    }
+}

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/utils/HttpRpcClient.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/utils/HttpRpcClient.kt
@@ -50,7 +50,8 @@ internal class HttpRpcClient(
         val INITIAL_DELAY = Duration.ofMillis(100)
         const val DELAY_INCREASE_FACTOR = 2L
         private const val SUCCESS = "SUCCESS"
-        private const val FAILED = "FAILED" }
+        private const val FAILED = "FAILED"
+    }
 
     inline fun <reified R : Any> send(uri: URI, requestBody: Any): R? {
         return send(uri, requestBody, R::class.java)

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/utils/HttpRpcClient.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/utils/HttpRpcClient.kt
@@ -1,0 +1,168 @@
+package net.corda.p2p.gateway.utils
+
+import net.corda.metrics.CordaMetrics
+import net.corda.schema.registry.AvroSchemaRegistry
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.ByteBuffer
+import java.time.Duration
+
+internal class HttpRpcClient(
+    private val avroSchemaRegistry: AvroSchemaRegistry,
+    private val httpClient: HttpClient = HttpClient.newBuilder().build(),
+    private val requestBuilderFactory: () -> HttpRequest.Builder = {
+        HttpRequest.newBuilder()
+    },
+    private val sleeper: (Long) -> Unit = {
+        Thread.sleep(it)
+    },
+) {
+    class HttpRpcException private constructor(
+        val statusCode: Int?,
+        val responseSize: Int?,
+        message: String?,
+        cause: Throwable?,
+    ) :
+        CordaRuntimeException(
+            message,
+            cause,
+        ) {
+        constructor(cause: Exception) :
+            this(statusCode = null, responseSize = null, message = cause.message, cause = cause)
+        constructor(response: HttpResponse<ByteArray>) :
+            this(
+                statusCode = response.statusCode(),
+                responseSize = response.body().size,
+                message = "Server returned HTTP status code: ${response.statusCode()}",
+                cause = null,
+            )
+    }
+
+    private companion object {
+        val logger = LoggerFactory.getLogger(HttpRpcClient::class.java)
+        const val MAX_RETRIES = 3
+        val TIMEOUT = Duration.ofSeconds(30)
+        val INITIAL_DELAY = Duration.ofMillis(100)
+        const val DELAY_INCREASE_FACTOR = 2L
+        private const val SUCCESS = "SUCCESS"
+        private const val FAILED = "FAILED" }
+
+    inline fun <reified R : Any> send(uri: URI, requestBody: Any): R? {
+        return send(uri, requestBody, R::class.java)
+    }
+
+    private fun <T : Any, R : Any> send(uri: URI, requestBody: T, clz: Class<R>): R? {
+        return try {
+            val payload = avroSchemaRegistry.serialize(requestBody).array()
+            val request = requestBuilderFactory()
+                .uri(uri)
+                .timeout(TIMEOUT)
+                .POST(HttpRequest.BodyPublishers.ofByteArray(payload))
+                .build()
+            val response = SendWithRetry(request).retry()
+            response?.let {
+                avroSchemaRegistry.deserialize(
+                    it,
+                    clz,
+                    null,
+                )
+            }
+        } catch (e: Exception) {
+            throw CordaRuntimeException("Failed to send message to $uri", e)
+        }
+    }
+
+    private inner class SendWithRetry(
+        private val request: HttpRequest,
+    ) {
+        private val startTime = System.nanoTime()
+        fun retry(): ByteBuffer? {
+            return retry(MAX_RETRIES, INITIAL_DELAY)
+        }
+        private fun retry(
+            retries: Int,
+            nextDelay: Duration,
+        ): ByteBuffer? {
+            return try {
+                sendMessage(request).let { (data, statusCode) ->
+                    publishMetric(
+                        success = true,
+                        request = request,
+                        responseSize = data?.size ?: 0,
+                        statusCode = statusCode,
+                    )
+                    if ((data == null) || (data.isEmpty())) {
+                        null
+                    } else {
+                        ByteBuffer.wrap(
+                            data,
+                        )
+                    }
+                }
+            } catch (e: HttpRpcException) {
+                if (retries > 0) {
+                    logger.info("Got error while sending HTTP request. Will retry again $retries times", e)
+                    sleeper(nextDelay.toMillis())
+                    return retry(retries - 1, nextDelay.multipliedBy(DELAY_INCREASE_FACTOR))
+                } else {
+                    publishMetric(
+                        success = false,
+                        request = request,
+                        responseSize = e.responseSize,
+                        statusCode = e.statusCode ?: -1,
+                    )
+
+                    throw e
+                }
+            }
+        }
+
+        @Suppress("ThrowsCount")
+        private fun sendMessage(request: HttpRequest): Pair<ByteArray?, Int> {
+            try {
+                val response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
+                val statusCode = response.statusCode()
+                if ((statusCode >= 200) && (statusCode < 300)) {
+                    return response.body() to statusCode
+                } else {
+                    throw HttpRpcException(response)
+                }
+            } catch (e: IOException) {
+                throw HttpRpcException(e)
+            }
+        }
+
+        private fun publishMetric(
+            success: Boolean,
+            request: HttpRequest,
+            responseSize: Int?,
+            statusCode: Int,
+        ) {
+            val endTime = System.nanoTime()
+            val operationStatus = if (success) {
+                SUCCESS
+            } else {
+                FAILED
+            }
+            val uri = request.method() + request.uri().toString()
+            CordaMetrics.Metric.Messaging.HTTPRPCResponseTime.builder()
+                .withTag(CordaMetrics.Tag.OperationStatus, operationStatus)
+                .withTag(CordaMetrics.Tag.HttpRequestUri, uri)
+                .withTag(CordaMetrics.Tag.HttpResponseCode, statusCode.toString())
+                .build()
+                .record(Duration.ofNanos(endTime - startTime))
+
+            if (responseSize != null) {
+                CordaMetrics.Metric.Messaging.HTTPRPCResponseSize.builder()
+                    .withTag(CordaMetrics.Tag.HttpRequestUri, uri)
+                    .build()
+                    .record(responseSize.toDouble())
+            }
+        }
+    }
+}

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/utils/HttpRpcClientTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/utils/HttpRpcClientTest.kt
@@ -1,0 +1,142 @@
+package net.corda.p2p.gateway.utils
+
+import net.corda.schema.registry.AvroSchemaRegistry
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doReturnConsecutively
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.ByteBuffer
+import java.time.Duration
+import java.util.Date
+import java.util.UUID
+
+class HttpRpcClientTest {
+    private val request = UUID(0, 1)
+    private val expectedResponse = Date(100L)
+    private val serializedRequest = byteArrayOf(1, 2, 3)
+    private val serializedResponse = byteArrayOf(4, 5)
+    private val avroSchemaRegistry = mock<AvroSchemaRegistry> {
+        on { serialize(request) } doReturn ByteBuffer.wrap(serializedRequest)
+        on {
+            deserialize(ByteBuffer.wrap(serializedResponse), Date::class.java, null)
+        } doReturn expectedResponse
+    }
+    private val httpRequest = mock<HttpRequest>()
+    private val httpResponse = mock<HttpResponse<ByteArray>> {
+        on { statusCode() } doReturn 200
+        on { body() } doReturn serializedResponse
+    }
+    private val httpClient = mock<HttpClient> {
+        on { send(eq(httpRequest), isA<HttpResponse.BodyHandler<ByteArray>>()) } doReturn httpResponse
+    }
+    private val uri = URI.create("http://corda.net/test")
+    private val requestBuilder = mock<HttpRequest.Builder> {
+        on { uri(uri) } doReturn mock
+        on { timeout(any()) } doReturn mock
+        on { POST(any()) } doReturn mock
+        on { build() } doReturn httpRequest
+    }
+
+    private val sleepers = mutableListOf<Long>()
+    private val client = HttpRpcClient(
+        avroSchemaRegistry,
+        httpClient,
+        { requestBuilder },
+        { sleepers.add(it) },
+    )
+
+    @Test
+    fun `send return the correct data`() {
+        val response: Date? = client.send(uri, request)
+
+        assertThat(response).isEqualTo(expectedResponse)
+    }
+
+    @Test
+    fun `send return the null if null is returned`() {
+        whenever(httpResponse.body()).doReturn(null)
+        val response: Date? = client.send(uri, request)
+
+        assertThat(response).isNull()
+    }
+
+    @Test
+    fun `send return the null if emptyAray is returned`() {
+        whenever(httpResponse.body()).doReturn(byteArrayOf())
+        val response: Date? = client.send(uri, request)
+
+        assertThat(response).isNull()
+    }
+
+    @Test
+    fun `send set the correct timeout`() {
+        val timout = argumentCaptor<Duration>()
+        whenever(requestBuilder.timeout(timout.capture())).doReturn(requestBuilder)
+
+        client.send<Date>(uri, request)
+
+        assertThat(timout.firstValue).isEqualTo(Duration.ofSeconds(30))
+    }
+
+    @Test
+    fun `send post the correct data`() {
+        val body = argumentCaptor<HttpRequest.BodyPublisher>()
+        whenever(requestBuilder.POST(body.capture())).doReturn(requestBuilder)
+
+        client.send<Date>(uri, request)
+
+        assertThat(body.firstValue.contentLength()).isEqualTo(serializedRequest.size.toLong())
+    }
+
+    @Test
+    fun `send with error throws exception`() {
+        whenever(httpResponse.statusCode()).doReturn(500)
+
+        assertThrows<CordaRuntimeException> {
+            client.send<Date>(uri, request)
+        }
+    }
+
+    @Test
+    fun `send with error and success will return data`() {
+        whenever(httpResponse.statusCode()).doReturnConsecutively(listOf(500, 700, 200))
+
+        val response: Date? = client.send(uri, request)
+
+        assertThat(response).isEqualTo(expectedResponse)
+    }
+
+    @Test
+    fun `send with wait before retrying`() {
+        whenever(httpResponse.statusCode()).doReturn(400)
+
+        assertThrows<CordaRuntimeException> {
+            client.send<Date>(uri, request)
+        }
+
+        assertThat(sleepers).containsExactly(100, 200, 400)
+    }
+
+    @Test
+    fun `send with IO exception will wrap the exception`() {
+        whenever(httpClient.send(eq(httpRequest), isA<HttpResponse.BodyHandler<ByteArray>>())).doThrow(IOException("oops"))
+
+        assertThrows<CordaRuntimeException> {
+            client.send<Date>(uri, request)
+        }
+    }
+}


### PR DESCRIPTION
Introduce an HTTP client to be used as RPC client for a `SyncRPCSubscriptionImpl` server without the overhead of the `RPCClient`.