### PR TITLE
CORE-19448: Add dummy REST APIs for managed key rotation

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -73,4 +73,39 @@ interface KeyRotationRestResource : RestResource {
         )
         newKeyAlias: String,
     ): ResponseEntity<KeyRotationResponse>
+
+    /**
+     * The [getManagedKeyRotationStatus] gets the latest key rotation status for [tenantId] if one exists.
+     *
+     * @return A list of wrapping keys with the total number of signing keys needs re-wrapping
+     *        and the number of already re-wrapped keys.
+     *
+     */
+    @HttpGET(
+        path = "managed/rotation/{tenantId}",
+        description = "This method gets the status of the latest key rotation for [tenantId].",
+        responseDescription = "Number of signing keys needs rotating grouped by tenantId's wrapping keys.",
+    )
+    fun getManagedKeyRotationStatus(
+        @RestPathParameter(description = "The tenantId whose wrapping keys are rotating.")
+        tenantId: String
+    ): String
+
+    /**
+     * Initiates the managed key rotation process.
+     *
+     * @param tenantId UUID of the virtual node.
+     *
+     */
+    @HttpPOST(
+        path = "managed/rotation/{tenantId}",
+        description = "This method enables to rotate all wrapping keys for tenantId.",
+        responseDescription = "Key rotation response",
+    )
+    fun startManagedKeyRotation(
+        @RestPathParameter(
+            description = "The tenantId whose wrapping keys are going to be rotated."
+        )
+        tenantId: String
+    ): ResponseEntity<String>
 }

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -101,6 +101,7 @@ interface KeyRotationRestResource : RestResource {
         path = "managed/rotation/{tenantId}",
         description = "This method enables to rotate all wrapping keys for tenantId.",
         responseDescription = "Key rotation response",
+        successCode = SC_ACCEPTED,
     )
     fun startManagedKeyRotation(
         @RestPathParameter(

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -84,7 +84,7 @@ interface KeyRotationRestResource : RestResource {
     @HttpGET(
         path = "managed/rotation/{tenantId}",
         description = "This method gets the status of the latest key rotation for [tenantId].",
-        responseDescription = "Number of signing keys needs rotating grouped by tenantId's wrapping keys.",
+        responseDescription = "Number of signing keys which need rotating grouped by tenantId's wrapping keys",
     )
     fun getManagedKeyRotationStatus(
         @RestPathParameter(description = "The tenantId whose wrapping keys are rotating.")
@@ -104,7 +104,7 @@ interface KeyRotationRestResource : RestResource {
     )
     fun startManagedKeyRotation(
         @RestPathParameter(
-            description = "The tenantId whose wrapping keys are going to be rotated."
+            description = "The tenantId whose wrapping keys are requested to be rotated."
         )
         tenantId: String
     ): ResponseEntity<String>

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -3,6 +3,7 @@ package net.corda.crypto.rest
 import net.corda.crypto.rest.response.KeyRotationResponse
 import net.corda.crypto.rest.response.KeyRotationStatusResponse
 import net.corda.rest.RestResource
+import net.corda.rest.SC_ACCEPTED
 import net.corda.rest.annotations.ClientRequestBodyParameter
 import net.corda.rest.annotations.HttpGET
 import net.corda.rest.annotations.HttpPOST
@@ -61,6 +62,7 @@ interface KeyRotationRestResource : RestResource {
         path = "unmanaged/rotation/{oldKeyAlias}",
         description = "This method enables to rotate a current wrapping key with a new wrapping key.",
         responseDescription = "Key rotation response",
+        successCode = SC_ACCEPTED,
     )
     fun startKeyRotation(
         @RestPathParameter(

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -231,6 +231,14 @@ class KeyRotationRestResourceImpl @Activate constructor(
         )
     }
 
+    override fun getManagedKeyRotationStatus(tenantId: String): String {
+        return "Tested."
+    }
+
+    override fun startManagedKeyRotation(tenantId: String): ResponseEntity<String> {
+        return ResponseEntity.accepted("Tested.")
+    }
+
     private fun hasPreviousRotationFinished(): Boolean {
         // The current state of this method is to prevent any key rotations being started when any other one is in progress.
         // Same check is done on the Crypto worker side because if user quickly issues two key rotation commands after each other,

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -4351,6 +4351,82 @@
         }
       }
     },
+    "/wrappingkey/managed/rotation/{tenantid}" : {
+      "get" : {
+        "tags" : [ "Key Rotation API" ],
+        "description" : "This method gets the status of the latest key rotation for [tenantId].",
+        "operationId" : "get_wrappingkey_managed_rotation__tenantid_",
+        "parameters" : [ {
+          "name" : "tenantid",
+          "in" : "path",
+          "description" : "The tenantId whose wrapping keys are rotating.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The tenantId whose wrapping keys are rotating.",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Number of signing keys which need rotating grouped by tenantId's wrapping keys",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "nullable" : false,
+                  "example" : "string"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      },
+      "post" : {
+        "tags" : [ "Key Rotation API" ],
+        "description" : "This method enables to rotate all wrapping keys for tenantId.",
+        "operationId" : "post_wrappingkey_managed_rotation__tenantid_",
+        "parameters" : [ {
+          "name" : "tenantid",
+          "in" : "path",
+          "description" : "The tenantId whose wrapping keys are requested to be rotated.",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "description" : "The tenantId whose wrapping keys are requested to be rotated.",
+            "nullable" : false,
+            "example" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "Key rotation response",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "string",
+                  "nullable" : false,
+                  "example" : "No example available for this type"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        }
+      }
+    },
     "/wrappingkey/unmanaged/rotation/{keyalias}" : {
       "get" : {
         "tags" : [ "Key Rotation API" ],

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -4406,7 +4406,7 @@
           }
         } ],
         "responses" : {
-          "200" : {
+          "202" : {
             "description" : "Key rotation response",
             "content" : {
               "application/json" : {

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -4502,7 +4502,7 @@
           "required" : true
         },
         "responses" : {
-          "200" : {
+          "202" : {
             "description" : "Key rotation response",
             "content" : {
               "application/json" : {


### PR DESCRIPTION
Current view of REST APIs for key rotation

![Screenshot 2024-01-25 at 12 41 47](https://github.com/corda/corda-runtime-os/assets/5993097/e49bc4f6-62c0-4881-b2fa-b572ceb1b000)
