### PR TITLE
DI-5 Allow filtered transaction serializers in the Verification sandbox

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^((CORDA|EG|ENT|INFRA|CORE|DOC|ES|DA5)-\d+)(.*)'
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE|DOC|ES|DA5|DI)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/serializer/amqp/FilteredTransactionSerializer.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/serializer/amqp/FilteredTransactionSerializer.kt
@@ -6,6 +6,7 @@ import net.corda.ledger.common.flow.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.flow.transaction.filtered.FilteredTransaction
 import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandbox.type.UsedByVerification
 import net.corda.serialization.BaseProxySerializer
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.v5.application.marshalling.JsonMarshallingService
@@ -18,7 +19,7 @@ import org.osgi.service.component.annotations.ReferenceScope.PROTOTYPE_REQUIRED
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
-    service = [ InternalCustomSerializer::class, UsedByFlow::class ],
+    service = [ InternalCustomSerializer::class, UsedByFlow::class, UsedByVerification::class ],
     property = [ CORDA_UNINJECTABLE_SERVICE ],
     scope = PROTOTYPE
 )
@@ -27,7 +28,7 @@ class FilteredTransactionSerializer @Activate constructor(
     private val jsonMarshallingService: JsonMarshallingService,
     @Reference(service = MerkleTreeProvider::class)
     private val merkleTreeProvider: MerkleTreeProvider
-) : BaseProxySerializer<FilteredTransaction, FilteredTransactionProxy>(), UsedByFlow {
+) : BaseProxySerializer<FilteredTransaction, FilteredTransactionProxy>(), UsedByFlow, UsedByVerification {
 
     override val proxyType
         get() = FilteredTransactionProxy::class.java

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionSerializer.kt
@@ -4,6 +4,7 @@ import net.corda.ledger.common.flow.transaction.filtered.FilteredTransaction
 import net.corda.ledger.utxo.flow.impl.transaction.filtered.UtxoFilteredTransactionImpl
 import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
+import net.corda.sandbox.type.UsedByVerification
 import net.corda.serialization.BaseProxySerializer
 import net.corda.serialization.InternalCustomSerializer
 import net.corda.v5.application.serialization.SerializationService
@@ -13,14 +14,14 @@ import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
 
 @Component(
-    service = [ InternalCustomSerializer::class, UsedByFlow::class ],
+    service = [ InternalCustomSerializer::class, UsedByFlow::class, UsedByVerification::class ],
     property = [ CORDA_UNINJECTABLE_SERVICE ],
     scope = PROTOTYPE
 )
 class UtxoFilteredTransactionSerializer @Activate constructor(
     @Reference(service = SerializationService::class)
     private val serializationService: SerializationService
-) : BaseProxySerializer<UtxoFilteredTransactionImpl, UtxoFilteredTransactionProxy>(), UsedByFlow {
+) : BaseProxySerializer<UtxoFilteredTransactionImpl, UtxoFilteredTransactionProxy>(), UsedByFlow, UsedByVerification {
 
     override fun toProxy(obj: UtxoFilteredTransactionImpl): UtxoFilteredTransactionProxy {
         return UtxoFilteredTransactionProxy(obj.filteredTransaction)


### PR DESCRIPTION
DI-5 Allow filtered transaction serializers in the Verification sandbox

E2E test requiring this: https://github.com/corda/corda-e2e-tests/pull/380 
