### PR TITLE
CORE-18961 explicit OSGi locking

### DIFF
--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -54,7 +54,7 @@ internal class SandboxServiceImpl @Activate constructor(
     /**
      * We use concurrent hash maps everywhere (including sets) to allow concurrent access whilst keeping gets lock free.
      * We also employ a lock to ensure writes are done to every map/set group atomically and we don't try to install
-     * and uninstall bundles from OSGi concurretly.
+     * and uninstall bundles from OSGi concurrently.
      */
     val bundleLock = ReentrantLock()
 

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -56,7 +56,7 @@ internal class SandboxServiceImpl @Activate constructor(
      * We also employ a lock to ensure writes are done to every map/set group atomically and we don't try to install
      * and uninstall bundles from OSGi concurrently.
      */
-    val bundleLock = ReentrantLock()
+    private val bundleLock = ReentrantLock()
 
     // Maps each bundle ID to the sandbox that the bundle is part of.
     private val bundleIdToSandbox = ConcurrentHashMap<Long, Sandbox>()


### PR DESCRIPTION
Added explicit locking to creation and removal methods to ensure maps/sets are updated atomically, but also OSGi bundle loading and unloading is not done concurrently. Methods which only read the already thread safe containers are not touched to avoid adding overhead.