### PR TITLE
CORE-19348: Add `SoftCryptoService.createWrappingKeyFrom`

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -651,7 +651,7 @@ open class SoftCryptoService(
      * @param oldWrappingKey The original wrapping key
      * @param wrappingRepository The WrappingRepository object to save the new key with
      */
-    fun createWrappingKeyFrom(wrappingRepository: WrappingRepository, oldWrappingKey: WrappingKeyInfo) {
+    private fun createWrappingKeyFrom(wrappingRepository: WrappingRepository, oldWrappingKey: WrappingKeyInfo) {
         logger.trace {
             "createWrappingKeyFrom(alias=${oldWrappingKey.alias})"
         }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -38,7 +38,11 @@ import net.corda.crypto.impl.getSigningData
 import net.corda.crypto.persistence.SigningKeyOrderBy
 import net.corda.crypto.persistence.SigningWrappedKeySaveContext
 import net.corda.crypto.persistence.WrappingKeyInfo
-import net.corda.crypto.softhsm.*
+import net.corda.crypto.softhsm.SigningRepositoryFactory
+import net.corda.crypto.softhsm.TenantInfoService
+import net.corda.crypto.softhsm.WrappingRepositoryFactory
+import net.corda.crypto.softhsm.deriveSupportedSchemes
+import net.corda.crypto.softhsm.WrappingRepository
 import net.corda.metrics.CordaMetrics
 import net.corda.utilities.debug
 import net.corda.utilities.trace
@@ -646,7 +650,6 @@ open class SoftCryptoService(
      *
      * @param oldWrappingKey The original wrapping key
      * @param wrappingRepository The WrappingRepository object to save the new key with
-     * @return The new wrapping key based on the existing one
      */
     private fun createWrappingKeyFrom(oldWrappingKey: WrappingKeyInfo, wrappingRepository: WrappingRepository){
         logger.trace {

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -648,8 +648,8 @@ open class SoftCryptoService(
     /**
      * Create a wrapping key from an existing key
      *
-     * @param oldWrappingKey The original wrapping key
      * @param wrappingRepository The WrappingRepository object to save the new key with
+     * @param oldWrappingKey The original wrapping key
      */
     private fun createWrappingKeyFrom(wrappingRepository: WrappingRepository, oldWrappingKey: WrappingKeyInfo) {
         logger.trace {

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -651,11 +651,11 @@ open class SoftCryptoService(
      * @param oldWrappingKey The original wrapping key
      * @param wrappingRepository The WrappingRepository object to save the new key with
      */
-    private fun createWrappingKeyFrom(oldWrappingKey: WrappingKeyInfo, wrappingRepository: WrappingRepository){
+    fun createWrappingKeyFrom(wrappingRepository: WrappingRepository, oldWrappingKey: WrappingKeyInfo) {
         logger.trace {
             "createWrappingKeyFrom(alias=${oldWrappingKey.alias})"
         }
-        val wrappingKey = recoverable("createWrappingKey generate wrapping key") { wrappingKeyFactory(schemeMetadata) }
+        val wrappingKey = recoverable("createWrappingKeyFrom generate wrapping key") { wrappingKeyFactory(schemeMetadata) }
         val parentKeyName = oldWrappingKey.parentKeyAlias
         val parentKey = unmanagedWrappingKeys[parentKeyName]
             ?: throw IllegalStateException("No wrapping key $parentKeyName found")

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -660,7 +660,7 @@ open class SoftCryptoService(
         val parentKey = unmanagedWrappingKeys[parentKeyName]
             ?: throw IllegalStateException("No wrapping key $parentKeyName found")
         val wrappingKeyEncrypted = recoverable("wrap") { parentKey.wrap(wrappingKey) }
-        val wrappingKeyInfo =
+        val newWrappingKey =
             WrappingKeyInfo(
                 oldWrappingKey.encodingVersion,
                 wrappingKey.algorithm,
@@ -669,11 +669,11 @@ open class SoftCryptoService(
                 parentKeyName,
                 oldWrappingKey.alias
             )
-        recoverable("createWrappingKey save key") {
-            wrappingRepository.saveKey(wrappingKeyInfo)
+        recoverable("createWrappingKeyFrom save key") {
+            wrappingRepository.saveKey(newWrappingKey)
         }
         logger.trace("Regenerated wrapping key alias ${oldWrappingKey.alias}")
-        wrappingKeyCache?.put(oldWrappingKey.alias, wrappingKey)
+        wrappingKeyCache?.put(newWrappingKey.alias, wrappingKey)
     }
 }
 


### PR DESCRIPTION
Add `SoftCryptoService.createWrappingKeyFrom` to create a new wrapping key with the same metadata as an existing one.

The function is private so cannot be directly unit tested, but it locally passed the following test and will be tested properly with the public function that will call it.
```kotlin
fun `createWrappingKeyFrom successfully creates identical key aside from key material`() {
    val firstWrappingKeyInfo = WrappingKeyInfo(
        WRAPPING_KEY_ENCODING_VERSION,
        knownWrappingKey.algorithm,
        knownWrappingKeyMaterial,
        1,
        rootKeyAlias,
        managedWrappingKey1Alias
    )
    val secondWrappingKeyInfo = cryptoService.createWrappingKeyFrom(firstWrappingKeyInfo)

    assertThat(firstWrappingKeyInfo.alias).isEqualTo(secondWrappingKeyInfo.alias)
    assertThat(firstWrappingKeyInfo.encodingVersion).isEqualTo(secondWrappingKeyInfo.encodingVersion)
    assertThat(firstWrappingKeyInfo.parentKeyAlias).isEqualTo(secondWrappingKeyInfo.parentKeyAlias)
    assertThat(firstWrappingKeyInfo.generation).isEqualTo(secondWrappingKeyInfo.generation - 1)
    assertThat(firstWrappingKeyInfo.keyMaterial).isNotEqualTo(secondWrappingKeyInfo.keyMaterial)
    rootWrappingKey.unwrapWrappingKey(secondWrappingKeyInfo.keyMaterial)
}
```