### PR TITLE
CORE-18645 placeholder .git-ignore-revs-file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+# .git-blame-ignore-revs


### PR DESCRIPTION
This is a placeholder file so developers can add their formatting commits for removal from git blame output.