### PR TITLE
CORE-18533: Remove Flow Retry Logic

### DIFF
--- a/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
+++ b/applications/examples/sandbox-app/src/main/kotlin/net/corda/example/vnode/CordaVNode.kt
@@ -22,7 +22,6 @@ import net.corda.osgi.api.Shutdown
 import net.corda.schema.Schemas.Flow.FLOW_START
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.schema.configuration.FlowConfig.PROCESSING_FLOW_CLEANUP_TIME
-import net.corda.schema.configuration.FlowConfig.PROCESSING_MAX_FLOW_SLEEP_DURATION
 import net.corda.schema.configuration.FlowConfig.SESSION_FLOW_CLEANUP_TIME
 import net.corda.schema.configuration.FlowConfig.SESSION_TIMEOUT_WINDOW
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
@@ -88,7 +87,6 @@ class CordaVNode @Activate constructor(
 
             val config = ConfigFactory.empty()
                 .withValue(PROCESSING_FLOW_CLEANUP_TIME, ConfigValueFactory.fromAnyRef(5000L))
-                .withValue(PROCESSING_MAX_FLOW_SLEEP_DURATION, ConfigValueFactory.fromAnyRef(5000L))
                 .withValue(PROCESSOR_TIMEOUT, ConfigValueFactory.fromAnyRef(60000L))
                 .withValue(SESSION_FLOW_CLEANUP_TIME, ConfigValueFactory.fromAnyRef(5000L))
                 .withValue(SESSION_TIMEOUT_WINDOW, ConfigValueFactory.fromAnyRef(500000L))

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/factory/MessageFactoryImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/factory/MessageFactoryImpl.kt
@@ -95,7 +95,7 @@ class MessageFactoryImpl : MessageFactory {
         )
 
         return when (flowStatus.flowStatus) {
-            FlowStates.START_REQUESTED, FlowStates.RUNNING, FlowStates.RETRYING -> ResponseEntity.accepted(
+            FlowStates.START_REQUESTED, FlowStates.RUNNING -> ResponseEntity.accepted(
                 flowResultResponse
             )
 

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -112,7 +112,6 @@ class FlowServiceTestContext @Activate constructor(
         FlowConfig.EXTERNAL_EVENT_MESSAGE_RESEND_WINDOW to 500000,
         FlowConfig.SESSION_TIMEOUT_WINDOW to 500000,
         FlowConfig.SESSION_FLOW_CLEANUP_TIME to 30000,
-        FlowConfig.PROCESSING_MAX_FLOW_SLEEP_DURATION to 60000,
         FlowConfig.PROCESSING_MAX_RETRY_DELAY to 16000,
         FlowConfig.PROCESSING_FLOW_CLEANUP_TIME to 30000,
         FlowConfig.PROCESSING_MAX_RETRY_WINDOW_DURATION to 300000,

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertions.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertions.kt
@@ -72,15 +72,11 @@ interface OutputAssertions {
 
     fun noFlowEvents()
 
-    fun checkpointHasRetry(expectedCount: Int)
-
-    fun checkpointDoesNotHaveRetry()
-
     fun flowStatus(
         state: FlowStates,
         result: String? = null,
         errorType: String? = null,
-        errorMessage:String? = null,
+        errorMessage: String? = null,
         flowTerminatedReason: String? = null
     )
 
@@ -99,4 +95,4 @@ interface OutputAssertions {
     fun flowFiberCacheDoesNotContainKey(holdingId: HoldingIdentity, flowId: String)
 }
 
-inline fun <reified T: Throwable> OutputAssertions.flowResumedWithError() = flowResumedWithError(T::class.java)
+inline fun <reified T : Throwable> OutputAssertions.flowResumedWithError() = flowResumedWithError(T::class.java)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/OutputAssertionsImpl.kt
@@ -279,30 +279,6 @@ class OutputAssertionsImpl(
         }
     }
 
-    override fun checkpointHasRetry(expectedCount: Int) {
-        asserts.add { testRun ->
-            assertThat(testRun.response?.updatedState?.value?.pipelineState?.retryState).isNotNull
-            val retry = testRun.response!!.updatedState!!.value?.pipelineState!!.retryState
-
-            assertThat(retry.retryCount).isEqualTo(expectedCount)
-
-            /** we can't assert the event the second time around as it's a wakeup event (initially)
-             * so the testRun.event, which records the event we send into the system, will not match
-             * the retry.failedEvent as internally the pipeline switches from the wakeup to the event that needs
-             * to be retried.
-             */
-            if (retry.retryCount == 1) {
-                assertThat(retry.failedEvent).isEqualTo(testRun.event.value)
-            }
-        }
-    }
-
-    override fun checkpointDoesNotHaveRetry() {
-        asserts.add { testRun ->
-            assertThat(testRun.response?.updatedState?.value?.pipelineState?.retryState).isNull()
-        }
-    }
-
     override fun flowStatus(state: FlowStates, result: String?, errorType: String?, errorMessage: String?, flowTerminatedReason: String?) {
         asserts.add { testRun ->
             assertNotNull(testRun.response)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowMessageFactory.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/FlowMessageFactory.kt
@@ -27,14 +27,6 @@ interface FlowMessageFactory {
     fun createFlowStartedStatusMessage(checkpoint: FlowCheckpoint): FlowStatus
 
     /**
-     * Creates [FlowStatus] message with a [FlowStates.RETRYING] status
-     *
-     * @param checkpoint of the flow being started.
-     * @return a new instance of a [FlowStatus] record.
-     */
-    fun createFlowRetryingStatusMessage(checkpoint: FlowCheckpoint): FlowStatus
-
-    /**
      * Creates [FlowStatus] message with a [FlowStates.FAILED] status
      *
      * @param checkpoint of the flow that failed.
@@ -48,7 +40,7 @@ interface FlowMessageFactory {
      * Creates [FlowStatus] message with a [FlowStates.KILLED] status.
      *
      * @param checkpoint of the flow
-     * @param details about flow termination
+     * @param message about flow termination
      * @return a new instance of a [FlowStatus] record.
      */
     fun createFlowKilledStatusMessage(checkpoint: FlowCheckpoint, message: String?): FlowStatus

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowMessageFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowMessageFactoryImpl.kt
@@ -34,12 +34,6 @@ class FlowMessageFactoryImpl(private val currentTimeProvider: () -> Instant) : F
         }
     }
 
-    override fun createFlowRetryingStatusMessage(checkpoint: FlowCheckpoint): FlowStatus {
-        return getCommonFlowStatus(checkpoint).apply {
-            flowStatus = FlowStates.RETRYING
-        }
-    }
-
     override fun createFlowFailedStatusMessage(checkpoint: FlowCheckpoint, errorType: String, message: String): FlowStatus {
         return getCommonFlowStatus(checkpoint).apply {
             flowStatus = FlowStates.FAILED

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventExceptionProcessorImpl.kt
@@ -16,15 +16,11 @@ import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.flow.pipeline.sessions.FlowSessionManager
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.libs.configuration.SmartConfig
-import net.corda.libs.configuration.getLongOrDefault
 import net.corda.messaging.api.records.Record
-import net.corda.schema.configuration.FlowConfig.PROCESSING_MAX_RETRY_WINDOW_DURATION
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
-import java.time.Duration
-import java.time.Instant
 
 @Suppress("Unused", "TooManyFunctions")
 @Component(service = [FlowEventExceptionProcessor::class])
@@ -43,15 +39,9 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
 
     private companion object {
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
-        private const val DEFAULT_MAX_RETRY_WINDOW_DURATION_MS = 300000L // 5 minutes
     }
 
-    private var maxRetryWindowDuration = Duration.ZERO
-
     override fun configure(config: SmartConfig) {
-        maxRetryWindowDuration = Duration.ofMillis(
-            config.getLongOrDefault(PROCESSING_MAX_RETRY_WINDOW_DURATION, DEFAULT_MAX_RETRY_WINDOW_DURATION_MS)
-        )
     }
 
     override fun process(throwable: Throwable, context: FlowEventContext<*>): FlowEventContext<*> {
@@ -61,11 +51,6 @@ class FlowEventExceptionProcessorImpl @Activate constructor(
             outputRecords = listOf(),
             sendToDlq = true
         )
-    }
-
-    private fun retryWindowExpired(firstFailureTimestamp: Instant?): Boolean {
-        return firstFailureTimestamp != null &&
-                Duration.between(firstFailureTimestamp, Instant.now()) >= maxRetryWindowDuration
     }
 
     override fun process(

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
@@ -101,10 +101,9 @@ class FlowEventProcessorImpl(
         }
 
         val checkpoint = state?.value
-        val isInRetryState = pipeline.context.checkpoint.inRetryState && checkpoint?.flowState == null
         val flowEventPayload = flowEvent.payload
 
-        if (flowEventPayload is StartFlow && checkpoint != null && !isInRetryState) {
+        if (flowEventPayload is StartFlow && checkpoint != null) {
             log.debug { "Ignoring duplicate '${StartFlow::class.java}'. Checkpoint has already been initialized" }
             return StateAndEventProcessor.Response(
                 state,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
@@ -195,7 +195,7 @@ class FlowEventProcessorImpl(
     ): CordaRuntimeException {
         return FlowFatalException(
             "Execution failed with \"${throwable.message}\" after $retryCount retry attempts in a " +
-                "retry window of $elapsedTime.",
+                "retry window of $elapsedTime milliseconds.",
             throwable
         )
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImpl.kt
@@ -1,16 +1,13 @@
 package net.corda.flow.pipeline.impl
 
-import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.mapper.ScheduleCleanup
-import net.corda.data.flow.output.FlowStatus
 import net.corda.data.flow.state.session.SessionState
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.flow.external.events.impl.ExternalEventManager
 import net.corda.flow.pipeline.FlowGlobalPostProcessor
 import net.corda.flow.pipeline.events.FlowEventContext
 import net.corda.flow.pipeline.exceptions.FlowFatalException
-import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.flow.state.impl.CheckpointMetadataKeys.STATE_META_SESSION_EXPIRY_KEY
 import net.corda.flow.utils.KeyValueStore
@@ -27,6 +24,7 @@ import net.corda.v5.base.types.MemberX500Name
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
@@ -37,8 +35,6 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
     private val externalEventManager: ExternalEventManager,
     @Reference(service = SessionManager::class)
     private val sessionManager: SessionManager,
-    @Reference(service = FlowMessageFactory::class)
-    private val flowMessageFactory: FlowMessageFactory,
     @Reference(service = FlowRecordFactory::class)
     private val flowRecordFactory: FlowRecordFactory,
     @Reference(service = MembershipGroupReaderProvider::class)
@@ -46,7 +42,7 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
 ) : FlowGlobalPostProcessor {
 
     private companion object {
-        val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
+        val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
     override fun postProcess(context: FlowEventContext<Any>): FlowEventContext<Any> {
@@ -55,9 +51,8 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
         postProcessPendingPlatformError(context)
 
         val outputRecords = getSessionEvents(context, now) +
-                getFlowMapperSessionCleanupEvents(context, now) +
-                getExternalEvent(context, now) +
-                postProcessRetries(context)
+            getFlowMapperSessionCleanupEvents(context, now) +
+            getExternalEvent(context, now)
 
         context.flowMetrics.flowEventCompleted(context.inputEvent.payload::class.java.name)
         val metadata = getStateMetadata(context)
@@ -101,7 +96,7 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
         sessionState: SessionState
     ): Boolean {
         if (sessionState.status == SessionStateType.CLOSED || sessionState.status == SessionStateType.ERROR) {
-            //we dont need to verify that a counterparty exists if the session is already terminated.
+            //we don't need to verify that a counterparty exists if the session is already terminated.
             return true
         }
         val checkpoint = context.checkpoint
@@ -111,10 +106,11 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
         val counterpartyExists: Boolean = null != groupReader.lookup(counterparty)
 
         /**
-         * If the counterparty doesn't exist in our network, throw a [FlowPlatformException]
+         * If the counterparty doesn't exist in our network, throw a [FlowFatalException]
          */
         if (!counterpartyExists) {
-            val msg = "[${context.checkpoint.holdingIdentity.x500Name}] has failed to create a flow with counterparty: " +
+            val msg =
+                "[${context.checkpoint.holdingIdentity.x500Name}] has failed to create a flow with counterparty: " +
                     "[${counterparty}] as the recipient doesn't exist in the network."
             sessionManager.errorSession(sessionState)
             if (doesCheckpointExist) {
@@ -176,34 +172,6 @@ class FlowGlobalPostProcessorImpl @Activate constructor(
                     }
                 }
         }
-    }
-
-    private fun postProcessRetries(context: FlowEventContext<Any>): List<Record<FlowKey, FlowStatus>> {
-        /**
-         * When the flow enters a retry state the flow status is updated to "RETRYING", this
-         * needs to be set back when a retry clears, however we only need to do this if the flow
-         * is still running, if it is now complete the status will have been updated already
-         */
-
-        val checkpoint = context.checkpoint
-
-        // The flow was not in a retry state so nothing to do
-        if (!checkpoint.inRetryState) {
-            return listOf()
-        }
-
-        // If we reach the post-processing step with a retry set we
-        // assume whatever the previous retry was it has now cleared
-        log.debug("The Flow was in a retry state that has now cleared.")
-        checkpoint.markRetrySuccess()
-
-        // If the flow has been completed, no need to update the status
-        if (!checkpoint.doesExist) {
-            return listOf()
-        }
-
-        val status = flowMessageFactory.createFlowStartedStatusMessage(checkpoint)
-        return listOf(flowRecordFactory.createFlowStatusRecord(status))
     }
 
     private fun getStateMetadata(context: FlowEventContext<Any>): Metadata? {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointFactoryImpl.kt
@@ -1,13 +1,11 @@
 package net.corda.flow.state.impl
 
-import java.time.Instant
 import net.corda.data.crypto.SecureHash
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.flow.state.checkpoint.PipelineState
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.platform.PlatformInfoProvider
-import net.corda.schema.configuration.FlowConfig
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -19,14 +17,12 @@ class FlowCheckpointFactoryImpl @Activate constructor(
     private val platformInfoProvider: PlatformInfoProvider,
 ) : FlowCheckpointFactory {
     override fun create(flowId: String, checkpoint: Checkpoint?, config: SmartConfig): FlowCheckpoint {
-        val checkpointToUse = checkpoint ?: newCheckpoint(flowId, config)
-        return FlowCheckpointImpl(checkpointToUse, config) { Instant.now() }
+        val checkpointToUse = checkpoint ?: newCheckpoint(flowId)
+        return FlowCheckpointImpl(checkpointToUse, config)
     }
 
-    private fun newCheckpoint(newFlowId: String, config: SmartConfig): Checkpoint {
+    private fun newCheckpoint(newFlowId: String): Checkpoint {
         val newPipelineState = PipelineState.newBuilder().apply {
-            retryState = null
-            maxFlowSleepDuration = config.getInt(FlowConfig.PROCESSING_MAX_FLOW_SLEEP_DURATION)
             pendingPlatformError = null
             cpkFileHashes = emptyList<SecureHash>()
         }.build()

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -7,7 +7,6 @@ import net.corda.data.KeyValuePair
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.flow.state.checkpoint.FlowState
 import net.corda.data.flow.state.external.ExternalEventState
@@ -21,13 +20,11 @@ import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import java.nio.ByteBuffer
-import java.time.Instant
 
 @Suppress("TooManyFunctions")
 class FlowCheckpointImpl(
     private val checkpoint: Checkpoint,
     private val config: SmartConfig,
-    instantProvider: () -> Instant
 ) : FlowCheckpoint {
 
     /**
@@ -50,7 +47,7 @@ class FlowCheckpointImpl(
         val objectMapper = ObjectMapper().registerKotlinModule()
     }
 
-    private val pipelineStateManager = PipelineStateManager(checkpoint.pipelineState, config, instantProvider)
+    private val pipelineStateManager = PipelineStateManager(checkpoint.pipelineState)
     private var flowStateManager = checkpoint.flowState?.let(::FlowStateManager)
     private var nullableFlowStack: FlowStackImpl? = checkpoint.flowState?.let {
         FlowStackImpl(it.flowStackItems)
@@ -60,10 +57,9 @@ class FlowCheckpointImpl(
 
     private val flowInitialisedOnCreation = checkpoint.flowState != null
 
-    // The checkpoint is live if it is not marked deleted and there is either some flow state, or a retry is currently
-    // occurring (for example, if a transient failure has happened while processing a start event).
+    // The checkpoint is live if it is not marked deleted and there is some flow state.
     private val checkpointLive: Boolean
-        get() = !deleted && (flowStateManager != null || inRetryState)
+        get() = !deleted && (flowStateManager != null)
 
     override val flowId: String
         get() = checkpoint.flowId
@@ -127,20 +123,8 @@ class FlowCheckpointImpl(
     override val doesExist: Boolean
         get() = flowStateManager != null && !deleted
 
-    override val currentRetryCount: Int
-        get() = pipelineStateManager.retryCount
-
-    override val firstFailureTimestamp: Instant?
-        get() = pipelineStateManager.firstFailureTimestamp
-
-    override val inRetryState: Boolean
-        get() = pipelineStateManager.retryState != null
-
     override val cpkFileHashes: Set<SecureHash>
         get() = pipelineStateManager.cpkFileHashes
-
-    override val retryEvent: FlowEvent
-        get() = pipelineStateManager.retryEvent
 
     override val pendingPlatformError: ExceptionEnvelope?
         get() = checkpoint.pipelineState.pendingPlatformError
@@ -156,8 +140,8 @@ class FlowCheckpointImpl(
         get() = checkpoint.initialPlatformVersion
 
     override val isCompleted: Boolean
-
         get() = deleted
+
     override val suspendCount: Int
         get() = checkNotNull(flowStateManager)
         { "Attempt to access context before flow state has been created" }.suspendCount
@@ -167,7 +151,7 @@ class FlowCheckpointImpl(
             val key = flowStartContext.statusKey
             throw IllegalStateException(
                 "Found existing checkpoint while starting to start a new flow." +
-                        " Flow ID='${flowId}' FlowKey='${key.id}-${key.identity.x500Name}."
+                    " Flow ID='${flowId}' FlowKey='${key.id}-${key.identity.x500Name}."
             )
         }
 
@@ -224,20 +208,8 @@ class FlowCheckpointImpl(
         }
     }
 
-    override fun markForRetry(flowEvent: FlowEvent, exception: Exception) {
-        pipelineStateManager.retry(flowEvent, exception)
-    }
-
-    override fun markRetrySuccess() {
-        pipelineStateManager.markRetrySuccess()
-    }
-
     override fun clearPendingPlatformError() {
         pipelineStateManager.clearPendingPlatformError()
-    }
-
-    override fun setFlowSleepDuration(sleepTimeMs: Int) {
-        pipelineStateManager.setFlowSleepDuration(sleepTimeMs)
     }
 
     override fun setPendingPlatformError(type: String, message: String) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/PipelineStateManager.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/PipelineStateManager.kt
@@ -3,17 +3,9 @@ package net.corda.flow.state.impl
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.crypto.core.bytes
 import net.corda.data.ExceptionEnvelope
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.PipelineState
-import net.corda.data.flow.state.checkpoint.RetryState
-import net.corda.flow.pipeline.exceptions.FlowProcessingExceptionTypes
-import net.corda.libs.configuration.SmartConfig
-import net.corda.schema.configuration.FlowConfig
 import net.corda.v5.crypto.SecureHash
 import java.nio.ByteBuffer
-import java.time.Instant
-import kotlin.math.min
-import kotlin.math.pow
 
 /**
  * Manages the state of the pipeline while the flow is executing.
@@ -23,57 +15,10 @@ import kotlin.math.pow
  */
 class PipelineStateManager(
     private val state: PipelineState,
-    private val config: SmartConfig,
-    private val instantProvider: () -> Instant
 ) {
-
-    private companion object {
-        private const val RETRY_INITIAL_DELAY_MS = 1000
-    }
-
-    init {
-        // Reset the max sleep time
-        state.maxFlowSleepDuration = config.getInt(FlowConfig.PROCESSING_MAX_FLOW_SLEEP_DURATION)
-    }
 
     val cpkFileHashes: Set<SecureHash>
         get() = state.cpkFileHashes.map { SecureHashImpl(it.algorithm, it.bytes.array()) }.toSet()
-
-    val retryState: RetryState?
-        get() = state.retryState
-
-    val retryEvent: FlowEvent
-        get() = state.retryState?.failedEvent
-            ?: throw IllegalStateException("Attempt to access null retry state. inRetryState must be tested before accessing retry fields")
-
-    val retryCount: Int
-        get() = state.retryState?.retryCount ?: -1
-
-    val firstFailureTimestamp: Instant?
-        get() = state.retryState?.firstFailureTimestamp
-
-    /**
-     * Update the current pipeline state to set a retry of the current event.
-     */
-    fun retry(event: FlowEvent, exception: Exception) {
-        val timestamp = instantProvider()
-        val retryState = state.retryState ?: RetryState().apply {
-            retryCount = 0
-            failedEvent = event
-            firstFailureTimestamp = timestamp
-        }
-        retryState.retryCount++
-        retryState.error = createAvroExceptionEnvelope(exception)
-        retryState.lastFailureTimestamp = timestamp
-        val maxRetrySleepTime = config.getInt(FlowConfig.PROCESSING_MAX_RETRY_DELAY)
-        val sleepTime = (2.0.pow(retryState.retryCount - 1.toDouble())) * RETRY_INITIAL_DELAY_MS
-        setFlowSleepDuration(min(maxRetrySleepTime, sleepTime.toInt()))
-        state.retryState = retryState
-    }
-
-    fun markRetrySuccess() {
-        state.retryState = null
-    }
 
     fun populateCpkFileHashes(cpkFileHashes: Set<SecureHash>) {
         if (state.cpkFileHashes.isNullOrEmpty()) {
@@ -98,18 +43,7 @@ class PipelineStateManager(
         state.pendingPlatformError = null
     }
 
-    fun setFlowSleepDuration(sleepTimeMs: Int) {
-        state.maxFlowSleepDuration = min(sleepTimeMs, state.maxFlowSleepDuration)
-    }
-
     fun toAvro(): PipelineState {
         return state
-    }
-
-    private fun createAvroExceptionEnvelope(exception: Exception): ExceptionEnvelope {
-        return ExceptionEnvelope().apply {
-            errorType = FlowProcessingExceptionTypes.FLOW_TRANSIENT_EXCEPTION
-            errorMessage = exception.message ?: "No exception message provided."
-        }
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventPipelineImplTest.kt
@@ -27,33 +27,29 @@ import org.mockito.kotlin.whenever
 import net.corda.data.flow.state.waiting.Wakeup as WakeUpWaitingFor
 
 class FlowEventPipelineImplTest {
-
+    private val runOrContinueTimeout = 60000L
     private val payload = ExternalEventResponse("foo")
     private val waitingForWakeup = WaitingFor(WakeUpWaitingFor())
-
-    private val RUN_OR_CONTINUE_TIMEOUT = 60000L
-
     private val mockHoldingIdentity = mock<HoldingIdentity>().apply {
         whenever(shortHash).thenReturn(ShortHash.Companion.of("0123456789abc"))
     }
     private val mockFlowId = "flow_id_111"
     private val checkpoint = mock<FlowCheckpoint>().apply {
         whenever(waitingFor).thenReturn(waitingForWakeup)
-        whenever(inRetryState).thenReturn(false)
         whenever(holdingIdentity).thenReturn(mockHoldingIdentity)
         whenever(flowId).thenReturn(mockFlowId)
         whenever(flowStartContext).thenReturn(FlowStartContext().apply {
-            this.flowClassName="f1"
-            this.requestId="r1"
-            this.initiatedBy = net.corda.data.identity.HoldingIdentity(BOB_X500,"group1")
+            this.flowClassName = "f1"
+            this.requestId = "r1"
+            this.initiatedBy = net.corda.data.identity.HoldingIdentity(BOB_X500, "group1")
         })
     }
 
-    private val defaultinputContext = buildFlowEventContext<Any>(checkpoint, payload)
+    private val defaultInputContext = buildFlowEventContext<Any>(checkpoint, payload)
     private val outputContext = buildFlowEventContext<Any>(checkpoint, payload)
 
     private val startFlowEventHandler = mock<FlowEventHandler<Any>>().apply {
-        whenever(preProcess(defaultinputContext)).thenReturn(outputContext)
+        whenever(preProcess(defaultInputContext)).thenReturn(outputContext)
     }
 
     private val externalEventResponseEventHandler = mock<FlowEventHandler<Any>>().apply {
@@ -61,7 +57,7 @@ class FlowEventPipelineImplTest {
     }
 
     private val flowGlobalPostProcessor = mock<FlowGlobalPostProcessor>().apply {
-        whenever(postProcess(defaultinputContext)).thenReturn(outputContext)
+        whenever(postProcess(defaultInputContext)).thenReturn(outputContext)
     }
 
     private val mockFlowExecutionPipelineStage = mock<FlowExecutionPipelineStage>().apply {
@@ -73,11 +69,12 @@ class FlowEventPipelineImplTest {
         whenever(get(any())).thenReturn(virtualNodeInfo)
     }
 
-    private fun buildPipeline(inputContext: FlowEventContext<Any> = defaultinputContext): FlowEventPipelineImpl {
+    private fun buildPipeline(inputContext: FlowEventContext<Any> = defaultInputContext): FlowEventPipelineImpl {
         return FlowEventPipelineImpl(
             mapOf(
                 StartFlow::class.java to startFlowEventHandler,
-                ExternalEventResponse::class.java to externalEventResponseEventHandler),
+                ExternalEventResponse::class.java to externalEventResponseEventHandler
+            ),
             mockFlowExecutionPipelineStage,
             flowGlobalPostProcessor,
             inputContext,
@@ -144,21 +141,21 @@ class FlowEventPipelineImplTest {
     @Test
     fun `execute flow invokes the execute flow pipeline stage`() {
         val pipeline = buildPipeline()
-        pipeline.executeFlow(RUN_OR_CONTINUE_TIMEOUT)
-        verify(mockFlowExecutionPipelineStage).runFlow(eq(defaultinputContext), eq(RUN_OR_CONTINUE_TIMEOUT), any())
+        pipeline.executeFlow(runOrContinueTimeout)
+        verify(mockFlowExecutionPipelineStage).runFlow(eq(defaultInputContext), eq(runOrContinueTimeout), any())
     }
 
     @Test
     fun `globalPostProcessing calls the FlowGlobalPostProcessor when output is set`() {
         val pipeline = buildPipeline()
         assertEquals(outputContext, pipeline.globalPostProcessing().context)
-        verify(flowGlobalPostProcessor).postProcess(defaultinputContext)
+        verify(flowGlobalPostProcessor).postProcess(defaultInputContext)
     }
 
     @Test
     fun `globalPostProcessing calls the FlowGlobalPostProcessor when output is not set`() {
         val pipeline = buildPipeline()
         assertEquals(outputContext, pipeline.globalPostProcessing().context)
-        verify(flowGlobalPostProcessor).postProcess(defaultinputContext)
+        verify(flowGlobalPostProcessor).postProcess(defaultInputContext)
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
@@ -103,12 +103,12 @@ class FlowEventProcessorImplTest {
 
     private val outputResponse = StateAndEventProcessor.Response<Checkpoint>(
         null,
-        listOf(Record("ok","",""))
+        listOf(Record("ok", "", ""))
     )
 
     private val errorResponse = StateAndEventProcessor.Response<Checkpoint>(
         null,
-        listOf(Record("error","",""))
+        listOf(Record("error", "", ""))
     )
 
     private val flowEventPipeline = mock<FlowEventPipeline>().apply {
@@ -277,7 +277,7 @@ class FlowEventProcessorImplTest {
         )
         val killErrorResponse = StateAndEventProcessor.Response<Checkpoint>(
             null,
-            listOf(Record("killError","",""))
+            listOf(Record("killError", "", ""))
         )
         whenever(flowEventPipeline.eventPreProcessing()).thenThrow(error)
         whenever(flowEventExceptionProcessor.process(error, updatedContext)).thenReturn(flowKillErrorContext)
@@ -306,33 +306,7 @@ class FlowEventProcessorImplTest {
 
         assertThat(response).isEqualTo(StateAndEventProcessor.Response(state, emptyList(), false))
         verify(flowMDCService, times(1)).getMDCLogging(anyOrNull(), any(), any())
-        verify(flowEventPipelineFactory, times(1)).create(any(),any(),any(),any(),any(),any())
-    }
-
-    @Test
-    fun `Execute flow pipeline with a checkpoint and start flow event in retry mode with no FlowState`() {
-        val inputEvent = getFlowEventRecord(FlowEvent(flowKey, startFlowEvent))
-        whenever(flowCheckpoint.inRetryState).thenReturn(true)
-        whenever(checkpoint.flowState).thenReturn(null)
-
-        val response = processor.onNext(state, inputEvent)
-
-        assertThat(response).isEqualTo(outputResponse)
-        verify(flowMDCService, times(1)).getMDCLogging(anyOrNull(), any(), any())
-        verify(flowEventPipelineFactory, times(1)).create(any(),any(),any(),any(),any(),any())
-    }
-
-    @Test
-    fun `Execute flow pipeline with a checkpoint and start flow event in retry mode with a FlowState`() {
-        val inputEvent = getFlowEventRecord(FlowEvent(flowKey, startFlowEvent))
-        whenever(flowCheckpoint.inRetryState).thenReturn(true)
-        whenever(checkpoint.flowState).thenReturn(flowState)
-
-        val response = processor.onNext(state, inputEvent)
-
-        assertThat(response).isEqualTo(StateAndEventProcessor.Response(state, emptyList(), false))
-        verify(flowMDCService, times(1)).getMDCLogging(anyOrNull(), any(), any())
-        verify(flowEventPipelineFactory, times(1)).create(any(),any(),any(),any(),any(),any())
+        verify(flowEventPipelineFactory, times(1)).create(any(), any(), any(), any(), any(), any())
     }
 
     @Test
@@ -349,19 +323,19 @@ class FlowEventProcessorImplTest {
     fun `Flow event postprocessing handlers are called`() {
         val inputEvent = getFlowEventRecord(FlowEvent(flowKey, sessionInitFlowEvent))
 
-        val record1 = Record("1","","")
-        val record2 = Record("2","","")
-        val record3 = Record("3","","")
+        val record1 = Record("1", "", "")
+        val record2 = Record("2", "", "")
+        val record3 = Record("3", "", "")
 
-        whenever(flowPostProcessingHandler1.postProcess(updatedContext)).thenReturn(listOf(record1,record2))
+        whenever(flowPostProcessingHandler1.postProcess(updatedContext)).thenReturn(listOf(record1, record2))
         whenever(flowPostProcessingHandler2.postProcess(updatedContext)).thenReturn(listOf(record3))
 
         val expectedContext = updatedContext.copy(
-            outputRecords = updatedContext.outputRecords + listOf(record1,record2,record3)
+            outputRecords = updatedContext.outputRecords + listOf(record1, record2, record3)
         )
         val responseWithPostProcessingRecords = StateAndEventProcessor.Response<Checkpoint>(
             null,
-            listOf(Record("postprocessing","",""))
+            listOf(Record("postprocessing", "", ""))
         )
 
         whenever(flowEventContextConverter.convert(eq(expectedContext))).thenReturn(responseWithPostProcessingRecords)
@@ -375,18 +349,18 @@ class FlowEventProcessorImplTest {
     fun `Flow event postprocessing handler errors don't prevent output`() {
         val inputEvent = getFlowEventRecord(FlowEvent(flowKey, sessionInitFlowEvent))
 
-        val record1 = Record("1","","")
-        val record2 = Record("2","","")
+        val record1 = Record("1", "", "")
+        val record2 = Record("2", "", "")
 
-        whenever(flowPostProcessingHandler1.postProcess(updatedContext)).thenReturn(listOf(record1,record2))
+        whenever(flowPostProcessingHandler1.postProcess(updatedContext)).thenReturn(listOf(record1, record2))
         whenever(flowPostProcessingHandler2.postProcess(updatedContext)).thenThrow(IllegalArgumentException("error"))
 
         val expectedContext = updatedContext.copy(
-            outputRecords = updatedContext.outputRecords + listOf(record1,record2)
+            outputRecords = updatedContext.outputRecords + listOf(record1, record2)
         )
         val responseWithPostProcessingRecords = StateAndEventProcessor.Response<Checkpoint>(
             null,
-            listOf(Record("postprocessing","",""))
+            listOf(Record("postprocessing", "", ""))
         )
 
         whenever(flowEventContextConverter.convert(eq(expectedContext))).thenReturn(responseWithPostProcessingRecords)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowGlobalPostProcessorImplTest.kt
@@ -16,7 +16,6 @@ import net.corda.flow.FLOW_ID_1
 import net.corda.flow.REQUEST_ID_1
 import net.corda.flow.external.events.impl.ExternalEventManager
 import net.corda.flow.pipeline.exceptions.FlowFatalException
-import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.state.impl.CheckpointMetadataKeys.STATE_META_SESSION_EXPIRY_KEY
@@ -103,13 +102,11 @@ class FlowGlobalPostProcessorImplTest {
     private val flowRecordFactory = mock<FlowRecordFactory>()
     private val membershipGroupReaderProvider = mock<MembershipGroupReaderProvider>()
     private val membershipGroupReader = mock<MembershipGroupReader>()
-    private val flowMessageFactory = mock<FlowMessageFactory>()
     private val checkpoint = mock<FlowCheckpoint>()
     private val testContext = buildFlowEventContext(checkpoint, Any())
     private val flowGlobalPostProcessor = FlowGlobalPostProcessorImpl(
         externalEventManager,
         sessionManager,
-        flowMessageFactory,
         flowRecordFactory,
         membershipGroupReaderProvider
     )

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.25-beta+
+cordaApiVersion=5.2.0.2024-alpha-1704377348399
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.2024-alpha-1704377348399
+cordaApiVersion=5.2.0.26-alpha-1704456583598
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,7 +44,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.26-alpha-1704456583598
+cordaApiVersion=5.2.0.26-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
@@ -3,7 +3,6 @@ package net.corda.flow.state
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.FlowStartContext
-import net.corda.data.flow.event.FlowEvent
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.flow.state.external.ExternalEventState
 import net.corda.data.flow.state.session.SessionState
@@ -12,7 +11,6 @@ import net.corda.serialization.checkpoint.NonSerializable
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
 import java.nio.ByteBuffer
-import java.time.Instant
 
 /**
  * The FlowCheckpoint provides an API for managing the checkpoint during the processing of a flow.
@@ -43,14 +41,6 @@ interface FlowCheckpoint : NonSerializable {
 
     val doesExist: Boolean
 
-    val currentRetryCount: Int
-
-    val firstFailureTimestamp: Instant?
-
-    val inRetryState: Boolean
-
-    val retryEvent: FlowEvent
-
     val pendingPlatformError: ExceptionEnvelope?
 
     val flowContext: FlowContext
@@ -75,13 +65,7 @@ interface FlowCheckpoint : NonSerializable {
 
     fun rollback()
 
-    fun markForRetry(flowEvent: FlowEvent, exception: Exception)
-
-    fun markRetrySuccess()
-
     fun clearPendingPlatformError()
-
-    fun setFlowSleepDuration(sleepTimeMs: Int)
 
     fun setPendingPlatformError(type: String, message: String)
 


### PR DESCRIPTION
As the flow engine has been updated to automatically retry transient
exceptions at source, remove retry related logic from the flow
checkpoint and relevant handlers.

API Change: https://github.com/corda/corda-api/pull/1429