### PR TITLE
CORE-19093: Ensure propagation of Tracing Data from E2E test call

### DIFF
--- a/libs/tracing-impl/build.gradle
+++ b/libs/tracing-impl/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(':libs:tracing')
+    implementation project(':libs:utilities')
 
     implementation("io.zipkin.reporter2:zipkin-sender-urlconnection:$zipkinVersion")
     implementation("io.zipkin.brave:brave-context-slf4j:$braveVersion")

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveRecordTracing.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveRecordTracing.kt
@@ -10,18 +10,18 @@ class BraveRecordTracing(private val tracing: Tracing) {
     private val tracer = tracing.tracer()
     private val recordExtractor = BraveRecordExtractor(tracing)
 
-    fun getTraceContext(headers: List<Pair<String, String>>): brave.propagation.TraceContext {
+    fun getTraceContext(headers: List<Pair<String, String>>): brave.propagation.TraceContext? {
         val extracted = recordExtractor.extract(headers)
         return getTraceContext(extracted)
     }
 
-    fun getTraceContext(headers: Map<String, Any>): brave.propagation.TraceContext {
+    fun getTraceContext(headers: Map<String, Any>): brave.propagation.TraceContext? {
         val extracted = recordExtractor.extract(headers)
         return getTraceContext(extracted)
     }
 
-    private fun getTraceContext(extracted: TraceContextOrSamplingFlags?): brave.propagation.TraceContext {
-        return extracted?.context() ?: tracing.currentTraceContext().get()
+    private fun getTraceContext(extracted: TraceContextOrSamplingFlags?): brave.propagation.TraceContext? {
+        return extracted?.context() ?: tracing.currentTraceContext()?.get()
     }
 
     fun nextSpan(record: Record<*, *>): Span {

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTraceContext.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTraceContext.kt
@@ -39,4 +39,7 @@ internal class BraveTraceContext(
     override fun finish() {
         span.finish()
     }
+
+    override val traceIdString: String
+        get() = span.context().traceIdString()
 }

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
@@ -26,6 +26,7 @@ import net.corda.tracing.BatchPublishTracing
 import net.corda.tracing.BatchRecordTracer
 import net.corda.tracing.TraceContext
 import net.corda.tracing.TracingService
+import net.corda.utilities.debug
 import org.eclipse.jetty.servlet.FilterHolder
 import org.slf4j.LoggerFactory
 import zipkin2.Span
@@ -116,7 +117,7 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
         HttpTracing.newBuilder(tracing)
             .serverRequestParser(
                 object : HttpRequestParser.Default() {
-                    override fun spanName(req: HttpRequest?, context: brave.propagation.TraceContext?): String? {
+                    override fun spanName(req: HttpRequest?, context: brave.propagation.TraceContext?): String {
                         return "http server - ${req?.method()} - ${req?.path()}"
                     }
                 }
@@ -153,7 +154,12 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
         traceHeadersToOverrideContext: List<Pair<String, String>>
     ): List<Pair<String, String>> {
         val ctx = recordTracing.getTraceContext(traceHeadersToOverrideContext)
-        return recordInjector.inject(ctx, headers)
+        return if (ctx == null) {
+            logger.debug { "Tracing context is not set" }
+            headers
+        } else {
+            recordInjector.inject(ctx, headers)
+        }
     }
 
     override fun addTraceHeaders(
@@ -161,7 +167,12 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
         traceHeadersToOverrideContext: Map<String, Any>
     ): List<Pair<String, String>> {
         val ctx = recordTracing.getTraceContext(traceHeadersToOverrideContext)
-        return recordInjector.inject(ctx, headers)
+        return if (ctx == null) {
+            logger.debug { "Tracing context is not set" }
+            headers
+        } else {
+            recordInjector.inject(ctx, headers)
+        }
     }
 
     override fun addTraceHeaders(
@@ -169,7 +180,12 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
         traceHeadersToOverrideContext: Map<String, Any>
     ): Map<String, Any> {
         val ctx = recordTracing.getTraceContext(traceHeadersToOverrideContext)
-        return recordInjector.inject(ctx, headers)
+        return if (ctx == null) {
+            logger.debug { "Tracing context is not set" }
+            headers
+        } else {
+            return recordInjector.inject(ctx, headers)
+        }
     }
 
     override fun traceBatch(operationName: String): BatchRecordTracer {

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/TraceContext.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/TraceContext.kt
@@ -14,4 +14,6 @@ interface TraceContext {
     fun errorAndFinish(e: Exception)
 
     fun finish()
+
+    val traceIdString: String
 }

--- a/libs/tracing/src/main/kotlin/net/corda/tracing/impl/NoopTracingService.kt
+++ b/libs/tracing/src/main/kotlin/net/corda/tracing/impl/NoopTracingService.kt
@@ -11,6 +11,9 @@ import java.util.concurrent.ExecutorService
 class NoopTracingService : TracingService {
 
     class NoopTraceContext : TraceContext {
+
+        override val traceIdString = "Noop traceId"
+
         override fun traceTag(key: String, value: String) {
         }
 

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -30,4 +30,7 @@ dependencies {
     implementation project(':tools:plugins:package')
     implementation project(":testing:packaging-test-utilities")
     implementation project(':testing:test-utilities')
+
+    implementation project(':libs:tracing')
+    runtimeOnly project(':libs:tracing-impl')
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -2,10 +2,12 @@ package net.corda.e2etest.utilities
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import net.corda.rest.annotations.RestApiVersion
+import net.corda.tracing.configureTracing
+import net.corda.tracing.trace
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
-import java.net.URI
 import java.nio.file.Paths
 import java.time.Instant
 
@@ -16,27 +18,18 @@ import java.time.Instant
  *  the json for the expected results.
  */
 @Suppress("TooManyFunctions")
-class ClusterBuilder {
+class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String) {
 
     internal companion object {
-        var REST_API_VERSION_PATH = ""
-    }
-
-    private var client: HttpsClient? = null
-
-    private fun endpoint(uri: URI, username: String, password: String) {
-        client = UnirestHttpsClient(uri, username, password)
-    }
-
-    fun init(
-        clusterInfo: ClusterInfo,
-        apiVersion: String,
-    ) {
-        REST_API_VERSION_PATH = apiVersion
-        with(clusterInfo.rest) {
-            endpoint(uri, user, password)
+        init {
+            configureTracing("E2eClusterTracing", null, null)
         }
     }
+
+    private val logger = LoggerFactory.getLogger("ClusterBuilder - ${clusterInfo.id}")
+
+    private val client: HttpsClient =
+        UnirestHttpsClient(clusterInfo.rest.uri, clusterInfo.rest.user, clusterInfo.rest.password)
 
     data class VNodeCreateBody(
         val cpiFileChecksum: String,
@@ -69,13 +62,13 @@ class ClusterBuilder {
 
 
     /** POST, but most useful for running flows */
-    fun post(cmd: String, body: String) = client!!.post(cmd, body)
+    fun post(cmd: String, body: String) = client.post(cmd, body)
 
-    fun put(cmd: String, body: String) = client!!.put(cmd, body)
+    fun put(cmd: String, body: String) = client.put(cmd, body)
 
-    fun get(cmd: String) = client!!.get(cmd)
+    fun get(cmd: String) = client.get(cmd)
 
-    fun delete(cmd: String) = client!!.delete(cmd)
+    fun delete(cmd: String) = client.delete(cmd)
 
     private fun uploadCpiResource(
         cmd: String,
@@ -85,14 +78,14 @@ class ClusterBuilder {
         cpiVersion: String
     ): SimpleResponse {
         return CpiLoader.get(cpbResourceName, groupPolicy, cpiName, cpiVersion).use {
-            client!!.postMultiPart(cmd, emptyMap(), mapOf("upload" to HttpsClientFileUpload(it, cpiName)))
+            client.postMultiPart(cmd, emptyMap(), mapOf("upload" to HttpsClientFileUpload(it, cpiName)))
         }
     }
 
     private fun uploadUnmodifiedResource(cmd: String, resourceName: String): SimpleResponse {
         val fileName = Paths.get(resourceName).fileName.toString()
         return CpiLoader.getRawResource(resourceName).use {
-            client!!.postMultiPart(cmd, emptyMap(), mapOf("upload" to HttpsClientFileUpload(it, fileName)))
+            client.postMultiPart(cmd, emptyMap(), mapOf("upload" to HttpsClientFileUpload(it, fileName)))
         }
     }
 
@@ -111,7 +104,7 @@ class ClusterBuilder {
     private fun InputStream.uploadCertificateInputStream(
         cmd: String, alias: String, fileName: String
     ) = use {
-        client!!.putMultiPart(
+        client.putMultiPart(
             cmd,
             mapOf("alias" to alias),
             mapOf("certificate" to HttpsClientFileUpload(it, fileName))
@@ -129,6 +122,7 @@ class ClusterBuilder {
             alias,
         )
 
+    @Suppress("unused")
     // Used to test RestApiVersion.C5_0 CertificateRestResource from 5.1 cluster, remove after LTS
     fun deprecatedImportCertificate(resourceName: String, usage: String, alias: String) =
         uploadCertificateResource(
@@ -138,8 +132,8 @@ class ClusterBuilder {
         )
 
     /**
-     * If [holdingIdentity] is not specified, it will be uploaded as a cluster-level certificate.
-     * If [holdingIdentity] is specified, it will be uploaded as a vnode-level certificate under the specified vnode.
+     * If [holdingIdentityId] is not specified, it will be uploaded as a cluster-level certificate.
+     * If [holdingIdentityId] is specified, it will be uploaded as a vnode-level certificate under the specified vnode.
      */
     fun importCertificate(file: File, usage: String, alias: String, holdingIdentityId: String?): SimpleResponse {
         return if (holdingIdentityId == null) {
@@ -164,7 +158,7 @@ class ClusterBuilder {
         )
 
     fun getCertificateChain(usage: String, alias: String) =
-        client!!.get("/api/$REST_API_VERSION_PATH/${REST_API_VERSION_PATH.certificatePath()}/cluster/$usage/$alias")
+        client.get("/api/$REST_API_VERSION_PATH/${REST_API_VERSION_PATH.certificatePath()}/cluster/$usage/$alias")
 
     /**
      * Returns the correct path for certificate rest resource based on the rest api version we use.
@@ -176,6 +170,7 @@ class ClusterBuilder {
             "certificate"
         }
 
+    @Suppress("unused")
     /** Assumes the resource *is* a CPB */
     fun cpbUpload(resourceName: String) = uploadUnmodifiedResource("/api/$REST_API_VERSION_PATH/cpi/", resourceName)
 
@@ -213,9 +208,11 @@ class ClusterBuilder {
         cpiVersion: String = "1.0.0.0-SNAPSHOT"
     ) = uploadCpiResource("/api/$REST_API_VERSION_PATH/cpi/", cpbResourceName, groupPolicy, cpiName, cpiVersion)
 
+    @Suppress("unused")
     fun updateVirtualNodeState(holdingIdHash: String, newState: String) =
         put("/api/$REST_API_VERSION_PATH/virtualnode/$holdingIdHash/state/$newState", "")
 
+    @Suppress("unused")
     /** Assumes the resource is a CPB and converts it to CPI by adding a group policy file */
     fun forceCpiUpload(
         cpbResourceName: String?,
@@ -232,15 +229,16 @@ class ClusterBuilder {
             cpiVersion
         )
 
+    @Suppress("unused")
     /** Assumes the resource is a CPB and converts it to CPI by adding a group policy file */
     fun syncVirtualNode(virtualNodeShortId: String) =
         post("/api/$REST_API_VERSION_PATH/maintenance/virtualnode/$virtualNodeShortId/vault-schema/force-resync", "")
 
     /** Return the status for the given request id */
-    fun cpiStatus(id: String) = client!!.get("/api/$REST_API_VERSION_PATH/cpi/status/$id")
+    fun cpiStatus(id: String) = client.get("/api/$REST_API_VERSION_PATH/cpi/status/$id")
 
     /** List all CPIs in the system */
-    fun cpiList() = client!!.get("/api/$REST_API_VERSION_PATH/cpi")
+    fun cpiList() = client.get("/api/$REST_API_VERSION_PATH/cpi")
 
     @Suppress("LongParameterList")
     private fun vNodeBody(
@@ -304,7 +302,7 @@ class ClusterBuilder {
         val context = (mapOf(
             "corda.key.scheme" to "CORDA.ECDSA.SECP256R1",
             "corda.roles.0" to "notary",
-            "corda.notary.service.name" to "$notaryServiceName",
+            "corda.notary.service.name" to notaryServiceName,
             "corda.notary.service.flow.protocol.name" to "com.r3.corda.notary.plugin.$notaryPlugin",
             "corda.notary.service.flow.protocol.version.0" to "1",
             "corda.notary.service.backchain.required" to "$isBackchainRequiredNotary"
@@ -342,12 +340,14 @@ class ClusterBuilder {
         return body.joinToString(prefix = "{", postfix = "}")
     }
 
+    @Suppress("unused")
     fun changeUserPasswordSelf(password: String) =
         post(
             "/api/$REST_API_VERSION_PATH/user/selfpassword",
             """{"password": "$password"}"""
         )
 
+    @Suppress("unused")
     fun changeUserPasswordOther(username: String, password: String) =
         post(
             "/api/$REST_API_VERSION_PATH/user/otheruserpassword",
@@ -392,18 +392,22 @@ class ClusterBuilder {
         return "{$bodyStr1$bodyStr2}"
     }
 
+    @Suppress("unused")
     /** Get schema SQL to create crypto DB */
     fun getCryptoSchemaSql() =
         get("/api/$REST_API_VERSION_PATH/virtualnode/create/db/crypto")
 
+    @Suppress("unused")
     /** Get schema SQL to create uniqueness DB */
     fun getUniquenessSchemaSql() =
         get("/api/$REST_API_VERSION_PATH/virtualnode/create/db/uniqueness")
 
+    @Suppress("unused")
     /** Get schema SQL to create vault and CPI DB */
     fun getVaultSchemaSql(cpiChecksum: String) =
         get("/api/$REST_API_VERSION_PATH/virtualnode/create/db/vault/$cpiChecksum")
 
+    @Suppress("unused")
     /** Get schema SQL to update vault and CPI DB */
     fun getUpdateSchemaSql(virtualNodeShortHash: String, newCpiChecksum: String) =
         get("/api/$REST_API_VERSION_PATH/virtualnode/$virtualNodeShortHash/db/vault/$newCpiChecksum")
@@ -429,7 +433,7 @@ class ClusterBuilder {
             )
         )
 
-    @Suppress("LongParameterList")
+    @Suppress("LongParameterList", "unused")
     fun vNodeChangeConnectionStrings(
         holdingIdShortHash: String,
         externalDBConnectionParams: ExternalDBConnectionParams? = null
@@ -447,26 +451,29 @@ class ClusterBuilder {
         )
 
 
+    @Suppress("unused")
     /** Trigger upgrade of a virtual node's CPI to the given  */
     fun vNodeUpgrade(virtualNodeShortHash: String, targetCpiFileChecksum: String) =
         put("/api/$REST_API_VERSION_PATH/virtualnode/$virtualNodeShortHash/cpi/$targetCpiFileChecksum", "")
 
+    @Suppress("unused")
     fun getVNodeOperationStatus(requestId: String) =
         get("/api/$REST_API_VERSION_PATH/virtualnode/status/$requestId")
 
     /** List all virtual nodes */
-    fun vNodeList() = client!!.get("/api/$REST_API_VERSION_PATH/virtualnode")
+    fun vNodeList() = client.get("/api/$REST_API_VERSION_PATH/virtualnode")
 
     /** List all virtual nodes */
     fun getVNode(holdingIdentityShortHash: String) =
-        client!!.get("/api/$REST_API_VERSION_PATH/virtualnode/$holdingIdentityShortHash")
+        client.get("/api/$REST_API_VERSION_PATH/virtualnode/$holdingIdentityShortHash")
 
-    fun getVNodeStatus(requestId: String) = client!!.get("/api/$REST_API_VERSION_PATH/virtualnode/status/$requestId")
+    fun getVNodeStatus(requestId: String) = client.get("/api/$REST_API_VERSION_PATH/virtualnode/status/$requestId")
 
     /**
      * Register a member to the network.
      *
-     * Optional: Use [customMetadata] to specify custom properties which will be added to the member's [MemberInfo].
+     * Optional: Use [customMetadata] to specify custom properties which will be added to the member's
+     * [net.corda.v5.membership.MemberInfo].
      * Keys of properties specified in [customMetadata] must have the prefix "ext.".
      *
      * KNOWN LIMITATION: Registering a notary static member will currently always provision a new
@@ -572,6 +579,7 @@ class ClusterBuilder {
     fun runnableFlowClasses(holdingIdentityShortHash: String) =
         get("/api/$REST_API_VERSION_PATH/flowclass/$holdingIdentityShortHash")
 
+    @Suppress("unused")
     /** Create a new RBAC role */
     fun createRbacRole(roleName: String, groupVisibility: String? = null) =
         post("/api/$REST_API_VERSION_PATH/role", createRbacRoleBody(roleName, groupVisibility))
@@ -579,11 +587,12 @@ class ClusterBuilder {
     /** Get all RBAC roles */
     fun getRbacRoles() = get("/api/$REST_API_VERSION_PATH/role")
 
+    @Suppress("unused")
     /** Get a role for a specified ID */
     fun getRole(roleId: String) = get("/api/$REST_API_VERSION_PATH/role/$roleId")
 
     /** Create new RBAC user */
-    @Suppress("LongParameterList")
+    @Suppress("LongParameterList", "unused")
     fun createRbacUser(
         enabled: Boolean,
         fullName: String,
@@ -597,22 +606,27 @@ class ClusterBuilder {
             createRbacUserBody(enabled, fullName, password, loginName, parentGroup, passwordExpiry)
         )
 
+    @Suppress("unused")
     /** Get an RBAC user for a specific login name */
     fun getRbacUser(loginName: String) =
         get("/api/$REST_API_VERSION_PATH/user/$loginName")
 
+    @Suppress("unused")
     /** Assign a specified role to a specified user */
     fun assignRoleToUser(loginName: String, roleId: String) =
         put("/api/$REST_API_VERSION_PATH/user/$loginName/role/$roleId", "")
 
+    @Suppress("unused")
     /** Remove the specified role from a specified user */
     fun removeRoleFromUser(loginName: String, roleId: String) =
         delete("/api/$REST_API_VERSION_PATH/user/$loginName/role/$roleId")
 
+    @Suppress("unused")
     /** Get a summary of the user's permissions */
     fun getPermissionSummary(loginName: String) =
         get("/api/$REST_API_VERSION_PATH/user/$loginName/permissionsummary")
 
+    @Suppress("unused")
     /** Create a new permission */
     fun createPermission(
         permissionString: String,
@@ -625,6 +639,7 @@ class ClusterBuilder {
             createPermissionBody(permissionString, permissionType, groupVisibility, virtualNode)
         )
 
+    @Suppress("unused")
     /** Create a set of permissions and optionally assigns them to existing roles */
     fun createBulkPermissions(
         permissionsToCreate: Set<Pair<String, String>>,
@@ -632,6 +647,7 @@ class ClusterBuilder {
     ) =
         post("/api/$REST_API_VERSION_PATH/permission/bulk", createBulkPermissionsBody(permissionsToCreate, roleIds))
 
+    @Suppress("unused")
     /** Get the permissions which satisfy the query */
     fun getPermissionByQuery(
         limit: Int,
@@ -645,14 +661,17 @@ class ClusterBuilder {
         return get("/api/$REST_API_VERSION_PATH/permission$queryStr")
     }
 
+    @Suppress("unused")
     /** Get the permission associated with a specific ID */
     fun getPermissionById(permissionId: String) =
         get("/api/$REST_API_VERSION_PATH/permission/$permissionId")
 
+    @Suppress("unused")
     /** Add the specified permission to the specified role */
     fun assignPermissionToRole(roleId: String, permissionId: String) =
         put("/api/$REST_API_VERSION_PATH/role/$roleId/permission/$permissionId", "")
 
+    @Suppress("unused")
     /** Remove the specified permission from the specified role */
     fun removePermissionFromRole(roleId: String, permissionId: String) =
         delete("/api/$REST_API_VERSION_PATH/role/$roleId/permission/$permissionId")
@@ -664,10 +683,16 @@ class ClusterBuilder {
         flowClassName: String,
         requestData: String
     ): SimpleResponse {
-        return post(
-            "/api/$REST_API_VERSION_PATH/flow/$holdingIdentityShortHash",
-            flowStartBody(clientRequestId, flowClassName, requestData)
-        )
+        return trace("flowStart") {
+            traceVirtualNodeId(holdingIdentityShortHash)
+            traceRequestId(clientRequestId)
+            logger.info("Sending flowStart, vNode: '$holdingIdentityShortHash', " +
+                    "clientRequestId: '$clientRequestId', traceId: '$traceIdString'")
+            post(
+                "/api/$REST_API_VERSION_PATH/flow/$holdingIdentityShortHash",
+                flowStartBody(clientRequestId, flowClassName, requestData)
+            )
+        }
     }
 
     private fun flowStartBody(clientRequestId: String, flowClassName: String, requestData: String) =
@@ -767,4 +792,4 @@ fun <T> cluster(
 
 fun <T> ClusterInfo.cluster(
     initialize: ClusterBuilder.() -> T
-): T = ClusterBuilder().apply { init(this@cluster, restApiVersion.versionPath) }.let(initialize)
+): T = ClusterBuilder(this, restApiVersion.versionPath).let(initialize)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -45,7 +45,7 @@ const val DEFAULT_NOTARY_SERVICE = "O=NotaryService, L=London, C=GB"
  *
  * @param cpb The path to the CPB to use when creating the CPI.
  * @param cpiName The name to be used for the CPI.
- * @param mgm The details of the MGM.
+ * @param groupPolicyFactory [GroupPolicyFactory] to be used.
  * @param x500Name The X500 name of the onboarding member.
  * @param waitForApproval Boolean flag to indicate whether the function should wait and assert for approved status.
  *  Defaults to true.
@@ -121,6 +121,7 @@ fun ClusterInfo.onboardMember(
     return NetworkOnboardingMetadata(holdingId, x500Name, registrationId, registrationContext, this)
 }
 
+@Suppress("unused")
 /**
  * Register a member who has registered previously using the [NetworkOnboardingMetadata] from the previous registration
  * for the cluster connection details and for the member identifier.
@@ -388,12 +389,13 @@ fun ClusterInfo.lookup(
         interval(1.seconds)
         command {
             val additionalQuery = statuses.joinToString(prefix = "?", separator = "&") { "statuses=$it" }
-            get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/members/$holdingId$additionalQuery")
+            get("/api/$REST_API_VERSION_PATH/members/$holdingId$additionalQuery")
         }
         condition { it.code == ResponseCode.OK.statusCode }
     }
 }
 
+@Suppress("unused")
 /**
  * Look up the current group parameters as viewed on a specific cluster by a specific holding ID.
  */
@@ -404,7 +406,7 @@ fun ClusterInfo.lookupGroupParameters(
         timeout(15.seconds)
         interval(1.seconds)
         command {
-            get("/api/${ClusterBuilder.REST_API_VERSION_PATH}/members/$holdingId/group-parameters")
+            get("/api/$REST_API_VERSION_PATH/members/$holdingId/group-parameters")
         }
         condition { it.code == ResponseCode.OK.statusCode }
     }


### PR DESCRIPTION
After the change on E2E test side:

```
16:36:44.453 [ForkJoinPool-1-worker-1] INFO  ClusterBuilder - B - Sending flowStart, vNode: 'A80B3DD2BBB9', clientRequestId: 'start_REST_flow-0', traceId: '65aaa51ce9a9d64190760b1fae7391dc'
```

On the cluster side:

```
2024-01-19 16:36:44.469 [qtp1411078979-2168] INFO  net.corda.rest.server.impl.context.ContextUtils.POST {http.method=POST, http.path=/api/v5_2/flow/A80B3DD2BBB9, http.user=admin, request_id=start_REST_flow-0, spanId=f89e8b77a1fd20d5, traceId=65aaa51ce9a9d64190760b1fae7391dc} - Servicing POST request to '/api/v5_2/flow/A80B3DD2BBB9' and invoking  method "startFlow"
2024-01-19 16:36:44.629 [qtp1411078979-2168] INFO  net.corda.rest.server.impl.context.ContextUtils.GET {http.method=GET, http.path=/api/v5_2/flow/A80B3DD2BBB9/start_REST_flow-0/result, http.user=admin, spanId=363a56e06d18d560, traceId=65aaa51c9daa9eac363a56e06d18d560} - Servicing GET request to '/api/v5_2/flow/A80B3DD2BBB9/start_REST_flow-0/result' and invoking  method "getFlowResult"
2024-01-19 16:36:44.630 [qtp1411078979-2168] INFO  net.corda.rest.server.impl.context.ContextUtils.GET {http.method=GET, http.path=/api/v5_2/flow/A80B3DD2BBB9/start_REST_flow-0/result, http.user=admin, spanId=363a56e06d18d560, traceId=65aaa51c9daa9eac363a56e06d18d560} - Error invoking path '/api/v5_2/flow/{holdingidentityshorthash}/{clientrequestid}/result' - Failed to find the flow status for holdingId = A80B3DD2BBB9 and clientRequestId = start_REST_flow-0.
2024-01-19 16:36:45.097 [flow-event-mediator-thread-0] INFO  net.corda.flow.pipeline.handlers.events.StartFlowEventHandler {corda.client.id=start_REST_flow-0, flow.id=1238ac04-e1be-4f37-b9f2-fbf1298b8834, request_id=start_REST_flow-0, spanId=256f77655fbcca17, traceId=65aaa51ce9a9d64190760b1fae7391dc, vnode.id=A80B3DD2BBB9} - Flow [1238ac04-e1be-4f37-b9f2-fbf1298b8834] started
```

I.e. `traceId` is correctly retained and can be matched to the actual E2E test executed.

This PR also includes few renames and simplifications. There should be no changes to the external API we supply to the E2E tests driver.