### PR TITLE
CORE-18620: Support persistence of authentication protocol data

### DIFF
--- a/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
+++ b/components/link-manager/src/integrationTest/kotlin/net/corda/p2p/linkmanager/integration/LinkManagerIntegrationTest.kt
@@ -30,12 +30,12 @@ import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
-import net.corda.p2p.crypto.protocol.api.RevocationCheckMode
 import net.corda.p2p.linkmanager.LinkManager
 import net.corda.p2p.linkmanager.integration.stub.CpiInfoReadServiceStub
 import net.corda.p2p.linkmanager.integration.stub.GroupPolicyProviderStub
 import net.corda.p2p.linkmanager.integration.stub.MembershipQueryClientStub
 import net.corda.p2p.linkmanager.integration.stub.VirtualNodeInfoReadServiceStub
+import net.corda.p2p.linkmanager.sessions.RevocationCheckMode
 import net.corda.schema.Schemas
 import net.corda.schema.configuration.BootConfig.BOOT_MAX_ALLOWED_MSG_SIZE
 import net.corda.schema.configuration.BootConfig.INSTANCE_ID

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/AvroSealedClasses.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/AvroSealedClasses.kt
@@ -4,7 +4,7 @@ import net.corda.data.p2p.crypto.AuthenticatedDataMessage
 import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
 import net.corda.p2p.crypto.protocol.api.AuthenticatedEncryptionSession
 import net.corda.p2p.crypto.protocol.api.AuthenticatedSession
