### PR TITLE
CORE-19378 Wrapping repo uses highest gen key

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -66,14 +66,14 @@ class CryptoRekeyBusProcessor(
             val virtualNodeTenantIds = virtualNodeInfo.map { it.holdingIdentity.shortHash.toString() }
 
             // we do not need to use separate wrapping repositories for the different cluster level tenants,
-            // since they share the cluster crypto database. So we scan over the virtual node tenants and an arbitary
+            // since they share the cluster crypto database. So we scan over the virtual node tenants and an arbitrary
             // choice of cluster level tenant. We pick CryptoTenants.CRYPTO as the arbitrary cluster level tenant,
             // and we should not also check CryptoTenants.P2P and CryptoTenants.REST since if we do we'll get duplicate.
             val allTenantIds = virtualNodeTenantIds + listOf(CryptoTenants.CRYPTO)
             logger.debug("Found ${allTenantIds.size} tenants; first few are: ${allTenantIds.take(10)}")
             val targetWrappingKeys = allTenantIds.asSequence().map { tenantId ->
                 wrappingRepositoryFactory.create(tenantId).use { wrappingRepo ->
-                    wrappingRepo.findKeysWrappedByAlias(request.oldParentKeyAlias).map { wki -> tenantId to wki }
+                    wrappingRepo.findKeysWrappedByParentKey(request.oldParentKeyAlias).map { wki -> tenantId to wki }
                 }
             }.flatten()
             rekeyPublisher.publish(

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
@@ -68,9 +68,9 @@ class CryptoRekeyBusProcessorTests {
             setOf(ConfigKeys.MESSAGING_CONFIG),
             mapOf(
                 ConfigKeys.MESSAGING_CONFIG to
-                        SmartConfigFactory.createWithoutSecurityServices().create(
-                            createMessagingConfig()
-                        )
+                    SmartConfigFactory.createWithoutSecurityServices().create(
+                        createMessagingConfig()
+                    )
             )
         )
         config = configEvent.config
@@ -81,7 +81,16 @@ class CryptoRekeyBusProcessorTests {
         virtualNodeInfoReadService = mock()
 
         val wrappingRepository: WrappingRepository = mock {
-            on { findKeysWrappedByAlias(any()) } doReturn listOf(WrappingKeyInfo(0, "", byteArrayOf(), 0, oldKeyAlias, "alias1"))
+            on { findKeysWrappedByParentKey(any()) } doReturn listOf(
+                WrappingKeyInfo(
+                    0,
+                    "",
+                    byteArrayOf(),
+                    0,
+                    oldKeyAlias,
+                    "alias1"
+                )
+            )
         }
 
         wrappingRepositoryFactory = mock {
@@ -103,7 +112,8 @@ class CryptoRekeyBusProcessorTests {
             cryptoService, virtualNodeInfoReadService,
             wrappingRepositoryFactory, rewrapPublisher,
             mock(),
-            cordaAvroSerializationFactory)
+            cordaAvroSerializationFactory
+        )
     }
 
     @Test

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestWrappingRepository.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestWrappingRepository.kt
@@ -25,8 +25,8 @@ class TestWrappingRepository(
 
     override fun findKeyAndId(alias: String): Pair<UUID, WrappingKeyInfo>? = TODO("Not needed")
 
-    override fun findKeysWrappedByParentKey(alias: String): List<WrappingKeyInfo> = TODO("Not needed")
-    
+    override fun findKeysWrappedByParentKey(parentKeyAlias: String): List<WrappingKeyInfo> = TODO("Not needed")
+
     override fun getKeyById(id: UUID): WrappingKeyInfo? = TODO("Not needed")
 
     override fun close() {

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestWrappingRepository.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestWrappingRepository.kt
@@ -25,10 +25,9 @@ class TestWrappingRepository(
 
     override fun findKeyAndId(alias: String): Pair<UUID, WrappingKeyInfo>? = TODO("Not needed")
 
-    override fun findKeysWrappedByAlias(alias: String): List<WrappingKeyInfo> = TODO("Not needed")
-
-
-    override fun getKeyById(id: UUID): WrappingKeyInfo? =TODO("Not yet implemented")
+    override fun findKeysWrappedByParentKey(alias: String): List<WrappingKeyInfo> = TODO("Not needed")
+    
+    override fun getKeyById(id: UUID): WrappingKeyInfo? = TODO("Not needed")
 
     override fun close() {
     }

--- a/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/WrappingRepositoryTest.kt
+++ b/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/WrappingRepositoryTest.kt
@@ -7,7 +7,6 @@ import net.corda.crypto.softhsm.impl.toDto
 import net.corda.crypto.testkit.SecureHashUtils
 import net.corda.orm.utils.use
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -37,8 +36,10 @@ class WrappingRepositoryTest : CryptoRepositoryTest() {
 
         val loadedKey = emf.createEntityManager().use {
             it
-                .createQuery("FROM ${WrappingKeyEntity::class.simpleName} AS k " +
-                        "WHERE k.alias = :alias", WrappingKeyEntity::class.java)
+                .createQuery(
+                    "FROM ${WrappingKeyEntity::class.simpleName} AS k " +
+                        "WHERE k.alias = :alias", WrappingKeyEntity::class.java
+                )
                 .setParameter("alias", keyAlias)
                 .singleResult
 
@@ -63,7 +64,7 @@ class WrappingRepositoryTest : CryptoRepositoryTest() {
     @MethodSource("emfs")
     fun findKey(emf: EntityManagerFactory) {
         val keyAlias = "find-key-${UUID.randomUUID()}"
-        val wrappingKeyInfoWithAlias = wrappingKeyInfo.copy(alias=keyAlias)
+        val wrappingKeyInfoWithAlias = wrappingKeyInfo.copy(alias = keyAlias)
         val repo = WrappingRepositoryImpl(emf, "test")
         repo.saveKey(wrappingKeyInfoWithAlias)
 
@@ -82,16 +83,36 @@ class WrappingRepositoryTest : CryptoRepositoryTest() {
 
     @ParameterizedTest
     @MethodSource("emfs")
-    fun `findKeyWithId returns the UUID and the key`(emf: EntityManagerFactory) {
+    fun `findKeyAndId returns the UUID and the key`(emf: EntityManagerFactory) {
         val keyAlias = "save-key-${UUID.randomUUID()}"
-        val wrappingKeyInfoWithUniqueAlias = wrappingKeyInfo.copy(alias=keyAlias)
+        val wrappingKeyInfoWithUniqueAlias = wrappingKeyInfo.copy(alias = keyAlias)
         val repo = WrappingRepositoryImpl(emf, "test")
         repo.saveKey(wrappingKeyInfoWithUniqueAlias)
         val loadedKeyAndId = repo.findKeyAndId(wrappingKeyInfoWithUniqueAlias.alias)
 
         assertThat(loadedKeyAndId).isNotNull()
-        assertInstanceOf(UUID::class.java, loadedKeyAndId!!.first)
-        assertThat(loadedKeyAndId.second).isEqualTo(wrappingKeyInfoWithUniqueAlias)
+        assertThat(loadedKeyAndId!!.second).isEqualTo(wrappingKeyInfoWithUniqueAlias)
+    }
+
+    @ParameterizedTest
+    @MethodSource("emfs")
+    fun `findKeyAndId returns latest generation key`(emf: EntityManagerFactory) {
+        val keyAlias = "save-key-${UUID.randomUUID()}"
+        val wrappingKeyInfoWithUniqueAlias = wrappingKeyInfo.copy(alias = keyAlias)
+        val repo = WrappingRepositoryImpl(emf, "test")
+        repo.saveKey(wrappingKeyInfoWithUniqueAlias)
+
+        val wrappingKeyGeneration2 =
+            wrappingKeyInfo.copy(generation = wrappingKeyInfoWithUniqueAlias.generation + 1, alias = keyAlias)
+        repo.saveKey(wrappingKeyGeneration2)
+        val wrappingKeyGeneration3 =
+            wrappingKeyInfo.copy(generation = wrappingKeyGeneration2.generation + 1, alias = keyAlias)
+        repo.saveKey(wrappingKeyGeneration3)
+
+        val loadedKeyAndId = repo.findKeyAndId(keyAlias)
+
+        assertThat(loadedKeyAndId).isNotNull()
+        assertThat(loadedKeyAndId!!.second).isEqualTo(wrappingKeyGeneration3)
     }
 
     @ParameterizedTest
@@ -125,5 +146,58 @@ class WrappingRepositoryTest : CryptoRepositoryTest() {
         val repo = WrappingRepositoryImpl(emf, "test")
         val loadedKey = repo.getKeyById(UUID.randomUUID())
         assertThat(loadedKey).isNull()
+    }
+
+    @ParameterizedTest
+    @MethodSource("emfs")
+    fun `findKeysWrappedByParentKey returns latest generation key`(emf: EntityManagerFactory) {
+        val repo = WrappingRepositoryImpl(emf, "test")
+
+        // Pairs are parent key alias, number of generations of wrapping key to create
+        listOf(
+            Pair("pka1", 1),
+            Pair("pka1", 3),
+            Pair("pka2", 2),
+            Pair("pka3", 1),
+            Pair("pka3", 2),
+            Pair("pka3", 3)
+        ).forEach {
+            val keyAlias = "save-key-${UUID.randomUUID()}"
+            var wrappingKeyInfo = wrappingKeyInfo.copy(alias = keyAlias, parentKeyAlias = it.first)
+
+            repeat(it.second) {
+                repo.saveKey(wrappingKeyInfo)
+                wrappingKeyInfo = wrappingKeyInfo.copy(generation = wrappingKeyInfo.generation + 1, alias = keyAlias)
+            }
+        }
+
+        // We have no control over what order the results come back in, so we make sure the correct generation wrapping
+        // keys are returned in any order where required
+
+        val resultsPka1 = repo.findKeysWrappedByParentKey("pka1")
+        assertThat(resultsPka1.size).isEqualTo(2)
+        val generationSetPka1 = mutableSetOf<Int>()
+        resultsPka1.forEach {
+            assertThat(it.parentKeyAlias).isEqualTo("pka1")
+            generationSetPka1 += it.generation
+        }
+        assertThat(generationSetPka1).contains(wrappingKeyInfo.generation)
+        assertThat(generationSetPka1).contains(wrappingKeyInfo.generation + 2)
+
+        val resultsPka2 = repo.findKeysWrappedByParentKey("pka2")
+        assertThat(resultsPka2.size).isEqualTo(1)
+        assertThat(resultsPka2[0].parentKeyAlias).isEqualTo("pka2")
+        assertThat(resultsPka2[0].generation).isEqualTo(wrappingKeyInfo.generation + 1)
+
+        val resultsPka3 = repo.findKeysWrappedByParentKey("pka3")
+        assertThat(resultsPka3.size).isEqualTo(3)
+        val generationSetPka3 = mutableSetOf<Int>()
+        resultsPka3.forEach {
+            assertThat(it.parentKeyAlias).isEqualTo("pka3")
+            generationSetPka3 += it.generation
+        }
+        assertThat(generationSetPka3).contains(wrappingKeyInfo.generation)
+        assertThat(generationSetPka3).contains(wrappingKeyInfo.generation + 1)
+        assertThat(generationSetPka3).contains(wrappingKeyInfo.generation + 2)
     }
 }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/WrappingRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/WrappingRepository.kt
@@ -6,8 +6,16 @@ import java.util.UUID
 
 /**
  *
- * Database operations for wrapping keys. Implementation of this interface will
- * cover access to specific databases for specific tenants.
+ * Database operations for wrapping keys. Implementation of this interface will cover access to specific databases for
+ * specific tenants and in all but one case that will mean the results will be limited only to that tenant.
+ *
+ * The exception to this is when [WrappingRepository] is bound to the cluster crypto database. In this case methods will
+ * return wrapping keys for any cluster tenant type. Where a single wrapping key is returned, you will always get back
+ * a wrapping key for a specific tenant anyway, because both the id and alias of the wrapping keys are unique to one
+ * tenant. In the case of [findKeysWrappedByParentKey] you will get all wrapping keys for all cluster tenants.
+ *
+ * In all cases, where there are more than one wrapping key per alias with different generation numbers, you will only
+ * receive the wrapping key with the highest generation number.
  *
  * Follows the JPA repository pattern.
  */
@@ -31,7 +39,7 @@ interface WrappingRepository : Closeable {
     fun saveKeyWithId(key: WrappingKeyInfo, id: UUID?): WrappingKeyInfo
 
     /**
-     * Find a wrapping key in the database
+     * Find a wrapping key in the database. The wrapping key with the highest generation is always returned.
      *
      * @param alias The name for the wrapping key, as previously passed into save.
      * @return The wrapping key material and metadata about version and algorithm.
@@ -47,12 +55,16 @@ interface WrappingRepository : Closeable {
     fun findKeyAndId(alias: String): Pair<UUID, WrappingKeyInfo>?
 
     /**
-     * Find all wrapping key in the database wrapping. This function will stream its output.
+     * Find all wrapping keys in the database which were wrapped by a specific parent key. As noted above, if you run
+     * this method on the cluster crypto db (as opposed to a vnode cypto db) you will get results that span multiple
+     * tenants. As each alias is unique across the entire cluster crypto db (i.e. cluster crypto tenants will not share
+     * an alias) you will never get back a list where aliases are used in more than one tenant even when called on a
+     * crypto cluster db.
      *
-     * @param alias The name of the parent wrapping key.
+     * @param parentKeyAlias The name of the parent wrapping key.
      * @return Information about each wrapping key, in a list
      */
-    fun findKeysWrappedByAlias(alias: String): List<WrappingKeyInfo>
+    fun findKeysWrappedByParentKey(parentKeyAlias: String): List<WrappingKeyInfo>
 
     /**
      * Find the wrapping key associated with the provided UUID

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceCachingTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceCachingTests.kt
@@ -198,7 +198,7 @@ class SoftCryptoServiceCachingTests {
             }
 
             override fun saveKeyWithId(key: WrappingKeyInfo, id: UUID?): WrappingKeyInfo {
-                TODO("Not yet implemented")
+                TODO("Not needed")
             }
 
             override fun findKey(alias: String): WrappingKeyInfo? {
@@ -208,12 +208,12 @@ class SoftCryptoServiceCachingTests {
 
             override fun findKeyAndId(alias: String): Pair<UUID, WrappingKeyInfo>? = TODO("Not needed")
 
-            override fun findKeysWrappedByAlias(alias: String): List<WrappingKeyInfo> {
-                TODO("Not yet implemented")
+            override fun findKeysWrappedByParentKey(parentKeyAlias: String): List<WrappingKeyInfo> {
+                TODO("Not needed")
             }
 
             override fun getKeyById(id: UUID): WrappingKeyInfo? {
-                TODO("Not yet implemented")
+                TODO("Not needed")
             }
 
             override fun close() {
@@ -227,7 +227,7 @@ class SoftCryptoServiceCachingTests {
             wrappingKeyCache = wrappingKeyCache,
             privateKeyCache = makePrivateKeyCache(),
             shortHashCache = makeShortHashCache()
-            
+
         )
 
         // starting fresh, all 3 aliases are missing from both store and cache

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImplTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImplTests.kt
@@ -34,10 +34,11 @@ class WrappingRepositoryImplTests {
     fun `save a wrapping key`() {
         val stored = ArrayList<WrappingKeyEntity>()
         val wrappingKeyInfo = WrappingKeyInfo(
-            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1")
+            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1"
+        )
         val savedWrappingKey = makeWrappingKeyEntity(UUID.randomUUID(), wrappingKeyInfo)
         val em = mock<EntityManager> {
-            on { merge(any<WrappingKeyEntity>()) } doReturn(savedWrappingKey)
+            on { merge(any<WrappingKeyEntity>()) } doReturn (savedWrappingKey)
             on { find<WrappingKeyEntity>(any(), any()) } doAnswer { stored.first() }
             on { transaction } doReturn mock()
         }
@@ -48,24 +49,25 @@ class WrappingRepositoryImplTests {
             "test"
         )
         val savedKey = repo.saveKey(wrappingKeyInfo)
-        verify(em).merge(argThat<WrappingKeyEntity>{
-                    this.encodingVersion == 1 &&
-                    this.algorithmName == "caesar" &&
-                    this.keyMaterial.contentEquals(wrappingKeyInfo.keyMaterial) &&
-                    this.generation == 1 &&
-                    this.parentKeyReference == "Enoch"
+        verify(em).merge(argThat<WrappingKeyEntity> {
+            this.encodingVersion == 1 &&
+                this.algorithmName == "caesar" &&
+                this.keyMaterial.contentEquals(wrappingKeyInfo.keyMaterial) &&
+                this.generation == 1 &&
+                this.parentKeyReference == "Enoch"
         })
-        assertThat (savedKey).isEqualTo(wrappingKeyInfo)
+        assertThat(savedKey).isEqualTo(wrappingKeyInfo)
     }
 
     @Test
     fun `save a wrapping key with id`() {
         val stored = ArrayList<WrappingKeyEntity>()
         val wrappingKeyInfo = WrappingKeyInfo(
-            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1")
+            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1"
+        )
         val savedWrappingKey = makeWrappingKeyEntity(UUID.randomUUID(), wrappingKeyInfo)
         val em = mock<EntityManager> {
-            on { merge(any<WrappingKeyEntity>()) } doReturn(savedWrappingKey)
+            on { merge(any<WrappingKeyEntity>()) } doReturn (savedWrappingKey)
             on { find<WrappingKeyEntity>(any(), any()) } doAnswer { stored.first() }
             on { transaction } doReturn mock()
         }
@@ -77,24 +79,24 @@ class WrappingRepositoryImplTests {
         )
         val id = UUID.randomUUID()
         val savedKey1 = repo.saveKeyWithId(wrappingKeyInfo, id)
-        verify(em).merge(argThat<WrappingKeyEntity>{
+        verify(em).merge(argThat<WrappingKeyEntity> {
             this.encodingVersion == 1 &&
-                    this.algorithmName == "caesar" &&
-                    this.keyMaterial.contentEquals(wrappingKeyInfo.keyMaterial) &&
-                    this.generation == 1 &&
-                    this.parentKeyReference == "Enoch" &&
-                    this.id == id
+                this.algorithmName == "caesar" &&
+                this.keyMaterial.contentEquals(wrappingKeyInfo.keyMaterial) &&
+                this.generation == 1 &&
+                this.parentKeyReference == "Enoch" &&
+                this.id == id
         })
         assertThat(savedKey1).isEqualTo(wrappingKeyInfo)
 
         val savedKey2 = repo.saveKeyWithId(wrappingKeyInfo, null)
-        verify(em).merge(argThat<WrappingKeyEntity>{
+        verify(em).merge(argThat<WrappingKeyEntity> {
             this.encodingVersion == 1 &&
-                    this.algorithmName == "caesar" &&
-                    this.keyMaterial.contentEquals(wrappingKeyInfo.keyMaterial) &&
-                    this.generation == 1 &&
-                    this.parentKeyReference == "Enoch" &&
-                    this.id != id
+                this.algorithmName == "caesar" &&
+                this.keyMaterial.contentEquals(wrappingKeyInfo.keyMaterial) &&
+                this.generation == 1 &&
+                this.parentKeyReference == "Enoch" &&
+                this.id != id
         })
 
         assertThat(savedKey2).isEqualTo(wrappingKeyInfo)
@@ -103,8 +105,9 @@ class WrappingRepositoryImplTests {
     @Test
     fun `find a wrapping key and its id`() {
         val wrappingKeyInfo = WrappingKeyInfo(
-            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1")
-        val newId  = UUID.randomUUID()
+            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1"
+        )
+        val newId = UUID.randomUUID()
         val savedWrappingKey = makeWrappingKeyEntity(newId, wrappingKeyInfo)
         val em = mock<EntityManager> {
             on { createQuery(any(), eq(WrappingKeyEntity::class.java)) } doAnswer {
@@ -112,9 +115,9 @@ class WrappingRepositoryImplTests {
                     on { setParameter(any<String>(), any()) } doReturn it
                     on { setMaxResults(any()) } doReturn it
                     on { resultList } doReturn listOf(savedWrappingKey)
-                    }
                 }
             }
+        }
 
         val repo = WrappingRepositoryImpl(
             mock {
@@ -134,8 +137,9 @@ class WrappingRepositoryImplTests {
     @Test
     fun `find a wrapping key using its alias`() {
         val wrappingKeyInfo = WrappingKeyInfo(
-            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1")
-        val newId  = UUID.randomUUID()
+            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1"
+        )
+        val newId = UUID.randomUUID()
         val savedWrappingKey = makeWrappingKeyEntity(newId, wrappingKeyInfo)
         val em = mock<EntityManager> {
             on { createQuery(any(), eq(WrappingKeyEntity::class.java)) } doAnswer {
@@ -158,7 +162,7 @@ class WrappingRepositoryImplTests {
 
         // Alias here doesn't matter, mock<EntityManager> returns savedWrappingKey regardless the alias.
         // There is an integration test dealing with the database where it checks for the alias.
-        val keys = repo.findKeysWrappedByAlias("alias1").toList()
+        val keys = repo.findKeysWrappedByParentKey("alias1").toList()
 
         assertThat(keys).hasSize(1)
         assertThat(keys.first()).isEqualTo(wrappingKeyInfo)
@@ -167,8 +171,9 @@ class WrappingRepositoryImplTests {
     @Test
     fun `find a wrapping key using its UUID`() {
         val wrappingKeyInfo = WrappingKeyInfo(
-            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1")
-        val newId  = UUID.randomUUID()
+            1, "caesar", SecureHashUtils.randomBytes(), 1, "Enoch", "alias1"
+        )
+        val newId = UUID.randomUUID()
         val savedWrappingKey = makeWrappingKeyEntity(newId, wrappingKeyInfo)
         val em = mock<EntityManager> {
             on { createQuery(any(), eq(WrappingKeyEntity::class.java)) } doAnswer {
@@ -202,13 +207,13 @@ class WrappingRepositoryImplTests {
     ): WrappingKeyEntity = WrappingKeyEntity(
         newId,
         "alias1",
-        wrappingKeyInfo.generation, 
-        mock(), 
-        wrappingKeyInfo.encodingVersion, 
-        wrappingKeyInfo.algorithmName, 
-        wrappingKeyInfo.keyMaterial, 
-        mock(), 
-        false, 
+        wrappingKeyInfo.generation,
+        mock(),
+        wrappingKeyInfo.encodingVersion,
+        wrappingKeyInfo.algorithmName,
+        wrappingKeyInfo.keyMaterial,
+        mock(),
+        false,
         wrappingKeyInfo.parentKeyAlias
-    ) 
+    )
 }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestWrappingRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestWrappingRepository.kt
@@ -33,13 +33,13 @@ class TestWrappingRepository(
     }
 
     override fun getKeyById(id: UUID): WrappingKeyInfo? {
-        TODO("Not yet implemented")
+        TODO("Not needed")
     }
 
-    override fun findKeysWrappedByAlias(alias: String): List<WrappingKeyInfo> {
-        TODO("Not yet implemented")
+    override fun findKeysWrappedByParentKey(parentKeyAlias: String): List<WrappingKeyInfo> {
+        TODO("Not needed")
     }
-    
+
     override fun close() {
     }
 }


### PR DESCRIPTION
There are only two functional changes here. `findKeyAndId` and `findKeysWrappedByParentKey` (renamed from `findKeysWrappedByAlias`) now return only the latest generation for each wrapping key per alias, plus tests for that. The other changes are for tidying/code clarity purposes.
