### PR TITLE
CORE-19413: Fix issues with the statefull session manager.

### DIFF
--- a/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/SessionEncryptionOpsClientImpl.kt
+++ b/components/crypto/crypto-client-impl/src/main/kotlin/net/corda/crypto/client/impl/SessionEncryptionOpsClientImpl.kt
@@ -10,7 +10,7 @@ import net.corda.libs.platform.PlatformInfoProvider
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
+import net.corda.schema.configuration.ConfigKeys.BOOT_CONFIG
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -34,7 +34,7 @@ class SessionEncryptionOpsClientImpl @Activate constructor(
             LifecycleCoordinatorName.forComponent<ConfigurationReadService>(),
         ),
     ),
-    configKeys = setOf(MESSAGING_CONFIG),
+    configKeys = setOf(BOOT_CONFIG),
 ),
     SessionEncryptionOpsClient {
     override fun encryptSessionData(plainBytes: ByteArray, alias: String?): ByteArray =
@@ -54,7 +54,7 @@ class SessionEncryptionOpsClientImpl @Activate constructor(
         val ops = SessionEncryptionImpl(
             publisherFactory.createHttpRpcClient(),
             platformInfoProvider,
-            event.config.getConfig(MESSAGING_CONFIG),
+            event.config.getConfig(BOOT_CONFIG),
         )
         override val downstream = DependenciesTracker.AlwaysUp()
     }

--- a/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/SessionEncryptionOpsClientComponentTest.kt
+++ b/components/crypto/crypto-client-impl/src/test/kotlin/net/corda/crypto/client/impl/SessionEncryptionOpsClientComponentTest.kt
@@ -63,8 +63,8 @@ class SessionEncryptionOpsClientComponentTest {
             val resource = mock<Resource>()
             handler.firstValue.processEvent(
                 ConfigChangedEvent(
-                    setOf(ConfigKeys.MESSAGING_CONFIG),
-                    mapOf(ConfigKeys.MESSAGING_CONFIG to messagingConfig)
+                    setOf(ConfigKeys.BOOT_CONFIG),
+                    mapOf(ConfigKeys.BOOT_CONFIG to messagingConfig)
                 ),
                 coordinator,
             )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StateManagerAction.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StateManagerAction.kt
@@ -1,0 +1,15 @@
+package net.corda.p2p.linkmanager.sessions
+
+import net.corda.libs.statemanager.api.State
+
+internal interface StateManagerAction {
+    val state: State
+}
+
+internal data class CreateAction(
+    override val state: State,
+) : StateManagerAction
+
+internal data class UpdateAction(
+    override val state: State,
+) : StateManagerAction

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/metadata/SessionMetadata.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/metadata/SessionMetadata.kt
@@ -81,7 +81,7 @@ internal data class OutboundSessionMetadata(
                 this.toCommonMetadata(),
                 this[SESSION_ID].toString(),
                 this[STATUS].toString().statusFromString(),
-                this[SERIAL] as Long,
+                (this[SERIAL] as Number).toLong(),
                 this[MEMBERSHIP_STATUS].toString().membershipStatusFromString(),
                 this[COMMUNICATION_WITH_MGM].toString().toBoolean(),
             )
@@ -143,8 +143,8 @@ internal data class CommonMetadata(
             return CommonMetadata(
                 HoldingIdentity(MemberX500Name.parse(this[SOURCE_VNODE].toString()), this[GROUP_ID_KEY].toString()),
                 HoldingIdentity(MemberX500Name.parse(this[DEST_VNODE].toString()), this[GROUP_ID_KEY].toString()),
-                Instant.ofEpochMilli(this[LAST_SEND_TIMESTAMP] as Long),
-                Instant.ofEpochMilli(this[EXPIRY] as Long),
+                Instant.ofEpochMilli((this[LAST_SEND_TIMESTAMP] as Number).toLong()),
+                Instant.ofEpochMilli((this[EXPIRY] as Number).toLong()),
             )
         }
     }


### PR DESCRIPTION
Fix a few issues in the state manager to allow it to pass the e2e tests:
* The config section in which the crypto URL can be found in the boot config, not the messaging config.
* The state manager won't support updates for new states; we have to be explicit if the state is new.
* The counterparties should have been revered for all the situations.
* The metadata map can hold `Int` or `Long`. We need to be able to parse both of them.
