### PR TITLE
CORE-18534 remaining external event processors

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/rpc/CryptoFlowOpsProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/rpc/CryptoFlowOpsProcessorTests.kt
@@ -23,7 +23,6 @@ import net.corda.crypto.service.impl.infra.ActResult
 import net.corda.crypto.service.impl.infra.ActResultTimestamps
 import net.corda.crypto.service.impl.infra.act
 import net.corda.crypto.service.impl.infra.assertClose
-import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePairList
 import net.corda.data.crypto.wire.CryptoResponseContext
 import net.corda.data.crypto.wire.CryptoSignatureWithKey
@@ -271,18 +270,6 @@ class CryptoFlowOpsProcessorTests {
                  externalEventResponseFactory.platformError(
                      eq(flowExternalEventContexts[it]),
                      any<Throwable>()
-                 )
-             ).thenReturn(
-                 Record(
-                     Schemas.Flow.FLOW_EVENT_TOPIC,
-                     flowExternalEventContexts[it].flowId,
-                     FlowEvent()
-                 )
-             )
-             whenever(
-                 externalEventResponseFactory.transientError(
-                     eq(flowExternalEventContexts[it]),
-                     any<ExceptionEnvelope>()
                  )
              ).thenReturn(
                  Record(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/LedgerPersistenceRequestProcessor.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/processor/LedgerPersistenceRequestProcessor.kt
@@ -3,13 +3,10 @@ package net.corda.ledger.persistence.processor
 import net.corda.crypto.core.parseSecureHash
 import net.corda.data.flow.event.FlowEvent
 import net.corda.data.ledger.persistence.LedgerPersistenceRequest
-import net.corda.flow.external.events.responses.exceptions.CpkNotAvailableException
-import net.corda.flow.external.events.responses.exceptions.VirtualNodeException
 import net.corda.flow.utils.toMap
 import net.corda.ledger.persistence.common.InconsistentLedgerStateException
 import net.corda.ledger.persistence.common.UnsupportedLedgerTypeException
 import net.corda.ledger.persistence.common.UnsupportedRequestTypeException
-import net.corda.messaging.api.exception.CordaHTTPServerTransientException
 import net.corda.messaging.api.processor.SyncRPCProcessor
 import net.corda.metrics.CordaMetrics
 import net.corda.persistence.common.EntitySandboxService
@@ -37,11 +34,6 @@ class LedgerPersistenceRequestProcessor(
     override val requestClass = LedgerPersistenceRequest::class.java
     override val responseClass = FlowEvent::class.java
 
-    private val transientExceptions = setOf(
-        CpkNotAvailableException::class.java,
-        VirtualNodeException::class.java
-    )
-
     override fun process(request: LedgerPersistenceRequest): FlowEvent {
         val startTime = System.nanoTime()
         val clientRequestId =
@@ -68,9 +60,6 @@ class LedgerPersistenceRequestProcessor(
 
                     delegatedRequestHandlerSelector.selectHandler(sandbox, request).execute()
                 } catch (e: Exception) {
-                    if (transientExceptions.contains(e::class.java)) {
-                        throw CordaHTTPServerTransientException(requestId, e)
-                    }
                     listOf(
                         when (e) {
                             is UnsupportedLedgerTypeException,

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestProcessorTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestProcessorTest.kt
@@ -106,6 +106,8 @@ class LedgerPersistenceRequestProcessorTest {
         val response = VirtualNodeException("vnode not there")
 
         whenever(entitySandboxService.get(cordaHoldingIdentity, cpkHashes)).thenThrow(response)
+        whenever(responseFactory.errorResponse(request.flowExternalEventContext, response))
+            .thenThrow(CordaHTTPServerTransientException(request.flowExternalEventContext.requestId, response))
 
         val e = assertThrows<CordaHTTPServerTransientException> {
             target.process(request)
@@ -123,6 +125,8 @@ class LedgerPersistenceRequestProcessorTest {
         val response = CpkNotAvailableException("cpk not there")
 
         whenever(entitySandboxService.get(cordaHoldingIdentity, cpkHashes)).thenThrow(response)
+        whenever(responseFactory.errorResponse(request.flowExternalEventContext, response))
+            .thenThrow(CordaHTTPServerTransientException(request.flowExternalEventContext.requestId, response))
 
         val e = assertThrows<CordaHTTPServerTransientException> {
             target.process(request)

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestProcessorTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/processor/impl/LedgerPersistenceRequestProcessorTest.kt
@@ -23,6 +23,7 @@ import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
@@ -63,7 +64,8 @@ class LedgerPersistenceRequestProcessorTest {
         }
     }
 
-    private fun defaultSetup() {
+    @BeforeEach
+    fun setup() {
         whenever(entitySandboxService.get(cordaHoldingIdentity, cpkHashes)).thenReturn(sandbox)
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(cordaHoldingIdentity)
@@ -72,7 +74,6 @@ class LedgerPersistenceRequestProcessorTest {
 
     @Test
     fun `requests routed to handlers to generate response messages`() {
-        defaultSetup()
         val request = createRequest("r1")
         val responseRecord = Record("", "1", flowEvent)
         val response = listOf(responseRecord)
@@ -86,7 +87,6 @@ class LedgerPersistenceRequestProcessorTest {
 
     @Test
     fun `failed request returns failure response back to the flow`() {
-        defaultSetup()
         val request = createRequest("r2")
         val failureResponseRecord = Record("", "3", FlowEvent())
         val response = IllegalStateException()

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheEventProcessorFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/factories/TokenCacheEventProcessorFactoryImpl.kt
@@ -27,7 +27,6 @@ import net.corda.ledger.utxo.token.cache.services.internal.AvailableTokenService
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.utilities.time.Clock
-import net.corda.utilities.time.UTCClock
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 
 @Suppress("LongParameterList")
@@ -46,7 +45,7 @@ class TokenCacheEventProcessorFactoryImpl(
     override fun createTokenSelectionSyncRPCProcessor(
         stateManager: StateManager
     ): TokenSelectionSyncRPCProcessor {
-        val tokenSelectionMetrics = TokenSelectionMetricsImpl(UTCClock())
+        val tokenSelectionMetrics = TokenSelectionMetricsImpl()
         val tokenPoolCacheManager = TokenPoolCacheManager(TokenPoolCacheImpl(), createEventHandlerMap(tokenSelectionMetrics))
         val claimStateStoreFactory = ClaimStateStoreFactoryImpl(stateManager, serialization, tokenPoolCacheManager, clock)
 

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenSelectionMetricsImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/TokenSelectionMetricsImpl.kt
@@ -2,16 +2,18 @@ package net.corda.ledger.utxo.token.cache.services
 
 import net.corda.ledger.utxo.token.cache.entities.TokenEvent
 import net.corda.metrics.CordaMetrics
-import net.corda.utilities.time.Clock
 import java.time.Duration
 
-class TokenSelectionMetricsImpl(private val clock: Clock) : TokenSelectionMetrics {
+class TokenSelectionMetricsImpl : TokenSelectionMetrics {
     override fun <T> recordProcessingTime(tokenEvent: TokenEvent, block: () -> T): T {
         val start = System.nanoTime()
-        val result = block()
-        CordaMetrics.Metric.TokenSelectionExecutionTime.builder()
-            .withTag(CordaMetrics.Tag.TokenSelectionEvent, tokenEvent.javaClass.simpleName)
-            .build().record(Duration.ofNanos(System.nanoTime() - start))
+        val result = try {
+            block()
+        } finally {
+            CordaMetrics.Metric.TokenSelectionExecutionTime.builder()
+                .withTag(CordaMetrics.Tag.TokenSelectionEvent, tokenEvent.javaClass.simpleName)
+                .build().record(Duration.ofNanos(System.nanoTime() - start))
+        }
         return result
     }
 

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/AvailableTokenServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/AvailableTokenServiceImplTest.kt
@@ -9,7 +9,6 @@ import net.corda.ledger.utxo.token.cache.services.TokenSelectionMetricsImpl
 import net.corda.ledger.utxo.token.cache.services.internal.AvailableTokenServiceImpl
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.orm.JpaEntitiesSet
-import net.corda.utilities.time.UTCClock
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
@@ -53,7 +52,7 @@ class AvailableTokenServiceImplTest {
         whenever(get(any())).thenReturn(JpaEntitiesSet.create("empty", emptySet()))
     }
 
-    private val tokenSelectionMetrics = TokenSelectionMetricsImpl(UTCClock())
+    private val tokenSelectionMetrics = TokenSelectionMetricsImpl()
     private val availableTokenService = AvailableTokenServiceImpl(
         virtualNodeInfoService,
         dbConnectionManager,

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenSelectionSyncRPCProcessorTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenSelectionSyncRPCProcessorTest.kt
@@ -96,7 +96,6 @@ class TokenSelectionSyncRPCProcessorTest {
     @Test
     fun `process failure (concurrency check) returns transient exception`() {
         val returnedEvent = FlowEvent(testFlowId, WakeUpWithException())
-        val responseRecord = Record("", "", returnedEvent)
         val processorResponse = TokenPoolCacheManager.ResponseAndState(
             returnedEvent,
             POOL_CACHE_STATE
@@ -105,7 +104,6 @@ class TokenSelectionSyncRPCProcessorTest {
 
         claimStateStore.inputPoolState = TOKEN_POOL_CACHE_STATE
         claimStateStore.completionType = false
-        whenever(externalEventResponseFactory.transientError(any(), any<Throwable>())).thenReturn(responseRecord)
         whenever(tokenPoolCacheManager.processEvent(any(), any(), any())).thenReturn(processorResponse)
 
         val e = assertThrows<CordaHTTPServerTransientException> {

--- a/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenSelectionSyncRPCProcessorTest.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/test/kotlin/net/corda/ledger/utxo/token/cache/impl/services/TokenSelectionSyncRPCProcessorTest.kt
@@ -21,10 +21,11 @@ import net.corda.ledger.utxo.token.cache.services.ClaimStateStoreCache
 import net.corda.ledger.utxo.token.cache.services.TokenPoolCacheManager
 import net.corda.ledger.utxo.token.cache.services.TokenSelectionMetricsImpl
 import net.corda.ledger.utxo.token.cache.services.TokenSelectionSyncRPCProcessor
+import net.corda.messaging.api.exception.CordaHTTPServerTransientException
 import net.corda.messaging.api.records.Record
-import net.corda.utilities.time.UTCClock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -65,7 +66,7 @@ class TokenSelectionSyncRPCProcessorTest {
             tokenPoolCacheManager,
             claimStateStoreCache,
             externalEventResponseFactory,
-            TokenSelectionMetricsImpl(UTCClock())
+            TokenSelectionMetricsImpl()
         )
 
     @Test
@@ -107,20 +108,13 @@ class TokenSelectionSyncRPCProcessorTest {
         whenever(externalEventResponseFactory.transientError(any(), any<Throwable>())).thenReturn(responseRecord)
         whenever(tokenPoolCacheManager.processEvent(any(), any(), any())).thenReturn(processorResponse)
 
-        val result = tokenSelectionSyncRPCProcessor.process(tokenPoolCacheEvent)
+        val e = assertThrows<CordaHTTPServerTransientException> {
+            tokenSelectionSyncRPCProcessor.process(tokenPoolCacheEvent)
+        }
 
-        assertThat(result).isEqualTo(returnedEvent)
-
-        val expectedExternalEventContext = ExternalEventContext(
-            testExternalEventRequestId,
-            testFlowId,
-            KeyValuePairList(listOf())
-        )
-
-        verify(externalEventResponseFactory).transientError(
-            eq(expectedExternalEventContext),
-            any<IllegalStateException>()
-        )
+        assertThat(e.requestId).isEqualTo(testExternalEventRequestId)
+        assertThat(e.cause!!.javaClass).isEqualTo(IllegalStateException::class.java)
+        assertThat(e.cause!!.message).isEqualTo("Failed to save state, version out of sync, please retry.")
     }
 
     @Test

--- a/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
@@ -17,7 +17,6 @@ import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -65,8 +64,7 @@ class VerificationRequestProcessorTest {
             )
         }
 
-    @BeforeEach
-    fun setup() {
+    private fun defaultSetup() {
         whenever(verificationSandboxService.get(cordaHoldingIdentity, cpkSummaries)).thenReturn(sandbox)
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(cordaHoldingIdentity)
@@ -75,6 +73,7 @@ class VerificationRequestProcessorTest {
 
     @Test
     fun `successful response messages`() {
+        defaultSetup()
         val request = createRequest("r1")
         val responseRecord = Record("", "1", flowEvent)
         whenever(verificationRequestHandler.handleRequest(sandbox, request)).thenReturn(responseRecord)
@@ -87,6 +86,7 @@ class VerificationRequestProcessorTest {
 
     @Test
     fun `failed request returns failure response back to the flow`() {
+        defaultSetup()
         val request = createRequest("r2")
         val failureResponseRecord = Record("", "3", FlowEvent())
         val response = IllegalStateException()
@@ -106,7 +106,7 @@ class VerificationRequestProcessorTest {
         val request = createRequest("r2")
         val response = CpkNotAvailableException("cpk not there")
 
-        whenever(verificationSandboxService.get(any(), any())).thenThrow(response)
+        whenever(verificationSandboxService.get(cordaHoldingIdentity, cpkSummaries)).thenThrow(response)
 
         val e = assertThrows<CordaHTTPServerTransientException> {
             verificationRequestProcessor.process(request)

--- a/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
+++ b/components/ledger/ledger-verification/src/test/kotlin/net/corda/ledger/verification/processor/impl/VerificationRequestProcessorTest.kt
@@ -18,6 +18,7 @@ import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -67,7 +68,8 @@ class VerificationRequestProcessorTest {
             )
         }
 
-    private fun defaultSetup() {
+    @BeforeEach
+    fun setup() {
         whenever(verificationSandboxService.get(cordaHoldingIdentity, cpkSummaries)).thenReturn(sandbox)
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(cordaHoldingIdentity)
@@ -76,7 +78,6 @@ class VerificationRequestProcessorTest {
 
     @Test
     fun `successful response messages`() {
-        defaultSetup()
         val request = createRequest("r1")
         val responseRecord = Record("", "1", flowEvent)
         whenever(verificationRequestHandler.handleRequest(sandbox, request)).thenReturn(responseRecord)
@@ -89,7 +90,6 @@ class VerificationRequestProcessorTest {
 
     @Test
     fun `failed request returns transient failure response back to the flow`() {
-        defaultSetup()
         val request = createRequest("r2")
         val response = IllegalStateException()
 
@@ -104,7 +104,6 @@ class VerificationRequestProcessorTest {
 
     @Test
     fun `not allowed cpk exception results in platform exception`() {
-        defaultSetup()
         val request = createRequest("r2")
         val failureResponseRecord = Record("", "3", FlowEvent())
         val response = NotAllowedCpkException("not allowed cpk")
@@ -121,7 +120,6 @@ class VerificationRequestProcessorTest {
 
     @Test
     fun `not serializable exception results in platform exception`() {
-        defaultSetup()
         val request = createRequest("r2")
         val failureResponseRecord = Record("", "3", FlowEvent())
         val response = NotSerializableException("not serializable")

--- a/libs/flows/external-event-responses-impl/src/main/kotlin/net/corda/flow/external/events/responses/impl/factory/ExternalEventResponseFactoryImpl.kt
+++ b/libs/flows/external-event-responses-impl/src/main/kotlin/net/corda/flow/external/events/responses/impl/factory/ExternalEventResponseFactoryImpl.kt
@@ -47,25 +47,6 @@ class ExternalEventResponseFactoryImpl(
             payload)
     }
 
-    override fun transientError(
-        flowExternalEventContext: ExternalEventContext,
-        throwable: Throwable
-    ): Record<String, FlowEvent> {
-        return transientError(
-            flowExternalEventContext,
-            ExceptionEnvelope(
-                throwable::class.java.name, throwable.message ?: "No exception message provided"
-            )
-        )
-    }
-
-    override fun transientError(
-        flowExternalEventContext: ExternalEventContext,
-        exceptionEnvelope: ExceptionEnvelope
-    ): Record<String, FlowEvent> {
-        return error(flowExternalEventContext, exceptionEnvelope, ExternalEventResponseErrorType.TRANSIENT)
-    }
-
     override fun platformError(
         flowExternalEventContext: ExternalEventContext,
         throwable: Throwable

--- a/libs/flows/external-event-responses-impl/src/test/kotlin/net/corda/flow/eternal/events/responses/impl/factory/ExternalEventResponseFactoryImplTest.kt
+++ b/libs/flows/external-event-responses-impl/src/test/kotlin/net/corda/flow/eternal/events/responses/impl/factory/ExternalEventResponseFactoryImplTest.kt
@@ -85,22 +85,6 @@ class ExternalEventResponseFactoryImplTest {
     }
 
     @Test
-    fun `transient with throwable input`() {
-        assertErrorResponse(
-            externalEventResponseFactory.transientError(EXTERNAL_EVENT_CONTEXT, EXCEPTION),
-            ExternalEventResponseErrorType.TRANSIENT
-        )
-    }
-
-    @Test
-    fun `transient with exception envelope input`() {
-        assertErrorResponse(
-            externalEventResponseFactory.transientError(EXTERNAL_EVENT_CONTEXT, EXCEPTION_ENVELOPE),
-            ExternalEventResponseErrorType.TRANSIENT
-        )
-    }
-
-    @Test
     fun `platformError with throwable input`() {
         assertErrorResponse(
             externalEventResponseFactory.platformError(EXTERNAL_EVENT_CONTEXT, EXCEPTION),

--- a/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/exceptions/CpkNotAvailableException.kt
+++ b/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/exceptions/CpkNotAvailableException.kt
@@ -1,8 +1,10 @@
 package net.corda.flow.external.events.responses.exceptions
 
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
 /**
  * Used to indicate that a CPKs cannot be retrieved (DB Worker might not be ready yet).
  *
  * This can happen if CPKs broadcast over kafka have not yet arrived.
  */
-class CpkNotAvailableException(message: String, cause: Throwable? = null) : Exception(message, cause)
+class CpkNotAvailableException(message: String, cause: Throwable? = null) : CordaRuntimeException(message, cause)

--- a/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/exceptions/NotAllowedCpkException.kt
+++ b/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/exceptions/NotAllowedCpkException.kt
@@ -1,7 +1,9 @@
 package net.corda.flow.external.events.responses.exceptions
 
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
 /**
  * Used to indicate that a CPK is not allowed. This can happen if CPK is workflow CPK and is being loaded into sandbox
  * that only allows contract CPKs.
  */
-class NotAllowedCpkException(message: String, cause: Throwable? = null) : Exception(message, cause)
+class NotAllowedCpkException(message: String, cause: Throwable? = null) : CordaRuntimeException(message, cause)

--- a/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/exceptions/VirtualNodeException.kt
+++ b/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/exceptions/VirtualNodeException.kt
@@ -1,9 +1,11 @@
 package net.corda.flow.external.events.responses.exceptions
 
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
 /**
  * Used to indicate a problem with retrieving virtual nodes from the system.
  *
  * This exception may occur because CPI metadata is missing from various
  * internal components because it simply hasn't been sent over Kafka yet.
  */
-class VirtualNodeException(message: String, cause: Throwable? = null) : Exception(message, cause)
+class VirtualNodeException(message: String, cause: Throwable? = null) : CordaRuntimeException(message, cause)

--- a/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/factory/ExternalEventResponseFactory.kt
+++ b/libs/flows/external-event-responses/src/main/kotlin/net/corda/flow/external/events/responses/factory/ExternalEventResponseFactory.kt
@@ -34,31 +34,6 @@ interface ExternalEventResponseFactory {
     fun success(flowExternalEventContext: ExternalEventContext, payload: Any): Record<String, FlowEvent>
 
     /**
-     * Creates a response representing a failed attempt at processing an external event which should be retried by
-     * the calling flow.
-     *
-     * @param flowExternalEventContext The [ExternalEventContext] that the received event contained.
-     * @param throwable The error that occurred.
-     *
-     * @return A [FlowEvent] record containing a [ExternalEventResponse] to send back to the calling flow.
-     */
-    fun transientError(flowExternalEventContext: ExternalEventContext, throwable: Throwable): Record<String, FlowEvent>
-
-    /**
-     * Creates a response representing a failed attempt at processing an external event which should be retried by
-     * the calling flow.
-     *
-     * @param flowExternalEventContext The [ExternalEventContext] that the received event contained.
-     * @param exceptionEnvelope The error that occurred.
-     *
-     * @return A [FlowEvent] record containing a [ExternalEventResponse] to send back to the calling flow.
-     */
-    fun transientError(
-        flowExternalEventContext: ExternalEventContext,
-        exceptionEnvelope: ExceptionEnvelope
-    ): Record<String, FlowEvent>
-
-    /**
      * Creates a response representing a failed attempt at processing an external event which should be propagated to
      * the calling flow and rethrown.
      *

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/exception/CordaHTTPExceptions.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/exception/CordaHTTPExceptions.kt
@@ -22,5 +22,5 @@ class CordaHTTPServerErrorException(val statusCode: Int, message: String?, excep
  * @param requestId the identifier for the request.
  * @param cause the cause of the transient exception.
  */
-class CordaHTTPServerTransientException(val requestId: String, cause: Exception? = null) :
+class CordaHTTPServerTransientException(val requestId: String, cause: Throwable? = null) :
     CordaRuntimeException("Transient server exception while processing request '$requestId'. Cause: ${cause?.message}", cause)


### PR DESCRIPTION
Note - This is the 2nd PR ([1st](https://github.com/corda/corda-runtime-os/pull/5366)) to update external event processors to throw CordaHTTPServerTransientExceptions  for transient errors. It includes:
- [x] `LedgerPersistenceRequestProcessor` 
- [x] `TokenSelectionSyncRPCProcessor` 
- [x] `VerificationRequestProcessor` 

**Problem description:**
All flow engine external events go through the RPCClient in the messaging library. This has a built-in retry mechanism to retry events for some period of time. If an external event hits a transient error in the external event handler, the flow engine should rely on this retry handling rather than implementing its own.

To do this, the external event handlers must always return a 503 retry code if a transient error is encountered. The messaging library handles this, the processor throws the exception mentioned above.

Remaining (separate PRs):
- [ ]  `CryptoFlowOpsProcessor` 
- [ ] `UniquenessCheckMessageProcessor` 