### PR TITLE
CORE-18169: Change User password - db worker changes

### DIFF
--- a/components/permissions/permission-rest-resource-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
+++ b/components/permissions/permission-rest-resource-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
@@ -108,12 +108,12 @@ class UserEndpointImpl @Activate constructor(
         return userResponseDto?.convertToEndpointType() ?: throw ResourceNotFoundException("User", loginName)
     }
 
-    override fun changeUserPasswordSelf(loginName: String, password: String): UserResponseType {
+    override fun changeUserPasswordSelf(password: String): UserResponseType {
         val principal = getRestThreadLocalContext()
 
         val userResponseDto = try {
             withPermissionManager(permissionManagementService.permissionManager, logger) {
-                changeUserPasswordSelf(ChangeUserPasswordDto(principal, loginName, password))
+                changeUserPasswordSelf(ChangeUserPasswordDto(principal, principal.lowercase(), password))
             }
         } catch (e: IllegalArgumentException) {
             throw InvalidStateChangeException(e.message ?: "New password must be different from old one.")
@@ -122,12 +122,12 @@ class UserEndpointImpl @Activate constructor(
         return userResponseDto.convertToEndpointType()
     }
 
-    override fun changeOtherUserPassword(loginName: String, password: String): UserResponseType {
+    override fun changeOtherUserPassword(username: String, password: String): UserResponseType {
         val principal = getRestThreadLocalContext()
 
         val userResponseDto = try {
             withPermissionManager(permissionManagementService.permissionManager, logger) {
-                changeUserPasswordOther(ChangeUserPasswordDto(principal, loginName, password))
+                changeUserPasswordOther(ChangeUserPasswordDto(principal, username.lowercase(), password))
             }
         } catch (e: IllegalArgumentException) {
             throw InvalidStateChangeException(e.message ?: "New password must be different from old one.")

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.21-alpha-1703075132231
+cordaApiVersion=5.2.0.21-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.20-beta+
+cordaApiVersion=5.2.0.20-alpha-1703002553817
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.20-alpha-1703002553817
+cordaApiVersion=5.2.0.21-alpha-1703075132231
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
@@ -122,7 +122,7 @@ interface UserEndpoint : RestResource {
     ): UserResponseType
 
     @HttpPOST(
-        path = "{loginName}/selfpassword",
+        path = "/selfpassword",
         description = "This method updates a users own password.",
         responseDescription = """
             A user with the following attributes:
@@ -143,8 +143,6 @@ interface UserEndpoint : RestResource {
         minVersion = RestApiVersion.C5_2
     )
     fun changeUserPasswordSelf(
-        @RestPathParameter(description = "The login name of the user.")
-        loginName: String,
         @ClientRequestBodyParameter(
             description = "The new password to apply.",
             required = true,
@@ -154,7 +152,7 @@ interface UserEndpoint : RestResource {
     ): UserResponseType
 
     @HttpPOST(
-        path = "{loginName}/otheruserpassword",
+        path = "/otheruserpassword",
         description = "This method updates another user's password, only usable by admin.",
         responseDescription = """
             A user with the following attributes:
@@ -175,8 +173,12 @@ interface UserEndpoint : RestResource {
         minVersion = RestApiVersion.C5_2
     )
     fun changeOtherUserPassword(
-        @RestPathParameter(description = "The login name of the user who's password will be changed")
-        loginName: String,
+        @ClientRequestBodyParameter(
+            description = "Username for the password change.",
+            required = true,
+            name = "username"
+        )
+        username: String,
         @ClientRequestBodyParameter(
             description = "The new password to apply.",
             required = true,

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/PermissionStorageWriterProcessorImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/PermissionStorageWriterProcessorImpl.kt
@@ -52,7 +52,7 @@ class PermissionStorageWriterProcessorImpl(
                 }
                 is ChangeUserPasswordRequest -> {
                     val avroUser = userWriter.changeUserPassword(permissionRequest, request.requestUserId)
-                    permissionStorageReader.publishNewUser(avroUser)
+                    permissionStorageReader.publishUpdatedUser(avroUser)
                     permissionStorageReader.reconcilePermissionSummaries()
                     avroUser
                 }

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/PermissionStorageWriterProcessorImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/PermissionStorageWriterProcessorImpl.kt
@@ -11,8 +11,7 @@ import net.corda.data.permissions.management.role.AddPermissionToRoleRequest
 import net.corda.data.permissions.management.role.CreateRoleRequest
 import net.corda.data.permissions.management.role.RemovePermissionFromRoleRequest
 import net.corda.data.permissions.management.user.AddRoleToUserRequest
-import net.corda.data.permissions.management.user.ChangeUserPasswordOtherRequest
-import net.corda.data.permissions.management.user.ChangeUserPasswordSelfRequest
+import net.corda.data.permissions.management.user.ChangeUserPasswordRequest
 import net.corda.data.permissions.management.user.CreateUserRequest
 import net.corda.data.permissions.management.user.RemoveRoleFromUserRequest
 import net.corda.libs.permissions.storage.reader.PermissionStorageReader
@@ -51,15 +50,9 @@ class PermissionStorageWriterProcessorImpl(
                     permissionStorageReader.publishNewRole(avroRole)
                     avroRole
                 }
-                is ChangeUserPasswordSelfRequest -> {
-                    val avroUser = userWriter.changeUserPasswordSelf(permissionRequest, request.requestUserId)
+                is ChangeUserPasswordRequest -> {
+                    val avroUser = userWriter.changeUserPassword(permissionRequest, request.requestUserId)
                     permissionStorageReader.publishNewUser(avroUser)
-                    permissionStorageReader.reconcilePermissionSummaries()
-                    avroUser
-                }
-                is ChangeUserPasswordOtherRequest -> {
-                    val avroUser = userWriter.changeUserPasswordOther(permissionRequest, request.requestUserId)
-                    permissionStorageReader.publishUpdatedUser(avroUser)
                     permissionStorageReader.reconcilePermissionSummaries()
                     avroUser
                 }

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/PermissionStorageWriterProcessorImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/PermissionStorageWriterProcessorImpl.kt
@@ -11,6 +11,8 @@ import net.corda.data.permissions.management.role.AddPermissionToRoleRequest
 import net.corda.data.permissions.management.role.CreateRoleRequest
 import net.corda.data.permissions.management.role.RemovePermissionFromRoleRequest
 import net.corda.data.permissions.management.user.AddRoleToUserRequest
+import net.corda.data.permissions.management.user.ChangeUserPasswordOtherRequest
+import net.corda.data.permissions.management.user.ChangeUserPasswordSelfRequest
 import net.corda.data.permissions.management.user.CreateUserRequest
 import net.corda.data.permissions.management.user.RemoveRoleFromUserRequest
 import net.corda.libs.permissions.storage.reader.PermissionStorageReader
@@ -48,6 +50,18 @@ class PermissionStorageWriterProcessorImpl(
                     val avroRole = roleWriter.createRole(permissionRequest, request.requestUserId)
                     permissionStorageReader.publishNewRole(avroRole)
                     avroRole
+                }
+                is ChangeUserPasswordSelfRequest -> {
+                    val avroUser = userWriter.changeUserPasswordSelf(permissionRequest, request.requestUserId)
+                    permissionStorageReader.publishNewUser(avroUser)
+                    permissionStorageReader.reconcilePermissionSummaries()
+                    avroUser
+                }
+                is ChangeUserPasswordOtherRequest -> {
+                    val avroUser = userWriter.changeUserPasswordOther(permissionRequest, request.requestUserId)
+                    permissionStorageReader.publishUpdatedUser(avroUser)
+                    permissionStorageReader.reconcilePermissionSummaries()
+                    avroUser
                 }
                 is CreatePermissionRequest -> {
                     val avroPermission = permissionWriter.createPermission(permissionRequest, request.requestUserId, request.virtualNodeId)

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/UserWriter.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/UserWriter.kt
@@ -1,8 +1,7 @@
 package net.corda.libs.permissions.storage.writer.impl.user
 
 import net.corda.data.permissions.management.user.AddRoleToUserRequest
-import net.corda.data.permissions.management.user.ChangeUserPasswordOtherRequest
-import net.corda.data.permissions.management.user.ChangeUserPasswordSelfRequest
+import net.corda.data.permissions.management.user.ChangeUserPasswordRequest
 import net.corda.data.permissions.management.user.CreateUserRequest
 import net.corda.data.permissions.management.user.RemoveRoleFromUserRequest
 import net.corda.data.permissions.User as AvroUser
@@ -22,18 +21,10 @@ interface UserWriter {
     /**
      * Change the password field of a User entity and return its Avro representation.
      *
-     * @param request ChangeUserPasswordSelfRequest containing the information of the password change request.
+     * @param request ChangeUserPasswordRequest containing the information of the password change request.
      * @param requestUserId ID of the user who made the request.
      */
-    fun changeUserPasswordSelf(request: ChangeUserPasswordSelfRequest, requestUserId: String): AvroUser
-
-    /**
-     * Change the password field of a User entity and return its Avro representation.
-     *
-     * @param request ChangeUserPasswordOtherRequest containing the information of the password change request.
-     * @param requestUserId ID of the user who made the request.
-     */
-    fun changeUserPasswordOther(request: ChangeUserPasswordOtherRequest, requestUserId: String): AvroUser
+    fun changeUserPassword(request: ChangeUserPasswordRequest, requestUserId: String): AvroUser
 
     /**
      * Associate a Role to a User and return its Avro representation.

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/UserWriter.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/UserWriter.kt
@@ -1,6 +1,8 @@
 package net.corda.libs.permissions.storage.writer.impl.user
 
 import net.corda.data.permissions.management.user.AddRoleToUserRequest
+import net.corda.data.permissions.management.user.ChangeUserPasswordOtherRequest
+import net.corda.data.permissions.management.user.ChangeUserPasswordSelfRequest
 import net.corda.data.permissions.management.user.CreateUserRequest
 import net.corda.data.permissions.management.user.RemoveRoleFromUserRequest
 import net.corda.data.permissions.User as AvroUser
@@ -16,6 +18,22 @@ interface UserWriter {
      * @param requestUserId ID of the user who made the request.
      */
     fun createUser(request: CreateUserRequest, requestUserId: String): AvroUser
+
+    /**
+     * Change the password field of a User entity and return its Avro representation.
+     *
+     * @param request ChangeUserPasswordSelfRequest containing the information of the password change request.
+     * @param requestUserId ID of the user who made the request.
+     */
+    fun changeUserPasswordSelf(request: ChangeUserPasswordSelfRequest, requestUserId: String): AvroUser
+
+    /**
+     * Change the password field of a User entity and return its Avro representation.
+     *
+     * @param request ChangeUserPasswordOtherRequest containing the information of the password change request.
+     * @param requestUserId ID of the user who made the request.
+     */
+    fun changeUserPasswordOther(request: ChangeUserPasswordOtherRequest, requestUserId: String): AvroUser
 
     /**
      * Associate a Role to a User and return its Avro representation.

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/impl/UserWriterImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/impl/UserWriterImpl.kt
@@ -53,7 +53,7 @@ class UserWriterImpl(
 
             val validator = EntityValidationUtil(entityManager)
             val user = validator.validateAndGetUniqueUser(request.requestedBy)
-            
+
             user.hashedPassword = request.hashedNewPassword
             user.saltValue = request.saltValue
             user.passwordExpiry = request.passwordExpiry

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/impl/UserWriterImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/impl/UserWriterImpl.kt
@@ -53,9 +53,7 @@ class UserWriterImpl(
 
             val validator = EntityValidationUtil(entityManager)
             val user = validator.validateAndGetUniqueUser(request.requestedBy)
-
-            println("old password hash: ${user.hashedPassword}")
-
+            
             user.hashedPassword = request.hashedNewPassword
             user.saltValue = request.saltValue
             user.passwordExpiry = request.passwordExpiry

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/impl/UserWriterImpl.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/user/impl/UserWriterImpl.kt
@@ -1,8 +1,7 @@
 package net.corda.libs.permissions.storage.writer.impl.user.impl
 
 import net.corda.data.permissions.management.user.AddRoleToUserRequest
-import net.corda.data.permissions.management.user.ChangeUserPasswordOtherRequest
-import net.corda.data.permissions.management.user.ChangeUserPasswordSelfRequest
+import net.corda.data.permissions.management.user.ChangeUserPasswordRequest
 import net.corda.data.permissions.management.user.CreateUserRequest
 import net.corda.data.permissions.management.user.RemoveRoleFromUserRequest
 import net.corda.libs.permissions.storage.common.converter.toAvroUser
@@ -45,22 +44,17 @@ class UserWriterImpl(
         }
     }
 
-    override fun changeUserPasswordSelf(
-        request: ChangeUserPasswordSelfRequest,
+    override fun changeUserPassword(
+        request: ChangeUserPasswordRequest,
         requestUserId: String
     ): net.corda.data.permissions.User {
-        TODO("Not yet implemented")
-    }
-
-    override fun changeUserPasswordOther(
-        request: ChangeUserPasswordOtherRequest,
-        requestUserId: String
-    ): AvroUser {
-        log.debug { "Received request to change password for user: ${request.username}" }
+        log.debug { "Received request to change password for user: ${request.requestedBy}" }
         return entityManagerFactory.transaction { entityManager ->
 
             val validator = EntityValidationUtil(entityManager)
-            val user = validator.validateAndGetUniqueUser(request.username)
+            val user = validator.validateAndGetUniqueUser(request.requestedBy)
+
+            println("old password hash: ${user.hashedPassword}")
 
             user.hashedPassword = request.hashedNewPassword
             user.saltValue = request.saltValue

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -3606,23 +3606,23 @@
         }
       }
     },
-    "/user/{loginname}" : {
-      "get" : {
+    "/user/otheruserpassword" : {
+      "post" : {
         "tags" : [ "RBAC User API" ],
-        "description" : "This method returns a user based on the specified login name.",
-        "operationId" : "get_user__loginname_",
-        "parameters" : [ {
-          "name" : "loginname",
-          "in" : "path",
-          "description" : "The login name of the user to be returned",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The login name of the user to be returned",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
+        "description" : "This method updates another user's password, only usable by admin.",
+        "operationId" : "post_user_otheruserpassword",
+        "parameters" : [ ],
+        "requestBody" : {
+          "description" : "requestBody",
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/ChangeOtherUserPasswordWrapperRequest"
+              }
+            }
+          },
+          "required" : true
+        },
         "responses" : {
           "200" : {
             "description" : "\n            A user with the following attributes:\n            id: Unique server generated identifier for the user\n            version: The version of the user; version 0 is assigned to a newly created user\n            updateTimestamp: The date and time when the user was last updated\n            fullName: The full name for the new user\n            loginName: The login name for the new user\n            enabled: If true, the user account is enabled; false, the account is disabled\n            ssoAuth: If true, the user account is enabled for SSO authentication; \n                false, the account is enabled for password authentication\n            passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire\n            parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n            properties: An optional set of key/value properties associated with a user account\n            roleAssociations: A set of roles associated with the user account",
@@ -3643,23 +3643,12 @@
         }
       }
     },
-    "/user/{loginname}/otheruserpassword" : {
+    "/user/selfpassword" : {
       "post" : {
         "tags" : [ "RBAC User API" ],
-        "description" : "This method updates another user's password, only usable by admin.",
-        "operationId" : "post_user__loginname__otheruserpassword",
-        "parameters" : [ {
-          "name" : "loginname",
-          "in" : "path",
-          "description" : "The login name of the user who's password will be changed",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The login name of the user who's password will be changed",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
+        "description" : "This method updates a users own password.",
+        "operationId" : "post_user_selfpassword",
+        "parameters" : [ ],
         "requestBody" : {
           "description" : "requestBody",
           "content" : {
@@ -3679,6 +3668,43 @@
           },
           "required" : true
         },
+        "responses" : {
+          "200" : {
+            "description" : "\n            A user with the following attributes:\n            id: Unique server generated identifier for the user\n            version: The version of the user; version 0 is assigned to a newly created user\n            updateTimestamp: The date and time when the user was last updated\n            fullName: The full name for the new user\n            loginName: The login name for the new user\n            enabled: If true, the user account is enabled; false, the account is disabled\n            ssoAuth: If true, the user account is enabled for SSO authentication; \n                false, the account is enabled for password authentication\n            passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire\n            parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n            properties: An optional set of key/value properties associated with a user account\n            roleAssociations: A set of roles associated with the user account",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserResponseType"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
+    "/user/{loginname}" : {
+      "get" : {
+        "tags" : [ "RBAC User API" ],
+        "description" : "This method returns a user based on the specified login name.",
+        "operationId" : "get_user__loginname_",
+        "parameters" : [ {
+          "name" : "loginname",
+          "in" : "path",
+          "description" : "The login name of the user to be returned",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The login name of the user to be returned",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
         "responses" : {
           "200" : {
             "description" : "\n            A user with the following attributes:\n            id: Unique server generated identifier for the user\n            version: The version of the user; version 0 is assigned to a newly created user\n            updateTimestamp: The date and time when the user was last updated\n            fullName: The full name for the new user\n            loginName: The login name for the new user\n            enabled: If true, the user account is enabled; false, the account is disabled\n            ssoAuth: If true, the user account is enabled for SSO authentication; \n                false, the account is enabled for password authentication\n            passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire\n            parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n            properties: An optional set of key/value properties associated with a user account\n            roleAssociations: A set of roles associated with the user account",
@@ -3813,62 +3839,6 @@
         "responses" : {
           "200" : {
             "description" : "\n            A newly created user with the following attributes:\n            id: Unique server generated identifier for the user\n            version: The version of the user; version 0 is assigned to a newly created user\n            updateTimestamp: The date and time when the user was last updated\n            fullName: The full name for the new user\n            loginName: The login name for the new user\n            enabled: If true, the user account is enabled; false, the account is disabled\n            ssoAuth: If true, the user account is enabled for SSO authentication; \n                false, the account is enabled for password authentication\n            passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire\n            parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n            properties: An optional set of key/value properties associated with a user account\n            roleAssociations: A set of roles associated with the user account",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/UserResponseType"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/user/{loginname}/selfpassword" : {
-      "post" : {
-        "tags" : [ "RBAC User API" ],
-        "description" : "This method updates a users own password.",
-        "operationId" : "post_user__loginname__selfpassword",
-        "parameters" : [ {
-          "name" : "loginname",
-          "in" : "path",
-          "description" : "The login name of the user.",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The login name of the user.",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "description" : "requestBody",
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "type" : "object",
-                "properties" : {
-                  "password" : {
-                    "type" : "string",
-                    "description" : "The new password to apply.",
-                    "nullable" : false,
-                    "example" : "string"
-                  }
-                }
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "\n            A user with the following attributes:\n            id: Unique server generated identifier for the user\n            version: The version of the user; version 0 is assigned to a newly created user\n            updateTimestamp: The date and time when the user was last updated\n            fullName: The full name for the new user\n            loginName: The login name for the new user\n            enabled: If true, the user account is enabled; false, the account is disabled\n            ssoAuth: If true, the user account is enabled for SSO authentication; \n                false, the account is enabled for password authentication\n            passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire\n            parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n            properties: An optional set of key/value properties associated with a user account\n            roleAssociations: A set of roles associated with the user account",
             "content" : {
               "application/json" : {
                 "schema" : {
@@ -4486,6 +4456,26 @@
             }
           }
         }
+      },
+      "ChangeOtherUserPasswordWrapperRequest" : {
+        "required" : [ "password", "username" ],
+        "type" : "object",
+        "properties" : {
+          "password" : {
+            "type" : "string",
+            "description" : "The new password to apply.",
+            "nullable" : false,
+            "example" : "string"
+          },
+          "username" : {
+            "type" : "string",
+            "description" : "Username for the password change.",
+            "nullable" : false,
+            "example" : "string"
+          }
+        },
+        "description" : "ChangeOtherUserPasswordWrapperRequest",
+        "nullable" : false
       },
       "ChangeVirtualNodeStateResponse" : {
         "required" : [ "holdingIdShortHash", "newState" ],

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -342,6 +342,14 @@ class ClusterBuilder {
         return body.joinToString(prefix = "{", postfix = "}")
     }
 
+    fun changeUserPasswordSelf(password: String) =
+        post("/api/$REST_API_VERSION_PATH/user/selfpassword",
+            """{"password": "$password"}""")
+
+    fun changeUserPasswordOther(username: String, password: String) =
+        post("/api/$REST_API_VERSION_PATH/user/otheruserpassword",
+            """{"username": "$username", "password": "$password"}""")
+
     private fun createPermissionBody(
         permissionString: String,
         permissionType: String,


### PR DESCRIPTION
This PR implements the db-worker side of the User password change feature in `UserWriterImpl.kt`

Because we can get the username from the request header, this also changes the endpoints: 
- `{loginName}/otheruserpassword` to `/otheruserpassword`
- `{loginName}/selfpassword` to `/selfpassword`

This adds change password methods to ClusterBuilder to support future e2e tests.

Corda-api changes to support this: https://github.com/corda/corda-api/pull/1418
