### PR TITLE
CORE-18535: Fail processing if the retry limit is exceeded and mark state with failed metadata key

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
@@ -1,6 +1,10 @@
 package net.corda.messaging.mediator.processor
 
+import net.corda.libs.statemanager.api.Metadata
 import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.State.Companion.VERSION_INITIAL_VALUE
+import net.corda.messaging.api.constants.FAILED_STATE
+import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient
@@ -44,18 +48,34 @@ class EventProcessor<K : Any, S : Any, E : Any>(
             }
             val asyncOutputs = mutableListOf<MediatorMessage<Any>>()
             val queue = ArrayDeque(groupEntry.value)
-            while (queue.isNotEmpty()) {
-                val event = queue.removeFirst()
-                val response = config.messageProcessor.onNext(processorState, event)
-                processorState = response.updatedState
-                val (syncEvents, asyncEvents) = response.responseEvents.map { convertToMessage(it) }.partition {
-                    messageRouter.getDestination(it).type == RoutingDestination.Type.SYNCHRONOUS
+            val processed = try {
+                while (queue.isNotEmpty()) {
+                    val event = queue.removeFirst()
+                    val response = config.messageProcessor.onNext(processorState, event)
+                    processorState = response.updatedState
+                    val (syncEvents, asyncEvents) = response.responseEvents.map { convertToMessage(it) }.partition {
+                        messageRouter.getDestination(it).type == RoutingDestination.Type.SYNCHRONOUS
+                    }
+                    asyncOutputs.addAll(asyncEvents)
+                    val returnedMessages = processSyncEvents(groupEntry.key, syncEvents)
+                    queue.addAll(returnedMessages)
                 }
-                asyncOutputs.addAll(asyncEvents)
-                val returnedMessages = processSyncEvents(groupEntry.key, syncEvents)
-                queue.addAll(returnedMessages)
+                stateManagerHelper.createOrUpdateState(groupKey, state, processorState)
+            } catch (e: CordaMessageAPIIntermittentException) {
+                // If an intermittent error occurs here, the RPC client has failed to deliver a message to another part
+                // of the system despite the retry loop implemented there. This should trigger individual processing to
+                // fail.
+                val newMetadata = (state?.metadata?.toMutableMap() ?: mutableMapOf()).also {
+                    it[FAILED_STATE] = true
+                }
+                asyncOutputs.clear()
+                State(
+                    groupKey,
+                    byteArrayOf(),
+                    version = state?.version ?: VERSION_INITIAL_VALUE,
+                    metadata = Metadata(newMetadata)
+                )
             }
-            val processed = stateManagerHelper.createOrUpdateState(groupKey, state, processorState)
             val stateChangeAndOperation = when {
                 state == null && processed != null -> StateChangeAndOperation.Create(processed)
                 state != null && processed != null -> StateChangeAndOperation.Update(processed)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
@@ -3,7 +3,7 @@ package net.corda.messaging.mediator.processor
 import net.corda.libs.statemanager.api.Metadata
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.State.Companion.VERSION_INITIAL_VALUE
-import net.corda.messaging.api.constants.FAILED_STATE
+import net.corda.messaging.api.constants.MessagingMetadataKeys.FAILED_STATE
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
@@ -2,6 +2,8 @@ package net.corda.messaging.mediator.processor
 
 import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.libs.statemanager.api.State
+import net.corda.messaging.api.constants.FAILED_STATE
+import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
 import net.corda.messaging.api.mediator.MessagingClient
@@ -9,9 +11,11 @@ import net.corda.messaging.api.mediator.RoutingDestination
 import net.corda.messaging.api.mediator.config.EventMediatorConfig
 import net.corda.messaging.api.mediator.factory.MessageRouterFactory
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.messaging.api.processor.StateAndEventProcessor.Response
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.getStringRecords
 import net.corda.messaging.mediator.StateManagerHelper
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -22,6 +26,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import kotlin.test.assertNotNull
 
 @Execution(ExecutionMode.SAME_THREAD)
 class EventProcessorTest {
@@ -37,33 +42,33 @@ class EventProcessorTest {
     private val syncMessage: String = "SYNC_PAYLOAD"
 
     @BeforeEach
+    @Suppress("unchecked_cast")
     fun setup() {
         client = mock()
         stateAndEventProcessor = mock()
         stateManagerHelper = mock()
         messageRouter = mock()
-        eventMediatorConfig = buildStringTestConfig()
-
-        eventProcessor = EventProcessor(eventMediatorConfig, stateManagerHelper, messageRouter)
-    }
-
-    @Test
-    @Suppress("unchecked_cast")
-    fun `processed record triggers 2 successive synchronous calls which are processed immediately, each input produces 1 async output`() {
         whenever(messageRouter.getDestination(any())).thenAnswer {
             val msg = it.arguments[0] as MediatorMessage<String>
             if (msg.payload == syncMessage) {
                 RoutingDestination(client, "endpoint", RoutingDestination.Type.SYNCHRONOUS)
             } else RoutingDestination(client, "endpoint", RoutingDestination.Type.ASYNCHRONOUS)
         }
+        eventMediatorConfig = buildStringTestConfig()
+
+        eventProcessor = EventProcessor(eventMediatorConfig, stateManagerHelper, messageRouter)
+    }
+
+    @Test
+    fun `processed record triggers 2 successive synchronous calls which are processed immediately, each input produces 1 async output`() {
 
         var counter = 0
         whenever(stateAndEventProcessor.onNext(anyOrNull(), any())).thenAnswer {
             if (counter == 3) {
-                StateAndEventProcessor.Response<String>(null, emptyList())
+                Response<String>(null, emptyList())
             } else {
                 counter++
-                StateAndEventProcessor.Response(null, listOf(
+                Response(null, listOf(
                     Record("", "key", asyncMessage),
                     Record("", "key", syncMessage)
                 ))
@@ -78,6 +83,24 @@ class EventProcessorTest {
         verify(messageRouter, times(9)).getDestination(any())
         verify(client, times(3)).send(any())
         verify(stateManagerHelper, times(1)).createOrUpdateState(any(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun `when the rpc client fails to send a message, a state is output with the correct metadata key filled in`() {
+        whenever(stateAndEventProcessor.onNext(anyOrNull(), any())).thenAnswer {
+            Response(
+                StateAndEventProcessor.State("bar", null), listOf(
+                Record("", "key", asyncMessage),
+                Record("", "key", syncMessage)
+            ))
+        }
+        whenever(client.send(any())).thenThrow(CordaMessageAPIIntermittentException("baz"))
+
+        val outputMap = eventProcessor.processEvents(mapOf("key" to getStringRecords(1, "key")), mapOf("key" to state))
+
+        val output = outputMap["key"]
+        assertEquals(emptyList<MediatorMessage<Any>>(), output?.asyncOutputs)
+        assertNotNull(output?.stateUpdate?.outputState?.metadata?.get(FAILED_STATE))
     }
 
     private fun buildStringTestConfig() = EventMediatorConfig(

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
@@ -2,7 +2,7 @@ package net.corda.messaging.mediator.processor
 
 import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.libs.statemanager.api.State
-import net.corda.messaging.api.constants.FAILED_STATE
+import net.corda.messaging.api.constants.MessagingMetadataKeys.FAILED_STATE
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
@@ -100,7 +100,7 @@ class EventProcessorTest {
 
         val output = outputMap["key"]
         assertEquals(emptyList<MediatorMessage<Any>>(), output?.asyncOutputs)
-        assertNotNull(output?.stateUpdate?.outputState?.metadata?.get(FAILED_STATE))
+        assertNotNull(output?.stateChangeAndOperation?.outputState?.metadata?.get(FAILED_STATE))
     }
 
     private fun buildStringTestConfig() = EventMediatorConfig(


### PR DESCRIPTION
### Problem description

If event mediator processing needs to send an event to another part of the system, it does so via a synchronous HTTP request. If this fails with a transient problem, the HTTP client will retry for a period of time. If the failure does not clear in the required period, then an intermittent error is thrown. This leads to an issue where an error can cause a message to be continuously replayed as the subscription is reset and consumption restarts at the event with the problem.

### Solution

If the RPC client fails, instead fail processing of the event(s) on this key and mark the corresponding state as failed.

This is implemented entirely within the event processor. The state update that is outputted from the event processor is modified in the event that RPC processing fails.

This allows the messaging client to identify states that have failed to process.