### PR TITLE
CORE-19142 Adding additional metrics to HTTPRetryExecutor, removing unused from RPCClient

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -13,7 +13,6 @@ import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_KEY
 import net.corda.messaging.utils.HTTPRetryConfig
 import net.corda.messaging.utils.HTTPRetryExecutor
 import net.corda.metrics.CordaMetrics
-import net.corda.utilities.debug
 import net.corda.utilities.trace
 import net.corda.v5.crypto.DigestAlgorithmName
 import org.slf4j.Logger
@@ -23,7 +22,7 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
-import java.time.Duration
+import java.util.EnumMap
 import java.util.concurrent.TimeoutException
 
 const val CORDA_REQUEST_KEY_HEADER = "corda-request-key"
@@ -34,23 +33,12 @@ class RPCClient(
     cordaAvroSerializerFactory: CordaAvroSerializationFactory,
     private val platformDigestService: PlatformDigestService,
     private val onSerializationError: ((ByteArray) -> Unit)?,
-    private val httpClient: HttpClient,
-    private val retryConfig: HTTPRetryConfig =
-        HTTPRetryConfig.Builder()
-            .retryOn(
-                IOException::class.java,
-                TimeoutException::class.java,
-                CordaHTTPClientErrorException::class.java,
-                CordaHTTPServerErrorException::class.java
-            )
-            .build()
+    private val httpClient: HttpClient
 ) : MessagingClient {
     private val deserializer = cordaAvroSerializerFactory.createAvroDeserializer({}, Any::class.java)
 
     private companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
-        private const val SUCCESS: String = "SUCCESS"
-        private const val FAILED: String = "FAILED"
     }
 
     override fun send(message: MediatorMessage<*>): MediatorMessage<*>? {
@@ -72,7 +60,6 @@ class RPCClient(
             MediatorMessage(deserializedResponse, mutableMapOf("statusCode" to response.statusCode()))
         }
     }
