### PR TITLE
CORE-17813: Implement skip-able backchain with verifying notary

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/DependencyPayload.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/DependencyPayload.kt
@@ -1,8 +1,0 @@
-package net.corda.ledger.utxo.flow.impl.flows.finality
-
-import net.corda.v5.base.annotations.CordaSerializable
-
-@CordaSerializable
-data class DependencyPayload(
-    val filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>
-)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/DependencyPayload.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/DependencyPayload.kt
@@ -1,0 +1,8 @@
+package net.corda.ledger.utxo.flow.impl.flows.finality
+
+import net.corda.v5.base.annotations.CordaSerializable
+
+@CordaSerializable
+data class DependencyPayload(
+    val filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>
+)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FilteredTransactionAndSignatures.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FilteredTransactionAndSignatures.kt
@@ -1,0 +1,11 @@
+package net.corda.ledger.utxo.flow.impl.flows.finality
+
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
+
+@CordaSerializable
+data class FilteredTransactionAndSignatures(
+    val filteredTransaction: UtxoFilteredTransaction,
+    val signatures: List<DigitalSignatureAndMetadata>
+)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
@@ -10,7 +10,6 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
     private companion object {
         const val INITIAL_TRANSACTION = "INITIAL_TRANSACTION"
         const val TRANSFER_ADDITIONAL_SIGNATURES = "TRANSFER_ADDITIONAL_SIGNATURES"
-        const val FILTERED_TRANSACTIONS_AND_SIGNATURES = "FILTERED_TRANSACTIONS_AND_SIGNATURES"
     }
     constructor(initialTransaction: UtxoSignedTransaction, transferAdditionalSignatures: Boolean) : this(
         mapOf(
@@ -19,13 +18,6 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
         )
     )
 
-    constructor(filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>) : this(
-        mapOf(FILTERED_TRANSACTIONS_AND_SIGNATURES to filteredTransactionsAndSignatures)
-    )
-
     val initialTransaction get() = map[INITIAL_TRANSACTION] as UtxoSignedTransactionInternal
     val transferAdditionalSignatures get() = map[TRANSFER_ADDITIONAL_SIGNATURES] as Boolean
-
-    @Suppress("UNCHECKED_CAST")
-    val filteredTransactionsAndSignatures get() = map[FILTERED_TRANSACTIONS_AND_SIGNATURES] as List<FilteredTransactionAndSignatures>
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
@@ -10,6 +10,7 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
     private companion object {
         const val INITIAL_TRANSACTION = "INITIAL_TRANSACTION"
         const val TRANSFER_ADDITIONAL_SIGNATURES = "TRANSFER_ADDITIONAL_SIGNATURES"
+        const val FILTERED_TRANSACTIONS_AND_SIGNATURES = "FILTERED_TRANSACTIONS_AND_SIGNATURES"
     }
     constructor(initialTransaction: UtxoSignedTransaction, transferAdditionalSignatures: Boolean) : this(
         mapOf(
@@ -17,6 +18,14 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
             TRANSFER_ADDITIONAL_SIGNATURES to transferAdditionalSignatures
         )
     )
+
+    constructor(filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>) : this(
+        mapOf(FILTERED_TRANSACTIONS_AND_SIGNATURES to filteredTransactionsAndSignatures)
+    )
+
     val initialTransaction get() = map[INITIAL_TRANSACTION] as UtxoSignedTransactionInternal
     val transferAdditionalSignatures get() = map[TRANSFER_ADDITIONAL_SIGNATURES] as Boolean
+
+    @Suppress("UNCHECKED_CAST")
+    val filteredTransactionsAndSignatures get() = map[FILTERED_TRANSACTIONS_AND_SIGNATURES] as List<FilteredTransactionAndSignatures>
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
@@ -10,6 +10,7 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
     private companion object {
         const val INITIAL_TRANSACTION = "INITIAL_TRANSACTION"
         const val TRANSFER_ADDITIONAL_SIGNATURES = "TRANSFER_ADDITIONAL_SIGNATURES"
+        const val FILTERED_TRANSACTIONS_AND_SIGNATURES = "FILTERED_TRANSACTIONS_AND_SIGNATURES"
     }
     constructor(initialTransaction: UtxoSignedTransaction, transferAdditionalSignatures: Boolean) : this(
         mapOf(
@@ -18,6 +19,13 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
         )
     )
 
+    constructor(filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>) : this(
+        mapOf(FILTERED_TRANSACTIONS_AND_SIGNATURES to filteredTransactionsAndSignatures)
+    )
+
     val initialTransaction get() = map[INITIAL_TRANSACTION] as UtxoSignedTransactionInternal
     val transferAdditionalSignatures get() = map[TRANSFER_ADDITIONAL_SIGNATURES] as Boolean
