### PR TITLE
CORE-19304 - Modify notary fields validation on MGM side

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -237,12 +237,10 @@ internal class StartRegistrationHandler(
                 val previousContext = previous.memberProvidedContext.toMap()
                 val pendingContext = pendingMemberInfo.memberProvidedContext.toMap()
                 val diffInvalidMsgFn = verifyReRegistrationChanges(previousContext, pendingContext)
-                validateRegistrationRequest(
-                    diffInvalidMsgFn.isEmpty(),
-                    registrationLogger,
-                    diffInvalidMsgFn,
-                    diffInvalidMsgFn
-                )
+                if (!diffInvalidMsgFn.isNullOrEmpty()) {
+                    registrationLogger.info(diffInvalidMsgFn)
+                    throw InvalidRegistrationRequestException(diffInvalidMsgFn, diffInvalidMsgFn)
+                }
             }
 
             // The group ID matches the group ID of the MGM

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandler.kt
@@ -236,10 +236,10 @@ internal class StartRegistrationHandler(
             activeOrSuspendedInfo?.let { previous ->
                 val previousContext = previous.memberProvidedContext.toMap()
                 val pendingContext = pendingMemberInfo.memberProvidedContext.toMap()
-                val diffInvalidMsgFn = verifyReRegistrationChanges(previousContext, pendingContext)
-                if (!diffInvalidMsgFn.isNullOrEmpty()) {
-                    registrationLogger.info(diffInvalidMsgFn)
-                    throw InvalidRegistrationRequestException(diffInvalidMsgFn, diffInvalidMsgFn)
+                val diffInvalidMsg = verifyReRegistrationChanges(previousContext, pendingContext)
+                if (!diffInvalidMsg.isNullOrEmpty()) {
+                    registrationLogger.info(diffInvalidMsg)
+                    throw InvalidRegistrationRequestException(diffInvalidMsg, diffInvalidMsg)
                 }
             }
 

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -58,7 +58,6 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_SIGNER_
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_CPI_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEY_SPEC
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_ROLE
-import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL_VERSIONS
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_NAME
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS
@@ -82,6 +81,7 @@ import net.corda.membership.lib.schema.validation.MembershipSchemaValidationExce
 import net.corda.membership.lib.schema.validation.MembershipSchemaValidatorFactory
 import net.corda.membership.lib.toMap
 import net.corda.membership.lib.toWire
+import net.corda.membership.lib.verifyReRegistrationChanges
 import net.corda.membership.locally.hosted.identities.LocallyHostedIdentitiesService
 import net.corda.membership.p2p.helpers.KeySpecExtractor
 import net.corda.membership.p2p.helpers.KeySpecExtractor.Companion.spec
@@ -471,26 +471,11 @@ class DynamicMemberRegistrationService @Activate constructor(
                 optionalContext +
                 tlsSubject
 
-            previousRegistrationContext?.let { previous ->
-                verifyBackchainFlagMovement(previousRegistrationContext, newRegistrationContext)
-                val newOrChangedKeys = newRegistrationContext.filter {
-                    previous[it.key] != it.value
-                }.keys
-                val removed = previous.keys.filter {
-                    !newRegistrationContext.keys.contains(it)
-                }
-                val changed = (newOrChangedKeys + removed).filter {
-                    it.startsWith(SESSION_KEYS) ||
-                        it.startsWith(LEDGER_KEYS) ||
-                        it.startsWith(ROLES_PREFIX) ||
-                        (it.startsWith("corda.notary") && !it.endsWith("service.backchain.required"))
-                }.filter {
-                    // Just ignore the notary key ID all together. It was part of the context in 5.1 and was removed in 5.2
-                    !notaryIdRegex.matches(it)
-                }
-                require(changed.isEmpty()) {
+            previousRegistrationContext?.let {
+                val diffInvalidMsg = verifyReRegistrationChanges(previousRegistrationContext, newRegistrationContext)
+                require(diffInvalidMsg.isEmpty()) {
                     throw InvalidMembershipRegistrationException(
-                        "Fields $changed cannot be added, removed or updated during re-registration."
+                        diffInvalidMsg
                     )
                 }
             }
@@ -822,21 +807,6 @@ class DynamicMemberRegistrationService @Activate constructor(
                 ),
                 CryptoSignatureSpec(signatureSpec, null, null),
             )
-        }
-    }
-
-    private fun verifyBackchainFlagMovement(previousContext: Map<String, String>, newContext: Map<String, String>) {
-        // This property can only be null when upgrading from 5.0/5.1, and we should move it to `true`
-        // because pre-5.2 notaries do not support optional backchain
-        // Once the flag is set it should never change during re-registrations
-        // (i.e. no true->false or false->true change allowed)
-        val previousOptionalBackchainValue = previousContext[NOTARY_SERVICE_BACKCHAIN_REQUIRED]?.toBoolean()
-        val currentOptionalBackchainValue = newContext[NOTARY_SERVICE_BACKCHAIN_REQUIRED]?.toBoolean()
-        require(
-            (previousOptionalBackchainValue == null && currentOptionalBackchainValue == true) ||
-                previousOptionalBackchainValue == currentOptionalBackchainValue
-        ) {
-            "Optional back-chain flag can only move from 'none' to 'true' during re-registration."
         }
     }
 }

--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -473,7 +473,7 @@ class DynamicMemberRegistrationService @Activate constructor(
 
             previousRegistrationContext?.let {
                 val diffInvalidMsg = verifyReRegistrationChanges(previousRegistrationContext, newRegistrationContext)
-                require(diffInvalidMsg.isEmpty()) {
+                if (!diffInvalidMsg.isNullOrEmpty()) {
                     throw InvalidMembershipRegistrationException(
                         diffInvalidMsg
                     )

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/handler/mgm/StartRegistrationHandlerTest.kt
@@ -30,12 +30,15 @@ import net.corda.membership.lib.MemberInfoExtension.Companion.CUSTOM_KEY_PREFIX
 import net.corda.membership.lib.MemberInfoExtension.Companion.ENDPOINTS
 import net.corda.membership.lib.MemberInfoExtension.Companion.GROUP_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.IS_MGM
+import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS
 import net.corda.membership.lib.MemberInfoExtension.Companion.LEDGER_KEYS_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_ACTIVE
 import net.corda.membership.lib.MemberInfoExtension.Companion.MEMBER_STATUS_PENDING
 import net.corda.membership.lib.MemberInfoExtension.Companion.MODIFIED_TIME
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_KEYS_ID
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_BACKCHAIN_REQUIRED
 import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_NAME
+import net.corda.membership.lib.MemberInfoExtension.Companion.NOTARY_SERVICE_PROTOCOL
 import net.corda.membership.lib.MemberInfoExtension.Companion.PARTY_SESSION_KEYS_ID
 import net.corda.membership.lib.MemberInfoExtension.Companion.PROTOCOL_VERSION
 import net.corda.membership.lib.MemberInfoExtension.Companion.ROLES_PREFIX
@@ -131,6 +134,13 @@ class StartRegistrationHandlerTest {
 
         fun getRegistrationState(registrationId: String, member: HoldingIdentity, mgm: HoldingIdentity) =
             RegistrationState(registrationId, member, mgm, emptyList())
+
+        const val NOTARY_KEY_PEM_KEY = "corda.notary.keys.0.pem"
+        const val NOTARY_KEY_HASH_KEY = "corda.notary.keys.0.hash"
+        const val NOTARY_KEY_SIG_SPEC_KEY = "corda.notary.keys.0.signature.spec"
+        const val NOTARY_KEY_PEM = "1234"
+        const val NOTARY_KEY_HASH = "SHA-256:73A2AF8864FC500FA49048BF3003776C19938F360E56BD03663866FB3087884A"
+        const val NOTARY_KEY_SIG_SPEC = "SHA256withECDSA"
     }
 
     // Class under test
@@ -141,18 +151,30 @@ class StartRegistrationHandlerTest {
     lateinit var membershipPersistenceClient: MembershipPersistenceClient
     private lateinit var membershipQueryClient: MembershipQueryClient
 
-    var ledgerKeys = mutableListOf(mock<PublicKey>())
+    private var ledgerKeys = mutableListOf(mock<PublicKey>())
 
     private val memberContextEntries = mapOf(
-        "$ROLES_PREFIX.0" to "notary",
         "$CUSTOM_KEY_PREFIX.0" to "test",
-        NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
-        NOTARY_KEYS_ID.format(0) to "ABC123456789",
         PARTY_SESSION_KEYS_ID.format(0) to "BBC123456789",
         LEDGER_KEYS_ID.format(0) to "CBC123456789",
         URL_KEY.format(0) to "https://localhost:1080",
         PROTOCOL_VERSION.format(0) to "1",
     )
+    private val notaryContextEntries = memberContextEntries.filter {
+        !it.key.contains(LEDGER_KEYS)
+    } + mapOf(
+        "$ROLES_PREFIX.0" to "notary",
+        NOTARY_SERVICE_PROTOCOL to "net.corda.notary.MyNotaryService",
+        NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
+        NOTARY_KEY_PEM_KEY to NOTARY_KEY_PEM,
+        NOTARY_KEY_HASH_KEY to NOTARY_KEY_HASH,
+        NOTARY_KEY_SIG_SPEC_KEY to NOTARY_KEY_SIG_SPEC,
+    )
+    private val notaryMemberContext: MemberContext = mock {
+        on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
+        on { parseList(eq(ENDPOINTS), eq(EndpointInfo::class.java)) } doReturn listOf(mock())
+        on { entries } doReturn notaryContextEntries.entries
+    }
     private val memberMemberContext: MemberContext = mock {
         on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
         on { parseList(eq(ENDPOINTS), eq(EndpointInfo::class.java)) } doReturn listOf(mock())
@@ -169,7 +191,7 @@ class StartRegistrationHandlerTest {
     }
     private val pendingMemberInfo: SelfSignedMemberInfo = mock {
         on { name } doReturn aliceX500Name
-        on { isActive } doReturn true
+        on { isActive } doReturn false
         on { memberProvidedContext } doReturn memberMemberContext
         on { mgmProvidedContext } doReturn pendingMemberMgmContext
         on { status } doReturn MEMBER_STATUS_PENDING
@@ -179,10 +201,19 @@ class StartRegistrationHandlerTest {
     }
     private val notaryPendingMemberInfo: SelfSignedMemberInfo = mock {
         on { name } doReturn notaryX500Name
-        on { isActive } doReturn true
-        on { memberProvidedContext } doReturn memberMemberContext
+        on { isActive } doReturn false
+        on { memberProvidedContext } doReturn notaryMemberContext
         on { mgmProvidedContext } doReturn pendingMemberMgmContext
         on { status } doReturn MEMBER_STATUS_PENDING
+        on { serial } doReturn 1L
+        on { platformVersion } doReturn 50100
+    }
+    private val notaryActiveMemberInfo: SelfSignedMemberInfo = mock {
+        on { name } doReturn notaryX500Name
+        on { isActive } doReturn true
+        on { memberProvidedContext } doReturn notaryMemberContext
+        on { mgmProvidedContext } doReturn memberMgmContext
+        on { status } doReturn MEMBER_STATUS_ACTIVE
         on { serial } doReturn 1L
         on { platformVersion } doReturn 50100
     }
@@ -693,7 +724,7 @@ class StartRegistrationHandlerTest {
             emptyList(),
             true
         )
-        whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+        whenever(notaryMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
 
         val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
         val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
@@ -711,7 +742,7 @@ class StartRegistrationHandlerTest {
             listOf(mock()),
             true
         )
-        whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+        whenever(notaryMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
         whenever(
             membershipQueryClient.queryMemberInfo(
                 mgmHoldingIdentity.toCorda(),
@@ -734,7 +765,7 @@ class StartRegistrationHandlerTest {
             listOf(mock()),
             true
         )
-        whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+        whenever(notaryMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
 
         val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
         val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
@@ -751,7 +782,7 @@ class StartRegistrationHandlerTest {
             listOf(mock()),
             true
         )
-        whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+        whenever(notaryMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
 
         val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
         val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
@@ -768,7 +799,7 @@ class StartRegistrationHandlerTest {
             listOf(mock()),
             true
         )
-        whenever(memberMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
+        whenever(notaryMemberContext.parse<MemberNotaryDetails>("corda.notary")).thenReturn(notaryDetails)
         val existingNotaryContext = mock<MemberContext> {
             on { entries } doReturn memberContextEntries.entries
         }
@@ -836,6 +867,108 @@ class StartRegistrationHandlerTest {
     }
 
     @Test
+    fun `re-registration with previous context that contains the notary key ID won't fail`() {
+        val previousContextWithKeyId = mock<MemberContext> {
+            on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
+            on { parseList(eq(ENDPOINTS), eq(EndpointInfo::class.java)) } doReturn listOf(mock())
+            on { entries } doReturn (notaryContextEntries + mapOf(NOTARY_KEYS_ID.format(0) to TEST_KEY_ID)).entries
+        }
+        whenever(notaryActiveMemberInfo.memberProvidedContext).doReturn(previousContextWithKeyId)
+        whenever(membershipQueryClient.queryMemberInfo(eq(mgmHoldingIdentity.toCorda()), any(), any()))
+            .doReturn(MembershipQueryResult.Success(listOf(notaryActiveMemberInfo)))
+        val registrationRequest = createRegistrationRequest(registeringMember = notaryHoldingIdentity, serial = 2L)
+        whenever(membershipQueryClient.queryRegistrationRequest(eq(mgmHoldingIdentity.toCorda()), eq(notaryRegistrationId)))
+            .doReturn(MembershipQueryResult.Success(registrationRequest))
+        whenever(
+            memberInfoFactory.createSelfSignedMemberInfo(eq(registrationRequest.memberProvidedContext.data.array()), any(), any(), any())
+        )
+            .doReturn(notaryPendingMemberInfo)
+
+        val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
+        val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
+
+        result.assertRegistrationStarted()
+    }
+
+    @Test
+    fun `re-registration allows optional backchain flag to be set to true from null`() {
+        val contextWithUpdates = mock<MemberContext> {
+            on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
+            on { parseList(eq(ENDPOINTS), eq(EndpointInfo::class.java)) } doReturn listOf(mock())
+            on { entries } doReturn (notaryContextEntries + mapOf(NOTARY_SERVICE_BACKCHAIN_REQUIRED to "true")).entries
+        }
+
+        whenever(notaryPendingMemberInfo.memberProvidedContext).doReturn(contextWithUpdates)
+        whenever(membershipQueryClient.queryMemberInfo(eq(mgmHoldingIdentity.toCorda()), any(), any()))
+            .doReturn(MembershipQueryResult.Success(listOf(notaryActiveMemberInfo)))
+        val registrationRequest = createRegistrationRequest(registeringMember = notaryHoldingIdentity, serial = 2L)
+        whenever(membershipQueryClient.queryRegistrationRequest(eq(mgmHoldingIdentity.toCorda()), eq(notaryRegistrationId)))
+            .doReturn(MembershipQueryResult.Success(registrationRequest))
+        whenever(
+            memberInfoFactory.createSelfSignedMemberInfo(eq(registrationRequest.memberProvidedContext.data.array()), any(), any(), any())
+        )
+            .doReturn(notaryPendingMemberInfo)
+
+        val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
+        val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
+
+        result.assertRegistrationStarted()
+    }
+
+    @Test
+    fun `re-registration does not allow optional backchain flag to be set to false from null`() {
+        val contextWithUpdates = mock<MemberContext> {
+            on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
+            on { parseList(eq(ENDPOINTS), eq(EndpointInfo::class.java)) } doReturn listOf(mock())
+            on { entries } doReturn (notaryContextEntries + mapOf(NOTARY_SERVICE_BACKCHAIN_REQUIRED to "false")).entries
+        }
+
+        whenever(notaryPendingMemberInfo.memberProvidedContext).doReturn(contextWithUpdates)
+        whenever(membershipQueryClient.queryMemberInfo(eq(mgmHoldingIdentity.toCorda()), any(), any()))
+            .doReturn(MembershipQueryResult.Success(listOf(notaryActiveMemberInfo)))
+        val registrationRequest = createRegistrationRequest(registeringMember = notaryHoldingIdentity, serial = 2L)
+        whenever(membershipQueryClient.queryRegistrationRequest(eq(mgmHoldingIdentity.toCorda()), eq(notaryRegistrationId)))
+            .doReturn(MembershipQueryResult.Success(registrationRequest))
+        whenever(
+            memberInfoFactory.createSelfSignedMemberInfo(eq(registrationRequest.memberProvidedContext.data.array()), any(), any(), any())
+        )
+            .doReturn(notaryPendingMemberInfo)
+
+        val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
+        val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
+
+        result.assertDeclinedRegistration()
+    }
+
+    @Test
+    fun `re-registration does not allow optional backchain flag to be set to false from true`() {
+        val contextWithUpdates = mock<MemberContext> {
+            on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
+            on { parseList(eq(ENDPOINTS), eq(EndpointInfo::class.java)) } doReturn listOf(mock())
+            on { entries } doReturn (notaryContextEntries + mapOf(NOTARY_SERVICE_BACKCHAIN_REQUIRED to "false")).entries
+        }
+
+        whenever(notaryPendingMemberInfo.memberProvidedContext).doReturn(contextWithUpdates)
+        whenever(
+            notaryActiveMemberInfo.memberProvidedContext.entries
+        ).doReturn((notaryContextEntries + mapOf(NOTARY_SERVICE_BACKCHAIN_REQUIRED to "true")).entries)
+        whenever(membershipQueryClient.queryMemberInfo(eq(mgmHoldingIdentity.toCorda()), any(), any()))
+            .doReturn(MembershipQueryResult.Success(listOf(notaryActiveMemberInfo)))
+        val registrationRequest = createRegistrationRequest(registeringMember = notaryHoldingIdentity, serial = 2L)
+        whenever(membershipQueryClient.queryRegistrationRequest(eq(mgmHoldingIdentity.toCorda()), eq(notaryRegistrationId)))
+            .doReturn(MembershipQueryResult.Success(registrationRequest))
+        whenever(
+            memberInfoFactory.createSelfSignedMemberInfo(eq(registrationRequest.memberProvidedContext.data.array()), any(), any(), any())
+        )
+            .doReturn(notaryPendingMemberInfo)
+
+        val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
+        val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
+
+        result.assertDeclinedRegistration()
+    }
+
+    @Test
     fun `declined if persistence failure happened when trying to query for existing member info`() {
         whenever(
             membershipQueryClient.queryMemberInfo(
@@ -858,19 +991,18 @@ class StartRegistrationHandlerTest {
     fun `declined if notary related properties are added during re-registration`() {
         val contextWithUpdates = mock<MemberContext> {
             on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
-            on { entries } doReturn (
-                memberContextEntries + mapOf(
-                    "$ROLES_PREFIX.1" to "added",
-                    NOTARY_SERVICE_NAME to "O=MyNotaryService, L=London, C=GB",
-                    NOTARY_KEYS_ID.format(1) to TEST_KEY_ID
-                )
-                ).entries
+            on { entries } doReturn (notaryContextEntries + mapOf("$ROLES_PREFIX.1" to "added")).entries
         }
         whenever(notaryPendingMemberInfo.memberProvidedContext).doReturn(contextWithUpdates)
         whenever(membershipQueryClient.queryMemberInfo(eq(mgmHoldingIdentity.toCorda()), any(), any()))
-            .doReturn(MembershipQueryResult.Success(listOf(activeMemberInfo)))
-        whenever(membershipQueryClient.queryRegistrationRequest(eq(mgmHoldingIdentity.toCorda()), eq(registrationId)))
-            .doReturn(MembershipQueryResult.Success(createRegistrationRequest(serial = 2L)))
+            .doReturn(MembershipQueryResult.Success(listOf(notaryActiveMemberInfo)))
+        val registrationRequest = createRegistrationRequest(registeringMember = notaryHoldingIdentity, serial = 2L)
+        whenever(membershipQueryClient.queryRegistrationRequest(eq(mgmHoldingIdentity.toCorda()), eq(notaryRegistrationId)))
+            .doReturn(MembershipQueryResult.Success(registrationRequest))
+        whenever(
+            memberInfoFactory.createSelfSignedMemberInfo(eq(registrationRequest.memberProvidedContext.data.array()), any(), any(), any())
+        )
+            .doReturn(notaryPendingMemberInfo)
         val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
         val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
         result.assertDeclinedRegistration()
@@ -931,20 +1063,24 @@ class StartRegistrationHandlerTest {
 
     @Test
     fun `declined if notary related properties are updated during re-registration`() {
-        val newContextEntries = memberContextEntries.toMutableMap().apply {
+        val newContextEntries = notaryContextEntries.toMutableMap().apply {
             put("${ROLES_PREFIX}.0", "changed")
             put(NOTARY_SERVICE_NAME, "O=ChangedNotaryService, L=London, C=GB")
-            put(NOTARY_KEYS_ID.format(0), TEST_KEY_ID)
         }.entries
         val contextWithUpdates = mock<MemberContext> {
             on { parse(eq(GROUP_ID), eq(String::class.java)) } doReturn groupId
             on { entries } doReturn newContextEntries
         }
-        whenever(pendingMemberInfo.memberProvidedContext).doReturn(contextWithUpdates)
+        whenever(notaryPendingMemberInfo.memberProvidedContext).doReturn(contextWithUpdates)
         whenever(membershipQueryClient.queryMemberInfo(eq(mgmHoldingIdentity.toCorda()), any(), any()))
-            .doReturn(MembershipQueryResult.Success(listOf(activeMemberInfo)))
+            .doReturn(MembershipQueryResult.Success(listOf(notaryActiveMemberInfo)))
+        val registrationRequest = createRegistrationRequest(registeringMember = notaryHoldingIdentity, serial = 2L)
         whenever(membershipQueryClient.queryRegistrationRequest(eq(mgmHoldingIdentity.toCorda()), eq(notaryRegistrationId)))
-            .doReturn(MembershipQueryResult.Success(createRegistrationRequest(serial = 2L)))
+            .doReturn(MembershipQueryResult.Success(registrationRequest))
+        whenever(
+            memberInfoFactory.createSelfSignedMemberInfo(eq(registrationRequest.memberProvidedContext.data.array()), any(), any(), any())
+        )
+            .doReturn(notaryPendingMemberInfo)
         val registrationState = getRegistrationState(notaryRegistrationId, notaryHoldingIdentity, mgmHoldingIdentity)
         val result = handler.invoke(registrationState, Record(testTopic, testTopicKey, startRegistrationCommand))
         result.assertDeclinedRegistration()

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/RegistrationUtils.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/RegistrationUtils.kt
@@ -5,6 +5,9 @@ import net.corda.data.KeyValuePairList
 import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.membership.MemberContext
 
+private const val NOTARY_KEY_ID = "corda.notary.keys.%s.id"
+private val notaryIdRegex = NOTARY_KEY_ID.format("[0-9]+").toRegex()
+
 /**
  * Transforms [KeyValuePairList] into map.
  */
@@ -36,3 +39,51 @@ fun LayeredPropertyMap.toWire(): KeyValuePairList {
  * Transforms [MemberContext] into map.
  */
 fun MemberContext.toMap() = entries.associate { it.key to it.value }
+
+/**
+ * Verify back-chain flag movement for notaries during re-registration.
+ */
+fun verifyBackchainFlagMovement(previousContext: Map<String, String>, newContext: Map<String, String>) {
+    // This property can only be null when upgrading from 5.0/5.1, and we should move it to `true`
+    // because pre-5.2 notaries do not support optional backchain
+    // Once the flag is set it should never change during re-registrations
+    // (i.e. no true->false or false->true change allowed)
+    val previousOptionalBackchainValue = previousContext[MemberInfoExtension.NOTARY_SERVICE_BACKCHAIN_REQUIRED]?.toBoolean()
+    val currentOptionalBackchainValue = newContext[MemberInfoExtension.NOTARY_SERVICE_BACKCHAIN_REQUIRED]?.toBoolean()
+    require(
+        (previousOptionalBackchainValue == null && currentOptionalBackchainValue == true) ||
+            previousOptionalBackchainValue == currentOptionalBackchainValue
+    ) {
+        "Optional back-chain flag can only move from 'none' to 'true' during re-registration."
+    }
+}
+
+/**
+ * Verify only certain data is modified during re-registration.
+ * If there are not allowed changes in the new context, the re-registration attempt will be marked as invalid/declined.
+ */
+fun verifyReRegistrationChanges(
+    previousRegistrationContext: Map<String, String>,
+    newRegistrationContext: Map<String, String>,
+): String {
+    verifyBackchainFlagMovement(previousRegistrationContext, newRegistrationContext)
+    val newOrChangedKeys = newRegistrationContext.filter {
+        previousRegistrationContext[it.key] != it.value
+    }.keys
+    val removed = previousRegistrationContext.keys.filter {
+        !newRegistrationContext.keys.contains(it)
+    }
+    val changed = (newOrChangedKeys + removed).filter {
+        it.startsWith(MemberInfoExtension.SESSION_KEYS) ||
+            it.startsWith(MemberInfoExtension.LEDGER_KEYS) ||
+            it.startsWith(MemberInfoExtension.ROLES_PREFIX) ||
+            (it.startsWith("corda.notary") && !it.endsWith("service.backchain.required"))
+    }.filter {
+        // Just ignore the notary key ID all together. It was part of the context in 5.1 and was removed in 5.2
+        !notaryIdRegex.matches(it)
+    }
+    if (changed.isNotEmpty()) {
+        return "Fields $changed cannot be added, removed or updated during re-registration."
+    }
+    return ""
+}

--- a/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/RegistrationUtils.kt
+++ b/libs/membership/membership-common/src/main/kotlin/net/corda/membership/lib/RegistrationUtils.kt
@@ -65,7 +65,7 @@ fun verifyBackchainFlagMovement(previousContext: Map<String, String>, newContext
 fun verifyReRegistrationChanges(
     previousRegistrationContext: Map<String, String>,
     newRegistrationContext: Map<String, String>,
-): String {
+): String? {
     verifyBackchainFlagMovement(previousRegistrationContext, newRegistrationContext)
     val newOrChangedKeys = newRegistrationContext.filter {
         previousRegistrationContext[it.key] != it.value
@@ -85,5 +85,5 @@ fun verifyReRegistrationChanges(
     if (changed.isNotEmpty()) {
         return "Fields $changed cannot be added, removed or updated during re-registration."
     }
-    return ""
+    return null
 }


### PR DESCRIPTION
Notary re-registration failed on MGM side, because we missed to modify the registration context validation on MGM side.

This PR contains:
- moved the context validation to utils class - to prevent this problem happening again and because we needed the same validation on both side (member and MGM) so far
- had to fix some of the negative scenario unit tests and mocking - even though these test registration cases were indeed declined, often the reason wasn't matching with what we expected (eg notary fields validation test scenarios in reality never even got to the point where the validation happened, they got declined much earlier)