### PR TITLE
CORE-19015: Close in memory topic after usage

### DIFF
--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/GatewayIntegrationTest.kt
@@ -144,7 +144,9 @@ internal class GatewayIntegrationTest : TestBase() {
         )
 
     private inner class Node(private val name: String) {
-        private val topicService = TopicServiceImpl()
+        private val topicService = TopicServiceImpl().also {
+            keep(it)
+        }
         private val rpcTopicService = RPCTopicServiceImpl()
 
         val lifecycleCoordinatorFactory =
@@ -538,6 +540,7 @@ internal class GatewayIntegrationTest : TestBase() {
             val linkInMessageTwo = LinkInMessage(authenticatedP2PMessage("two"))
             val messageTwo = GatewayMessage("two", linkInMessageTwo.payload)
             val configPublisher = ConfigPublisher()
+            keep(configPublisher)
             configPublisher.publishConfig(
                 GatewayConfiguration(
                     listOf(serverConfigurationOne),
@@ -777,6 +780,7 @@ internal class GatewayIntegrationTest : TestBase() {
             val gatewayMessage = GatewayMessage("msg-id", linkInMessage.payload)
 
             val configPublisher = ConfigPublisher()
+            keep(configPublisher)
 
             val messageReceivedLatch = AtomicReference(CountDownLatch(1))
             val listenToOutboundMessages = object : RequestListener {
@@ -1220,6 +1224,7 @@ internal class GatewayIntegrationTest : TestBase() {
         @Timeout(120)
         fun `Gateway can recover from bad configuration`() {
             val configPublisher = ConfigPublisher()
+            keep(configPublisher)
             val host = "www.alice.net"
             Gateway(
                 configPublisher.readerService,
@@ -1362,6 +1367,7 @@ internal class GatewayIntegrationTest : TestBase() {
             val bobAddress = URI.create("https://www.bob.net:${getOpenPort()}")
             val server = Node("server")
             val configPublisher = ConfigPublisher()
+            keep(configPublisher)
             configPublisher.publishConfig(
                 GatewayConfiguration(
                     listOf(

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapIntegrationTests.kt
@@ -24,7 +24,9 @@ internal class TrustStoresMapIntegrationTests : TestBase() {
         private const val GROUP_ID = "Group-A"
         private const val ALICE_NAME = "O=Alice, L=LDN, C=GB"
     }
-    private val topicService = TopicServiceImpl()
+    private val topicService = TopicServiceImpl().also {
+        keep(it)
+    }
     private val rpcTopicService = RPCTopicServiceImpl()
     private val subscriptionFactory = InMemSubscriptionFactory(topicService, rpcTopicService, lifecycleCoordinatorFactory)
     private val messagingConfig = SmartConfigImpl.empty()

--- a/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
+++ b/components/link-manager/src/nonOsgiIntegrationTest/kotlin/net/corda/p2p/P2PLayerEndToEndTest.kt
@@ -767,6 +767,7 @@ class P2PLayerEndToEndTest {
         override fun close() {
             linkManager.close()
             gateway.close()
+            topicService.close()
         }
 
         fun addReadWriter(): Subscription<String, AppMessage> {

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/ConsumerGroup.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/ConsumerGroup.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.emulation.topic.model
 
+import net.corda.lifecycle.Resource
 import net.corda.messaging.emulation.properties.SubscriptionConfiguration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -12,7 +13,7 @@ internal class ConsumerGroup(
     internal val subscriptionConfig: SubscriptionConfiguration,
     firstConsumer: Consumer,
     internal val lock: ReentrantReadWriteLock = ReentrantReadWriteLock(),
-) {
+): Resource {
     private val consumers = ConcurrentHashMap<Consumer, ConsumptionLoop>()
     private val commitments = ConcurrentHashMap<Partition, Long>()
 
@@ -174,5 +175,16 @@ internal class ConsumerGroup(
             },
             loop = loop!!
         )
+    }
+
+    override fun close() {
+        lock.write {
+            val activeConsumers = consumers.values.toList()
+            consumers.clear()
+            activeConsumers.forEach {
+                it.close()
+            }
+            commitments.clear()
+        }
     }
 }

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/ConsumptionLoop.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/ConsumptionLoop.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.emulation.topic.model
 
+import net.corda.lifecycle.Resource
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
@@ -8,7 +9,7 @@ import kotlin.concurrent.read
 internal class ConsumptionLoop(
     private val consumer: Consumer,
     private val group: ConsumerGroup,
-) : Runnable {
+) : Runnable, Resource {
 
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
@@ -90,4 +91,9 @@ internal class ConsumptionLoop(
 
     val partitions
         get() = partitionToLastReadOffset.keys
+
+    override fun close() {
+        group.stopConsuming(consumer)
+        partitionToLastReadOffset.clear()
+    }
 }

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Partition.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Partition.kt
@@ -7,6 +7,7 @@ import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
+import kotlin.concurrent.write
 
 internal class Partition(
     val partitionId: Int,
@@ -47,5 +48,12 @@ internal class Partition(
 
     fun latestOffset(): Long {
         return currentOffset.get()
+    }
+
+    fun clear() {
+        lock.write {
+            records.clear()
+            currentOffset.set(0)
+        }
     }
 }

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topic.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topic.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.emulation.topic.model
 
+import net.corda.lifecycle.Resource
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.emulation.properties.SubscriptionConfiguration
 import net.corda.messaging.emulation.properties.TopicConfiguration
@@ -15,7 +16,7 @@ import kotlin.math.abs
 internal class Topic(
     private val topicName: String,
     private val topicConfiguration: TopicConfiguration,
-) {
+): Resource {
     private val partitions = let {
         (1..topicConfiguration.partitionCount).map {
             Partition(
@@ -105,6 +106,16 @@ internal class Topic(
     fun wakeUpConsumers() {
         consumerGroups.values.forEach {
             it.wakeUp()
+        }
+    }
+
+    override fun close() {
+        consumerGroups.values.forEach {
+            it.close()
+        }
+        consumerGroups.clear()
+        partitions.forEach {
+            it.clear()
         }
     }
 }

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topics.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/model/Topics.kt
@@ -1,12 +1,13 @@
 package net.corda.messaging.emulation.topic.model
 
+import net.corda.lifecycle.Resource
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.emulation.properties.InMemoryConfiguration
 import java.util.concurrent.ConcurrentHashMap
 
 class Topics(
     private val config: InMemoryConfiguration = InMemoryConfiguration()
-) {
+): Resource {
     private val topics: ConcurrentHashMap<String, Topic> = ConcurrentHashMap()
 
     internal fun getWriteLock(records: Collection<Record<*, *>>): PartitionsWriteLock {
@@ -40,5 +41,12 @@ class Topics(
 
     fun getLatestOffsets(topicName: String): Map<Int, Long> {
         return getTopic(topicName).getLatestOffsets()
+    }
+
+    override fun close() {
+        topics.values.forEach {
+            it.close()
+        }
+        topics.clear()
     }
 }

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/service/TopicService.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/service/TopicService.kt
@@ -1,5 +1,6 @@
 package net.corda.messaging.emulation.topic.service
 
+import net.corda.lifecycle.Resource
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.emulation.topic.model.Consumer
 import net.corda.messaging.emulation.topic.model.Consumption
@@ -7,7 +8,7 @@ import net.corda.messaging.emulation.topic.model.Consumption
 /**
  * Service to interact with the kafka topic emulator
  */
-interface TopicService {
+interface TopicService : Resource {
     /**
      * Add a list of records to each of their topics.
      * This operation is done atomically per partition.

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/service/impl/TopicServiceImpl.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/topic/service/impl/TopicServiceImpl.kt
@@ -30,6 +30,10 @@ class TopicServiceImpl(
         topics.getTopic(consumer.topicName).unAssignPartition(consumer, partitionsIds)
     }
 
+    override fun close() {
+        topics.close()
+    }
+
     override fun getLatestOffsets(topicName: String): Map<Int, Long> {
         return topics.getLatestOffsets(topicName)
     }


### PR DESCRIPTION
With this change, the in-memory message bus tests can stop after the test has finished. This will prevent messages from being repeatedly sent to closed consumers.

This is more stable than before on Windows. See https://ci02.dev.r3.com/job/Corda5/job/Nightlys/job/Corda-Runtime-OS/job/Windows/job/yift%2Fcore-19015%2Fclose-in-mem/