### PR TITLE
CORE-18638 Add permission for ingress controller to read IngressClass

### DIFF
--- a/charts/corda-lib/templates/_nginx.tpl
+++ b/charts/corda-lib/templates/_nginx.tpl
@@ -3,7 +3,10 @@
 {{- end }}
 
 {{- define "corda.nginxClusterUniqueName" -}}
-{{- printf "%s-%s-nginx" .Release.Namespace . }}
+{{- $workerName := index . 1 }}
+{{- with ( index . 0 ) }}
+{{- printf "%s-%s" .Release.Namespace ( include "corda.nginxName" $workerName ) }}
+{{- end }}
 {{- end }}
 
 {{- define "corda.nginxComponent" -}}
@@ -64,7 +67,7 @@ kind: ClusterRole
 metadata:
   labels:
     {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
-  name: {{ include "corda.nginxClusterUniqueName" $workerName | quote }}
+  name: {{ include "corda.nginxClusterUniqueName" ( list . $workerName ) | quote }}
 rules:
   - apiGroups:
       - networking.k8s.io
@@ -80,11 +83,11 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
-  name: {{ include "corda.nginxClusterUniqueName" $workerName | quote }}
+  name: {{ include "corda.nginxClusterUniqueName" ( list . $workerName ) | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "corda.nginxClusterUniqueName" $workerName | quote }}
+  name: {{ include "corda.nginxClusterUniqueName" ( list . $workerName ) | quote }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "corda.nginxName" $workerName | quote }}

--- a/charts/corda-lib/templates/_nginx.tpl
+++ b/charts/corda-lib/templates/_nginx.tpl
@@ -2,6 +2,10 @@
 {{- printf "%s-nginx" . }}
 {{- end }}
 
+{{- define "corda.nginxClusterUniqueName" -}}
+{{- printf "%s-%s-nginx" .Release.Namespace . }}
+{{- end }}
+
 {{- define "corda.nginxComponent" -}}
 {{ printf "%s-nginx" . }}
 {{- end }}
@@ -54,6 +58,37 @@ metadata:
   name: {{ include "corda.nginxName" $workerName | quote }}
 data:
   allow-snippet-annotations: "false"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxClusterUniqueName" $workerName | quote }}
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 4 }}
+  name: {{ include "corda.nginxClusterUniqueName" $workerName | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "corda.nginxClusterUniqueName" $workerName | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "corda.nginxName" $workerName | quote }}
+    namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Without permission to read cluster-scoped `IngressClass` resources, the ingress-nginx controller processes updates to all `Ingress` resources in the target namespace, regardless of whether or not they are associated with the ingress class it is configured with. (Reported in https://github.com/kubernetes/ingress-nginx/issues/9662.) This results in the controller updating any `Ingress` resources defined for the REST API or P2P Gateway and consequent loss of connectivity until the rightful controller updates the resources again. The status flip-flops between the two controllers.

This change gives the controller permission to view `IngressClass` resources, which it does not really need (it uses the annotation-based approach to defining the ingress class) but causes it to check the ingress class name correctly.