### PR TITLE
CORE-1902: Make the group parameters reconciler thread safe

### DIFF
--- a/components/membership/group-params-writer-service-impl/src/main/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceImpl.kt
+++ b/components/membership/group-params-writer-service-impl/src/main/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceImpl.kt
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 @Component(service = [GroupParametersWriterService::class])
@@ -45,6 +46,7 @@ class GroupParametersWriterServiceImpl @Activate constructor(
     private companion object {
         val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         const val SERVICE = "GroupParametersWriterService"
+        val idIndex = AtomicInteger()
     }
 
     override val lifecycleCoordinatorName = LifecycleCoordinatorName.forComponent<GroupParametersWriterService>()
@@ -188,7 +190,7 @@ class GroupParametersWriterServiceImpl @Activate constructor(
         logger.info("Handling config changed event.")
 
         val publisher = publisherFactory.createPublisher(
-            PublisherConfig("group-parameters-writer-service"),
+            PublisherConfig("group-parameters-writer-service-${idIndex.incrementAndGet()}"),
             event.config.getConfig(MESSAGING_CONFIG)
         ).also {
             it.start()

--- a/components/membership/group-params-writer-service-impl/src/main/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceImpl.kt
+++ b/components/membership/group-params-writer-service-impl/src/main/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceImpl.kt
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
+import java.util.concurrent.atomic.AtomicReference
 
 @Component(service = [GroupParametersWriterService::class])
 class GroupParametersWriterServiceImpl @Activate constructor(
@@ -49,7 +50,7 @@ class GroupParametersWriterServiceImpl @Activate constructor(
     override val lifecycleCoordinatorName = LifecycleCoordinatorName.forComponent<GroupParametersWriterService>()
     private val coordinator = coordinatorFactory.createCoordinator(lifecycleCoordinatorName, ::handleEvent)
 
-    private var impl: InnerGroupParametersWriterService = InactiveImpl
+    private var impl: AtomicReference<InnerGroupParametersWriterService> = AtomicReference(InactiveImpl)
 
     override val isRunning: Boolean
         get() = coordinator.isRunning
@@ -65,22 +66,15 @@ class GroupParametersWriterServiceImpl @Activate constructor(
     }
 
     override fun put(recordKey: HoldingIdentity, recordValue: InternalGroupParameters) =
-        impl.put(recordKey, recordValue)
+        impl.get().put(recordKey, recordValue)
 
-    override fun remove(recordKey: HoldingIdentity) = impl.remove(recordKey)
+    override fun remove(recordKey: HoldingIdentity) = impl.get().remove(recordKey)
 
     // for watching the dependencies
     private var dependencyHandle: RegistrationHandle? = null
 
     // for watching the config changes
     private var configHandle: AutoCloseable? = null
-    private var _publisher: Publisher? = null
-
-    /**
-     * Publisher for Kafka messaging. Recreated after every [MESSAGING_CONFIG] change.
-     */
-    private val publisher: Publisher
-        get() = _publisher ?: throw IllegalArgumentException("Publisher is not initialized.")
 
     /**
      * Private interface used for implementation swapping in response to lifecycle events.
@@ -102,7 +96,9 @@ class GroupParametersWriterServiceImpl @Activate constructor(
 
     }
 
-    private inner class ActiveImpl : InnerGroupParametersWriterService {
+    private inner class ActiveImpl(
+        private val publisher: Publisher
+    ) : InnerGroupParametersWriterService {
         override fun put(recordKey: HoldingIdentity, recordValue: InternalGroupParameters) {
             publisher.publish(
                 listOf(
@@ -121,15 +117,21 @@ class GroupParametersWriterServiceImpl @Activate constructor(
         override fun close() = publisher.close()
     }
 
-    private fun activate(coordinator: LifecycleCoordinator) {
-        impl = ActiveImpl()
+    private fun activate(
+        coordinator: LifecycleCoordinator,
+        publisher: Publisher,
+    ) {
+        impl.getAndSet(
+            ActiveImpl(publisher)
+        ).close()
         coordinator.updateStatus(LifecycleStatus.UP)
     }
 
     private fun deactivate(coordinator: LifecycleCoordinator) {
         coordinator.updateStatus(LifecycleStatus.DOWN)
-        impl.close()
-        impl = InactiveImpl
+        impl
+            .getAndSet(InactiveImpl)
+            .close()
     }
 
     private fun handleEvent(event: LifecycleEvent, coordinator: LifecycleCoordinator) {
@@ -159,8 +161,6 @@ class GroupParametersWriterServiceImpl @Activate constructor(
         dependencyHandle = null
         configHandle?.close()
         configHandle = null
-        _publisher?.close()
-        _publisher = null
     }
 
     private fun handleRegistrationChangeEvent(
@@ -186,11 +186,13 @@ class GroupParametersWriterServiceImpl @Activate constructor(
 
     private fun handleConfigChange(event: ConfigChangedEvent) {
         logger.info("Handling config changed event.")
-        _publisher?.close()
-        _publisher = publisherFactory.createPublisher(
+
+        val publisher = publisherFactory.createPublisher(
             PublisherConfig("group-parameters-writer-service"),
             event.config.getConfig(MESSAGING_CONFIG)
-        ).also { it.start() }
-        activate(coordinator)
+        ).also {
+            it.start()
+        }
+        activate(coordinator, publisher)
     }
 }

--- a/components/membership/group-params-writer-service-impl/src/test/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceTest.kt
+++ b/components/membership/group-params-writer-service-impl/src/test/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceTest.kt
@@ -235,7 +235,7 @@ class GroupParametersWriterServiceTest {
             verify(coordinator, times(2)).updateStatus(eq(LifecycleStatus.UP), any())
 
             postStopEvent()
-            verify(mockPublisher, times(3)).close()
+            verify(mockPublisher, times(2)).close()
         }
 
         @Test

--- a/components/membership/group-params-writer-service-impl/src/test/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceTest.kt
+++ b/components/membership/group-params-writer-service-impl/src/test/kotlin/net/corda/membership/groupparams/writer/service/impl/GroupParametersWriterServiceTest.kt
@@ -222,7 +222,7 @@ class GroupParametersWriterServiceTest {
             verify(coordinator).updateStatus(eq(LifecycleStatus.UP), any())
 
             with(configCaptor.firstValue) {
-                assertThat(clientId).isEqualTo("group-parameters-writer-service")
+                assertThat(clientId).startsWith("group-parameters-writer-service")
             }
 
             postConfigChangedEvent()


### PR DESCRIPTION
The group parameters reconciler is not thread-safe; when we get a configuration update message, we will close the current publisher before activating the new one. This should fix it. 