### PR TITLE
CORE-18879: Ensure verifying notary implementation

### DIFF
--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
@@ -194,12 +194,7 @@ class ContractVerifyingNotaryServerFlowImpl() : ResponderFlow {
         filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>
     ) {
         try {
-
             val dependentStateAndRefs = filteredTransactionsAndSignatures.flatMap { (filteredTransaction, _) ->
-                require(filteredTransaction.id != initialTransaction.id) {
-                    "Either filtered transaction \"${filteredTransaction.id}\" or " +
-                            "current transaction \"${initialTransaction.id}\" is invalid."
-                }
                 (filteredTransaction.outputStateAndRefs as UtxoFilteredData.Audit<StateAndRef<*>>).values.values
             }.associateBy { it.ref }
 

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
@@ -196,6 +196,10 @@ class ContractVerifyingNotaryServerFlowImpl() : ResponderFlow {
         try {
 
             val dependentStateAndRefs = filteredTransactionsAndSignatures.flatMap { (filteredTransaction, _) ->
+                require(filteredTransaction.id != initialTransaction.id) {
+                    "Either filtered transaction \"${filteredTransaction.id}\" or " +
+                            "current transaction \"${initialTransaction.id}\" is invalid."
+                }
                 (filteredTransaction.outputStateAndRefs as UtxoFilteredData.Audit<StateAndRef<*>>).values.values
             }.associateBy { it.ref }
 

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
@@ -16,7 +16,6 @@ import net.corda.uniqueness.datamodel.impl.UniquenessCheckErrorUnhandledExceptio
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultFailureImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckResultSuccessImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateRefImpl
-import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.membership.MemberLookup
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.uniqueness.model.UniquenessCheckError
@@ -24,7 +23,6 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigestAlgorithmName
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 import net.corda.v5.ledger.utxo.NotarySignatureVerificationService
@@ -40,38 +38,23 @@ import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
-import org.junit.jupiter.api.TestMethodOrder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.time.Instant
 
 @TestInstance(PER_CLASS)
-@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class ContractVerifyingNotaryServerFlowImplTest {
 
     private companion object {
         const val NOTARY_SERVICE_NAME = "corda.notary.service.name"
         const val NOTARY_SERVICE_BACKCHAIN_REQUIRED = "corda.notary.service.backchain.required"
-        const val OUTPUT_STATE_AND_REFS = "outputStateRefs"
-        const val INPUT_STATE_AND_REFS = "inputStateRefs"
-        const val NOTARY_NAME = "notaryName"
-        const val NOTARY_KEY = "notaryKey"
-        const val TXID = "id"
-        const val TIME_WINDOW = "timeWindow"
-        const val REFSTATE_REFS = "referenceStateRefs"
-        const val METADATA = "metadata"
-        const val VERIFY_SIGNATORY_SIGNATURES = "VERIFY_SIGNATORY_SIGNATURES"
-        const val MOCK_THROW = "MOCK_THROW"
 
         val SIGNED_TX_ID = SecureHashUtils.randomSecureHash()
         val FILTERED_TX_ID = SecureHashUtils.randomSecureHash()
@@ -86,20 +69,20 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     // default mock for filtered transaction
-    private val mockDependencyInvalidOutputStateAndRef = mock<StateAndRef<*>> {
-        on { ref } doReturn INVALID_TX_OUTPUT
+    private val mockDependencyInvalidOutputStateAndRef = mock<StateAndRef<*>>().also {
+        whenever(it.ref).thenReturn(INVALID_TX_OUTPUT)
     }
-    private val mockDependencyOutputStateAndRef1 = mock<StateAndRef<*>> {
-        on { ref } doReturn SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_1
+    private val mockDependencyOutputStateAndRef1 = mock<StateAndRef<*>>().also {
+        whenever(it.ref).thenReturn(SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_1)
     }
-    private val mockDependencyOutputStateAndRef2 = mock<StateAndRef<*>> {
-        on { ref } doReturn SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_2
+    private val mockDependencyOutputStateAndRef2 = mock<StateAndRef<*>>().also {
+        whenever(it.ref).thenReturn(SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_2)
     }
-    private val mockDependencyOutputStateAndRef3 = mock<StateAndRef<*>> {
-        on { ref } doReturn SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1
+    private val mockDependencyOutputStateAndRef3 = mock<StateAndRef<*>>().also {
+        whenever(it.ref).thenReturn(SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1)
     }
-    private val mockDependencyOutputStateAndRef4 = mock<StateAndRef<*>> {
-        on { ref } doReturn SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2
+    private val mockDependencyOutputStateAndRef4 = mock<StateAndRef<*>>().also {
+        whenever(it.ref).thenReturn(SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2)
     }
     private val filteredTxOutputData = mapOf(
         0 to mockDependencyOutputStateAndRef1,
@@ -107,8 +90,8 @@ class ContractVerifyingNotaryServerFlowImplTest {
         2 to mockDependencyOutputStateAndRef3,
         3 to mockDependencyOutputStateAndRef4
     )
-    private val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
-        on { values } doReturn filteredTxOutputData
+    private val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>>().also {
+        whenever(it.values).thenReturn(filteredTxOutputData)
     }
 
     // Notary vnodes
@@ -119,26 +102,20 @@ class ContractVerifyingNotaryServerFlowImplTest {
     // Signatory vnodes
     private val signatoryVnodeCharlieKey = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x04)) }
 
-    // Notary signatures
     private val notarySignatureAlice = getSignatureWithMetadataExample(notaryVNodeAliceKey)
     private val notarySignatureBob = getSignatureWithMetadataExample(notaryVNodeBobKey)
 
-    // Signatory signatures
     private val signatorySignatureCharlie = getSignatureWithMetadataExample(signatoryVnodeCharlieKey)
 
-    // Notary Service and key
-    private val notaryServiceCompositeKey = mock<CompositeKey> {
-        on { leafKeys } doReturn setOf(notaryVNodeAliceKey, notaryVNodeBobKey)
+    private val notaryServiceCompositeKey = mock<CompositeKey>().also {
+        whenever(it.leafKeys).thenReturn(setOf(notaryVNodeAliceKey, notaryVNodeBobKey))
     }
 
-    // member names
+    // Member names
     private val notaryServiceName = MemberX500Name.parse("O=MyNotaryService, L=London, C=GB")
     private val notaryAliceName = MemberX500Name("Alice", "London", "GB")
-
-    // The client that initiated the session with the notary server
     private val memberCharlieName = MemberX500Name.parse("O=MemberCharlie, L=London, C=GB")
 
-    // mock for notary member lookup
     private val memberProvidedContext = mock<MemberContext>()
     private val mockMemberLookup = mock<MemberLookup>()
     private val notaryInfoAlice = mock<MemberInfo>().also {
@@ -146,36 +123,40 @@ class ContractVerifyingNotaryServerFlowImplTest {
         whenever(it.memberProvidedContext).thenReturn(memberProvidedContext)
     }
 
-    // Prepare filteredTransactionAndSignature data
+    private val signedTransaction = mock<UtxoSignedTransaction>()
+    private val filteredTransaction = mock<UtxoFilteredTransaction>()
+
     private val filteredTxAndSignature = FilteredTransactionAndSignatures(
-        mockFilteredTransaction(),
+        filteredTransaction,
         listOf(notarySignatureAlice)
     )
     private val filteredTxsAndSignatures = listOf(
         filteredTxAndSignature
     )
 
-    // mock fields for signed transaction
     private val transactionMetadata = mock<TransactionMetadata>()
-    private val mockTimeWindow = mock<TimeWindow> {
-        on { from } doReturn Instant.now()
-        on { until } doReturn Instant.now().plusMillis(100000)
+    private val mockTimeWindow = mock<TimeWindow>().also {
+        whenever(it.from).thenReturn(Instant.now())
+        whenever(it.until).thenReturn(Instant.now().plusMillis(100000))
     }
 
     private val mockOutputStateAndRef = mock<StateAndRef<*>>().also {
         whenever(it.ref).thenReturn(SIGNED_TX_OUTPUT)
     }
 
-    // mock services
     private val mockTransactionSignatureService = mock<TransactionSignatureServiceInternal>()
     private val mockLedgerService = mock<UtxoLedgerService>()
+    private val mockNotarySignatureVerificationService = mock<NotarySignatureVerificationService>()
 
-    // Cache for storing response from server
+    // cache for storing response from server
     private val responseFromServer = mutableListOf<NotarizationResponse>()
+
+    private val session = mock<FlowSession>()
 
     @BeforeEach
     fun beforeEach() {
         responseFromServer.clear()
+        reset(mockLedgerService, signedTransaction, filteredTransaction)
         whenever(mockTransactionSignatureService.signBatch(any(), any())).doAnswer { inv ->
             List((inv.arguments.first() as List<*>).size) {
                 @Suppress("unchecked_cast")
@@ -187,6 +168,43 @@ class ContractVerifyingNotaryServerFlowImplTest {
             }
         }
 
+        // Signed transaction
+        whenever(signedTransaction.id).thenReturn(SIGNED_TX_ID)
+        whenever(signedTransaction.inputStateRefs).thenReturn(
+            listOf(
+                SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_1,
+                SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_2
+            )
+        )
+        whenever(signedTransaction.referenceStateRefs).thenReturn(
+            listOf(
+                SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1,
+                SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2
+            )
+        )
+        whenever(signedTransaction.outputStateAndRefs).thenReturn(listOf(mockOutputStateAndRef))
+        whenever(signedTransaction.timeWindow).thenReturn(mockTimeWindow)
+        whenever(signedTransaction.notaryName).thenReturn(notaryServiceName)
+        whenever(signedTransaction.notaryKey).thenReturn(notaryServiceCompositeKey)
+        whenever(signedTransaction.metadata).thenReturn(transactionMetadata)
+        whenever(signedTransaction.verifySignatorySignatures()).thenAnswer {  }
+
+        // Filtered transaction
+        whenever(filteredTransaction.id).thenReturn(FILTERED_TX_ID)
+        whenever(filteredTransaction.outputStateAndRefs).thenReturn(mockOutputStateRefUtxoFilteredData)
+        whenever(filteredTransaction.notaryName).thenReturn(notaryServiceName)
+        whenever(filteredTransaction.timeWindow).thenReturn(mockTimeWindow)
+        whenever(filteredTransaction.verify()).thenAnswer {  }
+
+        whenever(
+            mockTransactionSignatureService.getIdOfPublicKey(
+                signedTransaction.notaryKey,
+                DigestAlgorithmName.SHA2_256.name
+            )
+        ).thenReturn(notarySignatureAlice.by)
+
+        whenever(mockNotarySignatureVerificationService.verifyNotarySignatures(any(), any(), any(), any())).doAnswer {  }
+
         // Get current notary and parse its data
         whenever(mockMemberLookup.myInfo()).thenReturn(notaryInfoAlice)
         whenever(notaryInfoAlice.memberProvidedContext).thenReturn(memberProvidedContext)
@@ -194,10 +212,18 @@ class ContractVerifyingNotaryServerFlowImplTest {
             notaryServiceName
         )
         whenever(memberProvidedContext.parse(NOTARY_SERVICE_BACKCHAIN_REQUIRED, Boolean::class.java)).thenReturn(false)
+
+        // Session
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java))
+            .thenReturn(ContractVerifyingNotarizationPayload(signedTransaction, filteredTxsAndSignatures))
+        whenever(session.send(any())).thenAnswer {
+            responseFromServer.add(it.arguments.first() as NotarizationResponse)
+            Unit
+        }
+        whenever(session.counterparty).thenReturn(memberCharlieName)
     }
 
     @Test
-    @Order(0)
     fun `Contract verifying notary should respond with error if no keys found for signing`() {
         // We sign with a key that is not part of the notary composite key
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenThrow(
@@ -215,21 +241,25 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(1)
     fun `Contract verifying notary plugin server should respond with error if request signature is invalid`() {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
             listOf(listOf(notarySignatureAlice))
         )
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf("notaryKey" to invalidVnodeKey)),
+        whenever(filteredTransaction.notaryKey).thenReturn(invalidVnodeKey)
+        val filteredTransactionSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature),
-            signatureVerificationLogic = ::throwVerify
-
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(
+                signedTransaction,
+                listOf(filteredTransactionSignatures)
+            )
         )
+        whenever(mockNotarySignatureVerificationService.verifyNotarySignatures(any(), any(), any(), any()))
+            .thenThrow(IllegalArgumentException("DUMMY ERROR"))
+
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -240,7 +270,6 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(2)
     fun `Contract verifying notary plugin server should respond with error if the uniqueness check fails`() {
         val unknownStateRef = UniquenessCheckStateRefImpl(SecureHashUtils.randomSecureHash(), 0)
 
@@ -261,7 +290,6 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(3)
     fun `Contract verifying notary plugin server should respond with error if an error encountered during uniqueness check`() {
         callServer(mockThrowErrorUniquenessCheckClientService())
         assertThat(responseFromServer).hasSize(1)
@@ -271,19 +299,15 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
         assertThat((responseError as NotaryExceptionGeneral).errorText)
             .contains("Error during notarization. Cause: Uniqueness checker cannot be reached")
-
     }
 
     @Test
-    @Order(4)
     fun `Contract verifying notary plugin server should respond with signatures if alice key is in composite key`() {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
             listOf(listOf(notarySignatureAlice))
         )
 
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-        )
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val response = responseFromServer.first()
@@ -293,15 +317,12 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(5)
     fun `Contract verifying notary plugin server should respond with signatures if bob key is in composite key`() {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
             listOf(listOf(notarySignatureBob))
         )
 
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-        )
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val response = responseFromServer.first()
@@ -311,17 +332,18 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(6)
     fun `Contract verifying notary plugin server should respond with error if time window not present on filtered tx`() {
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(TIME_WINDOW to null)),
+        whenever(filteredTransaction.timeWindow).thenReturn(null)
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
 
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
         )
+
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -330,20 +352,21 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat((responseError as NotaryExceptionGeneral).errorText).contains(
             "Error during notarization."
         )
-
     }
 
     @Test
-    @Order(7)
     fun `Contract verifying notary plugin server should respond with error if notary name not present on filtered tx`() {
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(NOTARY_NAME to null)),
+        whenever(filteredTransaction.notaryName).thenReturn(null)
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
         )
+
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -352,20 +375,21 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat((responseError as NotaryExceptionGeneral).errorText).contains(
             "Error during notarization."
         )
-
     }
 
     @Test
-    @Order(8)
     fun `Contract verifying notary plugin server should respond with error if notary key not present on filtered tx`() {
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(NOTARY_KEY to null)),
+        whenever(filteredTransaction.notaryKey).thenReturn(null)
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
         )
+
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -374,22 +398,23 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat((responseError as NotaryExceptionGeneral).errorText).contains(
             "Error during notarization."
         )
-
     }
 
     @Test
-    @Order(9)
     fun `Contract verifying notary plugin server should respond with error if output states are not audit type in the filtered tx`() {
-        val mockOutputStateProof = mock<UtxoFilteredData.SizeOnly<StateRef>>()
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateProof)),
+        @Suppress("unchecked_cast")
+        val mockOutputStateProof = mock<UtxoFilteredData.SizeOnly<StateRef>>() as UtxoFilteredData<StateAndRef<*>>
+        whenever(filteredTransaction.outputStateAndRefs).thenReturn(mockOutputStateProof)
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
 
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
         )
+
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -401,13 +426,18 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(10)
-    fun `Contract verifying notary plugin server should respond with error if transaction verification fails`() {
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(txVerificationLogic = ::throwVerify),
+    fun `Contract verifying notary plugin server should respond with error if Merkle proof verification of dependencies fails`() {
+        whenever(filteredTransaction.verify()).thenThrow(IllegalArgumentException("DUMMY ERROR"))
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
-        callServer(mockSuccessfulUniquenessClientService(), filteredTransactionAndSigs = listOf(filteredTxAndSignature))
+
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
+        )
+
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -415,11 +445,9 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
         assertThat((responseError as NotaryExceptionGeneral).errorText)
             .contains("Error during notarization. Cause: DUMMY ERROR")
-
     }
 
     @Test
-    @Order(11)
     fun `Contract verifying notary plugin server should throw general error when unhandled exception in uniqueness checker`() {
         callServer(
             mockErrorUniquenessClientService(
@@ -439,20 +467,21 @@ class ContractVerifyingNotaryServerFlowImplTest {
                 "Unhandled exception of type java.lang.IllegalArgumentException encountered during " +
                         "uniqueness checking with message: Unhandled error!"
             )
-
     }
 
     @Test
-    @Order(12)
     fun `Contract verifying notary plugin server should respond with error if notary identity invalid`() {
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(NOTARY_NAME to MemberX500Name.parse("C=GB,L=London,O=Bob"))),
+        whenever(filteredTransaction.notaryName).thenReturn(MemberX500Name.parse("C=GB,L=London,O=Bob"))
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
         )
+
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -460,25 +489,27 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
         assertThat((responseError as NotaryExceptionGeneral).errorText)
             .contains("Error during notarization.")
-
     }
 
     @Test
-    @Order(13)
     fun `Contract verifying notary should respond with error if dependency input is missing`() {
          val filteredTxOutputData = mapOf(0 to mockDependencyOutputStateAndRef1)
-         val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
-            on { values } doReturn filteredTxOutputData
+         val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>>().also {
+             whenever(it.values).thenReturn(filteredTxOutputData)
         }
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateRefUtxoFilteredData)),
+
+        whenever(filteredTransaction.outputStateAndRefs).thenReturn(mockOutputStateRefUtxoFilteredData)
+
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
 
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
         )