-
 
     private fun deserializePayload(payload: ByteArray): Any? {
         return try {
@@ -109,41 +96,23 @@ class RPCClient(
     }
 
     private fun sendWithRetry(request: HttpRequest): HttpResponse<ByteArray> {
-        val startTime = System.nanoTime()
-        return try {
-            val response = HTTPRetryExecutor.withConfig(retryConfig) {
-                httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
-            }
-            buildMetricForResponse(startTime, SUCCESS, request, response)
-            response
-        } catch (ex: Exception) {
-            log.debug { "Catching exception in HttpClient sendWithRetry in order to log metrics, $ex" }
-            buildMetricForResponse(startTime, FAILED, request)
-            throw ex
+        return HTTPRetryExecutor.withConfig(buildRetryConfig(request)) {
+            httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray())
         }
     }
 
-    private fun buildMetricForResponse(
-        startTime: Long,
-        operationStatus: String,
-        request: HttpRequest,
-        response: HttpResponse<ByteArray>? = null
-    ) {
-        val endTime = System.nanoTime()
+    private fun buildRetryConfig(request: HttpRequest): HTTPRetryConfig {
         val uri = request.method() + request.uri().toString()
-        CordaMetrics.Metric.Messaging.HTTPRPCResponseTime.builder()
-            .withTag(CordaMetrics.Tag.OperationStatus, operationStatus)
-            .withTag(CordaMetrics.Tag.HttpRequestUri, uri)
-            .withTag(CordaMetrics.Tag.HttpResponseCode, response?.statusCode().toString())
-            .build()
-            .record(Duration.ofNanos(endTime - startTime))
 
-        if (response != null) {
-            CordaMetrics.Metric.Messaging.HTTPRPCResponseSize.builder()
-                .withTag(CordaMetrics.Tag.HttpRequestUri, uri)
-                .build()
-                .record(response.body().size.toDouble())
-        }
+        return HTTPRetryConfig.Builder()
+            .retryOn(
+                IOException::class.java,
+                TimeoutException::class.java,
+                CordaHTTPClientErrorException::class.java,
+                CordaHTTPServerErrorException::class.java
+            )
+            .additionalMetrics(EnumMap(mutableMapOf(CordaMetrics.Tag.HttpRequestUri to uri)))
+            .build()
     }
 
     private fun handleExceptions(e: Exception, endpoint: String): Nothing {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryConfig.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryConfig.kt
@@ -1,5 +1,8 @@
 package net.corda.messaging.utils
 
+import net.corda.metrics.CordaMetrics
+import java.util.EnumMap
+
 /**
  * Configuration class for HTTP retry parameters.
  *
@@ -9,26 +12,31 @@ package net.corda.messaging.utils
  * @property retryOn A set of exception classes that should trigger a retry when caught.
  *                   If an exception not in this list is caught, it will be propagated immediately without retrying.
  *                   Default is the generic [Exception] class, meaning all exceptions will trigger a retry.
+ * @property additionalMetrics Provide a map of pre-populated <Enum, Value> pairs to be appended to any metric logging,
+ *                             allowing us to provide additional context from the calling class.
  */
 data class HTTPRetryConfig(
     val times: Int = 3,
     val initialDelay: Long = 100,
     val factor: Double = 2.0,
-    val retryOn: Set<Class<out Exception>> = setOf(Exception::class.java)
+    val retryOn: Set<Class<out Exception>> = setOf(Exception::class.java),
+    val additionalMetrics: EnumMap<CordaMetrics.Tag, String> = EnumMap(CordaMetrics.Tag::class.java)
 ) {
     class Builder {
         private var times: Int = 3
         private var initialDelay: Long = 100
         private var factor: Double = 2.0
         private var retryOn: Set<Class<out Exception>> = setOf(Exception::class.java)
+        private var additionalMetrics: EnumMap<CordaMetrics.Tag, String> = EnumMap(CordaMetrics.Tag::class.java)
 
         fun times(times: Int) = apply { this.times = times }
         fun initialDelay(delay: Long) = apply { this.initialDelay = delay }
         fun factor(factor: Double) = apply { this.factor = factor }
         fun retryOn(vararg exceptions: Class<out Exception>) = apply { this.retryOn = exceptions.toSet() }
+        fun additionalMetrics(tags: EnumMap<CordaMetrics.Tag, String>) = apply { this.additionalMetrics = tags }
 
         fun build(): HTTPRetryConfig {
-            return HTTPRetryConfig(times, initialDelay, factor, retryOn)
+            return HTTPRetryConfig(times, initialDelay, factor, retryOn, additionalMetrics)
         }
     }
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
@@ -1,18 +1,22 @@
 package net.corda.messaging.utils
 
-import java.net.http.HttpResponse
 import net.corda.messaging.api.exception.CordaHTTPClientErrorException
 import net.corda.messaging.api.exception.CordaHTTPServerErrorException
+import net.corda.metrics.CordaMetrics
 import net.corda.utilities.trace
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.net.http.HttpResponse
+import java.time.Duration
 
 class HTTPRetryExecutor {
     companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        private const val SUCCESS: String = "SUCCESS"
+        private const val FAILED: String = "FAILED"
 
-        fun <T> withConfig(config: HTTPRetryConfig, block: () -> HttpResponse<T>): HttpResponse<T> {
+        fun withConfig(config: HTTPRetryConfig, block: () -> HttpResponse<ByteArray>): HttpResponse<ByteArray> {
             var currentDelay = config.initialDelay
             for (i in 0 until config.times) {
                 val result = tryAttempt(i, config, block)
@@ -28,14 +32,22 @@ class HTTPRetryExecutor {
             throw CordaRuntimeException(errorMsg)
         }
 
-        private fun <T> tryAttempt(i: Int, config: HTTPRetryConfig, block: () -> HttpResponse<T>): HttpResponse<T>? {
+        private fun tryAttempt(
+            i: Int,
+            config: HTTPRetryConfig,
+            block: () -> HttpResponse<ByteArray>
+        ): HttpResponse<ByteArray>? {
+            val startTime = System.nanoTime()
+
             return try {
                 log.trace { "HTTPRetryExecutor making attempt #${i + 1}." }
                 val result = block()
                 checkResponseStatus(result.statusCode())
+                buildMetricForResponse(config, startTime, SUCCESS, result)
                 log.trace { "Operation successful after #${i + 1} attempt/s." }
                 result
             } catch (e: Exception) {
+                buildMetricForResponse(config, startTime, FAILED)
                 handleException(i, config, e)
                 null
             }
@@ -60,6 +72,42 @@ class HTTPRetryExecutor {
             when (statusCode) {
                 in 400..499 -> throw CordaHTTPClientErrorException(statusCode, "Server returned status code $statusCode.")
                 in 500..599 -> throw CordaHTTPServerErrorException(statusCode, "Server returned status code $statusCode.")
+            }
+        }
+
+        private fun buildMetricForResponse(
+            config: HTTPRetryConfig,
+            startTime: Long,
+            operationStatus: String,
+            response: HttpResponse<ByteArray>? = null
+        ) {
+            val endTime = System.nanoTime()
+            recordResponseTimeMetric(config, startTime, endTime, operationStatus, response)
+            response?.let { recordResponseSizeMetric(config, response) }
+        }
+
+        private fun recordResponseTimeMetric(
+            config: HTTPRetryConfig,
+            startTime: Long,
+            endTime: Long,
+            operationStatus: String,
+            response: HttpResponse<ByteArray>?
+        ) {
+            CordaMetrics.Metric.Messaging.HTTPRPCResponseTime.builder().apply {
+                withTag(CordaMetrics.Tag.OperationStatus, operationStatus)
+                withTag(CordaMetrics.Tag.HttpResponseCode, response?.statusCode()?.toString() ?: "null")
+                config.additionalMetrics.forEach { (tag, value) -> withTag(tag, value) }
+                build().record(Duration.ofNanos(endTime - startTime))
+            }
+        }
+
+        private fun recordResponseSizeMetric(
+            config: HTTPRetryConfig,
+            response: HttpResponse<ByteArray>
+        ) {
+            CordaMetrics.Metric.Messaging.HTTPRPCResponseSize.builder().apply {
+                config.additionalMetrics.forEach { (tag, value) -> withTag(tag, value) }
+                build().record(response.body().size.toDouble())
             }
         }
     }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/HTTPRetryExecutor.kt
@@ -93,22 +93,22 @@ class HTTPRetryExecutor {
             operationStatus: String,
             response: HttpResponse<ByteArray>?
         ) {
-            CordaMetrics.Metric.Messaging.HTTPRPCResponseTime.builder().apply {
-                withTag(CordaMetrics.Tag.OperationStatus, operationStatus)
-                withTag(CordaMetrics.Tag.HttpResponseCode, response?.statusCode()?.toString() ?: "null")
-                config.additionalMetrics.forEach { (tag, value) -> withTag(tag, value) }
-                build().record(Duration.ofNanos(endTime - startTime))
-            }
+            CordaMetrics.Metric.Messaging.HTTPRPCResponseTime.builder()
+                .withTag(CordaMetrics.Tag.OperationStatus, operationStatus)
+                .withTag(CordaMetrics.Tag.HttpResponseCode, response?.statusCode().toString())
+                .apply { config.additionalMetrics.forEach { (tag, value) -> withTag(tag, value) } }
+                .build()
+                .record(Duration.ofNanos(endTime - startTime))
         }
 
         private fun recordResponseSizeMetric(
             config: HTTPRetryConfig,
             response: HttpResponse<ByteArray>
         ) {
-            CordaMetrics.Metric.Messaging.HTTPRPCResponseSize.builder().apply {
-                config.additionalMetrics.forEach { (tag, value) -> withTag(tag, value) }
-                build().record(response.body().size.toDouble())
-            }
+            CordaMetrics.Metric.Messaging.HTTPRPCResponseSize.builder()
+                .apply { config.additionalMetrics.forEach { (tag, value) -> withTag(tag, value) } }
+                .build()
+                .record(response.body().size.toDouble())
         }
     }
 }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/HTTPRetryExecutorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/utils/HTTPRetryExecutorTest.kt
@@ -25,20 +25,20 @@ class HTTPRetryExecutorTest {
     @Test
     fun `successfully returns after first attempt`() {
         val mockResponse: HttpResponse<ByteArray> = mock()
-        whenever(mockResponse.body()).thenReturn("Success".toByteArray())
+        whenever(mockResponse.body()).thenReturn("Success".toByteArray(Charsets.UTF_8))
 
         val result: HttpResponse<ByteArray> = HTTPRetryExecutor.withConfig(retryConfig) {
             mockResponse
         }
 
-        assertEquals("Success", result.body().toString())
+        assertEquals("Success", result.body().toString(Charsets.UTF_8))
     }
 
     @Suppress("TooGenericExceptionThrown")
     @Test
     fun `should retry until successful`() {
         val mockResponse: HttpResponse<ByteArray> = mock()
-        whenever(mockResponse.body()).thenReturn("Success on attempt 3".toByteArray())
+        whenever(mockResponse.body()).thenReturn("Success on attempt 3".toByteArray(Charsets.UTF_8))
 
         var attempt = 0
 
@@ -50,7 +50,7 @@ class HTTPRetryExecutorTest {
             mockResponse
         }
 
-        assertEquals("Success on attempt 3", result.body().toString())
+        assertEquals("Success on attempt 3", result.body().toString(Charsets.UTF_8))
     }
 
     @Suppress("TooGenericExceptionThrown")
@@ -86,7 +86,7 @@ class HTTPRetryExecutorTest {
     @Test
     fun `should retry on client error status code`() {
         val mockResponse: HttpResponse<ByteArray> = mock()
-        whenever(mockResponse.body()).thenReturn("Success on attempt 3".toByteArray())
+        whenever(mockResponse.body()).thenReturn("Success on attempt 3".toByteArray(Charsets.UTF_8))
         val config = HTTPRetryConfig.Builder()
             .times(3)
             .initialDelay(100)
@@ -105,7 +105,7 @@ class HTTPRetryExecutorTest {
             mockResponse
         }
 
-        assertEquals("Success on attempt 3", result.body().toString())
+        assertEquals("Success on attempt 3", result.body().toString(Charsets.UTF_8))
     }
 
     internal class SpecificException(message: String) : Exception(message)


### PR DESCRIPTION
This PR adds metric logging to the `HTTPRetryExecutor` and removes them from the `RPCClient`, allowing us more granularity in our RPC request metrics. The `RPCClient` is an abstraction above the `HTTPRetryExecutor` internally, and so doesn't see all requests.