### PR TITLE
CORE-19093: More renames of HTTP RPC to REST

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/AmqpSerializationTests.kt
@@ -4,12 +4,12 @@ import net.corda.applications.workers.smoketest.utils.TEST_CPB_LOCATION
 import net.corda.applications.workers.smoketest.utils.TEST_CPI_NAME
 import net.corda.e2etest.utilities.ClusterReadiness
 import net.corda.e2etest.utilities.ClusterReadinessChecker
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.awaitRestFlowResult
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.BeforeAll
@@ -58,12 +58,12 @@ class AmqpSerializationTests : ClusterReadiness by ClusterReadinessChecker() {
     @Test
     fun `Serialize and deserialize a Pair`() {
 
-        val requestId = startRpcFlow(bobHoldingId, emptyMap(), AmqpSerializationTestFlow)
+        val requestId = startRestFlow(bobHoldingId, emptyMap(), AmqpSerializationTestFlow)
         val flowResult = awaitRestFlowResult(bobHoldingId, requestId)
 
         assertAll(
             { assertThat(flowResult.flowError).isNull() },
-            { assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS) },
+            { assertThat(flowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS) },
             { assertThat(flowResult.json!!.textValue()).isEqualTo("SerializableClass(pair=(A, B))") },
         )
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/ConfigurationChangeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/ConfigurationChangeTest.kt
@@ -5,8 +5,8 @@ import net.corda.applications.workers.smoketest.utils.TEST_CPI_NAME
 import net.corda.e2etest.utilities.ClusterReadiness
 import net.corda.e2etest.utilities.ClusterReadinessChecker
 import net.corda.e2etest.utilities.DEFAULT_CLUSTER
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
-import net.corda.e2etest.utilities.RpcSmokeTestInput
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.RestSmokeTestInput
 import net.corda.e2etest.utilities.awaitRestFlowResult
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.conditionallyUploadCpiSigningCertificate
@@ -17,7 +17,7 @@ import net.corda.e2etest.utilities.config.waitForConfigurationChange
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import org.assertj.core.api.Assertions.assertThat
@@ -92,32 +92,32 @@ class ConfigurationChangeTest : ClusterReadiness by ClusterReadinessChecker() {
         logger.info("Set new config")
         managedConfig()
             .load(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue).apply {
-            // Wait for the rpc-worker to reload the configuration and come back up
+            // Wait for the rest-worker to reload the configuration and come back up
             logger.info("Wait for the rest-worker to reload the configuration and come back up")
             waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue.toString(), false)
 
             // Execute some flows which require functionality from different workers and make sure they succeed
             logger.info("Execute some flows which require functionality from different workers and make sure they succeed")
             val flowIds = mutableListOf(
-                startRpcFlow(
+                startRestFlow(
                     bobHoldingId,
-                    RpcSmokeTestInput().apply {
+                    RestSmokeTestInput().apply {
                         command = "persistence_persist"
                         data = mapOf("id" to UUID.randomUUID().toString())
                     }
                 ),
 
-                startRpcFlow(
+                startRestFlow(
                     bobHoldingId,
-                    RpcSmokeTestInput().apply {
+                    RestSmokeTestInput().apply {
                         command = "crypto_sign_and_verify"
                         data = mapOf("memberX500" to bobX500)
                     }
                 ),
 
-                startRpcFlow(
+                startRestFlow(
                     bobHoldingId,
-                    RpcSmokeTestInput().apply {
+                    RestSmokeTestInput().apply {
                         command = "lookup_member_by_x500_name"
                         data = mapOf("id" to charlyX500)
                     }
@@ -128,7 +128,7 @@ class ConfigurationChangeTest : ClusterReadiness by ClusterReadinessChecker() {
             flowIds.forEach {
                 val flowResult = awaitRestFlowResult(bobHoldingId, it)
                 assertThat(flowResult.flowError).isNull()
-                assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+                assertThat(flowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
             }
         }
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
@@ -45,10 +45,10 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 /**
- * Tests for the Crypto RPC service
+ * Tests for the Crypto REST service
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class CryptoRPCSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
+class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     private val httpClient: HttpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(30))
         .build()
@@ -123,7 +123,7 @@ class CryptoRPCSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     }
 
     @Test
-    fun `RPC endpoint accepts a request and returns back a response`() {
+    fun `REST endpoint accepts a request and returns back a response`() {
         val url = "${System.getProperty("cryptoWorkerUrl")}api/$PLATFORM_VERSION/crypto"
 
         logger.info("crypto url: $url")
@@ -152,7 +152,7 @@ class CryptoRPCSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     }
 
     @Test
-    fun `RPC endpoint accepts a request and returns back an error response with 200 status`() {
+    fun `REST endpoint accepts a request and returns back an error response with 200 status`() {
         val url = "${System.getProperty("cryptoWorkerUrl")}api/$PLATFORM_VERSION/crypto"
 
         logger.info("crypto url: $url")
@@ -178,7 +178,7 @@ class CryptoRPCSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     }
 
     @Test
-    fun `RPC endpoint does not accept request and returns back a 500 error`() {
+    fun `REST endpoint does not accept request and returns back a 500 error`() {
         val url = "${System.getProperty("cryptoWorkerUrl")}api/$PLATFORM_VERSION/crypto"
 
         logger.info("crypto url: $url")

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/UniquenessCheckerRestSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/UniquenessCheckerRestSmokeTests.kt
@@ -42,10 +42,10 @@ import java.util.UUID
 import kotlin.random.Random
 
 /**
- * Tests for the UniquenessChecker RPC service
+ * Tests for the UniquenessChecker REST service
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class UniquenessCheckerRPCSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
+class UniquenessCheckerRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     private val httpClient: HttpClient = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(30))
         .build()
@@ -123,7 +123,7 @@ class UniquenessCheckerRPCSmokeTests : ClusterReadiness by ClusterReadinessCheck
     }
 
     @Test
-    fun `RPC endpoint accepts a request and returns back a response`() {
+    fun `REST endpoint accepts a request and returns back a response`() {
         val url = "${System.getProperty("uniquenessWorkerUrl")}api/$PLATFORM_VERSION/uniqueness-checker"
 
         logger.info("uniqueness url: $url")

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/SimpleHttpRestPerformanceTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/SimpleHttpRestPerformanceTest.kt
@@ -32,7 +32,7 @@ import kotlin.concurrent.scheduleAtFixedRate
 /*
  * This will be removed in future PRs, for now it's useful for testing different optimizations.
  */
-class SimpleHttpRPCPerformanceTest {
+class SimpleHttpRestPerformanceTest {
 
     private companion object {
         const val HOLDING_ID = "A332E0C2F697"

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/TokenSelectionTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/TokenSelectionTests.kt
@@ -5,17 +5,17 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import net.corda.e2etest.utilities.ClusterReadiness
 import net.corda.e2etest.utilities.ClusterReadinessChecker
 import net.corda.e2etest.utilities.DEFAULT_CLUSTER
-import net.corda.e2etest.utilities.RPC_FLOW_STATUS_SUCCESS
+import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
 import net.corda.e2etest.utilities.TEST_NOTARY_CPI_NAME
 import net.corda.e2etest.utilities.TestRequestIdGenerator
-import net.corda.e2etest.utilities.awaitRpcFlowFinished
+import net.corda.e2etest.utilities.awaitRestFlowFinished
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.conditionallyUploadCpiSigningCertificate
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
 import net.corda.e2etest.utilities.registerStaticMember
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
@@ -72,16 +72,16 @@ class TokenSelectionTests : ClusterReadiness by ClusterReadinessChecker() {
 
         val tokenBalanceQueryFlowName = "com.r3.corda.demo.utxo.token.selection.TokenBalanceQueryFlow"
 
-        val tokenBalanceQueryRpcStartArgs = mapOf(
+        val tokenBalanceQueryRestStartArgs = mapOf(
             "tokenType" to "com.r3.corda.demo.utxo.contract.CoinState",
             "issuerBankX500" to bobX500,
             "currency" to "USD"
         )
 
-        startRpcFlow(aliceHoldingId, tokenBalanceQueryRpcStartArgs, tokenBalanceQueryFlowName, requestId = flowRequestId)
+        startRestFlow(aliceHoldingId, tokenBalanceQueryRestStartArgs, tokenBalanceQueryFlowName, requestId = flowRequestId)
 
-        val flowResult = awaitRpcFlowFinished(aliceHoldingId, flowRequestId)
-        assertThat(flowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val flowResult = awaitRestFlowFinished(aliceHoldingId, flowRequestId)
+        assertThat(flowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
 
         return convertToTokenBalanceQueryResponseMsg(flowResult.flowResult!!)
     }
@@ -142,37 +142,37 @@ class TokenSelectionTests : ClusterReadiness by ClusterReadinessChecker() {
         val idGenerator = TestRequestIdGenerator(testInfo)
         // Create a simple UTXO transaction
         val input = "token test input"
-        val utxoFlowRequestId = startRpcFlow(
+        val utxoFlowRequestId = startRestFlow(
             bobHoldingId,
             mapOf("input" to input, "members" to listOf(aliceX500), "notary" to NOTARY_SERVICE_X500),
             "com.r3.corda.demo.utxo.UtxoDemoFlow",
             requestId = idGenerator.nextId
         )
-        val utxoFlowResult = awaitRpcFlowFinished(bobHoldingId, utxoFlowRequestId)
-        assertThat(utxoFlowResult.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val utxoFlowResult = awaitRestFlowFinished(bobHoldingId, utxoFlowRequestId)
+        assertThat(utxoFlowResult.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(utxoFlowResult.flowError).isNull()
 
         // Attempt to select the token created by the transaction
-        val tokenSelectionFlowId1 = startRpcFlow(
+        val tokenSelectionFlowId1 = startRestFlow(
             aliceHoldingId,
             mapOf(),
             "com.r3.corda.demo.utxo.token.selection.TokenSelectionFlow2",
             requestId = idGenerator.nextId
         )
-        val tokenSelectionResult1 = awaitRpcFlowFinished(aliceHoldingId, tokenSelectionFlowId1)
-        assertThat(tokenSelectionResult1.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val tokenSelectionResult1 = awaitRestFlowFinished(aliceHoldingId, tokenSelectionFlowId1)
+        assertThat(tokenSelectionResult1.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(tokenSelectionResult1.flowError).isNull()
         assertThat(tokenSelectionResult1.flowResult).isEqualTo("SUCCESS")
 
         // Attempt to select the token created by the transaction
-        val tokenSelectionFlowId2 = startRpcFlow(
+        val tokenSelectionFlowId2 = startRestFlow(
             aliceHoldingId,
             mapOf(),
             "com.r3.corda.demo.utxo.token.selection.TokenSelectionFlow2",
             requestId = idGenerator.nextId
         )
-        val tokenSelectionResult2 = awaitRpcFlowFinished(aliceHoldingId, tokenSelectionFlowId2)
-        assertThat(tokenSelectionResult2.flowStatus).isEqualTo(RPC_FLOW_STATUS_SUCCESS)
+        val tokenSelectionResult2 = awaitRestFlowFinished(aliceHoldingId, tokenSelectionFlowId2)
+        assertThat(tokenSelectionResult2.flowStatus).isEqualTo(REST_FLOW_STATUS_SUCCESS)
         assertThat(tokenSelectionResult2.flowError).isNull()
         assertThat(tokenSelectionResult2.flowResult).isEqualTo("SUCCESS")
     }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/websocket/FlowStatusFeedSmokeTest.kt
@@ -9,13 +9,13 @@ import net.corda.e2etest.utilities.CODE_SIGNER_CERT_ALIAS
 import net.corda.e2etest.utilities.CODE_SIGNER_CERT_USAGE
 import net.corda.e2etest.utilities.ClusterReadiness
 import net.corda.e2etest.utilities.ClusterReadinessChecker
-import net.corda.e2etest.utilities.RpcSmokeTestInput
+import net.corda.e2etest.utilities.RestSmokeTestInput
 import net.corda.e2etest.utilities.assertWithRetryIgnoringExceptions
 import net.corda.e2etest.utilities.cluster
 import net.corda.e2etest.utilities.conditionallyUploadCordaPackage
 import net.corda.e2etest.utilities.getHoldingIdShortHash
 import net.corda.e2etest.utilities.getOrCreateVirtualNodeFor
-import net.corda.e2etest.utilities.startRpcFlow
+import net.corda.e2etest.utilities.startRestFlow
 import net.corda.e2etest.utilities.websocket.client.useWebsocketConnection
 import net.corda.test.util.eventually
 import org.assertj.core.api.Assertions.assertThat
@@ -43,7 +43,7 @@ class FlowStatusFeedSmokeTest : ClusterReadiness by ClusterReadinessChecker() {
         )
     }
 
-    private enum class FlowStates { START_REQUESTED, RUNNING, RETRYING, COMPLETED, FAILED, KILLED }
+    private enum class FlowStates { START_REQUESTED, RUNNING, COMPLETED }
 
     private fun generateRequestId(identifyingTest: String): String {
         return "$identifyingTest-${UUID.randomUUID()}"
@@ -113,11 +113,11 @@ class FlowStatusFeedSmokeTest : ClusterReadiness by ClusterReadinessChecker() {
     }
 
     private fun startFlow(clientRequestId: String) {
-        val requestBody = RpcSmokeTestInput().apply {
+        val requestBody = RestSmokeTestInput().apply {
             command = "echo"
             data = mapOf("echo_value" to "hello")
         }
 
-        startRpcFlow(holdingId = bobHoldingId, args = requestBody, requestId = clientRequestId)
+        startRestFlow(holdingId = bobHoldingId, args = requestBody, requestId = clientRequestId)
     }
 }

--- a/testing/cpbs/test-cordapp/src/main/java/com/r3/corda/testing/smoketests/flow/inheritance/AbstractJavaFlow.java
+++ b/testing/cpbs/test-cordapp/src/main/java/com/r3/corda/testing/smoketests/flow/inheritance/AbstractJavaFlow.java
@@ -6,7 +6,6 @@ import net.corda.v5.application.flows.ClientStartableFlow;
 import net.corda.v5.application.marshalling.JsonMarshallingService;
 import net.corda.v5.application.membership.MemberLookup;
 import net.corda.v5.base.annotations.Suspendable;
-import net.corda.v5.base.types.MemberX500Name;
 import net.corda.v5.membership.MemberInfo;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -34,8 +33,7 @@ public abstract class AbstractJavaFlow implements ClientStartableFlow, JavaMembe
 
         try {
             Map<String, String> request = requestBody.getRequestBodyAsMap(jsonMarshallingService, String.class, String.class);
-            String memberInfoRequest = Objects.requireNonNull(request.get("id"), "Failed to find key 'id' in the RPC input args");
-            MemberInfo memberInfoResponse = memberLookupService.lookup(MemberX500Name.parse(memberInfoRequest));
+            String memberInfoRequest = Objects.requireNonNull(request.get("id"), "Failed to find key 'id' in the REST input args");
 
             return buildOutput(findMember(memberInfoRequest));
         } catch (Exception exception) {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/InheritanceTestFlows.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/InheritanceTestFlows.kt
@@ -34,7 +34,7 @@ abstract class AbstractFlow : ClientStartableFlow, MemberResolver {
 
         try {
             val request = requestBody.getRequestBodyAsMap(jsonMarshallingService, String::class.java, String::class.java)
-            val memberInfoRequest = checkNotNull(request["id"]) { "Failed to find key 'id' in the RPC input args" }
+            val memberInfoRequest = checkNotNull(request["id"]) { "Failed to find key 'id' in the REST input args" }
 
             return buildOutput(findMember(memberInfoRequest))
         } catch (e: Exception) {

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RestSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RestSmokeTestFlow.kt
@@ -27,7 +27,11 @@ import net.corda.v5.application.persistence.PersistenceService
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.*
+import net.corda.v5.crypto.CompositeKey
+import net.corda.v5.crypto.CompositeKeyNodeAndWeight
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import org.slf4j.LoggerFactory
 import java.security.PublicKey

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RestSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RestSmokeTestFlow.kt
@@ -204,6 +204,7 @@ class RestSmokeTestFlow : ClientStartableFlow {
         }
     }
 
+    @Suspendable
     private fun getDogId(input: RestSmokeTestInput): UUID {
         val id = input.getValue("id")
         return try {
@@ -214,6 +215,7 @@ class RestSmokeTestFlow : ClientStartableFlow {
         }
     }
 
+    @Suspendable
     private fun getDogIds(input: RestSmokeTestInput): List<UUID> {
         val ids = input.getValue("ids").split(";")
         return ids.map { id ->
@@ -240,10 +242,10 @@ class RestSmokeTestFlow : ClientStartableFlow {
             log.info("Creating session for '${x500}'...")
             val session = flowMessaging.initiateFlow(MemberX500Name.parse(x500))
 
-            val countpartyInfo = session.counterpartyFlowInfo
+            val counterpartyInfo = session.counterpartyFlowInfo
+            log.info("Creating session '${session}' with version ${counterpartyInfo.protocolVersion()} now sending and " +
+                    "waiting for response...")
 
-            log.info("Creating session '${session}' with version ${countpartyInfo.protocolVersion()} now sending and waiting for response" +
-                    " ...")
             val response = session
                 .sendAndReceive(InitiatedSmokeTestMessage::class.java, InitiatedSmokeTestMessage(messages[idx]))
 
@@ -262,6 +264,7 @@ class RestSmokeTestFlow : ClientStartableFlow {
         val signatureSpec: SignatureSpec
     )
 
+    @Suspendable
     private fun RestSmokeTestInput.performSigning() : SigningResult {
         val x500Name = getValue("memberX500")
         val member = memberLookup.lookup(MemberX500Name.parse(x500Name))
@@ -311,6 +314,7 @@ class RestSmokeTestFlow : ClientStartableFlow {
         }.toString()
     }
 
+    @Suspendable
     private fun RestSmokeTestInput.retrievePublicKeyAndDigest(): Pair<PublicKey, String?> {
         val x500Name = getValue("memberX500")
         val member = memberLookup.lookup(MemberX500Name.parse(x500Name))
@@ -442,6 +446,7 @@ class RestSmokeTestFlow : ClientStartableFlow {
         }""".trimIndent()
     }
 
+    @Suspendable
     private fun RestSmokeTestInput.getValue(key: String): String {
         return checkNotNull(this.data?.get(key)) { "Failed to find key '${key}' in the REST input args" }
     }

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RestSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RestSmokeTestFlow.kt
@@ -6,8 +6,8 @@ import com.r3.corda.testing.smoketests.flow.messages.InitiatedSmokeTestMessage
 import com.r3.corda.testing.smoketests.flow.messages.JsonSerializationFlowOutput
 import com.r3.corda.testing.smoketests.flow.messages.JsonSerializationInput
 import com.r3.corda.testing.smoketests.flow.messages.JsonSerializationOutput
-import com.r3.corda.testing.smoketests.flow.messages.RpcSmokeTestInput
-import com.r3.corda.testing.smoketests.flow.messages.RpcSmokeTestOutput
+import com.r3.corda.testing.smoketests.flow.messages.RestSmokeTestInput
+import com.r3.corda.testing.smoketests.flow.messages.RestSmokeTestOutput
 import net.corda.v5.application.crypto.CompositeKeyGenerator
 import net.corda.v5.application.crypto.DigestService
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
@@ -37,13 +37,13 @@ import java.util.UUID
 
 @Suppress("unused", "TooManyFunctions")
 @InitiatingFlow(protocol = "smoke-test-protocol")
-class RpcSmokeTestFlow : ClientStartableFlow {
+class RestSmokeTestFlow : ClientStartableFlow {
 
     private companion object {
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    private val commandMap: Map<String, (RpcSmokeTestInput) -> String> = mapOf(
+    private val commandMap: Map<String, (RestSmokeTestInput) -> String> = mapOf(
         "echo" to this::echo,
         "start_sessions" to this::startSessions,
         "persistence_persist" to this::persistencePersistDog,
@@ -107,16 +107,16 @@ class RpcSmokeTestFlow : ClientStartableFlow {
 
     @Suspendable
     override fun call(requestBody: ClientRequestBody): String {
-        val request = requestBody.getRequestBodyAs(jsonMarshallingService, RpcSmokeTestInput::class.java)
+        val request = requestBody.getRequestBodyAs(jsonMarshallingService, RestSmokeTestInput::class.java)
         return jsonMarshallingService.format(execute(request))
     }
 
-    private fun echo(input: RpcSmokeTestInput): String {
+    private fun echo(input: RestSmokeTestInput): String {
         return input.getValue("echo_value")
     }
 
     @Suspendable
-    private fun persistencePersistDog(input: RpcSmokeTestInput): String {
+    private fun persistencePersistDog(input: RestSmokeTestInput): String {
         val dogId = getDogId(input)
         val dog = Dog(dogId, "dog", Instant.now(), "none")
         persistenceService.persist(dog)
@@ -124,28 +124,28 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun persistencePersistDogs(input: RpcSmokeTestInput): String {
+    private fun persistencePersistDogs(input: RestSmokeTestInput): String {
         val dogs = getDogIds(input).map { id -> Dog(id, "dog-$id", Instant.now(), "none") }
         persistenceService.persist(dogs)
         return "dogs ${dogs.map { it.id }} saved"
     }
 
     @Suspendable
-    private fun persistenceDeleteDog(input: RpcSmokeTestInput): String {
+    private fun persistenceDeleteDog(input: RestSmokeTestInput): String {
         val dogId = getDogId(input)
         persistenceService.remove(Dog(dogId, "dog", Instant.now(), "none"))
         return "dog '${dogId}' deleted"
     }
 
     @Suspendable
-    private fun persistenceDeleteDogs(input: RpcSmokeTestInput): String {
+    private fun persistenceDeleteDogs(input: RestSmokeTestInput): String {
         val dogs = getDogIds(input).map { id -> Dog(id, "dog-$id", Instant.now(), "none") }
         persistenceService.remove(dogs)
         return "dogs ${dogs.map { it.id }} deleted"
     }
 
     @Suspendable
-    private fun persistenceMergeDog(input: RpcSmokeTestInput): String {
+    private fun persistenceMergeDog(input: RestSmokeTestInput): String {
         val dogId = getDogId(input)
         val newDogName = input.getValue("name")
         persistenceService.merge(Dog(dogId, newDogName, Instant.now(), "none"))
@@ -153,14 +153,14 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun persistenceMergeDogs(input: RpcSmokeTestInput): String {
+    private fun persistenceMergeDogs(input: RestSmokeTestInput): String {
         val dogs = getDogIds(input).map { id -> Dog(id, "dog-$id", Instant.now(), "merged") }
         persistenceService.merge(dogs)
         return "dogs ${dogs.map { it.id }} merged"
     }
 
     @Suspendable
-    private fun persistenceFindDog(input: RpcSmokeTestInput): String {
+    private fun persistenceFindDog(input: RestSmokeTestInput): String {
         val dogId = getDogId(input)
         val dog = persistenceService.find(Dog::class.java, dogId)
         return if (dog == null) {
@@ -171,7 +171,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun persistenceFindDogs(input: RpcSmokeTestInput): String {
+    private fun persistenceFindDogs(input: RestSmokeTestInput): String {
         val dogIds = getDogIds(input)
         val dogs = persistenceService.find(Dog::class.java, dogIds)
         return if (dogs.isEmpty()) {
@@ -201,7 +201,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
         }
     }
 
-    private fun getDogId(input: RpcSmokeTestInput): UUID {
+    private fun getDogId(input: RestSmokeTestInput): UUID {
         val id = input.getValue("id")
         return try {
             UUID.fromString(id)
@@ -211,7 +211,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
         }
     }
 
-    private fun getDogIds(input: RpcSmokeTestInput): List<UUID> {
+    private fun getDogIds(input: RestSmokeTestInput): List<UUID> {
         val ids = input.getValue("ids").split(";")
         return ids.map { id ->
             try {
@@ -224,7 +224,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun startSessions(input: RpcSmokeTestInput): String {
+    private fun startSessions(input: RestSmokeTestInput): String {
         val sessions = input.getValue("sessions").split(";")
         val messages = input.getValue("messages").split(";")
         if (sessions.size != messages.size) {
@@ -253,7 +253,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun signAndVerify(input: RpcSmokeTestInput): String {
+    private fun signAndVerify(input: RestSmokeTestInput): String {
         val x500Name = input.getValue("memberX500")
         val member = memberLookup.lookup(MemberX500Name.parse(x500Name))
         checkNotNull(member) { "Member $x500Name could not be looked up" }
@@ -276,7 +276,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun verifyInvalidSignature(input: RpcSmokeTestInput): String {
+    private fun verifyInvalidSignature(input: RestSmokeTestInput): String {
         val x500Name = input.getValue("memberX500")
         val member = memberLookup.lookup(MemberX500Name.parse(x500Name))
         checkNotNull(member) { "Member $x500Name could not be looked up" }
@@ -306,7 +306,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun getDefaultSignatureSpec(input: RpcSmokeTestInput): String {
+    private fun getDefaultSignatureSpec(input: RestSmokeTestInput): String {
         val x500Name = input.getValue("memberX500")
         val member = memberLookup.lookup(MemberX500Name.parse(x500Name))
         checkNotNull(member) { "Member $x500Name could not be looked up" }
@@ -327,7 +327,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun getCompatibleSignatureSpecs(input: RpcSmokeTestInput): String {
+    private fun getCompatibleSignatureSpecs(input: RestSmokeTestInput): String {
         val x500Name = input.getValue("memberX500")
         val member = memberLookup.lookup(MemberX500Name.parse(x500Name))
         checkNotNull(member) { "Member $x500Name could not be looked up" }
@@ -352,7 +352,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
 
     @Suppress("unused_parameter")
     @Suspendable
-    private fun findMySigningKeys(input: RpcSmokeTestInput): String {
+    private fun findMySigningKeys(input: RestSmokeTestInput): String {
         val myInfo = memberLookup.myInfo()
         val myKeysFromMemberInfo = myInfo.ledgerKeys.toSet()
         val myKeysFromCryptoWorker = signingService.findMySigningKeys(myKeysFromMemberInfo)
@@ -376,7 +376,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
 
     @Suppress("unused_parameter")
     @Suspendable
-    private fun compositeKeyGeneratorWorksInFlows(input: RpcSmokeTestInput): String {
+    private fun compositeKeyGeneratorWorksInFlows(input: RestSmokeTestInput): String {
         val someKeys = memberLookup.lookup().flatMap { it.ledgerKeys }
         val keysAndWeights = someKeys.map {
             CompositeKeyNodeAndWeight(it, 1)
@@ -391,7 +391,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
 
     @Suppress("unused_parameter")
     @Suspendable
-    private fun getDefaultDigestAlgorithm(input: RpcSmokeTestInput): String {
+    private fun getDefaultDigestAlgorithm(input: RestSmokeTestInput): String {
         val defaultDigestAlgorithm = digestService.defaultDigestAlgorithm()
         return if (defaultDigestAlgorithm == DigestAlgorithmName.SHA2_256) {
             "SUCCESS"
@@ -401,7 +401,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
 
     @Suppress("unused_parameter")
     @Suspendable
-    private fun getSupportedDigestAlgorithms(input: RpcSmokeTestInput): String {
+    private fun getSupportedDigestAlgorithms(input: RestSmokeTestInput): String {
         val supportedDigestAlgorithms = digestService.supportedDigestAlgorithms()
         val expectedSupportedDigestAlgorithms = linkedSetOf(
             DigestAlgorithmName.SHA2_256,
@@ -419,7 +419,7 @@ class RpcSmokeTestFlow : ClientStartableFlow {
     }
 
     @Suspendable
-    private fun lookupMember(input: RpcSmokeTestInput): String {
+    private fun lookupMember(input: RestSmokeTestInput): String {
         val memberX500Name = input.getValue("id")
         val memberInfo = memberLookup.lookup(MemberX500Name.parse(memberX500Name))
         checkNotNull(memberInfo) { IllegalStateException("Failed to find MemberInfo for $memberX500Name") }
@@ -440,20 +440,20 @@ class RpcSmokeTestFlow : ClientStartableFlow {
         }""".trimIndent()
     }
 
-    private fun RpcSmokeTestInput.getValue(key: String): String {
-        return checkNotNull(this.data?.get(key)) { "Failed to find key '${key}' in the RPC input args" }
+    private fun RestSmokeTestInput.getValue(key: String): String {
+        return checkNotNull(this.data?.get(key)) { "Failed to find key '${key}' in the REST input args" }
     }
 
     @Suspendable
-    private fun execute(input: RpcSmokeTestInput): RpcSmokeTestOutput {
-        return RpcSmokeTestOutput(
+    private fun execute(input: RestSmokeTestInput): RestSmokeTestOutput {
+        return RestSmokeTestOutput(
             checkNotNull(input.command) { "No smoke test command received" },
             checkNotNull(commandMap[input.command]) { "command '${input.command}' not recognised" }.invoke(input)
         )
     }
 
     @Suspendable
-    private fun jsonSerialization(input: RpcSmokeTestInput): String {
+    private fun jsonSerialization(input: RestSmokeTestInput): String {
         // First test checks custom serializers with message defined in the CorDapp
         // this should output json with 2 fields each with test-string as the value
         val jsonString = jsonMarshallingService.format(JsonSerializationInput("test-string"))

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/messages/RestSmokeTestInput.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/messages/RestSmokeTestInput.kt
@@ -1,6 +1,6 @@
 package com.r3.corda.testing.smoketests.flow.messages
 
-class RpcSmokeTestInput {
+class RestSmokeTestInput {
     var command: String? = null
     var data: Map<String, String>? = null
 }

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/messages/RestSmokeTestOutput.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/messages/RestSmokeTestOutput.kt
@@ -1,6 +1,6 @@
 package com.r3.corda.testing.smoketests.flow.messages
 
-data class RpcSmokeTestOutput(
+data class RestSmokeTestOutput(
     var command: String,
     var result: String
 )

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/testflows/NonValidatingNotaryTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/testflows/NonValidatingNotaryTestFlow.kt
@@ -29,7 +29,7 @@ import java.time.Instant
 
 /**
  * This flow is used to call the `NonValidatingNotaryClientFlowImpl`. Since `NonValidatingNotaryClientFlowImpl` is not
- * a HTTP RPC invokable flow, we need an extra layer to call that flow from tests and through HTTP RPC.
+ * REST invokable flow, we need an extra layer to call that flow from tests and through REST.
  *
  * This flow will generate a UTXO signed transaction using the provided HTTP parameters and pass that signed transaction
  * to the non-validating notary plugin. This flow will automatically find a notary on the network and use that as the
@@ -46,6 +46,7 @@ import java.time.Instant
  * will be the current  UTC time ([Instant.now]) + 1 hour.
  */
 @InitiatingFlow(protocol = "non-validating-test")
+@Suppress("unused")
 class NonValidatingNotaryTestFlow : ClientStartableFlow {
 
     @CordaInject
@@ -205,7 +206,7 @@ class NonValidatingNotaryTestFlow : ClientStartableFlow {
 
     /**
      * A helper function that will build a UTXO signed transaction from the provided input parameters using the
-     * [UtxoTransactionBuilder] utility class.
+     * [net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder] utility class.
      */
     @Suspendable
     private fun buildSignedTransaction(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -12,16 +12,16 @@ import org.junit.jupiter.api.TestInfo
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
-const val SMOKE_TEST_CLASS_NAME = "com.r3.corda.testing.smoketests.flow.RpcSmokeTestFlow"
+const val SMOKE_TEST_CLASS_NAME = "com.r3.corda.testing.smoketests.flow.RestSmokeTestFlow"
 
-const val RPC_FLOW_STATUS_SUCCESS = "COMPLETED"
-const val RPC_FLOW_STATUS_FAILED = "FAILED"
+const val REST_FLOW_STATUS_SUCCESS = "COMPLETED"
+const val REST_FLOW_STATUS_FAILED = "FAILED"
 
 private val RETRY_TIMEOUT = 6.minutes
 
-fun startRpcFlow(
+fun startRestFlow(
     holdingId: String,
-    args: RpcSmokeTestInput,
+    args: RestSmokeTestInput,
     expectedCode: Int = 202,
     requestId: String = UUID.randomUUID().toString()
 ): String {
@@ -44,15 +44,15 @@ fun startRpcFlow(
     }
 }
 
-fun startRpcFlow(
+fun startRestFlow(
     holdingId: String,
     args: Map<String, Any>,
     flowName: String,
     expectedCode: Int = 202,
     requestId: String = UUID.randomUUID().toString()
-) = DEFAULT_CLUSTER.startRpcFlow(holdingId, args, flowName, expectedCode, requestId)
+) = DEFAULT_CLUSTER.startRestFlow(holdingId, args, flowName, expectedCode, requestId)
 
-fun ClusterInfo.startRpcFlow(
+fun ClusterInfo.startRestFlow(
     holdingId: String,
     args: Map<String, Any>,
     flowName: String,
@@ -78,12 +78,12 @@ fun ClusterInfo.startRpcFlow(
     }
 }
 
-fun awaitRpcFlowFinished(
+fun awaitRestFlowFinished(
     holdingId: String,
     requestId: String
-) = DEFAULT_CLUSTER.awaitRpcFlowFinished(holdingId, requestId)
+) = DEFAULT_CLUSTER.awaitRestFlowFinished(holdingId, requestId)
 
-fun ClusterInfo.awaitRpcFlowFinished(holdingId: String, requestId: String): FlowStatus {
+fun ClusterInfo.awaitRestFlowFinished(holdingId: String, requestId: String): FlowStatus {
     return cluster {
         ObjectMapper().readValue(
             assertWithRetryIgnoringExceptions {
@@ -92,8 +92,8 @@ fun ClusterInfo.awaitRpcFlowFinished(holdingId: String, requestId: String): Flow
                 timeout(RETRY_TIMEOUT)
                 condition {
                     it.code == 200 &&
-                            (it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_SUCCESS ||
-                                    it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_FAILED)
+                            (it.toJson()["flowStatus"].textValue() == REST_FLOW_STATUS_SUCCESS ||
+                                    it.toJson()["flowStatus"].textValue() == REST_FLOW_STATUS_FAILED)
                 }
             }.body, FlowStatus::class.java
         )
@@ -113,8 +113,8 @@ fun ClusterInfo.awaitRestFlowResult(holdingId: String, requestId: String): FlowR
                 timeout(RETRY_TIMEOUT)
                 condition {
                     it.code == 200 &&
-                            (it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_SUCCESS ||
-                                    it.toJson()["flowStatus"].textValue() == RPC_FLOW_STATUS_FAILED)
+                            (it.toJson()["flowStatus"].textValue() == REST_FLOW_STATUS_SUCCESS ||
+                                    it.toJson()["flowStatus"].textValue() == REST_FLOW_STATUS_FAILED)
                 }
             }.body
         )
@@ -134,6 +134,7 @@ private fun JsonNode.handlingNulls(): JsonNode? {
     }
 }
 
+@Suppress("unused")
 fun getFlowStatus(
     holdingId: String,
     requestId: String,
@@ -161,7 +162,8 @@ private fun JsonNode.asFlowError(): FlowError {
     return flowError
 }
 
-fun awaitMultipleRpcFlowFinished(holdingId: String, expectedFlowCount: Int) {
+@Suppress("unused")
+fun awaitMultipleRestFlowFinished(holdingId: String, expectedFlowCount: Int) {
     return DEFAULT_CLUSTER.cluster {
         assertWithRetryIgnoringExceptions {
             command { multipleFlowStatus(holdingId) }
@@ -170,8 +172,8 @@ fun awaitMultipleRpcFlowFinished(holdingId: String, expectedFlowCount: Int) {
                 val json = it.toJson()
                 val flowStatuses = json["flowStatusResponses"]
                 val allStatusComplete = flowStatuses.map { flowStatus ->
-                    flowStatus["flowStatus"].textValue() == RPC_FLOW_STATUS_SUCCESS ||
-                            flowStatus["flowStatus"].textValue() == RPC_FLOW_STATUS_FAILED
+                    flowStatus["flowStatus"].textValue() == REST_FLOW_STATUS_SUCCESS ||
+                            flowStatus["flowStatus"].textValue() == REST_FLOW_STATUS_FAILED
                 }.all { true }
                 it.code == 200 && flowStatuses.size() == expectedFlowCount && allStatusComplete
             }
@@ -179,6 +181,7 @@ fun awaitMultipleRpcFlowFinished(holdingId: String, expectedFlowCount: Int) {
     }
 }
 
+@Suppress("unused")
 fun assertStatusFilter(
     holdingId: String,
     expectedCode: Int,
@@ -186,7 +189,7 @@ fun assertStatusFilter(
 ) = DEFAULT_CLUSTER.assertStatusFilter(holdingId, expectedCode, status)
 
 fun ClusterInfo.assertStatusFilter(holdingId: String, expectedCode: Int, status: String?) {
-    return DEFAULT_CLUSTER.cluster {
+    return cluster {
         assertWithRetryIgnoringExceptions {
             command { multipleFlowStatus(holdingId, status) }
             timeout(RETRY_TIMEOUT)
@@ -197,6 +200,7 @@ fun ClusterInfo.assertStatusFilter(holdingId: String, expectedCode: Int, status:
     }
 }
 
+@Suppress("unused")
 fun getFlowClasses(
     holdingId: String
 ) = DEFAULT_CLUSTER.getFlowClasses(holdingId)
@@ -214,7 +218,7 @@ fun ClusterInfo.getFlowClasses(holdingId: String): List<String> {
     }
 }
 
-class RpcSmokeTestInput {
+class RestSmokeTestInput {
     var command: String? = null
     var data: Map<String, String>? = null
 }


### PR DESCRIPTION
In smoke tests and test utilities.
Also warning elimination.

Functionally, this change is NOP.

e2e Tests PR: https://github.com/corda/corda-e2e-tests/pull/406