### PR TITLE
CORE-18706 - Fixed external messaging

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
@@ -6,7 +6,6 @@ import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_KEY
-import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_TOPIC
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.mediator.metrics.EventMediatorMetrics

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
@@ -167,7 +167,7 @@ internal class TaskManagerHelper<K : Any, S : Any, E : Any>(
     private fun Record<*, *>.toMessage() =
         MediatorMessage(
             value!!,
-            headers.toMessageProperties().also { it[MSG_PROP_KEY] = key },
+            headers.toMessageProperties().also { it[MSG_PROP_KEY] = key }
         )
 
     private fun List<Pair<String, String>>.toMessageProperties() =

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/TaskManagerHelper.kt
@@ -133,10 +133,6 @@ internal class TaskManagerHelper<K : Any, S : Any, E : Any>(
         }
     }
 
-    fun convertToMessage(record: Record<*, *>): MediatorMessage<Any> {
-        return record.toMessage()
-    }
-
     /**
      * Executes given [ClientTask]s and waits for all to finish.
      *
@@ -171,15 +167,7 @@ internal class TaskManagerHelper<K : Any, S : Any, E : Any>(
     private fun Record<*, *>.toMessage() =
         MediatorMessage(
             value!!,
-            headers
-                .toMessageProperties()
-                .also { properties ->
-                    properties[MSG_PROP_KEY] = key;
-
-                    if(topic != null && topic!!.isNotEmpty()) {
-                        properties[MSG_PROP_TOPIC] = topic!!
-                    }
-                },
+            headers.toMessageProperties().also { it[MSG_PROP_KEY] = key },
         )
 
     private fun List<Pair<String, String>>.toMessageProperties() =

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
@@ -125,7 +125,12 @@ class EventProcessor<K : Any, S : Any, E : Any>(
     private fun convertToMessage(record: Record<*, *>): MediatorMessage<Any> {
         return MediatorMessage(
             record.value!!,
-            record.headers.toMessageProperties().also { it[MessagingClient.MSG_PROP_KEY] = record.key },
+            record.headers.toMessageProperties().also { properties ->
+                properties[MessagingClient.MSG_PROP_KEY] = record.key;
+                if (record.topic != null && record.topic!!.isNotEmpty()) {
+                    properties[MessagingClient.MSG_PROP_TOPIC] = record.topic!!
+                }
+            },
         )
     }
 


### PR DESCRIPTION
After a recent code change, the name of the topic was not being added to the `MediatorMessage` in the right place. This PR corrects the issue.