### PR TITLE
CORE-19130: Avid forwarding messages to the session managed before the listener is ready

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,14 +2,14 @@
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',
-    runIntegrationTests: true,
+    runIntegrationTests: false,
     createPostgresDb: true,
     publishOSGiImage: true,
-    publishPreTestImage: true,
+    publishPreTestImage: false,
     publishHelmChart: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
-    runE2eTests: true,
-    combinedWorkere2eTests: true,
+    runE2eTests: false,
+    combinedWorkere2eTests: false,
     // allow publishing artifacts to S3 bucket
     publishToMavenS3Repository: true,
     // allow publishing an installer to a download site

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/LogWithContext.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/LogWithContext.kt
@@ -1,0 +1,12 @@
+package net.corda.p2p.linkmanager.common
+
+object LogWithContext {
+    private val mySource = ThreadLocal<Exception>()
+
+    fun create(): Exception {
+        return Exception("QQQ", mySource.get())
+    }
+    fun set(exception: Exception) {
+        mySource.set(exception)
+    }
+}

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/LogWithContext.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/LogWithContext.kt
@@ -9,4 +9,8 @@ object LogWithContext {
     fun set(exception: Exception) {
         mySource.set(exception)
     }
+
+    fun reset() {
+        mySource.set(null)
+    }
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
@@ -14,13 +14,13 @@ import net.corda.lifecycle.domino.logic.ComplexDominoTile
 import net.corda.lifecycle.domino.logic.ConfigurationChangeHandler
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
 import net.corda.lifecycle.domino.logic.util.ResourcesHolder
+import net.corda.p2p.linkmanager.common.LogWithContext
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.schema.configuration.ConfigKeys
 import net.corda.utilities.VisibleForTesting
 import net.corda.utilities.time.Clock
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
@@ -244,10 +244,9 @@ internal class ReplayScheduler<K: SessionManager.BaseCounterparties, M>(
             replayInfo?.future?.cancel(false)
             val firstReplayPeriod = replayCalculator.get().calculateReplayInterval()
             val delay = firstReplayPeriod.toMillis() + originalAttemptTimestamp - clock.instant().toEpochMilli()
-            val id = UUID.randomUUID()
-            logger.info("QQQ in scheduleForReplay ($id) my thread: ${Thread.currentThread().id}", Exception("QQQ"))
+            val id = LogWithContext.create()
             val future = executorService.schedule({
-                logger.info("QQQ in scheduleForReplay ($id) my thread: ${Thread.currentThread().id}")
+                LogWithContext.set(id)
                 replay(message, messageId)
                                                   }, delay, TimeUnit.MILLISECONDS)
             ReplayInfo(firstReplayPeriod, future)
@@ -317,12 +316,11 @@ internal class ReplayScheduler<K: SessionManager.BaseCounterparties, M>(
             } else {
                 oldReplayInfo.currentReplayPeriod
             }
-            val id = UUID.randomUUID()
-            logger.info("QQQ in reschedule ($id) ${Thread.currentThread().id}", Exception("QQQ"))
+            val id = LogWithContext.create()
             ReplayInfo(
                 delay,
                 executorService.schedule({
-                    logger.info("QQQ in reschedule ($id) ${Thread.currentThread().id}")
+                    LogWithContext.set(id)
                     replay(message, messageId)
                                          }, delay.toMillis(), TimeUnit.MILLISECONDS)
             )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
@@ -248,6 +248,7 @@ internal class ReplayScheduler<K: SessionManager.BaseCounterparties, M>(
             val future = executorService.schedule({
                 LogWithContext.set(id)
                 replay(message, messageId)
+                LogWithContext.reset()
                                                   }, delay, TimeUnit.MILLISECONDS)
             ReplayInfo(firstReplayPeriod, future)
         }
@@ -322,6 +323,7 @@ internal class ReplayScheduler<K: SessionManager.BaseCounterparties, M>(
                 executorService.schedule({
                     LogWithContext.set(id)
                     replay(message, messageId)
+                    LogWithContext.reset()
                                          }, delay.toMillis(), TimeUnit.MILLISECONDS)
             )
         }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/ReplayScheduler.kt
@@ -20,6 +20,7 @@ import net.corda.utilities.VisibleForTesting
 import net.corda.utilities.time.Clock
 import org.slf4j.LoggerFactory
 import java.time.Duration
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
@@ -243,7 +244,12 @@ internal class ReplayScheduler<K: SessionManager.BaseCounterparties, M>(
             replayInfo?.future?.cancel(false)
             val firstReplayPeriod = replayCalculator.get().calculateReplayInterval()
             val delay = firstReplayPeriod.toMillis() + originalAttemptTimestamp - clock.instant().toEpochMilli()
-            val future = executorService.schedule({ replay(message, messageId) }, delay, TimeUnit.MILLISECONDS)
+            val id = UUID.randomUUID()
+            logger.info("QQQ in scheduleForReplay ($id) my thread: ${Thread.currentThread().id}", Exception("QQQ"))
+            val future = executorService.schedule({
+                logger.info("QQQ in scheduleForReplay ($id) my thread: ${Thread.currentThread().id}")
+                replay(message, messageId)
+                                                  }, delay, TimeUnit.MILLISECONDS)
             ReplayInfo(firstReplayPeriod, future)
         }
     }
