### PR TITLE
CORE-19374: Prevent failed states from being processed in the event mediator

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/GroupAllocator.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/GroupAllocator.kt
@@ -1,7 +1,6 @@
 package net.corda.messaging.mediator
 
 import net.corda.messaging.api.mediator.config.EventMediatorConfig
-import net.corda.messaging.api.records.Record
 import net.corda.messaging.mediator.processor.EventProcessingInput
 import kotlin.math.ceil
 import kotlin.math.min
@@ -46,7 +45,7 @@ class GroupAllocator {
             ceil(events / config.minGroupSize).toInt(),
             config.threads
         )
-        
+
         return List(numGroups) { mutableMapOf() }
     }
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/GroupAllocator.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/GroupAllocator.kt
@@ -2,6 +2,7 @@ package net.corda.messaging.mediator
 
 import net.corda.messaging.api.mediator.config.EventMediatorConfig
 import net.corda.messaging.api.records.Record
+import net.corda.messaging.mediator.processor.EventProcessingInput
 import kotlin.math.ceil
 import kotlin.math.min
 
@@ -21,31 +22,31 @@ class GroupAllocator {
      * @return Records allocated to groups.
      */
     fun <K : Any, S : Any, E : Any> allocateGroups(
-        events: List<Record<K, E>>,
+        events: List<EventProcessingInput<K, E>>,
         config: EventMediatorConfig<K, S, E>
-    ): List<Map<K, List<Record<K, E>>>> {
-        val groups = setUpGroups(config, events)
-        val buckets = events
-            .groupBy { it.key }.toList()
-            .sortedByDescending { it.second.size }
-        
-        buckets.forEach { (key, records) ->
-            val leastFilledGroup = groups.minByOrNull { it.values.flatten().size }
-            leastFilledGroup?.put(key, records)
+    ): List<Map<K, EventProcessingInput<K, E>>> {
+        val eventCount = events.flatMap { it.records }.size.toDouble()
+        val groups = setUpGroups(config, eventCount)
+        val sortedEvents = events.sortedByDescending { it.records.size }
+        sortedEvents.forEach {
+            val leastFilledGroup = groups.minBy { group ->
+                group.flatMap { (_, input) -> input.records }.size
+            }
+            leastFilledGroup[it.key] = it
         }
-        
-        return groups.filter { it.values.isNotEmpty() }
+
+        return groups.filter { it.isNotEmpty() }
     }
 
     private fun <E : Any, S: Any, K : Any> setUpGroups(
         config: EventMediatorConfig<K, S, E>,
-        events: List<Record<K, E>>
-    ): MutableList<MutableMap<K, List<Record<K, E>>>> {
+        events: Double
+    ): List<MutableMap<K, EventProcessingInput<K, E>>> {
         val numGroups = min(
-            ceil(events.size.toDouble() / config.minGroupSize).toInt(),
+            ceil(events / config.minGroupSize).toInt(),
             config.threads
         )
         
-        return MutableList(numGroups) { mutableMapOf() }
+        return List(numGroups) { mutableMapOf() }
     }
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/StateManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/StateManagerHelper.kt
@@ -47,13 +47,19 @@ class StateManagerHelper<S : Any>(
         )
     }
 
+    /**
+     * Marks a state as having failed event mediator processing.
+     *
+     * In the event processing failed for a non-existent state, a new state is created with the metadata key set. This
+     * allows clients to detect issues with any failed processing.
+     */
     fun failStateProcessing(key: String, originalState: State?) : State {
         val newMetadata = (originalState?.metadata?.toMutableMap() ?: mutableMapOf()).also {
             it[PROCESSING_FAILURE] = true
         }
         return State(
             key,
-            byteArrayOf(),
+            originalState?.value ?: byteArrayOf(),
             version = originalState?.version ?: State.VERSION_INITIAL_VALUE,
             metadata = Metadata(newMetadata)
         )

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessingInput.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessingInput.kt
@@ -1,0 +1,10 @@
+package net.corda.messaging.mediator.processor
+
+import net.corda.libs.statemanager.api.State
+import net.corda.messaging.api.records.Record
+
+data class EventProcessingInput<K: Any, E: Any>(
+    val key: K,
+    val records: List<Record<K, E>>,
+    val state: State?
+)

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
@@ -33,21 +33,19 @@ class EventProcessor<K : Any, S : Any, E : Any>(
      * @param retrievedStates states for a group
      */
     fun processEvents(
-        group: Map<K, List<Record<K, E>>>,
-        retrievedStates: Map<String, State>
+        inputs: Map<K, EventProcessingInput<K, E>>
     ): Map<K, EventProcessingOutput> {
-        return group.mapValues { groupEntry ->
-            val groupKey = groupEntry.key.toString()
-            val state = retrievedStates.getOrDefault(groupKey, null)
-            val mediatorState = stateManagerHelper.deserializeMediatorState(state) ?: createNewMediatorState()
+        return inputs.mapValues { (key, input) ->
+            val groupKey = key.toString()
+            val mediatorState = stateManagerHelper.deserializeMediatorState(input.state) ?: createNewMediatorState()
             var processorState = stateManagerHelper.deserializeValue(mediatorState)?.let { stateValue ->
                 StateAndEventProcessor.State(
                     stateValue,
-                    state?.metadata
+                    input.state?.metadata
                 )
             }
             val asyncOutputs = mutableMapOf<Record<K, E>, MutableList<MediatorMessage<Any>>>()
-            val allConsumerInputs = groupEntry.value
+            val allConsumerInputs = input.records
             val processed = try {
                 allConsumerInputs.forEach { consumerInputEvent ->
                     val queue = ArrayDeque(listOf(consumerInputEvent))
@@ -59,23 +57,23 @@ class EventProcessor<K : Any, S : Any, E : Any>(
                             messageRouter.getDestination(it).type == RoutingDestination.Type.SYNCHRONOUS
                         }
                         asyncOutputs.computeIfAbsent(consumerInputEvent) { mutableListOf() }.addAll(asyncEvents)
-                        val returnedMessages = processSyncEvents(groupEntry.key, syncEvents)
+                        val returnedMessages = processSyncEvents(key, syncEvents)
                         queue.addAll(returnedMessages)
                     }
                 }
                 mediatorState.outputEvents = mediatorReplayService.getOutputEvents(mediatorState.outputEvents, asyncOutputs)
-                stateManagerHelper.createOrUpdateState(groupKey, state, mediatorState, processorState)
+                stateManagerHelper.createOrUpdateState(groupKey, input.state, mediatorState, processorState)
             } catch (e: CordaMessageAPIIntermittentException) {
                 // If an intermittent error occurs here, the RPC client has failed to deliver a message to another part
                 // of the system despite the retry loop implemented there. This should trigger individual processing to
                 // fail.
                 asyncOutputs.clear()
-                stateManagerHelper.failStateProcessing(groupKey, state)
+                stateManagerHelper.failStateProcessing(groupKey, input.state)
             }
             val stateChangeAndOperation = when {
-                state == null && processed != null -> StateChangeAndOperation.Create(processed)
-                state != null && processed != null -> StateChangeAndOperation.Update(processed)
-                state != null && processed == null -> StateChangeAndOperation.Delete(state)
+                input.state == null && processed != null -> StateChangeAndOperation.Create(processed)
+                input.state != null && processed != null -> StateChangeAndOperation.Update(processed)
+                input.state != null && processed == null -> StateChangeAndOperation.Delete(input.state)
                 else -> StateChangeAndOperation.Noop
             }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/GroupAllocatorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/GroupAllocatorTest.kt
@@ -99,7 +99,7 @@ class GroupAllocatorTest {
         assertEquals(groupSize.size, groups.size)
 
         groupSize.map {
-            assertEquals(groupSize[it.key], groups[it.key].values.map { it.records }.flatten().size)
+            assertEquals(groupSize[it.key], groups[it.key].values.map { input -> input.records }.flatten().size)
         }
     }
 
@@ -120,7 +120,7 @@ class GroupAllocatorTest {
 
     private fun getIntInputs(recordCountByKey: List<Int>): List<EventProcessingInput<Int, Int>> {
         return recordCountByKey.mapIndexed { index, count ->
-            val records = (0..count).map {value ->
+            val records = (1..count).map {value ->
                 Record(null, index, value)
             }
             EventProcessingInput(index, records, null)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/GroupAllocatorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/GroupAllocatorTest.kt
@@ -8,6 +8,7 @@ import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.mediator.processor.EventProcessingInput
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 
@@ -93,6 +94,14 @@ class GroupAllocatorTest {
         val result = groupAllocator.allocateGroups(records, config)
 
         assertGroupsSize(result, mapOf(0 to 50, 1 to 48))
+    }
+
+    @Test
+    fun `no groups allocated if there are no input events`() {
+        val config = buildTestConfig(2, 20)
+        val records = listOf<EventProcessingInput<Int, Int>>()
+        val result = groupAllocator.allocateGroups(records, config)
+        assertTrue(result.isEmpty())
     }
 
     private fun assertGroupsSize(groups: List<Map<Int, EventProcessingInput<Int, Int>>>, groupSize: Map<Int, Int> ) {

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessorTest.kt
@@ -98,15 +98,19 @@ class ConsumerProcessorTest {
                 RoutingDestination.Type.ASYNCHRONOUS
             )
         )
-        whenever(groupAllocator.allocateGroups<String, String, String>(any(), any())).thenReturn(getGroups(2, 4))
+        whenever(groupAllocator.allocateGroups<String, String, String>(any(), any())).thenReturn(
+            getGroups(2, 4),
+            listOf()
+        )
         whenever(stateManagerHelper.createOrUpdateState(any(), any(), any(), any())).thenReturn(mock())
+        whenever(stateManager.get(any())).thenReturn(mapOf())
 
         consumerProcessor.processTopic(getConsumerFactory(), getConsumerConfig())
 
         verify(consumer, times(1)).poll(any())
         verify(consumerFactory, times(1)).create<String, String>(any())
         verify(consumer, times(1)).subscribe()
-        verify(groupAllocator, times(1)).allocateGroups<String, String, String>(any(), any())
+        verify(groupAllocator, times(2)).allocateGroups<String, String, String>(any(), any())
         verify(taskManager, times(2)).executeShortRunningTask<Unit>(any())
 
         verify(stateManager, times(2)).get(any())
@@ -169,7 +173,7 @@ class ConsumerProcessorTest {
             future
         }
         whenever(stateManagerHelper.failStateProcessing(any(), anyOrNull())).thenReturn(mock())
-        whenever(groupAllocator.allocateGroups<String, String, String>(any(), any())).thenReturn(getGroups(2, 4))
+        whenever(groupAllocator.allocateGroups<String, String, String>(any(), any())).thenReturn(getGroups(2, 4), listOf())
 
         consumerProcessor.processTopic(getConsumerFactory(), getConsumerConfig())
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessorTest.kt
@@ -16,16 +16,15 @@ import net.corda.messaging.api.mediator.config.MediatorConsumerConfig
 import net.corda.messaging.api.mediator.factory.MediatorConsumerFactory
 import net.corda.messaging.api.mediator.factory.MessageRouterFactory
 import net.corda.messaging.api.processor.StateAndEventProcessor
-import net.corda.messaging.api.records.Record
 import net.corda.messaging.getStringRecords
 import net.corda.messaging.mediator.GroupAllocator
 import net.corda.messaging.mediator.MediatorSubscriptionState
 import net.corda.messaging.mediator.StateManagerHelper
 import net.corda.schema.configuration.MessagingConfig
 import net.corda.taskmanager.TaskManager
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
 import org.mockito.kotlin.any
@@ -148,7 +147,9 @@ class ConsumerProcessorTest {
         consumer.apply {
             whenever(poll(any())).thenReturn(listOf(getConsumerRecord()))
         }
-        assertThrows<CordaMessageAPIFatalException> { consumerProcessor.processTopic(consumerFactory, getConsumerConfig()) }
+        assertThrows(CordaMessageAPIFatalException::class.java) {
+            consumerProcessor.processTopic(consumerFactory, getConsumerConfig())
+        }
 
         verify(consumer, times(0)).poll(any())
         verify(consumerFactory, times(1)).create<String, String>(any())
@@ -176,12 +177,12 @@ class ConsumerProcessorTest {
     }
 
 
-    private fun getGroups(groupCount: Int, recordCountPerGroup: Int): List<Map<String, List<Record<String, String>>>> {
-        val groups = mutableListOf<Map<String, List<Record<String, String>>>>()
+    private fun getGroups(groupCount: Int, recordCountPerGroup: Int): List<Map<String, EventProcessingInput<String, String>>> {
+        val groups = mutableListOf<Map<String, EventProcessingInput<String, String>>>()
         for (i in 0 until groupCount) {
             val key = "key$i"
-            val records = getStringRecords(recordCountPerGroup, key)
-            val map = mapOf(key to records)
+            val input = EventProcessingInput(key, getStringRecords(recordCountPerGroup, key), null)
+            val map = mapOf(key to input)
             groups.add(map)
         }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
@@ -75,8 +75,8 @@ class EventProcessorTest {
             }
         }
         whenever(client.send(any())).thenReturn(MediatorMessage(syncMessage))
-
-        eventProcessor.processEvents(mapOf("key" to getStringRecords(1, "key")), mapOf("key" to state))
+        val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), state))
+        eventProcessor.processEvents(input)
 
         verify(stateManagerHelper, times(1)).deserializeValue(any())
         verify(stateAndEventProcessor, times(4)).onNext(anyOrNull(), any())
@@ -97,7 +97,8 @@ class EventProcessorTest {
         whenever(client.send(any())).thenThrow(CordaMessageAPIIntermittentException("baz"))
         whenever(stateManagerHelper.failStateProcessing(any(), anyOrNull())).thenReturn(mock())
 
-        val outputMap = eventProcessor.processEvents(mapOf("key" to getStringRecords(1, "key")), mapOf("key" to state))
+        val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), state))
+        val outputMap = eventProcessor.processEvents(input)
 
         val output = outputMap["key"]
         assertEquals(emptyList<MediatorMessage<Any>>(), output?.asyncOutputs)


### PR DESCRIPTION
### Problem statement

It is possible during event processing for a failure to occur. This will usually happen due to a processing timeout, either in handling a synchronous request or in completing the full event processing. These cases result in the state being marked as processing failed. This occurs even if the state had never been created, as the client may wish to inspect which states failed processing.

In some scenarios this can lead to the state value not containing the expected object type. This leads to a deserialization problem in the event processing code if a new set of events is polled for on the same key.

### Solution

Prevent the processing of events for states that are marked as failed.

To do this, the `ConsumerProcessor` now does some initial filtering to remove any states marked as failed from being eligible for processing, alongside the corresponding events for that state. To that end, a new `EventProcessingInput` class has been defined to make it clearer what actually will get processed. These are generated from the input events and states and provided to the event processor.