+
+        callServer(mockSuccessfulUniquenessClientService())
 
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
@@ -488,25 +519,28 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(14)
     fun `Contract verifying notary should respond with error if dependency reference is missing`() {
         val filteredTxOutputData = mapOf(
             0 to mockDependencyOutputStateAndRef1,
             1 to mockDependencyOutputStateAndRef2,
             2 to mockDependencyOutputStateAndRef3
         )
-        val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
-            on { values } doReturn filteredTxOutputData
+        val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>>().also {
+            whenever(it.values).thenReturn(filteredTxOutputData)
         }
 
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateRefUtxoFilteredData)),
+        whenever(filteredTransaction.outputStateAndRefs).thenReturn(mockOutputStateRefUtxoFilteredData)
+
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
         )
+
+        callServer(mockSuccessfulUniquenessClientService())
 
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
@@ -516,7 +550,6 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(15)
     fun `Contract verifying notary should respond with error if dependency is invalid`() {
         val filteredTxOutputData = mapOf(
             0 to mockDependencyOutputStateAndRef1,
@@ -524,18 +557,22 @@ class ContractVerifyingNotaryServerFlowImplTest {
             2 to mockDependencyOutputStateAndRef3,
             3 to mockDependencyInvalidOutputStateAndRef
         )
-        val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
-            on { values } doReturn filteredTxOutputData
+        val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>>().also {
+            whenever(it.values).thenReturn(filteredTxOutputData)
         }
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateRefUtxoFilteredData)),
+
+        whenever(filteredTransaction.outputStateAndRefs).thenReturn(mockOutputStateRefUtxoFilteredData)
+
+        val filteredTransactionsAndSignatures = FilteredTransactionAndSignatures(
+            filteredTransaction,
             listOf(notarySignatureAlice)
         )
 
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
+            ContractVerifyingNotarizationPayload(signedTransaction, listOf(filteredTransactionsAndSignatures))
         )
