### PR TITLE
CORE-18100 reduce flow cache size for combined worker tests to ensure all cache logic is exercised

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -88,7 +88,7 @@ pipeline {
                 JAR_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar"
                 JDBC_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/drivers"
                 REST_TLS_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/tls/rest/rest_worker.pfx"
-                VM_PARAMETERS = "-Dco.paralleluniverse.fibers.verifyInstrumentation=true -Pnet.corda.flow.fiber.cache.maximumSize=1"
+                VM_PARAMETERS = "-Dco.paralleluniverse.fibers.verifyInstrumentation=true -Dnet.corda.flow.fiber.cache.maximumSize=1"
                 LOG4J_PARAMETERS = "-Dlog4j.configurationFile=log4j2-console.xml"
                 PROGRAM_PARAMETERS = "--instance-id=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -ddatabase.user=u${postgresDb} -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://${postgresHost}:${postgresPort}/${postgresDb} -ddatabase.jdbc.directory=${JDBC_PATH} -rtls.keystore.path=${REST_TLS_PATH} -rtls.keystore.password=mySecretPassword --serviceEndpoint=endpoints.crypto=localhost:7004 --serviceEndpoint=endpoints.verification=localhost:7004 --serviceEndpoint=endpoints.uniqueness=localhost:7004 --serviceEndpoint=endpoints.persistence=localhost:7004 --serviceEndpoint=endpoints.tokenSelection=localhost:7004"
                 WORKING_DIRECTORY = "${env.WORKSPACE}"

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -88,7 +88,7 @@ pipeline {
                 JAR_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/build/bin/corda-combined-worker-*.jar"
                 JDBC_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/drivers"
                 REST_TLS_PATH = "${env.WORKSPACE}/applications/workers/release/combined-worker/tls/rest/rest_worker.pfx"
-                VM_PARAMETERS = "-Dco.paralleluniverse.fibers.verifyInstrumentation=true"
+                VM_PARAMETERS = "-Dco.paralleluniverse.fibers.verifyInstrumentation=true -Pnet.corda.flow.fiber.cache.maximumSize=1"
                 LOG4J_PARAMETERS = "-Dlog4j.configurationFile=log4j2-console.xml"
                 PROGRAM_PARAMETERS = "--instance-id=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -ddatabase.user=u${postgresDb} -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://${postgresHost}:${postgresPort}/${postgresDb} -ddatabase.jdbc.directory=${JDBC_PATH} -rtls.keystore.path=${REST_TLS_PATH} -rtls.keystore.password=mySecretPassword --serviceEndpoint=endpoints.crypto=localhost:7004 --serviceEndpoint=endpoints.verification=localhost:7004 --serviceEndpoint=endpoints.uniqueness=localhost:7004 --serviceEndpoint=endpoints.persistence=localhost:7004 --serviceEndpoint=endpoints.tokenSelection=localhost:7004"
                 WORKING_DIRECTORY = "${env.WORKSPACE}"


### PR DESCRIPTION
As part of our e2e tests it is important to exercise cache eviction and deserialization logic on a range of different flows. By setting the cache size to 1 for the combined worker tests and using the default 10000 for the corda cluster tests we can test both scenarios.