### PR TITLE
CORE-19373: Improvements to OpenAPI generation

### DIFF
--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiNullabilityTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiNullabilityTest.kt
@@ -98,6 +98,24 @@ class RestServerOpenApiNullabilityTest : RestServerTestBase() {
             val numberProperty = this.properties["number"]
             assertNotNull(numberProperty)
             assertThat(numberProperty.nullable).isFalse
+            assertThat(this.required.toSet()).isEqualTo(setOf("id", "number"))
+        }
+
+        with(openAPI.paths["/nullability/posttakesrequiredstringreturnsnullablestring"]) {
+            assertNotNull(this)
+            val post = this.post
+            assertNotNull(post)
+            val postReqBody = post.requestBody
+            assertTrue(postReqBody.required)
+            val requestBodyJson = post.requestBody.content["application/json"]
+            assertNotNull(requestBodyJson)
+            val schema = requestBodyJson.schema
+
+            val requiredString = assertNotNull(schema.properties["requiredString"])
+            assertThat(requiredString.nullable).isFalse()
+            assertThat(requiredString.type).isEqualTo("string")
+
+            assertThat(schema.required).isEqualTo("requiredString")
         }
     }
 }

--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiNullabilityTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiNullabilityTest.kt
@@ -111,11 +111,11 @@ class RestServerOpenApiNullabilityTest : RestServerTestBase() {
             assertNotNull(requestBodyJson)
             val schema = requestBodyJson.schema
 
-            val requiredString = assertNotNull(schema.properties["requiredString"])
+            val requiredString = assertNotNull(schema.properties["requiredString1"])
             assertThat(requiredString.nullable).isFalse()
             assertThat(requiredString.type).isEqualTo("string")
 
-            assertThat(schema.required).isEqualTo(listOf("requiredString"))
+            assertThat(schema.required).isEqualTo(listOf("requiredString1"))
         }
     }
 }

