### PR TITLE
CORE-19442: Move `jacksonVersion` to version catalog

### DIFF
--- a/applications/examples/sandbox-app/example-cpi/build.gradle
+++ b/applications/examples/sandbox-app/example-cpi/build.gradle
@@ -25,5 +25,5 @@ dependencies {
     cordaProvided 'net.corda:corda-application'
     cordaProvided 'net.corda:corda-crypto-extensions'
     cordaProvided 'org.slf4j:slf4j-api'
-    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation libs.jackson.annotations
 }

--- a/applications/tools/p2p-test/app-simulator/build.gradle
+++ b/applications/tools/p2p-test/app-simulator/build.gradle
@@ -29,9 +29,9 @@ dependencies {
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(':libs:rest:rest')
     implementation project(":libs:utilities")
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.datatype.jsr310
+    implementation libs.jackson.dataformat.yaml
+    implementation libs.jackson.module.kotlin
     implementation "org.postgresql:postgresql:$postgresDriverVersion"
 
     implementation project(":osgi-framework-api")

--- a/applications/workers/release/rest-worker/build.gradle
+++ b/applications/workers/release/rest-worker/build.gradle
@@ -80,8 +80,8 @@ dependencies {
     e2eTestImplementation project(':components:membership:membership-rest')
     e2eTestImplementation project(':testing:packaging-test-utilities')
     e2eTestImplementation project(':tools:plugins:package')
-    e2eTestImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    e2eTestImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    e2eTestImplementation libs.jackson.datatype.jsr310
+    e2eTestImplementation libs.jackson.module.kotlin
     e2eTestImplementation "net.corda:corda-avro-schema"
     e2eTestImplementation "net.corda:corda-topic-schema"
     e2eTestRuntimeOnly 'org.osgi:osgi.core'

--- a/applications/workers/worker-common/build.gradle
+++ b/applications/workers/worker-common/build.gradle
@@ -41,7 +41,7 @@ dependencies {
                     'This might be resolved in the future versions of Javalin.'
         }
     }
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
     implementation ("io.micrometer:micrometer-core:$micrometerVersion") {
         // we don't need these in classpath, so excluding them to reduce dependencies.
         exclude group: 'org.hdrhistogram', module: 'HdrHistogram'
@@ -58,7 +58,7 @@ dependencies {
     testRuntimeOnly 'org.osgi:osgi.core'
 
     // Required for enterprise addons, so must appear in all worker JARs even if they don't use them
-    runtimeOnly "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    runtimeOnly libs.jackson.module.kotlin
     runtimeOnly "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     runtimeOnly project(":libs:cache:cache-caffeine")
 }

--- a/applications/workers/workers-smoketest/build.gradle
+++ b/applications/workers/workers-smoketest/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     upgradeTestingCpiV1 project(path: ':testing:cpbs:test-cordapp-for-vnode-upgrade-testing-v1', configuration: 'cordaCPB')
     upgradeTestingCpiV2 project(path: ':testing:cpbs:test-cordapp-for-vnode-upgrade-testing-v2', configuration: 'cordaCPB')
 
-    smokeTestImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    smokeTestImplementation libs.jackson.module.kotlin
     smokeTestImplementation libs.slf4j.api
 
     smokeTestImplementation project(':components:flow:flow-rest-resource-service')

--- a/components/chunking/chunk-db-write-impl/build.gradle
+++ b/components/chunking/chunk-db-write-impl/build.gradle
@@ -49,8 +49,8 @@ dependencies {
     implementation project(':components:membership:certificates-service')
     integrationTestImplementation project(":libs:serialization:serialization-avro")
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.databind
+    implementation libs.jackson.module.kotlin
 
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":components:reconciliation:reconciliation")

--- a/components/crypto/crypto-service-impl/build.gradle
+++ b/components/crypto/crypto-service-impl/build.gradle
@@ -13,9 +13,9 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform("net.corda:corda-api:$cordaApiVersion")
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.databind
+    implementation libs.jackson.datatype.jsr310
+    implementation libs.jackson.module.kotlin
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "net.corda:corda-avro-schema"
     implementation "net.corda:corda-config-schema"

--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -63,10 +63,10 @@ dependencies {
 
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
     implementation "com.esotericsoftware:kryo:$kryoVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
 
     testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
-    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    testImplementation libs.jackson.module.kotlin
 
     testImplementation project(':libs:flows:session-manager-impl')
     testImplementation project(':libs:lifecycle:lifecycle-test-impl')

--- a/components/ledger/ledger-persistence/build.gradle
+++ b/components/ledger/ledger-persistence/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     // It's not an OSGi bundle, so you will get errors (despite Intellij appearing to allow you to use it).
 
     integrationTestImplementation libs.mockito.core
-    integrationTestImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    integrationTestImplementation(libs.jackson.module.kotlin)
 
     integrationTestImplementation project(':libs:db:db-admin-impl')
     integrationTestImplementation project(':libs:db:db-orm-impl')

--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     api 'net.corda:corda-config-schema'
     implementation 'net.corda:corda-ledger-utxo'
     implementation 'net.corda:corda-topic-schema'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
     implementation project(':components:ledger:ledger-common-flow-api')
     implementation project(':components:ledger:ledger-common-flow')
     implementation project(':components:ledger:notary-worker-selection')
@@ -59,8 +59,8 @@ dependencies {
     testImplementation project(':testing:ledger:ledger-utxo-base-test')
 
     // Dependencies for ProofOfActionSerializationTests:
-    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    testImplementation libs.jackson.module.kotlin
+    testImplementation libs.jackson.datatype.jsr310
     testImplementation project(':libs:crypto:merkle-impl')
 
     integrationTestImplementation project(':testing:sandboxes')

--- a/components/ledger/ledger-utxo-token-cache/build.gradle
+++ b/components/ledger/ledger-utxo-token-cache/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation libs.slf4j.api
 
     testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
-    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    testImplementation libs.jackson.module.kotlin
 
     testImplementation project(":libs:lifecycle:lifecycle-test-impl")
     testImplementation project(":libs:lifecycle:lifecycle-impl")

--- a/components/ledger/ledger-verification/build.gradle
+++ b/components/ledger/ledger-verification/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     // It's not an OSGi bundle, so you will get errors (despite Intellij appearing to allow you to use it).
 
     integrationTestImplementation libs.mockito.core
-    integrationTestImplementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    integrationTestImplementation(libs.jackson.module.kotlin)
 
     integrationTestImplementation project(':components:virtual-node:cpi-info-read-service')
     integrationTestImplementation project(':components:virtual-node:virtual-node-info-read-service')

--- a/components/uniqueness/backing-store-impl/build.gradle
+++ b/components/uniqueness/backing-store-impl/build.gradle
@@ -77,8 +77,8 @@ dependencies {
     backingStoreBenchmarkRuntimeOnly libs.log4j.slf4j
 
     // For JSON serialization to DB
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
+    implementation libs.jackson.datatype.jsr310
 }
 
 tasks.named('jar', Jar) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,7 +53,6 @@ guavaVersion=32.1.1-jre
 # Hibernate cannot be upgraded to 6.x due to missing OSGi support
 hibernateVersion=5.6.15.Final
 hikariCpVersion=5.0.1
-jacksonVersion=2.15.0
 jaxbVersion = 2.3.1
 jbossTransactionApiSpecVersion=1.1.1.Final
 jetbrainsAnnotationsVersion=24.0.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,8 @@ kotlinVersion = "1.8.21"
 
 bouncycastleVersion = "1.77"
 
+jacksonVersion = "2.15.0"
+
 # REST dependency versions
 javalinVersion = "4.6.8"
 # This version of Jetty must be the same major version as used by Javalin, please see above.
@@ -85,6 +87,12 @@ pf4j = { group = "org.pf4j", name = "pf4j", version.ref = "pf4jVersion" }
 brave-context-slf4j = { group = "io.zipkin.brave", name = "brave-context-slf4j", version.ref = "braveVersion" }
 brave-instrumentation-servlet = { group = "io.zipkin.brave", name = "brave-instrumentation-servlet", version.ref = "braveVersion" }
 zipkin-sender = { group = "io.zipkin.reporter2", name = "zipkin-sender-urlconnection", version.ref = "zipkinVersion" }
+jackson-annotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version.ref = "jacksonVersion" }
+jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jacksonVersion" }
+jackson-core = { group = "com.fasterxml.jackson.core", name = "jackson-core", version.ref = "jacksonVersion" }
+jackson-datatype-jsr310 = { group = "com.fasterxml.jackson.datatype", name = "jackson-datatype-jsr310", version.ref = "jacksonVersion" }
+jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name = "jackson-dataformat-yaml", version.ref = "jacksonVersion" }
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jacksonVersion" }
 
 gradle-enterprise = { group = "com.gradle", name = "gradle-enterprise-gradle-plugin", version.ref = "gradleEnterpriseVersion" }
 

--- a/libs/application/application-db-setup/build.gradle
+++ b/libs/application/application-db-setup/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
+    implementation libs.jackson.dataformat.yaml
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'net.corda:corda-base'

--- a/libs/application/application-impl/build.gradle
+++ b/libs/application/application-impl/build.gradle
@@ -18,9 +18,9 @@ dependencies {
     api project(":libs:serialization:json-serializers")
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
     implementation 'org.slf4j:slf4j-api'
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.datatype.jsr310
 
     testImplementation "com.google.jimfs:jimfs:$jimfsVersion"
 }

--- a/libs/configuration/configuration-validation/build.gradle
+++ b/libs/configuration/configuration-validation/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation project(":libs:configuration:configuration-core")
     implementation project(':libs:utilities')
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
     constraints {

--- a/libs/external-messaging/build.gradle
+++ b/libs/external-messaging/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
     implementation "net.corda:corda-config-schema"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.databind
+    implementation libs.jackson.module.kotlin
     
     implementation project(":libs:crypto:crypto-core")
     implementation project(":libs:packaging:packaging-core")

--- a/libs/ledger/ledger-common-data/build.gradle
+++ b/libs/ledger/ledger-common-data/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     implementation 'net.corda:corda-ledger-common'
 
-    implementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    implementation libs.jackson.annotations
 
     api project(':libs:base-internal')
     implementation project(':libs:crypto:crypto-core')

--- a/libs/membership/schema-validation/build.gradle
+++ b/libs/membership/schema-validation/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation "net.corda:corda-base"
     api "net.corda:corda-membership-schema"
 
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
     implementation "com.networknt:json-schema-validator:$networkntJsonSchemaVersion"
     constraints {
         implementation("com.ethlo.time:itu:$comEthloTimeItuVersion") {

--- a/libs/packaging/packaging/build.gradle
+++ b/libs/packaging/packaging/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:utilities')
     implementation project(":libs:packaging:packaging-core")
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
 
     testImplementation 'org.osgi:osgi.core'
     testImplementation project(':libs:crypto:cipher-suite')

--- a/libs/rest/json-serialization/build.gradle
+++ b/libs/rest/json-serialization/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-application"
 
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.datatype.jsr310
+    implementation libs.jackson.module.kotlin
 
     implementation libs.slf4j.api
     implementation project(":libs:serialization:json-serializers")

--- a/libs/rest/rest-client/build.gradle
+++ b/libs/rest/rest-client/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
     implementation libs.unirest.java
     implementation libs.unirest.objectmapper.jackson
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
 
     testImplementation project(":testing:test-utilities")
 

--- a/libs/rest/rest-server-impl/build.gradle
+++ b/libs/rest/rest-server-impl/build.gradle
@@ -40,10 +40,10 @@ dependencies {
     implementation libs.swagger.core
     implementation libs.jetty.http2.server
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
     implementation project(":libs:rest:rest-common")
 
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.datatype.jsr310
 
     testImplementation project(":libs:rest:rest-test-common")
 
@@ -51,8 +51,8 @@ dependencies {
     testRuntimeOnly libs.slf4j.simple
 
     runtimeOnly libs.swagger.ui
-    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    runtimeOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    runtimeOnly libs.jackson.databind
+    runtimeOnly libs.jackson.datatype.jsr310
     runtimeOnly "com.sun.activation:javax.activation:$activationVersion"
 
     integrationTestImplementation libs.unirest.java

--- a/libs/rest/rest-test-common/build.gradle
+++ b/libs/rest/rest-test-common/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-serialization"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
     implementation libs.nimbus.sdk
     implementation libs.unirest.java
 

--- a/libs/serialization/json-serializers/build.gradle
+++ b/libs/serialization/json-serializers/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-application"
     implementation 'net.corda:corda-base'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
 }

--- a/libs/serialization/json-validator/build.gradle
+++ b/libs/serialization/json-validator/build.gradle
@@ -29,7 +29,7 @@ dependencies {
             because "Version bundled with current version of 'com.networknt:json-schema-validator' does not have OSGi manifest."
         }
     }
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
 }
 
 def jar = tasks.named('jar', Jar) {

--- a/libs/serialization/serialization-amqp/build.gradle
+++ b/libs/serialization/serialization-amqp/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     testImplementation project(':testing:test-serialization')
     testImplementation project(':libs:crypto:cipher-suite')
     testImplementation "org.hamcrest:hamcrest-library:$hamcrestVersion"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    testImplementation libs.jackson.databind
     testRuntimeOnly libs.slf4j.simple
     testRuntimeOnly 'org.osgi:osgi.core'
 

--- a/libs/state-manager/state-manager-db-impl/build.gradle
+++ b/libs/state-manager/state-manager-db-impl/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     implementation project(':libs:utilities')
     implementation project(':libs:db:db-core')
     implementation project(":libs:configuration:configuration-core")
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.databind
+    implementation libs.jackson.module.kotlin
 
     testImplementation project(':testing:test-utilities')
     integrationTestImplementation project(':libs:db:db-admin')

--- a/osgi-framework-bootstrap/build.gradle
+++ b/osgi-framework-bootstrap/build.gradle
@@ -25,9 +25,9 @@ dependencies {
     runtimeOnly libs.log4j.layout.json
 
     // Jackson dependencies for JSON formatted logs
-    runtimeOnly "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-    runtimeOnly "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    runtimeOnly "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    runtimeOnly libs.jackson.core
+    runtimeOnly libs.jackson.databind
+    runtimeOnly libs.jackson.annotations
 
     testImplementation libs.mockito.core
     testImplementation "org.apache.sling:org.apache.sling.testing.osgi-mock.junit5:$slingVersion"

--- a/testing/cpbs/sandbox-security-manager-one/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-one/build.gradle
@@ -17,7 +17,7 @@ cordapp {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion") {
+    implementation(libs.jackson.module.kotlin) {
         // this transitive dependency is not needed as it is shaded in the jackson module, but there is a bug in
         //  the metadata: https://github.com/FasterXML/jackson-core/issues/999
         exclude group: "ch.randelshofer"

--- a/testing/cpbs/sandbox-security-manager-two/build.gradle
+++ b/testing/cpbs/sandbox-security-manager-two/build.gradle
@@ -18,7 +18,7 @@ cordapp {
 
 dependencies {
     cordaProvided platform("net.corda:corda-api:$cordaApiVersion")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion") {
+    implementation(libs.jackson.module.kotlin) {
         // this transitive dependency is not needed as it is shaded in the jackson module, but there is a bug in
         //  the metadata: https://github.com/FasterXML/jackson-core/issues/999
         exclude group: "ch.randelshofer"

--- a/testing/cpi-info-read-service-fake/build.gradle
+++ b/testing/cpi-info-read-service-fake/build.gradle
@@ -16,8 +16,8 @@ dependencies {
     implementation project(":libs:packaging:packaging-core")
     implementation project(':libs:lifecycle:lifecycle')
 
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.dataformat.yaml
+    implementation libs.jackson.module.kotlin
 
     testImplementation project(':libs:crypto:crypto-core')
     testImplementation project(":libs:lifecycle:lifecycle-impl")

--- a/testing/db-hsqldb-json/build.gradle
+++ b/testing/db-hsqldb-json/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly platform("net.corda:corda-api:$cordaApiVersion")
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly "org.hsqldb:hsqldb:$hsqldbVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation libs.jackson.databind
 }
 
 tasks.named('jar', Jar) {

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -14,8 +14,8 @@ dependencies {
 
     implementation "net.corda:corda-config-schema:$cordaApiVersion"
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
+    implementation libs.jackson.datatype.jsr310
     implementation libs.unirest.java
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "org.apache.commons:commons-text:$commonsTextVersion"

--- a/testing/virtual-node-info-read-service-fake/build.gradle
+++ b/testing/virtual-node-info-read-service-fake/build.gradle
@@ -17,9 +17,9 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(":components:reconciliation:reconciliation")
 
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.dataformat.yaml
+    implementation libs.jackson.module.kotlin
+    implementation libs.jackson.datatype.jsr310
 
     testImplementation project(":libs:lifecycle:lifecycle-impl")
     testImplementation project(":libs:lifecycle:registry")

--- a/tools/plugins/initial-config/build.gradle
+++ b/tools/plugins/initial-config/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     kapt "info.picocli:picocli:$picocliVersion"
 
     implementation 'net.corda:corda-config-schema'
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
 
     implementation project(':libs:permissions:permission-common')
     implementation project(':libs:permissions:permission-datamodel')

--- a/tools/plugins/network/build.gradle
+++ b/tools/plugins/network/build.gradle
@@ -21,8 +21,8 @@ dependencies {
 
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
 
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation libs.jackson.module.kotlin
+    implementation libs.jackson.datatype.jsr310
     implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
     implementation libs.unirest.java
     implementation project(":libs:crypto:certificate-generation")

--- a/tools/plugins/preinstall/build.gradle
+++ b/tools/plugins/preinstall/build.gradle
@@ -22,9 +22,9 @@ dependencies {
     testImplementation "com.github.stefanbirkner:system-lambda:$systemLambdaVersion"
     testImplementation "info.picocli:picocli:$picocliVersion"
 
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
+    implementation libs.jackson.dataformat.yaml
+    implementation libs.jackson.databind
+    implementation libs.jackson.module.kotlin
     implementation "io.fabric8:kubernetes-client:$kubernetesClientVersion"
 
     implementation "org.postgresql:postgresql:$postgresDriverVersion"

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -13,8 +13,8 @@ group 'net.corda.cli.deployment'
 
 dependencies {
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib'
-    compileOnly "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    compileOnly "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    compileOnly libs.jackson.module.kotlin
+    compileOnly libs.jackson.dataformat.yaml
 
     compileOnly libs.pf4j
     compileOnly "net.corda.cli.host:api:$pluginHostVersion"
@@ -36,8 +36,8 @@ dependencies {
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib'
     testImplementation libs.pf4j
     testImplementation "net.corda.cli.host:api:$pluginHostVersion"
-    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    testImplementation libs.jackson.module.kotlin
+    testImplementation libs.jackson.dataformat.yaml
     testImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
 }
 


### PR DESCRIPTION
Just a transition to Jackson libraries to version catalog without trying to upgrade Jackson.
Hopefully, Dependabot will be able to do it automatically after this PR is merged.