### PR TITLE
CORE-18863: Helm Schema Changes 4 State Isolation

### DIFF
--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -977,7 +977,7 @@
                 "tokenPoolCache": {
                     "type": "object",
                     "$ref": "#/$defs/stateTypePersistentStorageMapping",
-                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'keyRotation' states"
+                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'tokenPoolCache' states"
                 }
             }
         },
@@ -1429,7 +1429,6 @@
                             "type": "array",
                             "title": "Administrator credentials per database, used to configure users/roles and grant required runtime permissions",
                             "items": {
-                                "type": "array",
                                 "$ref": "#/$defs/databaseTemplate"
                             }
                         }
@@ -3958,10 +3957,10 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "default": "DATABASE",
+                    "default": "Database",
                     "title": "The type of the persistent storage used by the State Manager instance",
                     "enum": [
-                        "DATABASE"
+                        "Database"
                     ]
                 },
                 "storageId": {
@@ -3989,10 +3988,10 @@
             "properties": {
                 "type": {
                     "type": "string",
-                    "default": "DATABASE",
+                    "default": "Database",
                     "title": "The type of the persistent storage used by the State Manager instance",
                     "enum": [
-                        "DATABASE"
+                        "Database"
                     ]
                 },
                 "username": {
@@ -4020,7 +4019,7 @@
             "if": {
                 "properties": {
                     "type": {
-                        "const": "DATABASE"
+                        "const": "Database"
                     }
                 }
             },

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -953,7 +953,6 @@
             "title": "Persistent Storage configuration for each State Type managed by the State Manager within the Platform",
             "required": [
                 "flowCheckpoint",
-                "flowStatus",
                 "flowMapping",
                 "keyRotation",
                 "tokenPoolCache"
@@ -964,11 +963,6 @@
                     "type": "object",
                     "$ref": "#/$defs/stateTypePersistentStorageMapping",
                     "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'flowCheckpoint' states"
-                },
-                "flowStatus": {
-                    "type": "object",
-                    "$ref": "#/$defs/stateTypePersistentStorageMapping",
-                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'flowStatus' states"
                 },
                 "flowMapping": {
                     "type": "object",
@@ -1968,7 +1962,7 @@
                                 "resources": {},
                                 "kafka": {},
                                 "stateManager": {
-                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'flowCheckpoint' + 'flowStatus' only.",
+                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'flowCheckpoint' only.",
                                     "oneOf": [
                                         {
                                             "$ref": "#/$defs/stateManager"
@@ -1976,16 +1970,11 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "flowCheckpoint",
-                                                "flowStatus"
+                                                "flowCheckpoint"
                                             ],
                                             "additionalProperties": false,
                                             "properties": {
                                                 "flowCheckpoint": {
-                                                    "type": "object",
-                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
-                                                },
-                                                "flowStatus": {
                                                     "type": "object",
                                                     "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
                                                 }
@@ -2219,7 +2208,7 @@
                                 "resources": {},
                                 "kafka": {},
                                 "stateManager": {
-                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'flowStatus' + 'keyRotation' only.",
+                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'keyRotation' only.",
                                     "oneOf": [
                                         {
                                             "$ref": "#/$defs/stateManager"
@@ -2227,15 +2216,10 @@
                                         {
                                             "type": "object",
                                             "required": [
-                                                "flowStatus",
                                                 "keyRotation"
                                             ],
                                             "additionalProperties": false,
                                             "properties": {
-                                                "flowStatus": {
-                                                    "type": "object",
-                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
-                                                },
                                                 "keyRotation": {
                                                     "type": "object",
                                                     "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -955,6 +955,7 @@
                 "flowCheckpoint",
                 "flowMapping",
                 "keyRotation",
+                "p2pSession",
                 "tokenPoolCache"
             ],
             "additionalProperties": false,
@@ -973,6 +974,11 @@
                     "type": "object",
                     "$ref": "#/$defs/stateTypePersistentStorageMapping",
                     "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'keyRotation' states"
+                },
+                "p2pSession": {
+                    "type": "object",
+                    "$ref": "#/$defs/stateTypePersistentStorageMapping",
+                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'peerToPeerSession' states"
                 },
                 "tokenPoolCache": {
                     "type": "object",
@@ -2475,7 +2481,25 @@
                                 "resources": {},
                                 "kafka": {},
                                 "stateManager": {
-                                    "$ref": "#/$defs/stateManager"
+                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'p2pSession' only.",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/$defs/stateManager"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "p2pSession"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "p2pSession": {
+                                                    "type": "object",
+                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
+                                                }
+                                            }
+                                        }
+                                    ]
                                 }
                             },
                             "examples": [

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -5,6 +5,7 @@
     "default": {},
     "title": "Corda helm chart schema",
     "additionalProperties": false,
+    "$comment": "TODO-[CORE-19372]: make 'databases' and 'stateManager' required",
     "required": [
         "db",
         "kafka"
@@ -698,6 +699,7 @@
             }]
         },
         "db": {
+            "$comment": "TODO-[CORE-19372]: should we replace this by the new 'databases' instead?.",
             "type": "object",
             "default": {},
             "title": "cluster database configuration",
@@ -736,13 +738,8 @@
                             ]
                         },
                         "type": {
-                            "type": "string",
-                            "default": "postgresql",
-                            "title": "the cluster database type",
-                            "examples": [
-                                "postgresql"
-                            ],
-                            "enum": ["postgresql"]
+                            "$ref": "#/$defs/databaseEngine",
+                            "title": "the cluster database type"
                         },
                         "port": {
                             "type": "integer",
@@ -950,6 +947,73 @@
                 }
             }
         },
+        "stateManager": {
+            "type": "object",
+            "default": {},
+            "title": "Persistent Storage configuration for each State Type managed by the State Manager within the Platform",
+            "required": [
+                "flowCheckpoint",
+                "flowStatus",
+                "flowMapping",
+                "keyRotation",
+                "tokenPoolCache"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "flowCheckpoint": {
+                    "type": "object",
+                    "$ref": "#/$defs/stateTypePersistentStorageMapping",
+                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'flowCheckpoint' states"
+                },
+                "flowStatus": {
+                    "type": "object",
+                    "$ref": "#/$defs/stateTypePersistentStorageMapping",
+                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'flowStatus' states"
+                },
+                "flowMapping": {
+                    "type": "object",
+                    "$ref": "#/$defs/stateTypePersistentStorageMapping",
+                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'flowMapping' states"
+                },
+                "keyRotation": {
+                    "type": "object",
+                    "$ref": "#/$defs/stateTypePersistentStorageMapping",
+                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'keyRotation' states"
+                },
+                "tokenPoolCache": {
+                    "type": "object",
+                    "$ref": "#/$defs/stateTypePersistentStorageMapping",
+                    "title": "Persistent Storage configuration to be used by the State Manager when dealing with 'keyRotation' states"
+                }
+            }
+        },
+        "databases": {
+            "type": "array",
+            "minItems": 1,
+            "title": "List of databases uses by the platform",
+            "items": {
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/$defs/databaseTemplate"
+                    }
+                ],
+                "required": [
+                    "host",
+                    "port",
+                    "type"
+                ]
+            },
+            "contains": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "const": "default"
+                    }
+                }
+            }
+        },
         "bootstrap": {
             "type": "object",
             "default": {},
@@ -1038,7 +1102,61 @@
                         "enabled"
                     ],
                     "additionalProperties": false,
