### PR TITLE
CORE-19367: Implement wrapping of signing keys with new wrapping keys

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
@@ -3,6 +3,7 @@ package net.corda.crypto.service.impl.infra
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.SigningKeyInfo
 import net.corda.crypto.core.SigningKeyStatus
+import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.core.publicKeyHashFromBytes
 import net.corda.crypto.core.publicKeyShortHashFromBytes
 import net.corda.crypto.persistence.SigningKeyFilterMapImpl
@@ -20,6 +21,7 @@ import net.corda.layeredpropertymap.impl.LayeredPropertyMapImpl
 import net.corda.layeredpropertymap.impl.PropertyConverter
 import net.corda.v5.crypto.SecureHash
 import java.lang.IllegalStateException
+import java.security.PrivateKey
 import java.security.PublicKey
 import java.time.Instant
 import java.util.UUID
@@ -115,5 +117,15 @@ class TestSigningRepository : SigningRepository {
 
     override fun getKeyMaterials(wrappingKeyId: UUID): Collection<SigningKeyMaterialInfo> {
         throw IllegalStateException("Unexpected call to getKeyMaterials")
+    }
+
+    override fun createNewSigningMaterial(
+        newWrappingKey: WrappingKey,
+        signingKeyId: UUID,
+        signingKey: PrivateKey
+    ): SigningKeyMaterialInfo = SigningKeyMaterialInfo(signingKeyId, byteArrayOf())
+
+    override fun saveSigningKeyMaterial(signingKeyMaterialInfo: SigningKeyMaterialInfo, wrappingKeyId: UUID) {
+
     }
 }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
@@ -119,13 +119,15 @@ class TestSigningRepository : SigningRepository {
         throw IllegalStateException("Unexpected call to getKeyMaterials")
     }
 
-    override fun createNewSigningMaterial(
+    override fun createNewSigningKeyMaterial(
         newWrappingKey: WrappingKey,
         signingKeyId: UUID,
         signingKey: PrivateKey
-    ): SigningKeyMaterialInfo = SigningKeyMaterialInfo(signingKeyId, byteArrayOf())
+    ): SigningKeyMaterialInfo {
+        throw IllegalStateException("Unexpected call to createNewSigningKeyMaterial")
+    }
 
     override fun saveSigningKeyMaterial(signingKeyMaterialInfo: SigningKeyMaterialInfo, wrappingKeyId: UUID) {
-
+        throw IllegalStateException("Unexpected call to saveSigningKeyMaterial")
     }
 }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestSigningRepository.kt
@@ -3,7 +3,6 @@ package net.corda.crypto.service.impl.infra
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.SigningKeyInfo
 import net.corda.crypto.core.SigningKeyStatus
-import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.core.publicKeyHashFromBytes
 import net.corda.crypto.core.publicKeyShortHashFromBytes
 import net.corda.crypto.persistence.SigningKeyFilterMapImpl
@@ -21,7 +20,6 @@ import net.corda.layeredpropertymap.impl.LayeredPropertyMapImpl
 import net.corda.layeredpropertymap.impl.PropertyConverter
 import net.corda.v5.crypto.SecureHash
 import java.lang.IllegalStateException
-import java.security.PrivateKey
 import java.security.PublicKey
 import java.time.Instant
 import java.util.UUID