+
+        callServer(mockSuccessfulUniquenessClientService(),)
 
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
@@ -545,33 +582,11 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(16)
-    fun `Contract verifying notary should respond with error if either current or filtered tx is invalid`() {
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            mockFilteredTransaction(mapOf(TXID to SIGNED_TX_ID)),
-            listOf(notarySignatureAlice)
-        )
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
-        )
+    fun `Contract verifying notary should respond with error if a signed transaction failed to verify signatory signature`() {
+        whenever(signedTransaction.verifySignatorySignatures()).thenThrow(NotaryExceptionGeneral("Signature failed error"))
 
-        val responseError = responseFromServer.first().error
-        assertThat(responseError).isNotNull
-        assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
-        assertThat((responseError as NotaryExceptionTransactionVerificationFailure).errorText)
-            .contains("Either filtered transaction \"$SIGNED_TX_ID\" or current transaction \"$SIGNED_TX_ID\" is invalid")
-    }
+        callServer(mockSuccessfulUniquenessClientService())
 
-    @Test
-    @Order(17)
-    fun `Contract verifying notary should respond with error if a signed transaction failed to signatory signature verification`() {
-        val signedTransaction = mockSignedTransaction(mapOf(VERIFY_SIGNATORY_SIGNATURES to MOCK_THROW))
-
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            signedTx = signedTransaction
-        )
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
@@ -580,24 +595,18 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(Integer.MAX_VALUE)
     fun `Contract verifying notary should respond with error if contract verification failed`() {
-        val signedTransaction = mockSignedTransaction()
-
         whenever(
             mockLedgerService.verify(
                 signedTransaction.toLedgerTransaction(
-                    listOf(
-                        mockDependencyOutputStateAndRef1,
-                        mockDependencyOutputStateAndRef2
-                    ), listOf(mockDependencyOutputStateAndRef3, mockDependencyOutputStateAndRef4)
+                    listOf(mockDependencyOutputStateAndRef1, mockDependencyOutputStateAndRef2),
+                    listOf(mockDependencyOutputStateAndRef3, mockDependencyOutputStateAndRef4)
                 )
             )
         ).thenThrow(NotaryExceptionTransactionVerificationFailure("contract verification failed"))
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            signedTx = signedTransaction
-        )
+
+        callServer(mockSuccessfulUniquenessClientService())
+
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
         assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
@@ -606,153 +615,22 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
-    @Order(19)
     fun `Contract verifying notary should successfully notarise if a signed tx verifies signatory signatures`() {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
             listOf(listOf(signatorySignatureCharlie))
         )
 
-        val signedTransaction = mockSignedTransaction()
+        whenever(mockLedgerService.verify(any())).thenAnswer {  }
+
         whenever(signedTransaction.verifySignatorySignatures()).thenAnswer {  }
 
-        signedTransaction.verifySignatorySignatures()
-        callServer(
-            mockSuccessfulUniquenessClientService(),
-            signedTx = signedTransaction
-        )
-
+        callServer(mockSuccessfulUniquenessClientService())
         val response = responseFromServer.first()
         assertThat(response.error).isNull()
     }
 