+                    "$comment": "TODO-[CORE-19372]: should we replace 'cluster', 'crypto' and 'rbac' by the new 'databases' section instead?.",
                     "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": true,
+                            "title": "indicates whether DB bootstrap is enabled as part of installation",
+                            "examples": [
+                                true,
+                                false
+                            ]
+                        },
+                        "clientImage": {
+                            "type": "object",
+                            "default": {},
+                            "title": "db client image",
+                            "required": [
+                                "registry",
+                                "repository",
+                                "tag"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "registry": {
+                                    "type": "string",
+                                    "default": "",
+                                    "title": "registry for image containing a db client, used to set up the db",
+                                    "examples": [
+                                        "docker.io"
+                                    ]
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "default": "postgres",
+                                    "title": "repository for image containing a db client, used to set up the db",
+                                    "examples": [
+                                        "postgres"
+                                    ],
+                                    "minLength": 1
+                                },
+                                "tag": {
+                                    "type": "string",
+                                    "default": "14.4",
+                                    "title": "tag for image containing a db client, used to set up the db",
+                                    "examples": [
+                                        "14.4"
+                                    ],
+                                    "minLength": 1
+                                }
+                            },
+                            "examples": [{
+                                "registry": "docker.io",
+                                "repository": "postgres",
+                                "tag": "14.4"
+                            }]
+                        },
                         "cluster": {
                             "type": "object",
                             "default": {},
@@ -1064,15 +1182,6 @@
                                     "value": "username"
                                 }
                             }]
