### PR TITLE
CORE-19094: optimise sending transaction logic in finality flow

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
@@ -10,14 +10,18 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
     private companion object {
         const val INITIAL_TRANSACTION = "INITIAL_TRANSACTION"
         const val TRANSFER_ADDITIONAL_SIGNATURES = "TRANSFER_ADDITIONAL_SIGNATURES"
+        const val FILTERED_TRANSACTIONS_AND_SIGNATURES = "FILTERED_TRANSACTIONS_AND_SIGNATURES"
     }
-    constructor(initialTransaction: UtxoSignedTransaction, transferAdditionalSignatures: Boolean) : this(
+    constructor(initialTransaction: UtxoSignedTransaction, transferAdditionalSignatures: Boolean, filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>? = null) : this(
         mapOf(
             INITIAL_TRANSACTION to initialTransaction,
-            TRANSFER_ADDITIONAL_SIGNATURES to transferAdditionalSignatures
+            TRANSFER_ADDITIONAL_SIGNATURES to transferAdditionalSignatures,
+            FILTERED_TRANSACTIONS_AND_SIGNATURES to filteredTransactionsAndSignatures
         )
     )
 
     val initialTransaction get() = map[INITIAL_TRANSACTION] as UtxoSignedTransactionInternal
     val transferAdditionalSignatures get() = map[TRANSFER_ADDITIONAL_SIGNATURES] as Boolean
+    @Suppress("UNCHECKED_CAST")
+    val filteredTransactionsAndSignatures get() = map[FILTERED_TRANSACTIONS_AND_SIGNATURES] as List<FilteredTransactionAndSignatures>?
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
@@ -12,7 +12,11 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
         const val TRANSFER_ADDITIONAL_SIGNATURES = "TRANSFER_ADDITIONAL_SIGNATURES"
         const val FILTERED_TRANSACTIONS_AND_SIGNATURES = "FILTERED_TRANSACTIONS_AND_SIGNATURES"
     }
