### PR TITLE
CORE-18918: Resolve SNYK-JAVA-ORGECLIPSEJETTY-5769685

### DIFF
--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -34,9 +34,9 @@ dependencies {
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "info.picocli:picocli:$picocliVersion"
-    implementation "io.javalin:javalin-osgi:$javalinVersion"
+    implementation libs.javalin
     constraints {
-        implementation("org.eclipse.jetty:jetty-server:$jettyVersion") {
+        implementation(libs.bundles.jetty) {
             because 'Javalin uses an older version of Jetty which is exposed to CVE-2023-26048 and CVE-2023-26049. ' +
                     'This might be resolved in the future versions of Javalin.'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -113,16 +113,12 @@ mssqlDriverVersion=11.2.3.jre17
 slingVersion=3.3.6
 
 # REST dependency versions
-javalinVersion = 4.6.7
 swaggerVersion = 2.2.12
 # as defined in SWAGGERUI.version in io/javalin/core/util/OptionalDependency.kt
 swaggeruiVersion = 4.18.2
 nimbusVersion = 10.8
 jcipAnnotationsVersion = 1.0_2
 unirestVersion = 3.14.5
-# This version of Jetty must be the same major version as used by Javalin, please see above.
-# Once Javalin version is upgraded to the latest, this override may be removed.
-jettyVersion = 9.4.53.v20231009
 
 # Enables the substitution of binaries for source code if it exists in expected location
 # Default behaviour is false.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,14 +36,14 @@ mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", versio
 javalin = { group = "io.javalin", name = "javalin-osgi", version.ref = "javalinVersion" }
 jetty-server = { group = "org.eclipse.jetty", name = "jetty-server", version.ref = "jettyVersion" }
 jetty-xml = { group = "org.eclipse.jetty", name = "jetty-xml", version.ref = "jettyVersion" }
-jetty-websocket-servlet = { group = "org.eclipse.jetty.websocket", name = "jwebsocket-servlet", version.ref = "jettyVersion" }
-jetty-websocket-server = { group = "org.eclipse.jetty.websocket", name = "jwebsocket-server", version.ref = "jettyVersion" }
+jetty-websocket-servlet = { group = "org.eclipse.jetty.websocket", name = "websocket-servlet", version.ref = "jettyVersion" }
+jetty-websocket-server = { group = "org.eclipse.jetty.websocket", name = "websocket-server", version.ref = "jettyVersion" }
 jetty-websocket-client = { group = "org.eclipse.jetty.websocket", name = "websocket-client", version.ref = "jettyVersion" }
 jetty-http2-server = { group = "org.eclipse.jetty.http2", name = "http2-server", version.ref = "jettyVersion" }
 
 [bundles]
 bouncycastle = ["bouncycastle-prov", "bouncycastle-pkix"]
-jetty = ["jetty-server", "jetty-xml", "jetty-websocket-servlet", "jetty-websocket-server", "jetty-http2-server"]
+jetty = ["jetty-server", "jetty-xml", "jetty-websocket-servlet", "jetty-websocket-server"]
 test = ["junit", "junit-api", "junit-params", "mockito-core", "mockito-kotlin", "assertj-core", "kotlin-test"]
 test-runtime = ["junit-engine", "junit-platform"]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,12 @@ kotlinVersion = "1.8.21"
 
 bouncycastleVersion = "1.76"
 
+# REST dependency versions
+javalinVersion = "4.6.7"
+# This version of Jetty must be the same major version as used by Javalin, please see above.
+# Once Javalin version is upgraded to the latest, this override may be removed.
+jettyVersion = "9.4.52.v20230823"
+
 # Testing
 assertjVersion = "3.24.2"
 junitVersion = "5.10.1"
@@ -27,9 +33,17 @@ kotlin-reflect= { group = "org.jetbrains.kotlin", name = "kotlin-reflect", versi
 kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlinVersion" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockitoVersion" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlinVersion" }
+javalin = { group = "io.javalin", name = "javalin-osgi", version.ref = "javalinVersion" }
+jetty-server = { group = "org.eclipse.jetty", name = "jetty-server", version.ref = "jettyVersion" }
+jetty-xml = { group = "org.eclipse.jetty", name = "jetty-xml", version.ref = "jettyVersion" }
+jetty-websocket-servlet = { group = "org.eclipse.jetty.websocket", name = "jwebsocket-servlet", version.ref = "jettyVersion" }
+jetty-websocket-server = { group = "org.eclipse.jetty.websocket", name = "jwebsocket-server", version.ref = "jettyVersion" }
+jetty-websocket-client = { group = "org.eclipse.jetty.websocket", name = "websocket-client", version.ref = "jettyVersion" }
+jetty-http2-server = { group = "org.eclipse.jetty.http2", name = "http2-server", version.ref = "jettyVersion" }
 
 [bundles]
 bouncycastle = ["bouncycastle-prov", "bouncycastle-pkix"]
+jetty = ["jetty-server", "jetty-xml", "jetty-websocket-servlet", "jetty-websocket-server", "jetty-http2-server"]
 test = ["junit", "junit-api", "junit-params", "mockito-core", "mockito-kotlin", "assertj-core", "kotlin-test"]
 test-runtime = ["junit-engine", "junit-platform"]
 

--- a/libs/messaging/messaging-impl/build.gradle
+++ b/libs/messaging/messaging-impl/build.gradle
@@ -41,9 +41,9 @@ dependencies {
     testImplementation project(':libs:platform-info')
     testImplementation project(':libs:web:web-impl')
 
-    testImplementation "io.javalin:javalin-osgi:$javalinVersion"
+    testImplementation libs.javalin
     constraints {
-        implementation("org.eclipse.jetty:jetty-server:$jettyVersion") {
+        testImplementation(libs.bundles.jetty) {
             because 'Javalin uses an older version of Jetty which is exposed to CVE-2023-26048 and CVE-2023-26049. ' +
                     'This might be resolved in the future versions of Javalin.'
         }

--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation "com.nimbusds:oauth2-oidc-sdk:$nimbusVersion"
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.jcip-annotations:$jcipAnnotationsVersion"
     implementation "io.swagger.core.v3:swagger-core:$swaggerVersion"
+    implementation libs.jetty.http2.server
 
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     implementation project(":libs:rest:rest-common")

--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -28,18 +28,15 @@ dependencies {
 
     implementation project(":libs:rest:rest-server")
     implementation "net.corda:corda-crypto"
-    implementation "io.javalin:javalin-osgi:$javalinVersion"
+    implementation libs.javalin
     constraints {
-        implementation("org.eclipse.jetty:jetty-server:$jettyVersion") {
+        implementation(libs.bundles.jetty) {
             because 'Javalin uses an older version of Jetty which is exposed to CVE-2023-26048 and CVE-2023-26049. ' +
                     'This might be resolved in the future versions of Javalin.'
         }
     }
     implementation "com.nimbusds:oauth2-oidc-sdk:$nimbusVersion"
     implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.jcip-annotations:$jcipAnnotationsVersion"
-    implementation "org.eclipse.jetty.websocket:websocket-servlet:$jettyVersion"
-    implementation "org.eclipse.jetty.websocket:websocket-server:$jettyVersion"
-    implementation "org.eclipse.jetty.http2:http2-server:$jettyVersion"
     implementation "io.swagger.core.v3:swagger-core:$swaggerVersion"
 
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"

--- a/libs/tracing-impl/build.gradle
+++ b/libs/tracing-impl/build.gradle
@@ -15,9 +15,9 @@ dependencies {
     implementation("io.zipkin.brave:brave-context-slf4j:$braveVersion")
     implementation("io.zipkin.brave:brave-instrumentation-servlet:$braveVersion")
 
-    implementation "io.javalin:javalin-osgi:$javalinVersion"
+    implementation libs.javalin
     constraints {
-        implementation("org.eclipse.jetty:jetty-server:$jettyVersion") {
+        implementation(libs.bundles.jetty) {
             because 'Javalin uses an older version of Jetty which is exposed to CVE-2023-26048 and CVE-2023-26049. ' +
                     'This might be resolved in the future versions of Javalin.'
         }

--- a/libs/web/web-impl/build.gradle
+++ b/libs/web/web-impl/build.gradle
@@ -18,9 +18,9 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "commons-validator:commons-validator:$commonsVersion"
 
-    implementation "io.javalin:javalin-osgi:$javalinVersion"
+    implementation libs.javalin
     constraints {
-        implementation("org.eclipse.jetty:jetty-server:$jettyVersion") {
+        implementation(libs.bundles.jetty) {
             because 'Javalin uses an older version of Jetty which is exposed to CVE-2023-26048 and CVE-2023-26049. ' +
                     'This might be resolved in the future versions of Javalin.'
         }

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         }
     }
 
-    api "org.eclipse.jetty.websocket:websocket-client:$jettyVersion"
+    api libs.jetty.websocket.client
 
     implementation "net.corda:corda-config-schema:$cordaApiVersion"
 


### PR DESCRIPTION
More details available here: https://security.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-5769685

Also switching Javalin and Jetty to version catalogue.

Deliberately not putting Javalin and Jetty versions to the latest to see if Dependabot will be able to spot that and action.