### PR TITLE
ES-1738: update codeowners file so team leads must review toml changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@ Jenkinsfile        @corda/blt
 .ci/**             @corda/blt
 
 *.gradle           @corda/blt
-gradle.properties  @corda/corda5-team-leads
-gradle/*           @corda/blt
+gradle/wrapper     @corda/blt
+*.toml             @corda/corda5-team-leads
 
 .github/**          @corda/blt
 CODEOWNERS         @corda/blt @corda/corda5-team-leads


### PR DESCRIPTION
With the introduction of dependabot updates via a version catalogue (toml file), we should have team leads review any changes to this file as this impacts dependencies, this is in one with the previous gradle.properties workflows