### PR TITLE
CORE-19124: allow some slack on timings

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
@@ -26,6 +26,7 @@ import net.corda.messagebus.kafka.serialization.CordaAvroSerializationFactoryImp
 import net.corda.schema.registry.impl.AvroSchemaRegistryImpl
 import net.corda.test.util.time.AutoTickTestClock
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.byLessThan
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -40,6 +41,7 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 /**
@@ -256,7 +258,7 @@ class CryptoRPCSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     private fun assertValidTimestamp(timestamp: Instant, clock: AutoTickTestClock? = null) {
         assertThat(timestamp).isAfter(Instant.MIN)
         if (clock != null) {
-            assertThat(timestamp).isBeforeOrEqualTo(clock.peekTime())
+            assertThat(timestamp).isCloseTo(clock.peekTime(), byLessThan(1, ChronoUnit.MINUTES))
         }
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRPCSmokeTests.kt
@@ -193,7 +193,7 @@ class CryptoRPCSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
         assertThat(response.statusCode()).isEqualTo(404).withFailMessage("status code on response: ${response.statusCode()} url: $url")
     }
 
-    private val testClock = AutoTickTestClock(Instant.MAX, Duration.ofSeconds(1))
+    private val testClock = AutoTickTestClock(Instant.now(), Duration.ofSeconds(1))
 
     /**
      * Generate simple request to lookup for keys by their full key ids.


### PR DESCRIPTION
It's not necessarily the case that the system clocks where the e2e test is precsiely aligned or behind the clock where Corda is running, nor should we assume that. HTTP RPCs can be so fast as to show this up in test failures where we notice the response timestamp is before the request timestamp. So, provided they are within 1 minute I think we don't care which clock is ahead of the others.

Also set a  test clock to the real time since otherwise the 1 minute check doesn't work.