+
+    @Suppress("UNCHECKED_CAST")
+    val filteredTransactionsAndSignatures get() = map[FILTERED_TRANSACTIONS_AND_SIGNATURES] as List<FilteredTransactionAndSignatures>
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -159,7 +159,6 @@ class UtxoFinalityFlowV1(
                     )
                 }
             flowMessaging.sendAll(FinalityPayload(filteredTransactionsAndSignatures), sessions.toSet())
-            log.info(("SENT FILTERED TRANSACTION!!"))
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -126,7 +126,6 @@ class UtxoFinalityFlowV1(
                 }
             }
         } else {
-            // TODO - Optimise this logic.
             val filteredTransactionsAndSignatures = initialTransaction
                 .let { it.inputStateRefs + it.referenceStateRefs }
                 .groupBy { stateRef -> stateRef.transactionId }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -9,7 +9,6 @@ import net.corda.ledger.notary.worker.selection.NotaryVirtualNodeSelectorService
 import net.corda.ledger.utxo.flow.impl.PluggableNotaryDetails
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
-import net.corda.ledger.utxo.flow.impl.flows.finality.DependencyPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
@@ -165,7 +164,7 @@ class UtxoFinalityFlowV1(
                         dependency.signatures.filter { newTxNotaryKeyIds.contains(it.by) }
                     )
                 }
-            flowMessaging.sendAll(DependencyPayload(filteredTransactionsAndSignatures), sessions.toSet())
+            flowMessaging.sendAll(FinalityPayload(filteredTransactionsAndSignatures), sessions.toSet())
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -164,7 +164,7 @@ class UtxoFinalityFlowV1(
                         dependency.signatures.filter { newTxNotaryKeyIds.contains(it.by) }
                     )
                 }
-            flowMessaging.sendAll(FinalityPayload(filteredTransactionsAndSignatures), sessions.toSet())
+            flowMessaging.sendAll(filteredTransactionsAndSignatures, sessions.toSet())
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -149,9 +149,11 @@ class UtxoFinalityFlowV1(
                         mutableMapOf()
                     )
 
-                    val newTxNotaryKeyIds = if (newTxNotaryKey is CompositeKey) newTxNotaryKey.leafKeys.toSet()
-                    else setOf(newTxNotaryKey.fullIdHash())
-
+                    val newTxNotaryKeyIds = if (newTxNotaryKey is CompositeKey) {
+                        newTxNotaryKey.leafKeys.toSet()
+                    } else {
+                        setOf(newTxNotaryKey.fullIdHash())
+                    }
 
                     FilteredTransactionAndSignatures(
                         utxoLedgerService.filterSignedTransaction(dependency)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -9,6 +9,7 @@ import net.corda.ledger.notary.worker.selection.NotaryVirtualNodeSelectorService
 import net.corda.ledger.utxo.flow.impl.PluggableNotaryDetails
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
+import net.corda.ledger.utxo.flow.impl.flows.finality.DependencyPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
@@ -164,7 +165,7 @@ class UtxoFinalityFlowV1(
                         dependency.signatures.filter { newTxNotaryKeyIds.contains(it.by) }
                     )
                 }
