### PR TITLE
CORE-18691 Sandbox Logging

### DIFF
--- a/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
+++ b/components/virtual-node/sandbox-group-context-service/src/main/kotlin/net/corda/sandboxgroupcontext/service/impl/SandboxGroupContextCacheImpl.kt
@@ -42,7 +42,7 @@ internal class SandboxGroupContextCacheImpl private constructor(
         }.forEach { listener ->
             try {
                 listener.onEviction(vnc)
-            } catch(e: Exception) {
+            } catch (e: Exception) {
                 logger.warn("Error while evicting sandbox $vnc", e)
             }
         }
@@ -238,14 +238,11 @@ internal class SandboxGroupContextCacheImpl private constructor(
         }
 
         return sandboxCache.get(virtualNodeContext) {
-            if (logger.isDebugEnabled) {
-                logger.debug(
-                    "Caching {} sandbox for {} (cache size: {})",
-                    virtualNodeContext.sandboxGroupType,
-                    virtualNodeContext.holdingIdentity.x500Name,
-                    sandboxCache.estimatedSize()
-                )
-            }
+            logger.info(
+                "Creating {} sandbox for {}",
+                virtualNodeContext.sandboxGroupType,
+                virtualNodeContext.holdingIdentity.x500Name
+            )
             SandboxGroupContextWrapper(createFunction(virtualNodeContext))
         }
     }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -98,13 +98,8 @@ internal class SandboxServiceImpl @Activate constructor(
         }
     }
 
