### PR TITLE
CORE-18724 Add registration logger and update logging during registration to aid tracking registration progress

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/RegistrationLogger.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/RegistrationLogger.kt
@@ -1,0 +1,80 @@
+package net.corda.membership.impl.registration
+
+import net.corda.virtualnode.toCorda
+import org.slf4j.Logger
+
+/**
+ * A common logger for use across registration services/handlers to ensure consistent logging to aid in better analysis of logs.
+ */
+class RegistrationLogger(private val logger: Logger) {
+
+    private companion object {
+        const val REGISTRATION_ID = "registration-id"
+        const val MEMBER_HOLDING_ID = "member-holding-id"
+        const val MEMBER_NAME = "member-name"
+        const val MGM_HOLDING_ID = "mgm-holding-id"
+        const val MGM_NAME = "mgm-name"
+        const val GROUP_ID = "group-id"
+    }
+
+    private val loggingContext: MutableMap<String, String> = mutableMapOf()
+
+    fun setRegistrationId(registrationId: String): RegistrationLogger {
+        loggingContext[REGISTRATION_ID] = registrationId
+        return this
+    }
+
+    fun setMember(holdingId: net.corda.data.identity.HoldingIdentity): RegistrationLogger {
+        return setMember(holdingId.toCorda())
+    }
+
+    fun setMember(holdingId: net.corda.virtualnode.HoldingIdentity): RegistrationLogger {
+        loggingContext[MEMBER_HOLDING_ID] = holdingId.shortHash.value
+        loggingContext[MEMBER_NAME] = holdingId.x500Name.toString()
+        if (!loggingContext.containsKey(GROUP_ID)) {
+            loggingContext[GROUP_ID] = holdingId.groupId
+        }
+        return this
+    }
+
+    fun setMgm(holdingId: net.corda.data.identity.HoldingIdentity): RegistrationLogger {
+        return setMgm(holdingId.toCorda())
+    }
+
+    fun setMgm(holdingId: net.corda.virtualnode.HoldingIdentity): RegistrationLogger {
+        loggingContext[MGM_HOLDING_ID] = holdingId.shortHash.value
+        loggingContext[MGM_NAME] = holdingId.x500Name.toString()
+        if (!loggingContext.containsKey(GROUP_ID)) {
+            loggingContext[GROUP_ID] = holdingId.groupId
+        }
+        return this
+    }
+
+    fun info(msg: String) {
+        logger.info(concatContext(msg))
+    }
+
+    fun info(msg: String, e: Throwable) {
+        logger.info(concatContext(msg), e)
+    }
+
+    fun warn(msg: String) {
+        logger.warn(concatContext(msg))
+    }
+
+    fun warn(msg: String, e: Throwable) {
+        logger.warn(concatContext(msg), e)
+    }
+
+    fun error(msg: String) {
+        logger.error(concatContext(msg))
+    }
+
+    fun error(msg: String, e: Throwable) {
+        logger.error(concatContext(msg), e)
+    }
+
+    private fun concatContext(msg: String): String {
+        return msg.trim() + " $loggingContext"
+    }
+}

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ApproveRegistrationHandler.kt
@@ -76,6 +76,7 @@ internal class ApproveRegistrationHandler(
             .setRegistrationId(registrationId)
             .setMember(approvedMember)
             .setMgm(approvedBy)
+        registrationLogger.info("Processing registration approval.")
         val messages = try {
             val mgm = memberTypeChecker.getMgmMemberInfo(approvedBy.toCorda())
                 ?: throw CordaRuntimeException(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/CheckForPendingRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/CheckForPendingRegistrationHandler.kt
@@ -5,6 +5,7 @@ import net.corda.data.membership.command.registration.mgm.CheckForPendingRegistr
 import net.corda.data.membership.command.registration.mgm.StartRegistration
 import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.state.RegistrationState
+import net.corda.membership.impl.registration.RegistrationLogger
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
 import net.corda.membership.persistence.client.MembershipQueryClient
@@ -27,28 +28,28 @@ class CheckForPendingRegistrationHandler(
     override fun getOwnerHoldingId(state: RegistrationState?, command: CheckForPendingRegistration) = state?.mgm
 
     override fun invoke(state: RegistrationState?, key: String, command: CheckForPendingRegistration): RegistrationHandlerResult {
+        val registrationLogger = RegistrationLogger(logger)
+            .setMember(command.member)
+            .setMgm(command.mgm)
         val (outputState, outputCommand) = try {
             if(command.numberOfRetriesSoFar < MAX_RETRIES) {
                 state?.let {
-                    logger.info("There is a registration in progress for member ${state.registeringMember.x500Name} " +
-                            "from group `${state.registeringMember.groupId}` " +
-                            "with ID `${state.registrationId}`. The service will wait until processing the previous " +
-                            "request finishes.")
+                    registrationLogger.setRegistrationId(it.registrationId)
+                    registrationLogger.info("There is a registration in progress for member. " +
+                            "The service will wait until processing the previous request finishes.")
                     Pair(state, null)
                 } ?: run {
-                    getNextRequest(command)
+                    getNextRequest(command, registrationLogger)
                 }
             } else {
-                logger.warn(
-                    "Max re-tries exceeded to get next registration request registration " +
-                            "for member ${command.member.x500Name} from group `${command.member.groupId}`. " +
-                            "Registration is discarded."
+                registrationLogger.warn(
+                    "Max re-tries exceeded to get next registration request registration. Registration is discarded."
                 )
                 Pair(state, null)
             }
         } catch (ex: Exception) {
-            logger.warn("Exception happened while looking for the next request to process for member " +
-                    "${command.member.x500Name} from group `${command.member.groupId}`. Will re-try again.", ex)
+            registrationLogger.warn("Exception happened while looking for the next request to process for member. " +
+                    "Will re-try again.", ex)
             Pair(state, increaseNumberOfRetries(command))
         }
         return if(outputCommand != null) {
@@ -63,9 +64,11 @@ class CheckForPendingRegistrationHandler(
         }
     }
 
-    private fun getNextRequest(command: CheckForPendingRegistration): Pair<RegistrationState?, StartRegistration?> {
-        logger.info("Looking for the next request for member ${command.member.x500Name} from " +
-                "group `${command.member.groupId}`.")
+    private fun getNextRequest(
+        command: CheckForPendingRegistration,
+        registrationLogger: RegistrationLogger
+    ): Pair<RegistrationState?, StartRegistration?> {
+        registrationLogger.info("Looking for the next request for member.")
         val nextRequest = membershipQueryClient.queryRegistrationRequests(
             command.mgm.toCorda(),
             command.member.toCorda().x500Name,
@@ -74,14 +77,12 @@ class CheckForPendingRegistrationHandler(
         ).getOrThrow().firstOrNull()
         // need to check if there were any results at all
         return if(nextRequest != null) {
-            logger.info("Retrieved next request for member ${command.member.x500Name} from " +
-                    "group `${command.member.groupId}` " +
-                    "with ID `${nextRequest.registrationId}` from the database. Proceeding with registration.")
+            registrationLogger.setRegistrationId(nextRequest.registrationId)
+            registrationLogger.info("Retrieved next request for member from the database. Proceeding with registration.")
             // create state to make sure we process one registration at the same time
             Pair(RegistrationState(nextRequest.registrationId, command.member, command.mgm, emptyList()), StartRegistration())
         } else {
-            logger.info("There are no registration requests queued " +
-                    "for member ${command.member.x500Name} from group `${command.member.groupId}`.")
+            registrationLogger.info("There are no registration requests queued for member.")
             Pair(null, null)
         }
     }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
@@ -88,6 +88,8 @@ internal class ProcessMemberVerificationResponseHandler(
             .setMember(member)
             .setMgm(member)
 
+        registrationLogger.info("Processing member verification response.")
+
         val messages = try {
             val success = command.verificationResponse.payload.items.firstOrNull {
                 it.key == VERIFIED

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/ProcessMemberVerificationResponseHandler.kt
@@ -12,6 +12,7 @@ import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.libs.configuration.SmartConfig
+import net.corda.membership.impl.registration.RegistrationLogger
 import net.corda.membership.impl.registration.VerificationResponseKeys.FAILURE_REASONS
 import net.corda.membership.impl.registration.VerificationResponseKeys.VERIFIED
 import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
@@ -81,6 +82,12 @@ internal class ProcessMemberVerificationResponseHandler(
         val registrationId = state!!.registrationId
         val mgm = state.mgm
         val member = state.registeringMember
+
+        val registrationLogger = RegistrationLogger(logger)
+            .setRegistrationId(registrationId)
+            .setMember(member)
+            .setMgm(member)
+
         val messages = try {
             val success = command.verificationResponse.payload.items.firstOrNull {
                 it.key == VERIFIED
@@ -89,25 +96,24 @@ internal class ProcessMemberVerificationResponseHandler(
                 val reasons = command.verificationResponse.payload.items
                     .filter { it.key == FAILURE_REASONS }
                     .map { it.value }
-                val message = "Could not verify registration request: '$registrationId' - $reasons"
+                val message = "Could not verify registration request. $reasons"
                 throw CordaRuntimeException(message)
             }
             if (memberTypeChecker.isMgm(member)) {
                 throw CordaRuntimeException(
-                    "Member ${member.x500Name} is an MGM and can not register."
+                    "Member is an MGM and cannot register."
                 )
             }
             if (!memberTypeChecker.isMgm(mgm)) {
                 throw CordaRuntimeException(
-                    "Member ${mgm.x500Name} is not an MGM and can not process member's registration."
+                    "Member is not an MGM and cannot process member's registration."
                 )
             }
 
             val groupReader = membershipGroupReaderProvider.getGroupReader(mgm.toCorda())
-            val status = getNextRegistrationStatus(mgm.toCorda(), member.toCorda(), registrationId, groupReader)
+            val status = getNextRegistrationStatus(mgm.toCorda(), member.toCorda(), registrationId, groupReader, registrationLogger)
             val pendingInfo = groupReader.lookup(member.toCorda().x500Name, MembershipStatusFilter.PENDING)
-                ?: throw CordaRuntimeException("Could not find pending information " +
-                        "for member with holding ID '${member.toCorda().shortHash}'.")
+                ?: throw CordaRuntimeException("Could not find pending information for member.")
             val setRegistrationRequestStatusCommands = membershipPersistenceClient.setRegistrationRequestStatus(
                 mgm.toCorda(),
                 registrationId,
@@ -138,7 +144,7 @@ internal class ProcessMemberVerificationResponseHandler(
                 approveRecord,
             ) + setRegistrationRequestStatusCommands
         } catch (e: Exception) {
-            logger.warn("Could not process member verification response for registration request: '$registrationId'", e)
+            registrationLogger.warn("Could not process member verification response for registration request.", e)
             listOf(
                 Record(
                     REGISTRATION_COMMAND_TOPIC,
@@ -157,6 +163,7 @@ internal class ProcessMemberVerificationResponseHandler(
         member: HoldingIdentity,
         registrationId: String,
         groupReader: MembershipGroupReader,
+        registrationLogger: RegistrationLogger
     ): RegistrationStatus {
         val registrationRequest = membershipQueryClient
             .queryRegistrationRequest(mgm, registrationId)
@@ -164,8 +171,7 @@ internal class ProcessMemberVerificationResponseHandler(
         val proposedMemberInfo = registrationRequest
             ?.memberProvidedContext?.data?.array()?.deserializeContext(deserializer)
             ?: throw CordaRuntimeException(
-                "Could not read the proposed MemberInfo for registration request " +
-                        "(ID=$registrationId) submitted by ${member.x500Name}."
+                "Could not read the proposed MemberInfo for registration request."
             )
         val registrationContext = registrationRequest.registrationContext.data.array().deserializeContext(deserializer)
 
@@ -202,7 +208,7 @@ internal class ProcessMemberVerificationResponseHandler(
             membershipPersistenceClient.consumePreAuthToken(
                 mgm,
                 member.x500Name,
-                parsePreAuthToken(it)
+                parsePreAuthToken(it, registrationLogger)
             ).getOrThrow()
         }
 
@@ -218,11 +224,11 @@ internal class ProcessMemberVerificationResponseHandler(
         command: ProcessMemberVerificationResponse
     ) = state?.mgm
 
-    private fun parsePreAuthToken(input: String): UUID {
+    private fun parsePreAuthToken(input: String, registrationLogger: RegistrationLogger): UUID {
         return try {
             UUID.fromString(input)
         } catch (e: IllegalArgumentException) {
-            logger.warn(
+            registrationLogger.warn(
                 "Pre-auth token is incorrectly formatted and should have been handled when starting the " +
                         "registration.", e
             )

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/QueueRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/QueueRegistrationHandler.kt
@@ -11,6 +11,7 @@ import net.corda.data.membership.command.registration.mgm.QueueRegistration
 import net.corda.data.membership.common.v2.RegistrationStatus
 import net.corda.data.membership.state.RegistrationState
 import net.corda.data.p2p.app.MembershipStatusFilter
+import net.corda.membership.impl.registration.RegistrationLogger
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandlerResult
 import net.corda.membership.lib.MemberInfoExtension.Companion.KEYS_PEM_SUFFIX
@@ -71,18 +72,22 @@ internal class QueueRegistrationHandler(
 
     override fun invoke(state: RegistrationState?, key: String, command: QueueRegistration): RegistrationHandlerResult {
         val registrationId = command.memberRegistrationRequest.registrationId
+        val member = command.member.toCorda()
+        val mgm = command.mgm.toCorda()
+        val registrationLogger = RegistrationLogger(logger)
+            .setRegistrationId(registrationId)
+            .setMember(member)
+            .setMgm(mgm)
+
         val outputCommand = try {
             if (command.numberOfRetriesSoFar < MAX_RETRIES) {
-                queueRequest(key, command, registrationId)
+                queueRequest(key, command, registrationLogger)
             } else {
-                logger.warn(
-                    "Max re-tries exceeded for registration with ID `$registrationId`." +
-                            " Registration is discarded."
-                )
+                registrationLogger.warn("Max re-tries exceeded. Registration is discarded.")
                 emptyList()
             }
         } catch (ex: Exception) {
-            logger.warn("Exception happened while queueing the request with ID `$registrationId`. Will re-try again.")
+            registrationLogger.warn("Exception happened while queueing the request. Will re-try again.")
             increaseNumberOfRetries(key, command)
         }
         return RegistrationHandlerResult(state, outputCommand)
@@ -100,7 +105,9 @@ internal class QueueRegistrationHandler(
     }
 
     private fun queueRequest(
-        key: String, command: QueueRegistration, registrationId: String
+        key: String,
+        command: QueueRegistration,
+        registrationLogger: RegistrationLogger
     ): List<Record<*, *>> {
         val context = deserialize(command.memberRegistrationRequest.memberContext.data.array())
 
@@ -113,8 +120,7 @@ internal class QueueRegistrationHandler(
                 command.memberRegistrationRequest.memberContext.data.array(),
             )
         } catch (e: Exception) {
-            logger.warn("Signature verification failed. Discarding the registration with ID `$registrationId`. " +
-                    "Reason: ${e.message}")
+            registrationLogger.warn("Signature verification failed. Discarding the registration. Reason: ${e.message}")
             return emptyList()
         }
 
@@ -137,17 +143,13 @@ internal class QueueRegistrationHandler(
             )
         }
 
-        logger.info(
-            "MGM queueing registration request for ${command.member.x500Name} from group `${command.member.groupId}` " +
-                    "with request ID `$registrationId`."
-        )
+        registrationLogger.info("MGM queueing registration request.")
         membershipPersistenceClient.persistRegistrationRequest(
             command.mgm.toCorda(),
             command.toRegistrationRequest()
         ).getOrThrow()
-        logger.info(
-            "MGM put registration request for ${command.member.x500Name} from group `${command.member.groupId}` " +
-                    "with request ID `$registrationId` into the queue."
+        registrationLogger.info(
+            "MGM successfully queued the registration request."
         )
 
         return listOfNotNull(

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
@@ -59,6 +59,8 @@ internal class VerifyMemberHandler(
             .setMember(member)
             .setMgm(mgm)
 
+        registrationLogger.info("Verifying member.")
+
         val messages = try {
             if (!memberTypeChecker.isMgm(mgm)) {
                 registrationLogger.info("Could not verify registration request. Not an MGM.")

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/VerifyMemberHandler.kt
@@ -11,6 +11,7 @@ import net.corda.data.membership.p2p.VerificationRequest
 import net.corda.data.membership.state.RegistrationState
 import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.libs.configuration.SmartConfig
+import net.corda.membership.impl.registration.RegistrationLogger
 import net.corda.membership.impl.registration.dynamic.handler.MemberTypeChecker
 import net.corda.membership.impl.registration.dynamic.handler.MissingRegistrationStateException
 import net.corda.membership.impl.registration.dynamic.handler.RegistrationHandler
@@ -52,13 +53,21 @@ internal class VerifyMemberHandler(
         val mgm = state.mgm
         val member = state.registeringMember
         val registrationId = state.registrationId
+
+        val registrationLogger = RegistrationLogger(logger)
+            .setRegistrationId(registrationId)
+            .setMember(member)
+            .setMgm(mgm)
+
         val messages = try {
             if (!memberTypeChecker.isMgm(mgm)) {
+                registrationLogger.info("Could not verify registration request. Not an MGM.")
                 throw CordaRuntimeException("Could not verify registration request: '$registrationId' with ${mgm.x500Name} - Not an MGM.")
             }
             if (memberTypeChecker.isMgm(member)) {
+                registrationLogger.info("Could not verify registration request. Cannot be an MGM.")
                 throw CordaRuntimeException(
-                    "Could not verify registration request: '$registrationId' member ${member.x500Name} - Can not be an MGM."
+                    "Could not verify registration request: '$registrationId' member ${member.x500Name} - Cannot be an MGM."
                 )
             }
             val setRegistrationRequestStatusCommand = membershipPersistenceClient.setRegistrationRequestStatus(
@@ -79,7 +88,7 @@ internal class VerifyMemberHandler(
                         MembershipStatusFilter.PENDING,
                     )
         } catch (e: Exception) {
-            logger.warn("Member verification failed for registration request: '$registrationId'.", e)
+            registrationLogger.warn("Member verification failed for registration request.", e)
             listOf(
                 Record(
                     Schemas.Membership.REGISTRATION_COMMAND_TOPIC,

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/staticnetwork/StaticMemberRegistrationService.kt
@@ -29,6 +29,7 @@ import net.corda.membership.impl.registration.KeyDetails
 import net.corda.membership.impl.registration.KeysFactory
 import net.corda.membership.impl.registration.MemberRole
 import net.corda.membership.impl.registration.MemberRole.Companion.toMemberInfo
+import net.corda.membership.impl.registration.RegistrationLogger
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.ENDPOINT_PROTOCOL
 import net.corda.membership.impl.registration.staticnetwork.StaticMemberTemplateExtension.Companion.ENDPOINT_URL
 import net.corda.membership.impl.registration.staticnetwork.StaticNetworkGroupParametersUtils.addNotary
@@ -222,6 +223,9 @@ class StaticMemberRegistrationService(
         member: HoldingIdentity,
         context: Map<String, String>
     ): Collection<Record<*, *>> {
+        val registrationLogger = RegistrationLogger(logger)
+            .setRegistrationId(registrationId.toString())
+            .setMember(member)
         if (!isRunning || coordinator.status == LifecycleStatus.DOWN) {
             throw MembershipRegistrationException(
                 "Registration failed. Reason: StaticMemberRegistrationService is not running/down."
@@ -236,15 +240,14 @@ class StaticMemberRegistrationService(
                     context
                 )
         } catch (ex: MembershipSchemaValidationException) {
-            throw InvalidMembershipRegistrationException(
-                "Registration failed. The registration context is invalid: " + ex.message,
-                ex,
-            )
+            val err = "Registration failed. The registration context is invalid: " + ex.message
+            registrationLogger.info(err)
+            throw InvalidMembershipRegistrationException(err, ex)
         }
         val customFieldsValid = customFieldsVerifier.verify(context)
         if (customFieldsValid is RegistrationContextCustomFieldsVerifier.Result.Failure) {
-            val errorMessage = "Registration failed for ID '$registrationId'. ${customFieldsValid.reason}"
-            logger.warn(errorMessage)
+            val errorMessage = "Registration failed. ${customFieldsValid.reason}"
+            registrationLogger.warn(errorMessage)
             throw InvalidMembershipRegistrationException(errorMessage)
         }
         val membershipGroupReader = membershipGroupReaderProvider.getGroupReader(member)
@@ -294,19 +297,19 @@ class StaticMemberRegistrationService(
 
             return emptyList()
         } catch (e: InvalidMembershipRegistrationException) {
-            logger.warn("Registration failed. Reason:", e)
+            registrationLogger.warn("Registration failed. Reason:", e)
             throw e
         } catch (e: IllegalArgumentException) {
-            logger.warn("Registration failed. Reason:", e)
+            registrationLogger.warn("Registration failed. Reason:", e)
             throw InvalidMembershipRegistrationException("Registration failed. Reason: ${e.message}", e)
         } catch (e: MembershipPersistenceResult.PersistenceRequestException) {
-            logger.warn("Registration failed. Reason:", e)
+            registrationLogger.warn("Registration failed. Reason:", e)
             throw NotReadyMembershipRegistrationException("Registration failed. Reason: ${e.message}", e)
         } catch(e: InvalidGroupParametersUpdateException) {
-            logger.warn("Registration failed. Reason:", e)
+            registrationLogger.warn("Registration failed. Reason:", e)
             throw InvalidMembershipRegistrationException("Registration failed. Reason: ${e.message}", e)
         } catch (e: Exception) {
-            logger.warn("Registration failed. Reason:", e)
+            registrationLogger.warn("Registration failed. Reason:", e)
             throw NotReadyMembershipRegistrationException("Registration failed. Reason: ${e.message}", e)
         }
     }

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationLoggerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/RegistrationLoggerTest.kt
@@ -1,0 +1,166 @@
+package net.corda.membership.impl.registration
+
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.virtualnode.HoldingIdentity
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.slf4j.Logger
+import java.util.UUID
+
+class RegistrationLoggerTest {
+
+    private val mockLogger: Logger = mock()
+    private val testMemberX500Name = MemberX500Name.parse("O=Alice, L=London, C=GB")
+    private val testMgmX500Name = MemberX500Name.parse("O=MGM, L=London, C=GB")
+    private val testRegistrationId = UUID(0, 1).toString()
+    private val testGroupId = UUID(0, 2).toString()
+    private val testMemberHoldingIdentity = HoldingIdentity(testMemberX500Name, testGroupId)
+    private val testMgmHoldingIdentity = HoldingIdentity(testMgmX500Name, testGroupId)
+
+    // object under test
+    private val testObj: RegistrationLogger = RegistrationLogger(mockLogger)
+
+    @Test
+    fun `registration logger logs configured properties at info level`() {
+        testObj
+            .setRegistrationId(testRegistrationId)
+            .setMember(testMemberHoldingIdentity)
+            .setMgm(testMgmHoldingIdentity)
+
+        val expected = mapOf(
+            "registration-id" to testRegistrationId,
+            "member-holding-id" to testMemberHoldingIdentity.shortHash.value,
+            "member-name" to testMemberHoldingIdentity.x500Name.toString(),
+            "group-id" to testGroupId,
+            "mgm-holding-id" to testMgmHoldingIdentity.shortHash.value,
+            "mgm-name" to testMgmHoldingIdentity.x500Name.toString(),
+        )
+
+        val logLine = "log this info!"
+
+        testObj.info(logLine)
+        verify(mockLogger).info(getExpectedLogString(logLine, expected))
+    }
+
+    @Test
+    fun `registration logger logs configured properties at info level with exception`() {
+        testObj
+            .setRegistrationId(testRegistrationId)
+            .setMember(testMemberHoldingIdentity)
+            .setMgm(testMgmHoldingIdentity)
+
+        val expected = mapOf(
+            "registration-id" to testRegistrationId,
+            "member-holding-id" to testMemberHoldingIdentity.shortHash.value,
+            "member-name" to testMemberHoldingIdentity.x500Name.toString(),
+            "group-id" to testGroupId,
+            "mgm-holding-id" to testMgmHoldingIdentity.shortHash.value,
+            "mgm-name" to testMgmHoldingIdentity.x500Name.toString(),
+        )
+
+        val logLine = "log this info!"
+        val exception: Throwable = mock()
+
+        testObj.info(logLine, exception)
+        verify(mockLogger).info(getExpectedLogString(logLine, expected), exception)
+    }
+
+    @Test
+    fun `registration logger logs configured properties at warn level`() {
+        testObj
+            .setRegistrationId(testRegistrationId)
+            .setMember(testMemberHoldingIdentity)
+            .setMgm(testMgmHoldingIdentity)
+
+        val expected = mapOf(
+            "registration-id" to testRegistrationId,
+            "member-holding-id" to testMemberHoldingIdentity.shortHash.value,
+            "member-name" to testMemberHoldingIdentity.x500Name.toString(),
+            "group-id" to testGroupId,
+            "mgm-holding-id" to testMgmHoldingIdentity.shortHash.value,
+            "mgm-name" to testMgmHoldingIdentity.x500Name.toString(),
+        )
+
+        val logLine = "log this warning!"
+
+        testObj.warn(logLine)
+        verify(mockLogger).warn(getExpectedLogString(logLine, expected))
+
+    }
+
+    @Test
+    fun `registration logger logs configured properties at warn level with exception`() {
+        testObj
+            .setRegistrationId(testRegistrationId)
+            .setMember(testMemberHoldingIdentity)
+            .setMgm(testMgmHoldingIdentity)
+
+        val expected = mapOf(
+            "registration-id" to testRegistrationId,
+            "member-holding-id" to testMemberHoldingIdentity.shortHash.value,
+            "member-name" to testMemberHoldingIdentity.x500Name.toString(),
+            "group-id" to testGroupId,
+            "mgm-holding-id" to testMgmHoldingIdentity.shortHash.value,
+            "mgm-name" to testMgmHoldingIdentity.x500Name.toString(),
+        )
+
+        val logLine = "log this warning!"
+        val exception: Throwable = mock()
+
+        testObj.warn(logLine, exception)
+        verify(mockLogger).warn(getExpectedLogString(logLine, expected), exception)
+
+    }
+
+    @Test
+    fun `registration logger logs configured properties at error level`() {
+        testObj
+            .setRegistrationId(testRegistrationId)
+            .setMember(testMemberHoldingIdentity)
+            .setMgm(testMgmHoldingIdentity)
+
+        val expected = mapOf(
+            "registration-id" to testRegistrationId,
+            "member-holding-id" to testMemberHoldingIdentity.shortHash.value,
+            "member-name" to testMemberHoldingIdentity.x500Name.toString(),
+            "group-id" to testGroupId,
+            "mgm-holding-id" to testMgmHoldingIdentity.shortHash.value,
+            "mgm-name" to testMgmHoldingIdentity.x500Name.toString(),
+        )
+
+        val logLine = "log this error!"
+
+        testObj.error(logLine)
+        verify(mockLogger).error(getExpectedLogString(logLine, expected))
+
+    }
+
+    @Test
+    fun `registration logger logs configured properties at error level with exception`() {
+        testObj
+            .setRegistrationId(testRegistrationId)
+            .setMember(testMemberHoldingIdentity)
+            .setMgm(testMgmHoldingIdentity)
+
+        val expected = mapOf(
+            "registration-id" to testRegistrationId,
+            "member-holding-id" to testMemberHoldingIdentity.shortHash.value,
+            "member-name" to testMemberHoldingIdentity.x500Name.toString(),
+            "group-id" to testGroupId,
+            "mgm-holding-id" to testMgmHoldingIdentity.shortHash.value,
+            "mgm-name" to testMgmHoldingIdentity.x500Name.toString(),
+        )
+
+        val logLine = "log this error!"
+        val exception: Throwable = mock()
+
+        testObj.error(logLine, exception)
+        verify(mockLogger).error(getExpectedLogString(logLine, expected), exception)
+
+    }
+
+    private fun getExpectedLogString(logInput: String, expected: Map<String, String>): String {
+        return "$logInput $expected"
+    }
+}


### PR DESCRIPTION
From time to time we need to investigate failed registrations from application logs. Our logging through registrations can be a bit inconsistent and when we have a high volume of registrations (for example during large network or resiliency testing) it can be hard to follow the progress of a single registration. Some logs have registration ID, member holding ID, member name, MGM holding ID, group ID, some combination of those, or none of those. 
This PR adds a registration logger which is a wrapper around the log4j logger and includes registration metadata as part of logging lines in a standard way so we can more easily piece together at which stage a registration failed. It also adds logging to some areas we were lacking previously.

Example extract after change (from the e2e tests): 
```
09:46:12.647 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM queueing registration request. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:12.669 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM successfully queued the registration request. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:12.833 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Retrieved next request for member from the database. Proceeding with registration. {member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB, registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d}
09:46:12.850 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Registering member with MGM. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:12.859 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Updating the status of the registration request. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:12.878 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Successful initial validation of registration request. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:12.908 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.VerifyMemberHandler {} - Verifying member. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:12.996 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.member.ProcessMemberVerificationRequestHandler {} - Processing member verification request. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:13.077 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.ProcessMemberVerificationResponseHandler {} - Processing member verification response. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=5665D74AC7C4, mgm-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB}
09:46:13.139 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.ApproveRegistrationHandler {} - Processing registration approval. {registration-id=4bd809b9-e923-44c2-94bf-9856ec63cc3d, member-holding-id=5665D74AC7C4, member-name=CN=Alice-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:28.891 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM queueing registration request. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:28.900 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM successfully queued the registration request. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:28.931 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Retrieved next request for member from the database. Proceeding with registration. {member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB, registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c}
09:46:28.947 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Registering member with MGM. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:28.955 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Updating the status of the registration request. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:28.967 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Successful initial validation of registration request. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:28.978 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.VerifyMemberHandler {} - Verifying member. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:29.056 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.member.ProcessMemberVerificationRequestHandler {} - Processing member verification request. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:29.104 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.ProcessMemberVerificationResponseHandler {} - Processing member verification response. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=480574F6F628, mgm-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB}
09:46:29.143 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.ApproveRegistrationHandler {} - Processing registration approval. {registration-id=2deeac1a-2c79-4335-aefd-845670e35b2c, member-holding-id=480574F6F628, member-name=CN=Bob-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:38.130 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM queueing registration request. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:38.139 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM successfully queued the registration request. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:38.162 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Retrieved next request for member from the database. Proceeding with registration. {member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB, registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44}
09:46:38.179 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Registering member with MGM. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:38.186 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Updating the status of the registration request. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:38.206 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Successful initial validation of registration request. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:38.217 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.VerifyMemberHandler {} - Verifying member. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:38.292 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.member.ProcessMemberVerificationRequestHandler {} - Processing member verification request. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
09:46:38.374 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.ProcessMemberVerificationResponseHandler {} - Processing member verification response. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=0DCA410FFF1A, mgm-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB}
09:46:38.396 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.ApproveRegistrationHandler {} - Processing registration approval. {registration-id=4e59302c-089d-4e80-ab0c-c4e139547a44, member-holding-id=0DCA410FFF1A, member-name=CN=Notary-5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, OU=Application, O=R3, L=London, C=GB, group-id=9df6defc-e046-4edb-b206-055a8a168815, mgm-holding-id=B237C49BF201, mgm-name=OU=5c0c6e1f-bb81-4877-a4f6-1c648dc3064d, O=Mgm, L=London, C=GB}
```

For reference, the equivalent logs before this change would have been as follows. The new version ensures we can tie each log to a specific registration, and we log during stages after the start registration handler.
```
17:54:33.707 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM queueing registration request for CN=Alice-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with request ID `0df2ed8f-8de9-4538-97a6-129dcf82df05`.
17:54:33.783 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM put registration request for CN=Alice-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with request ID `0df2ed8f-8de9-4538-97a6-129dcf82df05` into the queue.
17:54:34.020 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Looking for the next request for member CN=Alice-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
17:54:34.030 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Retrieved next request for member CN=Alice-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with ID `0df2ed8f-8de9-4538-97a6-129dcf82df05` from the database. Proceeding with registration.
17:54:34.116 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Registering HoldingIdentity(x500Name=CN=Alice-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB, groupId=ed23fc80-937f-469c-9571-eedd8979bc29) with MGM for holding identity: HoldingIdentity(x500Name=OU=01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, O=Mgm, L=London, C=GB, groupId=ed23fc80-937f-469c-9571-eedd8979bc29)
17:54:34.176 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Updating the status of the registration request.
17:54:34.276 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Successful initial validation of registration request with ID 0df2ed8f-8de9-4538-97a6-129dcf82df05
17:54:34.899 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Looking for the next request for member CN=Alice-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
17:54:34.909 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - There are no registration requests queued for member CN=Alice-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
17:54:49.668 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM queueing registration request for CN=Bob-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with request ID `f6c9a4bc-0cc9-407f-8d92-9abc05a28d3c`.
17:54:50.223 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM put registration request for CN=Bob-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with request ID `f6c9a4bc-0cc9-407f-8d92-9abc05a28d3c` into the queue.
17:54:50.249 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Looking for the next request for member CN=Bob-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
17:54:50.257 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Retrieved next request for member CN=Bob-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with ID `f6c9a4bc-0cc9-407f-8d92-9abc05a28d3c` from the database. Proceeding with registration.
17:54:50.425 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Registering HoldingIdentity(x500Name=CN=Bob-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB, groupId=ed23fc80-937f-469c-9571-eedd8979bc29) with MGM for holding identity: HoldingIdentity(x500Name=OU=01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, O=Mgm, L=London, C=GB, groupId=ed23fc80-937f-469c-9571-eedd8979bc29)
17:54:50.434 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Updating the status of the registration request.
17:54:50.451 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Successful initial validation of registration request with ID f6c9a4bc-0cc9-407f-8d92-9abc05a28d3c
17:54:51.046 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Looking for the next request for member CN=Bob-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
17:54:51.053 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - There are no registration requests queued for member CN=Bob-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
17:55:01.593 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM queueing registration request for CN=Notary-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with request ID `d0c0516e-38ce-4b7a-a720-3281940670c7`.
17:55:01.604 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM put registration request for CN=Notary-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with request ID `d0c0516e-38ce-4b7a-a720-3281940670c7` into the queue.
17:55:01.624 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Looking for the next request for member CN=Notary-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
17:55:01.633 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Retrieved next request for member CN=Notary-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29` with ID `d0c0516e-38ce-4b7a-a720-3281940670c7` from the database. Proceeding with registration.
17:55:01.654 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Registering HoldingIdentity(x500Name=CN=Notary-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB, groupId=ed23fc80-937f-469c-9571-eedd8979bc29) with MGM for holding identity: HoldingIdentity(x500Name=OU=01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, O=Mgm, L=London, C=GB, groupId=ed23fc80-937f-469c-9571-eedd8979bc29)
17:55:01.664 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Updating the status of the registration request.
17:55:01.701 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Successful initial validation of registration request with ID d0c0516e-38ce-4b7a-a720-3281940670c7
17:55:02.652 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Looking for the next request for member CN=Notary-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
17:55:02.659 [Thread-71] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - There are no registration requests queued for member CN=Notary-01cd4c22-3110-415b-aee4-a2b0ef3ebe3f, OU=Application, O=R3, L=London, C=GB from group `ed23fc80-937f-469c-9571-eedd8979bc29`.
```