### PR TITLE
CORE-19194: implement subset operation on Merkle proofs

### DIFF
--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNode.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNode.kt
@@ -3,10 +3,11 @@ package net.corda.crypto.merkle.impl
 import net.corda.v5.crypto.SecureHash
 
 /**
- * A MerkleNode represents a node on a tree
+ * A MerkleNode represents a node on a tree, and is used as the parameter for callbacks when we walk
+ * a proof of Merkle tree - see MerkleProofImpl.calculateRootInstrumented.
  *
- * @param index the position of the node at its level, counting from the left (which is zero)
+ * @param indexWithinLevel the position of the node at its level, counting from the left (which is zero)
  * @param hash the hash of the node, which is a hash of its children
  */
 
-data class MerkleNode(val index: Int, val hash: SecureHash)
+internal data class MerkleNode(val indexWithinLevel: Int, val hash: SecureHash)

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNode.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNode.kt
@@ -6,8 +6,8 @@ import net.corda.v5.crypto.SecureHash
  * A MerkleNode represents a node on a tree, and is used as the parameter for callbacks when we walk
  * a proof of Merkle tree - see MerkleProofImpl.calculateRootInstrumented.
  *
- * @param indexWithinLevel the position of the node at its level, counting from the left (which is zero)
- * @param hash the hash of the node, which is a hash of its children
+ * @param indexWithinLevel The position of the node at its level, counting from the left (which is zero)
+ * @param hash The hash of the node, which is a hash of its children
  */
 
 internal data class MerkleNode(val indexWithinLevel: Int, val hash: SecureHash)

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNode.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNode.kt
@@ -1,0 +1,12 @@
+package net.corda.crypto.merkle.impl
+
+import net.corda.v5.crypto.SecureHash
+
+/**
+ * A MerkleNode represents a node on a tree
+ *
+ * @param index the position of the node at its level, counting from the left (which is zero)
+ * @param hash the hash of the node, which is a hash of its children
+ */
+
+data class MerkleNode(val index: Int, val hash: SecureHash)

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNodeInfo.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNodeInfo.kt
@@ -4,7 +4,7 @@ package net.corda.crypto.merkle.impl
  * Represents additional  information about a node
  *
  * @param node The node itself