--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiNullabilityTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiNullabilityTest.kt
@@ -1,0 +1,103 @@
+package net.corda.rest.server.impl
+
+import io.swagger.v3.core.util.Json
+import io.swagger.v3.oas.models.OpenAPI
+import net.corda.rest.server.config.models.RestServerSettings
+import net.corda.rest.server.impl.utils.compact
+import net.corda.rest.test.NullabilityRestResourceImpl
+import net.corda.rest.test.utils.TestHttpClientUnirestImpl
+import net.corda.rest.test.utils.WebRequest
+import net.corda.rest.test.utils.multipartDir
+import net.corda.rest.tools.HttpVerb.GET
+import net.corda.utilities.NetworkHostAndPort
+import org.apache.http.HttpStatus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RestServerOpenApiNullabilityTest : RestServerTestBase() {
+    companion object {
+        private val restServerSettings = RestServerSettings(
+            NetworkHostAndPort("localhost", 0),
+            context,
+            null,
+            null,
+            RestServerSettings.MAX_CONTENT_LENGTH_DEFAULT_VALUE,
+            20000L
+        )
+
+        @BeforeAll
+        @JvmStatic
+        fun setUpBeforeClass() {
+            server = RestServerImpl(
+                listOf(
+                    NullabilityRestResourceImpl(),
+                ),
+                ::securityManager,
+                restServerSettings,
+                multipartDir,
+                true
+            ).apply { start() }
+            client = TestHttpClientUnirestImpl(
+                "http://${restServerSettings.address.host}:${server.port}/" +
+                    "${restServerSettings.context.basePath}/${apiVersion.versionPath}/"
+            )
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun cleanUpAfterClass() {
+            if (isServerInitialized()) {
+                server.close()
+            }
+        }
+    }
+
+    @Test
+    fun `GET openapi should return the OpenApi spec json`() {
+        val apiSpec = client.call(GET, WebRequest<Any>("swagger.json"))
+        assertEquals(HttpStatus.SC_OK, apiSpec.responseStatus)
+        assertEquals("application/json", apiSpec.headers["Content-Type"])
+        val body = apiSpec.body!!.compact()
+        assertTrue(body.contains(""""openapi" : "3.0.1""""))
+        assertFalse(body.contains("\"null\""))
+        assertFalse(body.contains("null,"))
+
+        val openAPI = Json.mapper().readValue(body, OpenAPI::class.java)
+
+        with(openAPI.paths["/nullability/posttakesnullablereturnsnullable"]) {
+            assertNotNull(this)
+            val post = this.post
+            assertNotNull(post)
+            val postReqBody = post.requestBody
+            assertTrue(postReqBody.required)
+            val requestBodyJson = post.requestBody.content["application/json"]
+            assertNotNull(requestBodyJson)
+            val ref = requestBodyJson.schema.`$ref`
+            assertThat(ref).isEqualTo("#/components/schemas/SomeInfo")
+            val successResponse = post.responses["200"]
+            assertNotNull(successResponse)
+            val content = successResponse.content["application/json"]
+            assertNotNull(content)
+            val schema = content.schema
+            assertTrue(schema.nullable, "The schema should have the nullable property")
+        }
+
+        with(openAPI.components.schemas["SomeInfo"]) {
+            assertNotNull(this)
+            assertNull(this.nullable)
+            val idProperty = this.properties["id"]
+            assertNotNull(idProperty)
+            assertThat(idProperty.nullable).isFalse
+            val numberProperty = this.properties["number"]
+            assertNotNull(numberProperty)
+            assertThat(numberProperty.nullable).isFalse
+        }
+    }
+}

--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiNullabilityTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiNullabilityTest.kt
@@ -115,7 +115,7 @@ class RestServerOpenApiNullabilityTest : RestServerTestBase() {
             assertThat(requiredString.nullable).isFalse()
             assertThat(requiredString.type).isEqualTo("string")
 
-            assertThat(schema.required).isEqualTo("requiredString")
+            assertThat(schema.required).isEqualTo(listOf("requiredString"))
         }
     }
 }

--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiTest.kt
@@ -14,7 +14,6 @@ import net.corda.rest.server.config.models.RestServerSettings
 import net.corda.rest.server.impl.internal.OptionalDependency
 import net.corda.rest.server.impl.utils.compact
 import net.corda.rest.test.CalendarRestResourceImpl
-import net.corda.rest.test.NullabilityRestResourceImpl
 import net.corda.rest.test.ObjectsInJsonEndpointImpl
 import net.corda.rest.test.TestEntityRestResourceImpl
 import net.corda.rest.test.TestFileUploadImpl
@@ -57,7 +56,6 @@ class RestServerOpenApiTest : RestServerTestBase() {
                     TestHealthCheckAPIImpl(),
                     TestEntityRestResourceImpl(),
                     TestFileUploadImpl(),
-                    NullabilityRestResourceImpl(),
                     ObjectsInJsonEndpointImpl()
                 ),
                 ::securityManager,
@@ -210,35 +208,6 @@ class RestServerOpenApiTest : RestServerTestBase() {
             val schema = content.schema
             assertTrue(schema.nullable, "The schema should have the nullable property")
             assertEquals("string", schema.type)
-        }
-
-        with(openAPI.paths["/nullability/posttakesnullablereturnsnullable"]) {
-            assertNotNull(this)
-            val post = this.post
-            assertNotNull(post)
-            val postReqBody = post.requestBody
-            assertTrue(postReqBody.required)
-            val requestBodyJson = post.requestBody.content["application/json"]
-            assertNotNull(requestBodyJson)
-            val ref = requestBodyJson.schema.`$ref`
-            assertThat(ref).isEqualTo("#/components/schemas/SomeInfo")
-            val successResponse = post.responses["200"]
-            assertNotNull(successResponse)
-            val content = successResponse.content["application/json"]
-            assertNotNull(content)
-            val schema = content.schema
-            assertTrue(schema.nullable, "The schema should have the nullable property")
-        }
-
-        with(openAPI.components.schemas["SomeInfo"]) {
-            assertNotNull(this)
-            assertNull(this.nullable)
-            val idProperty = this.properties["id"]
-            assertNotNull(idProperty)
-            assertThat(idProperty.nullable).isFalse
-            val numberProperty = this.properties["number"]
-            assertNotNull(numberProperty)
-            assertThat(numberProperty.nullable).isFalse
         }
 
         with(openAPI.components.schemas["EchoParams"]) {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
@@ -155,9 +155,11 @@ private fun List<EndpointParameter>.toMediaType(
             )
         )
     } else {
+        // The case of a single parameter which is not a reference to a complex type
         MediaType().schema(
             Schema<Any>().properties(this.toProperties(schemaModelProvider))
                 .type(DataType.OBJECT.toString().lowercase())
+                .required(with(this.first()) { if (required) listOf(id) else null })
         )
     }
 }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
@@ -159,7 +159,7 @@ private fun List<EndpointParameter>.toMediaType(
         MediaType().schema(
             Schema<Any>().properties(this.toProperties(schemaModelProvider))
                 .type(DataType.OBJECT.toString().lowercase())
-                .required(with(this.first()) { if (required) listOf(id) else null })
+                .required(with(this.first()) { if (required) listOf(name) else null })
         )
     }
 }

--- a/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResource.kt
+++ b/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResource.kt
@@ -33,4 +33,10 @@ interface NullabilityRestResource : RestResource {
         @ClientRequestBodyParameter
         optionalString: String?
     ): String?
