### PR TITLE
CORE-18490: Be lenient in reconcilers for DB errors

### DIFF
--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReader.kt
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory
  * [GetRecordsErrorEvent] (depending on if the exception is a transient error or not its lifecycle should
  * be set to [LifecycleStatus.DOWN] or [LifecycleStatus.ERROR]). And then the exception needs to be re-thrown
  * for the reconciler to be notified immediately.
- * .
  */
 @Suppress("LongParameterList")
 class DbReconcilerReader<K : Any, V : Any>(
@@ -68,13 +67,13 @@ class DbReconcilerReader<K : Any, V : Any>(
 
     /**
      * [getAllVersionedRecords] is public API for this service i.e. it can be called by other lifecycle services,
-     * therefore it must be guarded from thrown exceptions. No exceptions should escape from it, instead an
+     * therefore it must be guarded against thrown exceptions. No exceptions should escape from it, instead an
      * event should be scheduled notifying the service about the error. Then the calling service which should
      * be following this service will get notified of this service's stop event as well.
      */
     @Suppress("SpreadOperator")
     override fun getAllVersionedRecords(): Stream<VersionedRecord<K, V>> {
-        return reconciliationContextFactory().map { context ->
+        val streamOfStreams: Stream<Stream<VersionedRecord<K, V>>> = reconciliationContextFactory().map { context ->
             try {
                 val currentTransaction = context.getOrCreateEntityManager().transaction
                 currentTransaction.begin()
@@ -85,10 +84,11 @@ class DbReconcilerReader<K : Any, V : Any>(
                     context.close()
                 }
             } catch (e: Exception) {
-                logger.warn("Error while retrieving DB records for reconciliation", e)
-                throw e
+                logger.warn("Error while retrieving DB records for reconciliation for ${context.prettyPrint()}", e)
+                Stream.empty()
             }
-        }.flatMap { i -> i }
+        }
+        return streamOfStreams.flatMap { i -> i }
     }
 
     override val isRunning: Boolean

--- a/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
+++ b/processors/db-processor/src/main/kotlin/net/corda/processors/db/internal/reconcile/db/ReconciliationContext.kt
@@ -11,11 +11,16 @@ import javax.persistence.EntityManagerFactory
  *
  * Context instances must be closed after use to close any created resources.
  */
-interface ReconciliationContext : AutoCloseable {
+sealed interface ReconciliationContext : AutoCloseable {
     /**
      * Return existing [EntityManager] or create one if one does not already exist.
      */
     fun getOrCreateEntityManager(): EntityManager
+
+    /**
+     * Provides human-readable description of the context
+     */
+    fun prettyPrint(): String
 }
 
 /**
@@ -29,6 +34,8 @@ class ClusterReconciliationContext(
     override fun getOrCreateEntityManager(): EntityManager = entityManager
         ?: dbConnectionManager.getClusterEntityManagerFactory().createEntityManager()
             .also { entityManager = it }
+
+    override fun prettyPrint(): String = "Cluster context"
 
     override fun close() {
         entityManager?.close()
@@ -55,6 +62,8 @@ class VirtualNodeReconciliationContext(
     override fun getOrCreateEntityManager(): EntityManager = entityManager
         ?: getOrCreateEntityManagerFactory().createEntityManager()
             .also { entityManager = it }
+
+    override fun prettyPrint(): String = "vNode ${virtualNodeInfo.holdingIdentity.shortHash} context"
 
     override fun close() {
         entityManager?.close()

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconcilerTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/CpiReconcilerTest.kt
@@ -4,9 +4,9 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Random
 import javax.persistence.EntityManager
-import kotlin.streams.toList
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.parseSecureHash
+import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.libs.cpi.datamodel.repository.CpiMetadataRepository
 import net.corda.libs.packaging.core.CordappManifest
 import net.corda.libs.packaging.core.CordappType
@@ -24,6 +24,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import javax.persistence.EntityManagerFactory
 
 class CpiReconcilerTest {
     private val random = Random(0)
@@ -86,9 +87,12 @@ class CpiReconcilerTest {
         val em = mock<EntityManager>()
         whenever(em.transaction).thenReturn(mock())
 
-
-        val reconciliationContext = mock<ReconciliationContext>()
-        whenever(reconciliationContext.getOrCreateEntityManager()).thenReturn(em)
+        val entityManagerFactory: EntityManagerFactory = mock()
+        whenever(entityManagerFactory.createEntityManager()).thenReturn(em)
+        
+        val dbConnectionManager: DbConnectionManager = mock()
+        whenever(dbConnectionManager.getClusterEntityManagerFactory()).thenReturn(entityManagerFactory)
+        val reconciliationContext = ClusterReconciliationContext(dbConnectionManager)
 
         val versionedRecords = cpiReconcilerMock.getAllCpiInfoDBVersionedRecords(reconciliationContext).toList()
         val record = versionedRecords.single()

--- a/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReaderTest.kt
+++ b/processors/db-processor/src/test/kotlin/net/corda/processors/db/internal/reconcile/db/DbReconcilerReaderTest.kt
@@ -1,5 +1,6 @@
 package net.corda.processors.db.internal.reconcile.db
 
+import net.corda.db.connection.manager.DbConnectionManager
 import java.util.stream.Collectors
 import java.util.stream.Stream
 import javax.persistence.EntityManager
@@ -28,9 +29,11 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import javax.persistence.EntityManagerFactory
 
 class DbReconcilerReaderTest {
 
@@ -47,13 +50,26 @@ class DbReconcilerReaderTest {
     private val mockVersionedRecord2: VersionedRecord<String, Int> = mock()
     private val realStream1 = Stream.of(mockVersionedRecord1)
     private val realStream2 = Stream.of(mockVersionedRecord2)
-    private val reconciliationContext1: ReconciliationContext = mock {
-        on { getOrCreateEntityManager() } doReturn em1
+
+    private val entityManagerFactory1 = mock<EntityManagerFactory> {
+        on { createEntityManager() } doReturn em1
     }
-    private val reconciliationContext2: ReconciliationContext = mock {
-        on { getOrCreateEntityManager() } doReturn em2
+    
+    private val dbConnectionManager1: DbConnectionManager = mock {
+        on { getClusterEntityManagerFactory() } doReturn entityManagerFactory1
+    }
+    private val reconciliationContext1: ReconciliationContext = spy(ClusterReconciliationContext(dbConnectionManager1))
+
+
+    private val entityManagerFactory2 = mock<EntityManagerFactory> {
+        on { createEntityManager() } doReturn em2
     }
 
+    private val dbConnectionManager2: DbConnectionManager = mock {
+        on { getClusterEntityManagerFactory() } doReturn entityManagerFactory2
+    }
+    private val reconciliationContext2: ReconciliationContext = spy(ClusterReconciliationContext(dbConnectionManager2))
+    
     private val dependencyMock: LifecycleCoordinatorName = LifecycleCoordinatorName("dependency")
     private val dependenciesMock: Set<LifecycleCoordinatorName> = setOf(dependencyMock)
     private val reconciliationContexts = Stream.of(
@@ -288,45 +304,6 @@ class DbReconcilerReaderTest {
             }
 
             verify(reconciliationContextFactory).invoke()
-            assertThat(ex.message).isEqualTo(errorMsg)
-        }
-
-        @Test
-        fun `Failure to get entity transaction rethrows exception`() {
-            whenever(em1.transaction) doThrow RuntimeException(errorMsg)
-
-            val ex = assertThrows<RuntimeException> {
-                // call terminal operation to process stream
-                dbReconcilerReader.getAllVersionedRecords().count()
-            }
-
-            verify(em1).transaction
-            assertThat(ex.message).isEqualTo(errorMsg)
-        }
-
-        @Test
-        fun `Failure to start transaction rethrows exception`() {
-            whenever(transaction1.begin()) doThrow RuntimeException(errorMsg)
-
-            val ex = assertThrows<RuntimeException> {
-                // call terminal operation to process stream
-                dbReconcilerReader.getAllVersionedRecords().count()
-            }
-
-            verify(transaction1).begin()
-            assertThat(ex.message).isEqualTo(errorMsg)
-        }
-
-        @Test
-        fun `Failure to get all versioned records rethrows exception`() {
-            whenever(getAllVersionRecordsMock.invoke(eq(reconciliationContext2))) doThrow RuntimeException(errorMsg)
-
-            val ex = assertThrows<RuntimeException> {
-                // call terminal operation to process stream
-                dbReconcilerReader.getAllVersionedRecords().count()
-            }
-
-            verify(getAllVersionRecordsMock, times(2)).invoke(any())
             assertThat(ex.message).isEqualTo(errorMsg)
         }
     }


### PR DESCRIPTION
There might be cases when DB error is intermittent. E.g. vNode is still being created when reconciliation is invoked. Rather than throwing an exception, which will put reconciler into `DOWN` state permanently, just log a warning and skip a reconciliation iteration.

E2E test runs to validate the change:
1. https://ci02.dev.r3.com/job/Corda5/view/Full%20Health%205.2/job/corda5-e2e-tests/job/release%252F5.2/151/
2. https://ci02.dev.r3.com/job/Corda5/view/Full%20Health%205.2/job/corda5-e2e-tests/job/release%252F5.2/153/