-                        },
-                        "enabled": {
-                            "type": "boolean",
-                            "default": true,
-                            "title": "indicates whether DB bootstrap is enabled as part of installation",
-                            "examples": [
-                                true,
-                                false
-                            ]
                         },
                         "crypto": {
                             "type": "object",
@@ -1277,6 +1386,7 @@
                             }]
                         },
                         "stateManager": {
+                            "$comment": "TODO-[CORE-19372]: remove the entire 'stateManager' section",
                             "flow": {
                                 "allOf": [
                                     {
@@ -1320,49 +1430,13 @@
                                 ]
                             }
                         },
-                        "clientImage": {
-                            "type": "object",
-                            "default": {},
-                            "title": "db client image",
-                            "required": [
-                                "registry",
-                                "repository",
-                                "tag"
-                            ],
-                            "additionalProperties": false,
-                            "properties": {
-                                "registry": {
-                                    "type": "string",
-                                    "default": "",
-                                    "title": "registry for image containing a db client, used to set up the db",
-                                    "examples": [
-                                        "docker.io"
-                                    ]
-                                },
-                                "repository": {
-                                    "type": "string",
-                                    "default": "postgres",
-                                    "title": "repository for image containing a db client, used to set up the db",
-                                    "examples": [
-                                        "postgres"
-                                    ],
-                                    "minLength": 1
-                                },
-                                "tag": {
-                                    "type": "string",
-                                    "default": "14.4",
-                                    "title": "tag for image containing a db client, used to set up the db",
-                                    "examples": [
-                                        "14.4"
-                                    ],
-                                    "minLength": 1
-                                }
-                            },
-                            "examples": [{
-                                "registry": "docker.io",
-                                "repository": "postgres",
-                                "tag": "14.4"
-                            }]
+                        "databases": {
+                            "type": "array",
+                            "title": "Administrator credentials per database, used to configure users/roles and grant required runtime permissions",
+                            "items": {
+                                "type": "array",
+                                "$ref": "#/$defs/databaseTemplate"
+                            }
                         }
                     },
                     "examples": [{
@@ -1665,8 +1739,8 @@
                         {
                             "additionalProperties": false,
                             "required": [
-                                "clusterDbConnectionPool",
-                                "stateManager"
+                                "stateManager",
+                                "clusterDbConnectionPool"
                             ],
                             "properties": {
                                 "image": {},
@@ -1679,7 +1753,25 @@
                                 "resources": {},
                                 "kafka": {},
                                 "stateManager": {
-                                    "$ref": "#/$defs/stateManager"
+                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'keyRotation' only.",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/$defs/stateManager"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "keyRotation"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "keyRotation": {
+                                                    "type": "object",
+                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
+                                                }
+                                            }
+                                        }
+                                    ]
                                 },
                                 "clusterDbConnectionPool": {
                                     "type": "object",
@@ -1875,7 +1967,30 @@
                                 "resources": {},
                                 "kafka": {},
                                 "stateManager": {
-                                    "$ref": "#/$defs/stateManager"
+                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'flowCheckpoint' + 'flowStatus' only.",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/$defs/stateManager"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "flowCheckpoint",
+                                                "flowStatus"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "flowCheckpoint": {
+                                                    "type": "object",
+                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
+                                                },
+                                                "flowStatus": {
+                                                    "type": "object",
+                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
+                                                }
+                                            }
+                                        }
+                                    ]
                                 },
                                 "verifyInstrumentation": {
                                     "type": "boolean",
@@ -1938,8 +2053,26 @@
                                 "profiling": {},
                                 "resources": {},
                                 "kafka": {},
-                                "stateManager" : {
-                                    "$ref": "#/$defs/stateManager"
+                                "stateManager": {
+                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'flowMapping' only.",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/$defs/stateManager"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "flowMapping"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "flowMapping": {
+                                                    "type": "object",
+                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
+                                                }
+                                            }
+                                        }
+                                    ]
                                 },
                                 "verifyInstrumentation": {
                                     "type": "boolean",
@@ -2084,8 +2217,31 @@
                                 "profiling": {},
                                 "resources": {},
                                 "kafka": {},
-                                "stateManager" : {
-                                    "$ref": "#/$defs/stateManager"
+                                "stateManager": {
+                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'flowStatus' + 'keyRotation' only.",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/$defs/stateManager"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "flowStatus",
+                                                "keyRotation"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "flowStatus": {
+                                                    "type": "object",
+                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
+                                                },
+                                                "keyRotation": {
+                                                    "type": "object",
+                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
+                                                }
+                                            }
+                                        }
+                                    ]
                                 },
                                 "service": {
                                     "type": "object",
@@ -2631,7 +2787,25 @@
                                 "profiling": {},
                                 "resources": {},
                                 "stateManager": {
-                                    "$ref": "#/$defs/stateManager"
+                                    "$comment": "TODO-[CORE-19372]: remove the condition and leave 'tokenPoolCache' only.",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/$defs/stateManager"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "required": [
+                                                "tokenPoolCache"
+                                            ],
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "tokenPoolCache": {
+                                                    "type": "object",
+                                                    "$ref": "#/$defs/stateManagerRuntimeConnectionSettings"
+                                                }
+                                            }
+                                        }
+                                    ]
                                 },
                                 "kafka": {},
                                 "sharding": {
@@ -3572,11 +3746,19 @@
                 }
             }
         },
