### PR TITLE
CORE-19195: proof merging and test cleanup

### DIFF
--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -305,6 +305,11 @@ class MerkleProofImpl(
      */
     @Suppress("UnusedParameters")
     fun merge(other: MerkleProofImpl, digest: MerkleTreeHashDigestProvider): MerkleProofImpl {
+        require(this.treeSize == other.treeSize) {
+            "underlying tree sizes must match; left hand side has underlying tree "+
+                "size ${this.treeSize} and right hand side has underlying tree size ${other.treeSize}"
+        }
+
         // First, work out the leaves for the output proof.
         val indexMapThis = leaves.associateBy { it.index }
         val indexMapOther = other.leaves.associateBy { it.index }

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -273,6 +273,28 @@ class MerkleProofImpl(
         return MerkleProofImpl(proofType, treeSize, outLeaves, outHashes)
     }
 
+    @Suppress("UnusedParameters")
+    fun merge(other: MerkleProofImpl): MerkleProofImpl {
+        // First, work out the leaves for the output proof.
+        val indexMapMe = leaves.map { it.index to it }.toMap()
+        val indexMapOther = other.leaves.map { it.index to it }.toMap()
+        val combinedIndexMap = indexMapMe + indexMapOther
+        val outLeaves = combinedIndexMap.values.toList().sortedWith( compareBy { it.index })
+
+        // We can now work out hashes for the nodes known in either proof.
+        //val outHashMap: Map< Pair<Int, Int>, SecureHash> = mutableMapOf()
+        //calculateRootInstrumented(digest) { hash, level, index, _ -> }
+        //other.calculateRootInstrumented(digest) { hash, level, index, _ -> }
+
+        // For each node, where X is me and Y is the other proof, and O is the output proof (so we're doing O = X∪Y)
+        // if X is calculated, it will be calculable in O, so no proof hash needed
+        //  or if Y is calculated, it will be calculable in O, so no proof hash needed
+        //    or if X uses a proof hash, add that proof hash for O
+        //      or if Y uses a proof hash, add that proof hash for O
+        //         else leave it unknown
+        return MerkleProofImpl(proofType, treeSize, outLeaves, emptyList())
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -312,10 +312,10 @@ class MerkleProofImpl(
 
                 when {
                     x != null && x.consumed == null -> {
-                        // X is calculated so it will be calcuable in O, no proof hash needed in O
+                        // x is calculated so it can be calculated in o, no proof hash needed in O
                     }
                     y != null && y.consumed == null -> {
-                        // Y is calculated so it will be calcuble in O, no proof hash needed in O
+                        // y is calculated so it can be calculated in o, no proof hash needed in O
                     }
                     x?.consumed != null -> {
                         outHashes += x.node.hash

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -412,7 +412,8 @@ class MerkleProofImpl(
 
     fun render(digest: MerkleTreeHashDigest): String {
         val nodeLabels: MutableMap<Pair<Int,Int>, String> = mutableMapOf()
-        for(x in 0..treeSize)
+        val treeDepth = MerkleTreeImpl.treeDepth(treeSize)         // initialised to the depth of tree we should
+        for(x in 0..treeDepth)
             for (y in 0 until (1 shl x)) // should be 0 until x?
                 nodeLabels[x to y] = "unknown"
         calculateRootInstrumented(digest) { info ->

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -19,7 +19,7 @@ import kotlin.math.min
  * @param hashes - the input hashes needed to rebuild the parts of the tree where data is not given
  *
  * The number of elements in hashes will depend on the tree size and where in the tree the unknown
- * data is. There will need to be at least one, to cover the gap left by missing data. There never
+ * data is. There will need to be at least one to cover the gap left by missing data. There never
  * needs to be more than the tree size minus the number of leaves specified.
  */
 
@@ -59,7 +59,7 @@ class MerkleProofImpl(
      *
      * @param digest the digest service to use, which must generate hashes compatible with the [hashes] constructor parameter.
      * @param onNewHash called with information about a node taken from incoming hashes or calculated during the proof.
-     *                  This will be called left to right then bottom to top. i.e. the same order as input hashes are consumed.
+     *                  This will be called left to right then bottom to top, i.e., the same order as input hashes are consumed.
      * @return the secure hash of the root of the Merkle proof
      */
     @Suppress("NestedBlockDepth", "ThrowsCount")
@@ -122,10 +122,10 @@ class MerkleProofImpl(
         var currentSize = treeSize                                 // outer loop variable; the number of
                                                                    // leaves left as we roll up the tree
 
-        // loop over each level of the tree, starting at the deepest level (i.e. furthest from root)
+        // loop over each level of the tree, starting at the deepest level (i.e., furthest from root)
         while (currentSize > 1) {
             val newPendingNodes = mutableListOf<MerkleNodeInfo>()
-            // Process a level of the tree which means generating the hashes for the level above (i.e. closer
+            // Process a level of the tree which means generating the hashes for the level above (i.e., closer
             // to the root).
 
             // There is nothing to do if the tree size $currentSize is 1, hence the loop condition
@@ -164,7 +164,7 @@ class MerkleProofImpl(
                         // Decide if we can consume the next two elements since they are adjacent in the Merkle tree
                         if (item.indexWithinLevel xor next.indexWithinLevel == 1) {       // ... and they are a pair with the current
                             // We now know that the indices ${item.first} and ${next.first} only differ on the bottom bit,
-                            // i.e. they are adjacent. Therefore, we can combine them.
+                            // i.e., they are adjacent. Therefore, we can combine them.
 
                             // So, make a single new item, computing a new hash
                             // (Pair is the Kotlin type, nothing to do with pairing nodes)

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -304,7 +304,7 @@ class MerkleProofImpl(
 
         val outHashes = mutableListOf<SecureHash>()
 
-        // now walk the whole tree
+        // Second, walk the whole tree structure.
         val levels = makeLevels(treeSize)
         levels.forEachIndexed { height, ranges ->
             val level = levels.size - height - 1
@@ -319,7 +319,7 @@ class MerkleProofImpl(
                 //  or if y is calculated, it will be calculable in o, so no proof hash needed
                 //    or if x uses a proof hash, add that proof hash for o
                 //      or if y uses a proof hash, add that proof hash for o
-                //         else it is unknown in both, so leave it unknown
+                //         else it is unknown in both, so it is unknown
 
                 when {
                     x != null && x.consumed == null -> {

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -313,15 +313,16 @@ class MerkleProofImpl(
 
         // Second, walk the whole proof structure, for both this and other.
         val nodeMapThis: MutableMap< Pair<Int, Int>, MerkleNodeInfo> = mutableMapOf()
-        calculateRootInstrumented(digest) {
+        val thisRoot = calculateRootInstrumented(digest) {
             val k = it.level to it.node.indexWithinLevel
             nodeMapThis[k] = it
         }
         val nodeMapOther: MutableMap< Pair<Int, Int>, MerkleNodeInfo> = mutableMapOf()
-        other.calculateRootInstrumented(digest) {
+        val otherRoot = other.calculateRootInstrumented(digest) {
             val k = it.level to it.node.indexWithinLevel
             nodeMapOther[k] = it
         }
+        require(thisRoot == otherRoot)
 
         // Third, walk the whole tree and figure out what to do based on what we know.
         val outHashes = mutableListOf<SecureHash>() // the goal is to fill this in

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -313,6 +313,12 @@ class MerkleProofImpl(
         // First, work out the leaves for the output proof.
         val indexMapThis = leaves.associateBy { it.index }
         val indexMapOther = other.leaves.associateBy { it.index }
+        // We should fail early, at this point, if any leaves in both mismatch.
+        indexMapThis.forEach { (index, leaf) ->
+            require(indexMapOther.getOrDefault(index, leaf) == leaf) {
+                "common leaves in a proof merge must match"
+            }
+        }
         val combinedIndexMap = indexMapThis + indexMapOther
         val outLeaves = combinedIndexMap.values.toList().sortedWith( compareBy { it.index })
 
@@ -327,7 +333,7 @@ class MerkleProofImpl(
             val k = it.level to it.node.indexWithinLevel
             nodeMapOther[k] = it
         }
-        require(thisRoot == otherRoot)
+        require(thisRoot == otherRoot) { "left hand and right hand size proof root hashes do not match"}
 
         // Third, walk the whole tree and figure out what to do based on what we know.
         val outHashes = mutableListOf<SecureHash>() // the goal is to fill this in

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -106,7 +106,7 @@ class MerkleProofImpl(
 
         // We will discover some hashes at a given level and some at the level above.
         // But we want to guarantee to our uses that they get out hashes on the `onNewHash` callback
-        // in a left to right then bototm to top order, rather than mix up leaves from different levels.
+        // in a left to right then bottom to top order, rather than mix up leaves from different levels.
         // That way the user code is simpler. So, we need to efficiently sort the output order.
 
         // Maintain the set of nodes from the current level, to be interspersed on the next level.

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/MerkleProofImpl.kt
@@ -105,7 +105,7 @@ class MerkleProofImpl(
         }
 
         // We will discover some hashes at a given level and some at the level above.
-        // But we want to guarnatee to our uses that the get out hashes on the `onNewHash` callback
+        // But we want to guarantee to our uses that they get out hashes on the `onNewHash` callback
         // in a left to right then bototm to top order, rather than mix up leaves from different levels.
         // That way the user code is simpler. So, we need to efficiently sort the output order.
 

--- a/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/RenderTree.kt
+++ b/libs/crypto/merkle-impl/src/main/kotlin/net/corda/crypto/merkle/impl/RenderTree.kt
@@ -91,6 +91,16 @@ fun renderTree(leafLabels: List<String>, nodeLabels: Map<Pair<Int, Int>, String>
     return lines.joinToString("\n")     // Return the whole tree as a single string.
 }
 
+/**
+ * Produce a list of the ranges covered by each node.
+ *
+ * The first entry will have a list with one element per leaf, e.g. listOf( 0 to 0, 1 to 1, 2 to 2 ...)
+ * The second entry will have the first level of nodes, e.g. listOf(0 to 1, 2 to 3, 4 to 5,... )
+ * The last entry entry will be a single item list of the root, with the first element of the pair being 0 and the last being the tree size.
+ *
+ * @param treeSize The number of leaves in the tree.
+ * @return list of ranges at a given level
+ */
 fun makeLevels(treeSize: Int): MutableList<List<Pair<Int, Int>>> {
     // Work out the tree structure, using iteration.
     // Loop variable is `values`: the leaf range values at the current level, starting at the bottom where each

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -591,6 +591,35 @@ class MerkleTreeTest {
                     }
                 }
 
+                testAllMergeCombinations(proof, leafIndicesCombination, trivialHashDigestProvider)
+
+            }
+        }
+    }
+
+    /**
+     * Given a MerkleProof, work out what happens if we split the proof into two subsets then merge them together.
+     *
+     * Try every possible combination of splits
+     *
+     * @param proof the source proof
+     * @param leaves the indices of the leaves that are known in the proof
+     * @param digest an object that implements the hash algorithm for the Merkle proof
+     */
+    private fun testAllMergeCombinations(proof: MerkleProofImpl, leaves: List<Int>, digest: MerkleTreeHashDigestProvider) {
+        val proofText = proof.render(digest)
+        for (i in 0 until (1 shl leaves.size)) {
+            val xSet = (0 until leaves.size).filter {j ->  i and (1 shl j) != 0 }
+            val ySet = (0 until leaves.size).filter {j ->  i and (1 shl j) == 0 }
+            println(proofText)
+            println("treeSize=${proof.treeSize} leaves=$leaves X=$xSet Y=$ySet")
+            if (xSet.isNotEmpty() && ySet.isNotEmpty()) {
+                check(xSet.size + ySet.size == leaves.size)
+                val xProof = proof.subset(digest, xSet)
+                val yProof = proof.subset(digest, ySet)
+                val mergedProof = xProof.merge(yProof, digest)
+                val mergedProofText = mergedProof.render(digest)
+                assertThat(mergedProofText).isEqualTo(proofText)
             }
         }
     }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -334,8 +334,7 @@ class MerkleTreeTest {
                       ┗92e96986┳e0cc7e23┳1d3a2328 00:00:00:04
                                ┃        ┗cf5f6713 00:00:00:05
                                ┗46086473━46086473 00:00:00:06
-        """
-        )
+        """)
         assertEquals(manualRoot, root)
     }
 
@@ -370,8 +369,7 @@ class MerkleTreeTest {
                                    ┃        ┗cf5f6713 00:00:00:05
                                    ┗a1a26281┳46086473 00:00:00:06
                                             ┗b0d020da 00:00:00:07
-        """
-        )
+        """)
     }
 
     @Test

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -1289,6 +1289,18 @@ class MerkleTreeTest {
         assertThat(mergedProofText).isEqualTo(proofText)
     }
 
+    @Test
+    fun `test merge tree size 2 with 3 fails`() {
+        val merkleTree2 = makeTestMerkleTree(2, defaultHashDigestProvider)
+        val merkleTree3 = makeTestMerkleTree(3, defaultHashDigestProvider)
+        val xProof = makeProof(merkleTree2, listOf(0))
+        val yProof = makeProof(merkleTree3, listOf(1))
+        val ex = assertFailsWith<IllegalArgumentException> {  xProof.merge(yProof, defaultHashDigestProvider) }
+        assertThat(ex.message).contains("underlying tree sizes must match")
+        assertThat(ex.message).contains("left hand side has underlying tree size 2")
+        assertThat(ex.message).contains("right hand side has underlying tree size 3")
+    }
+
 }
 
 fun SecureHash.hex() = bytes.joinToString(separator = "") { "%02x".format(it) }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -162,8 +162,11 @@ class MerkleTreeTest {
         @JvmStatic
         fun subsetTestCombinations(): List<Arguments> {
             val rng = Random(0)
-            val combinations:ULong =
-                MAXIMUM_TREE_SIZE_FOR_PROOF_TESTS.toULong() * (1UL shl MAXIMUM_TREE_SIZE_FOR_PROOF_TESTS) * (1UL shl MAXIMUM_TREE_SIZE_FOR_PROOF_TESTS)
+            val combinations: ULong = (
+                MAXIMUM_TREE_SIZE_FOR_PROOF_TESTS.toULong()
+                    * (1UL shl MAXIMUM_TREE_SIZE_FOR_PROOF_TESTS)
+                    * (1UL shl MAXIMUM_TREE_SIZE_FOR_PROOF_TESTS))
+
             return iterator {
                 while (true) {
                     val t: ULong = rng.nextULong(0UL..combinations)

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -350,12 +350,12 @@ class MerkleTreeTest {
                 """)
         }
 
-        val proofMerged = proof2.merge(proof3)
-        assertThat(proofMerged.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-            00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)━00000000 (calc) known leaf
-                           ┃                  ┗00000001 (calc)━00000001 (calc) known leaf
-                           ┗00000002 (input 0)━unknown        ━unknown         filtered
-        """.trimIndent())
+//        val proofMerged = proof2.merge(proof3)
+//        assertThat(proofMerged.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+//            00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)━known leaf
+//                           ┃                  ┗00000001 (calc)━known leaf
+//                           ┗00000002 (input 0)━unknown        ━filtered
+//        """.trimIndent())
     }
 
     @Test

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -42,9 +42,7 @@ class MerkleTreeTest {
         val digestAlgorithm = DigestAlgorithmName.SHA2_256D
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
-
-        private const val MAXIMUM_TREE_SIZE_FOR_PROOF_TESTS = 12
-
+        private const val MAXIMUM_TREE_SIZE_FOR_PROOF_TESTS = 32
         // Since there are 2^(2*n) permutations of source leafs we don't want to test too many,
         // so we do a few in a fixed shuffled order. Any new failures have specific tests to guard against regression,
         // in case the platform random number generator changes.
@@ -52,7 +50,7 @@ class MerkleTreeTest {
         // In offline testing this has been successfully taken up to 5000 which takes 30 minutes on a laptop.
         private const val NUMBER_OF_SUBSETS_TO_TEST = 1000
 
-        private const val MAXIMUM_TREE_SIZE_FOR_EXHAUSTIVE_MERGE_TESTS = 16
+        private const val MAXIMUM_TREE_SIZE_FOR_EXHAUSTIVE_MERGE_TESTS = 32
 
         // Since there are 60129542144 (slightly less than n*2^(2*n)) permutation for lists tests when we go up to tree
         // size 16, so again we take a stable random approach.
@@ -1307,9 +1305,9 @@ class MerkleTreeTest {
                     ┗00000044━00000044 00:00:42:02
         """.trimIndent())
         val xProof = makeProof(tree1, listOf(0,1))
-        val yProof = makeProof(tree1, listOf(1,2))
+        val yProof = makeProof(tree2, listOf(1,2))
         val ex = assertFailsWith<IllegalArgumentException> { xProof.merge(yProof, trivialHashDigestProvider) }
-        assertThat(ex.message).contains("Leaves in both proofs are not identical")
+        assertThat(ex.message).contains("common leaves in a proof merge must match")
     }
 
     @Test

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -62,8 +62,8 @@ class MerkleTreeTest {
 
         // There are n*2^n proof tests for tree size n so randomize.
         //
-        // This has been taken up to 50000 which takes 1 minute and 8GB of RAM.
-        private const val NUMBER_OF_PROOF_TESTS = 5000
+        // This has been taken up to 50000 which takes 5 seconds and 8GB of RAM.
+        private const val NUMBER_OF_PROOF_TESTS = 1000
 
         private lateinit var digestService: DigestService
         private lateinit var defaultHashDigestProvider: DefaultHashDigestProvider

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -46,6 +46,8 @@ class MerkleTreeTest {
         // which takes 30 minutes on a laptop.
         private const val NUMBER_OF_SUBSETS_TO_TEST = 10
 
+        private const val MAXIMUM_TREE_SIZE_FOR_EXHAUSTIVE_MERGE_TESTS = 8
+
         private lateinit var digestService: DigestService
         private lateinit var defaultHashDigestProvider: DefaultHashDigestProvider
         private lateinit var nonceHashDigestProvider: NonceHashDigestProvider
@@ -110,7 +112,7 @@ class MerkleTreeTest {
         fun merkleProofExtendedTestSizes(): List<Arguments> = merkleProofForTreeSizes(12, 15)
 
         @JvmStatic
-        fun merkleProofMergeCombinations(): List<Arguments> = (1..8).map { treeSize ->
+        fun merkleProofMergeCombinations(): List<Arguments> = (1..MAXIMUM_TREE_SIZE_FOR_EXHAUSTIVE_MERGE_TESTS).map { treeSize ->
             (1 until (1 shl treeSize)).map { sourceProofLeafSet ->
                 val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
                 (0 until (1 shl leafIndicesCombination.size)).map { i ->

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -413,21 +413,21 @@ class MerkleTreeTest {
         }
         val proofX = proof1.subset(trivialHashDigestProvider, listOf(0))
         assertThat(proofX.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-            00000612 (calc)┳0000069F (calc)   ┳00000630 (input 1)┳unknown            filtered
-                           ┃                  ┃                  ┗unknown            filtered
-                           ┃                  ┗00000634 (calc)   ┳00000002 (calc)    known leaf
-                           ┃                                     ┗00000003 (input 0) filtered
+            00000612 (calc)┳0000069F (calc)   ┳00000630 (calc)   ┳00000000 (calc)    known leaf
+                           ┃                  ┃                  ┗00000001 (input 0) filtered
+                           ┃                  ┗00000634 (input 1)┳unknown            filtered
+                           ┃                                     ┗unknown            filtered
                            ┗00000638 (input 2)━unknown           ┳unknown            filtered
-                                                                 ┗unknown            filtered         
+                                                                 ┗unknown            filtered   
         """.trimIndent())
         val proofY = proof1.subset(trivialHashDigestProvider, listOf(2))
         assertThat(proofY.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
-                00000612 (calc)┳0000069F (input 1)┳unknown        ┳unknown            filtered
-                               ┃                  ┃               ┗unknown            filtered
-                               ┃                  ┗unknown        ┳unknown            filtered
-                               ┃                                  ┗unknown            filtered
-                               ┗00000638 (calc)   ━00000638 (calc)┳00000004 (calc)    known leaf
-                                                                  ┗00000005 (input 0) filtered      
+                00000612 (calc)┳0000069F (calc)   ┳00000003 (input 1)┳unknown            filtered
+                               ┃                  ┃                  ┗unknown            filtered
+                               ┃                  ┗00000667 (calc)   ┳00000002 (calc)    known leaf
+                               ┃                                     ┗00000630 (input 0) filtered
+                               ┗00000638 (input 2)━unknown           ┳unknown            filtered
+                                                                     ┗unknown            filtered
         """.trimIndent())
         val proofMerged = proofX.merge(proofY, trivialHashDigestProvider)
         assertThat(proofMerged.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -43,12 +43,18 @@ class MerkleTreeTest {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
 
         // Since there are 2^(2*n) permutations of source leafs we don't want to test too many,
-        // so we do a few at random. In offline testing this has been successfully taken up to 5000
-        // which takes 30 minutes on a laptop.
+        // so we do a few in a fixed shuffled order. Any new failures have specific tests to guard against regression,
+        // in case the platform random number generator changes.
+        //
+        // In offline testing this has been successfully taken up to 5000 which takes 30 minutes on a laptop.
         private const val NUMBER_OF_SUBSETS_TO_TEST = 10
 
         private const val MAXIMUM_TREE_SIZE_FOR_EXHAUSTIVE_MERGE_TESTS = 16
-        private const val NUMBER_OF_MERGE_TESTS = 5000
+        // Since there are 60129542144 (slightly less than n*2^(2*n)) permutation for lists tests when we go up to tree
+        // size 16, again we take a stable random approach.
+        //
+        // This has been taken up to 50000 which takes 1 minute and 8GB of RAM.
+        private const val NUMBER_OF_MERGE_TESTS = 1000
 
         private lateinit var digestService: DigestService
         private lateinit var defaultHashDigestProvider: DefaultHashDigestProvider

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -110,7 +110,7 @@ class MerkleTreeTest {
         fun merkleProofExtendedTestSizes(): List<Arguments> = merkleProofForTreeSizes(12, 15)
 
         @JvmStatic
-        fun merkleProofMergeCombinations(): List<Arguments> = (1..12).map { treeSize ->
+        fun merkleProofMergeCombinations(): List<Arguments> = (1..8).map { treeSize ->
             (1 until (1 shl treeSize)).map { sourceProofLeafSet ->
                 val leafIndicesCombination = (0 until treeSize).filter { (sourceProofLeafSet and (1 shl it)) != 0 }
                 (0 until (1 shl leafIndicesCombination.size)).map { i ->

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -540,15 +540,6 @@ class MerkleTreeTest {
     fun `merkle proof size 4 merge bug`() {
         val merkleTree = makeTestMerkleTree(4, trivialHashDigestProvider)
         val proof = makeProof(merkleTree, listOf(0, 2, 3))
-        val yProof = proof.subset(trivialHashDigestProvider, listOf(0, 3))
-        assertThat(yProof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
-            """
-            0000069F (calc)┳00000630 (calc)┳00000000 (calc)    known leaf
-                           ┃               ┗00000001 (input 0) filtered
-                           ┗00000634 (calc)┳00000002 (input 1) filtered
-                                           ┗00000003 (calc)    known leaf
-        """.trimIndent()
-        )
         val proofText = proof.render(trivialHashDigestProvider)
         assertThat(proofText).isEqualToIgnoringWhitespace(
             """
@@ -565,6 +556,15 @@ class MerkleTreeTest {
                            ┃                  ┗unknown            filtered
                            ┗00000634 (calc)   ┳00000002 (calc)    known leaf
                                               ┗00000003 (input 0) filtered            
+        """.trimIndent()
+        )
+        val yProof = proof.subset(trivialHashDigestProvider, listOf(0, 3))
+        assertThat(yProof.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
+            """
+            0000069F (calc)┳00000630 (calc)┳00000000 (calc)    known leaf
+                           ┃               ┗00000001 (input 0) filtered
+                           ┗00000634 (calc)┳00000002 (input 1) filtered
+                                           ┗00000003 (calc)    known leaf
         """.trimIndent()
         )
         val mergedProof = xProof.merge(yProof, trivialHashDigestProvider)
@@ -594,6 +594,38 @@ class MerkleTreeTest {
                            ┗517A5DE6 (calc)┳66973B1A (input 1) filtered
                                            ┗568F8D2A (calc)    known leaf
                                        """.trimIndent()
+        )
+    }
+
+
+    @Test
+    fun `merkle proof subset bug`() {
+        val treeSize = 6
+        val merkleTree = makeTestMerkleTree(treeSize, defaultHashDigestProvider)
+
+        val proof1 = makeProof(merkleTree, listOf(0, 2))
+        val proof2 = makeProof(merkleTree, listOf(2))
+        assertThat(proof2.render(defaultHashDigestProvider)).isEqualToIgnoringWhitespace(
+            """
+            8696C1F4 (calc)┳FF3C3992 (calc)   ┳BAB170B1 (input 1)┳unknown            filtered
+                           ┃                  ┃                  ┗unknown            filtered
+                           ┃                  ┗517A5DE6 (calc)   ┳66973B1A (calc)    known leaf
+                           ┃                                     ┗568F8D2A (input 0) filtered
+                           ┗E0CC7E23 (input 2)━unknown           ┳unknown            filtered
+                                                                 ┗unknown            filtered
+        """.trimIndent()
+        )
+
+        val proofY = proof1.subset(defaultHashDigestProvider, listOf(2))
+        assertThat(proofY.render(defaultHashDigestProvider)).isEqualToIgnoringWhitespace(
+            """
+            8696C1F4 (calc)┳FF3C3992 (calc)   ┳BAB170B1 (input 1)┳unknown            filtered
+                           ┃                  ┃                  ┗unknown            filtered
+                           ┃                  ┗517A5DE6 (calc)   ┳66973B1A (calc)    known leaf
+                           ┃                                     ┗568F8D2A (input 0) filtered
+                           ┗E0CC7E23 (input 2)━unknown           ┳unknown            filtered
+                                                                 ┗unknown            filtered
+         """.trimIndent()
         )
     }
 
@@ -646,38 +678,6 @@ class MerkleTreeTest {
                                ┗00000638 (calc)━00000638 (calc)   ┳00000004 (calc)    known leaf
                                                                   ┗00000005 (input 1) filtered
         """.trimIndent()
-        )
-    }
-
-
-    @Test
-    fun `merkle proof subset bug`() {
-        val treeSize = 6
-        val merkleTree = makeTestMerkleTree(treeSize, defaultHashDigestProvider)
-
-        val proof1 = makeProof(merkleTree, listOf(0, 2))
-        val proof2 = makeProof(merkleTree, listOf(2))
-        assertThat(proof2.render(defaultHashDigestProvider)).isEqualToIgnoringWhitespace(
-            """
-            8696C1F4 (calc)┳FF3C3992 (calc)   ┳BAB170B1 (input 1)┳unknown            filtered
-                           ┃                  ┃                  ┗unknown            filtered
-                           ┃                  ┗517A5DE6 (calc)   ┳66973B1A (calc)    known leaf
-                           ┃                                     ┗568F8D2A (input 0) filtered
-                           ┗E0CC7E23 (input 2)━unknown           ┳unknown            filtered
-                                                                 ┗unknown            filtered
-        """.trimIndent()
-        )
-
-        val proofY = proof1.subset(defaultHashDigestProvider, listOf(2))
-        assertThat(proofY.render(defaultHashDigestProvider)).isEqualToIgnoringWhitespace(
-            """
-            8696C1F4 (calc)┳FF3C3992 (calc)   ┳BAB170B1 (input 1)┳unknown            filtered
-                           ┃                  ┃                  ┗unknown            filtered
-                           ┃                  ┗517A5DE6 (calc)   ┳66973B1A (calc)    known leaf
-                           ┃                                     ┗568F8D2A (input 0) filtered
-                           ┗E0CC7E23 (input 2)━unknown           ┳unknown            filtered
-                                                                 ┗unknown            filtered
-         """.trimIndent()
         )
     }
 

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -349,6 +349,13 @@ class MerkleTreeTest {
                                                                   ┗00000005 (input 1) filtered
                 """)
         }
+
+        val proofMerged = proof2.merge(proof3)
+        assertThat(proofMerged.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+            00000667 (calc)┳00000630 (calc)   ┳00000000 (calc)━00000000 (calc) known leaf
+                           ┃                  ┗00000001 (calc)━00000001 (calc) known leaf
+                           ┗00000002 (input 0)━unknown        ━unknown         filtered
+        """.trimIndent())
     }
 
     @Test

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -51,7 +51,7 @@ class MerkleTreeTest {
 
         private const val MAXIMUM_TREE_SIZE_FOR_EXHAUSTIVE_MERGE_TESTS = 16
         // Since there are 60129542144 (slightly less than n*2^(2*n)) permutation for lists tests when we go up to tree
-        // size 16, again we take a stable random approach.
+        // size 16, so again we take a stable random approach.
         //
         // This has been taken up to 50000 which takes 1 minute and 8GB of RAM.
         private const val NUMBER_OF_MERGE_TESTS = 1000

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -727,6 +727,107 @@ class MerkleTreeTest {
     }
 
     @Test
+    fun `merkle proof merge size 26 left 6 right 5,7,9,10,12,17,21 bug`() {
+        val treeSize = 26
+        val merkleTree = makeTestMerkleTree(treeSize, trivialHashDigestProvider)
+
+        val proof1 = makeProof(merkleTree, listOf(5,6,7,9,10,12,17,21))
+        val proofX = proof1.subset(trivialHashDigestProvider, listOf(6))
+        assertThat(proofX.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                00000569 (calc)┳0000058B (calc)   ┳00000589 (calc)   ┳0000069F (input 2)┳unknown           ┳unknown            filtered
+                               ┃                  ┃                  ┃                  ┃                  ┗unknown            filtered
+                               ┃                  ┃                  ┃                  ┗unknown           ┳unknown            filtered
+                               ┃                  ┃                  ┃                                     ┗unknown            filtered
+                               ┃                  ┃                  ┗000006AF (calc)   ┳00000638 (input 1)┳unknown            filtered
+                               ┃                  ┃                                     ┃                  ┗unknown            filtered
+                               ┃                  ┃                                     ┗0000063C (calc)   ┳00000006 (calc)    known leaf
+                               ┃                  ┃                                                        ┗00000007 (input 0) filtered
+                               ┃                  ┗000005C9 (input 3)┳unknown           ┳unknown           ┳unknown            filtered
+                               ┃                                     ┃                  ┃                  ┗unknown            filtered
+                               ┃                                     ┃                  ┗unknown           ┳unknown            filtered
+                               ┃                                     ┃                                     ┗unknown            filtered
+                               ┃                                     ┗unknown           ┳unknown           ┳unknown            filtered
+                               ┃                                                        ┃                  ┗unknown            filtered
+                               ┃                                                        ┗unknown           ┳unknown            filtered
+                               ┃                                                                           ┗unknown            filtered
+                               ┗000006A4 (input 4)┳unknown           ┳unknown           ┳unknown           ┳unknown            filtered
+                                                  ┃                  ┃                  ┃                  ┗unknown            filtered
+                                                  ┃                  ┃                  ┗unknown           ┳unknown            filtered
+                                                  ┃                  ┃                                     ┗unknown            filtered
+                                                  ┃                  ┗unknown           ┳unknown           ┳unknown            filtered
+                                                  ┃                                     ┃                  ┗unknown            filtered
+                                                  ┃                                     ┗unknown           ┳unknown            filtered
+                                                  ┃                                                        ┗unknown            filtered
+                                                  ┗unknown           ━unknown           ━unknown           ┳unknown            filtered
+                                                                                                           ┗unknown            filtered
+                                                                                                   """.trimIndent()
+        )
+
+        val proof1Text = proof1.render(trivialHashDigestProvider)
+        assertThat(proof1.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                00000569 (calc)┳0000058B (calc)┳00000589 (calc)    ┳0000069F (input 9)┳unknown           ┳unknown            filtered
+                               ┃               ┃                   ┃                  ┃                  ┗unknown            filtered
+                               ┃               ┃                   ┃                  ┗unknown           ┳unknown            filtered
+                               ┃               ┃                   ┃                                     ┗unknown            filtered
+                               ┃               ┃                   ┗000006AF (calc)   ┳00000638 (calc)   ┳00000004 (input 0) filtered
+                               ┃               ┃                                      ┃                  ┗00000005 (calc)    known leaf
+                               ┃               ┃                                      ┗0000063C (calc)   ┳00000006 (calc)    known leaf
+                               ┃               ┃                                                         ┗00000007 (calc)    known leaf
+                               ┃               ┗000005C9 (calc)    ┳000006BF (calc)   ┳00000640 (calc)   ┳00000008 (input 1) filtered
+                               ┃                                   ┃                  ┃                  ┗00000009 (calc)    known leaf
+                               ┃                                   ┃                  ┗00000644 (calc)   ┳0000000A (calc)    known leaf
+                               ┃                                   ┃                                     ┗0000000B (input 2) filtered
+                               ┃                                   ┗000006CF (calc)   ┳00000648 (calc)   ┳0000000C (calc)    known leaf
+                               ┃                                                      ┃                  ┗0000000D (input 3) filtered
+                               ┃                                                      ┗0000064C (input 6)┳unknown            filtered
+                               ┃                                                                         ┗unknown            filtered
+                               ┗000006A4 (calc)┳00000609 (calc)    ┳000006DF (calc)   ┳00000650 (calc)   ┳00000010 (input 4) filtered
+                                               ┃                   ┃                  ┃                  ┗00000011 (calc)    known leaf
+                                               ┃                   ┃                  ┗00000654 (input 7)┳unknown            filtered
+                                               ┃                   ┃                                     ┗unknown            filtered
+                                               ┃                   ┗000006EF (calc)   ┳00000658 (calc)   ┳00000014 (input 5) filtered
+                                               ┃                                      ┃                  ┗00000015 (calc)    known leaf
+                                               ┃                                      ┗0000065C (input 8)┳unknown            filtered
+                                               ┃                                                         ┗unknown            filtered
+                                               ┗00000660 (input 10)━unknown           ━unknown           ┳unknown            filtered
+                                                                                                         ┗unknown            filtered
+        """)
+        val proofY = proof1.subset(trivialHashDigestProvider, listOf(5,7,9,10,12,17,21))
+        assertThat(proofY.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace("""
+                00000569 (calc)┳0000058B (calc)┳00000589 (calc)    ┳0000069F (input 10)┳unknown           ┳unknown            filtered
+                               ┃               ┃                   ┃                   ┃                  ┗unknown            filtered
+                               ┃               ┃                   ┃                   ┗unknown           ┳unknown            filtered
+                               ┃               ┃                   ┃                                      ┗unknown            filtered
+                               ┃               ┃                   ┗000006AF (calc)    ┳00000638 (calc)   ┳00000004 (input 0) filtered
+                               ┃               ┃                                       ┃                  ┗00000005 (calc)    known leaf
+                               ┃               ┃                                       ┗0000063C (calc)   ┳00000006 (input 1) filtered
+                               ┃               ┃                                                          ┗00000007 (calc)    known leaf
+                               ┃               ┗000005C9 (calc)    ┳000006BF (calc)    ┳00000640 (calc)   ┳00000008 (input 2) filtered
+                               ┃                                   ┃                   ┃                  ┗00000009 (calc)    known leaf
+                               ┃                                   ┃                   ┗00000644 (calc)   ┳0000000A (calc)    known leaf
+                               ┃                                   ┃                                      ┗0000000B (input 3) filtered
+                               ┃                                   ┗000006CF (calc)    ┳00000648 (calc)   ┳0000000C (calc)    known leaf
+                               ┃                                                       ┃                  ┗0000000D (input 4) filtered
+                               ┃                                                       ┗0000064C (input 7)┳unknown            filtered
+                               ┃                                                                          ┗unknown            filtered
+                               ┗000006A4 (calc)┳00000609 (calc)    ┳000006DF (calc)    ┳00000650 (calc)   ┳00000010 (input 5) filtered
+                                               ┃                   ┃                   ┃                  ┗00000011 (calc)    known leaf
+                                               ┃                   ┃                   ┗00000654 (input 8)┳unknown            filtered
+                                               ┃                   ┃                                      ┗unknown            filtered
+                                               ┃                   ┗000006EF (calc)    ┳00000658 (calc)   ┳00000014 (input 6) filtered
+                                               ┃                                       ┃                  ┗00000015 (calc)    known leaf
+                                               ┃                                       ┗0000065C (input 9)┳unknown            filtered
+                                               ┃                                                          ┗unknown            filtered
+                                               ┗00000660 (input 11)━unknown            ━unknown           ┳unknown            filtered
+                                                                                                          ┗unknown            filtered
+        """.trimIndent()
+        )
+        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider)
+        val proofMergedText = proofMerged.render(trivialHashDigestProvider)
+        assertThat(proofMergedText).isEqualTo(proof1Text)
+    }
+
+    @Test
     fun `merkle proof merge size 4 0,2,3 left 0 right 2,3`() {
         val treeSize = 4
         val digest = defaultHashDigestProvider


### PR DESCRIPTION
A naive implementation of Merkle proof mering. We can work on a more efficient version later. 

Add test cases for proofs. This requires random test ordering and care not to use too much memory for the test lists, so we use the Kotlin iterator()/yield() library function. Use this same approach for simple proofs and subsets.

Convert various special cases inside inner function into their won test cases.

Rework test suites to unroll loops into JUnit, and allow larger tree sizes to be tested. Tree size is currently limited by the size of 64 bit unsigned longs.

Fix memory use in tree rendering.

Ensure that `MerkleProofImpl.calculateRootInstrumented` in all cases returns nodes in the expected order. This matters for use when merging.
