### PR TITLE
CORE-18501: Check flowStartOperationalStatus after flow checkpoint is initialized 

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowMessageFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowMessageFactoryImpl.kt
@@ -56,9 +56,6 @@ class FlowMessageFactoryImpl(private val currentTimeProvider: () -> Instant) : F
 
     private fun getCommonFlowStatus(checkpoint: FlowCheckpoint): FlowStatus {
         val startContext = checkpoint.flowStartContext
-        if (startContext.initiatorType == null) {
-            log.warn("Creating FlowStatus with null initiatorType")
-        }
         return FlowStatus().apply {
             key = startContext.statusKey
             initiatorType = startContext.initiatorType

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowMessageFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowMessageFactoryImpl.kt
@@ -7,6 +7,7 @@ import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.state.FlowCheckpoint
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
+import org.slf4j.LoggerFactory
 import java.time.Instant
 
 @Component(service = [FlowMessageFactory::class])
@@ -15,6 +16,10 @@ class FlowMessageFactoryImpl(private val currentTimeProvider: () -> Instant) : F
 
     @Activate
     constructor() : this(Instant::now)
+
+    private companion object {
+        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
 
     override fun createFlowCompleteStatusMessage(checkpoint: FlowCheckpoint, flowResult: String?): FlowStatus {
         return getCommonFlowStatus(checkpoint).apply {
@@ -51,6 +56,9 @@ class FlowMessageFactoryImpl(private val currentTimeProvider: () -> Instant) : F
 
     private fun getCommonFlowStatus(checkpoint: FlowCheckpoint): FlowStatus {
         val startContext = checkpoint.flowStartContext
+        if (startContext.initiatorType == null) {
+            log.warn("Creating FlowStatus with null initiatorType")
+        }
         return FlowStatus().apply {
             key = startContext.statusKey
             initiatorType = startContext.initiatorType

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
@@ -31,16 +31,6 @@ class StartFlowEventHandler @Activate constructor(
     override fun preProcess(context: FlowEventContext<StartFlow>): FlowEventContext<StartFlow> {
         log.info("Flow [${context.checkpoint.flowId}] started")
 
-        val holdingIdentity = context.inputEventPayload.startContext.identity.toCorda()
-        val virtualNodeInfo = virtualNodeInfoReadService.get(holdingIdentity)
-
-        if (virtualNodeInfo?.flowStartOperationalStatus == OperationalStatus.INACTIVE) {
-            throw FlowMarkedForKillException(
-                "flowStartOperationalStatus is INACTIVE, new flows cannot be started for virtual node with " +
-                        "shortHash ${holdingIdentity.shortHash}"
-            )
-        }
-
         checkpointInitializer.initialize(
             context.checkpoint,
             WaitingFor(WaitingForStartFlow),

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
@@ -4,10 +4,7 @@ import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.pipeline.CheckpointInitializer
 import net.corda.flow.pipeline.events.FlowEventContext
-import net.corda.flow.pipeline.exceptions.FlowMarkedForKillException
 import net.corda.flow.pipeline.handlers.waiting.WaitingForStartFlow
-import net.corda.virtualnode.OperationalStatus
-import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandler.kt
@@ -16,8 +16,6 @@ import org.slf4j.LoggerFactory
 
 @Component(service = [FlowEventHandler::class])
 class StartFlowEventHandler @Activate constructor(
-    @Reference(service = VirtualNodeInfoReadService::class)
-    private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
     @Reference(service = CheckpointInitializer::class)
     private val checkpointInitializer: CheckpointInitializer
 ) : FlowEventHandler<StartFlow> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -1,8 +1,5 @@
 package net.corda.flow.pipeline.impl
 
-import net.corda.data.flow.FlowInitiatorType
-import net.corda.data.flow.event.StartFlow
-import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.output.FlowStatus
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.fiber.cache.FlowFiberCache

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.flow.pipeline.impl
 
+import net.corda.data.flow.FlowInitiatorType
 import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.output.FlowStatus
@@ -242,6 +243,7 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             is StartFlow -> {
                 val status = FlowStatus().apply {
                     key = inputPayload.startContext.statusKey
+                    initiatorType = FlowInitiatorType.RPC
                     flowStatus = FlowStates.KILLED
                     this.flowId = flowId
                     processingTerminatedReason = message

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImpl.kt
@@ -75,6 +75,13 @@ internal class FlowEventPipelineImpl(
                         "'HoldingIdentity(x500Name=${holdingIdentity.x500Name}, groupId=${holdingIdentity.groupId})'"
             )
 
+        if (virtualNode.flowStartOperationalStatus == OperationalStatus.INACTIVE) {
+            throw FlowMarkedForKillException(
+                "flowStartOperationalStatus is INACTIVE, new flows cannot be started for virtual node with " +
+                        "shortHash ${holdingIdentity.shortHash}"
+            )
+        }
+
         if (virtualNode.flowOperationalStatus == OperationalStatus.INACTIVE) {
             throw FlowMarkedForKillException("Flow operational status is ${virtualNode.flowOperationalStatus.name}")
         }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandlerTest.kt
@@ -18,7 +18,6 @@ import org.mockito.kotlin.mock
 
 class StartFlowEventHandlerTest {
     private val holdingIdentity = BOB_X500_HOLDING_IDENTITY
-    private val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService>()
     private val startFlow = StartFlow(
         FlowStartContext().apply {
              identity = holdingIdentity
@@ -37,7 +36,7 @@ class StartFlowEventHandlerTest {
             holdingIdentity.toCorda(),
             contextExpected.checkpoint
         )
-        val handler = StartFlowEventHandler(virtualNodeInfoReadService, fakeCheckpointInitializer)
+        val handler = StartFlowEventHandler(fakeCheckpointInitializer)
         val actualContext = handler.preProcess(contextExpected)
         assertThat(actualContext).isEqualTo(contextExpected)
     }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/events/StartFlowEventHandlerTest.kt
@@ -10,7 +10,6 @@ import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.test.utils.buildFlowEventContext
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
-import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
@@ -114,6 +114,34 @@ class FlowEventPipelineImplTest {
     }
 
     @Test
+    fun `pipeline exits if flow start operational status is inactive`() {
+        val mockCheckpoint = mock<FlowCheckpoint> {
+            whenever(it.doesExist).thenReturn(true)
+            whenever(it.holdingIdentity).thenReturn(mockHoldingIdentity)
+        }
+        val mockContext = mock<FlowEventContext<Any>> {
+            whenever(it.checkpoint).thenReturn(mockCheckpoint)
+        }
+        val pipeline =
+            FlowEventPipelineImpl(
+                mapOf(),
+                mock(),
+                mock(),
+                mockContext,
+                virtualNodeInfoReadService
+            )
+
+        val mockVirtualNode = mock<VirtualNodeInfo> {
+            whenever(it.flowStartOperationalStatus).thenReturn(OperationalStatus.INACTIVE)
+        }
+        whenever(virtualNodeInfoReadService.get(mockHoldingIdentity)).thenReturn(mockVirtualNode)
+
+        assertThrows<FlowMarkedForKillException> {
+            pipeline.virtualNodeFlowOperationalChecks()
+        }
+    }
+
+    @Test
     fun `execute flow invokes the execute flow pipeline stage`() {
         val pipeline = buildPipeline()
         pipeline.executeFlow(RUN_OR_CONTINUE_TIMEOUT)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
@@ -3,8 +3,6 @@ package net.corda.flow.pipeline.impl
 import com.typesafe.config.ConfigFactory
 import com.typesafe.config.ConfigValueFactory
 import net.corda.data.flow.FlowKey
-import net.corda.data.flow.FlowStartContext
-import net.corda.data.flow.event.StartFlow
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.output.FlowStates
 import net.corda.data.flow.output.FlowStatus

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowToBeKilledExceptionProcessingTest.kt
@@ -79,19 +79,6 @@ class FlowToBeKilledExceptionProcessingTest {
     }
 
     @Test
-    fun `processing FlowMarkedForKillException when checkpoint does not exist only outputs flow killed status record`() {
-        whenever(checkpoint.doesExist).thenReturn(false)
-        val inputEventPayload = StartFlow(FlowStartContext().apply { statusKey = flowKey }, "")
-        val testContext = buildFlowEventContext(checkpoint, inputEventPayload)
-        val exception = FlowMarkedForKillException("reasoning")
-        whenever(flowRecordFactory.createFlowStatusRecord(any())).thenReturn(flowKilledStatusRecord)
-
-        val response = target.process(exception, testContext)
-
-        assertThat(response.outputRecords).hasSize(1).contains(flowKilledStatusRecord)
-    }
-
-    @Test
     fun `error processing FlowMarkedForKillException falls back to null state record, empty response events and marked for DLQ`() {
         val testContext = buildFlowEventContext(checkpoint, Any())
         val exception = FlowMarkedForKillException("reasoning")


### PR DESCRIPTION
This is intended to fix the underlying issue causing the e2e test "maintenance mode stops flows" to be flakey. https://r3-cev.atlassian.net/browse/CORE-18501

When this fails, it does so with the error: `Caused by: org.apache.avro.AvroTypeException: value null is not a FlowInitiatorType at FlowStatus.initiatorType`. This prevents the FlowStatus from being published to Kafka and so the flow never gets a KILLED status and is instead stuck in START_REQUESTED.

To fix this, this moves checking the flowStartOperationalStatus in StartFlowEventHandler to instead be checked in virtualNodeFlowOperationalChecks, after the flow checkpoint has been made. 

This means we don't have to create a FlowStatus without a checkpoint, which should remove the case where one was being made without a FlowInitiatorType. 