-    private fun mockSignedTransaction(signedTxContents: Map<String, Any?> = emptyMap()): UtxoSignedTransaction {
-        val mockThrow = signedTxContents.containsKey(VERIFY_SIGNATORY_SIGNATURES) &&
-                signedTxContents[VERIFY_SIGNATORY_SIGNATURES] == MOCK_THROW
-
-        return mock<UtxoSignedTransaction> {
-            on { id } doAnswer {
-                if (signedTxContents.containsKey(TXID)) signedTxContents[TXID] as SecureHash else SIGNED_TX_ID
-            }
-            on { inputStateRefs } doAnswer {
-                @Suppress("unchecked_cast")
-                if (signedTxContents.containsKey(INPUT_STATE_AND_REFS)) signedTxContents[INPUT_STATE_AND_REFS] as List<StateRef>
-                else listOf(SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_1, SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_2)
-            }
-            on { referenceStateRefs } doAnswer {
-                @Suppress("unchecked_cast")
-                if (signedTxContents.containsKey(REFSTATE_REFS)) signedTxContents[REFSTATE_REFS] as List<StateRef>
-                else listOf(
-                    SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1,
-                    SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2
-                )
-            }
-            on { outputStateAndRefs } doAnswer {
-                @Suppress("unchecked_cast")
-                if (signedTxContents.containsKey(OUTPUT_STATE_AND_REFS))
-                    signedTxContents[OUTPUT_STATE_AND_REFS] as List<StateAndRef<*>>
-                else listOf(mockOutputStateAndRef)
-            }
-            on { timeWindow } doAnswer {
-                if (signedTxContents.containsKey(TIME_WINDOW)) signedTxContents[TIME_WINDOW] as TimeWindow?
-                else mockTimeWindow
-            }
-            on { notaryKey } doAnswer {
-                if (signedTxContents.containsKey(NOTARY_KEY)) signedTxContents[NOTARY_KEY] as PublicKey?
-                else notaryServiceCompositeKey
-            }
-            on { notaryName } doAnswer {
-                if (signedTxContents.containsKey(NOTARY_NAME)) signedTxContents[NOTARY_NAME] as MemberX500Name?
-                else notaryServiceName
-            }
-            on { metadata } doAnswer {
-                if (signedTxContents.containsKey(METADATA)) signedTxContents[METADATA] as TransactionMetadata?
-                else transactionMetadata
-            }
-            if (mockThrow) {
-                on { verifySignatorySignatures() } doThrow (NotaryExceptionGeneral("Signature failed error"))
-            }
-        }
-    }
-
-    private fun mockFilteredTransaction(
-        filteredTxContents: Map<String, Any?> = emptyMap(),
-        txVerificationLogic: () -> Unit = {},
-    ): UtxoFilteredTransaction {
-        return mock<UtxoFilteredTransaction> {
-            on { id } doAnswer {
-                if (filteredTxContents.containsKey(TXID)) filteredTxContents[TXID] as SecureHash
-                else FILTERED_TX_ID
-            }
-            on { outputStateAndRefs } doAnswer {
-                @Suppress("unchecked_cast")
-                filteredTxContents[OUTPUT_STATE_AND_REFS] as? UtxoFilteredData<StateAndRef<*>>
-                    ?: mockOutputStateRefUtxoFilteredData
-            }
-            on { notaryName } doAnswer {
-                if (filteredTxContents.containsKey(NOTARY_NAME)) filteredTxContents[NOTARY_NAME] as MemberX500Name?
-                else notaryServiceName
-
-            }
-            on { notaryKey } doAnswer {
-                if (filteredTxContents.containsKey("notaryKey")) filteredTxContents["notaryKey"] as PublicKey?
-                 else notaryServiceCompositeKey
-            }
-            on { timeWindow } doAnswer {
-                if (filteredTxContents.containsKey("timeWindow")) filteredTxContents["timeWindow"] as TimeWindow?
-                 else mockTimeWindow
-            }
-            on { verify() } doAnswer {
-                txVerificationLogic()
-            }
-        }
-    }
-
-
-    /**
-     *  This function mocks up data such as filtered tx, signed tx and signatures to test verifying notary server.
-     *
-     *  @param clientService {@link LedgerUniquenessCheckerClientService} mock with UniquenessCheckResult that will be either
-     *  - UniquenessCheckResultFailureImpl using [mockErrorUniquenessClientService]
-     *  - UniquenessCheckResultSuccessImpl using [mockSuccessfulUniquenessClientService]
-     *  @param notarySignature DigitalSignatureAndMetadata of notary
-     *  @param signedTx {@link UtxoSignedTransaction} mock to use in test
-     *  @param filteredTransactionAndSigs a list of {@link FilteredTransactionAndSignatures}
-     *  dependency's transaction and its notary signatures
-     *  @param signatureVerificationLogic lambda function to execute on
-     *  UtxoFilteredTransaction.verifyAttachedNotarySignature() call
-     * */
     @Suppress("LongParameterList")
-    private fun callServer(
-        clientService: LedgerUniquenessCheckerClientService,
-        notarySignature: DigitalSignatureAndMetadata = notarySignatureAlice,
-        signedTx: UtxoSignedTransaction = mockSignedTransaction(),
-        filteredTransactionAndSigs: List<FilteredTransactionAndSignatures> = filteredTxsAndSignatures,
-        signatureVerificationLogic: () -> Unit = {}
-    ) {
-        whenever(
-            mockTransactionSignatureService.getIdOfPublicKey(
-                signedTx.notaryKey,
-                DigestAlgorithmName.SHA2_256.name
-            )
-        ).thenReturn(notarySignature.by)
-
-        val mockNotarySignatureVerificationService = mock<NotarySignatureVerificationService> {
-            on { verifyNotarySignatures(any(), any(), any(), any()) } doAnswer { signatureVerificationLogic() }
-        }
-
-        // Mock the receive and send from the counterparty session, unless it is overwritten
-        val paramOrDefaultSession = mock<FlowSession> {
-            on { receive(ContractVerifyingNotarizationPayload::class.java) } doReturn ContractVerifyingNotarizationPayload(
-                signedTx,
-                filteredTransactionAndSigs
-            )
-            on { send(any()) } doAnswer {
-                responseFromServer.add(it.arguments.first() as NotarizationResponse)
-                Unit
-            }
-            on { counterparty } doReturn memberCharlieName
-        }
-
+    private fun callServer(clientService: LedgerUniquenessCheckerClientService) {
         val server = ContractVerifyingNotaryServerFlowImpl(
             clientService,
             mockTransactionSignatureService,
@@ -761,11 +639,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             mockNotarySignatureVerificationService
         )
 
-        server.call(paramOrDefaultSession)
-    }
-
-    private fun throwVerify() {
-        throw IllegalArgumentException("DUMMY ERROR")
+        server.call(session)
     }
 
     private fun mockSuccessfulUniquenessClientService(): LedgerUniquenessCheckerClientService {
@@ -783,13 +657,14 @@ class ContractVerifyingNotaryServerFlowImplTest {
         )
     }
 
-    private fun mockThrowErrorUniquenessCheckClientService() = mock<LedgerUniquenessCheckerClientService> {
-        on { requestUniquenessCheck(any(), any(), any(), any(), any(), any(), any()) } doThrow
-                IllegalArgumentException("Uniqueness checker cannot be reached")
+    private fun mockThrowErrorUniquenessCheckClientService() = mock<LedgerUniquenessCheckerClientService>().also {
+        whenever(it.requestUniquenessCheck(any(), any(), any(), any(), any(), any(), any())).thenThrow(
+            IllegalArgumentException("Uniqueness checker cannot be reached")
+        )
     }
 
     private fun mockUniquenessClientService(response: UniquenessCheckResult) =
-        mock<LedgerUniquenessCheckerClientService> {
-            on { requestUniquenessCheck(any(), any(), any(), any(), any(), any(), any()) } doReturn response
+        mock<LedgerUniquenessCheckerClientService>().also {
+            whenever(it.requestUniquenessCheck(any(), any(), any(), any(), any(), any(), any())).thenReturn(response)
         }
 }

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
@@ -24,6 +24,7 @@ import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 import net.corda.v5.ledger.utxo.NotarySignatureVerificationService
@@ -39,8 +40,12 @@ import net.corda.v5.membership.MemberContext
 import net.corda.v5.membership.MemberInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
+import org.junit.jupiter.api.TestMethodOrder
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -50,68 +55,126 @@ import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.time.Instant
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestInstance(PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 class ContractVerifyingNotaryServerFlowImplTest {
 
     private companion object {
         const val NOTARY_SERVICE_NAME = "corda.notary.service.name"
         const val NOTARY_SERVICE_BACKCHAIN_REQUIRED = "corda.notary.service.backchain.required"
+        const val OUTPUT_STATE_AND_REFS = "outputStateRefs"
+        const val INPUT_STATE_AND_REFS = "inputStateRefs"
+        const val NOTARY_NAME = "notaryName"
+        const val NOTARY_KEY = "notaryKey"
+        const val TXID = "id"
+        const val TIME_WINDOW = "timeWindow"
+        const val REFSTATE_REFS = "referenceStateRefs"
+        const val METADATA = "metadata"
+        const val VERIFY_SIGNATORY_SIGNATURES = "VERIFY_SIGNATORY_SIGNATURES"
+        const val MOCK_THROW = "MOCK_THROW"
+
+        val SIGNED_TX_ID = SecureHashUtils.randomSecureHash()
+        val FILTERED_TX_ID = SecureHashUtils.randomSecureHash()
+        val INVALID_TX_ID = SecureHashUtils.randomSecureHash()
+        val SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_1 = StateRef(FILTERED_TX_ID, 0)
+        val SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_2 = StateRef(FILTERED_TX_ID, 1)
+
+        val SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1 = StateRef(FILTERED_TX_ID, 2)
+        val SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2 = StateRef(FILTERED_TX_ID, 3)
+        val SIGNED_TX_OUTPUT = StateRef(SIGNED_TX_ID, 0)
+        val INVALID_TX_OUTPUT = StateRef(INVALID_TX_ID, 4)
     }
 
-    // Cache for storing response from server
-    private val responseFromServer = mutableListOf<NotarizationResponse>()
+    // default mock for filtered transaction
+    private val mockDependencyInvalidOutputStateAndRef = mock<StateAndRef<*>> {
+        on { ref } doReturn INVALID_TX_OUTPUT
+    }
+    private val mockDependencyOutputStateAndRef1 = mock<StateAndRef<*>> {
+        on { ref } doReturn SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_1
+    }
+    private val mockDependencyOutputStateAndRef2 = mock<StateAndRef<*>> {
+        on { ref } doReturn SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_2
+    }
+    private val mockDependencyOutputStateAndRef3 = mock<StateAndRef<*>> {
+        on { ref } doReturn SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1
+    }
+    private val mockDependencyOutputStateAndRef4 = mock<StateAndRef<*>> {
+        on { ref } doReturn SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2
+    }
+    private val filteredTxOutputData = mapOf(
+        0 to mockDependencyOutputStateAndRef1,
+        1 to mockDependencyOutputStateAndRef2,
+        2 to mockDependencyOutputStateAndRef3,
+        3 to mockDependencyOutputStateAndRef4
+    )
+    private val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
+        on { values } doReturn filteredTxOutputData
+    }
 
     // Notary vnodes
     private val notaryVNodeAliceKey = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x01)) }
     private val notaryVNodeBobKey = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x02)) }
     private val invalidVnodeKey = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x03)) }
 
