### PR TITLE
CORE-18973: Windows formatting fix in `AuthenticationProtocolInitiatorTest`

### DIFF
--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolInitiatorTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolInitiatorTest.kt
@@ -40,7 +40,7 @@ cZyj8BXGy1y5rL75SE01/3qwAvSAatoTtVtPlPuHn5U1nGDe3AoaS1LvrqIypJjo
 ODGVZOuwAyZ6676J40yue06DiPpysNULHoZu3PEd+DEWKsCyPq3yYtB7E+HvLUAQ
 AQIDAQAB
 -----END PUBLIC KEY-----
-    """.trimIndent()
+    """
 
     private val publicKey by lazy {
         publicKeyPem.toPublicKey()

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolInitiatorTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolInitiatorTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import java.nio.ByteBuffer
+import java.security.PublicKey
 import java.security.Security
 
 class AuthenticationProtocolInitiatorTest {
@@ -42,7 +43,7 @@ AQIDAQAB
     """.trimIndent()
 
     private val publicKey by lazy {
-        publicKeyFactory(publicKeyPem.reader())!!
+        publicKeyPem.toPublicKey()
     }
 
     @Test
@@ -67,7 +68,7 @@ AQIDAQAB
             assertThat(avro.protocolCommonDetails.sessionId).isEqualTo("sessionId")
             assertThat(avro.supportedModes).containsOnly(ProtocolMode.AUTHENTICATION_ONLY)
             assertThat(avro.groupId).isEqualTo("group")
-            assertThat(avro.ourPublicKey.replace("\n", System.lineSeparator()).trim()).isEqualTo(publicKeyPem.trim())
+            assertThat(avro.ourPublicKey.toPublicKey()).isEqualTo(publicKey)
             assertThat(avro.certificateCheckMode?.revocationCheckMode).isEqualTo(RevocationCheckMode.HARD_FAIL)
             assertThat(avro.certificateCheckMode?.truststore).containsOnly("one")
         }
@@ -123,4 +124,7 @@ AQIDAQAB
             assertThat(initiator.getSession()).isInstanceOf(AuthenticatedEncryptionSession::class.java)
         }
     }
+
+    private fun String.toPublicKey() : PublicKey =
+        publicKeyFactory(this.reader())!!
 }

--- a/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolInitiatorTest.kt
+++ b/libs/p2p-crypto/src/test/kotlin/net/corda/p2p/crypto/protocol/api/AuthenticationProtocolInitiatorTest.kt
@@ -67,7 +67,7 @@ AQIDAQAB
             assertThat(avro.protocolCommonDetails.sessionId).isEqualTo("sessionId")
             assertThat(avro.supportedModes).containsOnly(ProtocolMode.AUTHENTICATION_ONLY)
             assertThat(avro.groupId).isEqualTo("group")
-            assertThat(avro.ourPublicKey.trim()).isEqualTo(publicKeyPem.trim())
+            assertThat(avro.ourPublicKey.replace("\n", System.lineSeparator()).trim()).isEqualTo(publicKeyPem.trim())
             assertThat(avro.certificateCheckMode?.revocationCheckMode).isEqualTo(RevocationCheckMode.HARD_FAIL)
             assertThat(avro.certificateCheckMode?.truststore).containsOnly("one")
         }

--- a/libs/utilities/src/test/kotlin/net/corda/utilities/crypto/PublicKeyFactoryTest.kt
+++ b/libs/utilities/src/test/kotlin/net/corda/utilities/crypto/PublicKeyFactoryTest.kt
@@ -5,12 +5,13 @@ import org.junit.jupiter.api.Test
 
 class PublicKeyFactoryTest {
     private companion object {
-        const val VALID_KEY_PEM = """
+        private val VALID_KEY_PEM = """
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7fFAKpIU1LlAf7S2n4847JcqvgaT
 rVwmQ9GmruPVpC2wEPpFggbVL3/mtm61qoCi81hphd0W9yVhSVwVT0wQHw==
 -----END PUBLIC KEY-----
-        """
+        """.replace("\r", "")
+            .replace("\n", System.lineSeparator())
 
         const val CERTIFICATE_PEM = """
 -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Build to validate that `toAvro returns the correct object()` is fixed on a Windows `runtime-os` run: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FNightlys%2FCorda-Runtime-OS%2FWindows/detail/benyip%2FCORE-18973%2Fwindows-test-fix/4/tests
Build to validate that `toPem return a valid public key PEM()` is fixed on a Windows `runtime-os` run: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FNightlys%2FCorda-Runtime-OS%2FWindows/detail/benyip%2FCORE-18973%2Fwindows-test-fix/5/tests/