### PR TITLE
CORE-19405 Get wrapping key ids for tenant

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestWrappingRepository.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/infra/TestWrappingRepository.kt
@@ -29,6 +29,8 @@ class TestWrappingRepository(
 
     override fun getKeyById(id: UUID): WrappingKeyInfo? = TODO("Not needed")
 
+    override fun getAllKeyIds(): Set<UUID> = TODO("Not needed")
+
     override fun close() {
     }
 }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/WrappingRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/WrappingRepository.kt
@@ -73,4 +73,11 @@ interface WrappingRepository : Closeable {
      * @return Information about the requested wrapping key if it exists
      */
     fun getKeyById(id: UUID): WrappingKeyInfo?
+
+    /**
+     * Get all wrapping key Ids in the database for the tenant to which this [WrappingRepository] is bound.
+     *
+     * @return A set of wrapping key UUIDs
+     */
+    fun getAllKeyIds(): Set<UUID>
 }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package net.corda.crypto.softhsm.impl
 
 import net.corda.crypto.persistence.WrappingKeyInfo
+import net.corda.crypto.persistence.db.model.SigningKeyEntity
+import net.corda.crypto.persistence.db.model.SigningKeyMaterialEntity
 import net.corda.crypto.persistence.db.model.WrappingKeyEntity
 import net.corda.crypto.softhsm.WrappingRepository
 import net.corda.orm.utils.transaction
@@ -78,6 +80,31 @@ class WrappingRepositoryImpl(
             WrappingKeyEntity::class.java
         ).setParameter("id", id).resultStream.map { dao -> dao.toDto() }.findFirst().orElse(null)
     }
+
+    override fun getAllKeyIds(): Set<UUID> =
+        entityManagerFactory.createEntityManager().use { it ->
+            it.createQuery(
+                "SELECT s, w FROM ${SigningKeyEntity::class.java.simpleName} s, ${SigningKeyMaterialEntity::class.java.simpleName} m," +
+                    " ${WrappingKeyEntity::class.java.simpleName} w " +
+                    "WHERE s.tenantId = :tenantId AND m.signingKeyId = s.id AND m.wrappingKeyId = w.id "
+            ).setParameter("tenantId", tenantId).resultList
+                .map {
+                    val signingKeyAndWrappingKey =
+                        checkNotNull(it as? Array<*>) { "JPA returned invalid results object" }
+                    val signingKeyEntity = checkNotNull(signingKeyAndWrappingKey[0] as? SigningKeyEntity)
+                    { "JPA returned wrong entity type for SigningKeyEntity" }
+                    val wrappingKeyEntity = checkNotNull(signingKeyAndWrappingKey[1] as? WrappingKeyEntity)
+                    { "JPA returned wrong entity type for WrappingKeyEntity" }
+                    Pair(signingKeyEntity, wrappingKeyEntity)
+                }
+                .groupBy { it.first.id } // group by signing key id
+                .map {
+                    it.value.sortedBy { it.second.generation }.lastOrNull()
+                } // highest generation wrapping key per signing key only
+                .filterNotNull()
+                .map { it.second.id } // extract UUID of wrapping keys
+                .toSet()
+        }
 }
 
 // NOTE: this should be on the entity object directly, but this means this repo (and the DTOs) need

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceCachingTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceCachingTests.kt
@@ -216,6 +216,10 @@ class SoftCryptoServiceCachingTests {
                 TODO("Not needed")
             }
 
+            override fun getAllKeyIds(): Set<UUID> {
+                TODO("Not needed")
+            }
+
             override fun close() {
             }
         }

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestWrappingRepository.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/infra/TestWrappingRepository.kt
@@ -42,4 +42,8 @@ class TestWrappingRepository(
 
     override fun close() {
     }
+
+    override fun getAllKeyIds(): Set<UUID> {
+        TODO("Not needed")
+    }
 }


### PR DESCRIPTION
Allow retrieval of all wrapping key uuids for the tenant of the wrapping repository. This will be used to fan out requests to rotate these keys to individual workers in a later change.