-    private val signatureAlice = getSignatureWithMetadataExample(notaryVNodeAliceKey)
-    private val signatureBob = getSignatureWithMetadataExample(notaryVNodeBobKey)
-    private val signatureInvalid = getSignatureWithMetadataExample(invalidVnodeKey)
+    // Signatory vnodes
+    private val signatoryVnodeCharlieKey = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x04)) }
+
+    // Notary signatures
+    private val notarySignatureAlice = getSignatureWithMetadataExample(notaryVNodeAliceKey)
+    private val notarySignatureBob = getSignatureWithMetadataExample(notaryVNodeBobKey)
+
+    // Signatory signatures
+    private val signatorySignatureCharlie = getSignatureWithMetadataExample(signatoryVnodeCharlieKey)
 
     // Notary Service and key
     private val notaryServiceCompositeKey = mock<CompositeKey> {
         on { leafKeys } doReturn setOf(notaryVNodeAliceKey, notaryVNodeBobKey)
     }
+
+    // member names
     private val notaryServiceName = MemberX500Name.parse("O=MyNotaryService, L=London, C=GB")
+    private val notaryAliceName = MemberX500Name("Alice", "London", "GB")
 
     // The client that initiated the session with the notary server
     private val memberCharlieName = MemberX500Name.parse("O=MemberCharlie, L=London, C=GB")
 
-    // mock services
-    private val mockTransactionSignatureService = mock<TransactionSignatureServiceInternal>()
-    private val mockLedgerService = mock<UtxoLedgerService>()
-
     // mock for notary member lookup
-    private val notaryInfo = mock<MemberInfo>()
     private val memberProvidedContext = mock<MemberContext>()
     private val mockMemberLookup = mock<MemberLookup>()
+    private val notaryInfoAlice = mock<MemberInfo>().also {
+        whenever(it.name).thenReturn(notaryAliceName)
+        whenever(it.memberProvidedContext).thenReturn(memberProvidedContext)
+    }
+
+    // Prepare filteredTransactionAndSignature data
+    private val filteredTxAndSignature = FilteredTransactionAndSignatures(
+        mockFilteredTransaction(),
+        listOf(notarySignatureAlice)
+    )
+    private val filteredTxsAndSignatures = listOf(
+        filteredTxAndSignature
+    )
 
     // mock fields for signed transaction
-    private val txId = SecureHashUtils.randomSecureHash()
     private val transactionMetadata = mock<TransactionMetadata>()
     private val mockTimeWindow = mock<TimeWindow> {
         on { from } doReturn Instant.now()
         on { until } doReturn Instant.now().plusMillis(100000)
     }
-    private  val mockInputRef = mock<StateRef>()
-    private val mockOutputStateAndRef = mock<StateAndRef<*>>()
 
-    // mock signed transaction
-    private val signedTx = mock<UtxoSignedTransaction> {
-        on { id } doReturn txId
-        on { inputStateRefs } doReturn listOf(mockInputRef)
-        on { referenceStateRefs } doReturn emptyList()
-        on { outputStateAndRefs } doReturn listOf(mockOutputStateAndRef)
-        on { timeWindow } doReturn mockTimeWindow
-        on { notaryKey } doReturn notaryServiceCompositeKey
-        on { notaryName } doReturn notaryServiceName
-        on { metadata } doReturn transactionMetadata
+    private val mockOutputStateAndRef = mock<StateAndRef<*>>().also {
+        whenever(it.ref).thenReturn(SIGNED_TX_OUTPUT)
     }
 
+    // mock services
+    private val mockTransactionSignatureService = mock<TransactionSignatureServiceInternal>()
+    private val mockLedgerService = mock<UtxoLedgerService>()
+
+    // Cache for storing response from server
+    private val responseFromServer = mutableListOf<NotarizationResponse>()
+
     @BeforeEach
-    fun clearCache() {
+    fun beforeEach() {
         responseFromServer.clear()
         whenever(mockTransactionSignatureService.signBatch(any(), any())).doAnswer { inv ->
             List((inv.arguments.first() as List<*>).size) {
@@ -123,15 +186,24 @@ class ContractVerifyingNotaryServerFlowImplTest {
                 }
             }
         }
+
+        // Get current notary and parse its data
+        whenever(mockMemberLookup.myInfo()).thenReturn(notaryInfoAlice)
+        whenever(notaryInfoAlice.memberProvidedContext).thenReturn(memberProvidedContext)
+        whenever(memberProvidedContext.parse(NOTARY_SERVICE_NAME, MemberX500Name::class.java)).thenReturn(
+            notaryServiceName
+        )
+        whenever(memberProvidedContext.parse(NOTARY_SERVICE_BACKCHAIN_REQUIRED, Boolean::class.java)).thenReturn(false)
     }
 
     @Test
+    @Order(0)
     fun `Contract verifying notary should respond with error if no keys found for signing`() {
         // We sign with a key that is not part of the notary composite key
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenThrow(
             TransactionNoAvailableKeysException("The publicKeys do not have any private counterparts available.", null)
         )
-        createAndCallServer(mockSuccessfulUniquenessClientService(), notarySignature = signatureInvalid)
+        createAndCallServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -140,18 +212,21 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
         assertThat((responseError as NotaryExceptionGeneral).errorText)
             .contains("The publicKeys do not have any private counterparts available.")
-
     }
 
     @Test
+    @Order(1)
     fun `Contract verifying notary plugin server should respond with error if request signature is invalid`() {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
-            listOf(listOf(signatureAlice))
+            listOf(listOf(notarySignatureAlice))
         )
-
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf("notaryKey" to invalidVnodeKey)),
+            listOf(notarySignatureAlice)
+        )
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            filteredTxContents = mapOf("notaryKey" to invalidVnodeKey),
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature),
             signatureVerificationLogic = ::throwVerify
 
         )
@@ -165,6 +240,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(2)
     fun `Contract verifying notary plugin server should respond with error if the uniqueness check fails`() {
         val unknownStateRef = UniquenessCheckStateRefImpl(SecureHashUtils.randomSecureHash(), 0)
 
@@ -182,10 +258,10 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat((responseError as NotaryExceptionReferenceStateUnknown).unknownStates).containsExactly(
             unknownStateRef
         )
-
     }
 
     @Test