-import net.corda.p2p.crypto.protocol.api.Session
+import net.corda.p2p.crypto.protocol.api.SessionWrapper
 import org.slf4j.LoggerFactory
 
 /**
@@ -25,7 +25,7 @@ class AvroSealedClasses {
     sealed class SessionAndMessage {
         companion object {
 
-            fun create(session: Session, sessionId: String, message: DataMessage): SessionAndMessage? {
+            fun create(session: SessionWrapper, sessionId: String, message: DataMessage): SessionAndMessage? {
                 return when (session) {
                     is AuthenticatedSession -> {
                         when (message) {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
@@ -21,7 +21,7 @@ import net.corda.p2p.crypto.protocol.api.AuthenticatedEncryptionSession
 import net.corda.p2p.crypto.protocol.api.AuthenticatedSession
 import net.corda.p2p.crypto.protocol.api.DecryptionFailedError
 import net.corda.p2p.crypto.protocol.api.InvalidMac
-import net.corda.p2p.crypto.protocol.api.Session
+import net.corda.p2p.crypto.protocol.api.SessionWrapper
 import net.corda.p2p.linkmanager.common.AvroSealedClasses.DataMessage
 import net.corda.p2p.linkmanager.common.AvroSealedClasses.SessionAndMessage
 import net.corda.p2p.linkmanager.grouppolicy.networkType
@@ -98,7 +98,7 @@ class MessageConverter {
             message: MessageAck,
             source: HoldingIdentity,
             destination: HoldingIdentity,
-            session: Session,
+            session: SessionWrapper,
             groupPolicyProvider: GroupPolicyProvider,
             membershipGroupReaderProvider: MembershipGroupReaderProvider,
         ): LinkOutMessage? {
@@ -121,7 +121,7 @@ class MessageConverter {
 
         fun linkOutMessageFromAuthenticatedMessageAndKey(
             message: AuthenticatedMessageAndKey,
-            session: Session,
+            session: SessionWrapper,
             groupPolicyProvider: GroupPolicyProvider,
             membershipGroupReaderProvider: MembershipGroupReaderProvider,
             serial: Long,
@@ -149,7 +149,7 @@ class MessageConverter {
             source: HoldingIdentity,
             destination: HoldingIdentity,
             message: HeartbeatMessage,
-            session: Session,
+            session: SessionWrapper,
             groupPolicyProvider: GroupPolicyProvider,
             membershipGroupReaderProvider: MembershipGroupReaderProvider,
             filter: MembershipStatusFilter,
@@ -192,7 +192,7 @@ class MessageConverter {
             serializedPayload: ByteBuffer,
             source: HoldingIdentity,
             destination: HoldingIdentity,
-            session: Session,
+            session: SessionWrapper,
             groupPolicyProvider: GroupPolicyProvider,
             membershipGroupReaderProvider: MembershipGroupReaderProvider,
             filter: MembershipStatusFilter,
@@ -210,14 +210,6 @@ class MessageConverter {
                         ByteBuffer.wrap(result.encryptedPayload),
                         ByteBuffer.wrap(result.authTag)
                     )
-                }
-                else -> {
-                    logger.warn(
-                        "Invalid Session type ${session::class.java.simpleName}.Session must be either " +
-                            "${AuthenticatedSession::class.java.simpleName} or ${AuthenticatedEncryptionSession::class.java.simpleName}." +
-                            " The message was discarded."
-                    )
-                    return null
                 }
             }
 
@@ -253,7 +245,7 @@ class MessageConverter {
             )
         }
 
-        fun <T> extractPayload(session: Session, sessionId: String, message: DataMessage, deserialize: (ByteBuffer) -> T): T? {
+        fun <T> extractPayload(session: SessionWrapper, sessionId: String, message: DataMessage, deserialize: (ByteBuffer) -> T): T? {
             val sessionAndMessage = SessionAndMessage.create(session, sessionId, message) ?: return null
             return when (sessionAndMessage) {
                 is SessionAndMessage.Authenticated -> extractPayloadFromAuthenticatedMessage(sessionAndMessage, deserialize)

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -23,7 +23,7 @@ import net.corda.data.p2p.crypto.InitiatorHandshakeMessage
 import net.corda.data.p2p.crypto.InitiatorHelloMessage
 import net.corda.data.p2p.crypto.ResponderHandshakeMessage
 import net.corda.data.p2p.crypto.ResponderHelloMessage
-import net.corda.p2p.crypto.protocol.api.Session
+import net.corda.p2p.crypto.protocol.api.SessionWrapper
 import net.corda.p2p.linkmanager.LinkManager
 import net.corda.p2p.linkmanager.common.AvroSealedClasses
 import net.corda.p2p.linkmanager.common.MessageConverter
@@ -202,7 +202,7 @@ internal class InboundMessageProcessor(
     private fun checkIdentityBeforeProcessing(
         counterparties: SessionManager.Counterparties,
         innerMessage: AuthenticatedMessageAndKey,
-        session: Session,
+        session: SessionWrapper,
         messages: MutableList<Record<*, *>>
     ) {
         val sessionSource = counterparties.counterpartyId
@@ -234,7 +234,7 @@ internal class InboundMessageProcessor(
 
     private fun processLinkManagerPayload(
         counterparties: SessionManager.Counterparties,
-        session: Session,
+        session: SessionWrapper,
         sessionId: String,
         message: AvroSealedClasses.DataMessage
     ): MutableList<Record<*, *>> {
@@ -263,7 +263,7 @@ internal class InboundMessageProcessor(
 
     private fun makeAckMessageForHeartbeatMessage(
         counterparties: SessionManager.Counterparties,
-        session: Session
+        session: SessionWrapper
     ): Record<String, LinkOutMessage>? {
         val ackDest = counterparties.counterpartyId
         val ackSource = counterparties.ourId
@@ -284,7 +284,7 @@ internal class InboundMessageProcessor(
 
     private fun makeAckMessageForFlowMessage(
         message: AuthenticatedMessage,
-        session: Session
+        session: SessionWrapper
     ): Record<String, LinkOutMessage>? {
         // We route the ACK back to the original source
         val ackDest = message.header.source.toCorda()

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/CryptoProtocolFactory.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/CryptoProtocolFactory.kt
@@ -7,12 +7,30 @@ import net.corda.p2p.crypto.protocol.api.CertificateCheckMode
 import java.security.PublicKey
 
 internal class CryptoProtocolFactory: ProtocolFactory {
-    override fun createInitiator(sessionId: String, supportedModes: Set<ProtocolMode>, ourMaxMessageSize: Int,
-                                 ourPublicKey: PublicKey, groupId: String, mode: CertificateCheckMode): AuthenticationProtocolInitiator {
-        return AuthenticationProtocolInitiator(sessionId, supportedModes, ourMaxMessageSize, ourPublicKey, groupId, mode)
+    override fun createInitiator(
+        sessionId: String,
+        supportedModes: Set<ProtocolMode>,
+        ourMaxMessageSize: Int,
+        ourPublicKey: PublicKey,
+        groupId: String,
+        mode: CertificateCheckMode,
+        revocationCheckerClient: RevocationCheckerClient,
+    ): AuthenticationProtocolInitiator {
+        return AuthenticationProtocolInitiator.create(
+            sessionId,
+            supportedModes,
+            ourMaxMessageSize,
+            ourPublicKey,
+            groupId,
+            mode,
+            revocationCheckerClient,
+        )
     }
 
     override fun createResponder(sessionId: String, ourMaxMessageSize: Int): AuthenticationProtocolResponder {
-        return AuthenticationProtocolResponder(sessionId, ourMaxMessageSize)
+        return AuthenticationProtocolResponder.create(
+            sessionId,
+            ourMaxMessageSize,
+        )
     }
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/PendingSessionMessageQueues.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/PendingSessionMessageQueues.kt
@@ -2,14 +2,14 @@ package net.corda.p2p.linkmanager.sessions
 
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.data.p2p.AuthenticatedMessageAndKey
-import net.corda.p2p.crypto.protocol.api.Session
+import net.corda.p2p.crypto.protocol.api.SessionWrapper
 
 internal interface PendingSessionMessageQueues : LifecycleWithDominoTile {
     fun queueMessage(message: AuthenticatedMessageAndKey, counterparties: SessionManager.SessionCounterparties)
     fun sessionNegotiatedCallback(
         sessionManager: SessionManager,
         counterparties: SessionManager.SessionCounterparties,
-        session: Session,
+        session: SessionWrapper,
     )
 
     fun destroyQueue(counterparties: SessionManager.SessionCounterparties)

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/PendingSessionMessageQueuesImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/PendingSessionMessageQueuesImpl.kt
@@ -7,7 +7,7 @@ import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
-import net.corda.p2p.crypto.protocol.api.Session
+import net.corda.p2p.crypto.protocol.api.SessionWrapper
 import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
 import java.util.LinkedList
@@ -53,7 +53,7 @@ internal class PendingSessionMessageQueuesImpl(
     override fun sessionNegotiatedCallback(
         sessionManager: SessionManager,
         counterparties: SessionManager.SessionCounterparties,
-        session: Session,
+        session: SessionWrapper,
     ) {
         publisher.withLifecycleLock {
             if (!isRunning) {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/ProtocolFactory.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/ProtocolFactory.kt
@@ -8,7 +8,14 @@ import java.security.PublicKey
 
 internal interface ProtocolFactory {
     @Suppress("LongParameterList")
-    fun createInitiator(sessionId: String, supportedModes: Set<ProtocolMode>, ourMaxMessageSize: Int,
-                        ourPublicKey: PublicKey, groupId: String, mode: CertificateCheckMode): AuthenticationProtocolInitiator
+    fun createInitiator(
+        sessionId: String,
+        supportedModes: Set<ProtocolMode>,
+        ourMaxMessageSize: Int,
+        ourPublicKey: PublicKey,
+        groupId: String,
+        mode: CertificateCheckMode,
+        revocationCheckerClient: RevocationCheckerClient,
+    ): AuthenticationProtocolInitiator
     fun createResponder(sessionId: String, ourMaxMessageSize: Int): AuthenticationProtocolResponder
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/RevocationCheckMode.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/RevocationCheckMode.kt
@@ -1,0 +1,14 @@
+package net.corda.p2p.linkmanager.sessions
+
+import net.corda.data.p2p.gateway.certificates.RevocationMode
+
+enum class RevocationCheckMode {
+    OFF, SOFT_FAIL, HARD_FAIL;
+    fun toData() : RevocationMode? {
+        return when (this) {
+            OFF -> null
+            SOFT_FAIL -> RevocationMode.SOFT_FAIL
+            HARD_FAIL -> RevocationMode.SOFT_FAIL
+        }
+    }
+}

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/RevocationCheckerClient.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/RevocationCheckerClient.kt
@@ -11,6 +11,7 @@ import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.lifecycle.domino.logic.util.RPCSenderWithDominoLogic
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.RPCConfig
+import net.corda.p2p.crypto.protocol.api.RevocationChecker
 import net.corda.schema.Schemas
 import net.corda.utilities.concurrent.getOrThrow
 import org.slf4j.LoggerFactory
@@ -20,7 +21,7 @@ import java.util.concurrent.TimeoutException
 class RevocationCheckerClient(
     publisherFactory: PublisherFactory,
     coordinatorFactory: LifecycleCoordinatorFactory,
-    messagingConfiguration: SmartConfig): LifecycleWithDominoTile {
+    messagingConfiguration: SmartConfig): LifecycleWithDominoTile, RevocationChecker {
 
     private companion object {
         const val groupAndClientName = "GatewayRevocationChecker"
@@ -39,7 +40,7 @@ class RevocationCheckerClient(
         publisherFactory, coordinatorFactory, publisherConfig, messagingConfiguration
     )
 
-    fun checkRevocation(request: RevocationCheckRequest): RevocationCheckResponse {
+    override fun checkRevocation(request: RevocationCheckRequest): RevocationCheckResponse {
         return try {
             rpcSender.sendRequest(request).getOrThrow(timeout)
         } catch (except: TimeoutException) {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManager.kt
@@ -6,7 +6,7 @@ import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.data.p2p.LinkInMessage
 import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.app.MembershipStatusFilter
-import net.corda.p2p.crypto.protocol.api.Session
+import net.corda.p2p.crypto.protocol.api.SessionWrapper
 import net.corda.virtualnode.HoldingIdentity
 
 internal interface SessionManager : LifecycleWithDominoTile {
@@ -18,7 +18,7 @@ internal interface SessionManager : LifecycleWithDominoTile {
     fun dataMessageReceived(sessionId: String, source: HoldingIdentity, destination: HoldingIdentity)
 
     fun recordsForSessionEstablished(
-        session: Session,
+        session: SessionWrapper,
         messageAndKey: AuthenticatedMessageAndKey,
         serial: Long,
     ): List<Record<String, *>>
@@ -46,14 +46,14 @@ internal interface SessionManager : LifecycleWithDominoTile {
         data class NewSessionsNeeded(val messages: List<Pair<String, LinkOutMessage>>,
                                      val sessionCounterparties: SessionCounterparties) : SessionState()
         data class SessionAlreadyPending(val sessionCounterparties: SessionCounterparties) : SessionState()
-        data class SessionEstablished(val session: Session,
+        data class SessionEstablished(val session: SessionWrapper,
                                       val sessionCounterparties: SessionCounterparties) : SessionState()
         object CannotEstablishSession : SessionState()
     }
 
     sealed class SessionDirection {
-        data class Inbound(val counterparties: Counterparties, val session: Session) : SessionDirection()
-        data class Outbound(val counterparties: Counterparties, val session: Session) : SessionDirection()
+        data class Inbound(val counterparties: Counterparties, val session: SessionWrapper) : SessionDirection()
+        data class Outbound(val counterparties: Counterparties, val session: SessionWrapper) : SessionDirection()
         object NoSession : SessionDirection()
     }
 }

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -65,13 +65,13 @@ import net.corda.messaging.emulation.rpc.RPCTopicServiceImpl
 import net.corda.messaging.emulation.subscription.factory.InMemSubscriptionFactory
 import net.corda.messaging.emulation.topic.service.impl.TopicServiceImpl
 import net.corda.p2p.crypto.protocol.ProtocolConstants
-import net.corda.p2p.crypto.protocol.api.RevocationCheckMode
 import net.corda.p2p.gateway.Gateway
 import net.corda.p2p.gateway.messaging.RevocationConfig
 import net.corda.p2p.gateway.messaging.RevocationConfigMode
 import net.corda.p2p.gateway.messaging.SslConfiguration
 import net.corda.p2p.gateway.messaging.TlsType
 import net.corda.p2p.linkmanager.LinkManager
+import net.corda.p2p.linkmanager.sessions.RevocationCheckMode
 import net.corda.schema.Schemas.Config.CONFIG_TOPIC
 import net.corda.schema.Schemas.P2P.P2P_HOSTED_IDENTITIES_TOPIC
 import net.corda.schema.Schemas.P2P.P2P_IN_TOPIC

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayerTest.kt
@@ -14,7 +14,6 @@ import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.data.p2p.crypto.InitiatorHelloMessage
 import net.corda.data.p2p.crypto.ProtocolMode
-import net.corda.p2p.crypto.protocol.api.AuthenticationProtocolInitiator
 import net.corda.p2p.crypto.protocol.api.CertificateCheckMode
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.p2p.linkmanager.utilities.LoggingInterceptor
@@ -43,6 +42,7 @@ import java.security.KeyPairGenerator
 import java.security.Security
 import java.util.UUID
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
+import net.corda.p2p.crypto.protocol.api.AuthenticationProtocolInitiator
 import org.mockito.kotlin.doThrow
 
 class InMemorySessionReplayerTest {
@@ -107,13 +107,14 @@ class InMemorySessionReplayerTest {
     fun `The InMemorySessionReplacer adds a message to be replayed (by the replayScheduler) when addMessageForReplay`() {
         val replayer = InMemorySessionReplayer(mock(), mock(), mock(), mock(), groupsAndMembers.second, groupsAndMembers.first,
             mockTimeFacilitiesProvider.clock)
-        val helloMessage = AuthenticationProtocolInitiator(
+        val helloMessage = AuthenticationProtocolInitiator.create(
             id,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             MAX_MESSAGE_SIZE,
             KEY_PAIR.public,
             GROUP_ID,
             CertificateCheckMode.NoCertificate,
+            mock(),
         ).generateInitiatorHello()
 
         setRunning()
@@ -154,13 +155,14 @@ class InMemorySessionReplayerTest {
     fun `The replaySchedular callback publishes the session message`() {
         InMemorySessionReplayer(mock(), mock(), mock(), mock(), groupsAndMembers.second, groupsAndMembers.first,
             mockTimeFacilitiesProvider.clock)
-        val helloMessage = AuthenticationProtocolInitiator(
+        val helloMessage = AuthenticationProtocolInitiator.create(
             id,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             MAX_MESSAGE_SIZE,
             KEY_PAIR.public,
             GROUP_ID,
             CertificateCheckMode.NoCertificate,
+            mock(),
         ).generateInitiatorHello()
 
         setRunning()
@@ -192,13 +194,14 @@ class InMemorySessionReplayerTest {
         }
 
         InMemorySessionReplayer(mock(), mock(), mock(), mock(), groups, groupsAndMembers.first, mockTimeFacilitiesProvider.clock)
-        val helloMessage = AuthenticationProtocolInitiator(
+        val helloMessage = AuthenticationProtocolInitiator.create(
             id,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             MAX_MESSAGE_SIZE,
             KEY_PAIR.public,
             GROUP_ID,
-            CertificateCheckMode.NoCertificate
+            CertificateCheckMode.NoCertificate,
+            mock(),
         ).generateInitiatorHello()
 
         setRunning()
@@ -217,13 +220,14 @@ class InMemorySessionReplayerTest {
         }
 
         InMemorySessionReplayer(mock(), mock(), mock(), mock(), groups, groupsAndMembers.first, mockTimeFacilitiesProvider.clock)
-        val helloMessage = AuthenticationProtocolInitiator(
+        val helloMessage = AuthenticationProtocolInitiator.create(
             id,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             MAX_MESSAGE_SIZE,
             KEY_PAIR.public,
             GROUP_ID,
-            CertificateCheckMode.NoCertificate
+            CertificateCheckMode.NoCertificate,
+            mock(),
         ).generateInitiatorHello()
 
         setRunning()
@@ -251,13 +255,14 @@ class InMemorySessionReplayerTest {
             membershipGroupReaderProvider,
             mockTimeFacilitiesProvider.clock,
         )
-        val helloMessage = AuthenticationProtocolInitiator(
+        val helloMessage = AuthenticationProtocolInitiator.create(
             id,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             MAX_MESSAGE_SIZE,
             KEY_PAIR.public,
             GROUP_ID,
-            CertificateCheckMode.NoCertificate
+            CertificateCheckMode.NoCertificate,
+            mock(),
         ).generateInitiatorHello()
 
         setRunning()
@@ -281,13 +286,14 @@ class InMemorySessionReplayerTest {
             membershipGroupReaderProvider,
             mockTimeFacilitiesProvider.clock,
         )
-        val helloMessage = AuthenticationProtocolInitiator(
+        val helloMessage = AuthenticationProtocolInitiator.create(
             id,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             MAX_MESSAGE_SIZE,
             KEY_PAIR.public,
             GROUP_ID,
-            CertificateCheckMode.NoCertificate
+            CertificateCheckMode.NoCertificate,
+            mock(),
         ).generateInitiatorHello()
 
         setRunning()
@@ -313,13 +319,14 @@ class InMemorySessionReplayerTest {
 
     @Test
     fun `The InMemorySessionReplayer will not replay before start`() {
-        val helloMessage = AuthenticationProtocolInitiator(
+        val helloMessage = AuthenticationProtocolInitiator.create(
             "",
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
             MAX_MESSAGE_SIZE,
             KEY_PAIR.public,
             GROUP_ID,
-            CertificateCheckMode.NoCertificate
+            CertificateCheckMode.NoCertificate,
+            mock(),
         ).generateInitiatorHello()
         val replayer = InMemorySessionReplayer(mock(), mock(), mock(), mock(),
             groupsAndMembers.second, groupsAndMembers.first, mockTimeFacilitiesProvider.clock)

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/OutboundSessionPoolTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/OutboundSessionPoolTest.kt
@@ -1,8 +1,9 @@
 package net.corda.p2p.linkmanager.sessions
 
 import net.corda.data.p2p.app.MembershipStatusFilter
+import net.corda.p2p.crypto.protocol.api.AuthenticatedSession
 import net.corda.p2p.crypto.protocol.api.AuthenticationProtocolInitiator
-import net.corda.p2p.crypto.protocol.api.Session
+import net.corda.p2p.crypto.protocol.api.SessionWrapper
 import net.corda.p2p.linkmanager.utilities.LoggingInterceptor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
@@ -91,7 +92,7 @@ class OutboundSessionPoolTest {
             authenticationProtocols.add(mockAuthenticationProtocol)
         }
 
-        val mockSession = mock<Session> {
+        val mockSession = mock<AuthenticatedSession> {
             on { sessionId } doReturn "session2"
         }
 
@@ -124,7 +125,7 @@ class OutboundSessionPoolTest {
         }
 
         val negotiatedSessionId = "session2"
-        val mockSession = mock<Session> {
+        val mockSession = mock<AuthenticatedSession> {
             on { sessionId } doReturn negotiatedSessionId
         }
 
@@ -164,16 +165,16 @@ class OutboundSessionPoolTest {
         }
         pool.addPendingSessions(sessionCounterparties, authenticationProtocols)
 
-        val mockSessions = mutableListOf<Session>()
+        val mockSessions = mutableListOf<SessionWrapper>()
         for (i in 0 until POOL_SIZE) {
-            val mockSession = mock<Session> {
+            val mockSession = mock<AuthenticatedSession> {
                 on { sessionId } doReturn "session$i"
             }
             mockSessions.add(mockSession)
             pool.updateAfterSessionEstablished(mockSession)
         }
 
-        val gotSessions = mutableListOf<Session>()
+        val gotSessions = mutableListOf<SessionWrapper>()
         // If all sessions have weight 1 then the total weight is POOL_SIZE. The sum of (total weight - weight) for each session is
         // (POOL_SIZE - 1) * total weight. Which is (POOL_SIZE - 1) * POOL_SIZE.
         for (i in 0 until (POOL_SIZE - 1) * POOL_SIZE) {
@@ -211,16 +212,16 @@ class OutboundSessionPoolTest {
         }
         pool.addPendingSessions(sessionCounterparties, authenticationProtocols)
 
-        val mockSessions = mutableListOf<Session>()
+        val mockSessions = mutableListOf<SessionWrapper>()
         for (i in 0 until POOL_SIZE) {
-            val mockSession = mock<Session> {
+            val mockSession = mock<AuthenticatedSession> {
                 on { sessionId } doReturn "session$i"
             }
             mockSessions.add(mockSession)
             pool.updateAfterSessionEstablished(mockSession)
         }
 
-        val gotSessions = mutableListOf<Session>()
+        val gotSessions = mutableListOf<SessionWrapper>()
         // If all sessions have weight 1 then the total weight is POOL_SIZE. The sum of (total weight - weight) for each session is
         // (POOL_SIZE - 1) * total weight. Which is (POOL_SIZE - 1) * POOL_SIZE.
         for (i in 0 until (POOL_SIZE - 1) * POOL_SIZE) {
@@ -259,16 +260,16 @@ class OutboundSessionPoolTest {
         }
         pool.addPendingSessions(sessionCounterparties, authenticationProtocols)
 
-        val mockSessions = mutableListOf<Session>()
+        val mockSessions = mutableListOf<SessionWrapper>()
         for (i in listOf(0, 1, 4)) {
-            val mockSession = mock<Session> {
+            val mockSession = mock<AuthenticatedSession> {
                 on { sessionId } doReturn "session$i"
             }
             mockSessions.add(mockSession)
             pool.updateAfterSessionEstablished(mockSession)
         }
 
-        val gotSessions = mutableListOf<Session>()
+        val gotSessions = mutableListOf<SessionWrapper>()
         for (i in 0 until (POOL_SIZE - 1) * POOL_SIZE) {
             gotSessions.add((pool.getNextSession(sessionCounterparties) as OutboundSessionPool.SessionPoolStatus.SessionActive).session)
         }
@@ -305,9 +306,9 @@ class OutboundSessionPoolTest {
         }
         pool.addPendingSessions(sessionCounterparties, authenticationProtocols)
 
-        val mockSessions = mutableListOf<Session>()
+        val mockSessions = mutableListOf<SessionWrapper>()
         for (i in 0 until POOL_SIZE) {
-            val mockSession = mock<Session> {
+            val mockSession = mock<AuthenticatedSession> {
                 on { sessionId } doReturn "session$i"
             }
             if (i != 2) mockSessions.add(mockSession)
@@ -320,7 +321,7 @@ class OutboundSessionPoolTest {
 
         pool.replaceSession(sessionCounterparties, timedOutSessionId, newPendingSession)
 
-        val gotSessions = mutableListOf<Session>()
+        val gotSessions = mutableListOf<SessionWrapper>()
         for (i in 0 until (POOL_SIZE - 1) * POOL_SIZE) {
             gotSessions.add((pool.getNextSession(sessionCounterparties) as OutboundSessionPool.SessionPoolStatus.SessionActive).session)
         }
@@ -357,9 +358,9 @@ class OutboundSessionPoolTest {
         }
         pool.addPendingSessions(sessionCounterparties, authenticationProtocols)
 
-        val mockSessions = mutableListOf<Session>()
+        val mockSessions = mutableListOf<SessionWrapper>()
         for (i in 0 until POOL_SIZE) {
-            val mockSession = mock<Session> {
+            val mockSession = mock<AuthenticatedSession> {
                 on { sessionId } doReturn "session$i"
             }
             if (i != 2) mockSessions.add(mockSession)
@@ -371,13 +372,13 @@ class OutboundSessionPoolTest {
         }
         pool.replaceSession(sessionCounterparties, timedOutSessionId, newPendingSession)
 
-        val mockSession = mock<Session> {
+        val mockSession = mock<AuthenticatedSession> {
             on { sessionId } doReturn "newSession"
         }
         pool.updateAfterSessionEstablished(mockSession)
         mockSessions.add(mockSession)
 
-        val gotSessions = mutableListOf<Session>()
+        val gotSessions = mutableListOf<SessionWrapper>()
         for (i in 0 until (POOL_SIZE - 1) * POOL_SIZE) {
             gotSessions.add((pool.getNextSession(sessionCounterparties) as OutboundSessionPool.SessionPoolStatus.SessionActive).session)
         }
@@ -419,16 +420,16 @@ class OutboundSessionPoolTest {
         }
         pool.addPendingSessions(sessionCounterparties, authenticationProtocols)
 
-        val mockSessions = mutableListOf<Session>()
+        val mockSessions = mutableListOf<SessionWrapper>()
         for (i in 0 until POOL_SIZE) {
-            val mockSession = mock<Session> {
+            val mockSession = mock<AuthenticatedSession> {
                 on { sessionId } doReturn "session$i"
             }
             mockSessions.add(mockSession)
             pool.updateAfterSessionEstablished(mockSession)
         }
 
-        val gotSessions = mutableListOf<Session>()
+        val gotSessions = mutableListOf<SessionWrapper>()
         // If Session 0 has weight 0, Session 1 has weight 1 etc. Then we have total weight is: POOL_SIZE * (POOL_SIZE - 1) / 2.
         // The sum of (total weight - weight) for each session is (POOL_SIZE - 1) * total weight. Which is
         // (POOL_SIZE - 1) * POOL_SIZE * (POOL_SIZE - 1) / 2.

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,7 +46,7 @@ commonsTextVersion = 1.10.0
 bouncycastleVersion=1.76
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.11-beta+
+cordaApiVersion=5.2.0.21-alpha-1701867346553
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/p2p-crypto/build.gradle
+++ b/libs/p2p-crypto/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation "net.corda:corda-crypto"
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:crypto:crypto-utils")
+    implementation project(":libs:utilities")
 
     api "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
     api "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"

--- a/libs/p2p-crypto/src/integrationTest/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
+++ b/libs/p2p-crypto/src/integrationTest/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
@@ -1,7 +1,9 @@
 package net.corda.p2p.crypto.protocol.api
 
 import net.corda.data.p2p.gateway.certificates.Active
+import net.corda.data.p2p.gateway.certificates.RevocationCheckRequest
 import net.corda.data.p2p.gateway.certificates.RevocationCheckResponse
+import net.corda.data.p2p.gateway.certificates.RevocationMode
 import net.corda.data.p2p.gateway.certificates.Revoked
 import net.corda.testing.p2p.certificates.Certificates
 import net.corda.v5.base.types.MemberX500Name
@@ -29,40 +31,51 @@ class CertificateValidatorTest {
     private val trustStoreWithRevocation = listOf(Certificates.truststoreCertificatePem.readText())
     private val wrongTrustStore = listOf(Certificates.c4TruststoreCertificatePem.readText())
     private val revokedResponse =  RevocationCheckResponse(Revoked("The certificate was revoked.", 0))
+    private class RevocationCheckerImpl(private val response: RevocationCheckResponse) : RevocationChecker {
+        override fun checkRevocation(request: RevocationCheckRequest) = response
+    }
 
     @Test
     fun `valid certificate passes validation`() {
-        val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, trustStore, { RevocationCheckResponse(Active()) })
+        val validator = CertificateValidator(RevocationMode.HARD_FAIL, trustStore, RevocationCheckerImpl(RevocationCheckResponse(Active())))
         validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey)
     }
 
     @Test
     fun `revoked certificate fails validation with HARD FAIL mode`() {
-        val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, trustStore, { revokedResponse })
+        val validator = CertificateValidator(RevocationMode.HARD_FAIL, trustStore, RevocationCheckerImpl(revokedResponse))
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey) }
     }
 
     @Test
     fun `revoked certificate fails validation with SOFT FAIL mode`() {
-        val validator = CertificateValidator(RevocationCheckMode.SOFT_FAIL, trustStore, { revokedResponse })
+        val validator = CertificateValidator(RevocationMode.SOFT_FAIL, trustStore, RevocationCheckerImpl(revokedResponse))
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey) }
     }
 
     @Test
     fun `revoked certificate passes validation with revocation OFF`() {
-        val validator = CertificateValidator(RevocationCheckMode.OFF, trustStore, { revokedResponse })
+        val validator = CertificateValidator(null, trustStore, RevocationCheckerImpl(revokedResponse))
         validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey)
     }
 
     @Test
     fun `if truststore is wrong validation fails`() {
-        val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, wrongTrustStore, { RevocationCheckResponse(Active()) })
+        val validator = CertificateValidator(
+            RevocationMode.HARD_FAIL,
+            wrongTrustStore,
+            RevocationCheckerImpl(RevocationCheckResponse(Active())),
+        )
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, alicePublicKey) }
     }
 
     @Test
     fun `if public key does not match validation fails`() {
-        val validator = CertificateValidator(RevocationCheckMode.HARD_FAIL, trustStoreWithRevocation, { RevocationCheckResponse(Active()) })
+        val validator = CertificateValidator(
+            RevocationMode.HARD_FAIL,
+            trustStoreWithRevocation,
+            RevocationCheckerImpl(RevocationCheckResponse(Active())),
+        )
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(aliceCert), aliceX500Name, wrongPublicKey) }
     }
 }

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolWrapper.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolWrapper.kt
@@ -3,6 +3,7 @@ package net.corda.p2p.crypto.protocol.api
 import net.corda.data.p2p.crypto.InitiatorHelloMessage
 import net.corda.data.p2p.crypto.ProtocolMode
 import net.corda.data.p2p.crypto.ResponderHelloMessage
+import net.corda.data.p2p.crypto.protocol.AuthenticationProtocolHeader
 import net.corda.p2p.crypto.protocol.ProtocolConstants.Companion.CIPHER_ALGO
 import net.corda.p2p.crypto.protocol.ProtocolConstants.Companion.CIPHER_KEY_SIZE_BYTES
 import net.corda.p2p.crypto.protocol.ProtocolConstants.Companion.CIPHER_NONCE_SIZE_BYTES
@@ -24,6 +25,7 @@ import net.corda.p2p.crypto.protocol.ProtocolConstants.Companion.RESPONDER_SESSI
 import net.corda.p2p.crypto.util.convertToBCDigest
 import net.corda.p2p.crypto.util.generateKey
 import net.corda.p2p.crypto.util.hash
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SignatureSpec
 import org.bouncycastle.crypto.generators.HKDFBytesGenerator
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -41,10 +43,8 @@ import javax.crypto.KeyAgreement
 import javax.crypto.Mac
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
-import net.corda.crypto.utils.PemCertificate
-import net.corda.data.p2p.gateway.certificates.RevocationCheckRequest
-import net.corda.data.p2p.gateway.certificates.RevocationCheckResponse
-import net.corda.v5.base.types.MemberX500Name
+import net.corda.data.p2p.crypto.protocol.SecretKeySpec as SecretKeySpecData
+
 
 /**
  * A base, abstract class containing the core utilities for the session authentication protocol.
@@ -53,9 +53,14 @@ import net.corda.v5.base.types.MemberX500Name
  *
  * For the detailed spec of the authentication protocol, refer to the corresponding design document.
  */
