### PR TITLE
CORE-19316 E2E Test - Add Cluster ready check after Config Update

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/ConfigurationChangeTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/flow/ConfigurationChangeTest.kt
@@ -96,6 +96,9 @@ class ConfigurationChangeTest : ClusterReadiness by ClusterReadinessChecker() {
             logger.info("Wait for the rest-worker to reload the configuration and come back up")
             waitForConfigurationChange(MESSAGING_CONFIG, MAX_ALLOWED_MSG_SIZE, newConfigurationValue.toString(), false)
 
+            //Ensure cluster is ready after Config Update.
+            assertIsReady(Duration.ofMinutes(1), Duration.ofMillis(100))
+
             // Execute some flows which require functionality from different workers and make sure they succeed
             logger.info("Execute some flows which require functionality from different workers and make sure they succeed")
             val flowIds = mutableListOf(


### PR DESCRIPTION
ConfigurationChangeTest initiates a config update request which restarts the workers with new config. Before we run further tests on that cluster, we should ensure that all the workers are up and running. This change adds that cluster ready check in the test, after config has been updated.

CORE-19316