### PR TITLE
CORE-18171: Adjust rest permissions for password change

### DIFF
--- a/components/permissions/permission-rest-resource-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
+++ b/components/permissions/permission-rest-resource-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/impl/UserEndpointImpl.kt
@@ -26,12 +26,11 @@ import net.corda.permissions.management.PermissionManagementService
 import net.corda.rest.PluggableRestResource
 import net.corda.rest.annotations.HttpPOST
 import net.corda.rest.authorization.AuthorizationProvider
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.exception.BadRequestException
-import net.corda.rest.exception.InvalidStateChangeException
+import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.rest.response.ResponseEntity
-import net.corda.rest.authorization.AuthorizingSubject
-import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.security.CURRENT_REST_CONTEXT
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component

--- a/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImpl.kt
+++ b/libs/permissions/permission-manager-impl/src/main/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImpl.kt
@@ -104,6 +104,7 @@ class PermissionUserManagerImpl(
         return result.convertToResponseDto()
     }
 
+    @Suppress("ThrowsCount")
     private fun validatePasswordAndGetHash(username: String, newPassword: String): PasswordHash {
         if (newPassword.isBlank()) {
             throw IllegalArgumentException("The passphrase must not be blank string.")

--- a/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImplTest.kt
+++ b/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImplTest.kt
@@ -246,7 +246,6 @@ class PermissionUserManagerImplTest {
         whenever(permissionManagementCache.getUser("loginname123")).thenReturn(avroUser)
         whenever(passwordService.verifies(eq("mypassword"), any())).thenReturn(true)
 
-
         val exception = assertThrows<IllegalArgumentException> {
             manager.changeUserPasswordSelf(changeUserPasswordDto)
         }
@@ -260,7 +259,7 @@ class PermissionUserManagerImplTest {
         whenever(passwordService.verifies(eq("mypassword"), any())).thenReturn(true)
 
         val exception = assertThrows<IllegalArgumentException> {
-              manager.changeUserPasswordOther(changeUserPasswordDto)
+            manager.changeUserPasswordOther(changeUserPasswordDto)
         }
 
         assertEquals("New password must be different from current one.", exception.message)

--- a/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImplTest.kt
+++ b/libs/permissions/permission-manager-impl/src/test/kotlin/net/corda/libs/permissions/manager/impl/PermissionUserManagerImplTest.kt
@@ -244,7 +244,8 @@ class PermissionUserManagerImplTest {
     @Test
     fun `changeUserPasswordSelf fails if the new password is the same as the existing one`() {
         whenever(permissionManagementCache.getUser("loginname123")).thenReturn(avroUser)
-        whenever(passwordService.saltAndHash(eq("mypassword"))).thenReturn(PasswordHash("randomSalt", "temp-hashed-password"))
+        whenever(passwordService.verifies(eq("mypassword"), any())).thenReturn(true)
+
 
         val exception = assertThrows<IllegalArgumentException> {
             manager.changeUserPasswordSelf(changeUserPasswordDto)
@@ -256,10 +257,10 @@ class PermissionUserManagerImplTest {
     @Test
     fun `changeUserPasswordOther fails if the new password is the same as the existing one`() {
         whenever(permissionManagementCache.getUser("loginname123")).thenReturn(avroUser)
-        whenever(passwordService.saltAndHash(eq("mypassword"))).thenReturn(PasswordHash("randomSalt", "temp-hashed-password"))
+        whenever(passwordService.verifies(eq("mypassword"), any())).thenReturn(true)
 
         val exception = assertThrows<IllegalArgumentException> {
-            manager.changeUserPasswordOther(changeUserPasswordDto)
+              manager.changeUserPasswordOther(changeUserPasswordDto)
         }
 
         assertEquals("New password must be different from current one.", exception.message)

--- a/libs/rest/rbac-security-manager/src/main/kotlin/net/corda/rest/security/read/rbac/RBACAuthorizingSubject.kt
+++ b/libs/rest/rbac-security-manager/src/main/kotlin/net/corda/rest/security/read/rbac/RBACAuthorizingSubject.kt
@@ -1,7 +1,7 @@
 package net.corda.rest.security.read.rbac
 
 import net.corda.libs.permission.PermissionValidator
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import java.util.function.Supplier
 
 /**

--- a/libs/rest/rbac-security-manager/src/main/kotlin/net/corda/rest/security/read/rbac/RBACSecurityManager.kt
+++ b/libs/rest/rbac-security-manager/src/main/kotlin/net/corda/rest/security/read/rbac/RBACSecurityManager.kt
@@ -3,7 +3,7 @@ package net.corda.rest.security.read.rbac
 import net.corda.libs.permission.PermissionValidator
 import net.corda.libs.permissions.manager.BasicAuthenticationService
 import net.corda.rest.security.AuthServiceId
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.security.read.Password
 import net.corda.rest.security.read.RestSecurityManager
 import java.util.function.Supplier

--- a/libs/rest/rbac-security-manager/src/main/kotlin/net/corda/rest/security/read/rbac/RBACSecurityManager.kt
+++ b/libs/rest/rbac-security-manager/src/main/kotlin/net/corda/rest/security/read/rbac/RBACSecurityManager.kt
@@ -2,8 +2,8 @@ package net.corda.rest.security.read.rbac
 
 import net.corda.libs.permission.PermissionValidator
 import net.corda.libs.permissions.manager.BasicAuthenticationService
-import net.corda.rest.security.AuthServiceId
 import net.corda.rest.authorization.AuthorizingSubject
+import net.corda.rest.security.AuthServiceId
 import net.corda.rest.security.read.Password
 import net.corda.rest.security.read.RestSecurityManager
 import java.util.function.Supplier

--- a/libs/rest/rest-common/src/main/kotlin/net/corda/rest/security/RestAuthContext.kt
+++ b/libs/rest/rest-common/src/main/kotlin/net/corda/rest/security/RestAuthContext.kt
@@ -1,5 +1,6 @@
 package net.corda.rest.security
 
+import net.corda.rest.authorization.AuthorizingSubject
 import org.slf4j.MDC
 
 data class RestAuthContext(

--- a/libs/rest/rest-security-read/src/main/kotlin/net/corda/rest/security/read/RestSecurityManager.kt
+++ b/libs/rest/rest-security-read/src/main/kotlin/net/corda/rest/security/read/RestSecurityManager.kt
@@ -2,7 +2,7 @@ package net.corda.rest.security.read
 
 import net.corda.lifecycle.Lifecycle
 import net.corda.rest.security.AuthServiceId
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import javax.security.auth.login.FailedLoginException
 
 /**

--- a/libs/rest/rest-security-read/src/main/kotlin/net/corda/rest/security/read/RestSecurityManager.kt
+++ b/libs/rest/rest-security-read/src/main/kotlin/net/corda/rest/security/read/RestSecurityManager.kt
@@ -1,8 +1,8 @@
 package net.corda.rest.security.read
 
 import net.corda.lifecycle.Lifecycle
-import net.corda.rest.security.AuthServiceId
 import net.corda.rest.authorization.AuthorizingSubject
+import net.corda.rest.security.AuthServiceId
 import javax.security.auth.login.FailedLoginException
 
 /**

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -5,12 +5,11 @@ import io.javalin.http.Context
 import io.javalin.http.ForbiddenResponse
 import io.javalin.http.UnauthorizedResponse
 import net.corda.metrics.CordaMetrics
-import net.corda.rest.authorization.AuthorizationProvider
 import net.corda.rest.authorization.AuthorizationUtils
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.exception.HttpApiException
 import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.security.Actor
-import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.security.CURRENT_REST_CONTEXT
 import net.corda.rest.security.InvocationContext
 import net.corda.rest.security.RestAuthContext
@@ -40,7 +39,14 @@ internal object ContextUtils {
     private const val CORDA_X500_NAME = "O=HTTP REST Server, L=New York, C=US"
 
     private fun <T> withMDC(user: String, method: String, path: String, block: () -> T): T {
-        return withMDC(listOf(AuthorizationUtils.USER_MDC to user, AuthorizationUtils.METHOD_MDC to method, AuthorizationUtils.PATH_MDC to path).toMap(), block)
+        return withMDC(
+            listOf(
+                AuthorizationUtils.USER_MDC to user,
+                AuthorizationUtils.METHOD_MDC to method,
+                AuthorizationUtils.PATH_MDC to path
+            ).toMap(),
+            block
+        )
     }
 
     private fun String.loggerFor(): Logger {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -6,6 +6,7 @@ import io.javalin.http.ForbiddenResponse
 import io.javalin.http.UnauthorizedResponse
 import net.corda.metrics.CordaMetrics
 import net.corda.rest.authorization.AuthorizationProvider
+import net.corda.rest.authorization.AuthorizationUtils
 import net.corda.rest.exception.HttpApiException
 import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.security.Actor
@@ -38,12 +39,8 @@ internal object ContextUtils {
 
     private const val CORDA_X500_NAME = "O=HTTP REST Server, L=New York, C=US"
 
-    private const val USER_MDC = "http.user"
-    private const val METHOD_MDC = "http.method"
-    private const val PATH_MDC = "http.path"
-
     private fun <T> withMDC(user: String, method: String, path: String, block: () -> T): T {
-        return withMDC(listOf(USER_MDC to user, METHOD_MDC to method, PATH_MDC to path).toMap(), block)
+        return withMDC(listOf(AuthorizationUtils.USER_MDC to user, AuthorizationUtils.METHOD_MDC to method, AuthorizationUtils.PATH_MDC to path).toMap(), block)
     }
 
     private fun String.loggerFor(): Logger {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -186,29 +186,13 @@ internal object ContextUtils {
         }
     }
 
-    fun authorize(authorizingSubject: AuthorizingSubject, resourceAccessString: String, authorizationProvider: AuthorizationProvider? = null) {
-        val principal = authorizingSubject.principal
-        log.trace { "Authorize \"$principal\" for \"$resourceAccessString\"." }
-
-        if (authorizationProvider != null) {
-            if (!authorizationProvider.isAuthorized(authorizingSubject, resourceAccessString)) {
-                val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
-                withMDC(principal, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
-                    "User not authorized.".let {
-                        log.info(it)
-                        throw ForbiddenResponse(it)
-                    }
-                }
-            }
-        } else if (!authorizingSubject.isPermitted(resourceAccessString)) {
-            val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
-            withMDC(principal, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
-                "User not authorized.".let {
-                    log.info(it)
-                    throw ForbiddenResponse(it)
-                }
+    fun userNotAuthorized(user: String, resourceAccessString: String) {
+        val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
+        withMDC(user, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
+            "User not authorized.".let {
+                log.info(it)
+                throw ForbiddenResponse(it)
             }
         }
-        log.trace { "Authorize \"$principal\" for \"$resourceAccessString\" completed." }
     }
 }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -192,7 +192,7 @@ internal object ContextUtils {
         }
     }
 
-    fun userNotAuthorized(user: String, resourceAccessString: String) {
+    internal fun userNotAuthorized(user: String, resourceAccessString: String) {
         val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
         withMDC(user, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
             "User not authorized.".let {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -11,6 +11,7 @@ import io.javalin.http.util.JsonEscapeUtil
 import io.javalin.http.util.MultipartUtil
 import io.javalin.http.util.RedirectToLowercasePathPlugin
 import io.javalin.plugin.json.JavalinJackson
+import net.corda.rest.authorization.AuthorizationProvider
 import net.corda.rest.server.config.RestServerSettingsProvider
 import net.corda.rest.server.impl.apigen.processing.RouteInfo
 import net.corda.rest.server.impl.apigen.processing.RouteProvider
@@ -195,7 +196,9 @@ internal class RestServerInternal(
                     ) {
                         val clientHttpRequestContext = ClientHttpRequestContext(it)
                         val authorizingSubject = authenticate(clientHttpRequestContext, restAuthProvider, credentialResolver)
-                        authorize(authorizingSubject, clientHttpRequestContext.getResourceAccessString())
+                        val authorizationProvider = routeInfo.method.instance.getAuthorizationProvider()
+
+                        authorize(authorizingSubject, clientHttpRequestContext.getResourceAccessString(), authorizationProvider)
                     } else {
                         log.debug { "Call to ${it.path()} for method ${it.method()} identified as an exempt from authorization check." }
                     }
@@ -249,7 +252,9 @@ internal class RestServerInternal(
                     }
                     val clientHttpRequestContext = ClientHttpRequestContext(it)
                     val authorizingSubject = authenticate(clientHttpRequestContext, restAuthProvider, credentialResolver)
-                    authorize(authorizingSubject, clientHttpRequestContext.getResourceAccessString())
+                    val authorizationProvider = routeInfo.method.instance.getAuthorizationProvider()
+
+                    authorize(authorizingSubject, clientHttpRequestContext.getResourceAccessString(), authorizationProvider)
                 }
             }
             registerHandlerForRoute(routeInfo, handlerType)

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -202,7 +202,6 @@ internal class RestServerInternal(
                         if (!authorize(authorizingSubject, resourceAccessString, authorizationProvider)) {
                             userNotAuthorized(authorizingSubject.principal, resourceAccessString)
                         }
-
                     } else {
                         log.debug { "Call to ${it.path()} for method ${it.method()} identified as an exempt from authorization check." }
                     }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -11,14 +11,13 @@ import io.javalin.http.util.JsonEscapeUtil
 import io.javalin.http.util.MultipartUtil
 import io.javalin.http.util.RedirectToLowercasePathPlugin
 import io.javalin.plugin.json.JavalinJackson
-import net.corda.rest.authorization.AuthorizationProvider
+import net.corda.rest.authorization.AuthorizationUtils.authorize
 import net.corda.rest.server.config.RestServerSettingsProvider
 import net.corda.rest.server.impl.apigen.processing.RouteInfo
 import net.corda.rest.server.impl.apigen.processing.RouteProvider
 import net.corda.rest.server.impl.apigen.processing.openapi.OpenApiInfoProvider
 import net.corda.rest.server.impl.context.ClientHttpRequestContext
 import net.corda.rest.server.impl.context.ContextUtils.authenticate
-import net.corda.rest.server.impl.context.ContextUtils.authorize
 import net.corda.rest.server.impl.context.ContextUtils.contentTypeApplicationJson
 import net.corda.rest.server.impl.context.ContextUtils.invokeHttpMethod
 import net.corda.rest.server.impl.security.RestAuthenticationProvider

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -196,7 +196,7 @@ internal class RestServerInternal(
                     ) {
                         val clientHttpRequestContext = ClientHttpRequestContext(it)
                         val authorizingSubject = authenticate(clientHttpRequestContext, restAuthProvider, credentialResolver)
-                        val authorizationProvider = routeInfo.method.instance.getAuthorizationProvider()
+                        val authorizationProvider = routeInfo.method.instance.authorizationProvider
                         val resourceAccessString = clientHttpRequestContext.getResourceAccessString()
 
                         if (!authorize(authorizingSubject, resourceAccessString, authorizationProvider)) {
@@ -255,7 +255,7 @@ internal class RestServerInternal(
                     }
                     val clientHttpRequestContext = ClientHttpRequestContext(it)
                     val authorizingSubject = authenticate(clientHttpRequestContext, restAuthProvider, credentialResolver)
-                    val authorizationProvider = routeInfo.method.instance.getAuthorizationProvider()
+                    val authorizationProvider = routeInfo.method.instance.authorizationProvider
                     val resourceAccessString = clientHttpRequestContext.getResourceAccessString()
 
                     if (!authorize(authorizingSubject, resourceAccessString, authorizationProvider)) {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProvider.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProvider.kt
@@ -1,6 +1,6 @@
 package net.corda.rest.server.impl.security
 
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.server.impl.security.provider.AuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.AuthenticationCredentials
 import net.corda.rest.server.impl.security.provider.scheme.AuthenticationSchemeProvider

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/provider/AuthenticationProvider.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/provider/AuthenticationProvider.kt
@@ -1,6 +1,6 @@
 package net.corda.rest.server.impl.security.provider
 
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.server.impl.security.provider.credentials.AuthenticationCredentials
 
 /**

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/provider/basic/UsernamePasswordAuthenticationProvider.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/provider/basic/UsernamePasswordAuthenticationProvider.kt
@@ -1,6 +1,6 @@
 package net.corda.rest.server.impl.security.provider.basic
 
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.security.read.Password
 import net.corda.rest.security.read.RestSecurityManager
 import net.corda.rest.server.impl.security.provider.AuthenticationProvider

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/provider/bearer/BearerTokenAuthenticationProvider.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/provider/bearer/BearerTokenAuthenticationProvider.kt
@@ -1,6 +1,6 @@
 package net.corda.rest.server.impl.security.provider.bearer
 
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.server.impl.security.provider.AuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.AuthenticationCredentials
 import net.corda.rest.server.impl.security.provider.credentials.tokens.BearerTokenAuthenticationCredentials

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/provider/bearer/oauth/JwtAuthenticationProvider.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/security/provider/bearer/oauth/JwtAuthenticationProvider.kt
@@ -3,7 +3,7 @@ package net.corda.rest.server.impl.security.provider.bearer.oauth
 import com.nimbusds.jose.proc.BadJOSEException
 import com.nimbusds.jwt.JWT
 import com.nimbusds.jwt.JWTParser
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.security.read.RestSecurityManager
 import net.corda.rest.server.impl.security.provider.bearer.BearerTokenAuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.tokens.BearerTokenAuthenticationCredentials

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/websocket/WebSocketRouteAdaptor.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/websocket/WebSocketRouteAdaptor.kt
@@ -66,8 +66,9 @@ internal class WebSocketRouteAdaptor(
                 try {
                     val authorizingSubject = authenticate(clientWsRequestContext, restAuthProvider, credentialResolver)
                     val resourceAccessString = clientWsRequestContext.getResourceAccessString()
+                    val authorizationProvider = routeInfo.method.instance.authorizationProvider
 
-                    if (!authorize(authorizingSubject, resourceAccessString)) {
+                    if (!authorize(authorizingSubject, resourceAccessString, authorizationProvider)) {
                         userNotAuthorized(authorizingSubject.principal, resourceAccessString)
                     }
                     val paramsFromRequest = routeInfo.retrieveParameters(clientWsRequestContext)

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/websocket/WebSocketRouteAdaptor.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/websocket/WebSocketRouteAdaptor.kt
@@ -9,10 +9,10 @@ import io.javalin.websocket.WsErrorContext
 import io.javalin.websocket.WsErrorHandler
 import io.javalin.websocket.WsMessageContext
 import io.javalin.websocket.WsMessageHandler
+import net.corda.rest.authorization.AuthorizationUtils.authorize
 import net.corda.rest.server.impl.apigen.processing.RouteInfo
 import net.corda.rest.server.impl.context.ClientWsRequestContext
 import net.corda.rest.server.impl.context.ContextUtils.authenticate
-import net.corda.rest.server.impl.context.ContextUtils.authorize
 import net.corda.rest.server.impl.context.ContextUtils.retrieveParameters
 import net.corda.rest.server.impl.security.RestAuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.DefaultCredentialResolver

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/websocket/WebSocketRouteAdaptor.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/websocket/WebSocketRouteAdaptor.kt
@@ -70,8 +70,6 @@ internal class WebSocketRouteAdaptor(
                     if (!authorize(authorizingSubject, resourceAccessString)) {
                         userNotAuthorized(authorizingSubject.principal, resourceAccessString)
                     }
-
-
                     val paramsFromRequest = routeInfo.retrieveParameters(clientWsRequestContext)
                     val fullListOfParams = listOf(newChannel) + paramsFromRequest
 

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/websocket/WebSocketRouteAdaptor.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/websocket/WebSocketRouteAdaptor.kt
@@ -14,6 +14,7 @@ import net.corda.rest.server.impl.apigen.processing.RouteInfo
 import net.corda.rest.server.impl.context.ClientWsRequestContext
 import net.corda.rest.server.impl.context.ContextUtils.authenticate
 import net.corda.rest.server.impl.context.ContextUtils.retrieveParameters
+import net.corda.rest.server.impl.context.ContextUtils.userNotAuthorized
 import net.corda.rest.server.impl.security.RestAuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.DefaultCredentialResolver
 import net.corda.rest.ws.DuplexChannel
@@ -64,7 +65,12 @@ internal class WebSocketRouteAdaptor(
 
                 try {
                     val authorizingSubject = authenticate(clientWsRequestContext, restAuthProvider, credentialResolver)
-                    authorize(authorizingSubject, clientWsRequestContext.getResourceAccessString())
+                    val resourceAccessString = clientWsRequestContext.getResourceAccessString()
+
+                    if (!authorize(authorizingSubject, resourceAccessString)) {
+                        userNotAuthorized(authorizingSubject.principal, resourceAccessString)
+                    }
+
 
                     val paramsFromRequest = routeInfo.retrieveParameters(clientWsRequestContext)
                     val fullListOfParams = listOf(newChannel) + paramsFromRequest

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -119,7 +120,7 @@ class RestAuthenticationProviderTest {
 
         val authenticatedBob = restAuthProvider.authenticate(UsernamePasswordAuthenticationCredentials(userBob.username, password))
 
-        assert(authorize(authenticatedBob, TestRestResource::class.java.getMethod("dummy")))
+        assertFalse(authorize(authenticatedBob, TestRestResource::class.java.getMethod("dummy")))
         assert(authorize(authenticatedBob, TestRestResource::class.java.getMethod("dummy2")))
     }
 

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
@@ -2,8 +2,8 @@ package net.corda.rest.server.impl.security
 
 import io.javalin.http.ForbiddenResponse
 import net.corda.rest.RestResource
+import net.corda.rest.authorization.AuthorizationUtils
 import net.corda.rest.authorization.AuthorizingSubject
-import net.corda.rest.server.impl.context.ContextUtils
 import net.corda.rest.server.impl.security.provider.AuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.tokens.BearerTokenAuthenticationCredentials
 import net.corda.rest.server.impl.security.provider.credentials.tokens.UsernamePasswordAuthenticationCredentials
@@ -33,7 +33,7 @@ class RestAuthenticationProviderTest {
     private companion object {
 
         private fun authorize(authenticatedUser: AuthorizingSubject, method: Method) {
-            return ContextUtils.authorize(authenticatedUser, methodFullName(method))
+            return AuthorizationUtils.authorize(authenticatedUser, methodFullName(method))
         }
 
         private fun methodFullName(method: Method): String = methodFullName(method.declaringClass, method.name)

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
@@ -1,6 +1,5 @@
 package net.corda.rest.server.impl.security
 
-import io.javalin.http.ForbiddenResponse
 import net.corda.rest.RestResource
 import net.corda.rest.authorization.AuthorizationUtils
 import net.corda.rest.authorization.AuthorizingSubject
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -32,7 +30,7 @@ class RestAuthenticationProviderTest {
 
     private companion object {
 
-        private fun authorize(authenticatedUser: AuthorizingSubject, method: Method) {
+        private fun authorize(authenticatedUser: AuthorizingSubject, method: Method): Boolean {
             return AuthorizationUtils.authorize(authenticatedUser, methodFullName(method))
         }
 
@@ -121,13 +119,8 @@ class RestAuthenticationProviderTest {
 
         val authenticatedBob = restAuthProvider.authenticate(UsernamePasswordAuthenticationCredentials(userBob.username, password))
 
-        assertThrows(ForbiddenResponse::class.java) {
-            authorize(authenticatedBob, TestRestResource::class.java.getMethod("dummy"))
-        }
-
-        assertDoesNotThrow {
-            authorize(authenticatedBob, TestRestResource::class.java.getMethod("dummy2"))
-        }
+        assert(authorize(authenticatedBob, TestRestResource::class.java.getMethod("dummy")))
+        assert(authorize(authenticatedBob, TestRestResource::class.java.getMethod("dummy2")))
     }
 
     @Test
@@ -137,12 +130,8 @@ class RestAuthenticationProviderTest {
 
         val authenticatedAlice = restAuthProvider.authenticate(UsernamePasswordAuthenticationCredentials(userAlice.username, password))
 
-        assertDoesNotThrow {
-            authorize(authenticatedAlice, TestRestResource::class.java.getMethod("dummy"))
-        }
-        assertDoesNotThrow {
-            authorize(authenticatedAlice, TestRestResource::class.java.getMethod("dummy2"))
-        }
+        assert(authorize(authenticatedAlice, TestRestResource::class.java.getMethod("dummy")))
+        assert(authorize(authenticatedAlice, TestRestResource::class.java.getMethod("dummy2")))
     }
 
     @Test

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
@@ -32,7 +32,11 @@ class RestAuthenticationProviderTest {
 
     private companion object {
 
-        private fun authorize(authenticatedUser: AuthorizingSubject, method: Method, authorizationProvider: AuthorizationProvider? = null): Boolean {
+        private fun authorize(
+            authenticatedUser: AuthorizingSubject,
+            method: Method,
+            authorizationProvider: AuthorizationProvider? = null
+        ): Boolean {
             return AuthorizationUtils.authorize(authenticatedUser, methodFullName(method), authorizationProvider)
         }
 
@@ -155,7 +159,7 @@ class RestAuthenticationProviderTest {
 
         val authenticatedAlice = restAuthProvider.authenticate(UsernamePasswordAuthenticationCredentials(userAlice.username, password))
 
-        assertFalse(authorize(authenticatedAlice, TestRestResource::class.java.getMethod("dummy") , authorizationProvider))
+        assertFalse(authorize(authenticatedAlice, TestRestResource::class.java.getMethod("dummy"), authorizationProvider))
         assert(authorize(authenticatedAlice, TestRestResource::class.java.getMethod("dummy2"), authorizationProvider))
     }
 

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/RestAuthenticationProviderTest.kt
@@ -2,7 +2,7 @@ package net.corda.rest.server.impl.security
 
 import io.javalin.http.ForbiddenResponse
 import net.corda.rest.RestResource
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.server.impl.context.ContextUtils
 import net.corda.rest.server.impl.security.provider.AuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.tokens.BearerTokenAuthenticationCredentials

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/provider/bearer/TestAdminSubject.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/security/provider/bearer/TestAdminSubject.kt
@@ -1,6 +1,6 @@
 package net.corda.rest.server.impl.security.provider.bearer
 
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 
 /**
  * An implementation of [AuthorizingSubject] permitting all actions

--- a/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/utils/FakeSecurityManager.kt
+++ b/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/utils/FakeSecurityManager.kt
@@ -1,7 +1,7 @@
 package net.corda.rest.test.utils
 
 import net.corda.rest.security.AuthServiceId
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.security.read.Password
 import net.corda.rest.security.read.RestSecurityManager
 import javax.security.auth.login.FailedLoginException

--- a/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/utils/FakeSecurityManager.kt
+++ b/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/utils/FakeSecurityManager.kt
@@ -1,7 +1,7 @@
 package net.corda.rest.test.utils
 
-import net.corda.rest.security.AuthServiceId
 import net.corda.rest.authorization.AuthorizingSubject
+import net.corda.rest.security.AuthServiceId
 import net.corda.rest.security.read.Password
 import net.corda.rest.security.read.RestSecurityManager
 import javax.security.auth.login.FailedLoginException

--- a/libs/rest/rest/build.gradle
+++ b/libs/rest/rest/build.gradle
@@ -9,7 +9,6 @@ ext.cordaEnableFormatting = true
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
     implementation "net.corda:corda-base"
-    implementation project(":libs:utilities")
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 }

--- a/libs/rest/rest/build.gradle
+++ b/libs/rest/rest/build.gradle
@@ -9,7 +9,7 @@ ext.cordaEnableFormatting = true
 dependencies {
     compileOnly "org.osgi:osgi.annotation"
     implementation "net.corda:corda-base"
+    implementation project(":libs:utilities")
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-
 }

--- a/libs/rest/rest/src/main/java/net/corda/rest/authorization/package-info.java
+++ b/libs/rest/rest/src/main/java/net/corda/rest/authorization/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.rest.authorization;
+
+import org.osgi.annotation.bundle.Export;

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/RestResource.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/RestResource.kt
@@ -1,5 +1,7 @@
 package net.corda.rest
 
+import net.corda.rest.authorization.AuthorizationProvider
+
 /**
  * [RestResource] is a marker interface to indicate a class that contains HTTP endpoints.
  * Any class that provides HTTP endpoints must implement
@@ -9,4 +11,11 @@ interface RestResource {
 
     /** Returns the HTTP Rest protocol version. Exists since version 0 so guaranteed to be present. */
     val protocolVersion: Int
+
+    /**
+     * Provides an AuthorizationProvider for this resource.
+     * By default, it returns the standard AuthorizationProvider.
+     * Implementations can override this to provide a custom AuthorizationProvider.
+     */
+    fun getAuthorizationProvider(): AuthorizationProvider = AuthorizationProvider.Default
 }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/RestResource.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/RestResource.kt
@@ -17,5 +17,4 @@ interface RestResource {
      * By default, it returns the standard AuthorizationProvider.
      * Implementations can override this to provide a custom AuthorizationProvider.
      */
-    fun getAuthorizationProvider(): AuthorizationProvider = AuthorizationProvider.Default
-}
+    val authorizationProvider: AuthorizationProvider get() = AuthorizationProvider.Default}

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/RestResource.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/RestResource.kt
@@ -17,4 +17,4 @@ interface RestResource {
      * By default, it returns the standard AuthorizationProvider.
      * Implementations can override this to provide a custom AuthorizationProvider.
      */
-    val authorizationProvider: AuthorizationProvider get() = AuthorizationProvider.Default}
+    val authorizationProvider: AuthorizationProvider get() = AuthorizationProvider.Default }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/RestResource.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/RestResource.kt
@@ -17,4 +17,5 @@ interface RestResource {
      * By default, it returns the standard AuthorizationProvider.
      * Implementations can override this to provide a custom AuthorizationProvider.
      */
-    val authorizationProvider: AuthorizationProvider get() = AuthorizationProvider.Default }
+    val authorizationProvider: AuthorizationProvider get() = AuthorizationProvider.Default
+}

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
@@ -12,9 +12,9 @@ interface AuthorizationProvider {
     companion object Default : AuthorizationProvider {
         override fun isAuthorized(subject: AuthorizingSubject, action: String): Boolean {
             return try {
-                ContextUtils.authorize(subject, action)
+                AuthorizationUtils.authorize(subject, action)
                 true
-            } catch (e: ForbiddenResponse) {
+            } catch (e: IllegalStateException) {
                 false
             }
         }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
@@ -1,7 +1,5 @@
 package net.corda.rest.authorization
 
-import net.corda.rest.exception.ForbiddenException
-
 interface AuthorizationProvider {
     /**
      * Checks if the given subject is authorized to perform the specified action.

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
@@ -13,12 +13,7 @@ interface AuthorizationProvider {
 
     companion object Default : AuthorizationProvider {
         override fun isAuthorized(subject: AuthorizingSubject, action: String): Boolean {
-            return try {
-                AuthorizationUtils.authorize(subject, action)
-                true
-            } catch (e: ForbiddenException) {
-                false
-            }
+            return AuthorizationUtils.authorize(subject, action)
         }
     }
 }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
@@ -1,0 +1,22 @@
+package net.corda.rest.authorization
+
+interface AuthorizationProvider {
+    /**
+     * Checks if the given subject is authorized to perform the specified action.
+     * @param subject The subject (user or service) requesting authorization.
+     * @param action The action for which authorization is requested.
+     * @return Boolean indicating whether the action is authorized.
+     */
+    fun isAuthorized(subject: AuthorizingSubject, action: String): Boolean
+
+    companion object Default : AuthorizationProvider {
+        override fun isAuthorized(subject: AuthorizingSubject, action: String): Boolean {
+            return try {
+                ContextUtils.authorize(subject, action)
+                true
+            } catch (e: ForbiddenResponse) {
+                false
+            }
+        }
+    }
+}

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationProvider.kt
@@ -1,5 +1,7 @@
 package net.corda.rest.authorization
 
+import net.corda.rest.exception.ForbiddenException
+
 interface AuthorizationProvider {
     /**
      * Checks if the given subject is authorized to perform the specified action.
@@ -14,7 +16,7 @@ interface AuthorizationProvider {
             return try {
                 AuthorizationUtils.authorize(subject, action)
                 true
-            } catch (e: IllegalStateException) {
+            } catch (e: ForbiddenException) {
                 false
             }
         }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
@@ -9,7 +9,11 @@ object AuthorizationUtils {
     const val METHOD_MDC = "http.method"
     const val PATH_MDC = "http.path"
 
-    fun authorize(authorizingSubject: AuthorizingSubject, resourceAccessString: String, authorizationProvider: AuthorizationProvider? = null) : Boolean {
+    fun authorize(
+        authorizingSubject: AuthorizingSubject,
+        resourceAccessString: String,
+        authorizationProvider: AuthorizationProvider? = null
+    ): Boolean {
         val principal = authorizingSubject.principal
         log.trace("Authorize \"$principal\" for \"$resourceAccessString\".")
 

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
@@ -1,5 +1,6 @@
 package net.corda.rest.authorization
 
+import net.corda.rest.exception.ForbiddenException
 import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
 import net.corda.utilities.withMDC
@@ -28,7 +29,7 @@ object AuthorizationUtils {
             withMDC(principal, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
                 "User not authorized.".let {
                     log.info(it)
-                    throw IllegalStateException(it)
+                    throw ForbiddenException(it)
                 }
             }
         }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
@@ -1,9 +1,6 @@
 package net.corda.rest.authorization
 
-import net.corda.rest.exception.ForbiddenException
-import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
-import net.corda.utilities.withMDC
 
 object AuthorizationUtils {
     private val log = LoggerFactory.getLogger(AuthorizationUtils::class.java)
@@ -11,13 +8,8 @@ object AuthorizationUtils {
     const val USER_MDC = "http.user"
     const val METHOD_MDC = "http.method"
     const val PATH_MDC = "http.path"
-    private const val METHOD_SEPARATOR = ":"
 
-    private fun <T> withMDC(user: String, method: String, path: String, block: () -> T): T {
-        return withMDC(listOf(USER_MDC to user, METHOD_MDC to method, PATH_MDC to path).toMap(), block)
-    }
-
-    fun authorize(authorizingSubject: AuthorizingSubject, resourceAccessString: String, authorizationProvider: AuthorizationProvider? = null) {
+    fun authorize(authorizingSubject: AuthorizingSubject, resourceAccessString: String, authorizationProvider: AuthorizationProvider? = null) : Boolean {
         val principal = authorizingSubject.principal
         log.trace("Authorize \"$principal\" for \"$resourceAccessString\".")
 
@@ -25,14 +17,9 @@ object AuthorizationUtils {
             ?: authorizingSubject.isPermitted(resourceAccessString)
 
         if (!isAuthorized) {
-            val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
-            withMDC(principal, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
-                "User not authorized.".let {
-                    log.info(it)
-                    throw ForbiddenException(it)
-                }
-            }
+            return false
         }
         log.trace("Authorize \"$principal\" for \"$resourceAccessString\" completed.")
+        return true
     }
 }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
@@ -1,0 +1,44 @@
+package net.corda.rest.authorization
+
+import net.corda.utilities.trace
+import org.slf4j.LoggerFactory
+import net.corda.utilities.withMDC
+
+object AuthorizationUtils {
+    private val log = LoggerFactory.getLogger(AuthorizationUtils::class.java)
+
+    const val USER_MDC = "http.user"
+    const val METHOD_MDC = "http.method"
+    const val PATH_MDC = "http.path"
+    private const val METHOD_SEPARATOR = ":"
+
+    private fun <T> withMDC(user: String, method: String, path: String, block: () -> T): T {
+        return withMDC(listOf(USER_MDC to user, METHOD_MDC to method, PATH_MDC to path).toMap(), block)
+    }
+
+    fun authorize(authorizingSubject: AuthorizingSubject, resourceAccessString: String, authorizationProvider: AuthorizationProvider? = null) {
+        val principal = authorizingSubject.principal
+        log.trace("Authorize \"$principal\" for \"$resourceAccessString\".")
+
+        if (authorizationProvider != null) {
+            if (!authorizationProvider.isAuthorized(authorizingSubject, resourceAccessString)) {
+                val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
+                withMDC(principal, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
+                    "User not authorized.".let {
+                        log.info(it)
+                        throw IllegalStateException(it)
+                    }
+                }
+            }
+        } else if (!authorizingSubject.isPermitted(resourceAccessString)) {
+            val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
+            withMDC(principal, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
+                "User not authorized.".let {
+                    log.info(it)
+                    throw IllegalStateException(it)
+                }
+            }
+        }
+        log.trace("Authorize \"$principal\" for \"$resourceAccessString\" completed.")
+    }
+}

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
@@ -20,17 +20,10 @@ object AuthorizationUtils {
         val principal = authorizingSubject.principal
         log.trace("Authorize \"$principal\" for \"$resourceAccessString\".")
 
-        if (authorizationProvider != null) {
-            if (!authorizationProvider.isAuthorized(authorizingSubject, resourceAccessString)) {
-                val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
-                withMDC(principal, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
-                    "User not authorized.".let {
-                        log.info(it)
-                        throw IllegalStateException(it)
-                    }
-                }
-            }
-        } else if (!authorizingSubject.isPermitted(resourceAccessString)) {
+        val isAuthorized = authorizationProvider?.isAuthorized(authorizingSubject, resourceAccessString)
+            ?: authorizingSubject.isPermitted(resourceAccessString)
+
+        if (!isAuthorized) {
             val pathParts = resourceAccessString.split(METHOD_SEPARATOR, limit = 2)
             withMDC(principal, pathParts.firstOrNull() ?: "no_method", pathParts.lastOrNull() ?: "no_path") {
                 "User not authorized.".let {

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
@@ -20,10 +20,7 @@ object AuthorizationUtils {
         val isAuthorized = authorizationProvider?.isAuthorized(authorizingSubject, resourceAccessString)
             ?: authorizingSubject.isPermitted(resourceAccessString)
 
-        if (!isAuthorized) {
-            return false
-        }
-        log.trace("Authorize \"$principal\" for \"$resourceAccessString\" completed.")
-        return true
+        log.trace("Authorize \"$principal\" for \"$resourceAccessString\" completed. Outcome: $isAuthorized")
+        return isAuthorized
     }
 }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizingSubject.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizingSubject.kt
@@ -1,4 +1,4 @@
-package net.corda.rest.security
+package net.corda.rest.authorization
 
 /**
  * Provides permission checking for the subject identified by the given [principal].

--- a/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/FakeSecurityManager.kt
+++ b/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/FakeSecurityManager.kt
@@ -1,10 +1,10 @@
 package net.corda.processors.rest
 
-import javax.security.auth.login.FailedLoginException
 import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.security.AuthServiceId
 import net.corda.rest.security.read.Password
 import net.corda.rest.security.read.RestSecurityManager
+import javax.security.auth.login.FailedLoginException
 
 /**
  * Note: We cannot use `FakeSecurityManager` from "net.corda.rest.test.utils" as this is non-OSGi module.

--- a/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/FakeSecurityManager.kt
+++ b/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/FakeSecurityManager.kt
@@ -1,10 +1,10 @@
 package net.corda.processors.rest
 
-import net.corda.rest.security.AuthServiceId
+import javax.security.auth.login.FailedLoginException
 import net.corda.rest.authorization.AuthorizingSubject
+import net.corda.rest.security.AuthServiceId
 import net.corda.rest.security.read.Password
 import net.corda.rest.security.read.RestSecurityManager
-import javax.security.auth.login.FailedLoginException
 
 /**
  * Note: We cannot use `FakeSecurityManager` from "net.corda.rest.test.utils" as this is non-OSGi module.

--- a/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/FakeSecurityManager.kt
+++ b/processors/rest-processor/src/integrationTest/kotlin/net/corda/processors/rest/FakeSecurityManager.kt
@@ -1,7 +1,7 @@
 package net.corda.processors.rest
 
 import net.corda.rest.security.AuthServiceId
-import net.corda.rest.security.AuthorizingSubject
+import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.security.read.Password
 import net.corda.rest.security.read.RestSecurityManager
 import javax.security.auth.login.FailedLoginException


### PR DESCRIPTION
This PR adds an AuthorizationProvider to the RestResource interface. This allows rest resources to provide custom authorization logic for particular routes, by overriding the default method in AuthorizationProvider.

This is used in UserEndpointImpl to ensure that the `changeUserPasswordSelf` method can always be called by a user, regardless of their permissions. 

Once this is merged, https://github.com/corda/corda-e2e-tests/pull/402 will enable further e2e tests which cover various permission scenarios. 
