### PR TITLE
CORE-19017 migrate flow TimeoutEventCleanupProcessor to expect the MediatorState wrapper class

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowMaintenanceHandlersFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowMaintenanceHandlersFactoryImpl.kt
@@ -2,6 +2,7 @@ package net.corda.flow.maintenance
 
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.data.flow.state.checkpoint.Checkpoint
+import net.corda.data.messaging.mediator.MediatorState
 import net.corda.flow.state.impl.FlowCheckpointFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.statemanager.api.StateManager
@@ -23,6 +24,7 @@ class FlowMaintenanceHandlersFactoryImpl @Activate constructor(
 ) : FlowMaintenanceHandlersFactory {
 
     private val checkpointDeserializer = avroSerializationFactory.createAvroDeserializer({}, Checkpoint::class.java)
+    private val mediatorStateDeserializer = avroSerializationFactory.createAvroDeserializer({}, MediatorState::class.java)
 
     override fun createScheduledTaskHandler(stateManager: StateManager, config: SmartConfig): FlowTimeoutTaskProcessor {
         return FlowTimeoutTaskProcessor(stateManager, config)
@@ -35,6 +37,7 @@ class FlowMaintenanceHandlersFactoryImpl @Activate constructor(
         return TimeoutEventCleanupProcessor(
             checkpointCleanupHandler,
             stateManager,
+            mediatorStateDeserializer,
             checkpointDeserializer,
             flowCheckpointFactory,
             config

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/TimeoutEventCleanupProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/TimeoutEventCleanupProcessor.kt
@@ -13,6 +13,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
 
+@Suppress("LongParameterList")
 class TimeoutEventCleanupProcessor(
     private val checkpointCleanupHandler: CheckpointCleanupHandler,
     private val stateManager: StateManager,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/TimeoutEventCleanupProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/TimeoutEventCleanupProcessor.kt
@@ -3,6 +3,7 @@ package net.corda.flow.maintenance
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.data.flow.FlowTimeout
 import net.corda.data.flow.state.checkpoint.Checkpoint
+import net.corda.data.messaging.mediator.MediatorState
 import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.state.impl.FlowCheckpointFactory
 import net.corda.libs.configuration.SmartConfig
@@ -15,7 +16,8 @@ import org.slf4j.LoggerFactory
 class TimeoutEventCleanupProcessor(
     private val checkpointCleanupHandler: CheckpointCleanupHandler,
     private val stateManager: StateManager,
-    private val avroDeserializer: CordaAvroDeserializer<Checkpoint>,
+    private val mediatorDeserializer: CordaAvroDeserializer<MediatorState>,
+    private val checkpointDeserializer: CordaAvroDeserializer<Checkpoint>,
     private val flowCheckpointFactory: FlowCheckpointFactory,
     private val config: SmartConfig
 ) : DurableProcessor<String, FlowTimeout> {
@@ -29,8 +31,10 @@ class TimeoutEventCleanupProcessor(
         val statesToRecords = stateManager.get(events.mapNotNull {
             it.value?.checkpointStateKey
         }).mapNotNull { (_, state) ->
-            avroDeserializer.deserialize(state.value)?.let {
-                state to generateCleanupRecords(it)
+            mediatorDeserializer.deserialize(state.value)?.let { mediatorState ->
+                checkpointDeserializer.deserialize(mediatorState.state.array())?.let {
+                    state to generateCleanupRecords(it)
+                }
             }
         }.toMap()
         if (statesToRecords.size < events.size) {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/maintenance/FlowMaintenanceImplTests.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/maintenance/FlowMaintenanceImplTests.kt
@@ -87,7 +87,7 @@ class FlowMaintenanceImplTests {
         doReturn(FlowTimeoutTaskProcessor(stateManager, flowConfig))
             .whenever(flowMaintenanceHandlersFactory).createScheduledTaskHandler(any(), any())
 
-        doReturn(TimeoutEventCleanupProcessor(mock(), stateManager, mock(), mock(), flowConfig))
+        doReturn(TimeoutEventCleanupProcessor(mock(), stateManager, mock(), mock(), mock(), flowConfig))
             .whenever(flowMaintenanceHandlersFactory).createTimeoutEventHandler(any(), any())
     }
 


### PR DESCRIPTION
States saved by the mediator message pattern use a MediatorState wrapper object. The TimeoutEventCleanupProcessor does not currently expect this.