### PR TITLE
ES-1589 Allow a user to trigger the e2e tests via a comment on corda-runtime-os PR

### DIFF
--- a/.ci/JenkinsfileCommentRebuild
+++ b/.ci/JenkinsfileCommentRebuild
@@ -1,3 +1,5 @@
 @Library('corda-shared-build-pipeline-steps@jacob/ES-1589') _
 
-githubCommentBuildTests()
+githubCommentBuildTests(
+    branch: 'release/5.2',
+)

--- a/.ci/JenkinsfileCommentRebuild
+++ b/.ci/JenkinsfileCommentRebuild
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@jacob/ES-1589') _
+@Library('corda-shared-build-pipeline-steps@ES-1589') _
 
 githubCommentBuildTests(
     branch: 'release/5.2',

--- a/.ci/JenkinsfileCommentRebuild
+++ b/.ci/JenkinsfileCommentRebuild
@@ -1,0 +1,3 @@
+@Library('corda-shared-build-pipeline-steps@jacob/ES-1589') _
+
+githubCommentBuildTests()

--- a/.ci/JenkinsfileCommentRebuild
+++ b/.ci/JenkinsfileCommentRebuild
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@ES-1589') _
+@Library('corda-shared-build-pipeline-steps@5.2') _
 
 githubCommentBuildTests(
     branch: 'release/5.2',

--- a/.ci/JenkinsfileCommentRebuild
+++ b/.ci/JenkinsfileCommentRebuild
@@ -2,4 +2,5 @@
 
 githubCommentBuildTests(
     branch: 'release/5.2',
+    chartVersion: '^5.2.0-alpha',
 )


### PR DESCRIPTION
This allows users to trigger an E2E Tests build by leaving a `build e2e` comment on the associated runtime-os PR 