+    @Order(3)
     fun `Contract verifying notary plugin server should respond with error if an error encountered during uniqueness check`() {
         createAndCallServer(mockThrowErrorUniquenessCheckClientService())
         assertThat(responseFromServer).hasSize(1)
@@ -199,9 +275,10 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(4)
     fun `Contract verifying notary plugin server should respond with signatures if alice key is in composite key`() {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
-            listOf(listOf(signatureAlice))
+            listOf(listOf(notarySignatureAlice))
         )
 
         createAndCallServer(
@@ -216,9 +293,10 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(5)
     fun `Contract verifying notary plugin server should respond with signatures if bob key is in composite key`() {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
-            listOf(listOf(signatureBob))
+            listOf(listOf(notarySignatureBob))
         )
 
         createAndCallServer(
@@ -233,8 +311,17 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(6)
     fun `Contract verifying notary plugin server should respond with error if time window not present on filtered tx`() {
-        createAndCallServer(mockSuccessfulUniquenessClientService(), filteredTxContents = mapOf("timeWindow" to null))
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(TIME_WINDOW to null)),
+            listOf(notarySignatureAlice)
+        )
+
+        createAndCallServer(
+            mockSuccessfulUniquenessClientService(),
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        )
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -247,10 +334,15 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(7)
     fun `Contract verifying notary plugin server should respond with error if notary name not present on filtered tx`() {
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(NOTARY_NAME to null)),
+            listOf(notarySignatureAlice)
+        )
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            filteredTxContents = mapOf("notaryName" to null)
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
         assertThat(responseFromServer).hasSize(1)
 
@@ -264,10 +356,15 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(8)
     fun `Contract verifying notary plugin server should respond with error if notary key not present on filtered tx`() {
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(NOTARY_KEY to null)),
+            listOf(notarySignatureAlice)
+        )
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            filteredTxContents = mapOf("notaryKey" to null)
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
         assertThat(responseFromServer).hasSize(1)
 
@@ -281,12 +378,17 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(9)
     fun `Contract verifying notary plugin server should respond with error if output states are not audit type in the filtered tx`() {
         val mockOutputStateProof = mock<UtxoFilteredData.SizeOnly<StateRef>>()
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateProof)),
+            listOf(notarySignatureAlice)
+        )
 
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            filteredTxContents = mapOf("outputStateRefs" to mockOutputStateProof)
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
         assertThat(responseFromServer).hasSize(1)
 
