### PR TITLE
ES-1873 Update E2E Corda-dev helm chart usage to version 0.2.0

### DIFF
--- a/.ci/e2eTests/Jenkinsfile
+++ b/.ci/e2eTests/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.2') _
+@Library('corda-shared-build-pipeline-steps@jacob/ES-1873') _
 
 endToEndPipeline(
     assembleAndCompile: false,

--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -84,6 +84,13 @@ kafka:
           key: "kafka-ca.crt"
   sasl:
     enabled: true
+    username:
+        value: "bootstrap"
+      password:
+        valueFrom:
+          secretKeyRef:
+            name: "kafka-credentials"
+            key: "bootstrap"
 
 workers:
   crypto:

--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -84,13 +84,6 @@ kafka:
           key: "kafka-ca.crt"
   sasl:
     enabled: true
-    username:
-        value: "bootstrap"
-      password:
-        valueFrom:
-          secretKeyRef:
-            name: "kafka-credentials"
-            key: "bootstrap"
 
 workers:
   crypto:

--- a/.ci/e2eTests/corda.yaml
+++ b/.ci/e2eTests/corda.yaml
@@ -80,8 +80,8 @@ kafka:
     truststore:
       valueFrom:
         secretKeyRef:
-          name: "prereqs-kafka-0-tls"
-          key: "ca.crt"
+          name: "prereqs-kafka-tls"
+          key: "kafka-ca.crt"
   sasl:
     enabled: true
 

--- a/.ci/e2eTests/prereqs-eks.yaml
+++ b/.ci/e2eTests/prereqs-eks.yaml
@@ -8,6 +8,10 @@ kafka:
   extraConfig: |-
     offsets.topic.replication.factor: 3
     transaction.state.log.replication.factor: 3
+    authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
+    auto.create.topics.enable=false
+    allow.everyone.if.no.acl.found=true
+    super.users=User:controller_user
   controller:
     replicaCount: 7
     startupProbe:

--- a/.ci/e2eTests/prereqs-eks.yaml
+++ b/.ci/e2eTests/prereqs-eks.yaml
@@ -5,6 +5,13 @@ global:
   storageClass: corda-sc
 
 kafka:
+  extraConfig: |-
+    offsets.topic.replication.factor: 3
+    transaction.state.log.replication.factor: 3
+  controller:
+    replicaCount: 7
+    startupProbe:
+      enabled: true
   replicaCount: 7
   resources:
     requests:
@@ -13,14 +20,6 @@ kafka:
     limits:
       memory: 1600Mi
       cpu: 1000m
-  startupProbe:
-    enabled: true
-  zookeeper:
-    replicaCount: 3
-    startupProbe:
-      enabled: true
-  offsetsTopicReplicationFactor: 3
-  transactionStateLogReplicationFactor: 3
 
 postgresql:
   primary:

--- a/.ci/e2eTests/prereqs-eks.yaml
+++ b/.ci/e2eTests/prereqs-eks.yaml
@@ -16,7 +16,6 @@ kafka:
     replicaCount: 7
     startupProbe:
       enabled: true
-  replicaCount: 7
   resources:
     requests:
       memory: 780Mi

--- a/.ci/e2eTests/prereqs.yaml
+++ b/.ci/e2eTests/prereqs.yaml
@@ -1,18 +1,17 @@
 kafka:
-  auth:
-    sasl:
-      jaas:
-        clientUsers:
-          - "bootstrap"
-          - "crypto"
-          - "db"
-          - "flow"
-          - "flowMapper"
-          - "verification"
-          - "membership"
-          - "p2pGateway"
-          - "p2pLinkManager"
-          - "persistence"
-          - "tokenSelection"
-          - "rest"
-          - "uniqueness"
+  sasl:
+    client:
+      users:
+        - "bootstrap"
+        - "crypto"
+        - "db"
+        - "flow"
+        - "flowMapper"
+        - "verification"
+        - "membership"
+        - "p2pGateway"
+        - "p2pLinkManager"
+        - "persistence"
+        - "tokenSelection"
+        - "rest"
+        - "uniqueness" 

--- a/.ci/e2eTests/prereqs.yaml
+++ b/.ci/e2eTests/prereqs.yaml
@@ -1,9 +1,4 @@
 kafka:
-  extraConfig: |-
-    authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
-    auto.create.topics.enable=false
-    allow.everyone.if.no.acl.found=true
-    super.users=User:controller_user
   sasl:
     client:
       users:

--- a/.ci/e2eTests/prereqs.yaml
+++ b/.ci/e2eTests/prereqs.yaml
@@ -1,4 +1,9 @@
 kafka:
+  extraConfig: |-
+    authorizer.class.name=org.apache.kafka.metadata.authorizer.StandardAuthorizer
+    auto.create.topics.enable=false
+    allow.everyone.if.no.acl.found=true
+    super.users=User:controller_user
   sasl:
     client:
       users:


### PR DESCRIPTION
Updates the override values that the end to end tests use when deploying Corda prereqs