- * @param node The level within the Merkle tree, counting from the top with 0 being the top
+ * @param level The level within the Merkle tree, counting from the top with 0 being the top
  * @param consumed If set, the index in the proof hashes used for this node. If unset, the node is calculated.
  */
 internal data class MerkleNodeInfo(val node: MerkleNode, val level: Int, val consumed: Int?)

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNodeInfo.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNodeInfo.kt
@@ -1,0 +1,10 @@
+package net.corda.crypto.merkle.impl
+
+/**
+ * Represents additional  information about a node
+ *
+ * @param node The node itself
+ * @param node The level within the Merkle tree, counting from the top with 0 being the top
+ * @param consumed If set, the index in the proof hashes used for this node. If unset, the node is calculated.
+ */
+internal data class MerkleNodeInfo(val node: MerkleNode, val level: Int, val consumed: Int?)

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNodeInfo.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleNodeInfo.kt
@@ -1,7 +1,7 @@
 package net.corda.crypto.merkle.impl
 
 /**
- * Represents additional  information about a node
+ * Represents additional information about a node
  *
  * @param node The node itself
  * @param level The level within the Merkle tree, counting from the top with 0 being the top

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -62,9 +62,8 @@ class MerkleProofImpl(
      *                          The arguments are the hash of the node, level (with top of the tree at 0),
      *                          index (position across from the left hand side of the tree, starting at 0),
      *                          plus the index of that hash within the incoming hashes (starting at 0),
-     *                          or null for calculated nodes. This will be called left to right then bottom to top.
-     *                          The order that this is called is left to right then bottom to top, i.e. the same
-     *                          order as input hashes are consumed.
+     *                          or null for calculated nodes. This will be called left to right then bottom to top,
+     *                          i.e. the same order as input hashes are consumed.
      * @return the secure hash of the root of the Merkle proof
      */
     @Suppress("NestedBlockDepth", "ThrowsCount")

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -244,10 +244,10 @@ class MerkleProofImpl(
         require(outLeaves.size == leafIndices.size) { "some leaves are not available in input proof"}
         require(outLeaves.size != 0) { "output proof must have at least one known leaf"}
         // We work out the hashes for the new subset proof by considering, for the original proof, each hash that
-        // is calculated when we verify the proof by calculate the root.
+        // is calculated when we verify the proof by calculating the root.
         val outHashes: MutableList<SecureHash> = mutableListOf()
         val treeDepth = MerkleTreeImpl.treeDepth(treeSize)
-        var knownLeaves = leafIndices.toMutableList()
+        var knownLeaves = leafIndices.toMutableSet()
         calculateRootInstrumented(digest) { hash, level, index, _ ->
             val height = treeDepth - level // how many levels above the leaves, 0 for being at the leaf
             val leftmostLeaf = index shl height

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -190,7 +190,7 @@ class MerkleProofImpl(
                         MerkleNode(newIndex, newHash)
                     } else {
                         // Remember we consumed a proof hash for the left hand child
-                        onNewHash(MerkleNodeInfo(MerkleNode(item.indexWithinLevel-1, hashes[hashIndex]), treeDepth+1, hashIndex))
+                        onNewHash(MerkleNodeInfo(MerkleNode(item.indexWithinLevel - 1, hashes[hashIndex]), treeDepth + 1, hashIndex))
                         // Make new node with:
                         //   - left being proof of hash at $hashIndex
                         //   - right being current element, index $item.first, hash $item.second

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -252,8 +252,9 @@ class MerkleProofImpl(
             val height = treeDepth - info.level // how many levels above the leaves, 0 for being at the leaf
             val leftmostLeaf = info.node.indexWithinLevel shl height
             val afterLeaf = min(leftmostLeaf + (1 shl height), treeSize)
-            val unknowns = (leftmostLeaf until afterLeaf).any { it !in availableLeaves }
-            val allUnknown = (leftmostLeaf until afterLeaf).all { it !in availableLeaves }
+            val numberOfUnknowns = (leftmostLeaf until afterLeaf).count { it !in availableLeaves }
+            val allUnknown = numberOfUnknowns == (afterLeaf-leftmostLeaf)
+            val unknowns = numberOfUnknowns > 0
             // work out the sibling node i.e. the node which shares a direct parent node with this one
             val siblingIndex = info.node.indexWithinLevel xor 1
             val siblingLeftmostLeaf = siblingIndex shl height

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -274,30 +274,18 @@ class MerkleProofImpl(
                 // So, if we are at a node and have a tree full of unknowns, and the adjacent node
                 // will be calculated in the output proof, then we need to produce an output hash
 
+
                 // The adjacent node will be known iff there is known data within it
 
 
                 // e.g. if height=2 and index= 0, adjacentIndex is 1,
                 // this node covers 0,1,2,3 and the adjacentTree 4,5,6,7, so the test is whether any of [4,7] are in leafIndices
 
-                if (height == 2 && adjacentIndex == 1) {
-                    if (leafIndices.any { it in 4..7 }) {
-                        println("\ttaking for output since adjacent node will be known")
-                        outHashes.add(hash)
-                    }
-                }
+                val adjLHS = adjacentIndex shl height
 
-                if (height == 1 && adjacentIndex == 1) {
-                    if (leafIndices.any { it in 2..3}) {
+                if (leafIndices.any { it in adjLHS until adjLHS + (1 shl height) }) {
                         println("\ttaking for output since adjacent node will be known")
                         outHashes.add(hash)
-                    }
-                }
-                if (height == 2 && adjacentIndex == 0) {
-                    if (leafIndices.any { it in 0..3}) {
-                        println("\ttaking for output since adjacent node will be known")
-                        outHashes.add(hash)
-                    }
                 }
             }
         }

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -182,7 +182,7 @@ class MerkleProofImpl(
                     // We pair the current element with a hash from the proof
                     val newNode = (if ((item.indexWithinLevel and 1) == 0) {      // Even index means, that the item is on the left
                         // Remember we consumed a proof hash for the right hand child
-                        onNewHash(MerkleNodeInfo(MerkleNode(item.indexWithinLevel+1, hashes[hashIndex]), treeDepth+1, hashIndex))
+                        onNewHash(MerkleNodeInfo(MerkleNode(item.indexWithinLevel + 1, hashes[hashIndex]), treeDepth + 1, hashIndex))
                         // Make new node with
                         //   - left being current element
                         //   - right being a consumed incoming hash from $hashes[$hashIndex]

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -178,7 +178,9 @@ class MerkleProofImpl(
                             "MerkleProof root calculation requires more hashes than the proof has."
                         )
                     }
-                    val newIndex = item.index /2
+
+                    // Make up a new node, which will be a level up so will have a node index shifted right one
+                    val newIndex = item.index / 2
 
                     // We pair the current element with a hash from the proof
                     val newNode = (if ((item.index and 1) == 0) {      // Even index means, that the item is on the left

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -69,7 +69,7 @@ class MerkleProofImpl(
      */
     @Suppress("NestedBlockDepth", "ThrowsCount")
 
-    fun calculateRootInstrumented(
+    private fun calculateRootInstrumented(
         digest: MerkleTreeHashDigest,
         onNewHash: (hash: SecureHash, level: Int, nodeIndex: Int, consumed: Int?) -> Unit =
              {_, _, _, _ -> }
@@ -84,13 +84,13 @@ class MerkleProofImpl(
         // We do support and test with leaves.size == treeSize, which may not
         // be very useful but needed not be a special case.
         if (leaves.size > treeSize) {
-            throw MerkleProofRebuildFailureException("MerkleProof has too many specified keys ${leaves.size} tree size ${treeSize}")
+            throw MerkleProofRebuildFailureException("MerkleProof has too many specified keys ${leaves.size} tree size $treeSize")
         }
         if (leaves.size < treeSize && hashes.isEmpty()) {
             throw MerkleProofRebuildFailureException("No fill-in hashes specified to MerkleProof")
         }
         if (hashes.size > treeSize + leaves.size) {
-            throw MerkleProofRebuildFailureException("More MerkleProof non-data hashes given than is possibily necessary")
+            throw MerkleProofRebuildFailureException("More MerkleProof non-data hashes given than is possibly necessary")
         }
         if (leaves.isEmpty()) {
             throw MerkleProofRebuildFailureException("MerkleProof should have at least one leaf.")
@@ -119,7 +119,7 @@ class MerkleProofImpl(
             // Process a level of the tree which means generating the hashes for the level above (i.e. closer
             // to the root).
 
-            // There'd be nothing to do if the tree size $currentSize is 1, hence the loop condition
+            // There is nothing to do if the tree size $currentSize is 1, hence the loop condition
             if (nodeHashes.isEmpty()) {
                 throw MerkleProofRebuildFailureException(
                     "MerkleProof does not have enough nodeHashes to calculate root hash."
@@ -154,7 +154,7 @@ class MerkleProofImpl(
                         // Decide if we can consume the next two elements since they are adjacent in the Merkle tree
                         if (item.first xor next.first == 1) {       // ... and they are a pair with the current
                             // We now know that the indices ${item.first} and ${next.first} only differ on the bottom bit,
-                            // i.e. they are adjacent. Therefore we can combine them.
+                            // i.e. they are adjacent. Therefore, we can combine them.
 
                             val newHash = digest.nodeHash(treeDepth, item.second, next.second)
                             onNewHash( newHash, treeDepth, newItems.size, null)
@@ -233,7 +233,7 @@ class MerkleProofImpl(
      *
      * Work out a Merkle proof with specified leaves.
      *
-     * Throws IllegalArgumentException if some requeted leaf indices are not available in the source proof,
+     * Throws IllegalArgumentException if some requested leaf indices are not available in the source proof,
      * or if no leaf indices are requested.
      *
      * @param leafIndices indices  of the known leaves to include in the output proof
@@ -242,8 +242,8 @@ class MerkleProofImpl(
     fun subset(digest: MerkleTreeHashDigest, leafIndices: List<Int>): MerkleProofImpl {
         val outLeaves = leaves.filter { it.index in leafIndices }
         require(outLeaves.size == leafIndices.size) { "some leaves are not available in input proof"}
-        require(outLeaves.size != 0) { "output proof must have at least one known leaf"}
-        // we will build up a set of avaialble leaves as we track. This will start out with the known leaves
+        require(outLeaves.isNotEmpty()) { "output proof must have at least one known leaf"}
+        // we will build up a set of available leaves as we track. This will start out with the known leaves
         // in the output subset proof, and will be augmented as we decide to add output hashes to the proof
         val availableLeaves = leafIndices.toMutableSet()
         // We work out the hashes for the new subset proof by considering, for the original proof, each hash that
@@ -312,7 +312,7 @@ class MerkleProofImpl(
                 .take(8) + (if (consumed!=null) " (input $consumed)" else " (calc)")
         }
         val leafHashes = (0 until treeSize).map { nodeLabels[treeDepth to it]?:"unknown"}
-        val longestLeafHash = leafHashes.map { it.length }.max()
+        val longestLeafHash = leafHashes.maxOfOrNull { it.length } ?: 0
         val leafLabels =  (0 until treeSize).map {
             "${leafHashes[it].padEnd(longestLeafHash)} ${if (it in getLeaves().map { l -> l.index }) "known leaf" else "filtered"}"
         }

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -229,6 +229,18 @@ class MerkleProofImpl(
         return nodeHashes.single().second
     }
 
+    /**
+     *
+     * Work out a Merkle proof with fewer leaves.
+     *
+     * NOTE: currently this is not complete
+     *
+     * @param leafIndices indices  of the known leaves to include in the output proof
+     * @return A new Merkle proof
+     */
+    fun subset(leafIndices: List<Int>): MerkleProofImpl =
+        MerkleProofImpl(proofType, treeSize, leaves.filter { it.index in leafIndices}, hashes)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -241,30 +241,22 @@ class MerkleProofImpl(
     fun subset(digest: MerkleTreeHashDigest, leafIndices: List<Int>): MerkleProofImpl {
         var outHashes: MutableList<SecureHash> = mutableListOf()
         val treeDepth = MerkleTreeImpl.treeDepth(treeSize)
-        println("working out subset for leaf indices $leafIndices")
         calculateRootInstrumented(digest) { hash, level, index, _ ->
             val adjacentIndex = (index xor 1) // the adjacent node for this level
             val height = treeDepth - level // how many levels above the leaves, 0 for at the leaf
-            println("found hash $hash at level $level  height $height index $index adjacent index $adjacentIndex ")
             // The adjacent sub-tree (be it leaf or node) will be known iff there is known data within it
             // There is known data if any member of leafIndices is set within that subtree.
             // Since we are $height levels up from the leaves (perhaps $height is zero), the start and end leaf indices
             // are double for each level of the tree, which we can factor in by bitshifting our indices to the left
             // $height times.
 
-
             // e.g. if height=2 and index= 0, adjacentIndex is 1,
             // this node covers 0,1,2,3 and the adjacentTree 4,5,6,7, so the test is whether any of [4,7] are in leafIndices
-
             val adjLHS = adjacentIndex shl height
 
-            if (leafIndices.any { it in adjLHS until adjLHS + (1 shl height) }) {
-                    println("\ttaking for output since adjacent tree will be known")
-                    outHashes.add(hash)
-            }
+            if (leafIndices.any { it in adjLHS until adjLHS + (1 shl height) }) outHashes.add(hash)
         }
         val outLeaves = leaves.filter { it.index in leafIndices }
-        println("output hashes $outHashes leaves $outLeaves")
         return MerkleProofImpl(proofType, treeSize, outLeaves, outHashes)
     }
 

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -261,7 +261,7 @@ class MerkleProofImpl(
             val siblingLeftmostLeaf = siblingIndex shl height
             val afterSiblingLeaf = min((siblingIndex + 1) shl height, treeSize)
             val siblingWillBeKnown = (siblingLeftmostLeaf until afterSiblingLeaf).any { it in availableLeaves }
-            // we need this hash in the subset proof iff it covers unknown content ($unknowns is true),
+            // we need this hash in the subset proof if and only if it covers unknown content ($unknowns is true),
             // and either there is:
             // - some known leaves under this node ($allUnknown is false)
             // - the sibling node has known leaves ($siblingWillBeKnown is true)

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -257,7 +257,15 @@ class MerkleProofImpl(
             // $height times.
 
             val adjLHS = adjacentIndex shl height
-            if (leafIndices.any { it in adjLHS until adjLHS + (1 shl height) }) outHashes.add(hash)
+
+            val knownContentInOtherSide = leafIndices.any { it in adjLHS until adjLHS + (1 shl height) }
+
+            // we won't need this hash if it is a known leaf, since the hash can be worked out directly from the leaf
+
+            val lastNode = index shl height == treeSize - 1
+            val isKnownLeaf = (level == treeDepth || lastNode) && (index shl height) in leafIndices
+
+            if (knownContentInOtherSide && !isKnownLeaf) outHashes.add(hash)
         }
         return MerkleProofImpl(proofType, treeSize, outLeaves, outHashes)
     }

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/RenderTree.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/RenderTree.kt
@@ -53,8 +53,11 @@ fun renderTree(leafLabels: List<String>, nodeLabels: Map<Pair<Int, Int>, String>
     // mostly get overwritten later to add the vertical elements.
     levels.forEachIndexed { level, ranges ->
         ranges.forEach { range ->
-            val x = levels.size - level - 1
-            grid.put(x to range.first, '━')
+            // we don't want ━ to the right of the leaves, since that looks like an extra node
+            if (level != 0) {
+                val x = levels.size - level - 1
+                grid.put(x to range.first, '━')
+            }
         }
     }
 
@@ -88,7 +91,7 @@ fun renderTree(leafLabels: List<String>, nodeLabels: Map<Pair<Int, Int>, String>
     }
 
     // Work out how much space to leave for node label columns.
-    val longestLabels = (0..values.size + 1).map { x ->
+    val longestLabels = (0 until levels.size).map { x ->
         (0 until treeSize).map { y ->
             (nodeLabels.get(x to y) ?: "").length
         }.max()
@@ -103,9 +106,9 @@ fun renderTree(leafLabels: List<String>, nodeLabels: Map<Pair<Int, Int>, String>
 
     // Work out the lines as strings, using the box characters, node and leaf labels.
     val lines: List<String> = (0 until treeSize).map { y ->
-        val line = (0..values.size + 1).map { x ->
+        val line = (0 until levels.size).map { x ->
             // x is the level of the tree, so x=0 is the top node
-            // work out how many nodes across at the current level of the tree we are at, or -1 if we aren't at a node
+            // work out this node's index at the current level of the tree we are at, or -1 if we aren't at a node
             val nodeIndex = nodeYCoordinates.get(x to y)?:-1
             "${nodeLabels[x to nodeIndex]?.padEnd(longestLabels[x], ' ')?:(" ".repeat(longestLabels[x]))}${grid.getOrDefault(x to y, ' ')}"
         }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -41,6 +41,11 @@ class MerkleTreeTest {
         val digestAlgorithm = DigestAlgorithmName.SHA2_256D
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
+        // Since there are 2^(2*n) permutations of source leafs we don't want to test too many,
+        // so we do a few at random. In local testing I've taken this up to 1000 which takes 30 minutes
+        // on my laptop.
+        private const val NUMBER_OF_SUBSETS_TO_TEST = 10
+
         private lateinit var digestService: DigestService
         private lateinit var defaultHashDigestProvider: DefaultHashDigestProvider
         private lateinit var nonceHashDigestProvider: NonceHashDigestProvider
@@ -502,7 +507,9 @@ class MerkleTreeTest {
                     subproof.render(trivialHashDigestProvider)
                 }
 
-                for (subsetProofLeafSet in (0 until (1 shl treeSize)).toList().shuffled(rng).take(10)) {
+                for (subsetProofLeafSet in (0 until (1 shl treeSize)).toList().shuffled(rng).take(
+                    NUMBER_OF_SUBSETS_TO_TEST
+                )) {
                     val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
                     val missingLeaves = (0 until treeSize).filter {
                         leaf -> subsetProofLeafSet and (1 shl leaf) != 0 &&  (sourceProofLeafSet and (1 shl leaf)) == 0

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -353,8 +353,7 @@ class MerkleTreeTest {
 
         val leafIndicesCombination = (0 until treeSize).filter { (i and (1 shl it)) != 0 }
         testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize).also {
-            assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-                """
+            assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
                     00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
                                    ┃               ┃                  ┗unknown            filtered
                                    ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
@@ -367,17 +366,16 @@ class MerkleTreeTest {
             val subsetLeafIndicesCombination = (0 until treeSize).filter { (subsetI and (1 shl it)) != 0 }
             assertThat(subsetLeafIndicesCombination).hasSize(1)
 
-            val proof2 = it.subset(subsetLeafIndicesCombination)
+            val proof2 = it.subset(trivialHashDigestProvider, subsetLeafIndicesCombination)
 
-            assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-            """
-                    00000612 (calc)┳0000069F (input 0)┳unknown        ┳unknown            filtered
-                                   ┃                  ┃               ┗unknown            filtered
-                                   ┃                  ┗unknown        ┳unknown            filtered
-                                   ┃                                  ┗unknown            filtered
-                                   ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
-                                                                      ┗00000005 (input 1) filtered
-                """)
+            assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                00000612 (calc)┳0000069F (input 1)┳               ┳unknown            filtered
+                               ┃                  ┃               ┗unknown            filtered
+                               ┃                  ┗               ┳unknown            filtered
+                               ┃                                  ┗unknown            filtered
+                               ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
+                                                                  ┗00000005 (input 0) filtered
+                    """)
         }
     }
 

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -504,20 +504,14 @@ class MerkleTreeTest {
         for (sourceProofLeafSet in 1 until (1 shl treeSize)) {
             val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
             testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize).also { proof ->
-
-                val hashes = calculateLeveledHashes(proof, trivialHashDigestProvider)
-
-                // `it` is a Merkle proof for a tree of size $treeSize with ${hashes.size}
+                // proof is a Merkle proof for a tree of size $treeSize with ${hashes.size}
                 // hashes supplied in the proof where we know $leafIndicesCombination
+                val hashes = calculateLeveledHashes(proof, trivialHashDigestProvider)
 
                 if (sourceProofLeafSet == 1 && treeSize == 2) {
                     assertThat(hashes).hasSize(1)
                     assertHash(hashes[0].hash, "00000001")
                     assertThat(hashes[0].level).isEqualTo(0)
-                    assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                            00000630 (calc)┳00000000 (calc)    known leaf
-                                           ┗00000001 (input 0) filtered
-                    """)
                 }
                 if (sourceProofLeafSet == 1 && treeSize == 3) {
                     assertThat(hashes).hasSize(2)
@@ -816,7 +810,7 @@ class MerkleTreeTest {
     }
 
     @Test
-    fun `Merkle proof size 1`() {
+    fun `Merkle proof size 1 with double SHA256`() {
         val treeSize = 1
         val sourceProofLeafSet = 1
         val merkleTree = makeTestMerkleTree(treeSize, defaultHashDigestProvider)
@@ -827,6 +821,23 @@ class MerkleTreeTest {
                         7901AF93 (calc) known leaf
                     """)
     }
+
+
+    @Test
+    fun `Merkle proof size 2 with trivial hash`() {
+        val treeSize = 2
+        val sourceProofLeafSet = 1
+        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
+        val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
+        val proof = testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize, trivialHashDigestProvider)
+
+        assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                            00000630 (calc)┳00000000 (calc)    known leaf
+                                           ┗00000001 (input 0) filtered
+                    """)
+    }
+
+
 }
 
 fun SecureHash.hex() = bytes.joinToString(separator = "") { "%02x".format(it) }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -415,54 +415,7 @@ class MerkleTreeTest {
     }
 
 
-    @Test
-    fun `merkle proof size 15 final countdown`() {
-        val treeSize = 15
-        val sourceProofLeafSet = 28416
-        val subsetProofLeafSet = 256
-        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
-        val treeText = renderTree((0 until treeSize).map { it.toString() }, emptyMap())
-        assertThat(treeText).isEqualToIgnoringWhitespace("""
-                ┳┳┳┳0
-                ┃┃┃┗1
-                ┃┃┗┳2
-                ┃┃ ┗3
-                ┃┗┳┳4
-                ┃ ┃┗5
-                ┃ ┗┳6
-                ┃  ┗7
-                ┗┳┳┳8
-                 ┃┃┗9
-                 ┃┗┳10
-                 ┃ ┗11
-                 ┗┳┳12
-                  ┃┗13
-                  ┗━14
-        """.trimIndent())
-        val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
-        val proof = testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize)
-        val proofText = proof.render(trivialHashDigestProvider)
-        assertThat(proofText).isEqualToIgnoringWhitespace("""
-            00000547 (calc)┳00000589 (input 1)┳unknown        ┳unknown        ┳unknown            filtered
-                           ┃                  ┃               ┃               ┗unknown            filtered
-                           ┃                  ┃               ┗unknown        ┳unknown            filtered
-                           ┃                  ┃                               ┗unknown            filtered
-                           ┃                  ┗unknown        ┳unknown        ┳unknown            filtered
-                           ┃                                  ┃               ┗unknown            filtered
-                           ┃                                  ┗unknown        ┳unknown            filtered
-                           ┃                                                  ┗unknown            filtered
-                           ┗00000585 (calc)   ┳000006BF (calc)┳00000640 (calc)┳00000008 (calc)    known leaf
-                                              ┃               ┃               ┗00000009 (calc)    known leaf
-                                              ┃               ┗00000644 (calc)┳0000000A (calc)    known leaf
-                                              ┃                               ┗0000000B (calc)    known leaf
-                                              ┗0000068B (calc)┳00000648 (calc)┳0000000C (input 0) filtered
-                                                              ┃               ┗0000000D (calc)    known leaf
-                                                              ┗0000000E (calc)━0000000E (calc)    known leaf
-                                                          """.trimIndent())
-        val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
-        val subproof = proof.subset(trivialHashDigestProvider, subLeafIndicesCombination)
-        println(subproof.render(trivialHashDigestProvider))
-    }
+
 
     private fun runMerkleProofTest(treeSize: Int) {
         // we don't want to take the time to do an expensive hash so we'll just make a cheap one
@@ -834,6 +787,72 @@ class MerkleTreeTest {
                                ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
                                                                   ┗00000005 (input 0) filtered            
         """.trimIndent(), trivialHashDigestProvider)
+    }
+
+    @Test
+    fun `merkle proof size 15 subset to leaf set 8 using trivial hashes`() {
+        val treeSize = 15
+        val sourceProofLeafSet = 28416
+        val subsetProofLeafSet = 256
+        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
+        val treeText = renderTree((0 until treeSize).map { it.toString() }, emptyMap())
+        assertThat(treeText).isEqualToIgnoringWhitespace("""
+                ┳┳┳┳0
+                ┃┃┃┗1
+                ┃┃┗┳2
+                ┃┃ ┗3
+                ┃┗┳┳4
+                ┃ ┃┗5
+                ┃ ┗┳6
+                ┃  ┗7
+                ┗┳┳┳8
+                 ┃┃┗9
+                 ┃┗┳10
+                 ┃ ┗11
+                 ┗┳┳12
+                  ┃┗13
+                  ┗━14
+        """.trimIndent())
+        val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
+        val proof = testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize)
+        val proofText = proof.render(trivialHashDigestProvider)
+        assertThat(proofText).isEqualToIgnoringWhitespace("""
+            00000547 (calc)┳00000589 (input 1)┳unknown        ┳unknown        ┳unknown            filtered
+                           ┃                  ┃               ┃               ┗unknown            filtered
+                           ┃                  ┃               ┗unknown        ┳unknown            filtered
+                           ┃                  ┃                               ┗unknown            filtered
+                           ┃                  ┗unknown        ┳unknown        ┳unknown            filtered
+                           ┃                                  ┃               ┗unknown            filtered
+                           ┃                                  ┗unknown        ┳unknown            filtered
+                           ┃                                                  ┗unknown            filtered
+                           ┗00000585 (calc)   ┳000006BF (calc)┳00000640 (calc)┳00000008 (calc)    known leaf
+                                              ┃               ┃               ┗00000009 (calc)    known leaf
+                                              ┃               ┗00000644 (calc)┳0000000A (calc)    known leaf
+                                              ┃                               ┗0000000B (calc)    known leaf
+                                              ┗0000068B (calc)┳00000648 (calc)┳0000000C (input 0) filtered
+                                                              ┃               ┗0000000D (calc)    known leaf
+                                                              ┗0000000E (calc)━0000000E (calc)    known leaf
+                                                          """.trimIndent())
+        val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
+        val subproof = proof.subset(trivialHashDigestProvider, subLeafIndicesCombination)
+        val subproofText = subproof.render(trivialHashDigestProvider)
+        assertThat(subproofText).isEqualToIgnoringWhitespace("""
+            00000547 (calc)┳00000589 (input 3)┳unknown           ┳unknown           ┳unknown            filtered
+                           ┃                  ┃                  ┃                  ┗unknown            filtered
+                           ┃                  ┃                  ┗unknown           ┳unknown            filtered
+                           ┃                  ┃                                     ┗unknown            filtered
+                           ┃                  ┗unknown           ┳unknown           ┳unknown            filtered
+                           ┃                                     ┃                  ┗unknown            filtered
+                           ┃                                     ┗unknown           ┳unknown            filtered
+                           ┃                                                        ┗unknown            filtered
+                           ┗00000585 (calc)   ┳000006BF (calc)   ┳00000640 (calc)   ┳00000008 (calc)    known leaf
+                                              ┃                  ┃                  ┗00000009 (input 0) filtered
+                                              ┃                  ┗00000644 (input 1)┳unknown            filtered
+                                              ┃                                     ┗unknown            filtered
+                                              ┗0000068B (input 2)┳unknown           ┳unknown            filtered
+                                                                 ┃                  ┗unknown            filtered
+                                                                 ┗unknown           ━unknown            filtered
+        """.trimIndent())
     }
 
 }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -558,7 +558,7 @@ class MerkleTreeTest {
                     subproof.render(trivialHashDigestProvider)
                 }
 
-                for (subsetProofLeafSet in (0 until (1 shl treeSize)).toList().shuffled(rng).take(10)) {
+                for (subsetProofLeafSet in (0 until (1 shl treeSize)).toList().shuffled(rng).take(100)) {
                     val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
                     val missingLeaves = (0 until treeSize).filter { leaf -> subsetProofLeafSet and (1 shl leaf) != 0 &&  (sourceProofLeafSet and (1 shl leaf)) == 0}
                     val missing = missingLeaves.isNotEmpty()

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -535,8 +535,8 @@ class MerkleTreeTest {
                     )
                 }
 
-                if (i == 3 && treeSize == 7) {
-                    it.subset(trivialHashDigestProvider, listOf(1,2))
+                if (i == 3 && treeSize == 3) {
+                    it.subset(trivialHashDigestProvider, listOf(1))
                 }
 
                 for (j in (0 until (1 shl treeSize)).toList().shuffled(rng).take(10)) {
@@ -551,12 +551,14 @@ class MerkleTreeTest {
                                 it.subset(trivialHashDigestProvider, subLeafIndicesCombination)
                             }
                         missing ->
-                            // there are leaves in subset which are not in
+                            // there are leaves in subset which are not in the source proof, which should fail
                             assertFailsWith<java.lang.IllegalArgumentException> {
                                 it.subset(trivialHashDigestProvider, subLeafIndicesCombination)
                             }
                         else ->
-                            println(it.subset(trivialHashDigestProvider, subLeafIndicesCombination).render(trivialHashDigestProvider))
+                            it.subset(trivialHashDigestProvider, subLeafIndicesCombination).also {
+                                println(it.render(trivialHashDigestProvider))
+                            }
                     }
                 }
 

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -31,6 +31,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.security.SecureRandom
 import kotlin.experimental.xor
+import kotlin.test.assertFailsWith
 
 class MerkleTreeTest {
     companion object {
@@ -395,18 +396,24 @@ class MerkleTreeTest {
                            ┃                  ┗00000001 (calc)━00000001 (calc) known leaf
                            ┗00000002 (input 0)━unknown        ━unknown         filtered
         """.trimIndent())
-        val proof2 = proof.subset(trivialHashDigestProvider, listOf(1))
+        val proof2 = proof.subset(trivialHashDigestProvider, listOf(0))
         assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                    00000667 (calc)┳00000630 (calc)   ┳00000000 (input 0)━00000000 (input 0) filtered
-                                   ┃                  ┗00000001 (calc)   ━00000001 (calc)    known leaf
-                                   ┗00000002 (input 1)━unknown           ━unknown            filtered
-                """)
-        val proof3 = proof.subset(trivialHashDigestProvider, listOf(0))
-        assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
                     00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)   ━00000000 (calc)    known leaf
                                    ┃                  ┗00000001 (input 0)━00000001 (input 0) filtered
                                    ┗00000002 (input 1)━unknown           ━unknown            filtered
                 """)
+        val proof3 = proof.subset(trivialHashDigestProvider, listOf(1))
+        assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                    00000667 (calc)┳00000630 (calc)   ┳00000000 (input 0)━00000000 (input 0) filtered
+                                   ┃                  ┗00000001 (calc)   ━00000001 (calc)    known leaf
+                                   ┗00000002 (input 1)━unknown           ━unknown            filtered
+                """)
+        assertFailsWith<IllegalArgumentException> {
+            proof.subset(trivialHashDigestProvider, listOf(2))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            proof.subset(trivialHashDigestProvider, emptyList())
+        }
     }
 
     private fun runMerkleProofTest(treeSize: Int) {

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -362,8 +362,7 @@ class MerkleTreeTest {
         """)
 
         val proof2 = proof.subset(trivialHashDigestProvider, listOf(4))
-        assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-            """
+        assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
                 00000612 (calc)┳0000069F (input 1)┳unknown        ┳unknown            filtered
                                ┃                  ┃               ┗unknown            filtered
                                ┃                  ┗unknown        ┳unknown            filtered

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -813,13 +813,14 @@ class MerkleTreeTest {
     fun `Merkle proof size 1 with double SHA256`() {
         val treeSize = 1
         val sourceProofLeafSet = 1
+        val expected = """
+                        7901AF93 (calc) known leaf
+                    """
         val merkleTree = makeTestMerkleTree(treeSize, defaultHashDigestProvider)
         val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
         val proof = testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize, defaultHashDigestProvider)
 
-        assertThat(proof.render(defaultHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                        7901AF93 (calc) known leaf
-                    """)
+        assertThat(proof.render(defaultHashDigestProvider)).isEqualToIgnoringWhitespace(expected)
     }
 
 
@@ -827,14 +828,14 @@ class MerkleTreeTest {
     fun `Merkle proof size 2 with trivial hash`() {
         val treeSize = 2
         val sourceProofLeafSet = 1
+        val expected ="""
+                            00000630 (calc)┳00000000 (calc)    known leaf
+                                           ┗00000001 (input 0) filtered
+        """
         val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
         val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
         val proof = testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize, trivialHashDigestProvider)
-
-        assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                            00000630 (calc)┳00000000 (calc)    known leaf
-                                           ┗00000001 (input 0) filtered
-                    """)
+        assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(expected)
     }
 
 

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -350,46 +350,63 @@ class MerkleTreeTest {
         val treeSize = 6
         val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
 
-        testLeafCombination(merkleTree, listOf(2,4), merkleTree.root, treeSize).also {
-            assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-                """
-                    00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
-                                   ┃               ┃                  ┗unknown            filtered
-                                   ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
-                                   ┃                                  ┗00000003 (input 0) filtered
-                                   ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
-                                                                      ┗00000005 (input 1) filtered
-                """
-            )
-
-            val proof2 = it.subset(trivialHashDigestProvider, listOf(4))
-
-            assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-                """
-                00000612 (calc)┳0000069F (input 1)┳               ┳unknown            filtered
-                               ┃                  ┃               ┗unknown            filtered
-                               ┃                  ┗               ┳unknown            filtered
-                               ┃                                  ┗unknown            filtered
-                               ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
-                                                                  ┗00000005 (input 0) filtered
-                    """
-            )
-        }
-    }
-    @Test
-    fun `merkle proof size 6 subset B`() {
-        val treeSize = 6
-        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
         val proof = testLeafCombination(merkleTree, listOf(2,4), merkleTree.root, treeSize)
+        assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
+            """
+                00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
+                               ┃               ┃                  ┗unknown            filtered
+                               ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
+                               ┃                                  ┗00000003 (input 0) filtered
+                               ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
+                                                                  ┗00000005 (input 1) filtered
+            """
+        )
+
+        val proof2 = proof.subset(trivialHashDigestProvider, listOf(4))
+        assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
+            """
+            00000612 (calc)┳0000069F (input 1)┳               ┳unknown            filtered
+                           ┃                  ┃               ┗unknown            filtered
+                           ┃                  ┗               ┳unknown            filtered
+                           ┃                                  ┗unknown            filtered
+                           ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
+                                                              ┗00000005 (input 0) filtered
+                """
+        )
 
         val proof3 = proof.subset(trivialHashDigestProvider, listOf(2))
         assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                    00000612 (calc)┳0000069F (calc)   ┳00000630 (input 1)┳unknown            filtered
-                                   ┃                  ┃                  ┗unknown            filtered
-                                   ┃                  ┗00000634 (calc)   ┳00000002 (calc)    known leaf
-                                   ┃                                     ┗00000003 (input 0) filtered
-                                   ┗00000638 (input 2)━                  ┳unknown            filtered
-                                                                         ┗unknown            filtered
+                00000612 (calc)┳0000069F (calc)   ┳00000630 (input 1)┳unknown            filtered
+                               ┃                  ┃                  ┗unknown            filtered
+                               ┃                  ┗00000634 (calc)   ┳00000002 (calc)    known leaf
+                               ┃                                     ┗00000003 (input 0) filtered
+                               ┗00000638 (input 2)━                  ┳unknown            filtered
+                                                                     ┗unknown            filtered
+            """)
+    }
+
+    @Test
+    fun `merkle proof size 3 subsets`() {
+        val treeSize = 3
+        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
+        val proof = testLeafCombination(merkleTree, listOf(0, 1), merkleTree.root, treeSize)
+
+        assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+            00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)━00000000 (calc) known leaf
+                           ┃                  ┗00000001 (calc)━00000001 (calc) known leaf
+                           ┗00000002 (input 0)━               ━unknown         filtered
+        """.trimIndent())
+        val proof2 = proof.subset(trivialHashDigestProvider, listOf(1))
+        assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                    00000667 (calc)┳00000630 (calc)   ┳00000000 (input 0)━00000000 (input 0) filtered
+                                   ┃                  ┗00000001 (calc)   ━00000001 (calc)    known leaf
+                                   ┗00000002 (input 1)━                  ━unknown            filtered
+                """)
+        val proof3 = proof.subset(trivialHashDigestProvider, listOf(0))
+        assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                    00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)   ━00000000 (calc)    known leaf
+                                   ┃                  ┗00000001 (input 0)━00000001 (input 0) filtered
+                                   ┗00000002 (input 1)━                  ━unknown            filtered
                 """)
     }
 

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -455,7 +455,7 @@ class MerkleTreeTest {
 
         val rng = Random(0)
 
-        // Test all the possible combinations of leaves for the proof.
+        // Test all the possible combinations of leaves for the proof, and a selection of subset proofs.
         for (sourceProofLeafSet in 1 until (1 shl treeSize)) {
             val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
             testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize).also {

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -602,7 +602,9 @@ class MerkleTreeTest {
 
                 for (subsetProofLeafSet in (0 until (1 shl treeSize)).toList().shuffled(rng).take(10)) {
                     val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
-                    val missingLeaves = (0 until treeSize).filter { leaf -> subsetProofLeafSet and (1 shl leaf) != 0 &&  (sourceProofLeafSet and (1 shl leaf)) == 0}
+                    val missingLeaves = (0 until treeSize).filter {
+                        leaf -> subsetProofLeafSet and (1 shl leaf) != 0 &&  (sourceProofLeafSet and (1 shl leaf)) == 0
+                    }
                     val missing = missingLeaves.isNotEmpty()
                     logger.trace(
                         "tree size {} source proof {} subset {} missing {} ({})",

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -565,7 +565,14 @@ class MerkleTreeTest {
                     val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
                     val missingLeaves = (0 until treeSize).filter { leaf -> subsetProofLeafSet and (1 shl leaf) != 0 &&  (sourceProofLeafSet and (1 shl leaf)) == 0}
                     val missing = missingLeaves.isNotEmpty()
-                    logger.trace("tree size $treeSize source proof $sourceProofLeafSet subset $subsetProofLeafSet missing $missingLeaves ($missing)")
+                    logger.trace(
+                        "tree size {} source proof {} subset {} missing {} ({})",
+                        treeSize,
+                        sourceProofLeafSet,
+                        subsetProofLeafSet,
+                        missingLeaves,
+                        missing
+                    )
                     when {
                         subsetProofLeafSet == 0 ->
                             // no leaves in output, which is never legal

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -157,8 +157,8 @@ class MerkleTreeTest {
         assertEquals(manualRoot, root)
         assertTree(
             merkleTree, """
-                bab170b1┳7901af93━ 00:00:00:00
-                        ┗471864d3━ 00:00:00:01"""
+                bab170b1┳7901af93 00:00:00:00
+                        ┗471864d3 00:00:00:01"""
         )
 
     }
@@ -177,9 +177,9 @@ class MerkleTreeTest {
         assertEquals(manualRoot, root)
         assertTree(
             merkleTree, """
-                a9d5543c┳bab170b1┳7901af93━00:00:00:00
-                        ┃        ┗471864d3━00:00:00:01
-                        ┗66973b1a━66973b1a━00:00:00:02
+                a9d5543c┳bab170b1┳7901af93 00:00:00:00
+                        ┃        ┗471864d3 00:00:00:01
+                        ┗66973b1a━66973b1a 00:00:00:02
             """
         )
     }
@@ -255,15 +255,14 @@ class MerkleTreeTest {
         val manualRoot = merkleTree.digest.nodeHash(0, node4, node5)
         assertTree(
             merkleTree, """
-                  4817d572┳ff3c3992┳bab170b1┳00:00:00:00
-                          ┃        ┃        ┗00:00:00:01
-                          ┃        ┗517a5de6┳00:00:00:02
-                          ┃                 ┗00:00:00:03
-                          ┗92e96986┳e0cc7e23┳00:00:00:04
-                                   ┃        ┗00:00:00:05
-                                   ┗46086473━00:00:00:06
-                                        """
-        )
+              4817d572┳ff3c3992┳bab170b1┳7901af93 00:00:00:00
+                      ┃        ┃        ┗471864d3 00:00:00:01
+                      ┃        ┗517a5de6┳66973b1a 00:00:00:02
+                      ┃                 ┗568f8d2a 00:00:00:03
+                      ┗92e96986┳e0cc7e23┳1d3a2328 00:00:00:04
+                               ┃        ┗cf5f6713 00:00:00:05
+                               ┗46086473━46086473 00:00:00:06
+        """)
         assertEquals(manualRoot, root)
     }
 
@@ -290,16 +289,15 @@ class MerkleTreeTest {
         assertEquals(manualRoot, root)
         assertTree(
             merkleTree, """
-              a868a19c┳ff3c3992┳bab170b1┳00:00:00:00
-                      ┃        ┃        ┗00:00:00:01
-                      ┃        ┗517a5de6┳00:00:00:02
-                      ┃                 ┗00:00:00:03
-                      ┗ef03791a┳e0cc7e23┳00:00:00:04
-                               ┃        ┗00:00:00:05
-                               ┗a1a26281┳00:00:00:06
-                                        ┗00:00:00:07
-                        """
-        )
+                  a868a19c┳ff3c3992┳bab170b1┳7901af93 00:00:00:00
+                          ┃        ┃        ┗471864d3 00:00:00:01
+                          ┃        ┗517a5de6┳66973b1a 00:00:00:02
+                          ┃                 ┗568f8d2a 00:00:00:03
+                          ┗ef03791a┳e0cc7e23┳1d3a2328 00:00:00:04
+                                   ┃        ┗cf5f6713 00:00:00:05
+                                   ┗a1a26281┳46086473 00:00:00:06
+                                            ┗b0d020da 00:00:00:07
+        """)
     }
 
     @Test
@@ -336,14 +334,13 @@ class MerkleTreeTest {
 
         val leafIndicesCombination = (0 until treeSize).filter { (i and (1 shl it)) != 0 }
         testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize).also {
-            assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-                """
-                    00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
-                                   ┃               ┃                  ┗unknown            filtered
-                                   ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
-                                   ┃                                  ┗00000003 (input 0) filtered
-                                   ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
-                                                                      ┗00000005 (input 1) filtered
+            assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
+                               ┃               ┃                  ┗unknown            filtered
+                               ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
+                               ┃                                  ┗00000003 (input 0) filtered
+                               ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
+                                                                  ┗00000005 (input 1) filtered
                 """)
         }
     }
@@ -355,16 +352,14 @@ class MerkleTreeTest {
         val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
 
         val proof = testLeafCombination(merkleTree, listOf(2,4), merkleTree.root, treeSize)
-        assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-            """
-                00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
-                               ┃               ┃                  ┗unknown            filtered
-                               ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
-                               ┃                                  ┗00000003 (input 0) filtered
-                               ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
-                                                                  ┗00000005 (input 1) filtered
-            """
-        )
+        assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                    00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
+                                   ┃               ┃                  ┗unknown            filtered
+                                   ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
+                                   ┃                                  ┗00000003 (input 0) filtered
+                                   ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
+                                                                      ┗00000005 (input 1) filtered
+        """)
 
         val proof2 = proof.subset(trivialHashDigestProvider, listOf(4))
         assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
@@ -375,7 +370,7 @@ class MerkleTreeTest {
                                ┃                                  ┗unknown            filtered
                                ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
                                                                   ┗00000005 (input 0) filtered
-                """)
+        """)
 
         val proof3 = proof.subset(trivialHashDigestProvider, listOf(2))
         assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
@@ -385,7 +380,7 @@ class MerkleTreeTest {
                                ┃                                     ┗00000003 (input 0) filtered
                                ┗00000638 (input 2)━unknown           ┳unknown            filtered
                                                                      ┗unknown            filtered
-            """)
+        """)
     }
 
     @Test
@@ -395,28 +390,78 @@ class MerkleTreeTest {
         val proof = testLeafCombination(merkleTree, listOf(0, 1), merkleTree.root, treeSize)
 
         assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-            00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)━00000000 (calc) known leaf
-                           ┃                  ┗00000001 (calc)━00000001 (calc) known leaf
-                           ┗00000002 (input 0)━unknown        ━unknown         filtered
-        """.trimIndent())
+            00000667 (calc)┳00000630 (calc)   ┳00000000 (calc) known leaf
+                           ┃                  ┗00000001 (calc) known leaf
+                           ┗00000002 (input 0)━unknown         filtered
+        """)
         val proof2 = proof.subset(trivialHashDigestProvider, listOf(0))
         assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                    00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)   ━00000000 (calc)    known leaf
-                                   ┃                  ┗00000001 (input 0)━00000001 (input 0) filtered
-                                   ┗00000002 (input 1)━unknown           ━unknown            filtered
-                """)
+            00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)    known leaf
+                           ┃                  ┗00000001 (input 0) filtered
+                           ┗00000002 (input 1)━unknown            filtered
+        """)
         val proof3 = proof.subset(trivialHashDigestProvider, listOf(1))
         assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                    00000667 (calc)┳00000630 (calc)   ┳00000000 (input 0)━00000000 (input 0) filtered
-                                   ┃                  ┗00000001 (calc)   ━00000001 (calc)    known leaf
-                                   ┗00000002 (input 1)━unknown           ━unknown            filtered
-                """)
+            00000667 (calc)┳00000630 (calc)   ┳00000000 (input 0) filtered
+                           ┃                  ┗00000001 (calc)    known leaf
+                           ┗00000002 (input 1)━unknown            filtered
+        """)
         assertFailsWith<IllegalArgumentException> {
             proof.subset(trivialHashDigestProvider, listOf(2))
         }
         assertFailsWith<IllegalArgumentException> {
             proof.subset(trivialHashDigestProvider, emptyList())
         }
+    }
+
+
+    @Test
+    fun `merkle proof size 15 final countdown`() {
+        val treeSize = 15
+        val sourceProofLeafSet = 28416
+        val subsetProofLeafSet = 256
+        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
+        val treeText = renderTree((0 until treeSize).map { it.toString() }, emptyMap())
+        assertThat(treeText).isEqualToIgnoringWhitespace("""
+                ┳┳┳┳0
+                ┃┃┃┗1
+                ┃┃┗┳2
+                ┃┃ ┗3
+                ┃┗┳┳4
+                ┃ ┃┗5
+                ┃ ┗┳6
+                ┃  ┗7
+                ┗┳┳┳8
+                 ┃┃┗9
+                 ┃┗┳10
+                 ┃ ┗11
+                 ┗┳┳12
+                  ┃┗13
+                  ┗━14
+        """.trimIndent())
+        val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
+        val proof = testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize)
+        val proofText = proof.render(trivialHashDigestProvider)
+        assertThat(proofText).isEqualToIgnoringWhitespace("""
+            00000547 (calc)┳00000589 (input 1)┳unknown        ┳unknown        ┳unknown            filtered
+                           ┃                  ┃               ┃               ┗unknown            filtered
+                           ┃                  ┃               ┗unknown        ┳unknown            filtered
+                           ┃                  ┃                               ┗unknown            filtered
+                           ┃                  ┗unknown        ┳unknown        ┳unknown            filtered
+                           ┃                                  ┃               ┗unknown            filtered
+                           ┃                                  ┗unknown        ┳unknown            filtered
+                           ┃                                                  ┗unknown            filtered
+                           ┗00000585 (calc)   ┳000006BF (calc)┳00000640 (calc)┳00000008 (calc)    known leaf
+                                              ┃               ┃               ┗00000009 (calc)    known leaf
+                                              ┃               ┗00000644 (calc)┳0000000A (calc)    known leaf
+                                              ┃                               ┗0000000B (calc)    known leaf
+                                              ┗0000068B (calc)┳00000648 (calc)┳0000000C (input 0) filtered
+                                                              ┃               ┗0000000D (calc)    known leaf
+                                                              ┗0000000E (calc)━0000000E (calc)    known leaf
+                                                          """.trimIndent())
+        val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
+        val subproof = proof.subset(trivialHashDigestProvider, subLeafIndicesCombination)
+        println(subproof.render(trivialHashDigestProvider))
     }
 
     private fun runMerkleProofTest(treeSize: Int) {
@@ -467,31 +512,26 @@ class MerkleTreeTest {
 
                 if (sourceProofLeafSet == 1 && treeSize == 1) {
                     assertThat(hashes).hasSize(0)
-                    assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-                        """
-                        00000000 (calc)━  00000000 (calc) known leaf
-                    """
-                    )
+                    assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                        00000000 (calc) known leaf
+                    """)
                 }
                 if (sourceProofLeafSet == 1 && treeSize == 2) {
                     assertThat(hashes).hasSize(1)
                     assertHash(hashes[0].hash, "00000001")
                     assertThat(hashes[0].level).isEqualTo(0)
-                    assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-                        """
-                            00000630 (calc)┳00000000 (calc)   ━ 00000000 (calc)    known leaf
-                                           ┗00000001 (input 0)━ 00000001 (input 0) filtered"""
-                    )
+                    assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                            00000630 (calc)┳00000000 (calc)    known leaf
+                                           ┗00000001 (input 0) filtered
+                    """)
                 }
                 if (sourceProofLeafSet == 1 && treeSize == 3) {
                     assertThat(hashes).hasSize(2)
-                    assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-                        """
-                            00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)   ━00000000 (calc)    known leaf
-                                           ┃                  ┗00000001 (input 0)━00000001 (input 0) filtered
-                                           ┗00000002 (input 1)━unknown           ━unknown            filtered
-                        """
-                    )
+                    assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                        00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)    known leaf
+                                       ┃                  ┗00000001 (input 0) filtered
+                                       ┗00000002 (input 1)━unknown            filtered
+                    """)
                 }
 
                 if (sourceProofLeafSet == 42 && treeSize == 6) {

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -379,7 +379,7 @@ class MerkleTreeTest {
                                ┃                  ┃                  ┗unknown            filtered
                                ┃                  ┗00000634 (calc)   ┳00000002 (calc)    known leaf
                                ┃                                     ┗00000003 (input 0) filtered
-                               ┗00000638 (input 2)━                  ┳unknown            filtered
+                               ┗00000638 (input 2)━unknown           ┳unknown            filtered
                                                                      ┗unknown            filtered
             """)
     }
@@ -507,12 +507,12 @@ class MerkleTreeTest {
                 }
                 if (i == 16 && treeSize == 6) {
                     assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                         00000612 (calc)┳0000069F (input 1)┳               ┳unknown            filtered
-                                        ┃                  ┃               ┗unknown            filtered
-                                        ┃                  ┗               ┳unknown            filtered
-                                        ┃                                  ┗unknown            filtered
-                                        ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
-                                                                           ┗00000005 (input 0) filtered
+                        00000612 (calc)┳0000069F (input 1)┳unknown        ┳unknown            filtered
+                                       ┃                  ┃               ┗unknown            filtered
+                                       ┃                  ┗unknown        ┳unknown            filtered
+                                       ┃                                  ┗unknown            filtered
+                                       ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
+                                                                          ┗00000005 (input 0) filtered
                     """.trimIndent())
                 }
             }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -551,6 +551,13 @@ class MerkleTreeTest {
                     subproof.render(trivialHashDigestProvider)
                 }
 
+
+                if (sourceProofLeafSet == 4 && treeSize == 3) {
+                    println(it.render(trivialHashDigestProvider))
+                    val subproof = it.subset(trivialHashDigestProvider, listOf(2))
+                    subproof.render(trivialHashDigestProvider)
+                }
+
                 for (subsetProofLeafSet in (0 until (1 shl treeSize)).toList().shuffled(rng).take(10)) {
                     val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
                     val missingLeaves = (0 until treeSize).filter { leaf -> subsetProofLeafSet and (1 shl leaf) != 0 &&  (sourceProofLeafSet and (1 shl leaf)) == 0}

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.slf4j.LoggerFactory
 import java.security.SecureRandom
 import kotlin.experimental.xor
 import kotlin.random.Random
@@ -37,6 +38,7 @@ import kotlin.test.assertFailsWith
 class MerkleTreeTest {
     companion object {
         val digestAlgorithm = DigestAlgorithmName.SHA2_256D
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         private lateinit var digestService: DigestService
         private lateinit var defaultHashDigestProvider: DefaultHashDigestProvider
@@ -546,23 +548,24 @@ class MerkleTreeTest {
                 }
 
                 if (sourceProofLeafSet == 5 && treeSize == 3) {
-                    println(it.render(trivialHashDigestProvider))
+                    logger.trace( "source proof ${it.render(trivialHashDigestProvider)}")
                     val subproof = it.subset(trivialHashDigestProvider, listOf(0,2))
-                    subproof.render(trivialHashDigestProvider)
+                    val text = subproof.render(trivialHashDigestProvider)
+                    logger.trace("subset proof $text")
                 }
 
 
                 if (sourceProofLeafSet == 4 && treeSize == 3) {
-                    println(it.render(trivialHashDigestProvider))
+                    logger.trace( "source proof ${it.render(trivialHashDigestProvider)}")
                     val subproof = it.subset(trivialHashDigestProvider, listOf(2))
                     subproof.render(trivialHashDigestProvider)
                 }
 
-                for (subsetProofLeafSet in (0 until (1 shl treeSize)).toList().shuffled(rng).take(100)) {
+                for (subsetProofLeafSet in (0 until (1 shl treeSize)).toList().shuffled(rng).take(10)) {
                     val subLeafIndicesCombination = (0 until treeSize).filter { leaf -> (subsetProofLeafSet and (1 shl leaf)) != 0 }
                     val missingLeaves = (0 until treeSize).filter { leaf -> subsetProofLeafSet and (1 shl leaf) != 0 &&  (sourceProofLeafSet and (1 shl leaf)) == 0}
                     val missing = missingLeaves.isNotEmpty()
-                    println("tree size $treeSize source proof $sourceProofLeafSet subset $subsetProofLeafSet missing $missingLeaves ($missing)")
+                    logger.trace("tree size $treeSize source proof $sourceProofLeafSet subset $subsetProofLeafSet missing $missingLeaves ($missing)")
                     when {
                         subsetProofLeafSet == 0 ->
                             // no leaves in output, which is never legal
@@ -576,7 +579,8 @@ class MerkleTreeTest {
                             }
                         else ->
                             it.subset(trivialHashDigestProvider, subLeafIndicesCombination).also {
-                                println(it.render(trivialHashDigestProvider))
+                                val text = it.render(trivialHashDigestProvider)
+                                logger.trace("subset proof $text")
                             }
                     }
                 }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -366,6 +366,18 @@ class MerkleTreeTest {
             val subsetI = 16;
             val subsetLeafIndicesCombination = (0 until treeSize).filter { (subsetI and (1 shl it)) != 0 }
             assertThat(subsetLeafIndicesCombination).hasSize(1)
+
+            val proof2 = it.subset(subsetLeafIndicesCombination)
+
+            assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
+            """
+                    00000612 (calc)┳0000069F (input 0)┳unknown        ┳unknown            filtered
+                                   ┃                  ┃               ┗unknown            filtered
+                                   ┃                  ┗unknown        ┳unknown            filtered
+                                   ┃                                  ┗unknown            filtered
+                                   ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
+                                                                      ┗00000005 (input 1) filtered
+                """)
         }
     }
 

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -722,7 +722,12 @@ class MerkleTreeTest {
         }
     }
 
-    private fun testProof(treeSize: Int, leaves: List<Int>, expected: String, digest: MerkleTreeHashDigestProvider = defaultHashDigestProvider) {
+    private fun testProof(
+        treeSize: Int,
+        leaves: List<Int>,
+        expected: String,
+        digest: MerkleTreeHashDigestProvider = defaultHashDigestProvider
+    ) {
         val tree = makeTestMerkleTree(treeSize, digest)
         val proof = testLeafCombination(tree, leaves, tree.root, treeSize, digest)
         assertThat(proof.render(digest)).isEqualToIgnoringWhitespace(expected)

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -343,6 +343,32 @@ class MerkleTreeTest {
                 """)
         }
     }
+
+    @Test
+    fun `merkle proof subset`() {
+        // a single simple test case which is easier to debug than the parameterised tree tests
+        val treeSize = 6
+        val i = 20
+        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
+
+        val leafIndicesCombination = (0 until treeSize).filter { (i and (1 shl it)) != 0 }
+        testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize).also {
+            assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
+                """
+                    00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
+                                   ┃               ┃                  ┗unknown            filtered
+                                   ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
+                                   ┃                                  ┗00000003 (input 0) filtered
+                                   ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
+                                                                      ┗00000005 (input 1) filtered
+                """)
+
+            val subsetI = 16;
+            val subsetLeafIndicesCombination = (0 until treeSize).filter { (subsetI and (1 shl it)) != 0 }
+            assertThat(subsetLeafIndicesCombination).hasSize(1)
+        }
+    }
+
     private fun runMerkleProofTest(treeSize: Int) {
         // we don't want to take the time to do an expensive hash so we'll just make a cheap one
         val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -345,38 +345,52 @@ class MerkleTreeTest {
     }
 
     @Test
-    fun `merkle proof subset`() {
+    fun `merkle proof size 6 subset A`() {
         // a single simple test case which is easier to debug than the parameterised tree tests
         val treeSize = 6
-        val i = 20
         val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
 
-        val leafIndicesCombination = (0 until treeSize).filter { (i and (1 shl it)) != 0 }
-        testLeafCombination(merkleTree, leafIndicesCombination, merkleTree.root, treeSize).also {
-            assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+        testLeafCombination(merkleTree, listOf(2,4), merkleTree.root, treeSize).also {
+            assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
+                """
                     00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
                                    ┃               ┃                  ┗unknown            filtered
                                    ┃               ┗00000634 (calc)   ┳00000002 (calc)    known leaf
                                    ┃                                  ┗00000003 (input 0) filtered
                                    ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
                                                                       ┗00000005 (input 1) filtered
-                """)
+                """
+            )
 
-            val subsetI = 16;
-            val subsetLeafIndicesCombination = (0 until treeSize).filter { (subsetI and (1 shl it)) != 0 }
-            assertThat(subsetLeafIndicesCombination).hasSize(1)
+            val proof2 = it.subset(trivialHashDigestProvider, listOf(4))
 
-            val proof2 = it.subset(trivialHashDigestProvider, subsetLeafIndicesCombination)
-
-            assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+            assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
+                """
                 00000612 (calc)┳0000069F (input 1)┳               ┳unknown            filtered
                                ┃                  ┃               ┗unknown            filtered
                                ┃                  ┗               ┳unknown            filtered
                                ┃                                  ┗unknown            filtered
                                ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
                                                                   ┗00000005 (input 0) filtered
-                    """)
+                    """
+            )
         }
+    }
+    @Test
+    fun `merkle proof size 6 subset B`() {
+        val treeSize = 6
+        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
+        val proof = testLeafCombination(merkleTree, listOf(2,4), merkleTree.root, treeSize)
+
+        val proof3 = proof.subset(trivialHashDigestProvider, listOf(2))
+        assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                    00000612 (calc)┳0000069F (calc)   ┳00000630 (input 1)┳unknown            filtered
+                                   ┃                  ┃                  ┗unknown            filtered
+                                   ┃                  ┗00000634 (calc)   ┳00000002 (calc)    known leaf
+                                   ┃                                     ┗00000003 (input 0) filtered
+                                   ┗00000638 (input 2)━                  ┳unknown            filtered
+                                                                         ┗unknown            filtered
+                """)
     }
 
     private fun runMerkleProofTest(treeSize: Int) {

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -42,8 +42,8 @@ class MerkleTreeTest {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         // Since there are 2^(2*n) permutations of source leafs we don't want to test too many,
-        // so we do a few at random. In local testing I've taken this up to 1000 which takes 30 minutes
-        // on my laptop.
+        // so we do a few at random. In offline testing this has been successfully taken up to 5000
+        // which takes 30 minutes on a laptop.
         private const val NUMBER_OF_SUBSETS_TO_TEST = 10
 
         private lateinit var digestService: DigestService

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -822,21 +822,19 @@ class MerkleTreeTest {
     @Test
     fun `Merkle proof size 2 with trivial hash`() {
         testProof(2, 1, """
-                            00000630 (calc)┳00000000 (calc)    known leaf
-                                           ┗00000001 (input 0) filtered
+            00000630 (calc)┳00000000 (calc)    known leaf
+                           ┗00000001 (input 0) filtered
         """, trivialHashDigestProvider)
     }
 
     @Test
     fun `Merkle proof size 3`() {
         testProof(3, 1, """
-                                    00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)    known leaf
-                                       ┃                  ┗00000001 (input 0) filtered
-                                       ┗00000002 (input 1)━unknown            filtered
-        """.trimIndent(), trivialHashDigestProvider)
+            A9D5543C (calc)┳BAB170B1 (calc)   ┳7901AF93 (calc)    known leaf
+                           ┃                  ┗471864D3 (input 0) filtered
+                           ┗66973B1A (input 1)━unknown            filtered
+        """.trimIndent())
     }
-
-
 }
 
 fun SecureHash.hex() = bytes.joinToString(separator = "") { "%02x".format(it) }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -386,6 +386,11 @@ class MerkleTreeTest {
                                ┗00000638 (input 2)━unknown           ┳unknown            filtered
                                                                      ┗unknown            filtered
         """)
+        val proofHash = proof.calculateRoot(trivialHashDigestProvider)
+        val proof2Hash = proof2.calculateRoot(trivialHashDigestProvider)
+        val proof3Hash = proof3.calculateRoot(trivialHashDigestProvider)
+        assertThat(proof2Hash).isEqualTo(proofHash)
+        assertThat(proof3Hash).isEqualTo(proofHash)
     }
 
     @Test

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -365,14 +365,13 @@ class MerkleTreeTest {
         val proof2 = proof.subset(trivialHashDigestProvider, listOf(4))
         assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
             """
-            00000612 (calc)┳0000069F (input 1)┳               ┳unknown            filtered
-                           ┃                  ┃               ┗unknown            filtered
-                           ┃                  ┗               ┳unknown            filtered
-                           ┃                                  ┗unknown            filtered
-                           ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
-                                                              ┗00000005 (input 0) filtered
-                """
-        )
+                00000612 (calc)┳0000069F (input 1)┳unknown        ┳unknown            filtered
+                               ┃                  ┃               ┗unknown            filtered
+                               ┃                  ┗unknown        ┳unknown            filtered
+                               ┃                                  ┗unknown            filtered
+                               ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
+                                                                  ┗00000005 (input 0) filtered
+                """)
 
         val proof3 = proof.subset(trivialHashDigestProvider, listOf(2))
         assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
@@ -394,19 +393,19 @@ class MerkleTreeTest {
         assertThat(proof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
             00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)━00000000 (calc) known leaf
                            ┃                  ┗00000001 (calc)━00000001 (calc) known leaf
-                           ┗00000002 (input 0)━               ━unknown         filtered
+                           ┗00000002 (input 0)━unknown        ━unknown         filtered
         """.trimIndent())
         val proof2 = proof.subset(trivialHashDigestProvider, listOf(1))
         assertThat(proof2.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
                     00000667 (calc)┳00000630 (calc)   ┳00000000 (input 0)━00000000 (input 0) filtered
                                    ┃                  ┗00000001 (calc)   ━00000001 (calc)    known leaf
-                                   ┗00000002 (input 1)━                  ━unknown            filtered
+                                   ┗00000002 (input 1)━unknown           ━unknown            filtered
                 """)
         val proof3 = proof.subset(trivialHashDigestProvider, listOf(0))
         assertThat(proof3.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
                     00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)   ━00000000 (calc)    known leaf
                                    ┃                  ┗00000001 (input 0)━00000001 (input 0) filtered
-                                   ┗00000002 (input 1)━                  ━unknown            filtered
+                                   ┗00000002 (input 1)━unknown           ━unknown            filtered
                 """)
     }
 
@@ -504,6 +503,16 @@ class MerkleTreeTest {
                                        ┃                                  ┗00000003 (input 0) filtered
                                        ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
                                                                           ┗00000005 (input 1) filtered
+                    """.trimIndent())
+                }
+                if (i == 16 && treeSize == 6) {
+                    assertThat(it.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                         00000612 (calc)┳0000069F (input 1)┳               ┳unknown            filtered
+                                        ┃                  ┃               ┗unknown            filtered
+                                        ┃                  ┗               ┳unknown            filtered
+                                        ┃                                  ┗unknown            filtered
+                                        ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
+                                                                           ┗00000005 (input 0) filtered
                     """.trimIndent())
                 }
             }


### PR DESCRIPTION
Includes test coverage. It's not viable to test too many permutations considering all subsets of all proofs up to 16 leaf trees so we use a predictable shuffle order to get some coverage.

Fix bug with MerkleProof.calculateRootInstrumented which showed up only on larger trees.

FIx bugs in Merkle Tree rendering which occur on larger trees, and also sometimes drew the trees out in strange ways that made it look like they had more nodes than they actually do.

Introduce MerkleNode dataclass rather than Pair, for clarity, suggested by Matthew.