@@ -299,8 +401,13 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(10)
     fun `Contract verifying notary plugin server should respond with error if transaction verification fails`() {
-        createAndCallServer(mockSuccessfulUniquenessClientService(), txVerificationLogic = ::throwVerify)
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(txVerificationLogic = ::throwVerify),
+            listOf(notarySignatureAlice)
+        )
+        createAndCallServer(mockSuccessfulUniquenessClientService(), filteredTransactionAndSigs = listOf(filteredTxAndSignature))
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -312,6 +419,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(11)
     fun `Contract verifying notary plugin server should throw general error when unhandled exception in uniqueness checker`() {
         createAndCallServer(
             mockErrorUniquenessClientService(
@@ -335,11 +443,15 @@ class ContractVerifyingNotaryServerFlowImplTest {
     }
 
     @Test
+    @Order(12)
     fun `Contract verifying notary plugin server should respond with error if notary identity invalid`() {
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(NOTARY_NAME to MemberX500Name.parse("C=GB,L=London,O=Bob"))),
+            listOf(notarySignatureAlice)
+        )
         createAndCallServer(
             mockSuccessfulUniquenessClientService(),
-            // What party we pass in here does not matter, it just needs to be different from the notary server party
-            filteredTxContents = mapOf("notaryName" to MemberX500Name.parse("C=GB,L=London,O=Bob"))
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
         assertThat(responseFromServer).hasSize(1)
 
@@ -351,6 +463,251 @@ class ContractVerifyingNotaryServerFlowImplTest {
 
     }
 
+    @Test
+    @Order(13)
+    fun `Contract verifying notary should respond with error if dependency input is missing`() {
+         val filteredTxOutputData = mapOf(0 to mockDependencyOutputStateAndRef1)
+         val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
+            on { values } doReturn filteredTxOutputData
+        }
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateRefUtxoFilteredData)),
+            listOf(notarySignatureAlice)
+        )
+
+        createAndCallServer(
+            mockSuccessfulUniquenessClientService(),
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        )
+
+        val responseError = responseFromServer.first().error
+        assertThat(responseError).isNotNull
+        assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
+        assertThat((responseError as NotaryExceptionTransactionVerificationFailure).errorText)
+            .contains("Missing input state and ref from the filtered transaction")
+    }
+
+    @Test
+    @Order(14)
+    fun `Contract verifying notary should respond with error if dependency reference is missing`() {
+        val filteredTxOutputData = mapOf(
+            0 to mockDependencyOutputStateAndRef1,
+            1 to mockDependencyOutputStateAndRef2,
+            2 to mockDependencyOutputStateAndRef3
+        )
+        val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
+            on { values } doReturn filteredTxOutputData
+        }
+
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateRefUtxoFilteredData)),
+            listOf(notarySignatureAlice)
+        )
+        createAndCallServer(
+            mockSuccessfulUniquenessClientService(),
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        )
+
+        val responseError = responseFromServer.first().error
+        assertThat(responseError).isNotNull
+        assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
+        assertThat((responseError as NotaryExceptionTransactionVerificationFailure).errorText)
+            .contains("Missing reference state and ref from the filtered transaction")
+    }
+
+    @Test
+    @Order(15)
+    fun `Contract verifying notary should respond with error if dependency is invalid`() {
+        val filteredTxOutputData = mapOf(
+            0 to mockDependencyOutputStateAndRef1,
+            1 to mockDependencyOutputStateAndRef2,
+            2 to mockDependencyOutputStateAndRef3,
+            3 to mockDependencyInvalidOutputStateAndRef
+        )
+        val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
+            on { values } doReturn filteredTxOutputData
+        }
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateRefUtxoFilteredData)),
+            listOf(notarySignatureAlice)
+        )
+
+        createAndCallServer(
+            mockSuccessfulUniquenessClientService(),
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        )
+
+        val responseError = responseFromServer.first().error
+        assertThat(responseError).isNotNull
+        assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
+        assertThat((responseError as NotaryExceptionTransactionVerificationFailure).errorText)
+            .contains("Missing reference state and ref from the filtered transaction")
+    }
+
+    @Test
+    @Order(16)
+    fun `Contract verifying notary should respond with error if either current or filtered tx is invalid`() {
+        val filteredTxAndSignature = FilteredTransactionAndSignatures(
+            mockFilteredTransaction(mapOf(TXID to SIGNED_TX_ID)),
+            listOf(notarySignatureAlice)
+        )
+        createAndCallServer(
+            mockSuccessfulUniquenessClientService(),
+            filteredTransactionAndSigs = listOf(filteredTxAndSignature)
+        )
+
+        val responseError = responseFromServer.first().error
+        assertThat(responseError).isNotNull
+        assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
+        assertThat((responseError as NotaryExceptionTransactionVerificationFailure).errorText)
+            .contains("Either filtered transaction \"$SIGNED_TX_ID\" or current transaction \"$SIGNED_TX_ID\" is invalid")
+    }
+
+    @Test
+    @Order(17)
+    fun `Contract verifying notary should respond with error if a signed transaction failed to signatory signature verification`() {
+        val signedTransaction = mockSignedTransaction(mapOf(VERIFY_SIGNATORY_SIGNATURES to MOCK_THROW))
+
+        createAndCallServer(
+            mockSuccessfulUniquenessClientService(),
+            signedTx = signedTransaction
+        )
+        val responseError = responseFromServer.first().error
+        assertThat(responseError).isNotNull
+        assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
+        assertThat((responseError as NotaryExceptionGeneral).message)
+            .contains("Signature failed error")
+    }
+
+    @Test
+    @Order(Integer.MAX_VALUE)
+    fun `Contract verifying notary should respond with error if contract verification failed`() {
+        val signedTransaction = mockSignedTransaction()
+
+        whenever(
+            mockLedgerService.verify(
+                signedTransaction.toLedgerTransaction(
+                    listOf(
+                        mockDependencyOutputStateAndRef1,
+                        mockDependencyOutputStateAndRef2
+                    ), listOf(mockDependencyOutputStateAndRef3, mockDependencyOutputStateAndRef4)
+                )
+            )
+        ).thenThrow(NotaryExceptionTransactionVerificationFailure("contract verification failed"))
+        createAndCallServer(
+            mockSuccessfulUniquenessClientService(),
+            signedTx = signedTransaction
+        )
+        val responseError = responseFromServer.first().error
+        assertThat(responseError).isNotNull
+        assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
+        assertThat((responseError as NotaryExceptionTransactionVerificationFailure).message)
+            .contains("Transaction failed to verify with error message", "contract verification failed")
+    }
+
+    // to remove --------------------------------------------------
+    @Test
+    @Order(19)
+    fun `Contract verifying notary should successfully verify signatories if a signed tx has all required signatures`() {
+        whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
+            listOf(listOf(signatorySignatureCharlie))
+        )
+
+        val signedTransaction = mockSignedTransaction()
+        whenever(signedTransaction.verifySignatorySignatures()).thenAnswer {  }
+
+        signedTransaction.verifySignatorySignatures()
+        createAndCallServer(
+            mockSuccessfulUniquenessClientService(),
+            signedTx = signedTransaction
+        )
+
+        val response = responseFromServer.first()
+        assertThat(response.error).isNull()
+    }
+
+    private fun mockSignedTransaction(signedTxContents: Map<String, Any?> = emptyMap()): UtxoSignedTransaction {
+        val mockThrow = signedTxContents.containsKey(VERIFY_SIGNATORY_SIGNATURES) &&
+                signedTxContents[VERIFY_SIGNATORY_SIGNATURES] == MOCK_THROW
+
+        return mock<UtxoSignedTransaction> {
+            on { id } doAnswer {
+                if (signedTxContents.containsKey(TXID)) signedTxContents[TXID] as SecureHash else SIGNED_TX_ID
+            }
+            on { inputStateRefs } doAnswer {
+                @Suppress("unchecked_cast")
+                if (signedTxContents.containsKey(INPUT_STATE_AND_REFS)) signedTxContents[INPUT_STATE_AND_REFS] as List<StateRef>
+                else listOf(SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_1, SIGNED_TX_INPUT_DEPENDENCY_STATE_REF_2)
+            }
+            on { referenceStateRefs } doAnswer {
+                @Suppress("unchecked_cast")
+                if (signedTxContents.containsKey(REFSTATE_REFS)) signedTxContents[REFSTATE_REFS] as List<StateRef>
+                else listOf(
+                    SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1,
+                    SIGNED_TX_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2
+                )
+            }
+            on { outputStateAndRefs } doAnswer {
+                @Suppress("unchecked_cast")
+                if (signedTxContents.containsKey(OUTPUT_STATE_AND_REFS))
+                    signedTxContents[OUTPUT_STATE_AND_REFS] as List<StateAndRef<*>>
+                else listOf(mockOutputStateAndRef)
+            }
+            on { timeWindow } doAnswer {
+                if (signedTxContents.containsKey(TIME_WINDOW)) signedTxContents[TIME_WINDOW] as TimeWindow?
+                else mockTimeWindow
+            }
+            on { notaryKey } doAnswer {
+                if (signedTxContents.containsKey(NOTARY_KEY)) signedTxContents[NOTARY_KEY] as PublicKey?
+                else notaryServiceCompositeKey
+            }
+            on { notaryName } doAnswer {
+                if (signedTxContents.containsKey(NOTARY_NAME)) signedTxContents[NOTARY_NAME] as MemberX500Name?
+                else notaryServiceName
+            }
+            on { metadata } doAnswer {
+                if (signedTxContents.containsKey(METADATA)) signedTxContents[METADATA] as TransactionMetadata?
+                else transactionMetadata
+            }
+            if (mockThrow) {
+                on { verifySignatorySignatures() } doThrow (NotaryExceptionGeneral("Signature failed error"))
+            }
+        }
+    }
+
+    private fun mockFilteredTransaction(
+        filteredTxContents: Map<String, Any?> = emptyMap(),
+        txVerificationLogic: () -> Unit = {},
+    ): UtxoFilteredTransaction {
+        return mock<UtxoFilteredTransaction> {
+            on { id } doAnswer {
+                if (filteredTxContents.containsKey(TXID)) filteredTxContents[TXID] as SecureHash
+                else FILTERED_TX_ID
+            }
+            on { outputStateAndRefs } doAnswer {
+                @Suppress("unchecked_cast")
+                filteredTxContents[OUTPUT_STATE_AND_REFS] as? UtxoFilteredData<StateAndRef<*>>
+                    ?: mockOutputStateRefUtxoFilteredData
+            }
+            on { notaryName } doAnswer {
+                if (filteredTxContents.containsKey(NOTARY_NAME)) filteredTxContents[NOTARY_NAME] as MemberX500Name?
+                else notaryServiceName
+
+            }
+            on { notaryKey } doAnswer {
+                if (filteredTxContents.containsKey("notaryKey")) filteredTxContents["notaryKey"] as PublicKey?
+                 else notaryServiceCompositeKey
+            }
+            on { timeWindow } doAnswer {
+                if (filteredTxContents.containsKey("timeWindow")) filteredTxContents["timeWindow"] as TimeWindow?
+                 else mockTimeWindow
+            }
+            on { verify() } doAnswer {
+                txVerificationLogic()
+            }
+        }
+    }
+
 
     /**
      *  This function mocks up data such as filtered tx, signed tx and signatures to test verifying notary server.
@@ -358,92 +715,27 @@ class ContractVerifyingNotaryServerFlowImplTest {
      *  @param clientService {@link LedgerUniquenessCheckerClientService} mock with UniquenessCheckResult that will be either
      *  - UniquenessCheckResultFailureImpl using [mockErrorUniquenessClientService]
      *  - UniquenessCheckResultSuccessImpl using [mockSuccessfulUniquenessClientService]
-     *  @param notaryServiceKey PublicKey of notary. CompositeKey by default.
      *  @param notarySignature DigitalSignatureAndMetadata of notary
-     *  @param filteredTxContents Map of content of FilteredTransaction to mock up with.
-     *  It will be mocked up with default values if it's empty.
-     *  filtered contests that can be in a map:
-     *  - outputStateRefs
-     *  - notaryName
-     *  - notaryKey
-     *  - timeWindow
-     *  @param txVerificationLogic lambda function to execute on UtxoFilteredTransaction.verify() call
+     *  @param signedTx {@link UtxoSignedTransaction} mock to use in test
+     *  @param filteredTransactionAndSigs a list of {@link FilteredTransactionAndSignatures}
+     *  dependency's transaction and its notary signatures
      *  @param signatureVerificationLogic lambda function to execute on
      *  UtxoFilteredTransaction.verifyAttachedNotarySignature() call
      * */
     @Suppress("LongParameterList")
     private fun createAndCallServer(
         clientService: LedgerUniquenessCheckerClientService,
-        notaryServiceKey: PublicKey = notaryServiceCompositeKey,
-        notarySignature: DigitalSignatureAndMetadata = signatureAlice,
-        filteredTxContents: Map<String, Any?> = emptyMap(),
-        txVerificationLogic: () -> Unit = {},
+        notarySignature: DigitalSignatureAndMetadata = notarySignatureAlice,
+        signedTx: UtxoSignedTransaction = mockSignedTransaction(),
+        filteredTransactionAndSigs: List<FilteredTransactionAndSignatures> = filteredTxsAndSignatures,
         signatureVerificationLogic: () -> Unit = {}
     ) {
-        // Get current notary and parse its data
-        whenever(mockMemberLookup.myInfo()).thenReturn(notaryInfo)
-        whenever(notaryInfo.memberProvidedContext).thenReturn(memberProvidedContext)
-        whenever(memberProvidedContext.parse(NOTARY_SERVICE_NAME, MemberX500Name::class.java)).thenReturn(
-            notaryServiceName
-        )
-        whenever(memberProvidedContext.parse(NOTARY_SERVICE_BACKCHAIN_REQUIRED, Boolean::class.java)).thenReturn(true)
         whenever(
             mockTransactionSignatureService.getIdOfPublicKey(
                 signedTx.notaryKey,
                 DigestAlgorithmName.SHA2_256.name
             )
         ).thenReturn(notarySignature.by)
-
-        // Mock Filtered Transaction
-        val mockDependencyOutputStateAndRef = mock<StateAndRef<*>> {
-            on { ref } doReturn mockInputRef
-        }
-
-        val mockOutputStateRefUtxoFilteredData = mock<UtxoFilteredData.Audit<StateAndRef<*>>> {
-            on { values } doReturn mapOf(0 to mockDependencyOutputStateAndRef)
-        }
-        val filteredTx = mock<UtxoFilteredTransaction> {
-            on { outputStateAndRefs } doAnswer {
-                @Suppress("unchecked_cast")
-                filteredTxContents["outputStateRefs"] as? UtxoFilteredData<StateAndRef<*>>
-                    ?: mockOutputStateRefUtxoFilteredData
-            }
-            on { notaryName } doAnswer {
-                if (filteredTxContents.containsKey("notaryName")) {
-                    filteredTxContents["notaryName"] as MemberX500Name?
-                } else {
-                    notaryServiceName
-                }
-            }
-            on { notaryKey } doAnswer {
-                if (filteredTxContents.containsKey("notaryKey")) {
-                    filteredTxContents["notaryKey"] as PublicKey?
-                } else {
-                    notaryServiceKey
-                }
-            }
-            on { timeWindow } doAnswer {
-                if (filteredTxContents.containsKey("timeWindow")) {
-                    filteredTxContents["timeWindow"] as TimeWindow?
-                } else {
-                    mockTimeWindow
-                }
-            }
-
-            on { verify() } doAnswer {
-                txVerificationLogic()
-            }
-            on { id } doReturn txId
-        }
-
-        // Prepare filteredTransactionAndSignature data
-        val filteredTxAndSignature = FilteredTransactionAndSignatures(
-            filteredTx,
-            listOf(notarySignature)
-        )
-        val filteredTxsAndSignatures = listOf(
-            filteredTxAndSignature
-        )
 
         val mockNotarySignatureVerificationService = mock<NotarySignatureVerificationService> {
             on { verifyNotarySignatures(any(), any(), any(), any()) } doAnswer { signatureVerificationLogic() }
@@ -453,7 +745,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         val paramOrDefaultSession = mock<FlowSession> {
             on { receive(ContractVerifyingNotarizationPayload::class.java) } doReturn ContractVerifyingNotarizationPayload(
                 signedTx,
-                filteredTxsAndSignatures
+                filteredTransactionAndSigs
             )
             on { send(any()) } doAnswer {
                 responseFromServer.add(it.arguments.first() as NotarizationResponse)

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
@@ -203,7 +203,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenThrow(
             TransactionNoAvailableKeysException("The publicKeys do not have any private counterparts available.", null)
         )
-        createAndCallServer(mockSuccessfulUniquenessClientService())
+        callServer(mockSuccessfulUniquenessClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -224,7 +224,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             mockFilteredTransaction(mapOf("notaryKey" to invalidVnodeKey)),
             listOf(notarySignatureAlice)
         )
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature),
             signatureVerificationLogic = ::throwVerify
@@ -244,7 +244,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
     fun `Contract verifying notary plugin server should respond with error if the uniqueness check fails`() {
         val unknownStateRef = UniquenessCheckStateRefImpl(SecureHashUtils.randomSecureHash(), 0)
 
-        createAndCallServer(
+        callServer(
             mockErrorUniquenessClientService(
                 UniquenessCheckErrorReferenceStateUnknownImpl(listOf(unknownStateRef))
             )
@@ -263,7 +263,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
     @Test
     @Order(3)
     fun `Contract verifying notary plugin server should respond with error if an error encountered during uniqueness check`() {
-        createAndCallServer(mockThrowErrorUniquenessCheckClientService())
+        callServer(mockThrowErrorUniquenessCheckClientService())
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -281,7 +281,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             listOf(listOf(notarySignatureAlice))
         )
 
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
         )
         assertThat(responseFromServer).hasSize(1)
@@ -299,7 +299,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             listOf(listOf(notarySignatureBob))
         )
 
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
         )
         assertThat(responseFromServer).hasSize(1)
@@ -318,7 +318,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             listOf(notarySignatureAlice)
         )
 
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -340,7 +340,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             mockFilteredTransaction(mapOf(NOTARY_NAME to null)),
             listOf(notarySignatureAlice)
         )
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -362,7 +362,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             mockFilteredTransaction(mapOf(NOTARY_KEY to null)),
             listOf(notarySignatureAlice)
         )
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -386,7 +386,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             listOf(notarySignatureAlice)
         )
 
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -407,7 +407,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             mockFilteredTransaction(txVerificationLogic = ::throwVerify),
             listOf(notarySignatureAlice)
         )
