### PR TITLE
CORE-19130: Avoid sending to the null endpoint

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/MessageConverter.kt
@@ -61,21 +61,30 @@ internal class MessageConverter(
             source: HoldingIdentity,
             dest: MemberInfo,
             networkType: NetworkType
-        ): LinkOutMessage {
-            val header = generateLinkOutHeaderFromPeer(source, dest, networkType)
-            return LinkOutMessage(header, payload)
+        ): LinkOutMessage? {
+            return generateLinkOutHeaderFromPeer(source, dest, networkType)?.let { header ->
+                LinkOutMessage(header, payload)
+            }
         }
 
         private fun generateLinkOutHeaderFromPeer(
             source: HoldingIdentity,
             peer: MemberInfo,
             networkType: NetworkType
-        ): LinkOutHeader {
+        ): LinkOutHeader? {
             val endPoint = peer.endpoints
                 .filter {
                     it.protocolVersion == ProtocolConstants.PROTOCOL_VERSION
                 }.shuffled().firstOrNull()
                 ?.url
+            if (endPoint == null) {
+                val availableEndpoints = peer.endpoints.map {
+                    "${it.url} with version ${it.protocolVersion}"
+                }.joinToString()
+                logger.warn("Could not find any valid endpoint to send a message to ${peer.name}." +
+                        " It has $availableEndpoints while we need ${ProtocolConstants.PROTOCOL_VERSION}.")
+                return null
+            }
             return LinkOutHeader(
                 peer.holdingIdentity.toAvro(),
                 source.toAvro(),
@@ -188,7 +197,7 @@ internal class MessageConverter(
             source: HoldingIdentity,
             destMemberInfo: MemberInfo,
             networkType: NetworkType,
-        ): LinkOutMessage {
+        ): LinkOutMessage? {
             return createLinkOutMessage(
                 message,
                 source,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/InMemorySessionReplayer.kt
@@ -161,7 +161,7 @@ internal class InMemorySessionReplayer(
             messageReplay.sessionCounterparties.ourId,
             destinationMemberInfo,
             networkType
-        )
+        ) ?: return
         logger.debug { "Replaying session message ${message.payload.javaClass} for session ${messageReplay.sessionId}." }
         publisher.publish(listOf(Record(LINK_OUT_TOPIC, LinkManager.generateKey(), message)))
         messageReplay.sentSessionMessageCallback(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -614,18 +614,17 @@ internal class SessionManagerImpl(
             )
             return emptyList()
         }
-
-        val linkOutMessages = mutableListOf<Pair<String, LinkOutMessage>>()
-        for (message in messages) {
-            heartbeatManager.sessionMessageSent(sessionCounterparties, message.first.sessionId)
-            linkOutMessages.add(
-                Pair(
-                    message.first.sessionId,
-                    createLinkOutMessage(message.second, sessionCounterparties.ourId, responderMemberInfo, p2pParams.networkType)
-                )
-            )
+        return messages.mapNotNull { message ->
+            createLinkOutMessage(
+                message.second,
+                sessionCounterparties.ourId,
+                responderMemberInfo,
+                p2pParams.networkType
+            )?.let {
+                heartbeatManager.sessionMessageSent(sessionCounterparties, message.first.sessionId)
+                message.first.sessionId to it
+            }
         }
-        return linkOutMessages
     }
 
     private fun ByteArray.toBase64(): String {

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/MessageConverterTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/common/MessageConverterTest.kt
@@ -4,12 +4,14 @@ import net.corda.data.p2p.AuthenticatedMessageAck
 import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.MessageAck
+import net.corda.data.p2p.NetworkType
 import net.corda.data.p2p.app.AuthenticatedMessage
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
 import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.data.p2p.crypto.AuthenticatedDataMessage
 import net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage
 import net.corda.data.p2p.crypto.CommonHeader
+import net.corda.data.p2p.crypto.InitiatorHandshakeMessage
 import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.data.p2p.markers.LinkManagerSentMarker
 import net.corda.p2p.crypto.protocol.api.AuthenticatedEncryptionSession
@@ -34,11 +36,19 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import java.nio.ByteBuffer
 import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.lib.MemberInfoExtension
+import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
+import net.corda.p2p.crypto.protocol.ProtocolConstants.Companion.PROTOCOL_VERSION
+import net.corda.p2p.linkmanager.common.MessageConverter.Companion.createLinkOutMessage
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.p2p.linkmanager.utilities.mockMembersAndGroups
 import net.corda.schema.Schemas
 import net.corda.test.util.time.MockTimeFacilitiesProvider
+import net.corda.v5.base.types.MemberX500Name
+import net.corda.v5.membership.EndpointInfo
+import net.corda.v5.membership.MemberContext
+import net.corda.v5.membership.MemberInfo
 import org.junit.jupiter.api.Nested
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -228,6 +238,65 @@ class MessageConverterTest {
             "Could not find the group info in the GroupPolicyProvider for our identity = $us." +
                     " The message was discarded."
         )
+    }
+
+    @Test
+    fun `createLinkOutMessage will fail if the peer has no valid endpoints`(){
+        val payload = mock<InitiatorHandshakeMessage>()
+        val groupId = "groupId"
+        val source = createTestHoldingIdentity("CN=Source, O=R3, L=LDN, C=GB", groupId)
+        val endpointsList = (6.. 8).map {  version ->
+            mock<EndpointInfo> {
+                on { protocolVersion } doReturn version
+            }
+        }
+        val memberContext = mock<MemberContext> {
+            on { parseList(ENDPOINTS, EndpointInfo::class.java) } doReturn endpointsList
+        }
+        val destination = mock<MemberInfo> {
+            on { memberProvidedContext } doReturn memberContext
+        }
+        val networkType = NetworkType.CORDA_5
+
+        val message = createLinkOutMessage(
+            payload,
+            source,
+            destination,
+            networkType
+        )
+
+        assertThat(message).isNull()
+    }
+
+    @Test
+    fun `createLinkOutMessage will choose the correct endpoint`(){
+        val payload = mock<InitiatorHandshakeMessage>()
+        val groupId = "groupId"
+        val source = createTestHoldingIdentity("CN=Source, O=R3, L=LDN, C=GB", groupId)
+        val endpointsList = ((PROTOCOL_VERSION - 3).. (PROTOCOL_VERSION + 3)).map {  version ->
+            mock<EndpointInfo> {
+                on { protocolVersion } doReturn version
+                on { url } doReturn "https://www.r3.com:8080/$version"
+            }
+        }
+        val memberContext = mock<MemberContext> {
+            on { parseList(ENDPOINTS, EndpointInfo::class.java) } doReturn endpointsList
+            on { parse(MemberInfoExtension.GROUP_ID, String::class.java) } doReturn groupId
+        }
+        val destination = mock<MemberInfo> {
+            on { memberProvidedContext } doReturn memberContext
+            on { name } doReturn MemberX500Name.parse("CN=Destination, O=R3, L=LDN, C=GB")
+        }
+        val networkType = NetworkType.CORDA_5
+
+        val message = createLinkOutMessage(
+            payload,
+            source,
+            destination,
+            networkType
+        )
+
+        assertThat(message?.header?.address).isEqualTo("https://www.r3.com:8080/$PROTOCOL_VERSION")
     }
 
     @Nested


### PR DESCRIPTION
Trying to post a link-out message with null in the address will crash the producer and make the link manager unstable.

This case will be avoided by only sending something if we can find the correct address.

Tests run on https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-e2e-tests-multi-cluster-tests/detail/release%2F5.2/139/tests (The test that failed is the one trying to set the protocol version to 2)