@@ -117,14 +115,6 @@ class TestSigningRepository : SigningRepository {
 
     override fun getKeyMaterials(wrappingKeyId: UUID): Collection<SigningKeyMaterialInfo> {
         throw IllegalStateException("Unexpected call to getKeyMaterials")
-    }
-
-    override fun createNewSigningKeyMaterial(
-        newWrappingKey: WrappingKey,
-        signingKeyId: UUID,
-        signingKey: PrivateKey
-    ): SigningKeyMaterialInfo {
-        throw IllegalStateException("Unexpected call to createNewSigningKeyMaterial")
     }
 
     override fun saveSigningKeyMaterial(signingKeyMaterialInfo: SigningKeyMaterialInfo, wrappingKeyId: UUID) {

--- a/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/SigningRepositoryTest.kt
+++ b/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/SigningRepositoryTest.kt
@@ -686,7 +686,7 @@ class SigningRepositoryTest : CryptoRepositoryTest() {
         val privateKey = keyPairGenerator.genKeyPair().private
         val newSigningUuid = UUID.randomUUID()
 
-        val signingMaterialEntity = repo.createNewSigningMaterial(key, newSigningUuid, privateKey)
+        val signingMaterialEntity = repo.createNewSigningKeyMaterial(key, newSigningUuid, privateKey)
 
         assertThat(signingMaterialEntity.signingKeyId).isEqualTo(newSigningUuid)
         assertThat(key.unwrap(signingMaterialEntity.keyMaterial)).isEqualTo(privateKey)

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SigningRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SigningRepository.kt
@@ -80,7 +80,8 @@ interface SigningRepository : Closeable {
     fun getKeyMaterials(wrappingKeyId: UUID): Collection<SigningKeyMaterialInfo>
 
     /**
-     * Saves a signing key material entity to the database after being rewrapped. Note: This is not for use when creating new keys, [savePrivateKey] includes that functionality.
+     * Saves a signing key material entity to the database after being rewrapped.
+     * Note: This is not for use when creating new keys, [savePrivateKey] includes that functionality.
      *
      * @param signingKeyMaterialInfo The signing key material to be saved to the database
      * @param wrappingKeyId The UUID of the wrapping key

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SigningRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SigningRepository.kt
@@ -3,11 +3,14 @@ package net.corda.crypto.softhsm
 import java.security.PublicKey
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.SigningKeyInfo
+import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.persistence.SigningKeyMaterialInfo
 import net.corda.crypto.persistence.SigningKeyOrderBy
 import net.corda.crypto.persistence.SigningWrappedKeySaveContext
+import net.corda.crypto.persistence.db.model.SigningKeyMaterialEntity
 import net.corda.v5.crypto.SecureHash
 import java.io.Closeable
+import java.security.PrivateKey
 import java.util.UUID
 
 /**
@@ -78,4 +81,23 @@ interface SigningRepository : Closeable {
      * @return a collection of all key materials all wrapped with the specified wrapping key
      */
     fun getKeyMaterials(wrappingKeyId: UUID): Collection<SigningKeyMaterialInfo>
+
+    /**
+     * Creates a new signing key material from an existing signing key and a wrapping key
+     *
+     * @param newWrappingKey The new wrapping key to encrypt the signing key
+     * @param signingKeyId The UUID of the signing key
+     * @param signingKey The signing key to be encrypted
+     *
+     * @return the [SigningKeyMaterialEntity] that describes the new key material
+     */
+    fun createNewSigningMaterial(newWrappingKey: WrappingKey, signingKeyId: UUID, signingKey: PrivateKey): SigningKeyMaterialInfo
+
+    /**
+     * Saves a signing key material entity to the database
+     *
+     * @param signingKeyMaterialInfo The signing key material to be saved to the database
+     * @param wrappingKeyId The UUID of the wrapping key
+     */
+    fun saveSigningKeyMaterial(signingKeyMaterialInfo: SigningKeyMaterialInfo, wrappingKeyId: UUID)
 }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SigningRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SigningRepository.kt
@@ -91,7 +91,7 @@ interface SigningRepository : Closeable {
      *
      * @return the [SigningKeyMaterialEntity] that describes the new key material
      */
-    fun createNewSigningMaterial(newWrappingKey: WrappingKey, signingKeyId: UUID, signingKey: PrivateKey): SigningKeyMaterialInfo
+    fun createNewSigningKeyMaterial(newWrappingKey: WrappingKey, signingKeyId: UUID, signingKey: PrivateKey): SigningKeyMaterialInfo
 
     /**
      * Saves a signing key material entity to the database

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SigningRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/SigningRepository.kt
@@ -3,14 +3,11 @@ package net.corda.crypto.softhsm
 import java.security.PublicKey
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.SigningKeyInfo
-import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.persistence.SigningKeyMaterialInfo
 import net.corda.crypto.persistence.SigningKeyOrderBy
 import net.corda.crypto.persistence.SigningWrappedKeySaveContext
-import net.corda.crypto.persistence.db.model.SigningKeyMaterialEntity
 import net.corda.v5.crypto.SecureHash
 import java.io.Closeable
-import java.security.PrivateKey
 import java.util.UUID
 
 /**
@@ -83,18 +80,7 @@ interface SigningRepository : Closeable {
     fun getKeyMaterials(wrappingKeyId: UUID): Collection<SigningKeyMaterialInfo>
 
     /**
-     * Creates a new signing key material from an existing signing key and a wrapping key
-     *
-     * @param newWrappingKey The new wrapping key to encrypt the signing key
-     * @param signingKeyId The UUID of the signing key
-     * @param signingKey The signing key to be encrypted
-     *
-     * @return the [SigningKeyMaterialEntity] that describes the new key material
-     */
-    fun createNewSigningKeyMaterial(newWrappingKey: WrappingKey, signingKeyId: UUID, signingKey: PrivateKey): SigningKeyMaterialInfo
-
-    /**
-     * Saves a signing key material entity to the database
+     * Saves a signing key material entity to the database after being rewrapped. Note: This is not for use when creating new keys, [savePrivateKey] includes that functionality.
      *
      * @param signingKeyMaterialInfo The signing key material to be saved to the database
      * @param wrappingKeyId The UUID of the wrapping key

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
@@ -229,7 +229,11 @@ class SigningRepositoryImpl(
             }
         }
 
-    override fun createNewSigningKeyMaterial(newWrappingKey: WrappingKey, signingKeyId: UUID, signingKey: PrivateKey): SigningKeyMaterialInfo {
+    override fun createNewSigningKeyMaterial(
+        newWrappingKey: WrappingKey,
+        signingKeyId: UUID,
+        signingKey: PrivateKey
+    ): SigningKeyMaterialInfo {
         val newKeyMaterial = newWrappingKey.wrap(signingKey)
         return SigningKeyMaterialInfo(signingKeyId, newKeyMaterial)
     }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
@@ -229,7 +229,7 @@ class SigningRepositoryImpl(
             }
         }
 
-    override fun createNewSigningMaterial(newWrappingKey: WrappingKey, signingKeyId: UUID, signingKey: PrivateKey): SigningKeyMaterialInfo {
+    override fun createNewSigningKeyMaterial(newWrappingKey: WrappingKey, signingKeyId: UUID, signingKey: PrivateKey): SigningKeyMaterialInfo {
         val newKeyMaterial = newWrappingKey.wrap(signingKey)
         return SigningKeyMaterialInfo(signingKeyId, newKeyMaterial)
     }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImpl.kt
@@ -36,10 +36,8 @@ import java.time.Instant
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import net.corda.crypto.core.CryptoConsts
-import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.persistence.SigningKeyMaterialInfo
 import java.util.UUID
-import java.security.PrivateKey
 
 @Suppress("LongParameterList")
 class SigningRepositoryImpl(
@@ -228,15 +226,6 @@ class SigningRepositoryImpl(
                     }
             }
         }
-
-    override fun createNewSigningKeyMaterial(
-        newWrappingKey: WrappingKey,
-        signingKeyId: UUID,
-        signingKey: PrivateKey
-    ): SigningKeyMaterialInfo {
-        val newKeyMaterial = newWrappingKey.wrap(signingKey)
-        return SigningKeyMaterialInfo(signingKeyId, newKeyMaterial)
-    }
 
     override fun saveSigningKeyMaterial(signingKeyMaterialInfo: SigningKeyMaterialInfo, wrappingKeyId: UUID) {
         val signingKeyMaterialEntity = SigningKeyMaterialEntity(

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -651,6 +651,7 @@ open class SoftCryptoService(
      *
      * @param wrappingRepository The WrappingRepository the new key will be saved in
      * @param oldWrappingKey The original wrapping key
+     * @return The [UUID] of the new wrapping key
      */
     private fun createWrappingKeyFrom(wrappingRepository: WrappingRepository, oldWrappingKey: WrappingKeyInfo): UUID {
         logger.trace {

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -57,6 +57,7 @@ import java.security.PrivateKey
 import java.security.Provider
 import java.security.PublicKey
 import java.time.Duration
+import java.util.UUID
 import javax.crypto.Cipher
 import javax.persistence.PersistenceException
 
@@ -651,7 +652,7 @@ open class SoftCryptoService(
      * @param wrappingRepository The WrappingRepository the new key will be saved in
      * @param oldWrappingKey The original wrapping key
      */
-    private fun createWrappingKeyFrom(wrappingRepository: WrappingRepository, oldWrappingKey: WrappingKeyInfo) {
+    private fun createWrappingKeyFrom(wrappingRepository: WrappingRepository, oldWrappingKey: WrappingKeyInfo): UUID {
         logger.trace {
             "createWrappingKeyFrom(alias=${oldWrappingKey.alias})"
         }
@@ -669,11 +670,13 @@ open class SoftCryptoService(
                 parentKeyAlias,
                 oldWrappingKey.alias
             )
+        val wrappingKeyUUID = UUID.randomUUID()
         recoverable("createWrappingKeyFrom save key") {
-            wrappingRepository.saveKey(wrappingKeyInfo)
+            wrappingRepository.saveKeyWithId(wrappingKeyInfo, wrappingKeyUUID)
         }
         logger.trace("Regenerated wrapping key alias ${oldWrappingKey.alias}")
         wrappingKeyCache?.put(wrappingKeyInfo.alias, wrappingKey)
+        return wrappingKeyUUID
     }
 }
 

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestSigningRepository.kt
@@ -3,7 +3,6 @@ package net.corda.crypto.softhsm.impl.infra
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.SigningKeyInfo
 import net.corda.crypto.core.SigningKeyStatus
-import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.core.publicKeyHashFromBytes
 import net.corda.crypto.core.publicKeyShortHashFromBytes
 import net.corda.crypto.persistence.SigningKeyMaterialInfo
@@ -12,7 +11,6 @@ import net.corda.crypto.persistence.SigningWrappedKeySaveContext
 import net.corda.crypto.softhsm.SigningRepository
 import net.corda.v5.crypto.SecureHash
 import java.lang.IllegalStateException
-import java.security.PrivateKey
 import java.security.PublicKey
 import java.time.Instant
 import java.util.UUID
@@ -67,14 +65,6 @@ class TestSigningRepository(val tenantId: String = "test") : SigningRepository {
 
     override fun getKeyMaterials(wrappingKeyId: UUID): Collection<SigningKeyMaterialInfo> {
         throw IllegalStateException("Unexpected call to getKeyMaterials")
-    }
-
-    override fun createNewSigningKeyMaterial(
-        newWrappingKey: WrappingKey,
-        signingKeyId: UUID,
-        signingKey: PrivateKey
-    ): SigningKeyMaterialInfo {
-        throw IllegalStateException("Unexpected call to createNewSigningKeyMaterial")
     }
 
     override fun saveSigningKeyMaterial(signingKeyMaterialInfo: SigningKeyMaterialInfo, wrappingKeyId: UUID) {

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestSigningRepository.kt
@@ -3,6 +3,7 @@ package net.corda.crypto.softhsm.impl.infra
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.SigningKeyInfo
 import net.corda.crypto.core.SigningKeyStatus
+import net.corda.crypto.core.aes.WrappingKey
 import net.corda.crypto.core.publicKeyHashFromBytes
 import net.corda.crypto.core.publicKeyShortHashFromBytes
 import net.corda.crypto.persistence.SigningKeyMaterialInfo
@@ -11,6 +12,7 @@ import net.corda.crypto.persistence.SigningWrappedKeySaveContext
 import net.corda.crypto.softhsm.SigningRepository
 import net.corda.v5.crypto.SecureHash
 import java.lang.IllegalStateException
+import java.security.PrivateKey
 import java.security.PublicKey
 import java.time.Instant
 import java.util.UUID
@@ -65,5 +67,15 @@ class TestSigningRepository(val tenantId: String = "test") : SigningRepository {
 
     override fun getKeyMaterials(wrappingKeyId: UUID): Collection<SigningKeyMaterialInfo> {
         throw IllegalStateException("Unexpected call to getKeyMaterials")
+    }
+
+    override fun createNewSigningMaterial(
+        newWrappingKey: WrappingKey,
+        signingKeyId: UUID,
+        signingKey: PrivateKey
+    ): SigningKeyMaterialInfo = SigningKeyMaterialInfo(signingKeyId, byteArrayOf())
+
+    override fun saveSigningKeyMaterial(signingKeyMaterialInfo: SigningKeyMaterialInfo, wrappingKeyId: UUID) {
+
     }
 }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestSigningRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestSigningRepository.kt
@@ -69,13 +69,15 @@ class TestSigningRepository(val tenantId: String = "test") : SigningRepository {
         throw IllegalStateException("Unexpected call to getKeyMaterials")
     }
 
-    override fun createNewSigningMaterial(
+    override fun createNewSigningKeyMaterial(
         newWrappingKey: WrappingKey,
         signingKeyId: UUID,
         signingKey: PrivateKey
-    ): SigningKeyMaterialInfo = SigningKeyMaterialInfo(signingKeyId, byteArrayOf())
+    ): SigningKeyMaterialInfo {
+        throw IllegalStateException("Unexpected call to createNewSigningKeyMaterial")
+    }
 
     override fun saveSigningKeyMaterial(signingKeyMaterialInfo: SigningKeyMaterialInfo, wrappingKeyId: UUID) {
-
+        throw IllegalStateException("Unexpected call to saveSigningKeyMaterial")
     }
 }


### PR DESCRIPTION
This PR implements functions to help with the rewrapping of signing keys as part of a key rotation. It also changes the SoftCryptoService.createWrappingKeyFrom function to return a UUID for future work which will require the UUID of the generated wrapping key.