### PR TITLE
CORE-19331 Remove ledger-persistence from db-worker

### DIFF
--- a/processors/db-processor/build.gradle
+++ b/processors/db-processor/build.gradle
@@ -15,7 +15,6 @@ dependencies {
     implementation project(':components:configuration:configuration-read-service')
     implementation project(':components:configuration:configuration-write-service')
     implementation project(':components:db:db-connection-manager')
-    implementation project(':components:ledger:ledger-persistence')
     implementation project(':components:membership:group-params-writer-service')
     implementation project(':components:membership:membership-group-read')
     implementation project(':components:membership:membership-client')


### PR DESCRIPTION
`ledger-persistence` is already included in the `persistence-worker` and
 shouldn't be included in the `db-worker`, so it has been removed.