### PR TITLE
CORE-19296 Retain the original error message. Flow Mapper is currently stripping out the error details.

### DIFF
--- a/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/FlowMapperEventExecutorFactoryImpl.kt
+++ b/components/flow/flow-mapper-impl/src/main/kotlin/net/corda/flow/mapper/impl/FlowMapperEventExecutorFactoryImpl.kt
@@ -40,11 +40,12 @@ class FlowMapperEventExecutorFactoryImpl @Activate constructor(
     ): FlowMapperEventExecutor {
         return when (val flowMapperEventPayload = flowMapperEvent.payload) {
             is SessionEvent -> {
-                when (flowMapperEventPayload.payload) {
+                when (val sessionEventPayload = flowMapperEventPayload.payload) {
                     is SessionError -> {
                         SessionErrorExecutor(
                             eventKey,
                             flowMapperEventPayload,
+                            sessionEventPayload,
                             state,
                             flowConfig,
                             recordFactory,


### PR DESCRIPTION
This is obfuscating the real error. This makes it hard to debug what caused a flow to fail.