### PR TITLE
CORE-19175: Fix new issue

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HostnameMatcher.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/HostnameMatcher.kt
@@ -35,7 +35,6 @@ class HostnameMatcher(private val keyStore: KeyStore) : SNIMatcher(0) {
             null -> MatchType.NONE
             true -> MatchType.C5
             false -> MatchType.C4
-
         }
     }
 

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/SNIKeyManager.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/SNIKeyManager.kt
@@ -27,7 +27,7 @@ class SNIKeyManager(
     }
 
     private fun chooseServerAlias(keyType: String?, issuers: Array<out Principal>?, matcher: SNIMatcher?): String? {
-        val aliases = keyManager.getServerAliases(keyType, issuers)
+        val aliases = keyManager.getServerAliases(keyType, null)
         if (aliases.isNullOrEmpty()) {
             logger.debug("Keystore doesn't contain any aliases for key type $keyType and issuers $issuers")
             return null

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/SNIKeyManagerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/SNIKeyManagerTest.kt
@@ -57,7 +57,7 @@ class SNIKeyManagerTest {
 
     @Test
     fun `Corda 4 will return corda 4`() {
-        whenever(keyManager.getServerAliases(keyType, arrayOf(issuer))).doReturn(
+        whenever(keyManager.getServerAliases(keyType, null)).doReturn(
             arrayOf(
                 aliasC4,
             )
@@ -81,7 +81,7 @@ class SNIKeyManagerTest {
 
     @Test
     fun `the first passed alias will be returned`() {
-        whenever(keyManager.getServerAliases(keyType, arrayOf(issuer))).doReturn(
+        whenever(keyManager.getServerAliases(keyType, null)).doReturn(
             arrayOf(
                 aliasNop,
                 aliasNop,
@@ -107,7 +107,7 @@ class SNIKeyManagerTest {
             on { issuerX500Principal } doReturn issuer
         }
         whenever(keyManager.getCertificateChain(aliasC5)).doReturn(arrayOf(certificate))
-        whenever(keyManager.getServerAliases(keyType, arrayOf(issuer))).doReturn(arrayOf(aliasC5))
+        whenever(keyManager.getServerAliases(keyType, null)).doReturn(arrayOf(aliasC5))
 
         val alias = manager.chooseEngineServerAlias(keyType, arrayOf(issuer), engine)
 

--- a/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/CertificateAuthorityFactory.kt
+++ b/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/CertificateAuthorityFactory.kt
@@ -18,7 +18,7 @@ object CertificateAuthorityFactory {
         keysFactoryDefinitions: KeysFactoryDefinitions,
         validDuration: Duration = Duration.ofDays(30),
     ): CertificateAuthority {
-        return LocalCertificatesAuthority(keysFactoryDefinitions, validDuration, null)
+        return LocalCertificatesAuthority(keysFactoryDefinitions, validDuration, null, issuerName = null)
     }
 
     /**

--- a/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/FileSystemCertificatesAuthorityImpl.kt
+++ b/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/FileSystemCertificatesAuthorityImpl.kt
@@ -6,14 +6,20 @@ import java.security.KeyStore
 import java.security.PrivateKey
 import java.time.Duration
 
+@Suppress("LongParameterList")
 internal class FileSystemCertificatesAuthorityImpl(
     keysFactoryDefinitions: KeysFactoryDefinitions,
     validDuration: Duration,
     defaultPrivateKeyAndCertificate: PrivateKeyWithCertificate?,
     private val home: File,
     firstSerialNumber: Long,
+    issuer: String?,
 ) : LocalCertificatesAuthority(
-    keysFactoryDefinitions, validDuration, defaultPrivateKeyAndCertificate, firstSerialNumber
+    keysFactoryDefinitions,
+    validDuration,
+    defaultPrivateKeyAndCertificate,
+    firstSerialNumber,
+    issuer,
 ),
     FileSystemCertificatesAuthority {
     companion object {
@@ -22,23 +28,33 @@ internal class FileSystemCertificatesAuthorityImpl(
             validDuration: Duration,
             home: File,
         ): FileSystemCertificatesAuthority {
-            val (firstSerialNumber, defaultPrivateKeyAndCertificate) = if (home.exists()) {
+            val (firstSerialNumber, defaultPrivateKeyAndCertificate, issuer) = if (home.exists()) {
                 val serialNumber = File(home, "serialNumber.txt").readText().toLong()
                 val keyStoreFile = File(home, "keystore.jks")
+                val issuer = File(home, "issuer.txt").let {
+                    if (it.exists()) {
+                        it.readText()
+                    } else {
+                        null
+                    }
+                }
                 val keyStore = keyStoreFile.inputStream().use { input ->
                     KeyStore.getInstance("JKS").also { keyStore ->
                         keyStore.load(input, PASSWORD.toCharArray())
                     }
                 }
                 val alias = keyStore.aliases().nextElement()
-                serialNumber to
+                Triple(
+                    serialNumber,
                     PrivateKeyWithCertificate(
                         keyStore.getKey(alias, PASSWORD.toCharArray())
-                            as PrivateKey,
+                                as PrivateKey,
                         keyStore.getCertificate(alias)
-                    )
+                    ),
+                    issuer,
+                )
             } else {
-                1L to null
+                Triple(1L, null, null)
             }
             return FileSystemCertificatesAuthorityImpl(
                 keysFactoryDefinitions,
@@ -46,6 +62,7 @@ internal class FileSystemCertificatesAuthorityImpl(
                 defaultPrivateKeyAndCertificate,
                 home,
                 firstSerialNumber,
+                issuer,
             )
         }
     }
@@ -53,6 +70,7 @@ internal class FileSystemCertificatesAuthorityImpl(
     override fun save() {
         home.mkdirs()
         File(home, "serialNumber.txt").writeText(serialNumber.toString())
+        File(home, "issuer.txt").writeText(issuer.toString())
         File(home, "keystore.jks").outputStream().use {
             asKeyStore("alias").store(it, PASSWORD.toCharArray())
         }

--- a/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/LocalCertificatesAuthority.kt
+++ b/libs/crypto/certificate-generation/src/main/kotlin/net/corda/crypto/test/certificates/generation/LocalCertificatesAuthority.kt
@@ -41,12 +41,12 @@ internal open class LocalCertificatesAuthority(
     private val validDuration: Duration,
     private val defaultPrivateKeyAndCertificate: PrivateKeyWithCertificate?,
     firstSerialNumber: Long = 1,
+    issuerName: String?,
 ) : CertificateAuthority {
 
     protected val serialNumber = AtomicLong(firstSerialNumber)
     private val now = System.currentTimeMillis()
-
-    private val issuer = X500Name("C=UK, CN=r3.com, OU=${UUID.randomUUID()}")
+    internal val issuer = X500Name(issuerName ?: "C=UK, CN=r3.com, OU=${UUID.randomUUID()}")
 
     private fun generateKeyPair(): KeyPair {
         val keysFactory = KeyPairGenerator.getInstance(keysFactoryDefinitions.algorithm.name, BouncyCastleProvider())


### PR DESCRIPTION
We had two issues:
1. The `keyManager.getServerAliases` doesn't always return the correct aliases when actual issuers are not null. Since we don't need the issuers for this method, I reverted it to pass null.
2. The `getCA` created a new issuer at any time instead of saving it and loading it from the disk.
With those fixes, the multi-cluster build looks more stable - see https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-e2e-tests-multi-cluster-tests/detail/yift%2Fcore-19128%2Ftest-what-went-wrong/4/pipeline