### PR TITLE
CORE-18725 Allow registration to move status from RECEIVED_BY_MGM to STARTED_PROCESSING_BY_MGM

### DIFF
--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationStatusExt.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationStatusExt.kt
@@ -9,7 +9,7 @@ object RegistrationStatusExt {
             when (this) {
                 RegistrationStatus.NEW -> 0
                 RegistrationStatus.SENT_TO_MGM -> 1
-                RegistrationStatus.RECEIVED_BY_MGM -> 2
+                RegistrationStatus.RECEIVED_BY_MGM -> 1
                 RegistrationStatus.STARTED_PROCESSING_BY_MGM -> 2
                 RegistrationStatus.PENDING_MEMBER_VERIFICATION -> 3
                 RegistrationStatus.PENDING_MANUAL_APPROVAL -> 4

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationStatusExt.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/registration/RegistrationStatusExt.kt
@@ -9,15 +9,15 @@ object RegistrationStatusExt {
             when (this) {
                 RegistrationStatus.NEW -> 0
                 RegistrationStatus.SENT_TO_MGM -> 1
-                RegistrationStatus.RECEIVED_BY_MGM -> 1
-                RegistrationStatus.STARTED_PROCESSING_BY_MGM -> 2
-                RegistrationStatus.PENDING_MEMBER_VERIFICATION -> 3
-                RegistrationStatus.PENDING_MANUAL_APPROVAL -> 4
-                RegistrationStatus.PENDING_AUTO_APPROVAL -> 4
-                RegistrationStatus.DECLINED -> 5
-                RegistrationStatus.INVALID -> 5
-                RegistrationStatus.FAILED -> 5
-                RegistrationStatus.APPROVED -> 5
+                RegistrationStatus.RECEIVED_BY_MGM -> 2
+                RegistrationStatus.STARTED_PROCESSING_BY_MGM -> 3
+                RegistrationStatus.PENDING_MEMBER_VERIFICATION -> 4
+                RegistrationStatus.PENDING_MANUAL_APPROVAL -> 5
+                RegistrationStatus.PENDING_AUTO_APPROVAL -> 5
+                RegistrationStatus.DECLINED -> 6
+                RegistrationStatus.INVALID -> 6
+                RegistrationStatus.FAILED -> 6
+                RegistrationStatus.APPROVED -> 6
             }
 
     fun RegistrationStatus.canMoveToStatus(newStatus: RegistrationStatus): Boolean {


### PR DESCRIPTION
Resolves error: 
`Could not update status of registration 6de0f6ca-46cb-4f61-a797-755d8dcf3900 from RECEIVED_BY_MGM to STARTED_PROCESSING_BY_MGM, will ignore the update` from `net.corda.membership.impl.persistence.service.handler.BasePersistenceHandler`

`RECEIVED_BY_MGM` and `STARTED_PROCESSING_BY_MGM` had the same order meaning persistence operations moving from one to the other were failing. This didn't seem to impact registrations since the next status will eventually overwrite `RECEIVED_BY_MGM` but if a registration was unsuccessful, the last status is misleading i.e. tests would fail due to status not progressing beyond `RECEIVED_BY_MGM` but in fact they had progressed beyond than `STARTED_PROCESSING_BY_MGM`.