### PR TITLE
CORE-19295: Clean Up Checkpoints Only

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -10,6 +10,7 @@ import net.corda.data.crypto.wire.ops.key.rotation.KeyRotationRequest
 import net.corda.data.crypto.wire.ops.key.rotation.KeyRotationStatus
 import net.corda.data.crypto.wire.ops.key.rotation.KeyType
 import net.corda.libs.statemanager.api.Metadata
+import net.corda.libs.statemanager.api.STATE_TYPE
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.messaging.api.processor.DurableProcessor
@@ -107,8 +108,16 @@ class CryptoRekeyBusProcessor(
                 now
             )
 
-            val flattend = checkNotNull(serializer.serialize(status))
-            stateManager?.create(listOf(State(request.requestId, flattend, 1, Metadata(), now)))
+            val flattened = checkNotNull(serializer.serialize(status))
+            stateManager?.create(
+                listOf(
+                    State(
+                        request.requestId,
+                        flattened, 1,
+                        Metadata(mapOf(STATE_TYPE to status::class.java.name))
+                    )
+                )
+            )
         }
 
         return emptyList()

--- a/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/PerformanceClaimStateStoreImpl.kt
+++ b/components/ledger/ledger-utxo-token-cache/src/main/kotlin/net/corda/ledger/utxo/token/cache/services/PerformanceClaimStateStoreImpl.kt
@@ -2,6 +2,8 @@ package net.corda.ledger.utxo.token.cache.services
 
 import net.corda.data.ledger.utxo.token.selection.state.TokenPoolCacheState
 import net.corda.ledger.utxo.token.cache.entities.TokenPoolKey
+import net.corda.libs.statemanager.api.Metadata
+import net.corda.libs.statemanager.api.STATE_TYPE
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.tracing.wrapWithTracingExecutor
@@ -156,6 +158,7 @@ class PerformanceClaimStateStoreImpl(
         val newStoredState = State(
             key = tokenPoolKey.toString(),
             value = stateBytes,
+            metadata = Metadata(mapOf(STATE_TYPE to tokenPoolCacheState::class.java.name)),
             modifiedTime = clock.instant()
         )
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/StateManagerHelperTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/StateManagerHelperTest.kt
@@ -4,6 +4,7 @@ import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.messaging.mediator.MediatorState
 import net.corda.libs.statemanager.api.Metadata
+import net.corda.libs.statemanager.api.STATE_TYPE
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.State.Companion.VERSION_INITIAL_VALUE
 import net.corda.messaging.api.constants.MessagingMetadataKeys.PROCESSING_FAILURE
@@ -46,7 +47,6 @@ class StateManagerHelperTest {
 
     @Test
     fun `successfully creates new state`() {
-
         val persistedState: State? = null
         val newState = StateAndEventProcessor.State(
             StateType(1),
@@ -66,7 +66,7 @@ class StateManagerHelperTest {
         assertEquals(TEST_KEY, state!!.key)
         assertArrayEquals(serialized(mediatorState), state.value)
         assertEquals(VERSION_INITIAL_VALUE, state.version)
-        assertEquals(newState.metadata, state.metadata)
+        assertEquals(Metadata(mapOf(STATE_TYPE to StateType::class.java.name)), state.metadata)
     }
 
     @Test
@@ -76,7 +76,7 @@ class StateManagerHelperTest {
             TEST_KEY,
             serialized(TEST_STATE_VALUE),
             stateVersion,
-            Metadata()
+            Metadata(mapOf(STATE_TYPE to StateType::class.java.simpleName))
         )
         val updatedState = StateAndEventProcessor.State(
             StateType(TEST_STATE_VALUE.id + 1),
@@ -96,7 +96,7 @@ class StateManagerHelperTest {
         assertEquals(persistedState.key, state!!.key)
         assertArrayEquals(serialized(MediatorState(ByteBuffer.wrap(serialized(updatedState.value!!)), emptyList())), state.value)
         assertEquals(persistedState.version, state.version)
-        assertEquals(updatedState.metadata, state.metadata)
+        assertEquals(Metadata(mapOf(STATE_TYPE to StateType::class.java.name)), state.metadata)
     }
 
     @Test

--- a/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/Metadata.kt
+++ b/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/Metadata.kt
@@ -1,6 +1,13 @@
 package net.corda.libs.statemanager.api
 
 /**
+ * Metadata key used to store the actual State Type, if relevant.
+ *
+ * TODO-[CORE-16416]: remove once Isolated State Managers per State Type has been implemented.
+ */
+const val STATE_TYPE = "state.type"
+
+/**
  * Map that allows only primitive types to be used as values.
  */
 class Metadata(
@@ -15,10 +22,12 @@ class Metadata(
             Boolean::class.java,
             java.lang.Boolean::class.java,
         )
+
         private fun isPrimitiveOrBoxedValue(value: Any): Boolean {
             return supportedType.any { it.isAssignableFrom(value.javaClass) }
         }
     }
+
     init {
         map.filter { kvp -> !isPrimitiveOrBoxedValue(kvp.value) }.takeIf { it.isNotEmpty() }?.also { kvp ->
             val invalidPairs = kvp.entries.joinToString { "${it.key}/${it.value::class.java.name}" }
@@ -40,6 +49,8 @@ class Metadata(
     override fun hashCode(): Int {
         return map.hashCode()
     }
+
+    fun containsKeyWithValue(key: String, value: Any) = map.containsKey(key) && map[key]!! == value
 }
 
 fun metadata(): Metadata = Metadata()


### PR DESCRIPTION
Fix "FlowTimeoutTaskProcessor" implementation so that only states
representing flow checkpoints are marked for deletion. Other types of
states should not be automatically deleted as that might cause issues,
especially when the persistent storage is shared  to store multiple
state types.
