### PR TITLE
CORE-19330: SonarCloud - Fix Code Reliability

### DIFF
--- a/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/Metadata.kt
+++ b/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/Metadata.kt
@@ -50,7 +50,7 @@ class Metadata(
         return map.hashCode()
     }
 
-    fun containsKeyWithValue(key: String, value: Any) = map.containsKey(key) && map[key]!! == value
+    fun containsKeyWithValue(key: String, value: Any) = map.containsKey(key) && map[key] == value
 }
 
 fun metadata(): Metadata = Metadata()

--- a/libs/state-manager/state-manager-api/src/test/kotlin/net/corda/libs/statemanager/api/MetadataTests.kt
+++ b/libs/state-manager/state-manager-api/src/test/kotlin/net/corda/libs/statemanager/api/MetadataTests.kt
@@ -50,5 +50,17 @@ class MetadataTests {
             .containsExactlyInAnyOrderEntriesOf(mapOf("foo" to "bar", "batman" to "joker"))
     }
 
+    @Test
+    fun `contains key with value returns true when key and value match`() {
+        val meta1 = Metadata(mapOf("foo" to "bar"))
+        assertThat(meta1.containsKeyWithValue("foo", "bar")).isTrue()
+    }
+
+    @Test
+    fun `contains key with value returns false when key matches but value does not`() {
+        val meta1 = Metadata(mapOf("foo" to true))
+        assertThat(meta1.containsKeyWithValue("foo", false)).isFalse()
+    }
+
     data class Superman(val kudos: Int)
 }


### PR DESCRIPTION
Fix code reliability detected by Sonar Cloud in a previous commit: remove
non-null assertion operator to prevent NullPointerException from being
thrown at runtime (the "==" operation will still work as expected).
