### PR TITLE
CORE-19355 Remove `search_path` from DB URLs

### DIFF
--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -107,9 +107,6 @@ class CombinedWorker @Activate constructor(
     private companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val DEFAULT_BOOT_STATE_MANAGER_TYPE = "DATABASE"
-        private const val MESSAGE_BUS_CONFIG_PATH_SUFFIX = "_messagebus"
-        private const val MESSAGEBUS_SCHEMA_NAME = "MESSAGEBUS"
-        private const val CONFIG_SCHEMA_NAME = "CONFIG"
     }
 
     /** Parses the arguments, then initialises and starts the processors. */
@@ -216,19 +213,13 @@ class CombinedWorker @Activate constructor(
     }
 
     /**
-     * Combined worker parameter for JDBC URL should be the schemaless database URL because the combined worker sets up
-     * schemas itself. However, Corda processors all expect the JDBC URL in the config to point to the config schema
-     * directly, so the name of that schema must be added to the params that are used to create the config.
+     * Sets the JDBC URL (as schema agnostic). It is the DB users responsibility to have set their search_path context
+     * to be able to see whichever schema they need to see.
      */
     private fun prepareDbConfig(dbConfig: Config): Config {
         val tempJdbcUrl = dbConfig.getString(BOOT_JDBC_URL)
         return dbConfig
-            // TODO there is no point differentiating urls now is it? I.e. the below 2 should now be stored under a single key
             .withValue(BOOT_JDBC_URL, fromAnyRef(tempJdbcUrl))
-            .withValue(
-                BOOT_JDBC_URL + MESSAGE_BUS_CONFIG_PATH_SUFFIX,
-                fromAnyRef(tempJdbcUrl)
-            )
     }
 
     override fun shutdown() {

--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -107,6 +107,7 @@ class CombinedWorker @Activate constructor(
     private companion object {
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
         private const val DEFAULT_BOOT_STATE_MANAGER_TYPE = "DATABASE"
+        private const val MESSAGE_BUS_CONFIG_PATH_SUFFIX = "_messagebus"
     }
 
     /** Parses the arguments, then initialises and starts the processors. */
@@ -220,6 +221,10 @@ class CombinedWorker @Activate constructor(
         val tempJdbcUrl = dbConfig.getString(BOOT_JDBC_URL)
         return dbConfig
             .withValue(BOOT_JDBC_URL, fromAnyRef(tempJdbcUrl))
+            .withValue(
+                BOOT_JDBC_URL + MESSAGE_BUS_CONFIG_PATH_SUFFIX,
+                fromAnyRef(tempJdbcUrl)
+            )
     }
 
     override fun shutdown() {

--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -223,10 +223,11 @@ class CombinedWorker @Activate constructor(
     private fun prepareDbConfig(dbConfig: Config): Config {
         val tempJdbcUrl = dbConfig.getString(BOOT_JDBC_URL)
         return dbConfig
-            .withValue(BOOT_JDBC_URL, fromAnyRef("$tempJdbcUrl?currentSchema=$CONFIG_SCHEMA_NAME"))
+            // TODO there is no point differentiating urls now is it? I.e. the below 2 should now be stored under a single key
+            .withValue(BOOT_JDBC_URL, fromAnyRef(tempJdbcUrl))
             .withValue(
                 BOOT_JDBC_URL + MESSAGE_BUS_CONFIG_PATH_SUFFIX,
-                fromAnyRef("$tempJdbcUrl?currentSchema=$MESSAGEBUS_SCHEMA_NAME")
+                fromAnyRef(tempJdbcUrl)
             )
     }
 

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/StateManagerConfigHelper.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/StateManagerConfigHelper.kt
@@ -11,7 +11,6 @@ import java.lang.IllegalArgumentException
 object StateManagerConfigHelper {
 
     private const val DEFAULT_TYPE = "DATABASE"
-    private const val DEFAULT_SCHEMA = "STATE_MANAGER"
     internal const val DEFAULT_DRIVER = "org.postgresql.Driver"
     internal const val DEFAULT_JDBC_POOL_MIN_SIZE = 0
     internal const val DEFAULT_JDBC_POOL_MAX_SIZE = 5
@@ -65,11 +64,9 @@ object StateManagerConfigHelper {
         )
 
     private fun createClusterConfig(config: Config): Config {
-        // if cluster JDBC url contains currentSchema, remove it and add state manager default schema
-        val jdbcUrl = config.getString(BootConfig.BOOT_JDBC_URL).split("?currentSchema").first()
         return ConfigFactory.parseMap(
             mapOf(
-                StateManagerConfig.Database.JDBC_URL to "$jdbcUrl?currentSchema=$DEFAULT_SCHEMA",
+                StateManagerConfig.Database.JDBC_URL to config.getString(BootConfig.BOOT_JDBC_URL),
                 StateManagerConfig.Database.JDBC_USER to config.getString(BootConfig.BOOT_JDBC_USER),
                 StateManagerConfig.Database.JDBC_PASS to config.getString(BootConfig.BOOT_JDBC_PASS),
             )

--- a/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/StateManagerConfigHelperTest.kt
+++ b/applications/workers/worker-common/src/test/kotlin/net/corda/applications/workers/workercommon/internal/StateManagerConfigHelperTest.kt
@@ -41,7 +41,7 @@ class StateManagerConfigHelperTest {
         SoftAssertions.assertSoftly { softly ->
             StateManagerConfig.StateType.values().map { type ->
                 assertStateType(softly, smConfig, type,
-                    url = "url?currentSchema=STATE_MANAGER", user = "user", pass = "pass")
+                    url = "url", user = "user", pass = "pass")
             }
         }
     }

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -314,24 +314,35 @@ spec:
               find /tmp/db -iname "*.sql" | xargs printf -- ' -f %s' | xargs psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "${DB_CLUSTER_NAME}"
 
               echo 'Applying initial configurations'
-              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" -f /tmp/rbac/db-config.sql -f /tmp/vnodes/db-config.sql -f /tmp/crypto/db-config.sql -f /tmp/crypto-config.sql --dbname "dbname=${DB_CLUSTER_NAME}"
+              (echo "SET search_path TO config;";
+              cat /tmp/rbac/db-config.sql;
+              echo ";";
+              cat /tmp/vnodes/db-config.sql;
+              echo ";";
+              cat /tmp/crypto/db-config.sql;
+              echo ";";
+              cat /tmp/crypto-config.sql) | psql -v ON_ERROR_STOP=1 \
+              -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "dbname=${DB_CLUSTER_NAME}"
 
               echo 'Applying initial RBAC configuration'
-              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" -f /tmp/rbac-config.sql --dbname "dbname=${DB_CLUSTER_NAME}"
+              (echo "SET search_path TO rbac;";
+              cat  /tmp/rbac-config.sql;) | psql -v ON_ERROR_STOP=1 \
+              -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "dbname=${DB_CLUSTER_NAME}"
 
               echo 'Creating users and granting permissions'
               psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" "${DB_CLUSTER_NAME}" << SQL
                 GRANT USAGE ON SCHEMA ${DB_CLUSTER_SCHEMA} TO "${DB_CLUSTER_USERNAME}";
                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_CLUSTER_SCHEMA} TO "${DB_CLUSTER_USERNAME}";
                 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA ${DB_CLUSTER_SCHEMA} TO "${DB_CLUSTER_USERNAME}";
+                ALTER ROLE "${DB_CLUSTER_USERNAME}" SET search_path TO ${DB_CLUSTER_SCHEMA};
                 DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${RBAC_DB_USER_USERNAME}') THEN RAISE NOTICE 'Role "${RBAC_DB_USER_USERNAME}" already exists'; ELSE CREATE USER "${RBAC_DB_USER_USERNAME}" WITH ENCRYPTED PASSWORD '${RBAC_DB_USER_PASSWORD}'; END IF; END \$\$;
                 GRANT USAGE ON SCHEMA ${DB_RBAC_SCHEMA} TO "$RBAC_DB_USER_USERNAME";
                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_RBAC_SCHEMA} TO "$RBAC_DB_USER_USERNAME";
-                ALTER ROLE "${RBAC_DB_USER_USERNAME}" SET search_path TO rbac;
+                ALTER ROLE "${RBAC_DB_USER_USERNAME}" SET search_path TO ${DB_RBAC_SCHEMA};
                 DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${CRYPTO_DB_USER_USERNAME}') THEN RAISE NOTICE 'Role "${CRYPTO_DB_USER_USERNAME}" already exists'; ELSE CREATE USER "${CRYPTO_DB_USER_USERNAME}" WITH ENCRYPTED PASSWORD '$CRYPTO_DB_USER_PASSWORD'; END IF; END \$\$;
                 GRANT USAGE ON SCHEMA ${DB_CRYPTO_SCHEMA} TO "${CRYPTO_DB_USER_USERNAME}";
                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_CRYPTO_SCHEMA} TO "${CRYPTO_DB_USER_USERNAME}";
-                ALTER ROLE "${CRYPTO_DB_USER_USERNAME}" SET search_path TO crypto;
+                ALTER ROLE "${CRYPTO_DB_USER_USERNAME}" SET search_path TO ${DB_CRYPTO_SCHEMA};
               SQL
 
               echo 'DB Bootstrapped'

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -314,7 +314,7 @@ spec:
               find /tmp/db -iname "*.sql" | xargs printf -- ' -f %s' | xargs psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "${DB_CLUSTER_NAME}"
 
               echo 'Applying initial configurations'
-              (echo "SET search_path TO config;";
+              (echo "SET search_path TO ${DB_CLUSTER_SCHEMA};";
               cat /tmp/rbac/db-config.sql;
               echo ";";
               cat /tmp/vnodes/db-config.sql;
@@ -325,7 +325,7 @@ spec:
               -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "dbname=${DB_CLUSTER_NAME}"
 
               echo 'Applying initial RBAC configuration'
-              (echo "SET search_path TO rbac;";
+              (echo "SET search_path TO ${DB_RBAC_SCHEMA};";
               cat  /tmp/rbac-config.sql;) | psql -v ON_ERROR_STOP=1 \
               -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "dbname=${DB_CLUSTER_NAME}"
 

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -323,7 +323,7 @@ spec:
 
               echo 'Applying initial RBAC configuration'
               (echo "SET search_path TO ${DB_RBAC_SCHEMA};";
-              cat  /tmp/rbac-config.sql;) | psql -v ON_ERROR_STOP=1 \
+              cat  /tmp/rbac-config.sql) | psql -v ON_ERROR_STOP=1 \
               -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "dbname=${DB_CLUSTER_NAME}"
 
               echo 'Creating users and granting permissions'

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -167,7 +167,7 @@ spec:
               java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar initial-config create-db-config \
                 -u "${RBAC_DB_USER_USERNAME}" -p "${RBAC_DB_USER_PASSWORD}" \
                 --name "corda-rbac" \
-                --jdbc-url "${JDBC_URL}?currentSchema=${DB_RBAC_SCHEMA}" \
+                --jdbc-url "${JDBC_URL}" \
                 --jdbc-pool-max-size {{ .Values.bootstrap.db.rbac.dbConnectionPool.maxSize | quote }} \
               {{- if not ( kindIs "invalid" .Values.bootstrap.db.rbac.dbConnectionPool.minSize ) }}
                 --jdbc-pool-min-size {{ .Values.bootstrap.db.rbac.dbConnectionPool.minSize | quote }}
@@ -209,7 +209,7 @@ spec:
               java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar initial-config create-db-config \
                 -u "${CRYPTO_DB_USER_USERNAME}" -p "${CRYPTO_DB_USER_PASSWORD}" \
                 --name "corda-crypto" \
-                --jdbc-url "${JDBC_URL}?currentSchema=${DB_CRYPTO_SCHEMA}" \
+                --jdbc-url "${JDBC_URL}" \
                 --jdbc-pool-max-size {{ .Values.bootstrap.db.crypto.dbConnectionPool.maxSize | quote }} \
               {{- if not ( kindIs "invalid" .Values.bootstrap.db.crypto.dbConnectionPool.minSize ) }}
                 --jdbc-pool-min-size {{ .Values.bootstrap.db.crypto.dbConnectionPool.minSize | quote }}
@@ -314,10 +314,10 @@ spec:
               find /tmp/db -iname "*.sql" | xargs printf -- ' -f %s' | xargs psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "${DB_CLUSTER_NAME}"
 
               echo 'Applying initial configurations'
-              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" -f /tmp/rbac/db-config.sql -f /tmp/vnodes/db-config.sql -f /tmp/crypto/db-config.sql -f /tmp/crypto-config.sql --dbname "dbname=${DB_CLUSTER_NAME} options=--search_path=${DB_CLUSTER_SCHEMA}"
+              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" -f /tmp/rbac/db-config.sql -f /tmp/vnodes/db-config.sql -f /tmp/crypto/db-config.sql -f /tmp/crypto-config.sql --dbname "dbname=${DB_CLUSTER_NAME}"
 
               echo 'Applying initial RBAC configuration'
-              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" -f /tmp/rbac-config.sql --dbname "dbname=${DB_CLUSTER_NAME} options=--search_path=${DB_RBAC_SCHEMA}"
+              psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" -f /tmp/rbac-config.sql --dbname "dbname=${DB_CLUSTER_NAME}"
 
               echo 'Creating users and granting permissions'
               psql -v ON_ERROR_STOP=1 -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" "${DB_CLUSTER_NAME}" << SQL
@@ -327,9 +327,11 @@ spec:
                 DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${RBAC_DB_USER_USERNAME}') THEN RAISE NOTICE 'Role "${RBAC_DB_USER_USERNAME}" already exists'; ELSE CREATE USER "${RBAC_DB_USER_USERNAME}" WITH ENCRYPTED PASSWORD '${RBAC_DB_USER_PASSWORD}'; END IF; END \$\$;
                 GRANT USAGE ON SCHEMA ${DB_RBAC_SCHEMA} TO "$RBAC_DB_USER_USERNAME";
                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_RBAC_SCHEMA} TO "$RBAC_DB_USER_USERNAME";
+                ALTER ROLE "${RBAC_DB_USER_USERNAME}" SET search_path TO rbac;
                 DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${CRYPTO_DB_USER_USERNAME}') THEN RAISE NOTICE 'Role "${CRYPTO_DB_USER_USERNAME}" already exists'; ELSE CREATE USER "${CRYPTO_DB_USER_USERNAME}" WITH ENCRYPTED PASSWORD '$CRYPTO_DB_USER_PASSWORD'; END IF; END \$\$;
                 GRANT USAGE ON SCHEMA ${DB_CRYPTO_SCHEMA} TO "${CRYPTO_DB_USER_USERNAME}";
                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${DB_CRYPTO_SCHEMA} TO "${CRYPTO_DB_USER_USERNAME}";
+                ALTER ROLE "${CRYPTO_DB_USER_USERNAME}" SET search_path TO crypto;
               SQL
 
               echo 'DB Bootstrapped'

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -316,11 +316,8 @@ spec:
               echo 'Applying initial configurations'
               (echo "SET search_path TO ${DB_CLUSTER_SCHEMA};";
               cat /tmp/rbac/db-config.sql;
-              echo ";";
               cat /tmp/vnodes/db-config.sql;
-              echo ";";
               cat /tmp/crypto/db-config.sql;
-              echo ";";
               cat /tmp/crypto-config.sql) | psql -v ON_ERROR_STOP=1 \
               -h "${DB_CLUSTER_HOST}" -p "${DB_CLUSTER_PORT}" -U "${CLUSTER_PGUSER}" --dbname "dbname=${DB_CLUSTER_NAME}"
 

--- a/charts/corda-lib/templates/_stateManager.tpl
+++ b/charts/corda-lib/templates/_stateManager.tpl
@@ -221,6 +221,7 @@ jdbc:{{- include "corda.clusterDbType" $ -}}://{{- $.Values.db.cluster.host -}}:
                 GRANT USAGE ON SCHEMA STATE_MANAGER TO "${STATE_MANAGER_USERNAME}";
                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA STATE_MANAGER TO "${STATE_MANAGER_USERNAME}";
                 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA STATE_MANAGER TO "${STATE_MANAGER_USERNAME}";
+                ALTER ROLE "${STATE_MANAGER_USERNAME}" SET search_path TO STATE_MANAGER;
               SQL
 
               echo 'Creating users and granting permissions for State Manager in {{ $workerName }}... Done!'

--- a/charts/corda-lib/templates/_stateManagerV2.tpl
+++ b/charts/corda-lib/templates/_stateManagerV2.tpl
@@ -192,6 +192,7 @@
                 GRANT USAGE ON SCHEMA "{{- $schemaName -}}" TO "${STATE_MANAGER_USERNAME}";
                 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA "{{- $schemaName -}}" TO "${STATE_MANAGER_USERNAME}";
                 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA "{{- $schemaName -}}" TO "${STATE_MANAGER_USERNAME}";
+                ALTER ROLE "${STATE_MANAGER_USERNAME}" SET search_path TO "{{- $schemaName -}}";
               SQL
 
               echo 'Applying State Manager Specification for Database '{{ $dbName }}'... Done!'

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -306,7 +306,7 @@ spec:
           {{- if $optionalArgs.clusterDbAccess }}
           - "-ddatabase.user=$(DB_CLUSTER_USERNAME)"
           - "-ddatabase.pass=$(DB_CLUSTER_PASSWORD)"
-          - "-ddatabase.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" $.Values.db.cluster.host }}:{{ $.Values.db.cluster.port }}/{{ $.Values.db.cluster.database }}?currentSchema={{ $.Values.db.cluster.schema }}"
+          - "-ddatabase.jdbc.url=jdbc:postgresql://{{ required "Must specify db.cluster.host" $.Values.db.cluster.host }}:{{ $.Values.db.cluster.port }}/{{ $.Values.db.cluster.database }}"
           - "-ddatabase.jdbc.directory=/opt/jdbc-driver"
           - "-ddatabase.pool.max_size={{ .clusterDbConnectionPool.maxSize }}"
           {{- if .clusterDbConnectionPool.minSize }}
@@ -325,7 +325,7 @@ spec:
           - "--stateManager"
           - "database.pass=$(STATE_MANAGER_PASSWORD)"
           - "--stateManager"
-          - "database.jdbc.url={{- include "corda.stateManagerJdbcUrl" ( list $ . ) -}}?currentSchema=STATE_MANAGER"
+          - "database.jdbc.url={{- include "corda.stateManagerJdbcUrl" ( list $ . ) -}}"
           - "--stateManager"
           - "database.jdbc.directory=/opt/jdbc-driver"
           - "--stateManager"

--- a/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/CryptoRepositoryTest.kt
+++ b/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/CryptoRepositoryTest.kt
@@ -9,6 +9,7 @@ import net.corda.db.testkit.DbUtils
 import net.corda.orm.EntityManagerConfiguration
 import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import org.junit.jupiter.api.AfterAll
+import java.util.UUID
 import javax.persistence.EntityManagerFactory
 
 @Suppress("warnings")
@@ -18,16 +19,14 @@ abstract class CryptoRepositoryTest {
     private companion object {
         private const val MIGRATION_FILE_LOCATION = "net/corda/db/schema/crypto/db.changelog-master.xml"
         private const val MIGRATION_FILE_LOCATION_VNODE = "net/corda/db/schema/vnode-crypto/db.changelog-master.xml"
-        private var char = 'A'
     }
-
-
 
     /**
      * Creates an in-memory database, applies the relevant migration scripts, and initialises
      * the entityManagerFactories.
      */
     init {
+        val schemaUniqueId = UUID.randomUUID().toString().split("-").get(0)
         dbs = mapOf(
             "cluster" to MIGRATION_FILE_LOCATION,
             "vnode" to MIGRATION_FILE_LOCATION_VNODE,
@@ -42,7 +41,7 @@ abstract class CryptoRepositoryTest {
                         )
                     )
                 )
-                val uniqueSchemaName = "$schemaName${char}"
+                val uniqueSchemaName = "${schemaName}_${schemaUniqueId}"
                 val dbConfig =
                     DbUtils.getEntityManagerConfiguration(
                         inMemoryDbName = "${this::class.java.simpleName}-$uniqueSchemaName",
@@ -63,7 +62,6 @@ abstract class CryptoRepositoryTest {
 
                 Pair(dbConfig, entityManagerFactory)
             }
-        char++
     }
 
     @Suppress("Unused")

--- a/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/CryptoRepositoryTest.kt
+++ b/components/crypto/crypto-softhsm-impl/src/integrationTest/kotlin/repository/CryptoRepositoryTest.kt
@@ -32,7 +32,7 @@ abstract class CryptoRepositoryTest {
             "cluster" to MIGRATION_FILE_LOCATION,
             "vnode" to MIGRATION_FILE_LOCATION_VNODE,
             )
-            .map { (schemaName,migrationFile) ->
+            .map { (schemaName, migrationFile) ->
                 val dbChange = ClassloaderChangeLog(
                     linkedSetOf(
                         ClassloaderChangeLog.ChangeLogResourceFiles(

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbAdmin.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbAdmin.kt
@@ -75,6 +75,7 @@ abstract class DbAdmin {
             GRANT $user TO current_user;
             GRANT USAGE ON SCHEMA $schemaName to $user;
             $permissions TO $user;
+            ALTER ROLE "$user" SET search_path TO $schemaName;
             """.trimIndent()
 
         withDbConnection { connection ->
@@ -140,12 +141,5 @@ abstract class DbAdmin {
         }
     }
 
-    /**
-     * Configure JDBC URL to use given DB schema
-     *
-     * @param jdbcUrl JDBC URL
-     * @param schemaName Schema name
-     * @return JDBC URL configured to use given DB schema
-     */
-    fun createJdbcUrl(schemaName: String) = "$jdbcRootUrl?currentSchema=$schemaName"
+    fun getJdbcUrl() = jdbcRootUrl
 }

--- a/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
+++ b/components/persistence/entity-processor-service-impl/src/integrationTest/kotlin/net/corda/entityprocessor/impl/tests/PersistenceExceptionTests.kt
@@ -342,7 +342,10 @@ class PersistenceExceptionTests {
 
         val cl = ClassloaderChangeLog(linkedSetOf(vnodeVaultSchema, sandboxedSchema))
         val ds = dbConnectionManager.getDataSource(virtualNodeInfo.vaultDmlConnectionId)
+        val schemaName = dbConnectionManager.getSchemaName(virtualNodeInfo.vaultDmlConnectionId)
         ds.connection.use {
+            it.prepareStatement("SET search_path TO $schemaName;").execute()
+            it.commit()
             lbm.updateDb(it, cl)
         }
     }

--- a/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreTestUtilities.kt
+++ b/components/uniqueness/backing-store-impl/src/integrationTest/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreTestUtilities.kt
@@ -1,25 +1,9 @@
 package net.corda.uniqueness.backingstore.impl
-
-import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
-import net.corda.db.testkit.DatabaseInstaller
-import net.corda.db.testkit.TestDbInfo
-import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
-import net.corda.orm.impl.JpaEntitiesRegistryImpl
-import javax.persistence.EntityManagerFactory
-
 /**
  * Creates a new (test) uniqueness database using the specified database information.
  */
 object JPABackingStoreTestUtilities {
-    fun setupUniquenessDatabase(dbInfo: TestDbInfo): EntityManagerFactory {
-        return DatabaseInstaller(
-            EntityManagerFactoryFactoryImpl(),
-            LiquibaseSchemaMigratorImpl(),
-            JpaEntitiesRegistryImpl()
-        ).setupDatabase(
-            dbInfo,
-            "vnode-uniqueness",
-            JPABackingStoreEntities.classes
-        )
+    fun getJPABackingStoreEntities(): Set<Class<*>> {
+        return JPABackingStoreEntities.classes
     }
 }

--- a/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/integrationTest/kotlin/net/corda/uniqueness/checker/impl/UniquenessCheckerImplDBIntegrationTests.kt
@@ -6,11 +6,14 @@ import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.uniqueness.UniquenessCheckRequestAvro
 import net.corda.data.uniqueness.UniquenessCheckResponseAvro
 import net.corda.data.uniqueness.UniquenessCheckResultSuccessAvro
+import net.corda.db.admin.impl.ClassloaderChangeLog
+import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.connection.manager.DBConfigurationException
 import net.corda.db.connection.manager.DbConnectionManager
 import net.corda.db.connection.manager.VirtualNodeDbType
+import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
-import net.corda.db.testkit.TestDbInfo
+import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
 import net.corda.orm.impl.JpaEntitiesRegistryImpl
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.AutoTickTestClock
@@ -61,7 +64,10 @@ import kotlin.test.assertEquals
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class UniquenessCheckerImplDBIntegrationTests {
 
-    private val clusterDbConfig = DbUtils.getEntityManagerConfiguration("clusterdb")
+    private val clusterDbConfig = DbUtils.getEntityManagerConfiguration(
+        inMemoryDbName = "clusterdb",
+        showSql = false
+    )
 
     private val baseTime: Instant = Instant.EPOCH
 
@@ -157,30 +163,75 @@ class UniquenessCheckerImplDBIntegrationTests {
      * Creates an in-memory database and applies the relevant migration scripts
      */
     init {
+        val persistenceUnitName = "uniq_test_default"
         // Each DB uses both a different db name and schema name, as HSQLDB does not appear to
         // respect schema name
-        defaultHoldingIdentityDb = JPABackingStoreTestUtilities.setupUniquenessDatabase(
-            TestDbInfo(
-                "uniq_test_default",
-                defaultHoldingIdentityDbName,
-                rewriteBatchedInserts = true
-            )
+
+        // Create users and schemas
+        val defaultEMConfig = DbUtils.getEntityManagerConfiguration(
+            dbUser = "user_$defaultHoldingIdentityDbName",
+            schemaName = defaultHoldingIdentityDbName,
+            createSchema = true,
+            showSql = false,
+            rewriteBatchedInserts = true,
         )
 
-        bobHoldingIdentityDb =  JPABackingStoreTestUtilities.setupUniquenessDatabase(
-            TestDbInfo(
-                "uniq_test_bob",
-                bobHoldingIdentityDbName,
-                rewriteBatchedInserts = true
-            )
+        val bobEMConfig = DbUtils.getEntityManagerConfiguration(
+            dbUser = "user_$bobHoldingIdentityDbName",
+            schemaName = bobHoldingIdentityDbName,
+            createSchema = true,
+            showSql = false,
+            rewriteBatchedInserts = true,
         )
 
-        charlieHoldingIdentityDb = JPABackingStoreTestUtilities.setupUniquenessDatabase(
-            TestDbInfo(
-                "uniq_test_charlie",
-                charlieHoldingIdentityDbName,
-                rewriteBatchedInserts = true
-            )
+        val charlieEMConfig = DbUtils.getEntityManagerConfiguration(
+            dbUser = "user_$charlieHoldingIdentityDbName",
+            schemaName = charlieHoldingIdentityDbName,
+            createSchema = true,
+            showSql = false,
+            rewriteBatchedInserts = true,
+        )
+
+        // Populate schemas with tables
+        val resourceSubPath = "vnode-uniqueness"
+        val uniquenessSchema = ClassloaderChangeLog.ChangeLogResourceFiles(
+            DbSchema::class.java.packageName,
+            listOf("net/corda/db/schema/$resourceSubPath/db.changelog-master.xml"),
+            DbSchema::class.java.classLoader
+        )
+
+        val lbm = LiquibaseSchemaMigratorImpl()
+        val cl = ClassloaderChangeLog(linkedSetOf(uniquenessSchema))
+        listOf(
+            Pair(defaultEMConfig.dataSource, defaultHoldingIdentityDbName),
+            Pair(bobEMConfig.dataSource, bobHoldingIdentityDbName),
+            Pair(charlieEMConfig.dataSource, charlieHoldingIdentityDbName)
+        ).forEach { (ds, schemaName) ->
+            ds.connection.use {
+                it.prepareStatement("SET search_path TO $schemaName;").execute()
+                it.commit()
+                lbm.updateDb(it, cl)
+            }
+        }
+
+        val emff = EntityManagerFactoryFactoryImpl()
+        val jpaBackingStoreEntities = JPABackingStoreTestUtilities.getJPABackingStoreEntities().toList()
+        defaultHoldingIdentityDb = emff.create(
+            persistenceUnitName,
+            jpaBackingStoreEntities,
+            defaultEMConfig
+        )
+
+        bobHoldingIdentityDb = emff.create(
+            persistenceUnitName,
+            jpaBackingStoreEntities,
+            bobEMConfig
+        )
+
+        charlieHoldingIdentityDb = emff.create(
+            persistenceUnitName,
+            jpaBackingStoreEntities,
+            charlieEMConfig
         )
     }
 

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -169,9 +169,9 @@ internal class VirtualNodeDbFactoryImpl(
             val password = generatePassword()
 
             // Add reWriteBatchedInserts JDBC parameter for uniqueness db to enable Hibernate batching
-            var jdbcUrl = virtualNodesDbAdmin.createJdbcUrl(getSchemaName(holdingIdentityShortHash))
+            var jdbcUrl = virtualNodesDbAdmin.getJdbcUrl()
             if (dbType == UNIQUENESS && jdbcUrl.startsWith("jdbc:postgresql")) {
-                jdbcUrl += "&reWriteBatchedInserts=true"
+                jdbcUrl += "?reWriteBatchedInserts=true"
             }
 
             val virtualNodePoolConfig = smartConfigFactory.create(

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -52,7 +52,7 @@ class VirtualNodeDbFactoryImplTest {
 
     private val JDBC_URL = "jdbc:url"
     private val virtualNodesDbAdmin = mock<VirtualNodesDbAdmin> {
-        on { createJdbcUrl(any()) } doReturn JDBC_URL
+        on { getJdbcUrl() } doReturn JDBC_URL
     }
     private val schemaMigrator = mock<LiquibaseSchemaMigrator>()
 

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/configuration/DbBusConfigMergerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/configuration/DbBusConfigMergerImpl.kt
@@ -26,11 +26,8 @@ class DbBusConfigMergerImpl : BusConfigMerger {
 
             // Cluster Database
             .withValue(Bus.BUS_TYPE, fromAnyRef("DATABASE"))
+            .withValue(Bus.DB_JDBC_URL, fromAnyRef(bootConfig.getStringOrNull(BootConfig.BOOT_JDBC_URL)))
             .withValue(Bus.DB_USER, fromAnyRef(bootConfig.getStringOrDefault(BootConfig.BOOT_JDBC_USER, "")))
             .withValue(Bus.DB_PASS, fromAnyRef(bootConfig.getStringOrDefault(BootConfig.BOOT_JDBC_PASS, "")))
-            .withValue(
-                Bus.DB_JDBC_URL,
-                fromAnyRef(bootConfig.getStringOrNull(BootConfig.BOOT_JDBC_URL + "_messagebus"))
-            )
     }
 }

--- a/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/configuration/DbBusConfigMergerImpl.kt
+++ b/libs/messaging/db-message-bus-impl/src/main/kotlin/net/corda/messagebus/db/configuration/DbBusConfigMergerImpl.kt
@@ -26,8 +26,11 @@ class DbBusConfigMergerImpl : BusConfigMerger {
 
             // Cluster Database
             .withValue(Bus.BUS_TYPE, fromAnyRef("DATABASE"))
-            .withValue(Bus.DB_JDBC_URL, fromAnyRef(bootConfig.getStringOrNull(BootConfig.BOOT_JDBC_URL)))
             .withValue(Bus.DB_USER, fromAnyRef(bootConfig.getStringOrDefault(BootConfig.BOOT_JDBC_USER, "")))
             .withValue(Bus.DB_PASS, fromAnyRef(bootConfig.getStringOrDefault(BootConfig.BOOT_JDBC_PASS, "")))
+            .withValue(
+                Bus.DB_JDBC_URL,
+                fromAnyRef(bootConfig.getStringOrNull(BootConfig.BOOT_JDBC_URL + "_messagebus"))
+            )
     }
 }

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/DatabaseInstaller.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/DatabaseInstaller.kt
@@ -123,7 +123,11 @@ class DatabaseInstaller(
         } else {
             cfg.dataSource.connection.use { connection ->
                 connection.createStatement().use { stmt ->
-                    stmt.execute("CREATE SCHEMA IF NOT EXISTS $schemaName")
+                    val sql = """
+                        CREATE SCHEMA IF NOT EXISTS "$schemaName";
+                        SET search_path TO "$schemaName";
+                    """.trimIndent()
+                    stmt.execute(sql)
                 }
                 connection.commit()
 

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/DatabaseInstaller.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/DatabaseInstaller.kt
@@ -124,8 +124,8 @@ class DatabaseInstaller(
             cfg.dataSource.connection.use { connection ->
                 connection.createStatement().use { stmt ->
                     val sql = """
-                        CREATE SCHEMA IF NOT EXISTS "$schemaName";
-                        SET search_path TO "$schemaName";
+                        CREATE SCHEMA IF NOT EXISTS $schemaName;
+                        SET search_path TO $schemaName;
                     """.trimIndent()
                     stmt.execute(sql)
                 }

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/dbutilsimpl/PostgresHelper.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/dbutilsimpl/PostgresHelper.kt
@@ -50,10 +50,11 @@ class PostgresHelper : ExternalDbHelper() {
                 }
             }
 
+            // TODO this now needs tidying up
             if (rewriteBatchedInserts) {
-                "$jdbcUrl?currentSchema=$schemaName&reWriteBatchedInserts=true"
+                "$jdbcUrl?reWriteBatchedInserts=true"
             } else {
-                "$jdbcUrl?currentSchema=$schemaName"
+                jdbcUrl
             }
         } else {
             jdbcUrl
@@ -68,7 +69,6 @@ class PostgresHelper : ExternalDbHelper() {
         )
     }
 
-
     override fun createConfig(
         inMemoryDbName: String,
         dbUser: String?,
@@ -77,15 +77,9 @@ class PostgresHelper : ExternalDbHelper() {
     ): Config {
         val user = dbUser ?: getAdminUser()
         val password = dbPassword ?: getAdminPassword()
-        val currentJdbcUrl = if (!schemaName.isNullOrBlank()) {
-            "$jdbcUrl?currentSchema=$schemaName"
-        } else {
-            jdbcUrl
-        }
         return ConfigFactory.empty()
-            .withValue(DatabaseConfig.JDBC_URL, ConfigValueFactory.fromAnyRef(currentJdbcUrl))
+            .withValue(DatabaseConfig.JDBC_URL, ConfigValueFactory.fromAnyRef(jdbcUrl))
             .withValue(DatabaseConfig.DB_USER, ConfigValueFactory.fromAnyRef(user))
             .withValue(DatabaseConfig.DB_PASS, ConfigValueFactory.fromAnyRef(password))
     }
-
 }

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/dbutilsimpl/PostgresHelper.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/dbutilsimpl/PostgresHelper.kt
@@ -35,27 +35,22 @@ class PostgresHelper : ExternalDbHelper() {
         val user = dbUser ?: getAdminUser()
         val password = dbPassword ?: getAdminPassword()
 
-        val jdbcUrlCopy = if (!schemaName.isNullOrBlank()) {
-            if (createSchema) {
-                logger.info("Creating schema: $schemaName".emphasise())
-                net.corda.db.core.createUnpooledDataSource(
-                    driverClass,
-                    jdbcUrl,
-                    user,
-                    password,
-                    maximumPoolSize = maximumPoolSize
-                ).connection.use{ conn ->
-                    conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS $schemaName;").execute()
-                    conn.commit()
-                }
+        if (!schemaName.isNullOrBlank() && createSchema) {
+            logger.info("Creating schema: $schemaName".emphasise())
+            net.corda.db.core.createUnpooledDataSource(
+                driverClass,
+                jdbcUrl,
+                user,
+                password,
+                maximumPoolSize = maximumPoolSize
+            ).connection.use { conn ->
+                conn.prepareStatement("CREATE SCHEMA IF NOT EXISTS $schemaName;").execute()
+                conn.commit()
             }
+        }
 
-            // TODO this now needs tidying up
-            if (rewriteBatchedInserts) {
-                "$jdbcUrl?reWriteBatchedInserts=true"
-            } else {
-                jdbcUrl
-            }
+        val jdbcUrlCopy = if (rewriteBatchedInserts) {
+            "$jdbcUrl?reWriteBatchedInserts=true"
         } else {
             jdbcUrl
         }

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/dbutilsimpl/PostgresHelper.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/dbutilsimpl/PostgresHelper.kt
@@ -50,7 +50,7 @@ class PostgresHelper : ExternalDbHelper() {
                 logger.info("Creating schema: $schemaName".emphasise())
                 adminDataSource.connection.use { conn ->
                     val sql = """
-                        CREATE SCHEMA IF NOT EXISTS "$schemaName";
+                        CREATE SCHEMA IF NOT EXISTS $schemaName;
                     """.trimIndent()
                     conn.prepareStatement(sql).execute()
                     conn.commit()
@@ -70,15 +70,15 @@ class PostgresHelper : ExternalDbHelper() {
                             END IF; 
                         END 
                         ${'$'}${'$'};
-                        GRANT ALL ON SCHEMA "$schemaName" TO "$dbUser";
-                        ALTER ROLE "$dbUser" SET search_path TO "$schemaName";
+                        GRANT ALL ON SCHEMA $schemaName TO "$dbUser";
+                        ALTER ROLE "$dbUser" SET search_path TO $schemaName;
                             """.trimIndent()
                     conn.prepareStatement(createUserSql).execute()
                     conn.commit()
                 }
             } else {
                 adminDataSource.connection.use { conn ->
-                    conn.prepareStatement("ALTER ROLE $adminUser SET search_path TO public, \"$schemaName\";").execute()
+                    conn.prepareStatement("ALTER ROLE $adminUser SET search_path TO public, $schemaName;").execute()
                     conn.commit()
                 }
             }

--- a/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/dbutilsimpl/PostgresHelper.kt
+++ b/testing/db-testkit/src/main/kotlin/net/corda/db/testkit/dbutilsimpl/PostgresHelper.kt
@@ -60,7 +60,16 @@ class PostgresHelper : ExternalDbHelper() {
             if (dbUser != null) {
                 adminDataSource.connection.use { conn ->
                     val createUserSql = """
-                        CREATE USER "$dbUser" WITH PASSWORD '$password';
+                        DO 
+                        ${'$'}${'$'} 
+                        BEGIN 
+                            IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$dbUser') THEN 
+                                RAISE NOTICE 'Role "$dbUser" already exists'; 
+                            ELSE 
+                                CREATE USER "$dbUser" WITH PASSWORD '$password'; 
+                            END IF; 
+                        END 
+                        ${'$'}${'$'};
                         GRANT ALL ON SCHEMA "$schemaName" TO "$dbUser";
                         ALTER ROLE "$dbUser" SET search_path TO "$schemaName";
                             """.trimIndent()

--- a/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
+++ b/testing/persistence-testkit/src/main/kotlin/net/corda/db/persistence/testkit/fake/FakeDbConnectionManager.kt
@@ -33,7 +33,12 @@ class FakeDbConnectionManager(
         private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    private data class NamedDataSources(val id: UUID, val persistenceUnitName: String, val schemaName: String, val dataSource: CloseableDataSource)
+    private data class NamedDataSources(
+        val id: UUID,
+        val persistenceUnitName: String,
+        val schemaName: String,
+        val dataSource: CloseableDataSource
+    )
 
     private val dbSources: List<NamedDataSources> = connections.map {
         val source = DbUtils.getEntityManagerConfiguration(

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/SqlFormatters.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/SqlFormatters.kt
@@ -26,7 +26,7 @@ fun Any.toInsertStatement(): String {
     }
 
     return "insert into ${formatTableName(this)} (${values.joinToString { it.first }}) " +
-            "values (${values.joinToString { it.second }})"
+            "values (${values.joinToString { it.second }});"
 }
 
 private fun formatValue(value: Any?): String? {

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginDb.kt
@@ -60,7 +60,7 @@ class TestInitialConfigPluginDb {
             "'connection name'," +
                 " 'DML'," +
                 " 'Setup Script',"
-        ).endsWith("Z', 0)\n")
+        ).endsWith("Z', 0);\n")
     }
 
     @Test
@@ -130,7 +130,7 @@ class TestInitialConfigPluginDb {
             "'connection name'," +
                     " 'DML'," +
                     " 'Setup Script',"
-        ).endsWith("Z', 0)\n")
+        ).endsWith("Z', 0);\n")
     }
 
     @Test

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForFieldAccess.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForFieldAccess.kt
@@ -101,7 +101,7 @@ class TestSqlFormattersForFieldAccess {
 
         assertEquals(
             "insert into testschema.testtable (testyMcTestFace, testNumber) " +
-                "values ('face', 42)",
+                "values ('face', 42);",
             statement
         )
     }
@@ -113,7 +113,7 @@ class TestSqlFormattersForFieldAccess {
 
         assertEquals(
             "insert into testschema.testtable (testDate, testyMcTestFace, testNumber) " +
-                "values ('1970-01-02T10:17:36Z', 'face', 42)",
+                "values ('1970-01-02T10:17:36Z', 'face', 42);",
             statement
         )
     }
@@ -125,7 +125,7 @@ class TestSqlFormattersForFieldAccess {
 
         assertEquals(
             "insert into testschema.testtable (crossRef, testyMcTestFace, testNumber) " +
-                "values ('ref#1', 'face', 42)",
+                "values ('ref#1', 'face', 42);",
             statement
         )
     }
@@ -137,7 +137,7 @@ class TestSqlFormattersForFieldAccess {
 
         assertEquals(
             "insert into testschema.testtable (testyMcTestFace, version) " +
-                "values ('face', 0)",
+                "values ('face', 0);",
             statement
         )
     }
@@ -149,7 +149,7 @@ class TestSqlFormattersForFieldAccess {
 
         assertEquals(
             "insert into testschema.testtable (testyMcTestFace, testNumber) " +
-                "values ('Robert\\'); DROP TABLE Students;--', 34)",
+                "values ('Robert\\'); DROP TABLE Students;--', 34);",
             statement
         )
     }
@@ -171,21 +171,21 @@ class TestSqlFormattersForFieldAccess {
     fun testToInsertStatementNoSchema() {
         val ent = NoSchemaEntity("test")
         val statement = ent.toInsertStatement()
-        assertEquals("insert into NoSchemaTable (testface) values ('test')", statement)
+        assertEquals("insert into NoSchemaTable (testface) values ('test');", statement)
     }
 
     @Test
     fun testMissingTableName() {
         val ent = NoNameEntity("test")
         val statement = ent.toInsertStatement()
-        assertEquals("insert into NoNameEntity (testface) values ('test')", statement)
+        assertEquals("insert into NoNameEntity (testface) values ('test');", statement)
     }
 
     @Test
     fun testMissingColumnName() {
         val ent = UnnamedColumnEntity("test")
         val statement = ent.toInsertStatement()
-        assertEquals("insert into UnnamedColumn (testFace) values ('test')", statement)
+        assertEquals("insert into UnnamedColumn (testFace) values ('test');", statement)
     }
 
     @Test

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForPropertyAccess.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestSqlFormattersForPropertyAccess.kt
@@ -101,7 +101,7 @@ class TestSqlFormattersForPropertyAccess {
 
         assertEquals(
             "insert into testSchema.testTable (testyMcTestFace, testNumber) " +
-                "values ('face', 42)",
+                "values ('face', 42);",
             statement
         )
     }
@@ -113,7 +113,7 @@ class TestSqlFormattersForPropertyAccess {
 
         assertEquals(
             "insert into testSchema.testTable (testDate, testyMcTestFace, testNumber) " +
-                "values ('1970-01-02T10:17:36Z', 'face', 42)",
+                "values ('1970-01-02T10:17:36Z', 'face', 42);",
             statement
         )
     }
@@ -125,7 +125,7 @@ class TestSqlFormattersForPropertyAccess {
 
         assertEquals(
             "insert into testSchema.testTable (crossRef, testyMcTestFace, testNumber) " +
-                "values ('ref#1', 'face', 42)",
+                "values ('ref#1', 'face', 42);",
             statement
         )
     }
@@ -137,7 +137,7 @@ class TestSqlFormattersForPropertyAccess {
 
         assertEquals(
             "insert into testSchema.testTable (testyMcTestFace, version) " +
-                "values ('face', 0)",
+                "values ('face', 0);",
             statement
         )
     }
@@ -149,7 +149,7 @@ class TestSqlFormattersForPropertyAccess {
 
         assertEquals(
             "insert into testSchema.testTable (testyMcTestFace, testNumber) " +
-                "values ('Robert\\'); DROP TABLE Students;--', 34)",
+                "values ('Robert\\'); DROP TABLE Students;--', 34);",
             statement
         )
     }
@@ -171,21 +171,21 @@ class TestSqlFormattersForPropertyAccess {
     fun testToInsertStatementNoSchema() {
         val ent = NoSchemaEntity("test")
         val statement = ent.toInsertStatement()
-        assertEquals("insert into NoSchemaTable (testface) values ('test')", statement)
+        assertEquals("insert into NoSchemaTable (testface) values ('test');", statement)
     }
 
     @Test
     fun testMissingTableName() {
         val ent = NoNameEntity("test")
         val statement = ent.toInsertStatement()
-        assertEquals("insert into NoNameEntity (testface) values ('test')", statement)
+        assertEquals("insert into NoNameEntity (testface) values ('test');", statement)
     }
 
     @Test
     fun testMissingColumnName() {
         val ent = UnnamedColumnEntity("test")
         val statement = ent.toInsertStatement()
-        assertEquals("insert into UnnamedColumn (testFace) values ('test')", statement)
+        assertEquals("insert into UnnamedColumn (testFace) values ('test');", statement)
     }
 
     @Test


### PR DESCRIPTION
## Issue:

To integrate PGBouncer with Corda we need to strip our DB URLs from `search_path`. PGBouncer doesn’t work with it. When we do this, then queries start failing with errors like for example ERROR:  relation "db_connection" does not exist, meaning the DB user can no longer see tables under schemas because we no longer include the schemas in the request's context. The closest thing to do (to where we are now) after having stripped the `search_path` from the db URLs is, on creating the DML DB users make them schema-context aware (on creation time). For example: `ALTER ROLE user SET search_path TO config;`. Now `user` will be aware of schema `config`. For DDL users we have to temporarily set the schema they need to see, to make sure DDL operations take place in the right schema.


## Changes:

- removes `search_path` from DB URLs
- persists `search_path` to DML DB users to always have it, so they can see the schemas throughout the DB interactions
- temporarily sets the `search_path` to DDL DB users to only have it per DDL session