### PR TITLE
CORE-17886: Protect Javalin server creation with `serverLock`

### DIFF
--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -72,7 +72,7 @@ internal class RestServerInternal(
 
     private val webSocketRouteAdaptors = LinkedList<AutoCloseable>()
     private val credentialResolver = DefaultCredentialResolver()
-    
+
     private lateinit var server: Javalin
     private val serverFactory: () -> Javalin = {
         Javalin.create {

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/RestServerTest.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/RestServerTest.kt
@@ -60,7 +60,7 @@ class RestServerTest {
                     ),
                     multiPartDir,
                     mock()
-                )
+                ).start()
             },
             SSL_PASSWORD_MISSING
         )
@@ -93,7 +93,7 @@ class RestServerTest {
                     ),
                     multiPartDir,
                     mock()
-                )
+                ).start()
             },
             INSECURE_SERVER_DEV_MODE_WARNING
         )

--- a/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinServer.kt
+++ b/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinServer.kt
@@ -69,22 +69,23 @@ class JavalinServer(
     private fun startServer(port: Int) {
         // Ensure the server can only be started once at a time.
             log.info("Starting Worker Web Server on port: $port")
-            server = javalinFactory()
-            endpoints.forEach {
-                registerEndpointInternal(it)
-            }
-
-            JavalinStarter.startServer(
+            
+            server = JavalinStarter.startServer(
                 "RPC Server",
-                server!!,
+                javalinFactory,
                 port,
             )
-
+        
             server?.events {
                 it.handlerAdded { meta ->
                     log.info("Handler added to webserver: $meta")
                 }
             }
+
+            endpoints.forEach {
+                registerEndpointInternal(it)
+            }
+        
             server?.exception(NotFoundResponse::class.java) { _, ctx ->
                 log.warn("Received request on non-existing endpoint: ${ctx.req.requestURI}")
                 ctx.result("404 Not Found")

--- a/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinStarter.kt
+++ b/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinStarter.kt
@@ -10,6 +10,7 @@ import org.osgi.framework.Bundle
 import org.osgi.framework.FrameworkUtil
 import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
+import java.util.function.Supplier
 import kotlin.concurrent.withLock
 
 object JavalinStarter {
@@ -24,10 +25,10 @@ object JavalinStarter {
     private val serverStartLock = ReentrantLock()
 
     /**
-     * Start the Javalin server and ensuring only one starts at a time.
+     * Creates and start the Javalin server and ensuring only one actioned at a time.
      *
      * @param name Name of the server (to be used in logging only)
-     * @param server the Javalin server object
+     * @param javalinFactory to create the Javalin server object
      * @param port the port to start the server on
      * @param host the host to use (default: localhost)
      * @param threadLocalClassLoaderBundles any bundles to use in the ThreadLocal class loader
@@ -35,12 +36,13 @@ object JavalinStarter {
     @Suppress("TooGenericExceptionThrown")
     fun startServer(
         name: String,
-        server: Javalin,
+        javalinFactory: () -> Javalin,
         port: Int,
         host: String? = null,
         threadLocalClassLoaderBundles: List<Bundle> = emptyList(),
-    ) {
-        serverStartLock.withLock {
+    ): Javalin {
+        return serverStartLock.withLock {
+            val server = javalinFactory()
             val existingSystemErrStream = System.err
             try {
                 logger.trace { "Starting the $name Javalin server." }
@@ -78,6 +80,7 @@ object JavalinStarter {
             } finally {
                 System.setErr(existingSystemErrStream)
             }
+            server
         }
     }
 }

--- a/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinStarter.kt
+++ b/libs/web/web-impl/src/main/kotlin/net/corda/web/server/JavalinStarter.kt
@@ -10,7 +10,6 @@ import org.osgi.framework.Bundle
 import org.osgi.framework.FrameworkUtil
 import org.slf4j.LoggerFactory
 import java.util.concurrent.locks.ReentrantLock
-import java.util.function.Supplier
 import kotlin.concurrent.withLock
 
 object JavalinStarter {
@@ -25,7 +24,7 @@ object JavalinStarter {
     private val serverStartLock = ReentrantLock()
 
     /**
-     * Creates and start the Javalin server and ensuring only one actioned at a time.
+     * Creates and starts the Javalin server and ensuring only one actioned at a time.
      *
      * @param name Name of the server (to be used in logging only)
      * @param javalinFactory to create the Javalin server object


### PR DESCRIPTION
When REST worker starts in `RestServerInternal` class it makes `addStaticFiles("/META-INF/resources/", ...)` call in the context of SwaggerUIClassloader.
This call is happening at `RestServerInternal` instantiation time and not protected by the lock. This call not just adds static files to the webserver, but also executes `JavalinLogger.addDelayed` call to log a line in the log at a later point.

When another Javalin instance starts for HTTP RPC processing (e.g. in Crypto) and if it obtains a lock ahead of `RestServerInternal`, it invokes `logAllDelayed` method. But, unfortunately, at this point in time SwaggerUIClassloader is no longer available and "/META-INF/resources/" can no longer be retrieved, hence logging fails. As an unfortunate side effect, this prevents Javalin HTTP RPC server from starting rendering Combined Worker in the unhealthy state.

In essence, before the change we had a race condition between Javalin server creation and start-up. After the change Javalin server creation and start-up are all happening under global lock protection.