+        "databaseEngine": {
+            "type": "string",
+            "default": "postgresql",
+            "title": "The Database Engine Type",
+            "enum": [
+                "postgresql"
+            ]
+        },
         "stateManager": {
             "type": "object",
             "default": {},
             "title": "State Manager configuration",
-            "additionalProperties": true,
+            "additionalProperties": false,
             "properties": {
                 "type": {
                     "type": "string",
@@ -3616,13 +3798,7 @@
                             ]
                         },
                         "type": {
-                            "type": "string",
-                            "default": "postgresql",
-                            "title": "the State Manager database type",
-                            "examples": [
-                                "postgresql"
-                            ],
-                            "enum": ["postgresql"]
+                            "$ref": "#/$defs/databaseEngine"
                         },
                         "port": {
                             "type": "integer",
@@ -3642,64 +3818,9 @@
                             "minLength": 1
                         },
                         "connectionPool": {
-                            "type": "object",
+                            "$ref": "#/$defs/connectionPool",
                             "default": {},
-                            "title": "JDBC connection pool configuration for State Manager DB",
-                            "required": [
-                                "maxSize",
-                                "idleTimeoutSeconds",
-                                "maxLifetimeSeconds",
-                                "keepAliveTimeSeconds",
-                                "validationTimeoutSeconds"
-                            ],
-                            "additionalProperties": false,
-                            "properties": {
-                                "maxSize": {
-                                    "type": "integer",
-                                    "default": 5,
-                                    "title": "JDBC connection pool size for State Manager DB",
-                                    "examples": [
-                                        5
-                                    ]
-                                },
-                                "minSize": {
-                                    "anyOf": [
-                                        {
-                                            "type": "integer",
-                                            "minimum": 0
-                                        },
-                                        {
-                                            "type": "null"
-                                        }
-                                    ],
-                                    "default": null,
-                                    "title": "Minimum JDBC connection pool size for State Manager DB; null value means pool's min size will default to pool's max size value"
-                                },
-                                "idleTimeoutSeconds": {
-                                    "type": "integer",
-                                    "default": 120,
-                                    "minimum": 0,
-                                    "title": "Maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool"
-                                },
-                                "maxLifetimeSeconds": {
-                                    "type": "integer",
-                                    "default": 1800,
-                                    "minimum": 1,
-                                    "title": "Maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached \"maxLifetime\" timeout, it will be removed from the pool only when it becomes idle"
-                                },
-                                "keepAliveTimeSeconds": {
-                                    "type": "integer",
-                                    "default": 0,
-                                    "minimum": 0,
-                                    "title": "Interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled"
-                                },
-                                "validationTimeoutSeconds": {
-                                    "type": "integer",
-                                    "minimum": 1,
-                                    "default": 5,
-                                    "title": "Maximum time (in seconds) that the pool will wait for a connection to be validated as alive"
-                                }
-                            }
+                            "title": "JDBC connection pool configuration for State Manager DB"
                         }
                     },
                     "examples": [{
@@ -3729,6 +3850,202 @@
                 },
                 "password": {
                     "$ref": "#/$defs/config"
+                }
+            }
+        },
+        "connectionPool": {
+            "type": "object",
+            "default": {},
+            "title": "Connection pool configuration for JDBC connections",
+            "required": [
+                "maxSize",
+                "idleTimeoutSeconds",
+                "maxLifetimeSeconds",
+                "keepAliveTimeSeconds",
+                "validationTimeoutSeconds"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "maxSize": {
+                    "type": "integer",
+                    "default": 5,
+                    "title": "Maximum pool size",
+                    "examples": [
+                        5
+                    ]
+                },
+                "minSize": {
+                    "anyOf": [
+                        {
+                            "type": "integer",
+                            "minimum": 0
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Minimum pool size (defaults to pool's max size value when null)"
+                },
+                "idleTimeoutSeconds": {
+                    "type": "integer",
+                    "default": 120,
+                    "minimum": 0,
+                    "title": "Maximum time (in seconds) a connection can stay idle in the pool; A value of 0 means that idle connections are never removed from the pool"
+                },
+                "maxLifetimeSeconds": {
+                    "type": "integer",
+                    "default": 1800,
+                    "minimum": 1,
+                    "title": "Maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; If a connection is in-use and has reached \"maxLifetimeSeconds\" timeout, it will be removed from the pool only when it becomes idle"
+                },
+                "keepAliveTimeSeconds": {
+                    "type": "integer",
+                    "default": 0,
+                    "minimum": 0,
+                    "title": "Interval time (in seconds) in which connections will be tested for aliveness; Connections which are no longer alive are removed from the pool; A value of 0 means this check is disabled"
+                },
+                "validationTimeoutSeconds": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "default": 5,
+                    "title": "Maximum time (in seconds) that the pool will wait for a connection to be validated as alive"
+                }
+            }
+        },
+        "databaseTemplate": {
+            "type": "object",
+            "default": {},
+            "title": "Connection settings for databases used by the Platform",
+            "additionalProperties": false,
+            "required": [
+                "name",
+                "username",
+                "password"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "host": {
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "format": "hostname"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "The database host"
+                },
+                "port": {
+                    "type": "integer",
+                    "default": 5432,
+                    "title": "The database port",
+                    "examples": [
+                        5432
+                    ]
+                },
+                "type": {
+                    "$ref": "#/$defs/databaseEngine"
+                },
+                "username": {
+                    "$ref": "#/$defs/config"
+                },
+                "password": {
+                    "$ref": "#/$defs/config"
+                }
+            }
+        },
+        "stateTypePersistentStorageMapping": {
+            "type": "object",
+            "default": {},
+            "title": "Association between a State Type managed by the State Manager and a defined Persistent Storage",
+            "additionalProperties": false,
+            "required": [
+                "type",
+                "storageId",
+                "partition"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "default": "DATABASE",
+                    "title": "The type of the persistent storage used by the State Manager instance",
+                    "enum": [
+                        "DATABASE"
+                    ]
+                },
+                "storageId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": "default",
+                    "title": "The id of the persistent storage, defined elsewhere, that will be used to manage states"
+                },
+                "partition": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": "default",
+                    "title": "The name of the internal representation (schema, region, partition, namespace, etc.) within the persistent storage that will be used to manage states"
+                }
+            }
+        },
+        "stateManagerRuntimeConnectionSettings": {
+            "type": "object",
+            "default": {},
+            "title": "Runtime connection settings for a given State Manager instance and Persistent Storage",
+            "additionalProperties": false,
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "default": "DATABASE",
+                    "title": "The type of the persistent storage used by the State Manager instance",
+                    "enum": [
+                        "DATABASE"
+                    ]
+                },
+                "username": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/config"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "password": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/$defs/config"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "connectionPool": {}
+            },
+            "if": {
+                "properties": {
+                    "type": {
+                        "const": "DATABASE"
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "connectionPool": {
+                        "$ref": "#/$defs/connectionPool",
+                        "default": {},
+                        "title": "JDBC connection pool configuration for the State Manager instance"
+                    }
                 }
             }
         }

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -990,7 +990,7 @@
         "databases": {
             "type": "array",
             "minItems": 1,
-            "title": "List of databases uses by the platform",
+            "title": "List of databases used by the platform",
             "items": {
                 "type": "object",
                 "allOf": [
@@ -1004,6 +1004,7 @@
                     "type"
                 ]
             },
+            "$comment": "At least one database with name 'default' must be defined",
             "contains": {
                 "type": "object",
                 "properties": {

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -277,34 +277,34 @@ stateManager:
   # Persistent storage configuration for the 'flowCheckpoint' state type
   flowCheckpoint:
     # -- persistent storage type
-    type: DATABASE
-    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    type: Database
+    # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
-    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
     partition: "state_manager"
   # Persistent storage configuration for the 'flowMapping' state type
   flowMapping:
     # -- persistent storage type
-    type: DATABASE
-    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    type: Database
+    # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
-    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
     partition: "state_manager"
   # Persistent storage configuration for the 'keyRotation' state type
   keyRotation:
     # -- persistent storage type
-    type: DATABASE
-    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    type: Database
+    # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
-    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
     partition: "state_manager"
   # Persistent storage configuration for the 'tokenPoolCache' state type
   tokenPoolCache:
     # -- persistent storage type
-    type: DATABASE
-    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    type: Database
+    # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
-    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
     partition: "state_manager"
 
 # Configuration for cluster bootstrap
@@ -361,7 +361,7 @@ bootstrap:
       # -- tag for image containing a db client, used to set up the db
       tag: "14.4"
 
-    # Administrator credentials per database to use when grating required runtime permissions
+    # Administrator credentials per database to use when creating required runtime permissions
     databases:
       - name: default
         # The bootstrap default database user configuration
@@ -834,7 +834,7 @@ workers:
 #      # Runtime configuration settings for the State Manager used to interact with 'KeyRotation' states
 #      keyRotation:
 #        # -- persistent storage type
-#        type: DATABASE
+#        type: Database
 #        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
 #        username:
 #          # -- the State Manager database user
@@ -1032,7 +1032,7 @@ workers:
 #      # Runtime configuration settings for the State Manager used to interact with 'flowCheckpoint' states
 #      flowCheckpoint:
 #        # -- persistent storage type
-#        type: DATABASE
+#        type: Database
 #        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
 #        username:
 #          # -- the State Manager database user
@@ -1177,7 +1177,7 @@ workers:
 #      # Runtime configuration settings for the State Manager used to interact with 'flowMapping' states
 #      flowMapping:
 #        # -- persistent storage type
-#        type: DATABASE
+#        type: Database
 #        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
 #        username:
 #          # -- the State Manager database user
@@ -1501,7 +1501,7 @@ workers:
 #      # Runtime configuration settings for the State Manager used to interact with 'keyRotation' states
 #      keyRotation:
 #        # -- persistent storage type
-#        type: DATABASE
+#        type: Database
 #        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
 #        username:
 #          # -- the State Manager database user
@@ -1927,7 +1927,7 @@ workers:
 #      # Runtime configuration settings for the State Manager used to interact with 'tokenPoolCache' states
 #      tokenPoolCache:
 #        # -- persistent storage type
-#        type: DATABASE
+#        type: Database
 #        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
 #        username:
 #          # -- the State Manager database user

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -298,6 +298,14 @@ stateManager:
     storageId: "default"
     # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
     partition: "state_manager"
+  # Persistent storage configuration for the 'p2pSession' state type
+  p2pSession:
+    # -- persistent storage type
+    type: Database
+    # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
+    storageId: "default"
+    # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
+    partition: "state_manager"
   # Persistent storage configuration for the 'tokenPoolCache' state type
   tokenPoolCache:
     # -- persistent storage type
@@ -1633,6 +1641,31 @@ workers:
       limits: {}
 
     stateManager:
+#      # Runtime configuration settings for the State Manager used to interact with 'p2pSession' states
+#      p2pSession:
+#        # -- persistent storage type
+#        type: Database
+#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        username:
+#          # -- the State Manager database user
+#          value: "p2p_session"
+#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        password: null
+#        # Connection pool configuration for the State Manager
+#        connectionPool:
+#          # -- maximum connection pool size
+#          maxSize: 5
+#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
+#          minSize: null
+#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
+#          idleTimeoutSeconds: 120
+#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+#          maxLifetimeSeconds: 1800
+#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
+#          keepAliveTimeSeconds: 0
+#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+#          validationTimeoutSeconds: 5
+#      TODO-[CORE-19372]: remove children and uncomment above 'p2pSession' section
       # Type of State Manager
       type: DATABASE
       # State Manager database configuration

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -281,7 +281,7 @@ stateManager:
     # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
     # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
-    partition: "state_manager"
+    partition: "sm_flow_checkpoint"
   # Persistent storage configuration for the 'flowMapping' state type
   flowMapping:
     # -- persistent storage type
@@ -289,7 +289,7 @@ stateManager:
     # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
     # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
-    partition: "state_manager"
+    partition: "sm_flow_mapping"
   # Persistent storage configuration for the 'keyRotation' state type
   keyRotation:
     # -- persistent storage type
@@ -297,7 +297,7 @@ stateManager:
     # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
     # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
-    partition: "state_manager"
+    partition: "sm_key_rotation"
   # Persistent storage configuration for the 'p2pSession' state type
   p2pSession:
     # -- persistent storage type
@@ -305,7 +305,7 @@ stateManager:
     # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
     # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
-    partition: "state_manager"
+    partition: "sm_p2p_session"
   # Persistent storage configuration for the 'tokenPoolCache' state type
   tokenPoolCache:
     # -- persistent storage type
@@ -313,7 +313,7 @@ stateManager:
     # -- name of the persistent storage to use. When using 'Database' as the type, an element with the given id should exist under the databases section
     storageId: "default"
     # -- name of the partition to use. When using 'Database' as the type, the 'partition' represents the name of the database schema
-    partition: "state_manager"
+    partition: "sm_token_pool_cache"
 
 # Configuration for cluster bootstrap
 bootstrap:

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -237,7 +237,7 @@ kafka:
           # -- the default SASL password secret key  for client connection to Kafka
           key: ""
 
-# List of databases uses by the Platform
+# List of databases used by the Platform
 databases:
   # The default database configuration
   - name: default

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -237,6 +237,84 @@ kafka:
           # -- the default SASL password secret key  for client connection to Kafka
           key: ""
 
+# List of databases uses by the Platform
+databases:
+  # The default database configuration
+  - name: default
+    # -- the default database host (required)
+    host: null
+    # -- the default database port
+    port: 5432
+    # -- the default database type
+    type: "postgresql"
+    # The default database user configuration
+    username:
+      # -- the default database user
+      value: ""
+      # The default database user secret configuration; used in preference to value if name is set
+      valueFrom:
+        # The default database user secret key reference
+        secretKeyRef:
+          # -- the default database user secret name
+          name: ""
+          # -- the default database user secret key
+          key: ""
+    # The default database password configuration
+    password:
+      # -- the default database password
+      value: ""
+      # The default database password secret configuration; used in preference to value if name is set
+      valueFrom:
+        # The default database password secret key reference
+        secretKeyRef:
+          # -- the default database password secret name
+          name: ""
+          # -- the default database password secret key
+          key: ""
+
+# Persistent Storage configuration to be used by each State type known by the Platform
+stateManager:
+  # Persistent storage configuration for the 'flowCheckpoint' state type
+  flowCheckpoint:
+    # -- persistent storage type
+    type: DATABASE
+    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    storageId: "default"
+    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    partition: "state_manager"
+  # Persistent storage configuration for the 'flowStatus' state type
+  flowStatus:
+    # -- persistent storage type
+    type: DATABASE
+    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    storageId: "default"
+    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    partition: "state_manager"
+  # Persistent storage configuration for the 'flowMapping' state type
+  flowMapping:
+    # -- persistent storage type
+    type: DATABASE
+    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    storageId: "default"
+    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    partition: "state_manager"
+  # Persistent storage configuration for the 'keyRotation' state type
+  keyRotation:
+    # -- persistent storage type
+    type: DATABASE
+    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    storageId: "default"
+    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    partition: "state_manager"
+  # Persistent storage configuration for the 'tokenPoolCache' state type
+  tokenPoolCache:
+    # -- persistent storage type
+    type: DATABASE
+    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
+    storageId: "default"
+    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
+    partition: "state_manager"
+
 # Configuration for cluster bootstrap
 bootstrap:
   # Configuration for the pre-installation check
@@ -281,6 +359,43 @@ bootstrap:
   db:
     # -- Indicates whether DB bootstrap is enabled as part of installation
     enabled: true
+
+    # Image containing DB client, used to set up the DB
+    clientImage:
+      # -- registry for image containing a db client, used to set up the db
+      registry: ""
+      # -- repository for image containing a db client, used to set up the db
+      repository: postgres
+      # -- tag for image containing a db client, used to set up the db
+      tag: "14.4"
+
+    # Administrator credentials per database to use when grating required runtime permissions
+    databases:
+      - name: default
+        # The bootstrap default database user configuration
+        username:
+          # -- the bootstrap default database user
+          value: ""
+          # The bootstrap default database user secret configuration; used in preference to value if name is set
+          valueFrom:
+            # The bootstrap default database user secret key reference
+            secretKeyRef:
+              # -- the bootstrap default database user secret name
+              name: ""
+              # -- the bootstrap default database user secret key
+              key: ""
+        # The bootstrap default database password configuration
+        password:
+          # -- the bootstrap default database password
+          value: ""
+          # The bootstrap default database password secret configuration; used in preference to value if name is set
+          valueFrom:
+            # The bootstrap default database password secret key reference
+            secretKeyRef:
+              # -- the bootstrap default database password secret name
+              name: ""
+              # -- the bootstrap default database password secret key
+              key: ""
 
     # Bootstrap cluster database configuration
     cluster:
@@ -547,14 +662,6 @@ bootstrap:
               name: ""
               # -- the password secret key
               key: ""
-    # Image containing DB client, used to set up the DB
-    clientImage:
-      # -- registry for image containing a db client, used to set up the db
-      registry: ""
-      # -- repository for image containing a db client, used to set up the db
-      repository: postgres
-      # -- tag for image containing a db client, used to set up the db
-      tag: "14.4"
 
   # Configuration for RBAC roles bootstrap
   rbac:
@@ -732,7 +839,32 @@ workers:
               # -- the crypto worker SASL password secret key for client connection to Kafka
               key: ""
     stateManager:
-      # Type of State Manager
+#      # Runtime configuration settings for the State Manager used to interact with 'KeyRotation' states
+#      keyRotation:
+#        # -- persistent storage type
+#        type: DATABASE
+#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        username:
+#          # -- the State Manager database user
+#          value: "key_rotation_writer"
+#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        password: null
+#        # Connection pool configuration for the State Manager
+#        connectionPool:
+#          # -- maximum connection pool size
+#          maxSize: 5
+#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
+#          minSize: null
+#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
+#          idleTimeoutSeconds: 120
+#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+#          maxLifetimeSeconds: 1800
+#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
+#          keepAliveTimeSeconds: 0
+#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+#          validationTimeoutSeconds: 5
+# TODO-[CORE-19372]: remove children and uncomment above 'keyRotation' section.
+      # -- type of State Manager
       type: DATABASE
       # State Manager database configuration
       db:
@@ -782,6 +914,7 @@ workers:
           keepAliveTimeSeconds: 0
           # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
           validationTimeoutSeconds: 5
+
   # DB worker configuration
   db:
     # DB worker image configuration
@@ -904,6 +1037,55 @@ workers:
     verifyInstrumentation: false
     # Flow Worker State Manager configuration
     stateManager:
+#      # Runtime configuration settings for the State Manager used to interact with 'flowCheckpoint' states
+#      flowCheckpoint:
+#        # -- persistent storage type
+#        type: DATABASE
+#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        username:
+#          # -- the State Manager database user
+#          value: "flow_checkpoint"
+#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        password: null
+#        # Connection pool configuration for the State Manager
+#        connectionPool:
+#          # -- maximum connection pool size
+#          maxSize: 5
+#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
+#          minSize: null
+#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
+#          idleTimeoutSeconds: 120
+#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+#          maxLifetimeSeconds: 1800
+#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
+#          keepAliveTimeSeconds: 0
+#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+#          validationTimeoutSeconds: 5
+#      # Runtime configuration settings for the State Manager used to interact with 'flowStatus' states
+#      flowStatus:
+#        # -- persistent storage type
+#        type: DATABASE
+#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        username:
+#          # -- the State Manager database user
+#          value: "flow_status_writer"
+#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        password: null
+#        # Connection pool configuration for the State Manager
+#        connectionPool:
+#          # -- maximum connection pool size
+#          maxSize: 5
+#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
+#          minSize: null
+#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
+#          idleTimeoutSeconds: 120
+#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+#          maxLifetimeSeconds: 1800
+#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
+#          keepAliveTimeSeconds: 0
+#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+#          validationTimeoutSeconds: 5
+#      TODO-[CORE-19372]: remove children and uncomment above 'flowCheckpoint' and 'flowStatus' sections
       # Type of State Manager
       type: DATABASE
       # State Manager database configuration
@@ -1024,6 +1206,31 @@ workers:
     verifyInstrumentation: false
     # Flow Mapper Worker State Manager configuration
     stateManager:
+#      # Runtime configuration settings for the State Manager used to interact with 'flowMapping' states
+#      flowMapping:
+#        # -- persistent storage type
+#        type: DATABASE
+#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        username:
+#          # -- the State Manager database user
+#          value: "flow_mapper"
+#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        password: null
+#        # Connection pool configuration for the State Manager
+#        connectionPool:
+#          # -- maximum connection pool size
+#          maxSize: 5
+#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
+#          minSize: null
+#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
+#          idleTimeoutSeconds: 120
+#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+#          maxLifetimeSeconds: 1800
+#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
+#          keepAliveTimeSeconds: 0
+#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+#          validationTimeoutSeconds: 5
+#      TODO-[CORE-19372]: remove children and uncomment above 'flowMapping' section
       # Type of State Manager
       type: DATABASE
       # State Manager database configuration
@@ -1323,6 +1530,55 @@ workers:
               # -- the REST worker SASL password secret key for client connection to Kafka
               key: ""
     stateManager:
+#      # Runtime configuration settings for the State Manager used to interact with 'flowStatus' states
+#      flowStatus:
+#        # -- persistent storage type
+#        type: DATABASE
+#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        username:
+#          # -- the State Manager database user
+#          value: "flow_status_reader"
+#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        password: null
+#        # Connection pool configuration for the State Manager
+#        connectionPool:
+#          # -- maximum connection pool size
+#          maxSize: 5
+#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
+#          minSize: null
+#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
+#          idleTimeoutSeconds: 120
+#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+#          maxLifetimeSeconds: 1800
+#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
+#          keepAliveTimeSeconds: 0
+#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+#          validationTimeoutSeconds: 5
+#      # Runtime configuration settings for the State Manager used to interact with 'keyRotation' states
+#      keyRotation:
+#        # -- persistent storage type
+#        type: DATABASE
+#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        username:
+#          # -- the State Manager database user
+#          value: "key_rotation_reader"
+#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        password: null
+#        # Connection pool configuration for the State Manager
+#        connectionPool:
+#          # -- maximum connection pool size
+#          maxSize: 5
+#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
+#          minSize: null
+#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
+#          idleTimeoutSeconds: 120
+#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+#          maxLifetimeSeconds: 1800
+#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
+#          keepAliveTimeSeconds: 0
+#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+#          validationTimeoutSeconds: 5
+#     TODO-[CORE-19372]: remove children and uncomment above 'flowCheckpoint' and 'flowStatus' sections
       # Type of State Manager
       type: DATABASE
       # State Manager database configuration
@@ -1724,6 +1980,31 @@ workers:
       validationTimeoutSeconds: 5
 
     stateManager:
+#      # Runtime configuration settings for the State Manager used to interact with 'tokenPoolCache' states
+#      tokenPoolCache:
+#        # -- persistent storage type
+#        type: DATABASE
+#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        username:
+#          # -- the State Manager database user
+#          value: "token_pool_cache"
+#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        password: null
+#        # Connection pool configuration for the State Manager
+#        connectionPool:
+#          # -- maximum connection pool size
+#          maxSize: 5
+#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
+#          minSize: null
+#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
+#          idleTimeoutSeconds: 120
+#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
+#          maxLifetimeSeconds: 1800
+#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
+#          keepAliveTimeSeconds: 0
+#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
+#          validationTimeoutSeconds: 5
+#     TODO-[CORE-19372]: remove children and uncomment above 'flowCheckpoint' and 'flowStatus' sections
       # Type of State Manager
       type: DATABASE
       # State Manager database configuration

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -282,14 +282,6 @@ stateManager:
     storageId: "default"
     # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
     partition: "state_manager"
-  # Persistent storage configuration for the 'flowStatus' state type
-  flowStatus:
-    # -- persistent storage type
-    type: DATABASE
-    # -- name of the persistent storage to use. When using 'DATABASE' as the type, an element with the given id should exist under the databases section
-    storageId: "default"
-    # -- name of the partition to use. When using 'DATABASE' as the type, the 'partition' represents the name of the database schema
-    partition: "state_manager"
   # Persistent storage configuration for the 'flowMapping' state type
   flowMapping:
     # -- persistent storage type
@@ -1061,31 +1053,7 @@ workers:
 #          keepAliveTimeSeconds: 0
 #          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
 #          validationTimeoutSeconds: 5
-#      # Runtime configuration settings for the State Manager used to interact with 'flowStatus' states
-#      flowStatus:
-#        # -- persistent storage type
-#        type: DATABASE
-#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        username:
-#          # -- the State Manager database user
-#          value: "flow_status_writer"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
-#        # Connection pool configuration for the State Manager
-#        connectionPool:
-#          # -- maximum connection pool size
-#          maxSize: 5
-#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
-#          minSize: null
-#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
-#          idleTimeoutSeconds: 120
-#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
-#          maxLifetimeSeconds: 1800
-#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
-#          keepAliveTimeSeconds: 0
-#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
-#          validationTimeoutSeconds: 5
-#      TODO-[CORE-19372]: remove children and uncomment above 'flowCheckpoint' and 'flowStatus' sections
+#      TODO-[CORE-19372]: remove children and uncomment above 'flowCheckpoint' section
       # Type of State Manager
       type: DATABASE
       # State Manager database configuration
@@ -1530,30 +1498,6 @@ workers:
               # -- the REST worker SASL password secret key for client connection to Kafka
               key: ""
     stateManager:
-#      # Runtime configuration settings for the State Manager used to interact with 'flowStatus' states
-#      flowStatus:
-#        # -- persistent storage type
-#        type: DATABASE
-#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        username:
-#          # -- the State Manager database user
-#          value: "flow_status_reader"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
-#        # Connection pool configuration for the State Manager
-#        connectionPool:
-#          # -- maximum connection pool size
-#          maxSize: 5
-#          # -- minimum connection pool size; null value means pool's min size will default to pool's max size value
-#          minSize: null
-#          # -- maximum time (in seconds) a connection can stay idle in the pool; a value of 0 means that idle connections are never removed from the pool
-#          idleTimeoutSeconds: 120
-#          # -- maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used; if a connection is in-use and has reached "maxLifetime" timeout, it will be removed from the pool only when it becomes idle
-#          maxLifetimeSeconds: 1800
-#          # -- interval time (in seconds) in which connections will be tested for aliveness; connections which are no longer alive are removed from the pool; a value of 0 means this check is disabled
-#          keepAliveTimeSeconds: 0
-#          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
-#          validationTimeoutSeconds: 5
 #      # Runtime configuration settings for the State Manager used to interact with 'keyRotation' states
 #      keyRotation:
 #        # -- persistent storage type
@@ -1578,7 +1522,7 @@ workers:
 #          keepAliveTimeSeconds: 0
 #          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
 #          validationTimeoutSeconds: 5
-#     TODO-[CORE-19372]: remove children and uncomment above 'flowCheckpoint' and 'flowStatus' sections
+#     TODO-[CORE-19372]: remove children and uncomment above 'keyRotation' section
       # Type of State Manager
       type: DATABASE
       # State Manager database configuration
@@ -2004,7 +1948,7 @@ workers:
 #          keepAliveTimeSeconds: 0
 #          # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
 #          validationTimeoutSeconds: 5
-#     TODO-[CORE-19372]: remove children and uncomment above 'flowCheckpoint' and 'flowStatus' sections
+#     TODO-[CORE-19372]: remove children and uncomment above 'tokenPoolCache' section
       # Type of State Manager
       type: DATABASE
       # State Manager database configuration


### PR DESCRIPTION
Update json schema changes (Helm only) to support new deployment model
on which state types can be isolated and workers are allowed to access
more than a single State Manager instance.
Changes introduced by this commit are backward compatible with the
existing schema, comments were added so that the relevant code can be
entirely removed once the new deployment model is fully rolled out.