-    constructor(initialTransaction: UtxoSignedTransaction, transferAdditionalSignatures: Boolean, filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>? = null) : this(
+    constructor(
+        initialTransaction: UtxoSignedTransaction,
+        transferAdditionalSignatures: Boolean,
+        filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>? = null
+    ) : this(
         mapOf(
             INITIAL_TRANSACTION to initialTransaction,
             TRANSFER_ADDITIONAL_SIGNATURES to transferAdditionalSignatures,
@@ -22,6 +26,7 @@ data class FinalityPayload @ConstructorForDeserialization constructor(val map: M
 
     val initialTransaction get() = map[INITIAL_TRANSACTION] as UtxoSignedTransactionInternal
     val transferAdditionalSignatures get() = map[TRANSFER_ADDITIONAL_SIGNATURES] as Boolean
+
     @Suppress("UNCHECKED_CAST")
     val filteredTransactionsAndSignatures get() = map[FILTERED_TRANSACTIONS_AND_SIGNATURES] as List<FilteredTransactionAndSignatures>?
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -132,7 +132,7 @@ class UtxoFinalityFlowV1(
                     val newTxNotaryKey = initialTransaction.notaryKey
                     require(initialTransaction.notaryName == dependency.notaryName) {
                         "Notary name of filtered transaction \"${dependency.notaryName}\" doesn't match with " +
-                                "notary service of current transaction \"${initialTransaction.notaryName}\""
+                            "notary service of current transaction \"${initialTransaction.notaryName}\""
                     }
                     notarySignatureVerificationService.verifyNotarySignatures(
                         dependency,
@@ -156,9 +156,14 @@ class UtxoFinalityFlowV1(
                         dependency.signatures.filter { newTxNotaryKeyIds.contains(it.by) }
                     )
                 }
-        } else null
+        } else {
+            null
+        }
 
-        flowMessaging.sendAll(FinalityPayload(initialTransaction, transferAdditionalSignatures, filteredTransactionsAndSignatures), sessions.toSet())
+        flowMessaging.sendAll(
+            FinalityPayload(initialTransaction, transferAdditionalSignatures, filteredTransactionsAndSignatures),
+            sessions.toSet()
+        )
 
         if (notaryInfo.isBackchainRequired) {
             sessions.forEach {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -159,7 +159,11 @@ class UtxoReceiveFinalityFlowV1(
             }
             InitialTransactionPayload(initialTransaction, transferAdditionalSignatures, emptyList(), emptyList())
         } else {
-            receiveDependencyPayloadAndVerify(payload.filteredTransactionsAndSignatures!!, initialTransaction, transferAdditionalSignatures)
+            val filteredTransactionsAndSignatures = payload.filteredTransactionsAndSignatures
+            requireNotNull(filteredTransactionsAndSignatures) {
+                "filtered transaction and signatures cannot be found."
+            }
+            receiveDependencyPayloadAndVerify(filteredTransactionsAndSignatures, initialTransaction, transferAdditionalSignatures)
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -159,7 +159,7 @@ class UtxoReceiveFinalityFlowV1(
             }
             InitialTransactionPayload(initialTransaction, transferAdditionalSignatures, emptyList(), emptyList())
         } else {
-            receiveDependencyPayloadAndVerify(initialTransaction, transferAdditionalSignatures)
+            receiveDependencyPayloadAndVerify(payload.filteredTransactionsAndSignatures!!, initialTransaction, transferAdditionalSignatures)
         }
     }
 
@@ -172,13 +172,10 @@ class UtxoReceiveFinalityFlowV1(
 
     @Suspendable
     private fun receiveDependencyPayloadAndVerify(
+        filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>,
         initialTransaction: UtxoSignedTransactionInternal,
         transferAdditionalSignatures: Boolean
     ): InitialTransactionPayload {
-        @Suppress("unchecked_cast")
-        val filteredTransactionsAndSignatures =
-            session.receive(List::class.java) as List<FilteredTransactionAndSignatures>
-
         val groupParameters = groupParametersLookup.currentGroupParameters
         val notary = requireNotNull(groupParameters.notaries.first { it.name == initialTransaction.notaryName }) {
             "Notary from initial transaction \"${initialTransaction.notaryName}\" cannot be found in group parameter notaries."

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -163,7 +163,7 @@ class UtxoReceiveFinalityFlowV1(
             requireNotNull(filteredTransactionsAndSignatures) {
                 "filtered transaction and signatures cannot be found."
             }
-            receiveDependencyPayloadAndVerify(filteredTransactionsAndSignatures, initialTransaction, transferAdditionalSignatures)
+            verifyDependencies(filteredTransactionsAndSignatures, initialTransaction, transferAdditionalSignatures)
         }
     }
 
@@ -175,7 +175,7 @@ class UtxoReceiveFinalityFlowV1(
     )
 
     @Suspendable
-    private fun receiveDependencyPayloadAndVerify(
+    private fun verifyDependencies(
         filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>,
         initialTransaction: UtxoSignedTransactionInternal,
         transferAdditionalSignatures: Boolean

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -150,8 +150,6 @@ class UtxoFinalityFlowV1Test {
     private val stateAndRef = mock<StateAndRef<TestState>>()
     private val testState = TestState(listOf(publicKeyAlice1))
 
-//    private dependencyTx =
-
     @BeforeEach
     fun beforeEach() {
         whenever(sessionAlice.counterparty).thenReturn(ALICE)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -48,6 +48,7 @@ import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.TransactionState
+import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.VisibilityChecker
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.membership.MemberInfo
@@ -88,6 +89,7 @@ class UtxoFinalityFlowV1Test {
     }
 
     private val memberLookup = mock<MemberLookup>()
+    private val utxoLedgerService = mock<UtxoLedgerService>()
     private val transactionSignatureService = mock<TransactionSignatureService>()
     private val persistenceService = mock<UtxoLedgerPersistenceService>()
     private val transactionVerificationService = mock<UtxoLedgerTransactionVerificationService>()
@@ -147,6 +149,8 @@ class UtxoFinalityFlowV1Test {
     private val transactionState = mock<TransactionState<TestState>>()
     private val stateAndRef = mock<StateAndRef<TestState>>()
     private val testState = TestState(listOf(publicKeyAlice1))
+
+//    private dependencyTx =
 
     @BeforeEach
     fun beforeEach() {
@@ -1350,6 +1354,7 @@ class UtxoFinalityFlowV1Test {
         flow.transactionVerificationService = transactionVerificationService
         flow.virtualNodeSelectorService = virtualNodeSelectorService
         flow.visibilityChecker = visibilityChecker
+        flow.utxoLedgerService = utxoLedgerService
         flow.call()
     }
 

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -149,8 +149,6 @@ class UtxoReceiveFinalityFlowV1Test {
     private val finalityPayload = FinalityPayload(signedTransaction, true)
     private val verifyingFinalityPayload = FinalityPayload(signedTransaction, true, filteredTxPayload)
 
-
-
     private val receivedPayloadV2 = FinalityPayload(signedTransaction, true)
     private val receivedPayloadV2ForTwoParties = FinalityPayload(signedTransaction, false)
 


### PR DESCRIPTION
This PR combines two flow communications into one, by putting all required payload in one container, which reduces performance.  