-            flowMessaging.sendAll(FinalityPayload(filteredTransactionsAndSignatures), sessions.toSet())
+            flowMessaging.sendAll(DependencyPayload(filteredTransactionsAndSignatures), sessions.toSet())
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.utxo.flow.impl.flows.backchain.InvalidBackchainException
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
+import net.corda.ledger.utxo.flow.impl.flows.finality.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
@@ -174,8 +175,10 @@ class UtxoReceiveFinalityFlowV1(
         initialTransaction: UtxoSignedTransactionInternal,
         transferAdditionalSignatures: Boolean
     ): InitialTransactionPayload {
+        @Suppress("unchecked_cast")
         val filteredTransactionsAndSignatures =
-            session.receive(FinalityPayload::class.java).filteredTransactionsAndSignatures
+            session.receive(List::class.java) as List<FilteredTransactionAndSignatures>
+
         val groupParameters = groupParametersLookup.currentGroupParameters
         val notary = requireNotNull(groupParameters.notaries.first { it.name == initialTransaction.notaryName }) {
             "Notary from initial transaction \"${initialTransaction.notaryName}\" cannot be found in group parameter notaries."

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -14,6 +14,7 @@ import net.corda.ledger.utxo.flow.impl.flows.finality.v1.FinalityNotarizationFai
 import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.membership.lib.SignedGroupParameters
 import net.corda.sandbox.CordaSystemFlow
 import net.corda.utilities.trace
@@ -22,8 +23,12 @@ import net.corda.v5.application.flows.CordaInject
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.ledger.common.NotaryLookup
+import net.corda.v5.ledger.common.transaction.TransactionSignatureVerificationService
+import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionValidator
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredData.Audit
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -54,14 +59,28 @@ class UtxoReceiveFinalityFlowV1(
     @CordaInject
     lateinit var signedGroupParametersVerifier: SignedGroupParametersVerifier
 
+    @CordaInject
+    lateinit var notaryLookup: NotaryLookup
+
+    @CordaInject
+    lateinit var transactionSignatureVerificationService: TransactionSignatureVerificationService
+
+    @CordaInject
+    lateinit var utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory
+
     @Suspendable
     override fun call(): UtxoSignedTransaction {
-        val (initialTransaction, transferAdditionalSignatures) = receiveTransactionAndBackchain()
+        val (
+            initialTransaction,
+            transferAdditionalSignatures,
+            inputStateAndRefs,
+            referenceStateAndRefs
+        ) = receiveTransactionAndBackchain()
         val transactionId = initialTransaction.id
         addTransactionIdToFlowContext(flowEngine, transactionId)
         verifyExistingSignatures(initialTransaction, session)
-        verifyTransaction(initialTransaction)
-        var transaction = if (validateTransaction(initialTransaction)) {
+        verifyTransaction(initialTransaction, inputStateAndRefs, referenceStateAndRefs)
+        var transaction = if (validateTransaction(initialTransaction, inputStateAndRefs, referenceStateAndRefs)) {
             if (log.isTraceEnabled) {
                 log.trace("Successfully validated transaction: $transactionId")
             }
@@ -105,7 +124,7 @@ class UtxoReceiveFinalityFlowV1(
     }
 
     @Suspendable
-    private fun receiveTransactionAndBackchain(): Pair<UtxoSignedTransactionInternal, Boolean> {
+    private fun receiveTransactionAndBackchain(): InitialTransactionPayload {
         val payload = session.receive(FinalityPayload::class.java)
         val initialTransaction = payload.initialTransaction
         val transferAdditionalSignatures = payload.transferAdditionalSignatures
@@ -115,26 +134,65 @@ class UtxoReceiveFinalityFlowV1(
         }
         val currentGroupParameters = verifyLatestGroupParametersAreUsed(initialTransaction)
         utxoLedgerGroupParametersPersistenceService.persistIfDoesNotExist(currentGroupParameters)
-        val transactionDependencies = initialTransaction.dependencies
-        if (transactionDependencies.isNotEmpty()) {
-            try {
-                flowEngine.subFlow(TransactionBackchainResolutionFlow(transactionDependencies, session))
-            } catch (e: InvalidBackchainException) {
-                log.warn(
-                    "Invalid transaction found during back-chain resolution, marking transaction with ID " +
-                        "${initialTransaction.id} as invalid.",
-                    e
-                )
-                persistInvalidTransaction(initialTransaction)
-                throw e
-            }
-        } else {
-            log.trace {
-                "Transaction with id ${initialTransaction.id} has no dependencies so backchain resolution will not be performed."
-            }
+        val notaryInfo = requireNotNull(notaryLookup.lookup(initialTransaction.notaryName)) {
+            "Notary ${initialTransaction.notaryName} does not exist in the network"
         }
-        return Pair(initialTransaction, transferAdditionalSignatures)
+        return if (notaryInfo.isBackchainRequired) {
+            val transactionDependencies = initialTransaction.dependencies
+            if (transactionDependencies.isNotEmpty()) {
+                try {
+                    flowEngine.subFlow(TransactionBackchainResolutionFlow(transactionDependencies, session))
+                } catch (e: InvalidBackchainException) {
+                    log.warn(
+                        "Invalid transaction found during back-chain resolution, marking transaction with ID " +
+                            "${initialTransaction.id} as invalid.",
+                        e
+                    )
+                    persistInvalidTransaction(initialTransaction)
+                    throw e
+                }
+            } else {
+                log.trace {
+                    "Transaction with id ${initialTransaction.id} has no dependencies so backchain resolution will not be performed."
+                }
+            }
+            InitialTransactionPayload(initialTransaction, transferAdditionalSignatures, emptyList(), emptyList())
+        } else {
+            val filteredTransactionsAndSignatures =
+                session.receive(FinalityPayload::class.java).filteredTransactionsAndSignatures
+            val dependentStateAndRefs =
+                filteredTransactionsAndSignatures.flatMap { (filteredTransaction, signatures) ->
+                    require(signatures.isNotEmpty()) { "No notary signatures were received" }
+                    filteredTransaction.verify()
+
+                    for (signature in signatures) {
+                        transactionSignatureVerificationService.verifySignature(
+                            filteredTransaction.id,
+                            signature,
+                            filteredTransaction.notaryKey
+                        )
+                    }
+                    (filteredTransaction.outputStateAndRefs as Audit<StateAndRef<*>>).values.values
+                }.associateBy { stateRef -> stateRef.ref }
+            val inputStateAndRefs = initialTransaction.inputStateRefs.map { stateRef ->
+                requireNotNull(dependentStateAndRefs[stateRef]) {
+                    "Missing input state and ref from the filtered transaction"
+                }
+            }
+            val referenceStateAndRefs = initialTransaction.referenceStateRefs.map { stateRef ->
+                requireNotNull(dependentStateAndRefs[stateRef]) {
+                    "Missing reference state and ref from the filtered transaction"
+                }
+            }
+            InitialTransactionPayload(initialTransaction, transferAdditionalSignatures, inputStateAndRefs, referenceStateAndRefs)
+        }
     }
+    private data class InitialTransactionPayload(
+        val initialTransaction: UtxoSignedTransactionInternal,
+        val transferAdditionalSignatures: Boolean,
+        val inputStateAndRefs: List<StateAndRef<*>>,
+        val referenceStateAndRefs: List<StateAndRef<*>>
+    )
 
     @Suspendable
     private fun verifyLatestGroupParametersAreUsed(initialTransaction: UtxoSignedTransactionInternal): SignedGroupParameters {
@@ -154,16 +212,52 @@ class UtxoReceiveFinalityFlowV1(
     }
 
     @Suspendable
-    private fun validateTransaction(signedTransaction: UtxoSignedTransaction): Boolean {
+    private fun verifyTransaction(
+        initialTransaction: UtxoSignedTransactionInternal,
+        inputStateAndRefs: List<StateAndRef<*>>,
+        referenceStateAndRefs: List<StateAndRef<*>>
+    ) {
+        val ledgerTransaction = if (inputStateAndRefs.isNotEmpty() || referenceStateAndRefs.isNotEmpty()) {
+            utxoLedgerTransactionFactory.createWithStateAndRefs(
+                initialTransaction.wireTransaction,
+                inputStateAndRefs,
+                referenceStateAndRefs
+            )
+        } else {
+            initialTransaction.toLedgerTransaction()
+        }
+        try {
+            transactionVerificationService.verify(ledgerTransaction)
+        } catch (e: Exception) {
+            persistInvalidTransaction(initialTransaction)
+            throw e
+        }
+    }
+
+    @Suspendable
+    private fun validateTransaction(
+        initialTransaction: UtxoSignedTransactionInternal,
+        inputStateAndRefs: List<StateAndRef<*>>,
+        referenceStateAndRefs: List<StateAndRef<*>>
+    ): Boolean {
+        val ledgerTransaction = if (inputStateAndRefs.isNotEmpty() || referenceStateAndRefs.isNotEmpty()) {
+            utxoLedgerTransactionFactory.createWithStateAndRefs(
+                initialTransaction.wireTransaction,
+                inputStateAndRefs,
+                referenceStateAndRefs
+            )
+        } else {
+            initialTransaction.toLedgerTransaction()
+        }
         return try {
-            validator.checkTransaction(signedTransaction.toLedgerTransaction())
+            validator.checkTransaction(ledgerTransaction)
             true
         } catch (e: Exception) {
             // Should we only catch a specific exception type? Otherwise, some errors can be swallowed by this warning.
             // Means contracts can't use [check] or [require] unless we provide our own functions for this.
             if (e is IllegalStateException || e is IllegalArgumentException || e is CordaRuntimeException) {
                 if (log.isDebugEnabled) {
-                    log.debug("Transaction ${signedTransaction.id} failed verification. Message: ${e.message}")
+                    log.debug("Transaction ${ledgerTransaction.id} failed verification. Message: ${e.message}")
                 }
                 false
             } else {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -7,7 +7,6 @@ import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.utxo.flow.impl.flows.backchain.InvalidBackchainException
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
-import net.corda.ledger.utxo.flow.impl.flows.finality.DependencyPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
@@ -176,7 +175,7 @@ class UtxoReceiveFinalityFlowV1(
         transferAdditionalSignatures: Boolean
     ): InitialTransactionPayload {
         val filteredTransactionsAndSignatures =
-            session.receive(DependencyPayload::class.java).filteredTransactionsAndSignatures
+            session.receive(FinalityPayload::class.java).filteredTransactionsAndSignatures
         val groupParameters = groupParametersLookup.currentGroupParameters
         val notary = requireNotNull(groupParameters.notaries.first { it.name == initialTransaction.notaryName }) {
             "Notary from initial transaction \"${initialTransaction.notaryName}\" cannot be found in group parameter notaries."

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality.v1
 
+import net.corda.crypto.core.fullIdHash
 import net.corda.flow.application.GroupParametersLookupInternal
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -166,6 +167,10 @@ class UtxoReceiveFinalityFlowV1(
                     filteredTransaction.verify()
 
                     for (signature in signatures) {
+                        require(notaryInfo.publicKey.fullIdHash() == signature.by) {
+                            "Signature received \"${signature.by}\" is not signed by current notary " +
+                                "\"${notaryInfo.publicKey.fullIdHash()}\""
+                        }
                         transactionSignatureVerificationService.verifySignature(
                             filteredTransaction.id,
                             signature,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -7,6 +7,7 @@ import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.utxo.flow.impl.flows.backchain.InvalidBackchainException
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
+import net.corda.ledger.utxo.flow.impl.flows.finality.DependencyPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
@@ -175,7 +176,7 @@ class UtxoReceiveFinalityFlowV1(
         transferAdditionalSignatures: Boolean
     ): InitialTransactionPayload {
         val filteredTransactionsAndSignatures =
-            session.receive(FinalityPayload::class.java).filteredTransactionsAndSignatures
+            session.receive(DependencyPayload::class.java).filteredTransactionsAndSignatures
         val groupParameters = groupParametersLookup.currentGroupParameters
         val notary = requireNotNull(groupParameters.notaries.first { it.name == initialTransaction.notaryName }) {
             "Notary from initial transaction \"${initialTransaction.notaryName}\" cannot be found in group parameter notaries."

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -24,7 +24,6 @@ import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.ledger.common.NotaryLookup
-import net.corda.v5.ledger.common.transaction.TransactionSignatureVerificationService
 import net.corda.v5.ledger.utxo.NotarySignatureVerificationService
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
@@ -62,9 +61,6 @@ class UtxoReceiveFinalityFlowV1(
 
     @CordaInject
     lateinit var notaryLookup: NotaryLookup
-
-    @CordaInject
-    lateinit var transactionSignatureVerificationService: TransactionSignatureVerificationService
 
     @CordaInject
     lateinit var utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -191,7 +191,7 @@ class UtxoReceiveFinalityFlowV1(
                 val newTxNotaryKeys = if (newTxNotaryKey is CompositeKey) {
                     require(KeyUtils.isKeyFulfilledBy(newTxNotaryKey, filteredTxNotaryKey)) {
                         "A composite notary key of new transaction $newTxNotaryKey doesn't contain " +
-                                "a filtered transaction notary key $filteredTxNotaryKey"
+                            "a filtered transaction notary key $filteredTxNotaryKey"
                     }
                     newTxNotaryKey.leafKeys.toSet()
                 } else {
@@ -201,14 +201,14 @@ class UtxoReceiveFinalityFlowV1(
                 val newTxNotaryNames = newTxNotaryKeys.map { memberLookup.lookup(it)?.name }
                 require(newTxNotaryNames.contains(filteredTxNotaryName)) {
                     "Notary name of filtered transaction \"${filteredTxNotaryName}\" doesn't match with " +
-                            "any names of initial transaction \"${newTxNotaryNames}\""
+                        "any names of initial transaction \"${newTxNotaryNames}\""
                 }
 
                 val newTxNotaryKeyIds = newTxNotaryKeys.map { it.fullIdHash() }
                 for (signature in signatures) {
                     require(newTxNotaryKeyIds.contains(signature.by)) {
                         "Signature received \"${signature.by}\" is not signed by current notary " +
-                                "\"${notaryInfo.publicKey.fullIdHash()}\""
+                            "\"${notaryInfo.publicKey.fullIdHash()}\""
                     }
                     transactionSignatureVerificationService.verifySignature(
                         filteredTransaction.id,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -183,7 +183,7 @@ data class UtxoSignedTransactionImpl(
     }
 
     override fun verifyAttachedNotarySignature() {
-        notarySignatureVerificationService.verifyNotarySignatures(wireTransaction, notaryKey, signatures, keyIdToNotaryKeys)
+        notarySignatureVerificationService.verifyNotarySignatures(this, notaryKey, signatures, keyIdToNotaryKeys)
     }
 
     override fun verifyNotarySignature(signature: DigitalSignatureAndMetadata) {
@@ -227,7 +227,6 @@ data class UtxoSignedTransactionImpl(
         return utxoLedgerTransactionFactory.create(wireTransaction)
     }
 
-    @Suspendable
     override fun toLedgerTransaction(
         inputStateAndRefs: List<StateAndRef<*>>,
         referenceStateAndRefs: List<StateAndRef<*>>

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionInternal.kt
@@ -46,14 +46,6 @@ interface UtxoSignedTransactionInternal : UtxoSignedTransaction {
     fun getMissingSignatories(): Set<PublicKey>
 
     /**
-     * Verify the signatories' signatures and check if there are any missing one.
-     * It ignores the non-signatory signatures! (including the notary's)
-     *
-     * @throws TransactionSignatureException if any signatures are missing or invalid.
-     */
-    fun verifySignatorySignatures()
-
-    /**
      * Verify if notary has signed the transaction.
      * It checks both the existence and the validity of that signature.
      *

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoLedgerTransactionFactoryImpl.kt
@@ -11,6 +11,7 @@ import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerStateQueryService
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
+import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
@@ -22,9 +23,13 @@ import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import org.osgi.service.component.annotations.ServiceScope
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
-@Component(service = [UtxoLedgerTransactionFactory::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE)
+@Component(
+    service = [UtxoLedgerTransactionFactory::class, UsedByFlow::class],
+    scope = PROTOTYPE,
+    property = [CORDA_SYSTEM_SERVICE],
+)
 class UtxoLedgerTransactionFactoryImpl @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serializationService: SerializationService,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -147,7 +147,7 @@ class UtxoReceiveFinalityFlowV1Test {
     }
     private val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureNotary))
     private val finalityPayload = FinalityPayload(signedTransaction, true)
-    private val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
+    private val filteredTxPayload = listOf(filteredTxAndSig)
 
     @BeforeEach
     fun beforeEach() {
@@ -559,8 +559,8 @@ class UtxoReceiveFinalityFlowV1Test {
     fun `skip backchain with a backchain not required notary`() {
         whenever(notaryInfo.isBackchainRequired).thenReturn(false)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
-        whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
+        whenever(session.receive(List::class.java)).thenReturn(filteredTxPayload, listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
         callReceiveFinalityFlow()
@@ -593,11 +593,11 @@ class UtxoReceiveFinalityFlowV1Test {
         }
         val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureAnotherNotary))
         val finalityPayload = FinalityPayload(signedTransaction, true)
-        val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
+        val filteredTxPayload = listOf(filteredTxAndSig)
 
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
-        whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
+        whenever(session.receive(List::class.java)).thenReturn(filteredTxPayload, listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
         whenever(notaryInfo.isBackchainRequired).thenReturn(false)
@@ -628,8 +628,8 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(signedTransaction.notaryName).thenReturn(anotherNotaryX500Name)
         whenever(signedTransaction.notaryKey).thenReturn(publicKeyAnotherNotary)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
-        whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
+        whenever(session.receive(List::class.java)).thenReturn(filteredTxPayload, listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
         assertThatThrownBy { callReceiveFinalityFlow() }
@@ -650,7 +650,7 @@ class UtxoReceiveFinalityFlowV1Test {
         }
         val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureNotary))
         val finalityPayload = FinalityPayload(signedTransaction, true)
-        val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
+        val filteredTxPayload = listOf(filteredTxAndSig)
 
         whenever(notaryInfo.publicKey).thenReturn(compositeKeyNotary)
         whenever(notaryInfo.isBackchainRequired).thenReturn(false)
@@ -660,8 +660,8 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(signedTransaction.notaryKey).thenReturn(compositeKeyNotary)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
 
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
-        whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
+        whenever(session.receive(List::class.java)).thenReturn(filteredTxPayload, listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
         whenever(

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -543,6 +543,7 @@ class UtxoReceiveFinalityFlowV1Test {
         val filteredTransaction = mock<UtxoFilteredTransaction>().also {
             whenever(it.outputStateAndRefs).thenReturn(filteredOutputStateAndRefs)
             whenever(it.notaryKey).thenReturn(publicKeyNotary)
+            whenever(it.notaryName).thenReturn(notaryX500Name)
         }
         val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureNotary))
         val finalityPayload = FinalityPayload(signedTransaction, true)
@@ -584,6 +585,7 @@ class UtxoReceiveFinalityFlowV1Test {
         val filteredTransaction = mock<UtxoFilteredTransaction>().also {
             whenever(it.outputStateAndRefs).thenReturn(filteredOutputStateAndRefs)
             whenever(it.notaryKey).thenReturn(publicKeyNotary)
+            whenever(it.notaryName).thenReturn(notaryX500Name)
         }
         val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureAnotherNotary))
         val finalityPayload = FinalityPayload(signedTransaction, true)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -15,6 +15,7 @@ import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
+import net.corda.ledger.utxo.flow.impl.flows.finality.DependencyPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
@@ -147,7 +148,7 @@ class UtxoReceiveFinalityFlowV1Test {
     }
     private val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureNotary))
     private val finalityPayload = FinalityPayload(signedTransaction, true)
-    private val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
+    private val dependencyPayload = DependencyPayload(listOf(filteredTxAndSig))
 
     @BeforeEach
     fun beforeEach() {
@@ -559,7 +560,9 @@ class UtxoReceiveFinalityFlowV1Test {
     fun `skip backchain with a backchain not required notary`() {
         whenever(notaryInfo.isBackchainRequired).thenReturn(false)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
+        whenever(session.receive(DependencyPayload::class.java)).thenReturn(dependencyPayload)
+
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
@@ -593,10 +596,11 @@ class UtxoReceiveFinalityFlowV1Test {
         }
         val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureAnotherNotary))
         val finalityPayload = FinalityPayload(signedTransaction, true)
-        val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
+        val dependencyPayload = DependencyPayload(listOf(filteredTxAndSig))
 
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
+        whenever(session.receive(DependencyPayload::class.java)).thenReturn(dependencyPayload)
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
@@ -628,7 +632,8 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(signedTransaction.notaryName).thenReturn(anotherNotaryX500Name)
         whenever(signedTransaction.notaryKey).thenReturn(publicKeyAnotherNotary)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
+        whenever(session.receive(DependencyPayload::class.java)).thenReturn(dependencyPayload)
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
@@ -650,7 +655,7 @@ class UtxoReceiveFinalityFlowV1Test {
         }
         val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureNotary))
         val finalityPayload = FinalityPayload(signedTransaction, true)
-        val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
+        val dependencyPayload = DependencyPayload(listOf(filteredTxAndSig))
 
         whenever(notaryInfo.publicKey).thenReturn(compositeKeyNotary)
         whenever(notaryInfo.isBackchainRequired).thenReturn(false)
@@ -660,7 +665,8 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(signedTransaction.notaryKey).thenReturn(compositeKeyNotary)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
 
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
+        whenever(session.receive(DependencyPayload::class.java)).thenReturn(dependencyPayload)
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -41,7 +41,6 @@ import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.common.transaction.TransactionSignatureException
-import net.corda.v5.ledger.common.transaction.TransactionSignatureVerificationService
 import net.corda.v5.ledger.utxo.NotarySignatureVerificationService
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
@@ -81,7 +80,6 @@ class UtxoReceiveFinalityFlowV1Test {
     private val groupParametersLookup = mock<GroupParametersLookupInternal>()
     private val utxoLedgerGroupParametersPersistenceService = mock<UtxoLedgerGroupParametersPersistenceService>()
     private val transactionVerificationService = mock<UtxoLedgerTransactionVerificationService>()
-    private val transactionSignatureVerificationService = mock<TransactionSignatureVerificationService>()
     private val signedGroupParametersVerifier = mock<SignedGroupParametersVerifier>()
     private val visibilityChecker = mock<VisibilityChecker>()
     private val notarySignatureVerificationService = mock<NotarySignatureVerificationService>()
@@ -696,7 +694,6 @@ class UtxoReceiveFinalityFlowV1Test {
         flow.groupParametersLookup = groupParametersLookup
         flow.utxoLedgerGroupParametersPersistenceService = utxoLedgerGroupParametersPersistenceService
         flow.signedGroupParametersVerifier = signedGroupParametersVerifier
-        flow.transactionSignatureVerificationService = transactionSignatureVerificationService
         flow.notarySignatureVerificationService = notarySignatureVerificationService
         flow.call()
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -549,8 +549,10 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
-        whenever(transactionSignatureVerificationService.verifySignature(filteredTransaction.id, signatureNotary, filteredTransaction.notaryKey))
-            .thenAnswer {  }
+        whenever(
+            transactionSignatureVerificationService.verifySignature(filteredTransaction.id, signatureNotary, filteredTransaction.notaryKey)
+        )
+            .thenAnswer { }
 
         callReceiveFinalityFlow()
 
@@ -571,7 +573,6 @@ class UtxoReceiveFinalityFlowV1Test {
 
         verify(flowEngine, timeout(100).times(1)).subFlow(any<TransactionBackchainResolutionFlow>())
     }
-
 
     private fun callReceiveFinalityFlow(validator: UtxoTransactionValidator = UtxoTransactionValidator { }) {
         val flow = UtxoReceiveFinalityFlowV1(session, validator)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -15,7 +15,6 @@ import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
-import net.corda.ledger.utxo.flow.impl.flows.finality.DependencyPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
@@ -148,7 +147,7 @@ class UtxoReceiveFinalityFlowV1Test {
     }
     private val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureNotary))
     private val finalityPayload = FinalityPayload(signedTransaction, true)
-    private val dependencyPayload = DependencyPayload(listOf(filteredTxAndSig))
+    private val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
 
     @BeforeEach
     fun beforeEach() {
@@ -560,9 +559,7 @@ class UtxoReceiveFinalityFlowV1Test {
     fun `skip backchain with a backchain not required notary`() {
         whenever(notaryInfo.isBackchainRequired).thenReturn(false)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
-        whenever(session.receive(DependencyPayload::class.java)).thenReturn(dependencyPayload)
-
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
@@ -596,11 +593,10 @@ class UtxoReceiveFinalityFlowV1Test {
         }
         val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureAnotherNotary))
         val finalityPayload = FinalityPayload(signedTransaction, true)
-        val dependencyPayload = DependencyPayload(listOf(filteredTxAndSig))
+        val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
 
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
-        whenever(session.receive(DependencyPayload::class.java)).thenReturn(dependencyPayload)
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
@@ -632,8 +628,7 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(signedTransaction.notaryName).thenReturn(anotherNotaryX500Name)
         whenever(signedTransaction.notaryKey).thenReturn(publicKeyAnotherNotary)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
-        whenever(session.receive(DependencyPayload::class.java)).thenReturn(dependencyPayload)
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
@@ -655,7 +650,7 @@ class UtxoReceiveFinalityFlowV1Test {
         }
         val filteredTxAndSig = FilteredTransactionAndSignatures(filteredTransaction, listOf(signatureNotary))
         val finalityPayload = FinalityPayload(signedTransaction, true)
-        val dependencyPayload = DependencyPayload(listOf(filteredTxAndSig))
+        val finalityPayloadWithFilteredTx = FinalityPayload(listOf(filteredTxAndSig))
 
         whenever(notaryInfo.publicKey).thenReturn(compositeKeyNotary)
         whenever(notaryInfo.isBackchainRequired).thenReturn(false)
@@ -665,8 +660,7 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(signedTransaction.notaryKey).thenReturn(compositeKeyNotary)
         whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
 
-        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload)
-        whenever(session.receive(DependencyPayload::class.java)).thenReturn(dependencyPayload)
+        whenever(session.receive(FinalityPayload::class.java)).thenReturn(finalityPayload, finalityPayloadWithFilteredTx)
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.22-beta+
+cordaApiVersion=5.2.0.23-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
@@ -81,7 +81,7 @@ class ContractVerifyingNotaryServerFlowImpl() : ResponderFlow {
 
             validateTransactionNotaryAgainstCurrentNotary(initialTransactionDetails)
 
-            verifySignatures(initialTransaction.notaryKey, filteredTransactionsAndSignatures)
+            verifySignatures(initialTransaction.notaryKey, filteredTransactionsAndSignatures, initialTransaction)
 
             verifyTransaction(initialTransaction, filteredTransactionsAndSignatures)
 
@@ -164,8 +164,11 @@ class ContractVerifyingNotaryServerFlowImpl() : ResponderFlow {
     @Suspendable
     fun verifySignatures(
         notaryKey: PublicKey,
-        filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>
+        filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>,
+        initialTransaction: UtxoSignedTransaction
     ) {
+        initialTransaction.verifySignatorySignatures()
+
         val keyIdToNotaryKeys: MutableMap<String, MutableMap<SecureHash, PublicKey>> = mutableMapOf()
 
         filteredTransactionsAndSignatures.forEach { (filteredTransaction, signatures) ->
@@ -191,6 +194,7 @@ class ContractVerifyingNotaryServerFlowImpl() : ResponderFlow {
         filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>
     ) {
         try {
+
             val dependentStateAndRefs = filteredTransactionsAndSignatures.flatMap { (filteredTransaction, _) ->
                 (filteredTransaction.outputStateAndRefs as UtxoFilteredData.Audit<StateAndRef<*>>).values.values
             }.associateBy { it.ref }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -118,7 +118,7 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
                 NotarizationResponse(
                     emptyList(),
                     NotaryExceptionGeneral("Error while processing request from client. " +
-                            "Please contact notary operator for further details.")
+                            "Cause: ${e.message}")
                 )
             )
         }


### PR DESCRIPTION
This PR implements skip-able backchain with a verifying notary.
The notary has to be able to: skip when backchain required flag is false with contract verifying notary or not skip when the flag is true.

The e2e tests for the implementation are [here](https://github.com/corda/corda-e2e-tests/pull/366)