+
+    @HttpPOST(path = "postTakesRequiredStringReturnsNullableString")
+    fun postTakesRequiredStringReturnsNullableString(
+        @ClientRequestBodyParameter
+        requiredString: String
+    ): String?
 }

--- a/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResource.kt
+++ b/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResource.kt
@@ -12,25 +12,25 @@ interface NullabilityRestResource : RestResource {
 
     @HttpPOST(path = "postTakesNullableReturnsNullable")
     fun postTakesNullableReturnsNullable(
-        @ClientRequestBodyParameter(name = "someInfo")
-        someInfo: SomeInfo?
+        @ClientRequestBodyParameter
+        optionalSomeInfo: SomeInfo?
     ): SomeInfo?
 
     @HttpPOST(path = "postTakesInfoReturnsNullable")
     fun postTakesInfoReturnsNullable(
-        @ClientRequestBodyParameter(name = "someInfo")
-        someInfo: SomeInfo
+        @ClientRequestBodyParameter
+        requiredSomeInfo: SomeInfo
     ): SomeInfo?
 
     @HttpPOST(path = "postTakesNullableReturnsInfo")
     fun postTakesNullableReturnsInfo(
-        @ClientRequestBodyParameter(name = "someInfo")
-        someInfo: SomeInfo?
+        @ClientRequestBodyParameter
+        optionalSomeInfo: SomeInfo?
     ): SomeInfo
 
     @HttpPOST(path = "postTakesNullableStringReturnsNullableString")
     fun postTakesNullableStringReturnsNullableString(
-        @ClientRequestBodyParameter(name = "input")
-        input: String?
+        @ClientRequestBodyParameter
+        optionalString: String?
     ): String?
 }

--- a/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResource.kt
+++ b/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResource.kt
@@ -36,7 +36,7 @@ interface NullabilityRestResource : RestResource {
 
     @HttpPOST(path = "postTakesRequiredStringReturnsNullableString")
     fun postTakesRequiredStringReturnsNullableString(
-        @ClientRequestBodyParameter
+        @ClientRequestBodyParameter(name = "requiredString1")
         requiredString: String
     ): String?
 }

--- a/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResourceImpl.kt
+++ b/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResourceImpl.kt
@@ -19,6 +19,10 @@ class NullabilityRestResourceImpl : PluggableRestResource<NullabilityRestResourc
         return null
     }
 
+    override fun postTakesRequiredStringReturnsNullableString(requiredString: String): String? {
+        return null
+    }
+
     override val protocolVersion: Int
         get() = 1
 

--- a/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResourceImpl.kt
+++ b/libs/rest/rest-test-common/src/main/kotlin/net/corda/rest/test/NullabilityRestResourceImpl.kt
@@ -3,19 +3,19 @@ package net.corda.rest.test
 import net.corda.rest.PluggableRestResource
 
 class NullabilityRestResourceImpl : PluggableRestResource<NullabilityRestResource>, NullabilityRestResource {
-    override fun postTakesNullableReturnsNullable(someInfo: SomeInfo?): SomeInfo? {
+    override fun postTakesNullableReturnsNullable(optionalSomeInfo: SomeInfo?): SomeInfo {
         return SomeInfo("tenantId", 1)
     }
 
-    override fun postTakesInfoReturnsNullable(someInfo: SomeInfo): SomeInfo? {
+    override fun postTakesInfoReturnsNullable(requiredSomeInfo: SomeInfo): SomeInfo {
         return SomeInfo("tenantId", 1)
     }
 
-    override fun postTakesNullableReturnsInfo(someInfo: SomeInfo?): SomeInfo {
+    override fun postTakesNullableReturnsInfo(optionalSomeInfo: SomeInfo?): SomeInfo {
         return SomeInfo("tenantId", 1)
     }
 
-    override fun postTakesNullableStringReturnsNullableString(input: String?): String? {
+    override fun postTakesNullableStringReturnsNullableString(optionalString: String?): String? {
         return null
     }
 

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v1.json
@@ -2413,6 +2413,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
+                "required" : [ "reason" ],
                 "type" : "object",
                 "properties" : {
                   "reason" : {

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
@@ -2413,6 +2413,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
+                "required" : [ "reason" ],
                 "type" : "object",
                 "properties" : {
                   "reason" : {

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -2427,6 +2427,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
+                "required" : [ "reason" ],
                 "type" : "object",
                 "properties" : {
                   "reason" : {
@@ -3654,6 +3655,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
+                "required" : [ "password" ],
                 "type" : "object",
                 "properties" : {
                   "password" : {
@@ -4408,6 +4410,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
+                "required" : [ "newKeyAlias" ],
                 "type" : "object",
                 "properties" : {
                   "newKeyAlias" : {


### PR DESCRIPTION
Populate `required` list even when there is a single non-nullable body parameter sent to the method.

Also some integration tests refactoring.