### PR TITLE
CORE-19243 - Record inbound session message metrics metrics outside the lambda function

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -127,8 +127,8 @@ internal class InboundMessageProcessor(
 
     private fun processSessionMessages(messages: List<TraceableItem<LinkInMessage, LinkInMessage>>):
             List<TraceableItem<List<Record<String, *>>, LinkInMessage>> {
+        recordInboundSessionMessagesMetric(messages.size)
         val responses = sessionManager.processSessionMessages(messages) { message ->
-            recordInboundSessionMessagesMetric()
             message.item
         }
         return responses.map { (traceableMessage, response) ->

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
@@ -63,8 +63,10 @@ fun recordInboundMessagesMetric(message: InboundUnauthenticatedMessage) {
         message.header.subsystem, message::class.java.simpleName)
 }
 
-fun recordInboundSessionMessagesMetric() {
-    recordInboundMessagesMetric(null, null, null, P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
+fun recordInboundSessionMessagesMetric(datapoints: Int = 1) {
+    repeat(datapoints) {
+        recordInboundMessagesMetric(null, null, null, P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
+    }
 }
 
 fun recordInboundHeartbeatMessagesMetric(sourceVnode: HoldingIdentity,


### PR DESCRIPTION
Moving the metrics emission outside the `getMessage` lambda function, so that we can be sure that the right number of data points are recorded regardless of how many times the lambda function is invoked. 