### PR TITLE
CORE-13499: Implement key rotation status

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -9,6 +9,8 @@ import net.corda.rest.annotations.HttpPOST
 import net.corda.rest.annotations.HttpRestResource
 import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.annotations.RestPathParameter
+import net.corda.rest.exception.ForbiddenException
+import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.rest.exception.ServiceUnavailableException
 import net.corda.rest.response.ResponseEntity
 
@@ -23,20 +25,21 @@ import net.corda.rest.response.ResponseEntity
 )
 interface KeyRotationRestResource : RestResource {
     /**
-     * The [getKeyRotationStatus] gets a list of unmanaged wrapping keys [{alias, [requestIds]}] where requestIds is
-     *                         list of rotations runs in progress.
+     * The [getKeyRotationStatus] gets the latest key rotation status for [keyAlias] if one exists.
      *
-     * @return A list of unmanaged wrapping keys [{alias, [requestIds]}] where requestIds is
-     *         the list of rotations runs in progress.
+     * @return A list of vNodes with the total number of keys needs re-rewrapping and the number of already re-wrapped
+     *          keys.
+     *
+     * @throws ResourceNotFoundException If no key rotation was in progress for [keyAlias].
      */
     @HttpGET(
-        path = "unmanaged/rotation/{rootKeyAlias}",
-        description = "This method gets the status of the current rotation.",
-        responseDescription = "",
+        path = "unmanaged/rotation/{keyAlias}",
+        description = "This method gets the status of the latest key rotation.",
+        responseDescription = "Number of wrapping keys needs rotating grouped by vNode.",
     )
     fun getKeyRotationStatus(
-        @RestPathParameter(description = "The rootKeyAlias we are rotating away from.")
-        rootKeyAlias: String
+        @RestPathParameter(description = "The keyAlias we are rotating away from.")
+        keyAlias: String
     ): KeyRotationStatusResponse
 
     /**
@@ -51,6 +54,7 @@ interface KeyRotationRestResource : RestResource {
      *  - newKeyAlias is the alias of the new key the oldKeyAlias key will be rotated with.
      *
      * @throws ServiceUnavailableException If the underlying service for sending messages is not available.
+     * @throws ForbiddenException If the same key rotation is already in progress.
      */
 
     @HttpPOST(

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -1,6 +1,7 @@
 package net.corda.crypto.rest
 
 import net.corda.crypto.rest.response.KeyRotationResponse
+import net.corda.crypto.rest.response.KeyRotationStatusResponse
 import net.corda.rest.RestResource
 import net.corda.rest.annotations.ClientRequestBodyParameter
 import net.corda.rest.annotations.HttpGET
@@ -29,14 +30,14 @@ interface KeyRotationRestResource : RestResource {
      *         the list of rotations runs in progress.
      */
     @HttpGET(
-        path = "unmanaged/rotation/{requestId}",
+        path = "unmanaged/rotation/{rootKeyAlias}",
         description = "This method gets the status of the current rotation.",
         responseDescription = "",
     )
     fun getKeyRotationStatus(
-        @RestPathParameter(description = "The requestId obtained when starting key rotation request.")
-        requestId: String
-    ): List<Pair<String, String>>
+        @RestPathParameter(description = "The rootKeyAlias we are rotating away from.")
+        rootKeyAlias: String
+    ): KeyRotationStatusResponse
 
     /**
      * Initiates the key rotation process. 

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -159,19 +159,19 @@ class KeyRotationRestResourceImpl @Activate constructor(
                 .also { it.start() }
     }
 
-    override fun getKeyRotationStatus(rootKeyAlias: String): KeyRotationStatusResponse {
+    override fun getKeyRotationStatus(keyAlias: String): KeyRotationStatusResponse {
         tryWithExceptionHandling(logger, "retrieve key rotation status") {
             checkNotNull(stateManager)
         }
 
         val entries = stateManager!!.findByMetadataMatchingAll(
             listOf(
-                MetadataFilter("rootKeyAlias", Operation.Equals, rootKeyAlias),
+                MetadataFilter("rootKeyAlias", Operation.Equals, keyAlias),
                 MetadataFilter("type", Operation.Equals, "keyRotation")
             )
         )
         // if entries are empty, there is no rootKeyAlias data stored in the state manager, so no key rotation is/was in progress
-        if (entries.isNullOrEmpty()) throw ResourceNotFoundException("No key rotation for $rootKeyAlias is in progress.")
+        if (entries.isNullOrEmpty()) throw ResourceNotFoundException("No key rotation for $keyAlias is in progress.")
 
         var lastUpdatedTimestamp = Instant.MIN
         var rotationStatus = "Done"
@@ -188,7 +188,7 @@ class KeyRotationRestResourceImpl @Activate constructor(
             if (state.modifiedTime.isAfter(lastUpdatedTimestamp)) lastUpdatedTimestamp = state.modifiedTime
             if (state.metadata["status"] != "Done") rotationStatus = "In Progress"
         }
-        return KeyRotationStatusResponse(rootKeyAlias, rotationStatus, lastUpdatedTimestamp, result)
+        return KeyRotationStatusResponse(keyAlias, rotationStatus, lastUpdatedTimestamp, result)
     }
 
     override fun startKeyRotation(oldKeyAlias: String, newKeyAlias: String): ResponseEntity<KeyRotationResponse> {

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -189,7 +189,7 @@ class KeyRotationRestResourceImpl @Activate constructor(
             if (state.modifiedTime > lastUpdatedTimestamp) lastUpdatedTimestamp = state.modifiedTime
             if (state.metadata["status"] != "Done") rotationStatus = "In Progress"
         }
-        return KeyRotationStatusResponse(rootKeyAlias, result, rotationStatus, lastUpdatedTimestamp)
+        return KeyRotationStatusResponse(rootKeyAlias, rotationStatus, lastUpdatedTimestamp, result)
     }
 
     override fun startKeyRotation(oldKeyAlias: String, newKeyAlias: String): ResponseEntity<KeyRotationResponse> {

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -217,7 +217,6 @@ class KeyRotationRestResourceImpl @Activate constructor(
                 MetadataFilter("type", Operation.Equals, "keyRotation")
             )
         ).forEach {
-            // if we find one In Progress status, we know we are not done
             if (it.value.metadata["status"] != "Done") return false
         }
         return true

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -181,7 +181,7 @@ class KeyRotationRestResourceImpl @Activate constructor(
             val keyRotationStatus = deserializer.deserialize(state.value)
             println("XXX: key: $key, state.key: ${state.key}, state.value: $keyRotationStatus")
             result.add(
-                state.metadata["rootKeyAlias"].toString() to TenantIdWrappingKeysStatus(
+                state.metadata["tenantId"].toString() to TenantIdWrappingKeysStatus(
                     keyRotationStatus!!.total,
                     keyRotationStatus.rotatedKeys
                 )

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -187,7 +187,7 @@ class KeyRotationRestResourceImpl @Activate constructor(
         val result = mutableListOf<Pair<String, TenantIdWrappingKeysStatus>>()
         entries.forEach {
             val state = it.value
-            val keyRotationStatus = deserializer.deserialize(state.value)!!
+            val keyRotationStatus = checkNotNull(deserializer.deserialize(state.value))
             result.add(
                 state.metadata[KeyRotationMetadataValues.TENANT_ID].toString() to TenantIdWrappingKeysStatus(
                     keyRotationStatus.total,

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
@@ -1,5 +1,7 @@
 package net.corda.crypto.rest.response
 
+import java.time.Instant
+
 /**
  * The result of a key rotation request.
  *
@@ -10,6 +12,7 @@ data class KeyRotationStatusResponse(
     val oldKeyAlias: String,
     val wrappingKeys: List<Pair<String, TenantIdWrappingKeysStatus>>,
     val status: String,
+    val lastUpdatedTimestamp: Instant
 )
 
 data class TenantIdWrappingKeysStatus(

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
@@ -10,9 +10,9 @@ import java.time.Instant
 
 data class KeyRotationStatusResponse(
     val oldKeyAlias: String,
-    val wrappingKeys: List<Pair<String, TenantIdWrappingKeysStatus>>,
     val status: String,
-    val lastUpdatedTimestamp: Instant
+    val lastUpdatedTimestamp: Instant,
+    val wrappingKeys: List<Pair<String, TenantIdWrappingKeysStatus>>,
 )
 
 data class TenantIdWrappingKeysStatus(

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
@@ -1,0 +1,17 @@
+package net.corda.crypto.rest.response
+
+/**
+ * The result of a key rotation request.
+ *
+ * @param oldKeyAlias Alias of the key to be rotated.
+ */
+
+data class KeyRotationStatusResponse(
+    val oldKeyAlias: String,
+    val wrappingKeys: List<Pair<String, TenantIdWrappingKeysStatus>>,
+)
+
+data class TenantIdWrappingKeysStatus(
+    val total: Int,
+    val rotatedKeys: Int,
+)

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
@@ -9,6 +9,7 @@ package net.corda.crypto.rest.response
 data class KeyRotationStatusResponse(
     val oldKeyAlias: String,
     val wrappingKeys: List<Pair<String, TenantIdWrappingKeysStatus>>,
+    val status: String,
 )
 
 data class TenantIdWrappingKeysStatus(

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
@@ -3,17 +3,27 @@ package net.corda.crypto.rest.response
 import java.time.Instant
 
 /**
- * The result of a key rotation request.
+ * The result of a key rotation status request.
  *
- * @param oldKeyAlias Alias of the key to be rotated.
+ * @param rootKeyAlias Alias of the key to be rotated.
+ * @param status Overall status of the key rotation. Either In Progress or Done.
+ * @param lastUpdatedTimestamp The last updated timestamp.
+ * @param wrappingKeys Number of wrapping keys needs rotating grouped by tenantId.
  */
 
 data class KeyRotationStatusResponse(
-    val oldKeyAlias: String,
+    val rootKeyAlias: String,
     val status: String,
     val lastUpdatedTimestamp: Instant,
     val wrappingKeys: List<Pair<String, TenantIdWrappingKeysStatus>>,
 )
+
+/**
+ * The key rotation status for wrapping keys per particular tenantId.
+ *
+ * @param total Total number of wrapping keys to be rotated for particular tenantId.
+ * @param rotatedKeys The number of wrapping keys already rotated for particular tenantId.
+ */
 
 data class TenantIdWrappingKeysStatus(
     val total: Int,

--- a/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
+++ b/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
@@ -96,21 +96,18 @@ class KeyRotationRestResourceTest {
             )
         }
 
-        deserializer = mock<CordaAvroDeserializer<UnmanagedKeyStatus>>().also {
-            whenever(it.deserialize(any())).thenReturn(
-                UnmanagedKeyStatus("keyAlias", 10, 5)
-            )
+        deserializer = mock<CordaAvroDeserializer<UnmanagedKeyStatus>> {
+            on {deserialize(any()) } doReturn UnmanagedKeyStatus("keyAlias", 10, 5)
         }
 
-        cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory>().also {
-            whenever(it.createAvroDeserializer({}, UnmanagedKeyStatus::class.java)).thenReturn(
-                deserializer
-            )
+        cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
+            on {createAvroDeserializer({}, UnmanagedKeyStatus::class.java) } doReturn deserializer
         }
 
-        stateManagerFactory = mock<StateManagerFactory>().also {
-            whenever(it.create(any())).thenReturn(stateManager)
+        stateManagerFactory = mock<StateManagerFactory> {
+            on {create(any()) } doReturn stateManager
         }
+
         stateManagerPublicationCount = 0
     }
 

--- a/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
+++ b/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
@@ -28,7 +28,6 @@ import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.schema.configuration.ConfigKeys
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.never
@@ -97,32 +96,29 @@ class KeyRotationRestResourceTest {
         }
 
         deserializer = mock<CordaAvroDeserializer<UnmanagedKeyStatus>> {
-            on {deserialize(any()) } doReturn UnmanagedKeyStatus("keyAlias", 10, 5)
+            on { deserialize(any()) } doReturn UnmanagedKeyStatus(oldKeyAlias, 10, 5)
         }
 
         cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
-            on {createAvroDeserializer({}, UnmanagedKeyStatus::class.java) } doReturn deserializer
+            on { createAvroDeserializer<UnmanagedKeyStatus>(any(), any()) } doReturn deserializer
         }
 
         stateManagerFactory = mock<StateManagerFactory> {
-            on {create(any()) } doReturn stateManager
+            on { create(any()) } doReturn stateManager
         }
 
         stateManagerPublicationCount = 0
     }
 
-    @Disabled
     @Test
     fun `get key rotation status triggers successfully`() {
-
-        //populate state manager with some data and then run command and see if correct data are retrieved.
         val keyRotationRestResource = createKeyRotationRestResource()
-        val response = keyRotationRestResource.getKeyRotationStatus("keyAlias")
+        val response = keyRotationRestResource.getKeyRotationStatus(oldKeyAlias)
 
         verify(stateManager, times(1)).findByMetadataMatchingAll(any())
 
-        assertThat(response.status).isEqualTo("Done")
-        assertThat(response.rootKeyAlias).isEqualTo("keyAlias")
+        assertThat(response.status).isEqualTo("In Progress")
+        assertThat(response.rootKeyAlias).isEqualTo(oldKeyAlias)
     }
 
     @Test

--- a/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
+++ b/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
@@ -134,7 +134,7 @@ class KeyRotationRestResourceTest {
     fun `get key rotation status throws when state manager is not initialised`() {
         val keyRotationRestResource =
             createKeyRotationRestResource(initialiseKafkaPublisher = true, initialiseStateManager = false)
-        assertThrows<InternalServerException> {
+        assertThrows<IllegalStateException> {
             keyRotationRestResource.getKeyRotationStatus("")
         }
         verify(stateManager, never()).findByMetadataMatchingAll(any())
@@ -170,7 +170,7 @@ class KeyRotationRestResourceTest {
     fun `start key rotation event throws when state manager is not initialised`() {
         val keyRotationRestResource =
             createKeyRotationRestResource(initialiseKafkaPublisher = true, initialiseStateManager = false)
-        assertThrows<InternalServerException> {
+        assertThrows<IllegalStateException> {
             keyRotationRestResource.startKeyRotation("", "")
         }
         verify(publishToKafka, never()).publish(any())

--- a/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
+++ b/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
@@ -8,6 +8,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.config.impl.CryptoHSMConfig
 import net.corda.crypto.config.impl.HSM
+import net.corda.crypto.core.KeyRotationStatus
 import net.corda.crypto.rest.KeyRotationRestResource
 import net.corda.data.crypto.wire.ops.key.rotation.KeyRotationRequest
 import net.corda.data.crypto.wire.ops.key.status.UnmanagedKeyStatus
@@ -117,7 +118,7 @@ class KeyRotationRestResourceTest {
 
         verify(stateManager, times(1)).findByMetadataMatchingAll(any())
 
-        assertThat(response.status).isEqualTo("In Progress")
+        assertThat(response.status).isEqualTo(KeyRotationStatus.IN_PROGRESS)
         assertThat(response.rootKeyAlias).isEqualTo(oldKeyAlias)
     }
 

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -56,8 +56,8 @@ class CryptoRekeyBusProcessor(
 
 
             // TODO: first delete the data in state manager, so we can correctly report on the key rotation status
-            // TODO: do we need to delete key status here as well? Probably yes, that means we don't need to filter, if key starts with 'kr' or 'ks'
-            // TODO: deal with optimistic locking, just in case. We should have checked in the rest worker if key rotation is in progress and don't start a new one if one is
+            // TODO: do we need to delete key status here as well? Probably yes.
+            // TODO: deal with optimistic locking, just in case. We should have checked in the rest worker if the key rotation is in progress and don't start a new one if one is
             val toDelete = stateManager!!.findByMetadataMatchingAll(
                 listOf(
                     MetadataFilter("rootKeyAlias", Operation.Equals, request.oldParentKeyAlias),

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -103,7 +103,7 @@ class CryptoRekeyBusProcessor(
                     State(
                         // key is set as a unique string to prevent table search in re-wrap bus processor
                         getKeyRotationStatusRecordKey(request.oldParentKeyAlias, tenantId),
-                        serializer.serialize(status)!!,
+                        checkNotNull(serializer.serialize(status)),
                         1,
                         Metadata(
                             mapOf(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -121,7 +121,7 @@ class CryptoRekeyBusProcessor(
                         1,
                         Metadata(
                             mapOf("rootKeyAlias" to request.oldParentKeyAlias,
-                                "tenantId" to request.tenantId,
+                                "tenantId" to it.key,
                                 "type" to "keyRotation", // maybe create an enum from type, so we can easily add more if needed
                                 STATE_TYPE to status::class.java.name)
                         )

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -98,7 +98,8 @@ class CryptoRekeyBusProcessor(
                 val status = UnmanagedKeyStatus(request.oldParentKeyAlias, it.value.size, 0)
                 records.add(
                     State(
-                        UUID.randomUUID().toString(),
+                        // key is set as a unique string to prevent table search in rewrap bus processor
+                        request.oldParentKeyAlias + it.key + "keyRotation",  // rootKeyAlias + tenantId + keyRotation
                         serializer.serialize(status)!!,
                         1,
                         Metadata(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -96,19 +96,19 @@ class CryptoRekeyBusProcessor(
             val records = mutableListOf<State>()
 
             // Group by tenantId/vNode
-            targetWrappingKeys.groupBy { it.first }.forEach {
-                logger.debug("Grouping wrapping keys by vNode/tenantId ${it.key}")
-                val status = UnmanagedKeyStatus(request.oldParentKeyAlias, it.value.size, 0)
+            targetWrappingKeys.groupBy { it.first }.forEach { (tenantId, wrappingKeys) ->
+                logger.debug("Grouping wrapping keys by vNode/tenantId $tenantId")
+                val status = UnmanagedKeyStatus(request.oldParentKeyAlias, wrappingKeys.size, 0)
                 records.add(
                     State(
                         // key is set as a unique string to prevent table search in re-wrap bus processor
-                        getKeyRotationStatusRecordKey(request.oldParentKeyAlias, it.key),
+                        getKeyRotationStatusRecordKey(request.oldParentKeyAlias, tenantId),
                         serializer.serialize(status)!!,
                         1,
                         Metadata(
                             mapOf(
                                 KeyRotationMetadataValues.ROOT_KEY_ALIAS to request.oldParentKeyAlias,
-                                KeyRotationMetadataValues.TENANT_ID to it.key,
+                                KeyRotationMetadataValues.TENANT_ID to tenantId,
                                 KeyRotationMetadataValues.TYPE to KeyRotationRecordType.KEY_ROTATION,
                                 KeyRotationMetadataValues.STATUS to KeyRotationStatus.IN_PROGRESS,
                                 STATE_TYPE to status::class.java.name

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -58,7 +58,8 @@ class CryptoRekeyBusProcessor(
             // Same check is done on the Rest worker side, but if user quickly issues two key rotation commands after each other,
             // it will pass rest worker check as state manager was not yet populated.
             if (!hasPreviousRotationFinished(request.oldParentKeyAlias)) {
-                logger.error("There is already a key rotation of unmanaged wrapping key with alias ${request.oldParentKeyAlias} in progress.")
+                logger.error("There is already a key rotation of unmanaged wrapping key " +
+                        "with alias ${request.oldParentKeyAlias} in progress.")
                 return emptyList()
             }
 
@@ -137,7 +138,8 @@ class CryptoRekeyBusProcessor(
                             wrappingKeyInfo.alias,
                             KeyType.UNMANAGED
                         ),
-                        timestamp // TODO: probably remove timestamp? not sure if we need this here. If we are keeping the track of start time, than yes, this is useful
+                        timestamp // TODO probably remove timestamp? not sure if we need this here.
+                            // If we are keeping the track of start time, than yes, this is useful
                     )
                 }.toList()
             )
@@ -172,5 +174,7 @@ class CryptoRekeyBusProcessor(
         )
 
         // TODO should we throw the exception?
-        if (failedToDelete.isNotEmpty()) println("XXX: RekeyBusProcessor failed to delete following states from the state manager: ${failedToDelete.keys}")    }
+        if (failedToDelete.isNotEmpty()) println("XXX: RekeyBusProcessor failed to delete following states " +
+                "from the state manager: ${failedToDelete.keys}")
+    }
 }

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -83,7 +83,7 @@ class CryptoRewrapBusProcessor(
                         state.metadata
                     }
                     val failedToUpdate =
-                        stateManager.update(listOf(State(state.key, newValue!!, state.version, newMetadata)))
+                        stateManager.update(listOf(State(state.key, newValue, state.version, newMetadata)))
                     if (failedToUpdate.isNotEmpty()) {
                         logger.debug("Failed to update following states ${failedToUpdate.keys}, retrying.")
                         Thread.sleep(Random.nextLong(0, 1000))

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -1,7 +1,11 @@
 package net.corda.crypto.service.impl.bus
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.crypto.core.CryptoService
 import net.corda.data.crypto.wire.ops.key.rotation.IndividualKeyRotationRequest
+import net.corda.data.crypto.wire.ops.key.status.UnmanagedKeyStatus
+import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.StateManager
 import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.metrics.CordaMetrics
@@ -14,8 +18,10 @@ private const val REWRAP_KEYS_OPERATION_NAME = "rewrapKeys"
  */
 @Suppress("LongParameterList")
 class CryptoRewrapBusProcessor(
-    val cryptoService: CryptoService
-) : DurableProcessor<String, IndividualKeyRotationRequest> {
+    val cryptoService: CryptoService,
+    private val stateManager: StateManager?,
+    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory,
+    ) : DurableProcessor<String, IndividualKeyRotationRequest> {
     override val keyClass: Class<String> = String::class.java
     override val valueClass = IndividualKeyRotationRequest::class.java
     private val rewrapTimer = CordaMetrics.Metric.Crypto.RewrapKeysTimer.builder()
@@ -26,6 +32,18 @@ class CryptoRewrapBusProcessor(
         events.mapNotNull { it.value }.map { request ->
             rewrapTimer.recordCallable {
                 cryptoService.rewrapWrappingKey(request.tenantId, request.targetKeyAlias, request.newParentKeyAlias)
+            }
+            // Once rewrap is done, we can update state manager db
+            val tenantIdWrappingKeysRecord = stateManager!!.get(listOf("kr${request.tenantId}"))
+            require(tenantIdWrappingKeysRecord.size == 1)
+
+            val deserializer = cordaAvroSerializationFactory.createAvroDeserializer({}, UnmanagedKeyStatus::class.java)
+            val serializer = cordaAvroSerializationFactory.createAvroSerializer<UnmanagedKeyStatus>()
+            tenantIdWrappingKeysRecord.forEach { (key, state) ->
+                val keyR = deserializer.deserialize(state.value)!!
+                val newValue = serializer.serialize(UnmanagedKeyStatus(keyR.rootKeyAlias, keyR.total, keyR.rotatedKeys++))
+                val failedToUpdate = stateManager.update(listOf(State(state.key, newValue!!, state.version + 1, state.metadata)))
+                println("XXX: RewrapBusProcessor failed to update following states: ${failedToUpdate.keys}")
             }
         }
         return emptyList()

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -43,10 +43,12 @@ class CryptoRewrapBusProcessor(
             // Once rewrap is done, we can update state manager db
             var statusUpdated = false
             while (!statusUpdated) {
-                // rootKeyAlias + tenantId + keyRotation is the unique key, therefore we don't need to do the table search through state manager db
+                // rootKeyAlias + tenantId + keyRotation is the unique key, therefore we don't need to do the table
+                // search through state manager db
                 val tenantIdWrappingKeysRecords =
-                    stateManager!!.get(listOf(request.oldParentKeyAlias + request.tenantId + "keyRotation"))  // rootKeyAlias + tenantId + keyRotation
-                require(tenantIdWrappingKeysRecords.size == 1) { "Found more than 1 ${request.tenantId} records in the database for rootKeyAlias = ${request.oldParentKeyAlias}." }
+                    stateManager!!.get(listOf(request.oldParentKeyAlias + request.tenantId + "keyRotation"))
+                require(tenantIdWrappingKeysRecords.size == 1) { "Found more than 1 ${request.tenantId} record " +
+                        "in the database for rootKeyAlias = ${request.oldParentKeyAlias}." }
 
                 tenantIdWrappingKeysRecords.forEach { (key, state) ->
                     println("XXX: dealing with tenantId: $key, wrapping key: ${request.targetKeyAlias}")

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -67,11 +67,13 @@ class CryptoRewrapBusProcessor(
                     )
                     val deserializedStatus = checkNotNull(deserializer.deserialize(state.value))
                     val newValue =
-                        serializer.serialize(
-                            UnmanagedKeyStatus(
-                                deserializedStatus.rootKeyAlias,
-                                deserializedStatus.total,
-                                deserializedStatus.rotatedKeys + 1
+                        checkNotNull(
+                            serializer.serialize(
+                                UnmanagedKeyStatus(
+                                    deserializedStatus.rootKeyAlias,
+                                    deserializedStatus.total,
+                                    deserializedStatus.rotatedKeys + 1
+                                )
                             )
                         )
                     // Update status to Done if all keys for the tenant have been rotated

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -51,7 +51,7 @@ class CryptoRewrapBusProcessor(
                         "in the database for rootKeyAlias = ${request.oldParentKeyAlias}." }
 
                 tenantIdWrappingKeysRecords.forEach { (key, state) ->
-                    println("XXX: dealing with tenantId: $key, wrapping key: ${request.targetKeyAlias}")
+                    println("XXX: dealing with tenantId: ${state.metadata["tenantId"]}, wrapping key: ${request.targetKeyAlias}")
                     val deserializedStatus = deserializer.deserialize(state.value)!!
                     val newValue =
                         serializer.serialize(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -60,7 +60,7 @@ class CryptoRewrapBusProcessor(
                     val newValue =
                         serializer.serialize(UnmanagedKeyStatus(keyR.rootKeyAlias, keyR.total, keyR.rotatedKeys + 1))
                     val failedToUpdate =
-                        stateManager.update(listOf(State(key, newValue!!, state.version + 1, state.metadata)))
+                        stateManager.update(listOf(State(key, newValue!!, state.version, state.metadata)))
                     if (failedToUpdate.isNotEmpty()) {
                         println(
                             "XXX: RewrapBusProcessor failed to update following states: ${failedToUpdate.keys}. " +

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -4,6 +4,8 @@ import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.crypto.core.CryptoService
 import net.corda.data.crypto.wire.ops.key.rotation.IndividualKeyRotationRequest
 import net.corda.data.crypto.wire.ops.key.status.UnmanagedKeyStatus
+import net.corda.libs.statemanager.api.MetadataFilter
+import net.corda.libs.statemanager.api.Operation
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.messaging.api.processor.DurableProcessor
@@ -21,7 +23,7 @@ class CryptoRewrapBusProcessor(
     val cryptoService: CryptoService,
     private val stateManager: StateManager?,
     private val cordaAvroSerializationFactory: CordaAvroSerializationFactory,
-    ) : DurableProcessor<String, IndividualKeyRotationRequest> {
+) : DurableProcessor<String, IndividualKeyRotationRequest> {
     override val keyClass: Class<String> = String::class.java
     override val valueClass = IndividualKeyRotationRequest::class.java
     private val rewrapTimer = CordaMetrics.Metric.Crypto.RewrapKeysTimer.builder()
@@ -33,17 +35,31 @@ class CryptoRewrapBusProcessor(
             rewrapTimer.recordCallable {
                 cryptoService.rewrapWrappingKey(request.tenantId, request.targetKeyAlias, request.newParentKeyAlias)
             }
+
             // Once rewrap is done, we can update state manager db
-            val tenantIdWrappingKeysRecord = stateManager!!.get(listOf("kr${request.tenantId}"))
-            require(tenantIdWrappingKeysRecord.size == 1)
+
+            val tenantIdWrappingKeysRecord = stateManager!!.findByMetadataMatchingAll(
+                listOf(
+                    MetadataFilter("rootKeyAlias", Operation.Equals, request.oldParentKeyAlias),
+                    MetadataFilter("tenantId", Operation.Equals, request.tenantId),
+                    MetadataFilter("type", Operation.Equals, "keyRotation")
+                )
+            )
+            require(tenantIdWrappingKeysRecord.size == 1) { "Found more than 1 ${request.tenantId} records in the database for rootKeyAlias = ${request.oldParentKeyAlias}." }
 
             val deserializer = cordaAvroSerializationFactory.createAvroDeserializer({}, UnmanagedKeyStatus::class.java)
             val serializer = cordaAvroSerializationFactory.createAvroSerializer<UnmanagedKeyStatus>()
             tenantIdWrappingKeysRecord.forEach { (key, state) ->
+                println("XXX: dealing with tenantId: $key, wrapping key: ${request.targetKeyAlias}")
                 val keyR = deserializer.deserialize(state.value)!!
-                val newValue = serializer.serialize(UnmanagedKeyStatus(keyR.rootKeyAlias, keyR.total, keyR.rotatedKeys++))
-                val failedToUpdate = stateManager.update(listOf(State(state.key, newValue!!, state.version + 1, state.metadata)))
-                println("XXX: RewrapBusProcessor failed to update following states: ${failedToUpdate.keys}")
+                val newValue =
+                    serializer.serialize(UnmanagedKeyStatus(keyR.rootKeyAlias, keyR.total, keyR.rotatedKeys + 1))
+                val failedToUpdate =
+                    stateManager.update(listOf(State(key, newValue!!, state.version + 1, state.metadata)))
+                if (failedToUpdate.isNotEmpty()) println(
+                    "XXX: RewrapBusProcessor failed to update following states: ${failedToUpdate.keys}. " +
+                            "If we would be successfull, rotated keys would be ${keyR.rotatedKeys++}"
+                )
             }
         }
         return emptyList()

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -55,13 +55,17 @@ class CryptoRewrapBusProcessor(
                 // we defined the key to be unique to avoid table search through state manager
                 val tenantIdWrappingKeysRecords =
                     stateManager.get(listOf(getKeyRotationStatusRecordKey(request.oldParentKeyAlias, request.tenantId)))
-                require(tenantIdWrappingKeysRecords.size == 1) { "Found none or more than 1 ${request.tenantId} record " +
-                        "in the database for rootKeyAlias ${request.oldParentKeyAlias}. Found records $tenantIdWrappingKeysRecords." }
+                require(tenantIdWrappingKeysRecords.size == 1) {
+                    "Found none or more than 1 ${request.tenantId} record " +
+                            "in the database for rootKeyAlias ${request.oldParentKeyAlias}. Found records $tenantIdWrappingKeysRecords."
+                }
 
                 tenantIdWrappingKeysRecords.forEach { (_, state) ->
-                    logger.debug("Updating state manager record for tenantId ${state.metadata[KeyRotationMetadataValues.TENANT_ID]} " +
-                            "after re-wrapping ${request.targetKeyAlias}.")
-                    val deserializedStatus = deserializer.deserialize(state.value)!!
+                    logger.debug(
+                        "Updating state manager record for tenantId ${state.metadata[KeyRotationMetadataValues.TENANT_ID]} " +
+                                "after re-wrapping ${request.targetKeyAlias}."
+                    )
+                    val deserializedStatus = checkNotNull(deserializer.deserialize(state.value))
                     val newValue =
                         serializer.serialize(
                             UnmanagedKeyStatus(

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -14,7 +14,6 @@ import net.corda.messaging.api.processor.DurableProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.metrics.CordaMetrics
 import org.slf4j.LoggerFactory
-import kotlin.random.Random
 
 private const val REWRAP_KEYS_OPERATION_NAME = "rewrapKeys"
 
@@ -86,7 +85,6 @@ class CryptoRewrapBusProcessor(
                         stateManager.update(listOf(State(state.key, newValue, state.version, newMetadata)))
                     if (failedToUpdate.isNotEmpty()) {
                         logger.debug("Failed to update following states ${failedToUpdate.keys}, retrying.")
-                        Thread.sleep(Random.nextLong(0, 1000))
                     } else {
                         statusUpdated = true
                     }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
@@ -126,7 +126,7 @@ class CryptoRekeyBusProcessorTests {
      * Other tenants return null, therefore no rewrapWrappingKey function is called.
      */
     @Test
-    fun `key rotation re-wraps only those keys where oldKeyAlias alias in the wrapping repo for the tenant`() {
+    fun `key rotation re-wraps only those keys where oldKeyAlias alias is in the wrapping repo for the tenant`() {
         val oldKeyAlias = "Eris"
         val newId = UUID.randomUUID()
         val wrappingKeyInfo = WrappingKeyInfo(

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
@@ -17,8 +17,8 @@ import net.corda.crypto.softhsm.WrappingRepositoryFactory
 import net.corda.crypto.softhsm.impl.WrappingRepositoryImpl
 import net.corda.crypto.testkit.SecureHashUtils
 import net.corda.data.crypto.wire.ops.key.rotation.KeyRotationRequest
-import net.corda.data.crypto.wire.ops.key.rotation.KeyRotationStatus
 import net.corda.data.crypto.wire.ops.key.rotation.KeyType
+import net.corda.data.crypto.wire.ops.key.status.UnmanagedKeyStatus
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.libs.packaging.core.CpiIdentifier
@@ -92,11 +92,11 @@ class CryptoRekeyBusProcessorTests {
             on { publish(rewrapPublishCapture.capture()) } doReturn emptyList()
         }
 
-        val serializer = mock<CordaAvroSerializer<KeyRotationStatus>> {
+        val serializer = mock<CordaAvroSerializer<UnmanagedKeyStatus>> {
             on { serialize(any()) } doReturn byteArrayOf(42)
         }
         cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
-            on { createAvroSerializer<KeyRotationStatus>() } doReturn serializer
+            on { createAvroSerializer<UnmanagedKeyStatus>() } doReturn serializer
         }
 
         cryptoRekeyBusProcessor = CryptoRekeyBusProcessor(

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
@@ -1,21 +1,44 @@
 package net.corda.crypto.service.impl.bus
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.crypto.core.CryptoService
 import net.corda.data.crypto.wire.ops.key.rotation.IndividualKeyRotationRequest
 import net.corda.data.crypto.wire.ops.key.rotation.KeyType
+import net.corda.data.crypto.wire.ops.key.status.UnmanagedKeyStatus
 import net.corda.messaging.api.records.Record
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import java.util.UUID
 
 class CryptoRewrapBusProcessorTests {
+    private lateinit var cryptoRewrapBusProcessor: CryptoRewrapBusProcessor
+    private lateinit var cordaAvroSerializationFactory: CordaAvroSerializationFactory
+
     companion object {
         private val cryptoService: CryptoService = mock<CryptoService> { }
-        private val cryptoRewrapBusProcessor = CryptoRewrapBusProcessor(cryptoService)
         private val tenantId = UUID.randomUUID().toString()
+    }
+
+    @BeforeEach
+    fun setup() {
+        val serializer = mock<CordaAvroSerializer<UnmanagedKeyStatus>> {
+            on { serialize(any()) } doReturn byteArrayOf(42)
+        }
+        cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
+            on { createAvroSerializer<UnmanagedKeyStatus>() } doReturn serializer
+        }
+
+        cryptoRewrapBusProcessor = CryptoRewrapBusProcessor(
+            cryptoService,
+            mock(),
+            cordaAvroSerializationFactory
+        )
     }
 
     @Test
@@ -25,7 +48,14 @@ class CryptoRewrapBusProcessorTests {
                 Record(
                     "TBC",
                     UUID.randomUUID().toString(),
-                    IndividualKeyRotationRequest(UUID.randomUUID().toString(), tenantId, "alias1", "root2", "alias1", KeyType.UNMANAGED)
+                    IndividualKeyRotationRequest(
+                        UUID.randomUUID().toString(),
+                        tenantId,
+                        "alias1",
+                        "root2",
+                        "alias1",
+                        KeyType.UNMANAGED
+                    )
                 )
             )
         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -82,10 +82,6 @@ picocliVersion = 4.7.3
 protonjVersion=0.34.1
 quasarVersion = 0.9.1_r3-SNAPSHOT
 reflectAsmVersion = 1.11.9
-# SLF4J cannot be ugraded to 2.x due to CorDapps requiring the 1.7 <= x < 2.0
-slf4jVersion=1.7.36
-# The CLI uses SLF4J version 2
-slf4jV2Version=2.0.6
 # Snappy version used for serialization
 snappyVersion=0.4
 # Completely different version of Snappy used in Kafka client

--- a/gradle.properties
+++ b/gradle.properties
@@ -82,6 +82,10 @@ picocliVersion = 4.7.3
 protonjVersion=0.34.1
 quasarVersion = 0.9.1_r3-SNAPSHOT
 reflectAsmVersion = 1.11.9
+# SLF4J cannot be ugraded to 2.x due to CorDapps requiring the 1.7 <= x < 2.0
+slf4jVersion=1.7.36
+# The CLI uses SLF4J version 2
+slf4jV2Version=2.0.6
 # Snappy version used for serialization
 snappyVersion=0.4
 # Completely different version of Snappy used in Kafka client

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyRotationUtils.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyRotationUtils.kt
@@ -1,23 +1,13 @@
 package net.corda.crypto.core
 
+/**
+ * Metadata keys used when storing key rotation status in state manager
+ */
 object KeyRotationMetadataValues {
-
-    /**
-     *
-     */
     const val ROOT_KEY_ALIAS: String = "rootKeyAlias"
-
-    /**
-     *
-     */
     const val TENANT_ID: String = "tenantId"
-
-    /**
-     *
-     */
     const val STATUS: String = "status"
     const val TYPE: String = "type"
-
 }
 
 object KeyRotationStatus {
@@ -25,6 +15,9 @@ object KeyRotationStatus {
     const val DONE: String = "done"
 }
 
+/**
+ * Specifies the type of the record stored in state manager
+ */
 object KeyRotationRecordType {
     const val KEY_ROTATION: String = "keyRotation"
 }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyRotationUtils.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyRotationUtils.kt
@@ -1,0 +1,34 @@
+package net.corda.crypto.core
+
+object KeyRotationMetadataValues {
+
+    /**
+     *
+     */
+    const val ROOT_KEY_ALIAS: String = "rootKeyAlias"
+
+    /**
+     *
+     */
+    const val TENANT_ID: String = "tenantId"
+
+    /**
+     *
+     */
+    const val STATUS: String = "status"
+    const val TYPE: String = "type"
+
+}
+
+object KeyRotationStatus {
+    const val IN_PROGRESS: String = "inProgress"
+    const val DONE: String = "done"
+}
+
+object KeyRotationRecordType {
+    const val KEY_ROTATION: String = "keyRotation"
+}
+
+fun getKeyRotationStatusRecordKey(keyAlias: String, tenantId: String) =
+    keyAlias + tenantId + KeyRotationRecordType.KEY_ROTATION
+

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -375,7 +375,7 @@ class CryptoProcessorImpl @Activate constructor(
             coordinator, messagingConfig, wrappingRepositoryFactory,
             stateManager, cordaAvroSerializationFactory
         )
-        createRewrapSubscription(coordinator, messagingConfig)
+        createRewrapSubscription(coordinator, messagingConfig, stateManager,  cordaAvroSerializationFactory)
         createSessionEncryptionSubscription(coordinator, retryingConfig)
         createSessionDecryptionSubscription(coordinator, retryingConfig)
     }
@@ -385,7 +385,7 @@ class CryptoProcessorImpl @Activate constructor(
         messagingConfig: SmartConfig,
         wrappingRepositoryFactory: (String) -> WrappingRepositoryImpl,
         stateManager: StateManager?,
-        cordaAvroSerializationFactory: CordaAvroSerializationFactory
+        cordaAvroSerializationFactory: CordaAvroSerializationFactory,
     ) {
         val publisherConfig = PublisherConfig("RekeyBusProcessor", false)
         val rekeyPublisher = publisherFactory.createPublisher(publisherConfig, messagingConfig)
@@ -417,8 +417,10 @@ class CryptoProcessorImpl @Activate constructor(
     private fun createRewrapSubscription(
         coordinator: LifecycleCoordinator,
         messagingConfig: SmartConfig,
+        stateManager: StateManager?,
+        cordaAvroSerializationFactory: CordaAvroSerializationFactory,
     ) {
-        val rewrapProcessor = CryptoRewrapBusProcessor(cryptoService)
+        val rewrapProcessor = CryptoRewrapBusProcessor(cryptoService, stateManager, cordaAvroSerializationFactory)
         val rewrapGroupName = "crypto.key.rotation.individual"
         coordinator.createManagedResource(REWRAP_SUBSCRIPTION) {
             subscriptionFactory.createDurableSubscription(

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -4349,6 +4349,43 @@
         }
       }
     },
+    "/wrappingkey/unmanaged/rotation/{keyalias}" : {
+      "get" : {
+        "tags" : [ "Key Rotation API" ],
+        "description" : "This method gets the status of the latest key rotation.",
+        "operationId" : "get_wrappingkey_unmanaged_rotation__keyalias_",
+        "parameters" : [ {
+          "name" : "keyalias",
+          "in" : "path",
+          "description" : "The keyAlias we are rotating away from.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The keyAlias we are rotating away from.",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Number of wrapping keys needs rotating grouped by vNode.",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/KeyRotationStatusResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
     "/wrappingkey/unmanaged/rotation/{oldkeyalias}" : {
       "post" : {
         "tags" : [ "Key Rotation API" ],
@@ -4392,61 +4429,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/KeyRotationResponse"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/wrappingkey/unmanaged/rotation/{requestid}" : {
-      "get" : {
-        "tags" : [ "Key Rotation API" ],
-        "description" : "This method gets the status of the current rotation.",
-        "operationId" : "get_wrappingkey_unmanaged_rotation__requestid_",
-        "parameters" : [ {
-          "name" : "requestid",
-          "in" : "path",
-          "description" : "The requestId obtained when starting key rotation request.",
-          "required" : true,
-          "schema" : {
-            "type" : "string",
-            "description" : "The requestId obtained when starting key rotation request.",
-            "nullable" : false,
-            "example" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "Success",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "uniqueItems" : false,
-                  "type" : "array",
-                  "nullable" : false,
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "first" : {
-                        "type" : "string",
-                        "nullable" : false,
-                        "example" : "string"
-                      },
-                      "second" : {
-                        "type" : "string",
-                        "nullable" : false,
-                        "example" : "string"
-                      }
-                    },
-                    "example" : "No example available for this type"
-                  }
                 }
               }
             }
@@ -5322,6 +5304,47 @@
           }
         }
       },
+      "KeyRotationStatusResponse" : {
+        "required" : [ "lastUpdatedTimestamp", "rootKeyAlias", "status", "wrappingKeys" ],
+        "type" : "object",
+        "properties" : {
+          "lastUpdatedTimestamp" : {
+            "type" : "string",
+            "format" : "datetime",
+            "nullable" : false,
+            "example" : "2022-06-24T10:15:30Z"
+          },
+          "rootKeyAlias" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          },
+          "wrappingKeys" : {
+            "uniqueItems" : false,
+            "type" : "array",
+            "nullable" : false,
+            "items" : {
+              "type" : "object",
+              "properties" : {
+                "first" : {
+                  "type" : "string",
+                  "nullable" : false,
+                  "example" : "string"
+                },
+                "second" : {
+                  "$ref" : "#/components/schemas/TenantIdWrappingKeysStatus"
+                }
+              },
+              "example" : "No example available for this type"
+            }
+          }
+        }
+      },
       "MemberInfoSubmitted" : {
         "required" : [ "data" ],
         "type" : "object",
@@ -5850,6 +5873,24 @@
           }
         },
         "description" : "Parameters for suspending or activating a member."
+      },
+      "TenantIdWrappingKeysStatus" : {
+        "required" : [ "rotatedKeys", "total" ],
+        "type" : "object",
+        "properties" : {
+          "rotatedKeys" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : false,
+            "example" : 0
+          },
+          "total" : {
+            "type" : "integer",
+            "format" : "int32",
+            "nullable" : false,
+            "example" : 0
+          }
+        }
       },
       "UpdateConfigParameters" : {
         "required" : [ "config", "schemaVersion", "section", "version" ],

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -748,9 +748,9 @@ class ClusterBuilder {
         )
     }
 
-    fun getCryptoUnmanagedWrappingKeysRotationStatus(requestid: String): SimpleResponse {
+    fun getCryptoUnmanagedWrappingKeysRotationStatus(keyAlias: String): SimpleResponse {
         return get(
-            "/api/$REST_API_VERSION_PATH/wrappingkey/unmanaged/rotation/${requestid}",
+            "/api/$REST_API_VERSION_PATH/wrappingkey/unmanaged/rotation/${keyAlias}",
         )
     }
 

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -234,10 +234,10 @@ fun ClusterInfo.rotateCryptoUnmanagedWrappingKeys(
 }
 
 fun ClusterInfo.getStatusForUnmanagedWrappingKeysRotation(
-    requestid: String
+    keyAlias: String
 ) = cluster {
     assertWithRetry {
-        command { getCryptoUnmanagedWrappingKeysRotationStatus(requestid) }
+        command { getCryptoUnmanagedWrappingKeysRotationStatus(keyAlias) }
         condition { it.code == ResponseCode.OK.statusCode }
     }
 }


### PR DESCRIPTION
**Changes**:
* store key rotation status in RekeyBusProcessor when we first get the key rotation request
* update key rotation status after each rewrap, update overall status if we rotated all keys in the current tenantId
* show user the resulting status of the key rotation (In Progress or Done) if the rotation ever started
* add check if the previous key rotation is in progress
* show user the timestamp of the last key rotation status, as the last key rotation might have happened long time ago