@@ -311,9 +317,14 @@ internal class ReplayScheduler<K: SessionManager.BaseCounterparties, M>(
             } else {
                 oldReplayInfo.currentReplayPeriod
             }
+            val id = UUID.randomUUID()
+            logger.info("QQQ in reschedule ($id) ${Thread.currentThread().id}", Exception("QQQ"))
             ReplayInfo(
                 delay,
-                executorService.schedule({ replay(message, messageId) }, delay.toMillis(), TimeUnit.MILLISECONDS)
+                executorService.schedule({
+                    logger.info("QQQ in reschedule ($id) ${Thread.currentThread().id}")
+                    replay(message, messageId)
+                                         }, delay.toMillis(), TimeUnit.MILLISECONDS)
             )
         }
     }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -78,6 +78,7 @@ internal class OutboundMessageProcessor(
                     "No partitions from topic ${Schemas.P2P.LINK_IN_TOPIC} are currently assigned to the inbound message processor." +
                         " Sessions: $sessionIds will not be initiated."
                 )
+                logger.info("QQQ OOPS recordsForNewSessions too soon Thread ID: ${Thread.currentThread().id}", Exception("QQQ"))
                 emptyList()
             } else {
                 state.messages.forEach {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory
 import java.time.Instant
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import net.corda.p2p.linkmanager.TraceableItem
+import net.corda.p2p.linkmanager.common.LogWithContext
 import net.corda.p2p.linkmanager.metrics.recordOutboundMessagesMetric
 import net.corda.p2p.linkmanager.metrics.recordOutboundSessionMessagesMetric
 
@@ -78,7 +79,7 @@ internal class OutboundMessageProcessor(
                     "No partitions from topic ${Schemas.P2P.LINK_IN_TOPIC} are currently assigned to the inbound message processor." +
                         " Sessions: $sessionIds will not be initiated."
                 )
-                logger.info("QQQ OOPS recordsForNewSessions too soon Thread ID: ${Thread.currentThread().id}", Exception("QQQ"))
+                logger.info("QQQ OOPS recordsForNewSessions too soon", LogWithContext.create())
                 emptyList()
             } else {
                 state.messages.forEach {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -91,6 +91,8 @@ internal class OutboundMessageProcessor(
                         Record(Schemas.P2P.SESSION_OUT_PARTITIONS, it.first, SessionPartitions(partitions.toList()))
                     )
                 }
+            }.also {
+                LogWithContext.reset()
             }
         }
     }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -779,6 +779,7 @@ internal class SessionManagerImpl(
             {
                 LogWithContext.set(id)
                 refreshSessionAndLog(sessionCounterparties, message.header.sessionId)
+                LogWithContext.reset()
             },
             sessionManagerConfig.sessionRefreshThreshold.toLong(),
             TimeUnit.SECONDS
@@ -1141,6 +1142,7 @@ internal class SessionManagerImpl(
                             {
                                 LogWithContext.set(id)
                                 outboundSessionTimeout(counterparties, sessionId)
+                                LogWithContext.reset()
                             },
                             config.get().sessionTimeout.toMillis(),
                             TimeUnit.MILLISECONDS
@@ -1242,6 +1244,7 @@ internal class SessionManagerImpl(
                     {
                         LogWithContext.set(id)
                         outboundSessionTimeout(counterparties, sessionId)
+                        LogWithContext.reset()
                     },
                     sessionTimeoutMs - timeSinceLastAck,
                     TimeUnit.MILLISECONDS

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -773,8 +773,13 @@ internal class SessionManagerImpl(
                 "(local=${sessionCounterparties.ourId}, remote=${sessionCounterparties.counterpartyId})."
         )
         val sessionManagerConfig = config.get()
+        val id = UUID.randomUUID()
+        logger.info("QQQ in processResponderHandshake going to call refreshSessionAndLog ($id)", Exception("QQQ"))
         executorService.schedule(
-            { refreshSessionAndLog(sessionCounterparties, message.header.sessionId) },
+            {
+                logger.info("QQQ in processResponderHandshake going to call refreshSessionAndLog ($id)")
+                refreshSessionAndLog(sessionCounterparties, message.header.sessionId)
+            },
             sessionManagerConfig.sessionRefreshThreshold.toLong(),
             TimeUnit.SECONDS
         )
@@ -1131,8 +1136,15 @@ internal class SessionManagerImpl(
                         initialTrackedSession.lastSendTimestamp = timeStamp()
                         initialTrackedSession
                     } else {
+                        val id = UUID.randomUUID()
+                        logger.info("QQQ in sessionMessageSent going to call outboundSessionTimeout ($id)", Exception("QQQ"))
                         executorService.schedule(
-                            { outboundSessionTimeout(counterparties, sessionId) },
+                            {
+                                logger.info(
+                                    "QQQ in sessionMessageSent going to call outboundSessionTimeout ($id) ${Thread.currentThread().id}"
+                                )
+                                outboundSessionTimeout(counterparties, sessionId)
+                            },
                             config.get().sessionTimeout.toMillis(),
                             TimeUnit.MILLISECONDS
                         )
@@ -1228,8 +1240,13 @@ internal class SessionManagerImpl(
                 trackedOutboundSessions.remove(sessionId)
                 recordOutboundSessionTimeoutMetric(counterparties.ourId, counterparties.counterpartyId)
             } else {
+                val id = UUID.randomUUID()
+                logger.info("QQQ in outboundSessionTimeout going to call outboundSessionTimeout ($id)", Exception("QQQ"))
                 executorService.schedule(
-                    { outboundSessionTimeout(counterparties, sessionId) },
+                    {
+                        logger.info("QQQ in outboundSessionTimeout going to call outboundSessionTimeout ($id) ${Thread.currentThread().id}")
+                        outboundSessionTimeout(counterparties, sessionId)
+                    },
                     sessionTimeoutMs - timeSinceLastAck,
                     TimeUnit.MILLISECONDS
                 )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -96,6 +96,7 @@ import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import net.corda.metrics.CordaMetrics.NOT_APPLICABLE_TAG_VALUE
 import net.corda.p2p.crypto.protocol.api.InvalidSelectedModeError
 import net.corda.p2p.crypto.protocol.api.NoCommonModeError
+import net.corda.p2p.linkmanager.common.LogWithContext
 import net.corda.p2p.linkmanager.metrics.recordOutboundHeartbeatMessagesMetric
 import net.corda.p2p.linkmanager.sessions.SessionManagerWarnings.badGroupPolicy
 import kotlin.concurrent.read
@@ -773,11 +774,10 @@ internal class SessionManagerImpl(
                 "(local=${sessionCounterparties.ourId}, remote=${sessionCounterparties.counterpartyId})."
         )
         val sessionManagerConfig = config.get()
-        val id = UUID.randomUUID()
-        logger.info("QQQ in processResponderHandshake going to call refreshSessionAndLog ($id)", Exception("QQQ"))
+        val id = LogWithContext.create()
         executorService.schedule(
             {
-                logger.info("QQQ in processResponderHandshake going to call refreshSessionAndLog ($id)")
+                LogWithContext.set(id)
                 refreshSessionAndLog(sessionCounterparties, message.header.sessionId)
             },
             sessionManagerConfig.sessionRefreshThreshold.toLong(),
@@ -1136,13 +1136,10 @@ internal class SessionManagerImpl(
                         initialTrackedSession.lastSendTimestamp = timeStamp()
                         initialTrackedSession
                     } else {
-                        val id = UUID.randomUUID()
-                        logger.info("QQQ in sessionMessageSent going to call outboundSessionTimeout ($id)", Exception("QQQ"))
+                        val id = LogWithContext.create()
                         executorService.schedule(
                             {
-                                logger.info(
-                                    "QQQ in sessionMessageSent going to call outboundSessionTimeout ($id) ${Thread.currentThread().id}"
-                                )
+                                LogWithContext.set(id)
                                 outboundSessionTimeout(counterparties, sessionId)
                             },
                             config.get().sessionTimeout.toMillis(),
@@ -1240,11 +1237,10 @@ internal class SessionManagerImpl(
                 trackedOutboundSessions.remove(sessionId)
                 recordOutboundSessionTimeoutMetric(counterparties.ourId, counterparties.counterpartyId)
             } else {
-                val id = UUID.randomUUID()
-                logger.info("QQQ in outboundSessionTimeout going to call outboundSessionTimeout ($id)", Exception("QQQ"))
+                val id = LogWithContext.create()
                 executorService.schedule(
                     {
-                        logger.info("QQQ in outboundSessionTimeout going to call outboundSessionTimeout ($id) ${Thread.currentThread().id}")
+                        LogWithContext.set(id)
                         outboundSessionTimeout(counterparties, sessionId)
                     },
                     sessionTimeoutMs - timeSinceLastAck,

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
@@ -887,12 +887,6 @@ class InboundMessageProcessorTest {
                 on { header } doReturn commonHeader
             }
             val message = LinkInMessage(hello)
-            val header = LinkOutHeader(myIdentity.toAvro(), remoteIdentity.toAvro(), NetworkType.CORDA_5, "https://example.com")
-            val response = LinkOutMessage(header, hello)
-            val captor = argumentCaptor<List<TraceableItem<LinkInMessage, LinkInMessage>>>()
-            whenever(sessionManager.processSessionMessages(captor.capture(), any())).doAnswer {
-                captor.firstValue.map { it to response }
-            }
             whenever(assignedListener.getCurrentlyAssignedPartitions()).thenReturn(emptySet())
 
             val records = processor.onNext(
@@ -906,8 +900,10 @@ class InboundMessageProcessorTest {
                 .hasSize(1)
                 .contains(
                     "No partitions from topic link.in are currently assigned to the inbound message processor. " +
-                            "Not going to reply to session initiation for session Session."
+                            "Not going to reply to session initiation."
                 )
+            verify(sessionManager, never())
+                .processSessionMessages(any<List<TraceableItem<LinkInMessage, LinkInMessage>>>(), any())
         }
 
         @Test


### PR DESCRIPTION
Avoid forwarding session messages to the session manager if the inbound listener is not ready.