### PR TITLE
CORE-19342: Add tests and docs to `WrappingRepository.getKeyById`

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/WrappingRepositoryTest.kt
+++ b/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/WrappingRepositoryTest.kt
@@ -118,4 +118,12 @@ class WrappingRepositoryTest : CryptoRepositoryTest() {
         assertThat(loadedKeyAndId2).isNotNull()
         assertThat(loadedKeyAndId!!.first).isEqualTo(loadedKeyAndId2!!.first)
     }
+
+    @ParameterizedTest
+    @MethodSource("emfs")
+    fun `getKeyByID returns null for non existing id`(emf: EntityManagerFactory) {
+        val repo = WrappingRepositoryImpl(emf, "test")
+        val loadedKey = repo.getKeyById(UUID.randomUUID())
+        assertThat(loadedKey).isNull()
+    }
 }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/WrappingRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/WrappingRepository.kt
@@ -54,5 +54,11 @@ interface WrappingRepository : Closeable {
      */
     fun findKeysWrappedByAlias(alias: String): List<WrappingKeyInfo>
 
+    /**
+     * Find the wrapping key associated with the provided UUID
+     *
+     * @param id The UUID of the wrapping key
+     * @return Information about the requested wrapping key if it exists
+     */
     fun getKeyById(id: UUID): WrappingKeyInfo?
 }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImplTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImplTests.kt
@@ -188,8 +188,8 @@ class WrappingRepositoryImplTests {
             "test"
         )
 
-        // Alias here doesn't matter, mock<EntityManager> returns savedWrappingKey regardless the alias.
-        // There is an integration test dealing with the database where it checks for the alias.
+        // ID here doesn't matter, mock<EntityManager> returns savedWrappingKey regardless the id.
+        // There is an integration test dealing with the database where it checks for the id.
         val foundKey = repo.getKeyById(newId)
 
         assertThat(foundKey).isEqualTo(wrappingKeyInfo)


### PR DESCRIPTION
Add tests and docs to `WrappingRepository.getKeyById` to ensure it works properly.