### PR TITLE
CORE-19247: Workaround Time Overflow

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowTimeoutTaskProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowTimeoutTaskProcessor.kt
@@ -59,7 +59,7 @@ class FlowTimeoutTaskProcessor(
                     // Flows that have not been updated in at least [maxIdleTime] seconds
                     stateManager.updatedBetween(
                         IntervalFilter(
-                            Instant.MIN,
+                            Instant.EPOCH,
                             now().minusMillis(maxIdleTimeMilliseconds)
                         )
                     )


### PR DESCRIPTION
Use "Instant.EPOCH" instead of "Instant.MIN" when filtering by
interval of time through State Manager operations.