-    override fun createSandboxGroup(cpks: Iterable<Cpk>, securityDomain: String) =
-        createSandboxes(cpks, securityDomain, startBundles = true)
-
-    override fun createSandboxGroupWithoutStarting(cpks: Iterable<Cpk>, securityDomain: String) =
-        createSandboxes(cpks, securityDomain, startBundles = false)
-
     override fun unloadSandboxGroup(sandboxGroup: SandboxGroup) = bundleLock.withLock {
+        logger.info("Uninstalling bundles for SandboxGroup $sandboxGroup.id")
         (sandboxGroup as SandboxGroupInternal).also { sandboxGroupInternal ->
             sandboxGroupInternal.cpkSandboxes.forEach { sandbox ->
                 val unloaded = sandbox.unload()
@@ -184,16 +179,11 @@ internal class SandboxServiceImpl @Activate constructor(
     }
 
     /**
-     * Creates a [SandboxGroup] in the [securityDomain], containing a [Sandbox] for each of the [cpks]. On the first
-     * run, also initialises a public sandbox. [startBundles] controls whether the CPK bundles are also started.
+     * Creates a [SandboxGroup] in the [securityDomain], containing a [Sandbox] for each of the [cpks].
      *
      * Grants each sandbox visibility of the public sandboxes and of the other sandboxes in the group.
      */
-    private fun createSandboxes(
-        cpks: Iterable<Cpk>,
-        securityDomain: String,
-        startBundles: Boolean
-    ): SandboxGroup = bundleLock.withLock {
+    override fun createSandboxGroup(cpks: Iterable<Cpk>, securityDomain: String): SandboxGroup = bundleLock.withLock {
         sandboxForbidsThat(securityDomain.contains('/')) {
             "Security domain cannot contain a '/' character."
         }
@@ -269,11 +259,7 @@ internal class SandboxServiceImpl @Activate constructor(
             throw ex
         }
 
-        // We only start the bundles once all the CPKs' bundles have been installed and sandboxed, since there are
-        // likely dependencies between the CPKs' bundles.
-        if (startBundles) {
-            startBundles(bundles)
-        }
+        startBundles(bundles)
 
         val sandboxGroup = SandboxGroupImpl(
             id = UUID.randomUUID(),
@@ -286,6 +272,8 @@ internal class SandboxServiceImpl @Activate constructor(
         bundles.forEach { bundle ->
             bundleIdToSandboxGroup[bundle.bundleId] = sandboxGroup
         }
+
+        logger.info("Installed bundles for SandboxGroup $sandboxGroup.id")
 
         return sandboxGroup
     }

--- a/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
+++ b/libs/sandbox-internal/src/main/kotlin/net/corda/sandbox/internal/SandboxServiceImpl.kt
@@ -99,7 +99,7 @@ internal class SandboxServiceImpl @Activate constructor(
     }
 
     override fun unloadSandboxGroup(sandboxGroup: SandboxGroup) = bundleLock.withLock {
-        logger.info("Uninstalling bundles for SandboxGroup $sandboxGroup.id")
+        logger.info("Uninstalling bundles for SandboxGroup ${sandboxGroup.id}")
         (sandboxGroup as SandboxGroupInternal).also { sandboxGroupInternal ->
             sandboxGroupInternal.cpkSandboxes.forEach { sandbox ->
                 val unloaded = sandbox.unload()
@@ -273,7 +273,7 @@ internal class SandboxServiceImpl @Activate constructor(
             bundleIdToSandboxGroup[bundle.bundleId] = sandboxGroup
         }
 
-        logger.info("Installed bundles for SandboxGroup $sandboxGroup.id")
+        logger.info("Installed bundles for SandboxGroup ${sandboxGroup.id}")
 
         return sandboxGroup
     }

--- a/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
+++ b/libs/sandbox-internal/src/test/kotlin/net/corda/sandbox/internal/SandboxServiceImplTests.kt
@@ -86,7 +86,12 @@ class SandboxServiceImplTests {
             val mainBundlePath = contents.cpk.metadata.mainBundle
             val libPath = contents.cpk.metadata.libraries.single()
 
-            whenever(bundleContext.installBundle(argThat { endsWith(mainBundlePath) || endsWith(libPath) }, any())).then { answer ->
+            whenever(
+                bundleContext.installBundle(
+                    argThat { endsWith(mainBundlePath) || endsWith(libPath) },
+                    any()
+                )
+            ).then { answer ->
                 val bundleLocation = answer.arguments.first() as String
                 val (bundleName, bundleClass) = if (bundleLocation.endsWith(mainBundlePath)) {
                     contents.mainBundleName to contents.mainBundleClass
@@ -122,9 +127,11 @@ class SandboxServiceImplTests {
         assertEquals(2, sandboxes.size)
 
         val sandboxesRetrievedFromSandboxGroup =
-            cpks.map { cpk -> sandboxGroup.cpkSandboxes.find { sandbox ->
-                sandbox.cpkMetadata.fileChecksum == cpk.metadata.fileChecksum
-            } }
+            cpks.map { cpk ->
+                sandboxGroup.cpkSandboxes.find { sandbox ->
+                    sandbox.cpkMetadata.fileChecksum == cpk.metadata.fileChecksum
+                }
+            }
         assertEquals(sandboxes.toSet(), sandboxesRetrievedFromSandboxGroup.toSet())
     }
 
@@ -132,12 +139,6 @@ class SandboxServiceImplTests {
     fun `creating a sandbox installs and starts its bundles`() {
         sandboxService.createSandboxGroup(setOf(cpkOne))
         assertEquals(2, startedBundles.size)
-    }
-
-    @Test
-    fun `can create a sandbox without starting its bundles`() {
-        sandboxService.createSandboxGroupWithoutStarting(setOf(cpkOne))
-        assertEquals(0, startedBundles.size)
     }
 
     @Test
@@ -299,7 +300,8 @@ class SandboxServiceImplTests {
 
         val sandboxOneBundles = startedBundles.filter(sandboxOne::containsBundle)
         val sandboxTwoBundles = startedBundles.filter(sandboxTwo::containsBundle)
-        val sandboxTwoPublicBundles = sandboxTwoBundles.filterTo(HashSet()) { bundle -> bundle in sandboxTwo.publicBundles }
+        val sandboxTwoPublicBundles =
+            sandboxTwoBundles.filterTo(HashSet()) { bundle -> bundle in sandboxTwo.publicBundles }
         val sandboxTwoPrivateBundles = sandboxTwoBundles - sandboxTwoPublicBundles
 
         sandboxOneBundles.forEach { sandboxOneBundle ->
@@ -574,12 +576,15 @@ private data class CpkAndContents(
                 whenever(bundleVersion).thenAnswer { "${random.nextInt()}" }
             },
             type = CpkType.UNKNOWN,
-            fileChecksum = cpkChecksum ?:
-                SecureHashImpl(HASH_ALGORITHM, MessageDigest.getInstance(HASH_ALGORITHM).digest(cpkBytes.toByteArray())),
+            fileChecksum = cpkChecksum ?: SecureHashImpl(
+                HASH_ALGORITHM,
+                MessageDigest.getInstance(HASH_ALGORITHM).digest(cpkBytes.toByteArray())
+            ),
             cordappCertificates = emptySet(),
             timestamp = Instant.now(),
             null
         )
+
         override fun getInputStream() = ByteArrayInputStream(cpkBytes.toByteArray())
         override fun getResourceAsStream(resourceName: String) = ByteArrayInputStream(ByteArray(0))
         override fun getMainBundle(): InputStream = ByteArrayInputStream(ByteArray(0))

--- a/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxCreationService.kt
+++ b/libs/sandbox/src/main/kotlin/net/corda/sandbox/SandboxCreationService.kt
@@ -23,17 +23,6 @@ interface SandboxCreationService {
     fun createSandboxGroup(cpks: Iterable<Cpk>, securityDomain: String = ""): SandboxGroup
 
     /**
-     * Creates a new [SandboxGroup] in the [securityDomain] containing a sandbox for each of the [cpks].
-     *
-     * Duplicate [cpks] are discarded (i.e. only one sandbox will be created per unique hash).
-     *
-     * The bundles in each sandbox are not started, meaning that their bundle activators are not called.
-     *
-     * A [SandboxException] is thrown if the sandbox creation fails.
-     */
-    fun createSandboxGroupWithoutStarting(cpks: Iterable<Cpk>, securityDomain: String = ""): SandboxGroup
-
-    /**
      * Attempts to uninstall each of the sandbox group's bundles in turn, and removes the sandbox group from the
      * service's cache.
      */


### PR DESCRIPTION
The bug described in CORE-18691 intermittently pops up despite thread safety improvements (although less regularly). This PR adds more logging to sandbox creation and also bundle installation and uninstallation so we can ensure the correct sandbox is being used at the point of failure.

We already have logging for sandbox eviction and closing and so this extra logging adds some symmetry to that.

On top of this I removed a function we only ever called in tests. This reduces some complexity in the `SandboxCreationService` which has no need for "non started" bundles.