### PR TITLE
CORE-18648: Validate DB schema at Virtual Node creation time

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
@@ -42,4 +42,14 @@ internal interface VirtualNodeDb {
      * @param migrationTagToApply
      */
     fun runCpiMigrations(dbChange: DbChange, migrationTagToApply: String)
+
+    /**
+     * Returns true if all DB migrations have been applied, false otherwise.
+     */
+    fun checkDbMigrationsArePresent(): Boolean
+
+    /**
+     * Returns true if all DB migrations have been applied, false otherwise.
+     */
+    fun checkCpiMigrationsArePresent(dbChange: DbChange): Boolean
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDb.kt
@@ -45,11 +45,15 @@ internal interface VirtualNodeDb {
 
     /**
      * Returns true if all DB migrations have been applied, false otherwise.
+     *
+     * Checks the platform DB schema matching the dbType field.
      */
     fun checkDbMigrationsArePresent(): Boolean
 
     /**
      * Returns true if all DB migrations have been applied, false otherwise.
+     *
+     * @param dbChange holds the DB schema resources read from the CPI
      */
     fun checkCpiMigrationsArePresent(dbChange: DbChange): Boolean
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
@@ -116,8 +116,8 @@ internal class VirtualNodeDbImpl(
     }
 
     override fun checkDbMigrationsArePresent(): Boolean {
-        val dbConnection = dbConnections[DDL]
-            ?: throw VirtualNodeDbException("No DDL database connection when due to apply system migrations")
+        val dbConnection = dbConnections[DML]
+            ?: throw VirtualNodeDbException("No DML database connection when due to check system migrations")
         return dbConnectionManager.getDataSource(dbConnection.config).use { dataSource ->
             val dbChangeFiles = dbType.dbChangeFiles
             val changeLogResourceFiles = setOf(DbSchema::class.java).mapTo(LinkedHashSet()) { klass ->
@@ -132,8 +132,8 @@ internal class VirtualNodeDbImpl(
     }
 
     override fun checkCpiMigrationsArePresent(dbChange: DbChange): Boolean {
-        val dbConnection = dbConnections[DDL]
-            ?: throw VirtualNodeDbException("No DDL database connection when due to apply CPI migrations")
+        val dbConnection = dbConnections[DML]
+            ?: throw VirtualNodeDbException("No DML database connection when due to check CPI migrations")
         return dbConnectionManager.getDataSource(dbConnection.config).use { dataSource ->
             dataSource.connection.use { connection ->
                 schemaMigrator.listUnrunChangeSets(connection, dbChange).isEmpty()

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
@@ -114,4 +114,30 @@ internal class VirtualNodeDbImpl(
             }
         }
     }
+
+    override fun checkDbMigrationsArePresent(): Boolean {
+        val dbConnection = dbConnections[DDL]
+            ?: throw VirtualNodeDbException("No DDL database connection when due to apply system migrations")
+        return dbConnectionManager.getDataSource(dbConnection.config).use { dataSource ->
+            val dbChangeFiles = dbType.dbChangeFiles
+            val changeLogResourceFiles = setOf(DbSchema::class.java).mapTo(LinkedHashSet()) { klass ->
+                ClassloaderChangeLog.ChangeLogResourceFiles(klass.packageName, dbChangeFiles, klass.classLoader)
+            }
+            val dbChange = ClassloaderChangeLog(changeLogResourceFiles)
+
+            dataSource.connection.use { connection ->
+                schemaMigrator.listUnrunChangeSets(connection, dbChange).isEmpty()
+            }
+        }
+    }
+
+    override fun checkCpiMigrationsArePresent(dbChange: DbChange): Boolean {
+        val dbConnection = dbConnections[DDL]
+            ?: throw VirtualNodeDbException("No DDL database connection when due to apply CPI migrations")
+        return dbConnectionManager.getDataSource(dbConnection.config).use { dataSource ->
+            dataSource.connection.use { connection ->
+                schemaMigrator.listUnrunChangeSets(connection, dbChange).isEmpty()
+            }
+        }
+    }
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
@@ -2,6 +2,7 @@ package net.corda.virtualnode.write.db.impl.writer.asyncoperation.handlers
 
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
 import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.core.DbPrivilege.DML
 import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGenerator
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
@@ -159,7 +160,7 @@ internal class CreateVirtualNodeOperationHandler(
     ) {
         // Select externally managed VNode DBs
         val dbaManagedDbs = vNodeDbs.filterNot {
-            it.isPlatformManagedDb || it.ddlConnectionProvided
+            it.isPlatformManagedDb || it.ddlConnectionProvided || it.dbConnections[DML] == null
         }
 
         // Are any platform schemas missing?

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/CreateVirtualNodeOperationHandler.kt
@@ -3,10 +3,14 @@ package net.corda.virtualnode.write.db.impl.writer.asyncoperation.handlers
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
 import net.corda.db.connection.manager.VirtualNodeDbType
 import net.corda.libs.external.messaging.ExternalMessagingRouteConfigGenerator
+import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
 import net.corda.messaging.api.publisher.Publisher
+import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toCorda
+import net.corda.virtualnode.write.db.VirtualNodeWriteServiceException
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeConnectionStrings
+import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDb
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDbFactory
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeWriterProcessor
 import net.corda.virtualnode.write.db.impl.writer.asyncoperation.VirtualNodeAsyncOperationHandler
@@ -95,6 +99,8 @@ internal class CreateVirtualNodeOperationHandler(
                 }
             }
 
+            checkSchemasArePresentOnExternalDbs(vNodeDbs.values, cpiMetadata, holdingId)
+
             val externalMessagingRouteConfig = externalMessagingRouteConfigGenerator.generateNewConfig(
                 holdingId,
                 cpiMetadata.cpiId,
@@ -144,5 +150,33 @@ internal class CreateVirtualNodeOperationHandler(
         }
 
         publishProcessingCompletedStatus(requestId)
+    }
+
+    private fun checkSchemasArePresentOnExternalDbs(
+        vNodeDbs: Collection<VirtualNodeDb>,
+        cpiMetadata: CpiMetadata,
+        holdingId: HoldingIdentity
+    ) {
+        // Select externally managed VNode DBs
+        val dbaManagedDbs = vNodeDbs.filterNot {
+            it.isPlatformManagedDb || it.ddlConnectionProvided
+        }
+
+        // Are any platform schemas missing?
+        val missingPlatformSchemas = dbaManagedDbs.filterNot { it.checkDbMigrationsArePresent() }
+            .map { it.dbType.toString() }
+
+        // Are any CPI schemas missing?
+        val missingCpiSchemas = dbaManagedDbs.filter { it.dbType == VirtualNodeDbType.VAULT }
+            .filterNot { createVirtualNodeService.checkCpiMigrations(cpiMetadata, it, holdingId) }
+            .map { cpiMetadata.cpiId.name }
+
+        // If any schemas are missing, throw exception listing them
+        val allMissingSchemas = missingPlatformSchemas + missingCpiSchemas
+        if (allMissingSchemas.any()) {
+            throw VirtualNodeWriteServiceException(
+                "DB schemas missing from external DB: ${allMissingSchemas.joinToString(",")}"
+            )
+        }
     }
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeService.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeService.kt
@@ -18,6 +18,7 @@ internal interface CreateVirtualNodeService {
     fun getCpiMetaData(cpiFileChecksum: String): CpiMetadata
 
     fun runCpiMigrations(cpiMetadata: CpiMetadata, vaultDb: VirtualNodeDb, holdingIdentity: HoldingIdentity)
+    fun checkCpiMigrations(cpiMetadata: CpiMetadata, vaultDb: VirtualNodeDb, holdingIdentity: HoldingIdentity): Boolean
 
     fun persistHoldingIdAndVirtualNode(
         holdingIdentity: HoldingIdentity,

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/services/CreateVirtualNodeServiceImpl.kt
@@ -118,7 +118,7 @@ internal class CreateVirtualNodeServiceImpl(
         vaultDb: VirtualNodeDb,
         holdingIdentity: HoldingIdentity
     ): Boolean {
-        dbConnectionManager.getClusterEntityManagerFactory().createEntityManager().transaction { em ->
+        dbConnectionManager.getClusterEntityManagerFactory().createEntityManager().use { em ->
 
             val changelogsPerCpk = cpkDbChangeLogRepository.findByCpiId(em, cpiMetadata.cpiId)
                 .groupBy { it.id.cpkFileChecksum }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/ExampleData.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/ExampleData.kt
@@ -12,6 +12,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.write.db.impl.writer.DbConnection
 import net.corda.virtualnode.write.db.impl.writer.VirtualNodeDb
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.Instant
@@ -67,6 +68,8 @@ internal fun getVNodeDb(
                 DbPrivilege.DML to dmlConnection,
             )
         )
+        whenever(this.checkDbMigrationsArePresent()).thenReturn(true)
+        whenever(this.checkCpiMigrationsArePresent(any())).thenReturn(true)
     }
 }
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -31,6 +31,7 @@ class VirtualNodeDbImplTest {
     private val ddlUuser = "ddluser"
     private val dmlUuser = "dmluser"
     private val ddlConfig = mock<SmartConfig>()
+    private val dmlConfig = mock<SmartConfig>()
     private val holdingIdShortHash = ShortHash.of("AAAAAAAAAAAA")
     private val dbType = VirtualNodeDbType.VAULT
     private val schema = dbType.getSchemaName(holdingIdShortHash)
@@ -49,6 +50,7 @@ class VirtualNodeDbImplTest {
         whenever(privilege).thenReturn(DbPrivilege.DML)
         whenever(getUser()).thenReturn(dmlUuser)
         whenever(getPassword()).thenReturn(password)
+        whenever(config).thenReturn(dmlConfig)
     }
 
     @Test
@@ -178,7 +180,7 @@ class VirtualNodeDbImplTest {
             whenever(connection).thenReturn(sqlConnection)
         }
 
-        whenever(dbConnectionManager.getDataSource(ddlConfig)).thenReturn(dataSource)
+        whenever(dbConnectionManager.getDataSource(dmlConfig)).thenReturn(dataSource)
         whenever(schemaMigrator.listUnrunChangeSets(sqlConnection, dbChange)).thenReturn(listOf("Missing Changeset"))
 
         val target = createVirtualNodeDb(isPlatformManagedDb = false)
@@ -193,7 +195,7 @@ class VirtualNodeDbImplTest {
             whenever(connection).thenReturn(sqlConnection)
         }
 
-        whenever(dbConnectionManager.getDataSource(ddlConfig)).thenReturn(dataSource)
+        whenever(dbConnectionManager.getDataSource(dmlConfig)).thenReturn(dataSource)
         whenever(schemaMigrator.listUnrunChangeSets(sqlConnection, dbChange)).thenReturn(emptyList())
 
         val target = createVirtualNodeDb(isPlatformManagedDb = false)
@@ -207,7 +209,7 @@ class VirtualNodeDbImplTest {
             whenever(connection).thenReturn(sqlConnection)
         }
 
-        whenever(dbConnectionManager.getDataSource(ddlConfig)).thenReturn(dataSource)
+        whenever(dbConnectionManager.getDataSource(dmlConfig)).thenReturn(dataSource)
         whenever(schemaMigrator.listUnrunChangeSets(eq(sqlConnection), any())).thenReturn(listOf("Missing Changeset"))
 
         val target = createVirtualNodeDb(isPlatformManagedDb = false)
@@ -221,7 +223,7 @@ class VirtualNodeDbImplTest {
             whenever(connection).thenReturn(sqlConnection)
         }
 
-        whenever(dbConnectionManager.getDataSource(ddlConfig)).thenReturn(dataSource)
+        whenever(dbConnectionManager.getDataSource(dmlConfig)).thenReturn(dataSource)
         whenever(schemaMigrator.listUnrunChangeSets(eq(sqlConnection), any())).thenReturn(emptyList())
 
         val target = createVirtualNodeDb(isPlatformManagedDb = false)

--- a/libs/db/db-admin-impl/src/main/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImpl.kt
+++ b/libs/db/db-admin-impl/src/main/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImpl.kt
@@ -82,7 +82,7 @@ class LiquibaseSchemaMigratorImpl(
                 database
             )
 
-            return liquibase.listUnrunChangeSets(Contexts(), LabelExpression()).map { it.filePath }
+            return liquibase.listUnrunChangeSets(Contexts(), LabelExpression(), false).map { it.filePath }
         }
     }
 

--- a/libs/db/db-admin-impl/src/test/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorTest.kt
+++ b/libs/db/db-admin-impl/src/test/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorTest.kt
@@ -82,6 +82,6 @@ class LiquibaseSchemaMigratorTest {
     @Test
     fun `when listUnrunChangeSets call liquibase API` (){
         migrator.listUnrunChangeSets(connection, dbChange)
-        verify(lb).listUnrunChangeSets(any<Contexts>(), any())
+        verify(lb).listUnrunChangeSets(any<Contexts>(), any(), eq(false))
     }
 }


### PR DESCRIPTION
Check that DB schemas already exist on external DB when creating Virtual Node using external DB connection strings.