### PR TITLE
CORE-18961 Reject fiber cache sandbox mismatches

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlowFiberFactory.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlowFiberFactory.kt
@@ -69,6 +69,10 @@ class FakeFlowFiberFactory : FlowFiberFactory {
             TODO("Not yet implemented")
         }
 
+        override fun getSandboxGroupId(): UUID? {
+            TODO("Not yet implemented")
+        }
+
         override fun startFlow(flowFiberExecutionContext: FlowFiberExecutionContext): Future<FlowIORequest<*>> {
             startContext = flowFiberExecutionContext
             flowContinuation = FlowContinuation.Run(Unit)

--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlowFiberFactory.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/fakes/FakeFlowFiberFactory.kt
@@ -66,11 +66,11 @@ class FakeFlowFiberFactory : FlowFiberFactory {
         }
 
         override fun getExecutionContext(): FlowFiberExecutionContext {
-            TODO("Not yet implemented")
+            TODO("Not needed")
         }
 
         override fun getSandboxGroupId(): UUID? {
-            TODO("Not yet implemented")
+            TODO("Not needed")
         }
 
         override fun startFlow(flowFiberExecutionContext: FlowFiberExecutionContext): Future<FlowIORequest<*>> {
@@ -84,7 +84,7 @@ class FakeFlowFiberFactory : FlowFiberFactory {
             suspensionOutcome: FlowContinuation,
             scheduler: FiberScheduler
         ): Future<FlowIORequest<*>> {
-            TODO("Not yet implemented")
+            TODO("Not needed")
         }
 
         fun resume(
@@ -95,11 +95,11 @@ class FakeFlowFiberFactory : FlowFiberFactory {
         }
 
         override fun <SUSPENDRETURN> suspend(request: FlowIORequest<SUSPENDRETURN>): SUSPENDRETURN {
-            TODO("Not yet implemented")
+            TODO("Not needed")
         }
 
         override fun attemptInterrupt() {
-            TODO("Not yet implemented")
+            TODO("Not needed")
         }
 
         private fun getCompletedFuture(): Future<FlowIORequest<*>> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiber.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiber.kt
@@ -7,11 +7,13 @@ import java.util.UUID
 import java.util.concurrent.Future
 
 @DoNotImplement
-interface FlowFiber: Interruptable {
+interface FlowFiber : Interruptable {
     val flowId: UUID
     val flowLogic: FlowLogicAndArgs
 
     fun getExecutionContext(): FlowFiberExecutionContext
+
+    fun getSandboxGroupId(): UUID?
 
     fun startFlow(flowFiberExecutionContext: FlowFiberExecutionContext): Future<FlowIORequest<*>>
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -43,6 +43,10 @@ class FlowFiberImpl(
     @Transient
     private var boundSandboxUUID: UUID? = null
 
+    override fun getSandboxGroupId(): UUID? {
+        return boundSandboxUUID
+    }
+
     override fun getExecutionContext(): FlowFiberExecutionContext {
         return flowFiberExecutionContext!!
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
@@ -15,7 +15,7 @@ interface FlowFiberCache : SandboxedCache {
     fun put(key: FlowKey, suspendCount: Int, fiber: FlowFiber)
 
     /**
-     * Get a flow fiber from the cache with the given [FlowKey] and [suspendCount], or else return null.
+     * Get a flow fiber from the cache with the given [FlowKey], [suspendCount] and [sandboxGroupId], or else return null.
      */
     fun get(key: FlowKey, suspendCount: Int, sandboxGroupId: UUID): FlowFiber?
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
@@ -3,11 +3,12 @@ package net.corda.flow.fiber.cache
 import net.corda.data.flow.FlowKey
 import net.corda.flow.fiber.FlowFiber
 import net.corda.sandboxgroupcontext.SandboxedCache
+import java.util.UUID
 
 /**
  * Cache for flow fibers.
  */
-interface FlowFiberCache: SandboxedCache {
+interface FlowFiberCache : SandboxedCache {
     /**
      * Put a flow fiber into the cache keyed by the given [FlowKey] and [suspendCount].
      */
@@ -16,7 +17,7 @@ interface FlowFiberCache: SandboxedCache {
     /**
      * Get a flow fiber from the cache with the given [FlowKey] and [suspendCount], or else return null.
      */
-    fun get(key: FlowKey, suspendCount: Int): FlowFiber?
+    fun get(key: FlowKey, suspendCount: Int, sandboxGroupId: UUID): FlowFiber?
 
     /**
      * Invalidate and remove a flow fiber from the cache with the given [FlowKey].

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -91,6 +91,7 @@ class FlowFiberCacheImpl @Activate constructor(
                 // cached at suspension after the sandbox was already evicted from the cache, so when we resume this
                 // fiber we are going to need another one bound to the new sandbox instead.
                 logger.info("Fiber found in cache but for wrong sandbox group id")
+                cache.invalidate(key)
             }
             null
         }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -84,15 +84,15 @@ class FlowFiberCacheImpl @Activate constructor(
             fiberCacheEntry.fiber
         } else {
             if (fiberCacheEntry.suspendCount != suspendCount) {
-                logger.warn("Fiber found in cache but at wrong suspendCount (${fiberCacheEntry.suspendCount} <-> $suspendCount): ${key.id}")
+                logger.info("Fiber found in cache but at wrong suspendCount (${fiberCacheEntry.suspendCount} <-> $suspendCount): ${key.id}")
             }
             if (sandboxGroupId != fiberCacheEntry.fiber.getSandboxGroupId()) {
                 // This is for information only, actually it's quite possible because the flow fiber might have been
                 // cached at suspension after the sandbox was already evicted from the cache, so when we resume this
                 // fiber we are going to need another one bound to the new sandbox instead.
                 logger.info("Fiber found in cache but for wrong sandbox group id")
-                cache.invalidate(key)
             }
+            cache.invalidate(key)
             null
         }
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/factory/FlowFiberFactoryImpl.kt
@@ -29,12 +29,13 @@ class FlowFiberFactoryImpl @Activate constructor(
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    private val currentThreadFiberExecutor = object : FiberExecutorScheduler("Flow Fiber scheduler", SameThreadExecutor.getExecutor()) {
+    private val currentThreadFiberExecutor =
+        object : FiberExecutorScheduler("Flow Fiber scheduler", SameThreadExecutor.getExecutor()) {
 
-        override fun isCurrentThreadInScheduler(): Boolean {
-            return true
+            override fun isCurrentThreadInScheduler(): Boolean {
+                return true
+            }
         }
-    }
 
     override fun createAndStartFlowFiber(
         flowFiberExecutionContext: FlowFiberExecutionContext,
@@ -50,7 +51,11 @@ class FlowFiberFactoryImpl @Activate constructor(
             val flowFiber = FlowFiberImpl(id, logic, currentThreadFiberExecutor)
             return FiberFuture(flowFiber, flowFiber.startFlow(flowFiberExecutionContext))
         } catch (e: Throwable) {
-            throw FlowFatalException(FiberExceptionConstants.UNABLE_TO_EXECUTE.format(e.message ?: "No exception message provided."), e)
+            throw FlowFatalException(
+                FiberExceptionConstants.UNABLE_TO_EXECUTE.format(
+                    e.message ?: "No exception message provided."
+                ), e
+            )
         }
     }
 
@@ -60,20 +65,28 @@ class FlowFiberFactoryImpl @Activate constructor(
     ): FiberFuture {
         val fiber = CordaMetrics.Metric.FlowFiberDeserializationTime.builder()
             .forVirtualNode(flowFiberExecutionContext.flowCheckpoint.holdingIdentity.shortHash.toString())
-            .withTag(CordaMetrics.Tag.FlowClass, flowFiberExecutionContext.flowCheckpoint.flowStartContext.flowClassName)
+            .withTag(
+                CordaMetrics.Tag.FlowClass,
+                flowFiberExecutionContext.flowCheckpoint.flowStartContext.flowClassName
+            )
             .build()
             .recordCallable {
                 getFromCacheOrDeserialize(flowFiberExecutionContext)
             }!!
 
-        return FiberFuture(fiber, fiber.resume(flowFiberExecutionContext, suspensionOutcome, currentThreadFiberExecutor))
+        return FiberFuture(
+            fiber,
+            fiber.resume(flowFiberExecutionContext, suspensionOutcome, currentThreadFiberExecutor)
+        )
     }
 
     private fun getFromCacheOrDeserialize(flowFiberExecutionContext: FlowFiberExecutionContext): FlowFiber {
         val cachedFiber: FlowFiber? = try {
             flowFiberCache.get(
                 flowFiberExecutionContext.flowCheckpoint.flowKey,
-                flowFiberExecutionContext.flowCheckpoint.suspendCount)
+                flowFiberExecutionContext.flowCheckpoint.suspendCount,
+                flowFiberExecutionContext.sandboxGroupContext.sandboxGroup.id
+            )
         } catch (e: Exception) {
             logger.warn("Exception when getting from flow fiber cache.", e)
             null

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -21,6 +21,7 @@ import net.corda.serialization.checkpoint.CheckpointSerializer;
 import net.corda.v5.application.messaging.FlowSession;
 import net.corda.v5.base.types.MemberX500Name;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import java.util.HashMap;
 import java.util.Map;
@@ -107,6 +108,12 @@ public class FlowSessionImplJavaTest {
 
         @Override
         public void attemptInterrupt() {
+        }
+
+        @Nullable
+        @Override
+        public UUID getSandboxGroupId() {
+            return null;
         }
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
@@ -38,11 +38,12 @@ class FlowFibreCacheTest {
     }
 
     @Test
-    fun `when get and entry wrong version return null`() {
+    fun `when get and entry wrong version return null and entry evicted`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         cache.put(key, 1, value)
-        val entry = cache.get(mock(), 123, sandboxGroupId)
+        val entry = cache.get(key, 123, sandboxGroupId)
         assertThat(entry).isNull()
+        assertThat(cache.get(key, 1, sandboxGroupId)).isNull()
     }
 
     @Test

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
@@ -9,20 +9,31 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.UUID
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FlowFibreCacheTest {
-    private val cacheEviction = mock< CacheEviction>()
+    private val cacheEviction = mock<CacheEviction>()
     private val key = mock<FlowKey>()
     private val value = mock<FlowFiber>()
+    private val sandboxGroupId = mock<UUID>()
+
+    @BeforeAll
+    fun setup() {
+        whenever(value.getSandboxGroupId()).thenReturn(sandboxGroupId)
+    }
 
     @Test
     fun `when get and no entry return null`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
-        val entry = cache.get(mock(), 123)
+        val entry = cache.get(mock(), 123, sandboxGroupId)
         assertThat(entry).isNull()
     }
 
@@ -30,15 +41,24 @@ class FlowFibreCacheTest {
     fun `when get and entry wrong version return null`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         cache.put(key, 1, value)
-        val entry = cache.get(mock(), 123)
+        val entry = cache.get(mock(), 123, sandboxGroupId)
         assertThat(entry).isNull()
     }
 
     @Test
-    fun `when get and entry and version exist return`() {
+    fun `when get and entry wrong sandbox group ID return null and entry evicted`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         cache.put(key, 1, value)
-        val entry = cache.get(key, 1)
+        val entry = cache.get(key, 1, mock())
+        assertThat(entry).isNull()
+        assertThat(cache.get(key, 1, sandboxGroupId)).isNull()
+    }
+
+    @Test
+    fun `when get and entry and version exist and matches sandbox group ID return`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        cache.put(key, 1, value)
+        val entry = cache.get(key, 1, sandboxGroupId)
         assertThat(entry).isSameAs(value)
     }
 
@@ -55,7 +75,7 @@ class FlowFibreCacheTest {
         val cache = FlowFiberCacheImpl(cacheEviction)
         cache.put(key, 1, value)
         cache.remove(key)
-        assertThat(cache.get(key, 1)).isNull()
+        assertThat(cache.get(key, 1, mock())).isNull()
     }
 
     @Test
@@ -78,7 +98,7 @@ class FlowFibreCacheTest {
         cache.put(key1, 1, mock())
         cache.put(key2, 1, mock())
         cache.remove(vnodeContext)
-        assertThat(cache.get(key1, 1)).isNull()
-        assertThat(cache.get(key2, 1)).isNull()
+        assertThat(cache.get(key1, 1, sandboxGroupId)).isNull()
+        assertThat(cache.get(key2, 1, sandboxGroupId)).isNull()
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
@@ -23,7 +23,7 @@ class FlowFibreCacheTest {
     private val cacheEviction = mock<CacheEviction>()
     private val key = mock<FlowKey>()
     private val value = mock<FlowFiber>()
-    private val sandboxGroupId = mock<UUID>()
+    private val sandboxGroupId = UUID.randomUUID()
 
     @BeforeAll
     fun setup() {
@@ -49,7 +49,7 @@ class FlowFibreCacheTest {
     fun `when get and entry wrong sandbox group ID return null and entry evicted`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         cache.put(key, 1, value)
-        val entry = cache.get(key, 1, mock())
+        val entry = cache.get(key, 1, UUID.randomUUID())
         assertThat(entry).isNull()
         assertThat(cache.get(key, 1, sandboxGroupId)).isNull()
     }
@@ -75,7 +75,7 @@ class FlowFibreCacheTest {
         val cache = FlowFiberCacheImpl(cacheEviction)
         cache.put(key, 1, value)
         cache.remove(key)
-        assertThat(cache.get(key, 1, mock())).isNull()
+        assertThat(cache.get(key, 1, sandboxGroupId)).isNull()
     }
 
     @Test


### PR DESCRIPTION
Fibers can be pulled from the singleton Fiber cache after the sandbox in which the Fiber classes are instantiated was evicted from the cache. Cache eviction listeners don't work as a solution to this in the case where the sequence of events is:

1. thread 1: Grabs sandbox to process flow, flow processing begins
2. thread 2: Sandbox is evicted
3. thread 2: Listeners informed - fiber cache cleared
4. thread 1: Flow processing ends, fiber added to fiber cache for a sandbox no longer in sandbox cache.

Implemented solution rejects the fiber if there's a mismatch with sandbox (like it's done with suspend count), and additionally evicts the entry from the cache when this is discovered.