### PR TITLE
CORE-19330: FlowTimeout Traceability

### DIFF
--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/maintenance/TimeoutEventCleanupProcessorTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/maintenance/TimeoutEventCleanupProcessorTest.kt
@@ -4,6 +4,7 @@ import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.data.flow.FlowTimeout
 import net.corda.data.flow.state.checkpoint.Checkpoint
 import net.corda.data.messaging.mediator.MediatorState
+import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.state.impl.FlowCheckpointFactory
 import net.corda.libs.configuration.SmartConfig
 import net.corda.libs.statemanager.api.State
@@ -14,21 +15,33 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
 
 class TimeoutEventCleanupProcessorTest {
-    private val checkpointCleanupHandler = mock<CheckpointCleanupHandler>()
+    private val config = mock<SmartConfig>()
     private val stateManager = mock<StateManager>()
+    private val flowCheckpointFactory = mock<FlowCheckpointFactory>()
+    private val checkpointCleanupHandler = mock<CheckpointCleanupHandler>()
     private val checkpointCordaAvroDeserializer = mock<CordaAvroDeserializer<Checkpoint>>()
     private val mediatorDeserializer = mock<CordaAvroDeserializer<MediatorState>>()
-    private val flowCheckpointFactory = mock<FlowCheckpointFactory>()
-    private val config = mock<SmartConfig>()
+    private val exceptionCaptor = argumentCaptor<FlowFatalException>()
+    private val processor = TimeoutEventCleanupProcessor(
+        checkpointCleanupHandler,
+        stateManager,
+        mediatorDeserializer,
+        checkpointCordaAvroDeserializer,
+        flowCheckpointFactory,
+        config
+    )
 
     private val inputRecords = listOf(
-        buildRecord("foo"),
-        buildRecord("bar")
+        buildRecord("key1", "TestReason1"),
+        buildRecord("key2", "TestReason2")
     )
 
     @BeforeEach
@@ -42,6 +55,7 @@ class TimeoutEventCleanupProcessorTest {
         val mediatorState = mock<MediatorState>().apply {
             whenever(state).thenReturn(checkpointBytes)
         }
+
         whenever(checkpointCordaAvroDeserializer.deserialize(any())).thenReturn(checkpoint)
         whenever(mediatorDeserializer.deserialize(any())).thenReturn(mediatorState)
         whenever(flowCheckpointFactory.create(any(), any(), any())).thenReturn(mock())
@@ -49,33 +63,28 @@ class TimeoutEventCleanupProcessorTest {
     }
 
     @Test
+    fun `records with null values are not processed and no output records are generated`() {
+        val output = processor.onNext(listOf(Record("timeout", "key", null)))
+        assertThat(output.size).isEqualTo(0)
+    }
+
+    @Test
     fun `when timeout processor receives events with states output records are generated`() {
         whenever(stateManager.get(any())).thenReturn(inputRecords.associate { it.key to buildState(it.key) })
         whenever(stateManager.delete(any())).thenReturn(mapOf())
-        val processor = TimeoutEventCleanupProcessor(
-            checkpointCleanupHandler,
-            stateManager,
-            mediatorDeserializer,
-            checkpointCordaAvroDeserializer,
-            flowCheckpointFactory,
-            config
-        )
+
         val output = processor.onNext(inputRecords)
         assertThat(output.size).isEqualTo(2)
+        verify(checkpointCleanupHandler, times(2)).cleanupCheckpoint(any(), any(), exceptionCaptor.capture())
+        assertThat(exceptionCaptor.firstValue.message).isEqualTo("TestReason1")
+        assertThat(exceptionCaptor.secondValue.message).isEqualTo("TestReason2")
     }
 
     @Test
     fun `when timeout processor fails to delete a state no records are output`() {
         whenever(stateManager.get(any())).thenReturn(inputRecords.associate { it.key to buildState(it.key) })
         whenever(stateManager.delete(any())).thenReturn(inputRecords.associate { it.key to buildState(it.key) })
-        val processor = TimeoutEventCleanupProcessor(
-            checkpointCleanupHandler,
-            stateManager,
-            mediatorDeserializer,
-            checkpointCordaAvroDeserializer,
-            flowCheckpointFactory,
-            config
-        )
+
         val output = processor.onNext(inputRecords)
         assertThat(output).isEmpty()
     }
@@ -84,14 +93,7 @@ class TimeoutEventCleanupProcessorTest {
     fun `when state manager does not have states available no records are output`() {
         whenever(stateManager.get(any())).thenReturn(mapOf())
         whenever(stateManager.delete(any())).thenReturn(mapOf())
-        val processor = TimeoutEventCleanupProcessor(
-            checkpointCleanupHandler,
-            stateManager,
-            mediatorDeserializer,
-            checkpointCordaAvroDeserializer,
-            flowCheckpointFactory,
-            config
-        )
+
         val output = processor.onNext(inputRecords)
         assertThat(output).isEmpty()
     }
@@ -101,23 +103,16 @@ class TimeoutEventCleanupProcessorTest {
         whenever(stateManager.get(any())).thenReturn(inputRecords.associate { it.key to buildState(it.key) })
         whenever(checkpointCordaAvroDeserializer.deserialize(any())).thenReturn(null)
         whenever(stateManager.delete(any())).thenReturn(mapOf())
-        val processor = TimeoutEventCleanupProcessor(
-            checkpointCleanupHandler,
-            stateManager,
-            mediatorDeserializer,
-            checkpointCordaAvroDeserializer,
-            flowCheckpointFactory,
-            config
-        )
+
         val output = processor.onNext(inputRecords)
         assertThat(output).isEmpty()
     }
 
-    private fun buildRecord(key: String) : Record<String, FlowTimeout> {
-        return Record("timeout", key, FlowTimeout(key, Instant.now()))
+    private fun buildRecord(key: String, timeOutReason: String? = ""): Record<String, FlowTimeout> {
+        return Record("timeout", key, FlowTimeout(key, timeOutReason, Instant.now()))
     }
 
-    private fun buildState(key: String) : State {
+    private fun buildState(key: String): State {
         return State(key, byteArrayOf())
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.JR-alpha-1705942138754
+cordaApiVersion=5.2.0.JR-alpha-1706026163838
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.JR-alpha-1706026163838
+cordaApiVersion=5.2.0.31-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.30-beta+
+cordaApiVersion=5.2.0.JR-alpha-1705942138754
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/StateManagerHelper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/StateManagerHelper.kt
@@ -10,6 +10,8 @@ import net.corda.libs.statemanager.api.StateManager
 import net.corda.libs.statemanager.api.metadata
 import net.corda.messaging.api.constants.MessagingMetadataKeys.PROCESSING_FAILURE
 import net.corda.messaging.api.processor.StateAndEventProcessor
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
 
 /**
@@ -20,6 +22,9 @@ class StateManagerHelper<S : Any>(
     private val stateDeserializer: CordaAvroDeserializer<S>,
     private val mediatorStateDeserializer: CordaAvroDeserializer<MediatorState>,
 ) {
+    private companion object {
+        private val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
 
     /**
      * Creates an updated [State] or a new one if there was no previous version.
@@ -52,8 +57,14 @@ class StateManagerHelper<S : Any>(
      *
      * In the event processing failed for a non-existent state, a new state is created with the metadata key set. This
      * allows clients to detect issues with any failed processing.
+     *
+     * @param key the unique identifier of the [State] to mark as failed.
+     * @param originalState the original [State] that will me be marked as failed.
+     * @param reason the actual reason for which the [State] will be marked as a failure, for logging purposes only.
      */
-    fun failStateProcessing(key: String, originalState: State?) : State {
+    fun failStateProcessing(key: String, originalState: State?, reason: String): State {
+        logger.warn("State with key $key will be marked as failed, $reason.")
+
         val newMetadata = (originalState?.metadata?.toMutableMap() ?: mutableMapOf()).also {
             it[PROCESSING_FAILURE] = true
         }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessor.kt
@@ -128,7 +128,11 @@ class ConsumerProcessor<K : Any, S : Any, E : Any>(
                     } catch (e: TimeoutException) {
                         group.mapValues { (key, input) ->
                             val oldState = input.state
-                            val state = stateManagerHelper.failStateProcessing(key.toString(), oldState)
+                            val state = stateManagerHelper.failStateProcessing(
+                                key.toString(),
+                                oldState,
+                                "timeout occurred while processing events"
+                            )
                             val stateChange = if (oldState != null) {
                                 StateChangeAndOperation.Update(state)
                             } else {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessor.kt
@@ -1,7 +1,6 @@
 package net.corda.messaging.mediator.processor
 
 import net.corda.data.messaging.mediator.MediatorState
-import net.corda.libs.statemanager.api.State
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessageRouter
@@ -26,7 +25,6 @@ class EventProcessor<K : Any, S : Any, E : Any>(
     private val messageRouter: MessageRouter,
     private val mediatorReplayService: MediatorReplayService,
 ) {
-
     /**
      * Process a group of events.
      * @param group Group of records of various keys
@@ -68,8 +66,13 @@ class EventProcessor<K : Any, S : Any, E : Any>(
                 // of the system despite the retry loop implemented there. This should trigger individual processing to
                 // fail.
                 asyncOutputs.clear()
-                stateManagerHelper.failStateProcessing(groupKey, input.state)
+                stateManagerHelper.failStateProcessing(
+                    groupKey,
+                    input.state,
+                    "unable to contact Corda services while processing events"
+                )
             }
+
             val stateChangeAndOperation = when {
                 input.state == null && processed != null -> StateChangeAndOperation.Create(processed)
                 input.state != null && processed != null -> StateChangeAndOperation.Update(processed)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/StateManagerHelperTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/StateManagerHelperTest.kt
@@ -131,7 +131,7 @@ class StateManagerHelperTest {
             wrapperDeserializer
         )
 
-        val state = stateManagerHelper.failStateProcessing(TEST_KEY, persistedState)
+        val state = stateManagerHelper.failStateProcessing(TEST_KEY, persistedState, "")
 
         assertEquals(persistedState.key, state.key)
         assertEquals(persistedState.version, state.version)
@@ -146,7 +146,7 @@ class StateManagerHelperTest {
             wrapperDeserializer
         )
 
-        val state = stateManagerHelper.failStateProcessing(TEST_KEY, null)
+        val state = stateManagerHelper.failStateProcessing(TEST_KEY, null, "")
 
         assertEquals(TEST_KEY, state.key)
         assertEquals(VERSION_INITIAL_VALUE, state.version)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessorTest.kt
@@ -177,12 +177,12 @@ class ConsumerProcessorTest {
             future.completeExceptionally(TimeoutException())
             future
         }
-        whenever(stateManagerHelper.failStateProcessing(any(), anyOrNull())).thenReturn(mock())
+        whenever(stateManagerHelper.failStateProcessing(any(), anyOrNull(), any())).thenReturn(mock())
         whenever(groupAllocator.allocateGroups<String, String, String>(any(), any())).thenReturn(getGroups(2, 4), listOf())
 
         consumerProcessor.processTopic(getConsumerFactory(), getConsumerConfig())
 
-        verify(stateManagerHelper, times(2)).failStateProcessing(any(), anyOrNull())
+        verify(stateManagerHelper, times(2)).failStateProcessing(any(), anyOrNull(), any())
     }
 
     @Test

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
@@ -95,14 +95,14 @@ class EventProcessorTest {
             ))
         }
         whenever(client.send(any())).thenThrow(CordaMessageAPIIntermittentException("baz"))
-        whenever(stateManagerHelper.failStateProcessing(any(), anyOrNull())).thenReturn(mock())
+        whenever(stateManagerHelper.failStateProcessing(any(), anyOrNull(), any())).thenReturn(mock())
 
         val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), state))
         val outputMap = eventProcessor.processEvents(input)
 
         val output = outputMap["key"]
         assertEquals(emptyList<MediatorMessage<Any>>(), output?.asyncOutputs)
-        verify(stateManagerHelper).failStateProcessing(any(), anyOrNull())
+        verify(stateManagerHelper).failStateProcessing(any(), anyOrNull(), any())
     }
 
     private fun buildStringTestConfig() = EventMediatorConfig(


### PR DESCRIPTION
Whenever the conditions are met to declare that a flow has 'FAILED' due
to timeout, correctly register the actual reason within the final flow
status and identify the cause within the logs for tracking purposes.
