### PR TITLE
CORE-18698: move filtered transaction implementation to ledger libs

### DIFF
--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/serializer/amqp/FilteredTransactionSerializer.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/serializer/amqp/FilteredTransactionSerializer.kt
@@ -3,7 +3,7 @@ package net.corda.ledger.common.flow.impl.transaction.filtered.serializer.amqp
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.ledger.common.data.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
-import net.corda.ledger.common.flow.impl.transaction.filtered.FilteredTransactionImpl
+import net.corda.ledger.common.data.transaction.filtered.impl.FilteredTransactionImpl
 import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandbox.type.UsedByVerification

--- a/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImplTest.kt
+++ b/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/filtered/factory/FilteredTransactionFactoryImplTest.kt
@@ -8,9 +8,10 @@ import net.corda.common.json.validation.impl.JsonValidatorImpl
 import net.corda.crypto.merkle.impl.MerkleTreeProviderImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
+import net.corda.ledger.common.data.transaction.filtered.factory.impl.FilteredTransactionFactoryImpl
 import net.corda.ledger.common.testkit.getWireTransactionExample
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.CordaSerializable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderImpl.kt
@@ -1,7 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.transaction.filtered
 
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.filtered.factory.UtxoFilteredTransactionFactory

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderInternal.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderInternal.kt
@@ -1,6 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.transaction.filtered
 
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
 import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionBuilder
 
 /**

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactoryImpl.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.utxo.flow.impl.transaction.filtered.factory
 
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
-import net.corda.ledger.common.flow.transaction.filtered.factory.FilteredTransactionFactory
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
+import net.corda.ledger.common.data.transaction.filtered.factory.FilteredTransactionFactory
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup.METADATA
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup.NOTARY

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionBuilderImplTest.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.utxo.flow.impl.transaction.filtered
 
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.SizeProof
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.SizeProof
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.ContractState

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionImplTest.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.utxo.flow.impl.transaction.filtered
 
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionTestBase.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/UtxoFilteredTransactionTestBase.kt
@@ -10,10 +10,10 @@ import net.corda.crypto.core.parseSecureHash
 import net.corda.crypto.merkle.impl.MerkleTreeProviderImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
-import net.corda.ledger.common.flow.impl.transaction.filtered.factory.FilteredTransactionFactoryImpl
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
+import net.corda.ledger.common.data.transaction.filtered.factory.impl.FilteredTransactionFactoryImpl
 import net.corda.ledger.common.testkit.getWireTransactionExample
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactoryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactoryImplTest.kt
@@ -1,7 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.transaction.filtered.factory
 
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
-import net.corda.ledger.common.flow.transaction.filtered.factory.FilteredTransactionFactory
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.factory.FilteredTransactionFactory
 import net.corda.ledger.common.testkit.publicKeyExample
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.flow.impl.timewindow.TimeWindowBetweenImpl

--- a/libs/ledger/ledger-common-data/src/integrationTest/kotlin/net/corda/ledger/common/data/transaction/filtered/impl/FilteredTransactionImplIntegrationTest.kt
+++ b/libs/ledger/ledger-common-data/src/integrationTest/kotlin/net/corda/ledger/common/data/transaction/filtered/impl/FilteredTransactionImplIntegrationTest.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.common.flow.impl.transaction.filtered
+package net.corda.ledger.common.data.transaction.filtered.impl
 
 import net.corda.application.impl.services.json.JsonMarshallingServiceImpl
 import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
@@ -8,10 +8,10 @@ import net.corda.common.json.validation.impl.JsonValidatorImpl
 import net.corda.crypto.merkle.impl.MerkleTreeProviderImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
-import net.corda.ledger.common.flow.impl.transaction.filtered.factory.FilteredTransactionFactoryImpl
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
+import net.corda.ledger.common.data.transaction.filtered.factory.impl.FilteredTransactionFactoryImpl
 import net.corda.ledger.common.testkit.getWireTransactionExample
 import net.corda.v5.application.serialization.SerializationService
 import net.corda.v5.base.annotations.CordaSerializable

--- a/libs/ledger/ledger-common-data/src/main/java/net/corda/ledger/common/data/transaction/filtered/FilteredTransactionVerificationException.kt
+++ b/libs/ledger/ledger-common-data/src/main/java/net/corda/ledger/common/data/transaction/filtered/FilteredTransactionVerificationException.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.common.flow.transaction.filtered
+package net.corda.ledger.common.data.transaction.filtered
 
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash

--- a/libs/ledger/ledger-common-data/src/main/java/net/corda/ledger/common/data/transaction/filtered/factory/package-info.java
+++ b/libs/ledger/ledger-common-data/src/main/java/net/corda/ledger/common/data/transaction/filtered/factory/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.ledger.common.data.transaction.filtered.factory;
+
+import org.osgi.annotation.bundle.Export;

--- a/libs/ledger/ledger-common-data/src/main/java/net/corda/ledger/common/data/transaction/filtered/impl/package-info.java
+++ b/libs/ledger/ledger-common-data/src/main/java/net/corda/ledger/common/data/transaction/filtered/impl/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.ledger.common.data.transaction.filtered.impl;
+
+import org.osgi.annotation.bundle.Export;

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/ComponentGroupFilterParameters.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/ComponentGroupFilterParameters.kt
@@ -1,6 +1,5 @@
-package net.corda.ledger.common.flow.transaction.filtered.factory
+package net.corda.ledger.common.data.transaction.filtered
 
-import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.v5.crypto.merkle.MerkleProof
 import net.corda.v5.crypto.merkle.MerkleProofType
 import java.util.function.Predicate

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/factory/FilteredTransactionFactory.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/factory/FilteredTransactionFactory.kt
@@ -1,6 +1,7 @@
-package net.corda.ledger.common.flow.transaction.filtered.factory
+package net.corda.ledger.common.data.transaction.filtered.factory
 
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.v5.base.annotations.Suspendable
 import java.util.function.Predicate

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/factory/impl/FilteredTransactionFactoryImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/factory/impl/FilteredTransactionFactoryImpl.kt
@@ -1,13 +1,13 @@
-package net.corda.ledger.common.flow.impl.transaction.filtered.factory
+package net.corda.ledger.common.data.transaction.filtered.factory.impl
 
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof
 import net.corda.ledger.common.data.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
-import net.corda.ledger.common.flow.impl.transaction.filtered.FilteredTransactionImpl
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters
-import net.corda.ledger.common.flow.transaction.filtered.factory.ComponentGroupFilterParameters.AuditProof
-import net.corda.ledger.common.flow.transaction.filtered.factory.FilteredTransactionFactory
+import net.corda.ledger.common.data.transaction.filtered.factory.FilteredTransactionFactory
+import net.corda.ledger.common.data.transaction.filtered.impl.FilteredTransactionImpl
 import net.corda.sandbox.type.SandboxConstants.CORDA_SYSTEM_SERVICE
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.marshalling.JsonMarshallingService

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/impl/FilteredTransactionImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/impl/FilteredTransactionImpl.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.common.flow.impl.transaction.filtered
+package net.corda.ledger.common.data.transaction.filtered.impl
 
 import net.corda.crypto.cipher.suite.merkle.MerkleTreeProvider
 import net.corda.crypto.core.SecureHashImpl
@@ -10,20 +10,16 @@ import net.corda.ledger.common.data.transaction.ROOT_MERKLE_TREE_DIGEST_PROVIDER
 import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
-import net.corda.ledger.common.flow.transaction.filtered.FilteredTransactionVerificationException
+import net.corda.ledger.common.data.transaction.filtered.FilteredTransactionVerificationException
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.extensions.merkle.MerkleTreeHashDigestProvider
-import net.corda.v5.crypto.merkle.HashDigestConstants.HASH_DIGEST_PROVIDER_LEAF_PREFIX_OPTION
-import net.corda.v5.crypto.merkle.HashDigestConstants.HASH_DIGEST_PROVIDER_NODE_PREFIX_OPTION
-import net.corda.v5.crypto.merkle.HashDigestConstants.HASH_DIGEST_PROVIDER_NONCE_SIZE_ONLY_VERIFY_NAME
-import net.corda.v5.crypto.merkle.HashDigestConstants.HASH_DIGEST_PROVIDER_NONCE_VERIFY_NAME
+import net.corda.v5.crypto.merkle.HashDigestConstants
 import net.corda.v5.crypto.merkle.MerkleProof
 import net.corda.v5.crypto.merkle.MerkleProofType
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
-import java.util.Base64
-import java.util.Objects
+import java.util.*
 
 class FilteredTransactionImpl(
     override val id: SecureHash,
@@ -97,9 +93,13 @@ class FilteredTransactionImpl(
     }
 
     override val metadata: TransactionMetadata by lazy {
-        val proof = checkNotNull(filteredComponentGroups[0]?.merkleProof) { "Component group 0's Merkle proof does not exist" }
+        val proof =
+            checkNotNull(filteredComponentGroups[0]?.merkleProof) { "Component group 0's Merkle proof does not exist" }
         check(proof.leaves.size == 1) { "Component group 0's Merkle proof must have a single leaf but contains ${proof.leaves.size}" }
-        jsonMarshallingService.parse(proof.leaves.single().leafData.decodeToString(), TransactionMetadataImpl::class.java)
+        jsonMarshallingService.parse(
+            proof.leaves.single().leafData.decodeToString(),
+            TransactionMetadataImpl::class.java
+        )
     }
 
     override fun getComponentGroupContent(componentGroupIndex: Int): List<Pair<Int, ByteArray>>? {
@@ -112,9 +112,9 @@ class FilteredTransactionImpl(
             merkleTreeHashDigestProviderName = digestSettings[ROOT_MERKLE_TREE_DIGEST_PROVIDER_NAME_KEY] as String,
             DigestAlgorithmName(digestSettings[ROOT_MERKLE_TREE_DIGEST_ALGORITHM_NAME_KEY] as String),
             options = mapOf(
-                HASH_DIGEST_PROVIDER_LEAF_PREFIX_OPTION to Base64.getDecoder()
+                HashDigestConstants.HASH_DIGEST_PROVIDER_LEAF_PREFIX_OPTION to Base64.getDecoder()
                     .decode(digestSettings[ROOT_MERKLE_TREE_DIGEST_OPTIONS_LEAF_PREFIX_B64_KEY] as String),
-                HASH_DIGEST_PROVIDER_NODE_PREFIX_OPTION to Base64.getDecoder()
+                HashDigestConstants.HASH_DIGEST_PROVIDER_NODE_PREFIX_OPTION to Base64.getDecoder()
                     .decode(digestSettings[ROOT_MERKLE_TREE_DIGEST_OPTIONS_NODE_PREFIX_B64_KEY] as String)
             )
         )
@@ -124,7 +124,7 @@ class FilteredTransactionImpl(
         componentGroupDigestAlgorithmName: DigestAlgorithmName
     ): MerkleTreeHashDigestProvider {
         return merkleTreeProvider.createHashDigestProvider(
-            merkleTreeHashDigestProviderName = HASH_DIGEST_PROVIDER_NONCE_VERIFY_NAME,
+            merkleTreeHashDigestProviderName = HashDigestConstants.HASH_DIGEST_PROVIDER_NONCE_VERIFY_NAME,
             componentGroupDigestAlgorithmName
         )
     }
@@ -133,7 +133,7 @@ class FilteredTransactionImpl(
         componentGroupDigestAlgorithmName: DigestAlgorithmName
     ): MerkleTreeHashDigestProvider {
         return merkleTreeProvider.createHashDigestProvider(
-            merkleTreeHashDigestProviderName = HASH_DIGEST_PROVIDER_NONCE_SIZE_ONLY_VERIFY_NAME,
+            merkleTreeHashDigestProviderName = HashDigestConstants.HASH_DIGEST_PROVIDER_NONCE_SIZE_ONLY_VERIFY_NAME,
             componentGroupDigestAlgorithmName
         )
     }

--- a/libs/ledger/ledger-common-data/src/test/kotlin/net/corda/ledger/common/data/transaction/filtered/impl/FilteredTransactionImplTest.kt
+++ b/libs/ledger/ledger-common-data/src/test/kotlin/net/corda/ledger/common/data/transaction/filtered/impl/FilteredTransactionImplTest.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.common.flow.impl.transaction.filtered
+package net.corda.ledger.common.data.transaction.filtered.impl
 
 import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.cipher.suite.impl.DigestServiceImpl
@@ -11,7 +11,7 @@ import net.corda.ledger.common.data.transaction.TransactionMetadataImpl
 import net.corda.ledger.common.data.transaction.WireTransactionDigestSettings
 import net.corda.ledger.common.data.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
-import net.corda.ledger.common.flow.transaction.filtered.FilteredTransactionVerificationException
+import net.corda.ledger.common.data.transaction.filtered.FilteredTransactionVerificationException
 import net.corda.v5.application.marshalling.JsonMarshallingService
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -3,7 +3,7 @@ package net.corda.ledger.utxo.test
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
-import net.corda.ledger.common.flow.impl.transaction.filtered.factory.FilteredTransactionFactoryImpl
+import net.corda.ledger.common.data.transaction.filtered.factory.impl.FilteredTransactionFactoryImpl
 import net.corda.ledger.common.test.CommonLedgerTest
 import net.corda.ledger.common.testkit.anotherPublicKeyExample
 import net.corda.ledger.common.testkit.publicKeyExample


### PR DESCRIPTION
Refactoring broken out from https://github.com/corda/corda-runtime-os/pull/5485.