-        createAndCallServer(mockSuccessfulUniquenessClientService(), filteredTransactionAndSigs = listOf(filteredTxAndSignature))
+        callServer(mockSuccessfulUniquenessClientService(), filteredTransactionAndSigs = listOf(filteredTxAndSignature))
         assertThat(responseFromServer).hasSize(1)
 
         val responseError = responseFromServer.first().error
@@ -421,7 +421,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
     @Test
     @Order(11)
     fun `Contract verifying notary plugin server should throw general error when unhandled exception in uniqueness checker`() {
-        createAndCallServer(
+        callServer(
             mockErrorUniquenessClientService(
                 UniquenessCheckErrorUnhandledExceptionImpl(
                     IllegalArgumentException::class.java.name,
@@ -449,7 +449,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             mockFilteredTransaction(mapOf(NOTARY_NAME to MemberX500Name.parse("C=GB,L=London,O=Bob"))),
             listOf(notarySignatureAlice)
         )
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -475,7 +475,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             listOf(notarySignatureAlice)
         )
 
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -503,7 +503,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             mockFilteredTransaction(mapOf(OUTPUT_STATE_AND_REFS to mockOutputStateRefUtxoFilteredData)),
             listOf(notarySignatureAlice)
         )
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -532,7 +532,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             listOf(notarySignatureAlice)
         )
 
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -551,7 +551,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             mockFilteredTransaction(mapOf(TXID to SIGNED_TX_ID)),
             listOf(notarySignatureAlice)
         )
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             filteredTransactionAndSigs = listOf(filteredTxAndSignature)
         )
@@ -568,7 +568,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
     fun `Contract verifying notary should respond with error if a signed transaction failed to signatory signature verification`() {
         val signedTransaction = mockSignedTransaction(mapOf(VERIFY_SIGNATORY_SIGNATURES to MOCK_THROW))
 
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             signedTx = signedTransaction
         )
@@ -594,7 +594,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
                 )
             )
         ).thenThrow(NotaryExceptionTransactionVerificationFailure("contract verification failed"))
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             signedTx = signedTransaction
         )
@@ -617,7 +617,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         whenever(signedTransaction.verifySignatorySignatures()).thenAnswer {  }
 
         signedTransaction.verifySignatorySignatures()
-        createAndCallServer(
+        callServer(
             mockSuccessfulUniquenessClientService(),
             signedTx = signedTransaction
         )
@@ -723,7 +723,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
      *  UtxoFilteredTransaction.verifyAttachedNotarySignature() call
      * */
     @Suppress("LongParameterList")
-    private fun createAndCallServer(
+    private fun callServer(
         clientService: LedgerUniquenessCheckerClientService,
         notarySignature: DigitalSignatureAndMetadata = notarySignatureAlice,
         signedTx: UtxoSignedTransaction = mockSignedTransaction(),

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
@@ -605,10 +605,9 @@ class ContractVerifyingNotaryServerFlowImplTest {
             .contains("Transaction failed to verify with error message", "contract verification failed")
     }
 
-    // to remove --------------------------------------------------
     @Test
     @Order(19)
-    fun `Contract verifying notary should successfully verify signatories if a signed tx has all required signatures`() {
+    fun `Contract verifying notary should successfully notarise if a signed tx verifies signatory signatures`() {
         whenever(mockTransactionSignatureService.signBatch(any(), any())).thenReturn(
             listOf(listOf(signatorySignatureCharlie))
         )


### PR DESCRIPTION
In this PR, I added more unit test cases for verifying notary, and checking any missing checks, and refactored the test.

**added tests:**
- Contract verifying notary should successfully notarise if a signed tx verifies signatory signatures
- Contract verifying notary should respond with error if contract verification failed
- Contract verifying notary should respond with error if a signed transaction failed to signatory signature verification
- Contract verifying notary should respond with error if either current or filtered tx is invalid 
- Contract verifying notary should respond with error if dependency is invalid
- Contract verifying notary should respond with error if dependency reference is missing
- Contract verifying notary should respond with error if dependency input is missing