### PR TITLE
CORE-18634 Add HSM category for symmetric encryption

### DIFF
--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoConsts.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoConsts.kt
@@ -19,6 +19,7 @@ object CryptoConsts {
         const val SESSION_INIT = "SESSION_INIT"
         const val TLS = "TLS"
         const val JWT_KEY = "JWT_KEY"
+        const val ENCRYPTION_SECRET = "ENCRYPTION_SECRET"
 
         val all: Set<String> = setOf(
             ACCOUNTS,
@@ -28,7 +29,8 @@ object CryptoConsts {
             PRE_AUTH,
             SESSION_INIT,
             TLS,
-            JWT_KEY
+            JWT_KEY,
+            ENCRYPTION_SECRET,
         )
     }
 


### PR DESCRIPTION
Adds a new HSM category `ENCRYPTION_SECRET` whose associated `ManagedKey` will be used for encryption operations.

This category is assigned to cluster-level tenant 'p2p' when `CryptoProcessor` starts:

<img width="684" alt="Screenshot 2023-12-11 at 15 10 08" src="https://github.com/corda/corda-runtime-os/assets/17948697/07fc9a15-0fcb-4944-8d6a-d1c61c15e60b">
