### PR TITLE
CORE-18978 Remove Kafka schema validation on reconciliation

### DIFF
--- a/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
+++ b/components/configuration/configuration-write-service-impl/src/main/kotlin/net/corda/configuration/write/impl/publish/ConfigPublishServiceImpl.kt
@@ -128,29 +128,20 @@ class ConfigPublishServiceImpl @Activate constructor(
                 )
             }
 
-        val kafkaConfigValue =
-            smartConfigFactory.create(ConfigFactory.parseString(kafkaRecordValue.value)).run {
-                validator.validate(
-                    recordKey,
-                    Version(schemaMajorVersion, schemaMinorVersion),
-                    this,
-                    applyDefaults = false,
-                )
-            }
-
+        val kafkaConfigValue = smartConfigFactory.create(ConfigFactory.parseString(kafkaRecordValue.value))
 
         val configsAreNotEqual = dbConfigValueWithDefaults != kafkaConfigValue
         if (configsAreNotEqual) {
             logger.info(
                 "Configuration for key $recordKey is misaligned on Kafka after applying defaults (Kafka will be updated).\n" +
-                        "DB config value: ${
-                            dbConfigValueWithDefaults.toSafeConfig().root()
-                                .render(ConfigRenderOptions.concise().setFormatted(true))
-                        }\n" +
-                        "Kafka config value: ${
-                            kafkaConfigValue.toSafeConfig().root()
-                                .render(ConfigRenderOptions.concise().setFormatted(true))
-                        }"
+                    "DB config value: ${
+                        dbConfigValueWithDefaults.toSafeConfig().root()
+                            .render(ConfigRenderOptions.concise().setFormatted(true))
+                    }\n" +
+                    "Kafka config value: ${
+                        kafkaConfigValue.toSafeConfig().root()
+                            .render(ConfigRenderOptions.concise().setFormatted(true))
+                    }"
             )
         }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutorImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.flow.service
 
-import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigValueFactory
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.Checkpoint
@@ -85,12 +84,6 @@ class FlowExecutorImpl constructor(
             )
             stateManager?.start()
             multiSourceEventMediator?.start()
-            coordinator.updateStatus(LifecycleStatus.UP)
-        } catch (configEx: ConfigException) {
-            val reason =
-                "Invalid Config, likely schema mismatch, cannot start flow executor at this time, setting status to DOWN awaiting valid Config"
-            log.info(reason, configEx)
-            coordinator.updateStatus(LifecycleStatus.DOWN, reason)
         } catch (ex: Exception) {
             val reason = "Failed to configure the flow executor using '${config}'"
             log.error(reason, ex)
@@ -116,10 +109,7 @@ class FlowExecutorImpl constructor(
         val flowConfig = initialConfigs.getConfig(FLOW_CONFIG)
         val updatedFlowConfig = flowConfig
             .withValue(PROCESSOR_TIMEOUT, ConfigValueFactory.fromAnyRef(messagingConfig.getLong(PROCESSOR_TIMEOUT)))
-            .withValue(
-                MAX_ALLOWED_MSG_SIZE,
-                ConfigValueFactory.fromAnyRef(messagingConfig.getLong(MAX_ALLOWED_MSG_SIZE))
-            )
+            .withValue(MAX_ALLOWED_MSG_SIZE, ConfigValueFactory.fromAnyRef(messagingConfig.getLong(MAX_ALLOWED_MSG_SIZE)))
 
         return initialConfigs.mapValues {
             if (it.key == FLOW_CONFIG) {
@@ -146,7 +136,7 @@ class FlowExecutorImpl constructor(
         }
     }
 
-    private fun SmartConfig.withServiceEndpoints(config: Map<String, SmartConfig>): SmartConfig {
+    private fun SmartConfig.withServiceEndpoints(config: Map<String, SmartConfig>) : SmartConfig {
         val bootConfig = config.getConfig(BOOT_CONFIG)
 
         return listOf(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/service/FlowExecutorImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.flow.service
 
+import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigValueFactory
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.Checkpoint
@@ -84,6 +85,12 @@ class FlowExecutorImpl constructor(
             )
             stateManager?.start()
             multiSourceEventMediator?.start()
+            coordinator.updateStatus(LifecycleStatus.UP)
+        } catch (configEx: ConfigException) {
+            val reason =
+                "Invalid Config, likely schema mismatch, cannot start flow executor at this time, setting status to DOWN awaiting valid Config"
+            log.info(reason, configEx)
+            coordinator.updateStatus(LifecycleStatus.DOWN, reason)
         } catch (ex: Exception) {
             val reason = "Failed to configure the flow executor using '${config}'"
             log.error(reason, ex)
@@ -109,7 +116,10 @@ class FlowExecutorImpl constructor(
         val flowConfig = initialConfigs.getConfig(FLOW_CONFIG)
         val updatedFlowConfig = flowConfig
             .withValue(PROCESSOR_TIMEOUT, ConfigValueFactory.fromAnyRef(messagingConfig.getLong(PROCESSOR_TIMEOUT)))
-            .withValue(MAX_ALLOWED_MSG_SIZE, ConfigValueFactory.fromAnyRef(messagingConfig.getLong(MAX_ALLOWED_MSG_SIZE)))
+            .withValue(
+                MAX_ALLOWED_MSG_SIZE,
+                ConfigValueFactory.fromAnyRef(messagingConfig.getLong(MAX_ALLOWED_MSG_SIZE))
+            )
 
         return initialConfigs.mapValues {
             if (it.key == FLOW_CONFIG) {
@@ -136,7 +146,7 @@ class FlowExecutorImpl constructor(
         }
     }
 
-    private fun SmartConfig.withServiceEndpoints(config: Map<String, SmartConfig>) : SmartConfig {
+    private fun SmartConfig.withServiceEndpoints(config: Map<String, SmartConfig>): SmartConfig {
         val bootConfig = config.getConfig(BOOT_CONFIG)
 
         return listOf(


### PR DESCRIPTION
It is unnecessary to validate the schema from Kafka (this is old Config which is about to be reconciled with the new schema if it is incorrect anyway), and doing so (unexpectedly) adds defaults even though we ask it not to. This breaks the reconciliation check on upgrades as the db worker believes new fields are already published to Kafka when they are not.

A separate JIRA ticket is raised to cover the problem with validate https://r3-cev.atlassian.net/browse/CORE-19186, it's not fixed here because we don't need it and it's much lower priority.