### PR TITLE
ES-1827: Corda Runtime Gradle Plugin start stop corda tasks

### DIFF
--- a/tools/corda-runtime-gradle-plugin/README.md
+++ b/tools/corda-runtime-gradle-plugin/README.md
@@ -7,8 +7,8 @@ Add the following extension properties
 
 ```groovy
     cordaRuntimeGradlePlugin {
-        combinedWorkerVersion = "5.1.0.0"
-        postgresJdbcVersion = "42.4.3"
+        combinedWorkerVersion = "5.2.0.0"
+        postgresJdbcVersion = "42.6.0"
         // Only need to supply these if you want to use an unpublished version
         artifactoryUsername = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
         artifactoryPassword = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')

--- a/tools/corda-runtime-gradle-plugin/README.md
+++ b/tools/corda-runtime-gradle-plugin/README.md
@@ -1,4 +1,16 @@
 # Corda-Runtime-Gradle-Plugin
 
 A Gradle plugin that wraps a subset of the SDK functions to facilitate their use in developer and CI scenarios.  
-This supercedes the CSDE Gradle plugin.
+This supersedes the CSDE Gradle plugin.
+
+Add the following extension properties
+
+```groovy
+    cordaRuntimeGradlePlugin {
+        combinedWorkerVersion = "5.1.0.0"
+        postgresJdbcVersion = "42.4.3"
+        // Only need to supply these if you want to use an unpublished version
+        artifactoryUsername = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+        artifactoryPassword = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+    }
+```

--- a/tools/corda-runtime-gradle-plugin/build.gradle
+++ b/tools/corda-runtime-gradle-plugin/build.gradle
@@ -17,10 +17,13 @@ repositories {
 }
 
 dependencies {
+    api libs.junit.api
+    testImplementation libs.bundles.test
 }
 
-test {
-    useJUnitPlatform()
+integrationTest {
+    systemProperty 'cordaArtifactoryUsername', findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+    systemProperty 'cordaArtifactoryPassword', findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
 }
 
 gradlePlugin {

--- a/tools/corda-runtime-gradle-plugin/src/integrationTest/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupHelperTests.kt
+++ b/tools/corda-runtime-gradle-plugin/src/integrationTest/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupHelperTests.kt
@@ -1,0 +1,123 @@
+package net.corda.gradle.plugin.cordalifecycle
+
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.test.assertTrue
+
+class EnvironmentSetupHelperTests {
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun downloadCombinedWorkerFromGitHub() {
+        val version = "5.1.0.0"
+        val fileName = "corda-combined-worker-$version.jar"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadCombinedWorker(
+            fileName,
+            version,
+            "release-$version",
+            targetFile.path,
+            "",
+            ""
+        )
+        assertTrue(targetFile.exists(), "The combined worker file should have been downloaded from GitHub")
+    }
+
+    @Test
+    fun downloadCombinedWorkerHC() {
+        val username = System.getProperty("cordaArtifactoryUsername")
+        val password = System.getProperty("cordaArtifactoryPassword")
+        val version = "5.1.0.0-HC15"
+        val fileName = "corda-combined-worker-$version.jar"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadCombinedWorker(
+            fileName,
+            version,
+            "release-$version",
+            targetFile.path,
+            username,
+            password
+        )
+        assertTrue(targetFile.exists(), "The HC combined worker file should have been downloaded from Artifactory")
+    }
+
+    @Test
+    fun downloadCombinedWorkerRC() {
+        val username = System.getProperty("cordaArtifactoryUsername")
+        val password = System.getProperty("cordaArtifactoryPassword")
+        val version = "5.1.0.0-RC03"
+        val fileName = "corda-combined-worker-$version.jar"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadCombinedWorker(
+            fileName,
+            version,
+            "release-$version",
+            targetFile.path,
+            username,
+            password
+        )
+        assertTrue(targetFile.exists(), "The RC combined worker file should have been downloaded from Artifactory")
+    }
+
+    @Test
+    fun downloadCombinedWorkerAlpha() {
+        val username = System.getProperty("cordaArtifactoryUsername")
+        val password = System.getProperty("cordaArtifactoryPassword")
+        val version = "5.2.0.0-alpha-1706270718014"
+        val fileName = "corda-combined-worker-$version.jar"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadCombinedWorker(
+            fileName,
+            version,
+            "release-$version",
+            targetFile.path,
+            username,
+            password
+        )
+        assertTrue(targetFile.exists(), "The alpha combined worker file should have been downloaded from Artifactory")
+    }
+
+    @Test
+    fun downloadCombinedWorkerBeta() {
+        val username = System.getProperty("cordaArtifactoryUsername")
+        val password = System.getProperty("cordaArtifactoryPassword")
+        val version = "5.2.0.0-beta-1706271586528"
+        val fileName = "corda-combined-worker-$version.jar"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadCombinedWorker(
+            fileName,
+            version,
+            "release-$version",
+            targetFile.path,
+            username,
+            password
+        )
+        assertTrue(targetFile.exists(), "The beta combined worker file should have been downloaded from Artifactory")
+    }
+
+    @Test
+    fun unableToDownloadUnpublishedCombinedWorkerWithoutCredentials() {
+        val version = "5.2.0.0-beta-1706271586528"
+        val fileName = "corda-combined-worker-$version.jar"
+        val targetFile = File("$tempDir/$fileName")
+        val exception = assertThrows<CordaRuntimeGradlePluginException> {
+            EnvironmentSetupHelper().downloadCombinedWorker(
+                fileName,
+                version,
+                "release-$version",
+                targetFile.path,
+                "",
+                ""
+            )
+        }
+        assertTrue(
+            exception.message!!.contains("require a username and password"),
+            "We should not be able to download an unpublished version without credentials"
+        )
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/CordaRuntimeGradlePlugin.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/CordaRuntimeGradlePlugin.kt
@@ -1,10 +1,17 @@
 package net.corda.gradle.plugin
 
+import net.corda.gradle.plugin.configuration.PluginConfiguration
+import net.corda.gradle.plugin.cordalifecycle.createCordaLifeCycleTasks
+import net.corda.gradle.plugin.cordalifecycle.createPluginEnvSetupTasks
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-class CordaRuntimeGradlePlugin: Plugin<Project> {
-    override fun apply(target: Project) {
-        TODO("Not yet implemented")
-    }
 
+const val CONFIG_BLOCK_NAME = "cordaRuntimeGradlePlugin"
+
+class CordaRuntimeGradlePlugin: Plugin<Project> {
+    override fun apply(project: Project) {
+        val projectConfig = project.extensions.create(CONFIG_BLOCK_NAME, PluginConfiguration::class.java)
+        createPluginEnvSetupTasks(project, projectConfig)
+        createCordaLifeCycleTasks(project, projectConfig)
+    }
 }

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/ProjectUtils.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/ProjectUtils.kt
@@ -1,0 +1,61 @@
+package net.corda.gradle.plugin
+
+import java.net.ConnectException
+import java.net.Socket
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Sleeps the thread for the specified time period.
+ * @param millis number of milliseconds to sleep the thread for.
+ */
+fun rpcWait(millis: Long = 1000) {
+    try {
+        Thread.sleep(millis)
+    } catch (e: InterruptedException) {
+        throw UnsupportedOperationException("Interrupts not supported.", e)
+    }
+}
+
+/**
+ * Checks if the given port is in use.
+ * @return true if the port is in use, false otherwise.
+ */
+fun isPortInUse(host: String, port: Int): Boolean {
+    return try {
+        Socket(host, port)
+        true
+    } catch (_: ConnectException) {
+        false
+    }
+}
+
+/**
+ * Automatically retries the [block] until the operation is successful or [timeout] is reached.
+ * @param timeout time to wait for the operation to complete. Default value is 10 seconds.
+ * @param cooldown time to wait between retries. Default value is 1 second.
+ * @param block the block of code to execute
+ * @throws CsdeException if the operation fails after all retries
+ */
+fun <R> retry(
+    timeout: Duration = Duration.ofMillis(10000),
+    cooldown: Duration = Duration.ofMillis(1000),
+    block: () -> R
+): R {
+
+    var firstException: Exception? = null
+    val start = Instant.now()
+    var elapsed = Duration.between(start, Instant.now())
+
+    while (elapsed < timeout) {
+        try {
+            return block()
+        } catch (e: Exception) {
+            if (firstException == null) {
+                firstException = e
+            }
+            rpcWait(cooldown.toMillis())
+            elapsed = Duration.between(start, Instant.now())
+        }
+    }; throw firstException!!
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/PluginConfiguration.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/PluginConfiguration.kt
@@ -24,7 +24,7 @@ open class PluginConfiguration @Inject constructor(objects: ObjectFactory) {
     val combinedWorkerVersion: Property<String> = objects.property(String::class.java).convention("5.0.1.0")
 
     @get:Input
-    val postgresJdbcVersion: Property<String> = objects.property(String::class.java).convention("42.4.3")
+    val postgresJdbcVersion: Property<String> = objects.property(String::class.java).convention("42.6.0")
 
     @get:Input
     var cordaDbContainerName: Property<String> = objects.property(String::class.java).convention("cordaPostgres")

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/PluginConfiguration.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/PluginConfiguration.kt
@@ -1,3 +1,46 @@
 package net.corda.gradle.plugin.configuration
 
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import javax.inject.Inject
+
 // Gradle extension config in here
+open class PluginConfiguration @Inject constructor(objects: ObjectFactory) {
+
+    @get:Input
+    val cordaClusterURL: Property<String> = objects.property(String::class.java).convention("https://localhost:8888")
+
+    @get:Input
+    val cordaRpcUser: Property<String> = objects.property(String::class.java).convention("admin")
+
+    @get:Input
+    val cordaRpcPasswd: Property<String> = objects.property(String::class.java).convention("admin")
+
+    @get:Input
+    val cordaRuntimePluginWorkspaceDir: Property<String> = objects.property(String::class.java).convention("workspace")
+
+    @get:Input
+    val combinedWorkerVersion: Property<String> = objects.property(String::class.java).convention("5.0.1.0")
+
+    @get:Input
+    val postgresJdbcVersion: Property<String> = objects.property(String::class.java).convention("42.4.3")
+
+    @get:Input
+    var cordaDbContainerName: Property<String> = objects.property(String::class.java).convention("cordaPostgres")
+
+    @get:Input
+    val cordaBinDir: Property<String> = objects.property(String::class.java)
+        .convention(System.getenv("CORDA_BIN") ?: "${System.getProperty("user.home")}/.corda/corda5")
+
+    @get:Input
+    val cordaCliBinDir: Property<String> = objects.property(String::class.java)
+        .convention(System.getenv("CORDA_CLI") ?: "${System.getProperty("user.home")}/.corda/cli")
+
+    @get:Input
+    val artifactoryUsername: Property<String> = objects.property(String::class.java).convention("")
+
+    @get:Input
+    val artifactoryPassword: Property<String> = objects.property(String::class.java).convention("")
+
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/ProjectContext.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/ProjectContext.kt
@@ -1,0 +1,41 @@
+package net.corda.gradle.plugin.configuration
+
+import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+
+/**
+ * Class which holds all the context properties for the gradle build. This is split between:
+ * - Properties which are obtained from the csde block in the csde build.gralde file
+ * - The network config
+ * - Properties which are non-configurable by the user
+ * A version of this class will typically be passed to each of the helper classes.
+ */
+class ProjectContext(val project: Project, pluginConfig: PluginConfiguration) {
+
+    // Capture values of user configurable context properties items from pluginConfig
+    val cordaClusterURL: String = pluginConfig.cordaClusterURL.get()
+    val cordaRpcUser: String = pluginConfig.cordaRpcUser.get()
+    val cordaRpcPassword: String = pluginConfig.cordaRpcPasswd.get()
+    val workspaceDir: String = pluginConfig.cordaRuntimePluginWorkspaceDir.get()
+    val combinedWorkerVersion: String = pluginConfig.combinedWorkerVersion.get()
+    val postgresJdbcVersion: String = pluginConfig.postgresJdbcVersion.get()
+    val cordaDbContainerName: String =pluginConfig.cordaDbContainerName.get()
+    val cordaBinDir: String = pluginConfig.cordaBinDir.get()
+    val cordaCliBinDir: String = pluginConfig.cordaCliBinDir.get()
+    val artifactoryUsername: String = pluginConfig.artifactoryUsername.get()
+    val artifactoryPassword: String = pluginConfig.artifactoryPassword.get()
+
+    // Set Non user configurable context properties
+    val javaBinDir: String = "${System.getProperty("java.home")}/bin"
+    val cordaPidCache: String = "$workspaceDir/CordaPIDCache.dat"
+    val jdbcDir: String = "$cordaBinDir/jdbcDrivers"
+
+    val cordaClusterHost: String = cordaClusterURL.split("://").last().split(":").first()
+    val cordaClusterPort: Int = cordaClusterURL.split("://").last().split(":").last().toInt()
+
+    val combinedWorkerFileName: String = "corda-combined-worker-$combinedWorkerVersion.jar"
+    val combinedWorkerFilePath: String = "$cordaBinDir/combinedWorker/$combinedWorkerFileName"
+    val cordaReleaseBranchName: String = "release-$combinedWorkerVersion"
+
+    val logger: Logger = project.logger
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleHelper.kt
@@ -25,7 +25,7 @@ class CordaLifecycleHelper {
             "POSTGRES_USER=postgres",
             "-e",
             "POSTGRES_PASSWORD=password",
-            "postgres:latest"
+            "postgres:14.10"
         )
 
         val dockerProcessBuilder = ProcessBuilder(dockerCmdList)

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleHelper.kt
@@ -1,0 +1,146 @@
+package net.corda.gradle.plugin.cordalifecycle
+
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import net.corda.gradle.plugin.retry
+import java.io.File
+import java.io.FileOutputStream
+import java.io.PrintStream
+import java.util.*
+
+class CordaLifecycleHelper {
+
+    fun startPostgresContainer(containerName: String) : Process {
+        val dockerCmdList = listOf(
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-p",
+            "5432:5432",
+            "--name",
+            containerName,
+            "-e",
+            "POSTGRES_DB=cordacluster",
+            "-e",
+            "POSTGRES_USER=postgres",
+            "-e",
+            "POSTGRES_PASSWORD=password",
+            "postgres:latest"
+        )
+
+        val dockerProcessBuilder = ProcessBuilder(dockerCmdList)
+        val dockerProcess = dockerProcessBuilder.start()
+        dockerProcess.waitFor()
+        return dockerProcess
+    }
+
+    fun waitForContainerStatus(containerName: String) {
+        val dockerStatusCmd = listOf(
+            "docker",
+            "ps",
+            "-f",
+            "name=$containerName",
+            "--format",
+            "{{.State}}"
+        )
+        val dockerProcess = ProcessBuilder(dockerStatusCmd).start()
+        dockerProcess.waitFor()
+
+        var containerStatus: String
+        retry {
+            containerStatus = dockerProcess.inputStream.bufferedReader().use { it.readText() }
+            isContainerRunning(containerName, containerStatus)
+        }
+    }
+
+    private fun isContainerRunning(containerName: String, containerStatus: String) {
+        if (!containerStatus.contains("running")) {
+            throw CordaRuntimeGradlePluginException("Expected $containerName to be `running` but was `$containerStatus`")
+        }
+    }
+
+    fun stopDockerContainer(containerName: String) {
+        ProcessBuilder("docker", "stop", containerName).start()
+    }
+
+    fun startCombinedWorkerProcess(
+        pidFilePath: String,
+        combinedWorkerJarFilePath: String,
+        javaBinDir: String,
+        jdbcDir: String,
+        projectRootDir: String
+    ) : Process {
+        val pidStore = PrintStream(FileOutputStream(File(pidFilePath)))
+        val cordaCmdList = listOf(
+            "$javaBinDir/java",
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005",
+            "-Dlog4j.configurationFile=$projectRootDir/config/log4j2.xml",
+            "-Dco.paralleluniverse.fibers.verifyInstrumentation=true",
+            "-jar",
+            combinedWorkerJarFilePath,
+            "--instance-id=0",
+            "-mbus.busType=DATABASE",
+            "-spassphrase=password",
+            "-ssalt=salt",
+            "-ddatabase.user=user",
+            "-ddatabase.pass=password",
+            "-ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster",
+            "-ddatabase.jdbc.directory=$jdbcDir"
+        )
+
+        val cordaProcessBuilder = ProcessBuilder(cordaCmdList)
+        cordaProcessBuilder.redirectErrorStream(true)
+        val cordaProcess = cordaProcessBuilder.start()
+        pidStore.print(cordaProcess.pid())
+        cordaProcess.inputStream.transferTo(System.out)
+        return cordaProcess
+    }
+
+    fun stopCombinedWorkerProcess(pidFilePath: String) {
+        val cordaPIDFile = File(pidFilePath)
+        val sc = Scanner(cordaPIDFile)
+        val pid = sc.nextLong()
+        sc.close()
+        if (System.getProperty("os.name").lowercase(Locale.getDefault()).contains("windows")) {
+            val parentProcessId: Long? = getAnyParentProcessId(pid)
+            killWindowsProcess(pid) // Kill child first
+            parentProcessId?.let {
+                killWindowsProcess(it)
+            }
+        } else {
+            ProcessBuilder("kill", "-9", "$pid").start()
+        }
+
+        val fileDeleted = cordaPIDFile.delete()
+        if (!fileDeleted) {
+            throw CordaRuntimeGradlePluginException(
+                "Failed to delete ${cordaPIDFile.absolutePath}, please remove before starting Corda again."
+            )
+        }
+    }
+
+    private fun getAnyParentProcessId(pid: Long): Long? {
+        val findParentProcess = ProcessBuilder(
+            "Powershell",
+            "-Command",
+            "(gwmi win32_process | ? processid -eq  $pid).parentprocessid"
+        ).start()
+        val parentOutput = findParentProcess.inputStream.bufferedReader().use { it.readText() }.trim()
+        return if (parentOutput.isBlank()) {
+            null
+        } else {
+            parentOutput.toLong()
+        }
+    }
+
+    private fun killWindowsProcess(pid: Long) {
+        ProcessBuilder(
+            "Powershell",
+            "-Command",
+            "Stop-Process",
+            "-Id",
+            "$pid",
+            "-PassThru"
+        ).start().waitFor()
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleTaskImpl.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleTaskImpl.kt
@@ -1,0 +1,82 @@
+package net.corda.gradle.plugin.cordalifecycle
+
+import net.corda.gradle.plugin.configuration.ProjectContext
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import net.corda.gradle.plugin.isPortInUse
+import java.io.File
+
+/**
+ * Manages Starting and stopping the local Corda Combined Worker.
+ */
+class CordaLifecycleTaskImpl(var pc: ProjectContext) {
+
+    private val cordaLifecycleHelper = CordaLifecycleHelper()
+
+    fun startCorda() {
+        var exceptionMessage: String? = null
+        val cordaPIDFile = File(pc.cordaPidCache)
+        if (cordaPIDFile.exists()) {
+            exceptionMessage = "Cannot start the Combined worker. Cached process ID file $cordaPIDFile existing. " +
+                    "Was the combined worker already started?"
+        } else if (isPortInUse(pc.cordaClusterHost, pc.cordaClusterPort)) {
+            exceptionMessage = "Port ${pc.cordaClusterPort} is unavailable and is required to start the Combined Worker. " +
+                    "Free the port before starting again."
+        }
+        exceptionMessage?.let {
+            throw CordaRuntimeGradlePluginException(it)
+        }
+
+        pc.logger.quiet("Starting Docker postgres container.")
+        val dockerProcess = cordaLifecycleHelper.startPostgresContainer(pc.cordaDbContainerName)
+        val dockerCmdError = dockerProcess.errorStream.bufferedReader().use { it.readText() }
+        pc.logger.quiet(dockerCmdError)
+
+        // Fail if Docker is not running before going on to start Corda
+        val dockerNotRunningError = "the docker daemon"
+
+        if (dockerCmdError.contains(dockerNotRunningError)) {
+            throw CordaRuntimeGradlePluginException(dockerCmdError)
+        }
+
+        // Wait for the container to be running before starting Corda
+        pc.logger.quiet("Waiting for the Db Docker container to be running")
+        cordaLifecycleHelper.waitForContainerStatus(pc.cordaDbContainerName)
+        val cordaProcess = cordaLifecycleHelper.startCombinedWorkerProcess(
+            pc.cordaPidCache,
+            pc.combinedWorkerFilePath,
+            pc.javaBinDir,
+            pc.jdbcDir,
+            pc.project.rootDir.absolutePath
+        )
+        pc.logger.quiet("Corda Process-id=" + cordaProcess.pid())
+    }
+
+    fun stopCorda() {
+        cordaLifecycleHelper.stopDockerContainer(pc.cordaDbContainerName)
+        val cordaPIDFile = File(pc.cordaPidCache)
+        if (!cordaPIDFile.exists()) {
+            throw CordaRuntimeGradlePluginException(
+                "Cannot stop the Combined worker. Cached process ID file ${pc.cordaPidCache} missing. " +
+                        "Was the combined worker not started?"
+            )
+        }
+        cordaLifecycleHelper.stopCombinedWorkerProcess(pc.cordaPidCache)
+    }
+
+    fun stopCordaAndCleanWorkspace() {
+        try {
+            stopCorda()
+        } catch (e: CordaRuntimeGradlePluginException) {
+            pc.logger.info("Failed to run 'stopCorda'. Was the combined worker already stopped?")
+        }
+
+        val workspacePath = File("${pc.project.rootDir}/${pc.workspaceDir}")
+        val dirDeleted = workspacePath.deleteRecursively()
+        if (!dirDeleted) {
+            throw CordaRuntimeGradlePluginException(
+                "Failed to delete ${workspacePath.absolutePath}, please remove before starting Corda again."
+            )
+        }
+        pc.logger.quiet("Successfully deleted '${workspacePath.name}' folder")
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleTasks.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleTasks.kt
@@ -1,3 +1,75 @@
 package net.corda.gradle.plugin.cordalifecycle
 
+import net.corda.gradle.plugin.configuration.PluginConfiguration
+import net.corda.gradle.plugin.configuration.ProjectContext
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
+const val CLUSTER_TASKS_GROUP = "corda-runtime-plugin"
+const val START_CORDA_TASK_NAME = "startCorda"
+const val STOP_CORDA_TASK_NAME = "stopCorda"
+const val STOP_CORDA_AND_CLEAN_TASK_NAME = "stopCordaAndCleanWorkspace"
+
 // Corda lifecycle tasks in here, such as start/stop the CombinedWorker
+fun createCordaLifeCycleTasks(project: Project, pluginConfig: PluginConfiguration) {
+
+    project.afterEvaluate {
+
+        project.tasks.create(START_CORDA_TASK_NAME, StartCorda::class.java) {
+            it.group = CLUSTER_TASKS_GROUP
+            it.dependsOn(PROJINIT_TASK_NAME, GET_POSTGRES_JDBC_TASK_NAME, GET_COMBINED_WORKER_JAR_TASK_NAME)
+            it.pluginConfig.set(pluginConfig)
+        }
+
+        project.tasks.create(STOP_CORDA_TASK_NAME, StopCorda::class.java) {
+            it.group = CLUSTER_TASKS_GROUP
+            it.pluginConfig.set(pluginConfig)
+        }
+
+        project.tasks.create(STOP_CORDA_AND_CLEAN_TASK_NAME, StopCordaAndCleanWorkspace::class.java) {
+            it.group = CLUSTER_TASKS_GROUP
+            it.pluginConfig.set(pluginConfig)
+        }
+    }
+}
+
+open class StartCorda @Inject constructor(objects: ObjectFactory): DefaultTask() {
+
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+
+    @TaskAction
+    fun startCorda() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        CordaLifecycleTaskImpl(pc).startCorda()
+    }
+}
+
+open class StopCorda @Inject constructor(objects: ObjectFactory): DefaultTask() {
+
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+
+    @TaskAction
+    fun stopCorda() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        CordaLifecycleTaskImpl(pc).stopCorda()
+    }
+}
+
+open class StopCordaAndCleanWorkspace @Inject constructor(objects: ObjectFactory): DefaultTask() {
+
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+
+    @TaskAction
+    fun stopCordaAndCleanWorkspace() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        CordaLifecycleTaskImpl(pc).stopCordaAndCleanWorkspace()
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupHelper.kt
@@ -1,0 +1,70 @@
+package net.corda.gradle.plugin.cordalifecycle
+
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import java.io.File
+import java.net.Authenticator
+import java.net.PasswordAuthentication
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class EnvironmentSetupHelper {
+
+    @Suppress("LongParameterList")
+    fun downloadCombinedWorker(
+        combinedWorkerFileName: String,
+        combinedWorkerVersion: String,
+        cordaReleaseVersion: String,
+        targetFilePath: String,
+        artifactoryUsername: String,
+        artifactoryPassword: String
+    ) {
+        val url = if (nameContainsRcOrHc(combinedWorkerFileName) || nameContainsAlphaOrBeta(combinedWorkerFileName)) {
+            setupAuthentication(artifactoryUsername, artifactoryPassword)
+            URL(
+                "https://software.r3.com/artifactory/corda-os-maven/net/corda/" +
+                        "corda-combined-worker/$combinedWorkerVersion/$combinedWorkerFileName"
+            )
+        } else URL("https://github.com/corda/corda-runtime-os/releases/download/$cordaReleaseVersion/$combinedWorkerFileName")
+        if (!File(targetFilePath).exists()) {
+            File(targetFilePath).parentFile.mkdirs()
+            url.openStream().use { Files.copy(it, Paths.get(targetFilePath)) }
+        }
+    }
+
+    private fun nameContainsRcOrHc(combinedWorkerFileName: String) : Boolean {
+        return combinedWorkerFileName.contains("-RC") || combinedWorkerFileName.contains("-HC")
+    }
+
+    private fun nameContainsAlphaOrBeta(combinedWorkerFileName: String) : Boolean {
+        return combinedWorkerFileName.contains("alpha") || combinedWorkerFileName.contains("beta")
+    }
+
+    internal fun setupAuthentication(artifactoryUsername: String, artifactoryPassword: String) {
+        if (artifactoryUsername.isBlank() || artifactoryPassword.isBlank()) {
+            throw CordaRuntimeGradlePluginException(
+                "Unpublished assets can only be pulled from R3's internal registry and require a username and password"
+            )
+        }
+        MyAuthenticator.setPasswordAuthentication(artifactoryUsername, artifactoryPassword)
+        Authenticator.setDefault(MyAuthenticator())
+    }
+
+    internal class MyAuthenticator : Authenticator() {
+        protected override fun getPasswordAuthentication(): PasswordAuthentication {
+            return PasswordAuthentication(
+                username,
+                password.toCharArray()
+            )
+        }
+
+        companion object {
+            private var username = ""
+            private var password = ""
+            fun setPasswordAuthentication(username: String, password: String) {
+                Companion.username = username
+                Companion.password = password
+            }
+        }
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupTasks.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupTasks.kt
@@ -1,0 +1,93 @@
+package net.corda.gradle.plugin.cordalifecycle
+
+import net.corda.gradle.plugin.configuration.PluginConfiguration
+import net.corda.gradle.plugin.configuration.ProjectContext
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import javax.inject.Inject
+
+// Task Group Names
+const val UTIL_TASK_GROUP = "corda-runtime-plugin-supporting"
+
+// Configuration Names
+const val POSTGRES_JDBC_CFG = "myPostgresJDBC"
+
+// Setup task names
+const val PROJINIT_TASK_NAME = "projInit"
+const val GET_POSTGRES_JDBC_TASK_NAME = "getPostgresJDBC"
+const val GET_COMBINED_WORKER_JAR_TASK_NAME = "getCombinedWorkerJar"
+
+/**
+ * Creates the supporting gradle tasks for downloading the combined worker, postgres, also creates
+ * the workspace directory
+ */
+fun createPluginEnvSetupTasks(project: Project, pluginConfig: PluginConfiguration) {
+    // Note, project.afterEvaluate {} runs the provided lambda after the rest of the build
+    // script has been read. This is important because if the below code is evaluated at
+    // this point in the initialisation then the extension block has not yet been read and
+    // will contain the default values, ie overriding in the extension block won't have any effect.
+    project.afterEvaluate {
+        val pc = ProjectContext(project, pluginConfig)
+
+        val postgresJDBCConfig = project.configurations.create(POSTGRES_JDBC_CFG) { conf ->
+            conf.isCanBeConsumed = false
+            conf.isCanBeResolved = true
+        }
+
+        val postgresJDBCDep =
+            project.dependencies.create("org.postgresql:postgresql:${pc.postgresJdbcVersion}")
+        postgresJDBCConfig.dependencies.add(postgresJDBCDep)
+
+        project.tasks.create(GET_POSTGRES_JDBC_TASK_NAME, Copy::class.java) {
+            it.group = UTIL_TASK_GROUP
+            it.from(postgresJDBCConfig)
+            it.into(pc.jdbcDir)
+        }
+
+        project.tasks.create(PROJINIT_TASK_NAME, ProjInit::class.java) {
+            it.group = UTIL_TASK_GROUP
+            it.pluginConfig.set(pluginConfig)
+        }
+
+        project.tasks.create(GET_COMBINED_WORKER_JAR_TASK_NAME, DownloadCombinedWorkerJar::class.java) {
+            it.group = UTIL_TASK_GROUP
+            it.pluginConfig.set(pluginConfig)
+        }
+    }
+}
+
+open class ProjInit @Inject constructor(objects: ObjectFactory): DefaultTask() {
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+
+    @TaskAction
+    fun projInit() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        File("${project.rootDir}/${pc.workspaceDir}").mkdirs()
+    }
+}
+
+open class DownloadCombinedWorkerJar @Inject constructor(objects: ObjectFactory): DefaultTask() {
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+
+    @TaskAction
+    fun downloadCombinedWorker() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        EnvironmentSetupHelper().downloadCombinedWorker(
+            pc.combinedWorkerFileName,
+            pc.combinedWorkerVersion,
+            pc.cordaReleaseBranchName,
+            pc.combinedWorkerFilePath,
+            pc.artifactoryUsername,
+            pc.artifactoryPassword
+        )
+    }
+}
+

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/exception/CordaRuntimeGradlePluginException.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/exception/CordaRuntimeGradlePluginException.kt
@@ -1,0 +1,3 @@
+package net.corda.gradle.plugin.exception
+
+class CordaRuntimeGradlePluginException(message: String?, cause: Throwable? = null) : Exception(message, cause)


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/ES-1827
PR 2 of 4 relating to the Corda Runtime Gradle Plugin
Aim of this ticket was to:

- Recreate the start/stop/stop&clear tasks of the CSDE
- Add new use case for downloading alpha/beta builds

Added automated tests for the download Combined Worker logic
Not sure how we can test the start/stop tasks which spin up a docker container, in the pipeline
Tested manually:
<img width="305" alt="Screenshot 2024-01-26 at 15 33 07" src="https://github.com/corda/corda-runtime-os/assets/92731849/29e097aa-6b9e-4aac-b710-5d3ca4d0aabb">


1. Is there a better way to handle the credentials?
2. Is the Postgres JDBC version ok?