-abstract class AuthenticationProtocol(private val certificateValidatorFactory: (revocationCheckMode: RevocationCheckMode,
-                                       pemTrustStore: List<PemCertificate>,
-                                       checkRevocation: (RevocationCheckRequest) -> RevocationCheckResponse) -> CertificateValidator){
+sealed class AuthenticationProtocolWrapper(
+    internal val header: AuthenticationProtocolHeader,
+    private val certificateValidatorFactory: CertificateValidatorFactory,
+) {
+    companion object {
+        internal val secureRandom = SecureRandom()
+    }
+
     protected var myPrivateDHKey: PrivateKey? = null
     protected var myPublicDHKey: ByteArray? = null
     protected var peerPublicDHKey: PublicKey? = null
@@ -70,7 +75,6 @@ abstract class AuthenticationProtocol(private val certificateValidatorFactory: (
     protected var responderHandshakePayloadBytes: ByteArray? = null
     protected var agreedMaxMessageSize: Int? = null
 
-    protected val secureRandom = SecureRandom()
     protected val provider = BouncyCastleProvider.PROVIDER_NAME
     protected val ephemeralKeyFactory = KeyFactory.getInstance(ELLIPTIC_CURVE_ALGO, provider)
     protected val keyPairGenerator = KeyPairGenerator.getInstance(ELLIPTIC_CURVE_ALGO, provider).apply {
@@ -87,67 +91,121 @@ abstract class AuthenticationProtocol(private val certificateValidatorFactory: (
         return Signature.getInstance(signatureSpec.signatureName, provider)
     }
 
+    val sessionId: String
+        get() = header.sessionId
+    internal val ourMaxMessageSize: Int
+        get() = header.ourMaxMessageSize
+
+
     fun generateHandshakeSecrets(inputKeyMaterial: ByteArray, initiatorHelloToResponderHello: ByteArray): SharedHandshakeSecrets {
-        val initiatorEncryptionKeyBytes = hkdfGenerator.generateKey(initiatorHelloToResponderHello, inputKeyMaterial,
-                                                                    INITIATOR_HANDSHAKE_ENCRYPTION_KEY_INFO, CIPHER_KEY_SIZE_BYTES)
+        val initiatorEncryptionKeyBytes = hkdfGenerator.generateKey(
+            initiatorHelloToResponderHello,
+            inputKeyMaterial,
+            INITIATOR_HANDSHAKE_ENCRYPTION_KEY_INFO,
+            CIPHER_KEY_SIZE_BYTES,
+        )
         val initiatorEncryptionKey = SecretKeySpec(initiatorEncryptionKeyBytes, CIPHER_ALGO)
 
-        val responderEncryptionKeyBytes = hkdfGenerator.generateKey(initiatorHelloToResponderHello, inputKeyMaterial,
-                                                                    RESPONDER_HANDSHAKE_ENCRYPTION_KEY_INFO, CIPHER_KEY_SIZE_BYTES)
+        val responderEncryptionKeyBytes = hkdfGenerator.generateKey(
+            initiatorHelloToResponderHello,
+            inputKeyMaterial,
+            RESPONDER_HANDSHAKE_ENCRYPTION_KEY_INFO,
+            CIPHER_KEY_SIZE_BYTES,
+        )
         val responderEncryptionKey = SecretKeySpec(responderEncryptionKeyBytes, CIPHER_ALGO)
 
-        val initiatorNonce = hkdfGenerator.generateKey(initiatorHelloToResponderHello, inputKeyMaterial,
-                                                                    INITIATOR_HANDSHAKE_ENCRYPTION_NONCE_INFO, CIPHER_NONCE_SIZE_BYTES)
-        val responderNonce = hkdfGenerator.generateKey(initiatorHelloToResponderHello, inputKeyMaterial,
-                                                                    RESPONDER_HANDSHAKE_ENCRYPTION_NONCE_INFO, CIPHER_NONCE_SIZE_BYTES)
+        val initiatorNonce = hkdfGenerator.generateKey(
+            initiatorHelloToResponderHello,
+            inputKeyMaterial,
+            INITIATOR_HANDSHAKE_ENCRYPTION_NONCE_INFO,
+            CIPHER_NONCE_SIZE_BYTES,
+        )
+        val responderNonce = hkdfGenerator.generateKey(
+            initiatorHelloToResponderHello,
+            inputKeyMaterial,
+            RESPONDER_HANDSHAKE_ENCRYPTION_NONCE_INFO,
+            CIPHER_NONCE_SIZE_BYTES,
+        )
 
-        val initiatorMacKeyBytes = hkdfGenerator.generateKey(initiatorHelloToResponderHello, inputKeyMaterial,
-                                                                    INITIATOR_HANDSHAKE_MAC_KEY_INFO, HMAC_KEY_SIZE_BYTES)
+        val initiatorMacKeyBytes = hkdfGenerator.generateKey(
+            initiatorHelloToResponderHello,
+            inputKeyMaterial,
+            INITIATOR_HANDSHAKE_MAC_KEY_INFO,
+            HMAC_KEY_SIZE_BYTES,
+        )
         val initiatorMacKey = SecretKeySpec(initiatorMacKeyBytes, HMAC_ALGO)
 
-        val responderMackKeyBytes = hkdfGenerator.generateKey(initiatorHelloToResponderHello, inputKeyMaterial,
-                                                                    RESPONDER_HANDSHAKE_MAC_KEY_INFO, HMAC_KEY_SIZE_BYTES)
+        val responderMackKeyBytes = hkdfGenerator.generateKey(
+            initiatorHelloToResponderHello,
+            inputKeyMaterial,
+            RESPONDER_HANDSHAKE_MAC_KEY_INFO,
+            HMAC_KEY_SIZE_BYTES,
+        )
         val responderMacKey = SecretKeySpec(responderMackKeyBytes, HMAC_ALGO)
 
-        return SharedHandshakeSecrets(initiatorMacKey, responderMacKey,
-                                      initiatorEncryptionKey, responderEncryptionKey, initiatorNonce, responderNonce)
+        return SharedHandshakeSecrets(
+            initiatorMacKey,
+            responderMacKey,
+            initiatorEncryptionKey,
+            responderEncryptionKey,
+            initiatorNonce,
+            responderNonce,
+        )
     }
 
     fun generateSessionSecrets(inputKeyMaterial: ByteArray, initiatorHelloToResponderFinished: ByteArray): SharedSessionSecrets {
-        val initiatorEncryptionKeyBytes = hkdfGenerator.generateKey(initiatorHelloToResponderFinished, inputKeyMaterial,
-                                                                    INITIATOR_SESSION_ENCRYPTION_KEY_INFO, CIPHER_KEY_SIZE_BYTES)
+        val initiatorEncryptionKeyBytes = hkdfGenerator.generateKey(
+            initiatorHelloToResponderFinished,
+            inputKeyMaterial,
+            INITIATOR_SESSION_ENCRYPTION_KEY_INFO,
+            CIPHER_KEY_SIZE_BYTES,
+        )
         val initiatorEncryptionKey = SecretKeySpec(initiatorEncryptionKeyBytes, CIPHER_ALGO)
 
-        val responderEncryptionKeyBytes = hkdfGenerator.generateKey(initiatorHelloToResponderFinished, inputKeyMaterial,
-                                                                    RESPONDER_SESSION_ENCRYPTION_KEY_INFO, CIPHER_KEY_SIZE_BYTES)
+        val responderEncryptionKeyBytes = hkdfGenerator.generateKey(
+            initiatorHelloToResponderFinished,
+            inputKeyMaterial,
+            RESPONDER_SESSION_ENCRYPTION_KEY_INFO,
+            CIPHER_KEY_SIZE_BYTES,
+        )
         val responderEncryptionKey = SecretKeySpec(responderEncryptionKeyBytes, CIPHER_ALGO)
 
-        val initiatorNonce = hkdfGenerator.generateKey(initiatorHelloToResponderFinished, inputKeyMaterial,
-                                                                    INITIATOR_SESSION_NONCE_INFO, CIPHER_NONCE_SIZE_BYTES)
-        val responderNonce = hkdfGenerator.generateKey(initiatorHelloToResponderFinished, inputKeyMaterial,
-                                                                    RESPONDER_SESSION_NONCE_INFO, CIPHER_NONCE_SIZE_BYTES)
+        val initiatorNonce = hkdfGenerator.generateKey(
+            initiatorHelloToResponderFinished,
+            inputKeyMaterial,
+            INITIATOR_SESSION_NONCE_INFO,
+            CIPHER_NONCE_SIZE_BYTES,
+        )
+        val responderNonce = hkdfGenerator.generateKey(
+            initiatorHelloToResponderFinished,
+            inputKeyMaterial,
+            RESPONDER_SESSION_NONCE_INFO,
+            CIPHER_NONCE_SIZE_BYTES,
+        )
 
         return SharedSessionSecrets(initiatorEncryptionKey, responderEncryptionKey, initiatorNonce, responderNonce)
     }
 
+    @Suppress("LongParameterList")
     protected fun validateCertificate(
         certificateCheckMode: CertificateCheckMode,
         peerCertificate: List<String>?,
         peerX500Name: MemberX500Name,
         expectedPeerPublicKey: PublicKey,
-        messageName: String
+        messageName: String,
+        checkRevocation: RevocationChecker,
     ) {
         if (certificateCheckMode is CertificateCheckMode.CheckCertificate) {
             if (peerCertificate != null) {
-                val certificateValidator = certificateValidatorFactory(
+                val certificateValidator = certificateValidatorFactory.create(
                     certificateCheckMode.revocationCheckMode,
                     certificateCheckMode.truststore,
-                    certificateCheckMode.revocationChecker
+                    checkRevocation,
                 )
                 certificateValidator.validate(
                     peerCertificate,
                     peerX500Name,
-                    expectedPeerPublicKey
+                    expectedPeerPublicKey,
                 )
             } else {
                 throw InvalidPeerCertificate("No peer certificate was sent in the $messageName.")
@@ -162,12 +220,14 @@ abstract class AuthenticationProtocol(private val certificateValidatorFactory: (
      * @property responderEncryptionKey used for authenticated encryption on handshake messages by responder.
      *
      */
-    data class SharedHandshakeSecrets(val initiatorAuthKey: SecretKey,
-                                      val responderAuthKey: SecretKey,
-                                      val initiatorEncryptionKey: SecretKey,
-                                      val responderEncryptionKey: SecretKey,
-                                      val initiatorNonce: ByteArray,
-                                      val responderNonce: ByteArray) {
+    data class SharedHandshakeSecrets(
+        val initiatorAuthKey: SecretKey,
+        val responderAuthKey: SecretKey,
+        val initiatorEncryptionKey: SecretKey,
+        val responderEncryptionKey: SecretKey,
+        val initiatorNonce: ByteArray,
+        val responderNonce: ByteArray,
+    ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
@@ -199,10 +259,12 @@ abstract class AuthenticationProtocol(private val certificateValidatorFactory: (
      * @property initiatorEncryptionKey used for authentication encryption on session messages by us.
      * @property responderEncryptionKey used for authenticated encryption on session messages by peer.
      */
-    data class SharedSessionSecrets(val initiatorEncryptionKey: SecretKey,
-                                    val responderEncryptionKey: SecretKey,
-                                    val initiatorNonce: ByteArray,
-                                    val responderNonce: ByteArray) {
+    data class SharedSessionSecrets(
+        val initiatorEncryptionKey: SecretKey,
+        val responderEncryptionKey: SecretKey,
+        val initiatorNonce: ByteArray,
+        val responderNonce: ByteArray,
+    ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
@@ -233,3 +295,13 @@ abstract class AuthenticationProtocol(private val certificateValidatorFactory: (
 
 internal fun Long.toByteArray(): ByteArray = ByteBuffer.allocate(Long.SIZE_BYTES).putLong(this).array()
 
+internal fun SecretKeySpecData.toSecretKey() =
+    SecretKeySpec(
+        this.key.array(),
+        this.algorithm,
+    )
+internal fun SecretKey.toData() =
+    SecretKeySpecData(
+        this.algorithm,
+        ByteBuffer.wrap(this.encoded),
+    )

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/CertificateCheckMode.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/CertificateCheckMode.kt
@@ -1,8 +1,7 @@
 package net.corda.p2p.crypto.protocol.api
 
 import net.corda.crypto.utils.PemCertificate
-import net.corda.data.p2p.gateway.certificates.RevocationCheckRequest
-import net.corda.data.p2p.gateway.certificates.RevocationCheckResponse
+import net.corda.data.p2p.gateway.certificates.RevocationMode
 
 /**
  * How should the authentication protocol check the certificates sent as a part of authentication protocol.
@@ -20,11 +19,6 @@ sealed class CertificateCheckMode {
      */
     data class CheckCertificate(
         val truststore: List<PemCertificate>,
-        val revocationCheckMode: RevocationCheckMode,
-        val revocationChecker: (request: RevocationCheckRequest) -> RevocationCheckResponse
+        val revocationCheckMode: RevocationMode?,
     ): CertificateCheckMode()
-}
-
-enum class RevocationCheckMode {
-    OFF, SOFT_FAIL, HARD_FAIL
 }

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorFactory.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorFactory.kt
@@ -1,0 +1,23 @@
+package net.corda.p2p.crypto.protocol.api
+
+import net.corda.crypto.utils.PemCertificate
+import net.corda.data.p2p.gateway.certificates.RevocationMode
+
+interface CertificateValidatorFactory {
+    fun create(
+        revocationCheckMode: RevocationMode?,
+        pemTrustStore: List<PemCertificate>,
+        checkRevocation: RevocationChecker,
+    ): CertificateValidator
+
+    object Default : CertificateValidatorFactory {
+        override fun create(
+            revocationCheckMode: RevocationMode?,
+            pemTrustStore: List<PemCertificate>,
+            checkRevocation: RevocationChecker,
+        ): CertificateValidator {
+            return CertificateValidator(revocationCheckMode, pemTrustStore, checkRevocation)
+        }
+
+    }
+}

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/RevocationChecker.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/RevocationChecker.kt
@@ -1,0 +1,8 @@
+package net.corda.p2p.crypto.protocol.api
+
+import net.corda.data.p2p.gateway.certificates.RevocationCheckRequest
+import net.corda.data.p2p.gateway.certificates.RevocationCheckResponse
+
+interface RevocationChecker {
+    fun checkRevocation(request: RevocationCheckRequest): RevocationCheckResponse
+}

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/Session.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/Session.kt
@@ -1,8 +1,0 @@
-package net.corda.p2p.crypto.protocol.api
-
-/**
- * A marker interface supposed to be implemented by the different types of sessions supported by the authentication protocol.
- */
-interface Session {
-    val sessionId: String
-}

--- a/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/SessionWrapper.kt
+++ b/libs/p2p-crypto/src/main/kotlin/net/corda/p2p/crypto/protocol/api/SessionWrapper.kt
@@ -1,0 +1,27 @@
+package net.corda.p2p.crypto.protocol.api
+
+import net.corda.data.p2p.crypto.protocol.AuthenticatedEncryptionSessionDetails
+import net.corda.data.p2p.crypto.protocol.AuthenticatedSessionDetails
+import net.corda.data.p2p.crypto.protocol.Session
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+/**
+ * A marker interface supposed to be implemented by the different types of sessions supported by the authentication protocol.
+ */
+sealed interface SessionWrapper {
+    companion object {
+        fun wrap(session: Session): SessionWrapper {
+            return when (val details = session.details) {
+                is AuthenticatedEncryptionSessionDetails -> {
+                    AuthenticatedEncryptionSession(session, details)
+                }
+                is AuthenticatedSessionDetails -> {
+                    AuthenticatedSession(session, details)
+                }
+                else -> throw CordaRuntimeException("Invalid session type: ${details.javaClass.simpleName}")
+            }
+        }
+    }
+    val sessionId: String
+    val session: Session
+}

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedEncryptionSessionTest.kt
@@ -10,6 +10,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
 import java.security.Security
@@ -29,19 +30,20 @@ class AuthenticatedEncryptionSessionTest {
     // party A
     private val partyAMaxMessageSize = 1_000_000
     private val partyASessionKey = keyPairGenerator.generateKeyPair()
-    private val authenticationProtocolA = AuthenticationProtocolInitiator(
+    private val authenticationProtocolA = AuthenticationProtocolInitiator.create(
         sessionId,
         setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
         partyAMaxMessageSize,
         partyASessionKey.public,
         groupId,
-        CertificateCheckMode.NoCertificate
+        CertificateCheckMode.NoCertificate,
+        mock(),
     )
 
     // party B
     private val partyBMaxMessageSize = 1_500_000
     private val partyBSessionKey = keyPairGenerator.generateKeyPair()
-    private val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
+    private val authenticationProtocolB = AuthenticationProtocolResponder.create(sessionId, partyBMaxMessageSize)
 
     companion object {
         @BeforeAll
@@ -87,7 +89,8 @@ class AuthenticatedEncryptionSessionTest {
         authenticationProtocolB.validateEncryptedExtensions(
             CertificateCheckMode.NoCertificate,
             setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
-            aliceX500Name
+            aliceX500Name,
+            mock(),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -179,7 +182,8 @@ class AuthenticatedEncryptionSessionTest {
         authenticationProtocolB.validateEncryptedExtensions(
             CertificateCheckMode.NoCertificate,
             setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
-            aliceX500Name
+            aliceX500Name,
+            mock(),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -277,7 +281,8 @@ class AuthenticatedEncryptionSessionTest {
         authenticationProtocolB.validateEncryptedExtensions(
             CertificateCheckMode.NoCertificate,
             setOf(ProtocolMode.AUTHENTICATED_ENCRYPTION),
-            aliceX500Name
+            aliceX500Name,
+            mock(),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticatedSessionTest.kt
@@ -10,6 +10,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
 import java.nio.ByteBuffer
 import java.security.KeyPairGenerator
 import java.security.Security
@@ -30,19 +31,20 @@ class AuthenticatedSessionTest {
     // party A
     private val partyAMaxMessageSize = 1_000_000
     private val partyASessionKey = keyPairGenerator.generateKeyPair()
-    private val authenticationProtocolA = AuthenticationProtocolInitiator(
+    private val authenticationProtocolA = AuthenticationProtocolInitiator.create(
         sessionId,
         setOf(ProtocolMode.AUTHENTICATION_ONLY),
         partyAMaxMessageSize,
         partyASessionKey.public,
         groupId,
-        CertificateCheckMode.NoCertificate
+        CertificateCheckMode.NoCertificate,
+        mock(),
     )
 
     // party B
     private val partyBMaxMessageSize = 1_500_000
     private val partyBSessionKey = keyPairGenerator.generateKeyPair()
-    private val authenticationProtocolB = AuthenticationProtocolResponder(sessionId, partyBMaxMessageSize)
+    private val authenticationProtocolB = AuthenticationProtocolResponder.create(sessionId, partyBMaxMessageSize)
 
     companion object {
         @BeforeAll
@@ -86,7 +88,8 @@ class AuthenticatedSessionTest {
         authenticationProtocolB.validateEncryptedExtensions(
             CertificateCheckMode.NoCertificate,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
-            aliceX500Name
+            aliceX500Name,
+            mock(),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -171,7 +174,8 @@ class AuthenticatedSessionTest {
         authenticationProtocolB.validateEncryptedExtensions(
             CertificateCheckMode.NoCertificate,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
-            aliceX500Name
+            aliceX500Name,
+            mock(),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.
@@ -247,7 +251,8 @@ class AuthenticatedSessionTest {
         authenticationProtocolB.validateEncryptedExtensions(
             CertificateCheckMode.NoCertificate,
             setOf(ProtocolMode.AUTHENTICATION_ONLY),
-            aliceX500Name
+            aliceX500Name,
+            mock(),
         )
 
         // Step 4: responder sending handshake message and initiator validating it.

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/CertificateValidatorTest.kt
@@ -1,7 +1,6 @@
 package net.corda.p2p.crypto.protocol.api
 
-import net.corda.data.p2p.gateway.certificates.Active
-import net.corda.data.p2p.gateway.certificates.RevocationCheckResponse
+import net.corda.data.p2p.gateway.certificates.RevocationMode
 import net.corda.v5.base.types.MemberX500Name
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -52,7 +51,7 @@ class CertificateValidatorTest {
         whenever(certificate.keyUsage).thenReturn(BooleanArray(10) { it == 0 }) //Set key usage bit
         whenever(certificateFactory.generateCertificate(any())).thenThrow(CertificateException("Invalid certificate."))
         val validator = CertificateValidator(
-            RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
+            RevocationMode.HARD_FAIL, mock(), mock(), certPathValidator, certificateFactory
         )
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }
@@ -60,9 +59,15 @@ class CertificateValidatorTest {
     @Test
     fun `certificate fails validation if X500 name doesn't match`() {
         val validator = CertificateValidator(
-            RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
+            RevocationMode.HARD_FAIL, mock(), mock(), certPathValidator, certificateFactory
         )
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), aliceX500Name, publicKey) }
+        assertThrows<InvalidPeerCertificate> {
+            validator.validate(
+                listOf(certificatePemString),
+                aliceX500Name,
+                publicKey,
+            )
+        }
     }
 
     @Test
@@ -70,9 +75,15 @@ class CertificateValidatorTest {
         val nonX500Certificate = mock<Certificate>()
         whenever(certificateChain.certificates).thenReturn(listOf(nonX500Certificate))
         val validator = CertificateValidator(
-            RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
+            RevocationMode.HARD_FAIL, mock(), mock(), certPathValidator, certificateFactory
         )
-        assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
+        assertThrows<InvalidPeerCertificate> {
+            validator.validate(
+                listOf(certificatePemString),
+                certX500Name,
+                publicKey,
+            )
+        }
     }
 
     @Test
@@ -83,7 +94,7 @@ class CertificateValidatorTest {
         }
         whenever(certificateChain.certificates).thenReturn(listOf(certificate))
         val validator = CertificateValidator(
-            RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
+            RevocationMode.HARD_FAIL, mock(), mock(), certPathValidator, certificateFactory
         )
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }
@@ -92,7 +103,7 @@ class CertificateValidatorTest {
     fun `certificate fails validation if x509 cert does not have digital signature set`() {
         whenever(certificate.keyUsage).thenReturn(BooleanArray(10) { it != 0 })
         val validator = CertificateValidator(
-            RevocationCheckMode.HARD_FAIL, mock(), { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
+            RevocationMode.HARD_FAIL, mock(), mock(), certPathValidator, certificateFactory
         )
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }
@@ -104,7 +115,7 @@ class CertificateValidatorTest {
         whenever(certificateFactory.generateCertificate(any()))
             .thenReturn(certificate).thenThrow(CertificateException("Invalid certificate."))
         val validator = CertificateValidator(
-            RevocationCheckMode.HARD_FAIL, pemTruststore, { RevocationCheckResponse(Active()) }, certPathValidator, certificateFactory
+            RevocationMode.HARD_FAIL, pemTruststore, mock(), certPathValidator, certificateFactory
         )
         assertThrows<InvalidPeerCertificate> { validator.validate(listOf(certificatePemString), certX500Name, publicKey) }
     }

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/SessionWrapperTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/SessionWrapperTest.kt
@@ -1,0 +1,57 @@
+package net.corda.p2p.crypto.protocol.api
+
+import net.corda.data.p2p.crypto.protocol.AuthenticatedEncryptionSessionDetails
+import net.corda.data.p2p.crypto.protocol.AuthenticatedSessionDetails
+import net.corda.data.p2p.crypto.protocol.Session
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.assertj.core.api.Assertions.assertThat
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import java.security.Security
+
+class SessionWrapperTest {
+    companion object {
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            Security.addProvider(BouncyCastleProvider())
+        }
+    }
+
+    @Test
+    fun `wrap will return AuthenticatedEncryptionSession when needed`() {
+        val session = mock<Session> {
+            on { details } doReturn mock<AuthenticatedEncryptionSessionDetails>()
+        }
+
+        val wrapper = SessionWrapper.wrap(session)
+
+        assertThat(wrapper).isInstanceOf(AuthenticatedEncryptionSession::class.java)
+    }
+
+    @Test
+    fun `wrap will return AuthenticatedSession when needed`() {
+        val session = mock<Session> {
+            on { details } doReturn mock<AuthenticatedSessionDetails>()
+        }
+
+        val wrapper = SessionWrapper.wrap(session)
+
+        assertThat(wrapper).isInstanceOf(AuthenticatedSession::class.java)
+    }
+
+    @Test
+    fun `wrap will throw an exception when details type is unexpected`() {
+        val session = mock<Session> {
+            on { details } doReturn 12
+        }
+
+        assertThrows<CordaRuntimeException> {
+            SessionWrapper.wrap(session)
+        }
+    }
+}

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/crypto/PublicKeyFactory.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/crypto/PublicKeyFactory.kt
@@ -3,7 +3,10 @@ package net.corda.utilities.crypto
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.openssl.PEMParser
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import java.io.Reader
+import java.io.StringWriter
+import java.security.Key
 import java.security.PublicKey
 
 fun publicKeyFactory(pem: Reader): PublicKey? {
@@ -18,5 +21,13 @@ fun publicKeyFactory(pem: Reader): PublicKey? {
             }
         }.filterNotNull()
             .firstOrNull()
+    }
+}
+fun Key.toPem(): String {
+    return StringWriter().use { str ->
+        JcaPEMWriter(str).use { writer ->
+            writer.writeObject(this)
+        }
+        str.toString()
     }
 }

--- a/libs/utilities/src/test/kotlin/net/corda/utilities/crypto/PublicKeyFactoryTest.kt
+++ b/libs/utilities/src/test/kotlin/net/corda/utilities/crypto/PublicKeyFactoryTest.kt
@@ -38,4 +38,11 @@ ORC/w+12HlGG968CICBvpZAN2HHIlo2Vmgak+avL2zdIK6LQo0nXuY+4e0KT
 
         assertThat(key).isNull()
     }
+
+    @Test
+    fun `toPem return a valid PEM`() {
+        val key = publicKeyFactory(VALID_KEY_PEM.reader())
+
+        assertThat(key?.toPem()?.trim()).isEqualTo(VALID_KEY_PEM.trim())
+    }
 }


### PR DESCRIPTION
This change supports persisting and restoring the link manager authentication protocol sessions.

API pull request in https://github.com/corda/corda-api/pull/1385

Multi-cluster tests in [here](https://ci02.dev.r3.com/job/Corda5/job/corda-e2e-tests-multi-cluster-tests/job/release%2F5.2/57/)
