### PR TITLE
CORE-19123 Fix declined registrations due to clock sync gaps between workers

### DIFF
--- a/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImpl.kt
+++ b/components/membership/membership-persistence-client-impl/src/main/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImpl.kt
@@ -68,7 +68,8 @@ internal class MembershipPersistenceOperationImpl<T>(
                         "Request ID in the response received does not match what was sent in the request.",
                     ),
                 )
-            } else if (context.requestTimestamp > response.context.responseTimestamp) {
+            // Allow for a tolerance of 120 seconds to account for clock synchronisation gaps between workers.
+            } else if (context.requestTimestamp > response.context.responseTimestamp.plusSeconds(120)) {
                 Either.Right(
                     MembershipPersistenceResult.Failure(
                         "Response timestamp is before the request timestamp.",

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -506,7 +506,7 @@ class MembershipPersistenceClientImplTest {
     }
 
     @Test
-    fun `Response timestamp before request timestamp causes failed response`() {
+    fun `Response timestamp over two minutes before request timestamp causes failed response`() {
         postConfigChangedEvent()
         mockPersistenceResponse(
             rsTimestampOverride = clock.instant().minusSeconds(180)

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceClientImplTest.kt
@@ -509,7 +509,7 @@ class MembershipPersistenceClientImplTest {
     fun `Response timestamp before request timestamp causes failed response`() {
         postConfigChangedEvent()
         mockPersistenceResponse(
-            rsTimestampOverride = clock.instant().minusSeconds(10)
+            rsTimestampOverride = clock.instant().minusSeconds(180)
         )
 
         val result = membershipPersistenceClient.persistMemberInfo(ourHoldingIdentity, listOf(ourSignedMemberInfo))

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImplTest.kt
@@ -133,7 +133,7 @@ class MembershipPersistenceOperationImplTest {
 
         @Test
         fun `early response timestamp will give error`() {
-            responseContext.responseTimestamp = requestContext.requestTimestamp.minusMillis(1000)
+            responseContext.responseTimestamp = requestContext.requestTimestamp.minusSeconds(180)
 
             val reply = operation.send()
 

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipPersistenceOperationImplTest.kt
@@ -132,7 +132,7 @@ class MembershipPersistenceOperationImplTest {
         }
 
         @Test
-        fun `early response timestamp will give error`() {
+        fun `early response timestamp over two minutes before request timestamp will give error`() {
             responseContext.responseTimestamp = requestContext.requestTimestamp.minusSeconds(180)
 
             val reply = operation.send()

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -421,7 +421,7 @@ class MembershipQueryClientImplTest {
         postConfigChangedEvent()
         mockPersistenceResponse(
             MemberInfoQueryResponse(emptyList()),
-            rsTimestampOverride = clock.instant().minusSeconds(10)
+            rsTimestampOverride = clock.instant().minusSeconds(180)
         )
         assertThat(membershipQueryClient.queryMemberInfo(ourHoldingIdentity, listOf(ourHoldingIdentity))).isInstanceOf(
             MembershipQueryResult.Failure::class.java

--- a/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
+++ b/components/membership/membership-persistence-client-impl/src/test/kotlin/net/corda/membership/impl/persistence/client/MembershipQueryClientImplTest.kt
@@ -417,7 +417,7 @@ class MembershipQueryClientImplTest {
     }
 
     @Test
-    fun `Response timestamp before request timestamp causes failed response`() {
+    fun `Response timestamp over two minutes before request timestamp causes failed response`() {
         postConfigChangedEvent()
         mockPersistenceResponse(
             MemberInfoQueryResponse(emptyList()),


### PR DESCRIPTION
Intermittent e2e test failures were observed in some membership tests with the error `Response timestamp is before the request timestamp.`. This change adds some tolerance to the request-response timestamp check on persistence operations, to take clock sync gaps between workers into account.

E2E test (AKS) pipeline: [link](https://ci02.dev.r3.com/job/Corda5/view/Full%20Health%205.1/job/Nightlys/job/Corda-E2E-Tests/job/AKS/job/PR-yash%252Ftest/2/)