### PR TITLE
CORE-18706 - Fixed external messaging after the mediator pattern was introduced

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
@@ -148,7 +148,7 @@ class FlowEventMediatorFactoryImpl @Activate constructor(
                     rpcEndpoint(UNIQUENESS_WORKER_REST_ENDPOINT, UNIQUENESS_PATH), SYNCHRONOUS)
                 is FlowEvent -> routeTo(messageBusClient,
                     FLOW_EVENT_TOPIC, ASYNCHRONOUS)
-                is String -> routeTo(messageBusClient,
+                is String -> routeTo(messageBusClient, // Handling external messaging
                     message.properties[MSG_PROP_TOPIC] as String, ASYNCHRONOUS)
                 else -> {
                     val eventType = event?.let { it::class.java }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowEventMediatorFactoryImpl.kt
@@ -23,6 +23,7 @@ import net.corda.messaging.api.constants.WorkerRPCPaths.UNIQUENESS_PATH
 import net.corda.messaging.api.constants.WorkerRPCPaths.VERIFICATION_PATH
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
+import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_TOPIC
 import net.corda.messaging.api.mediator.RoutingDestination.Companion.routeTo
 import net.corda.messaging.api.mediator.RoutingDestination.Type.ASYNCHRONOUS
 import net.corda.messaging.api.mediator.RoutingDestination.Type.SYNCHRONOUS
@@ -147,6 +148,8 @@ class FlowEventMediatorFactoryImpl @Activate constructor(
                     rpcEndpoint(UNIQUENESS_WORKER_REST_ENDPOINT, UNIQUENESS_PATH), SYNCHRONOUS)
                 is FlowEvent -> routeTo(messageBusClient,
                     FLOW_EVENT_TOPIC, ASYNCHRONOUS)
+                is String -> routeTo(messageBusClient,
+                    message.properties[MSG_PROP_TOPIC] as String, ASYNCHRONOUS)
                 else -> {
                     val eventType = event?.let { it::class.java }
                     throw IllegalStateException("No route defined for event type [$eventType]")

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/FlowEventMediatorFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/FlowEventMediatorFactoryImplTest.kt
@@ -23,6 +23,7 @@ import net.corda.messaging.api.constants.WorkerRPCPaths.TOKEN_SELECTION_PATH
 import net.corda.messaging.api.constants.WorkerRPCPaths.UNIQUENESS_PATH
 import net.corda.messaging.api.constants.WorkerRPCPaths.VERIFICATION_PATH
 import net.corda.messaging.api.mediator.MediatorMessage
+import net.corda.messaging.api.mediator.MessagingClient
 import net.corda.messaging.api.mediator.config.EventMediatorConfig
 import net.corda.messaging.api.mediator.factory.MediatorConsumerFactoryFactory
 import net.corda.messaging.api.mediator.factory.MessagingClientFactoryFactory
@@ -112,5 +113,15 @@ class FlowEventMediatorFactoryImplTest {
         assertThat(router.getDestination(MediatorMessage(UniquenessCheckRequestAvro())).endpoint).isEqualTo(
             endpoint(UNIQUENESS_PATH)
         )
+
+        // External messaging
+        val externalMessagingKafkaTopic = "custom.kafka.topic"
+        val externalMessagingMessage = "message"
+        assertThat(router.getDestination(
+            MediatorMessage(
+                payload = externalMessagingMessage,
+                properties = mutableMapOf(MessagingClient.MSG_PROP_TOPIC to externalMessagingKafkaTopic)
+            )
+        ).endpoint).isEqualTo(externalMessagingKafkaTopic)
     }
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
@@ -173,9 +173,11 @@ internal class TaskManagerHelper<K : Any, S : Any, E : Any>(
             value!!,
             headers
                 .toMessageProperties()
-                .also {
-                    it[MSG_PROP_KEY] = key;
-                    it[MSG_PROP_TOPIC] = topic?: ""
+                .also { properties ->
+                    properties[MSG_PROP_KEY] = key;
+                    if(topic!=null) {
+                        properties[MSG_PROP_TOPIC] = topic!!
+                    }
                 },
         )
 

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
@@ -165,8 +165,6 @@ internal class TaskManagerHelper<K : Any, S : Any, E : Any>(
             replyMessage!!.payload,
         )
 
-    // This conversion does not preserve all the data contained on the record!
-    // The timestamp is lost
     /**
      * Converts [Record] to [MediatorMessage].
      */

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
@@ -175,7 +175,8 @@ internal class TaskManagerHelper<K : Any, S : Any, E : Any>(
                 .toMessageProperties()
                 .also { properties ->
                     properties[MSG_PROP_KEY] = key;
-                    if(topic!=null) {
+
+                    if(topic != null && topic!!.isNotEmpty()) {
                         properties[MSG_PROP_TOPIC] = topic!!
                     }
                 },

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
@@ -6,6 +6,7 @@ import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_KEY
+import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_TOPIC
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.mediator.metrics.EventMediatorMetrics
@@ -164,13 +165,20 @@ internal class TaskManagerHelper<K : Any, S : Any, E : Any>(
             replyMessage!!.payload,
         )
 
+    // This conversion does not preserve all the data contained on the record!
+    // The timestamp is lost
     /**
      * Converts [Record] to [MediatorMessage].
      */
     private fun Record<*, *>.toMessage() =
         MediatorMessage(
             value!!,
-            headers.toMessageProperties().also { it[MSG_PROP_KEY] = key },
+            headers
+                .toMessageProperties()
+                .also {
+                    it[MSG_PROP_KEY] = key;
+                    it[MSG_PROP_TOPIC] = topic?: ""
+                },
         )
 
     private fun List<Pair<String, String>>.toMessageProperties() =

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
@@ -10,6 +10,8 @@ interface MessagingClient : AutoCloseable {
 
         /** Name of the property for specifying the message key */
         const val MSG_PROP_KEY = "key"
+
+        const val MSG_PROP_TOPIC = "topic"
     }
 
     /**

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
@@ -11,6 +11,7 @@ interface MessagingClient : AutoCloseable {
         /** Name of the property for specifying the message key */
         const val MSG_PROP_KEY = "key"
 
+        /** Name of the property for specifying the kafka topic name */
         const val MSG_PROP_TOPIC = "topic"
     }
 


### PR DESCRIPTION
The mediator pattern introduced a translation from `Record< * , *>` to `MediatorMessage<*>`. There are two key points to keep in mind. The field `topic` in the `Record<*,*>` is dropped and the `payload` field in the `MediatorMessage<*>` contains the message to be sent when the `external messaging` feature is used. In order to fix the issue, the value in the `topic` field is now added to the `properties` field in the `MediatorMessage<*>` which is later used by `FlowEventMediatorFactoryImpl`.