### PR TITLE
CORE-18935 handle completion exceptions thrown within the mediator properly

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImpl.kt
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory
 import java.lang.Thread.sleep
 import java.time.Duration
 import java.util.UUID
+import java.util.concurrent.CompletionException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -113,7 +114,8 @@ class MultiSourceEventMediatorImpl<K : Any, S : Any, E : Any>(
                         }
                         pollAndProcessEvents(consumer)
                     } catch (exception: Exception) {
-                        when (exception) {
+                        val cause = if (exception is CompletionException) exception.cause else exception
+                        when (cause) {
                             is CordaMessageAPIIntermittentException -> {
                                 attempts++
                                 log.warn(

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
@@ -38,7 +38,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -94,7 +93,7 @@ class MultiSourceEventMediatorImplTest {
         }
 
         val messageRouter = MessageRouter { _ ->
-            RoutingDestination.routeTo(messagingClient, "endpoint", RoutingDestination.Type.ASYNCHRONOUS)
+            RoutingDestination.routeTo(messagingClient, "endpoint", RoutingDestination.Type.SYNCHRONOUS)
         }
         whenever(messageRouterFactory.create(any<MessagingClientFinder>())).thenReturn(messageRouter)
 
@@ -194,7 +193,7 @@ class MultiSourceEventMediatorImplTest {
 
         whenever(messagingClient.send(any())).thenAnswer {
             if (sendCount.getAndIncrement() < errorsCount) {
-                throw CompletionException(CordaMessageAPIIntermittentException("IntermittentException"))
+                throw CordaMessageAPIIntermittentException("IntermittentException")
             }
             null
         }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/MultiSourceEventMediatorImplTest.kt
@@ -38,12 +38,13 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 class MultiSourceEventMediatorImplTest {
     companion object {
-        private const val TEST_TIMEOUT_SECONDS = 20L
+        private const val TEST_TIMEOUT_SECONDS = 2000L
         private const val TEST_PROCESSOR_RETRIES = 3
         const val KEY1 = "key1"
         const val KEY2 = "key2"
@@ -176,8 +177,8 @@ class MultiSourceEventMediatorImplTest {
         verify(messagingClient, times(events.size)).send(any())
     }
 
-//    @Test
-    fun `mediator retries after intermittent exceptions`() {
+    @Test
+    fun `mediator retries after intermittent exceptions wrapped in completion exception`() {
         val event1 = cordaConsumerRecords(KEY1, "event1")
         val sendCount = AtomicInteger(0)
         val errorsCount = TEST_PROCESSOR_RETRIES + 1
@@ -193,7 +194,7 @@ class MultiSourceEventMediatorImplTest {
 
         whenever(messagingClient.send(any())).thenAnswer {
             if (sendCount.getAndIncrement() < errorsCount) {
-                throw CordaMessageAPIIntermittentException("IntermittentException")
+                throw CompletionException(CordaMessageAPIIntermittentException("IntermittentException"))
             }
             null
         }
@@ -202,9 +203,9 @@ class MultiSourceEventMediatorImplTest {
         waitWhile(Duration.ofSeconds(TEST_TIMEOUT_SECONDS)) { sendCount.get() < expectedProcessingCount }
         mediator.close()
 
-        verify(mediatorConsumerFactory, times(2)).create(any<MediatorConsumerConfig<Any, Any>>())
-        verify(messagingClientFactory, times(2)).create(any<MessagingClientConfig>())
-        verify(messageRouterFactory, times(2)).create(any<MessagingClientFinder>())
+        verify(mediatorConsumerFactory, times(1)).create(any<MediatorConsumerConfig<Any, Any>>())
+        verify(messagingClientFactory, times(1)).create(any<MessagingClientConfig>())
+        verify(messageRouterFactory, times(1)).create(any<MessagingClientFinder>())
         verify(messageProcessor, times(expectedProcessingCount)).onNext(anyOrNull(), any())
         verify(consumer, atLeast(expectedProcessingCount)).poll(any())
         verify(messagingClient, times(expectedProcessingCount)).send(any())


### PR DESCRIPTION
Can be thrown by CompletableFuture join calls. this will wrap the thrown CordaMessageAPIIntermittentExceptions in CompletionExceptions. This can erroneously treat them as fatal 