### PR TITLE
ES-1800 Clarify Helm publish messages

### DIFF
--- a/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
+++ b/.ci/PublishHelmChart/Jenkinsfile_PublishHelmChart
@@ -110,9 +110,8 @@ pipeline {
             post {
                 success {
                     script{
-                        renderWidget("Published Corda helm chart version to Artifactory: ${env.HELM_CHART_VERSION}")
-                        renderWidget("Published Corda helm chart repo name: ${env.HELM_CHART_REPO_NAME}")
-                        renderWidget("Published Corda helm chart OCI path: oci://${env.HELM_REGISTRY}/${env.HELM_CHART_REPO_NAME}/corda")
+                        renderWidget("Published Corda Helm chart OCI path: oci://${env.HELM_REGISTRY}/${env.HELM_CHART_REPO_NAME}/corda")
+                        renderWidget("Published Corda Helm chart version: ${env.HELM_CHART_VERSION}")
                     }
                 }
             }


### PR DESCRIPTION
The "chart repo name" is misleading as it doesn't include the `/corda`.