### PR TITLE
CORE-18864: State Types - Helm Bootstrap Changes

### DIFF
--- a/charts/corda-lib/templates/_stateManagerV2.tpl
+++ b/charts/corda-lib/templates/_stateManagerV2.tpl
@@ -1,0 +1,208 @@
+{{/*
+    State Manager Named Templates
+    Kept in an isolated file for easier maintenance and development.
+    TODO-[CORE-19372]: rename this file to _stateManager.tpl (and remove the old one _stateManager.tpl).
+*/}}
+
+
+{{/*
+    Transform the given string input into kebab case
+*/}}
+{{- define "corda.kebabCase" -}}
+{{ . | kebabcase | replace "p-2p" "p2p" }}
+{{- end }}
+
+
+{{/*
+    Default Name for Secrets Containing Bootstrap Database Credentials
+    The resulting secret name is "chartName-bootstrap-databaseName-db"
+*/}}
+{{- define "corda.defaultDatabaseBootstrapCredentialsSecretName" -}}
+{{- $ := index . 0 -}}
+{{- $dbName := index . 1 -}}
+{{ printf "%s-bootstrap-%s-db" ( include "corda.fullname" $ ) $dbName }}
+{{- end -}}
+
+
+{{/*
+    Default Name for Secrets Containing Database Credentials
+    The resulting secret name is "chartName-runtime-databaseName-db"
+*/}}
+{{- define "corda.defaultDatabaseRuntimeCredentialsSecretName" -}}
+{{- $ := index . 0 -}}
+{{- $dbName := index . 1 -}}
+{{ printf "%s-runtime-%s-db" ( include "corda.fullname" $ ) $dbName }}
+{{- end -}}
+
+
+{{/*
+    Name for Secrets Containing State Manager Runtime Credentials (custom, defined at the worker level)
+    The resulting secret name is "chartName-runtime-workerNameKebabCase-stateTypeKebabCase-db"
+*/}}
+{{- define "corda.stateManagerDefaultRuntimeSecretName" -}}
+{{- $ := index . 0 -}}
+{{- $stateType := index . 1 -}}
+{{- $workerName := index . 2 -}}
+{{ printf "%s-runtime-%s-%s-db" ( include "corda.fullname" $ ) ( include "corda.kebabCase" $workerName ) ( include "corda.kebabCase" $stateType ) }}
+{{- end -}}
+
+
+{{/*
+    Environment variables to be used when bootstrapping state manager databases (BOOT_PG_USERNAME and BOOT_PG_PASSWORD)
+*/}}
+{{- define "corda.stateManagerDatabaseBootstrapEnvironment" -}}
+{{- $ := index . 0 -}}
+{{- $dbName := index . 1 -}}
+{{- $bootstrapSettings := index . 2 -}}
+- name: BOOT_PG_USERNAME
+  valueFrom:
+    secretKeyRef:
+      {{-   if $bootstrapSettings.username.valueFrom.secretKeyRef.name }}
+      name: {{ $bootstrapSettings.username.valueFrom.secretKeyRef.name | quote }}
+      key: {{ required ( printf "Must specify username.valueFrom.secretKeyRef.key for database '%s'" $dbName ) $bootstrapSettings.username.valueFrom.secretKeyRef.key | quote }}
+      {{-   else }}
+      name: {{ include "corda.defaultDatabaseBootstrapCredentialsSecretName" ( list $ $dbName ) | quote }}
+      key: "username"
+      {{-   end }}
+- name: BOOT_PG_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      {{-   if $bootstrapSettings.password.valueFrom.secretKeyRef.name }}
+      name: {{ $bootstrapSettings.password.valueFrom.secretKeyRef.name | quote }}
+      key: {{ required ( printf "Must specify password.valueFrom.secretKeyRef.key for database '%s'" $dbName ) $bootstrapSettings.password.valueFrom.secretKeyRef.key | quote }}
+      {{-   else }}
+      name: {{ include "corda.defaultDatabaseBootstrapCredentialsSecretName" ( list $ $dbName ) | quote }}
+      key: "password"
+      {{-   end }}
+{{- end -}}
+
+
+{{/*
+    Environment variables to be used when using state manager databases (STATE_MANAGER_USERNAME and STATE_MANAGER_PASSWORD)
+    The order of preference when choosing the actual values (username and password) are shown below:
+        - Custom, set at the worker level through a kubernetes secret provided by the user.
+        - Custom, set at the worker level through a plain value provided by the user (transformed into a Secret by the chart)
+        - Default, set at the root "databases" level through a kubernetes secret provided by the user.
+        - Default, set at the root "databases" level through a plain value provided by the user (transformed into a Secret by the chart)
+*/}}
+{{- define "corda.stateManagerDatabaseRuntimeEnvironment" -}}
+{{- $ := index . 0 -}}
+{{- $dbName := index . 1 -}}
+{{- $stateType := index . 2 -}}
+{{- $workerName := index . 3 -}}
+{{- $defaultSettings := index . 4 -}}
+{{- $runtimeSettings := index . 5 -}}
+- name: STATE_MANAGER_USERNAME
+  valueFrom:
+    secretKeyRef:
+      {{-   if $runtimeSettings.username.valueFrom.secretKeyRef.name }}
+      name: {{ $runtimeSettings.username.valueFrom.secretKeyRef.name | quote }}
+      key: {{ required ( printf "Must specify workers.%s.stateManager.%s.username.valueFrom.secretKeyRef.key" $workerName $stateType ) $runtimeSettings.username.valueFrom.secretKeyRef.key | quote }}
+      {{-   else if $runtimeSettings.username.value }}
+      name: {{ include "corda.stateManagerDefaultRuntimeSecretName" ( list $ $stateType $workerName ) | quote }}
+      key: "username"
+      {{-   else if $defaultSettings.username.valueFrom.secretKeyRef.name }}
+      name: {{ $defaultSettings.username.valueFrom.secretKeyRef.name | quote }}
+      key: {{ required ( printf "Must specify username.valueFrom.secretKeyRef.key for database '%s'" $dbName ) $defaultSettings.username.valueFrom.secretKeyRef.key | quote }}
+      {{-   else  }}
+      name: {{ include "corda.defaultDatabaseRuntimeCredentialsSecretName" ( list $ $dbName ) | quote }}
+      key: "username"
+      {{-   end }}
+- name: STATE_MANAGER_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      {{-   if $runtimeSettings.password.valueFrom.secretKeyRef.name }}
+      name: {{ $runtimeSettings.password.valueFrom.secretKeyRef.name | quote }}
+      key: {{ required ( printf "Must specify workers.%s.stateManager.%s.password.valueFrom.secretKeyRef.key" $workerName $stateType ) $runtimeSettings.password.valueFrom.secretKeyRef.key | quote }}
+      {{-   else if $runtimeSettings.password.value }}
+      name: {{ include "corda.stateManagerDefaultRuntimeSecretName" ( list $ $stateType $workerName ) | quote }}
+      key: "password"
+      {{-   else if $defaultSettings.password.valueFrom.secretKeyRef.name }}
+      name: {{ $defaultSettings.password.valueFrom.secretKeyRef.name | quote }}
+      key: {{ required ( printf "Must specify password.valueFrom.secretKeyRef.key for database '%s'" $dbName ) $defaultSettings.password.valueFrom.secretKeyRef.key | quote }}
+      {{-   else  }}
+      name: {{ include "corda.defaultDatabaseRuntimeCredentialsSecretName" ( list $ $dbName ) | quote }}
+      key: "password"
+      {{-   end }}
+{{- end -}}
+
+
+{{/* State Manager Containers to Create & Apply Database Schemas Within The Bootstrap Job */}}
+{{- define "corda.stateManagerDatabaseBootstrap" -}}
+{{- $ := index . 0 -}}
+{{- $stateType := index . 1 -}}
+{{- $workerName := index . 2 -}}
+{{- $schemaName := index . 3 -}}
+{{- $databaseConfig := index . 4 -}}
+{{- $runtimeSettings := index . 5 -}}
+{{- $bootstrapSettings := index . 6 -}}
+{{- with index . 0 -}}
+{{- $dbName := $databaseConfig.name -}}
+{{- $workerKebabCase := include "corda.kebabCase" $workerName -}}
+{{- $stateTypeKebabCase := include "corda.kebabCase" $stateType -}}
+{{/*    -- We use two init-containers for serial execution to prevent issues when applying the same Liquibase files at the same time (developer use case where multiple workers use the same state manager database) */}}
+        - name: generate-db-schema-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }}
+          image: {{ include "corda.bootstrapCliImage" . }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
+          env:
+            {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
+            {{- include "corda.stateManagerDatabaseBootstrapEnvironment" ( list $ $dbName $bootstrapSettings ) | nindent 12 }}
+          command: [ 'sh', '-c', '-e' ]
+          args:
+            - |
+              #!/bin/sh
+              set -ev
+              echo "Generating Database Specification for Database '{{ $dbName }}'..."
+              JDBC_URL="jdbc:{{- $databaseConfig.type -}}://{{- required ( printf "Must specify a host for database '%s'" $dbName ) $databaseConfig.host -}}:{{- $databaseConfig.port -}}/{{- $dbName -}}"
+              mkdir /tmp/database-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }}
+              java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar database spec \
+                -s "{{ $schemaName }}" -g "{{ $schemaName }}:state_manager" \
+                -u "${BOOT_PG_USERNAME}" -p "${BOOT_PG_PASSWORD}" \
+                --jdbc-url "${JDBC_URL}" \
+                -c -l /tmp/database-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }}
+              echo "Generating Database Specification for Database '{{ $dbName }}'... Done"
+          workingDir: /tmp
+          volumeMounts:
+            - mountPath: /tmp
+              name: temp
+            {{- include "corda.log4jVolumeMount" . | nindent 12 }}
+        - name: apply-db-schema-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }}
+          image: {{ include "corda.bootstrapDbClientImage" . }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- include "corda.bootstrapResources" . | nindent 10 }}
+          {{- include "corda.containerSecurityContext" . | nindent 10 }}
+          env:
+            {{- include "corda.stateManagerDatabaseBootstrapEnvironment" ( list $ $dbName $bootstrapSettings ) | nindent 12 }}
+            - name: STATE_MANAGER_DB_NAME
+              value: {{ $dbName | quote }}
+            - name: STATE_MANAGER_DB_HOST
+              value: {{ $databaseConfig.host | quote }}
+            - name: STATE_MANAGER_DB_PORT
+              value: {{ $databaseConfig.port | quote }}
+            {{- include "corda.stateManagerDatabaseRuntimeEnvironment" ( list $ $dbName $stateType $workerName $databaseConfig $runtimeSettings ) | nindent 12 }}
+          command: [ 'sh', '-c', '-e' ]
+          args:
+            - |
+              #!/bin/sh
+              set -ev
+              echo 'Applying State Manager Specification for Database '{{ $dbName }}'..."
+              export PGPASSWORD="${BOOT_PG_PASSWORD}"
+              find /tmp/database-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }} -iname "*.sql" | xargs printf -- ' -f %s' | xargs psql -v ON_ERROR_STOP=1 -h "${STATE_MANAGER_DB_HOST}" -p "${STATE_MANAGER_DB_PORT}" -U "${BOOT_PG_USERNAME}" --dbname "${STATE_MANAGER_DB_NAME}"
+              echo 'Applying State Manager Specification for {{ $workerName }}... Done!'
+
+              echo 'Creating users and granting permissions for State Manager in {{ $workerName }}...'
+              psql -v ON_ERROR_STOP=1 -h "${STATE_MANAGER_DB_HOST}" -p "${STATE_MANAGER_DB_PORT}" -U "${BOOT_PG_USERNAME}" "${STATE_MANAGER_DB_NAME}" << SQL
+                DO \$\$ BEGIN IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '${STATE_MANAGER_USERNAME}') THEN RAISE NOTICE 'Role "${STATE_MANAGER_USERNAME}" already exists'; ELSE CREATE USER "${STATE_MANAGER_USERNAME}" WITH ENCRYPTED PASSWORD '${STATE_MANAGER_PASSWORD}'; END IF; END \$\$;
+                GRANT USAGE ON SCHEMA STATE_MANAGER TO "${STATE_MANAGER_USERNAME}";
+                GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA STATE_MANAGER TO "${STATE_MANAGER_USERNAME}";
+                GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA STATE_MANAGER TO "${STATE_MANAGER_USERNAME}";
+              SQL
+
+              echo 'Applying State Manager Specification for Database '{{ $dbName }}'... Done!'
+          volumeMounts:
+            - mountPath: /tmp
+              name: temp
+{{- end -}}
+{{- end -}}

--- a/charts/corda-lib/templates/_stateManagerV2.tpl
+++ b/charts/corda-lib/templates/_stateManagerV2.tpl
@@ -158,7 +158,7 @@
               JDBC_URL="jdbc:{{- $databaseConfig.type -}}://{{- required ( printf "Must specify a host for database '%s'" $dbName ) $databaseConfig.host -}}:{{- $databaseConfig.port -}}/{{- $dbName -}}"
               mkdir /tmp/database-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }}
               java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar database spec \
-                -s "{{ $schemaName }}" -g "{{ $schemaName }}:state_manager" \
+                -s "statemanager" -g "statemanager:{{ $schemaName }}" \
                 -u "${BOOT_PG_USERNAME}" -p "${BOOT_PG_PASSWORD}" \
                 --jdbc-url "${JDBC_URL}" \
                 -c -l /tmp/database-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -8,6 +8,19 @@
     ( dict "cleanup" true )
   )
 }}
+{{/* Default Database Secrets - TODO-[CORE-19372]: make 'username' and 'password' required */}}
+{{- range $index, $dbConfig  := .Values.databases -}}
+{{-   include "corda.secret"
+        ( list
+            $
+            $dbConfig
+            ( printf "databases.[%d]" $index )
+            ( include "corda.defaultDatabaseRuntimeCredentialsSecretName" ( list $ $dbConfig.name ) )
+            ( dict "username" ( dict ) "password" ( dict ) )
+            ( dict "cleanup" true )
+        )
+}}
+{{- end -}}
 {{- include "corda.secret"
   ( list
     $
@@ -26,6 +39,7 @@
     ( dict "salt" ( dict "generate" 32 ) "passphrase" ( dict "generate" 32 ) )
   )
 }}
+{{/* TODO-[CORE-19372]: remove the following range code block */}}
 {{/* If host is set at the worker level, user is expected to also set runtime connection credentials */}}
 {{- range $workerKey, $workerConfig := .Values.workers }}
 {{-   if  ( $workerConfig.stateManager ).db.host  -}}
@@ -41,6 +55,19 @@
 {{-   end }}
 {{- end }}
 {{- if .Values.bootstrap.db.enabled }}
+{{/* Bootstrap Database Secrets - TODO-[CORE-19372]: make 'username' and 'password' required */}}
+{{-   range $index, $bootConfig  := .Values.bootstrap.db.databases -}}
+{{-     include "corda.secret"
+          ( list
+              $
+              $bootConfig
+              ( printf "bootstrap.db.databases.[%d]" $index )
+              ( include "corda.defaultDatabaseBootstrapCredentialsSecretName" ( list $ $bootConfig.name ) )
+              ( dict "username" ( dict ) "password" ( dict ) )
+              ( dict "cleanup" true )
+          )
+}}
+{{-   end -}}
 {{- include "corda.secret"
   ( list
     $
@@ -61,6 +88,7 @@
     ( dict "cleanup" true )
   )
 }}
+{{/* TODO-[CORE-19372]: remove the following range code block */}}
 {{/* If host is set at the worker level and bootstrap is enabled, user is expected to also set bootstrap connection credentials */}}
 {{- range $workerKey, $authConfig := .Values.bootstrap.db.stateManager }}
 {{-   $workerConfig := (index $.Values.workers $workerKey) }}
@@ -109,3 +137,31 @@
   )
 }}
 {{- end }}
+{{/*  State Manager Runtime Connection Secrets */}}
+{{- range $stateType, $stateTypeConfig  := .Values.stateManager -}}
+{{-   $databaseFound := false -}}
+{{-   $storageId := $stateTypeConfig.storageId -}}
+{{-   range $.Values.databases -}}
+{{-     if eq .name $storageId -}}
+{{-       $databaseFound = true -}}
+{{-     end -}}
+{{-   end -}}
+{{-   if not $databaseFound -}}
+{{-     fail ( printf "Undefined persistent storage '%s' detected at stateManager.%s.storageId" $storageId $stateType ) -}}
+{{-   end -}}
+{{-   range $workerName, $workerConfig := $.Values.workers -}}
+{{-     $runtimeCredentials := ( index $workerConfig "stateManager" ) -}}
+{{-     if and $runtimeCredentials ( index $runtimeCredentials $stateType ) -}}
+{{-       include "corda.secret"
+            ( list
+                $
+                ( index $runtimeCredentials $stateType )
+                ( printf "workers.%s.stateManager.[%s]" $workerName $stateType )
+                ( include "corda.stateManagerDefaultRuntimeSecretName" ( list $ $stateType $workerName ) )
+                ( dict "username" ( dict ) "password" ( dict ) )
+                ( dict "cleanup" true )
+            )
+}}
+{{-     end -}}
+{{-   end -}}
+{{- end -}}

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -204,8 +204,6 @@ kafka:
             name: ""
             # -- the truststore password secret key
             key: ""
-
-
   # SASL configuration for client connection to Kafka
   sasl:
     # -- SASL mechanism for client connection to Kafka
@@ -518,6 +516,7 @@ bootstrap:
             # -- the password secret key
             key: ""
 
+    # TODO-[CORE-19372]: remove 'stateManager' section.
     # State Manager DB Bootstrap Configuration
     stateManager:
       flow:
@@ -851,12 +850,30 @@ workers:
 #      keyRotation:
 #        # -- persistent storage type
 #        type: Database
-#        # Database user, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
+#        # Database user, empty values instructs the chart to use the default settings configured for the associated persistent storage
 #        username:
 #          # -- the State Manager database user
 #          value: "key_rotation_writer"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
+#          # The State Manager database username secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
+#        # Database password, empty values instructs the chart to use the default settings configured for the associated persistent storage
+#        password:
+#          # -- the State Manager database user
+#          value: ""
+#          # The State Manager database password secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
 #        # Connection pool configuration for the State Manager
 #        connectionPool:
 #          # -- maximum connection pool size
@@ -1053,8 +1070,26 @@ workers:
 #        username:
 #          # -- the State Manager database user
 #          value: "flow_checkpoint"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
+#          # The State Manager database username secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
+#        # Database password, empty values instructs the chart to use the default settings configured for the associated persistent storage
+#        password:
+#          # -- the State Manager database user
+#          value: ""
+#          # The State Manager database password secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
 #        # Connection pool configuration for the State Manager
 #        connectionPool:
 #          # -- maximum connection pool size
@@ -1198,8 +1233,26 @@ workers:
 #        username:
 #          # -- the State Manager database user
 #          value: "flow_mapper"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
+#          # The State Manager database username secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
+#        # Database password, empty values instructs the chart to use the default settings configured for the associated persistent storage
+#        password:
+#          # -- the State Manager database user
+#          value: ""
+#          # The State Manager database password secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
 #        # Connection pool configuration for the State Manager
 #        connectionPool:
 #          # -- maximum connection pool size
@@ -1522,8 +1575,26 @@ workers:
 #        username:
 #          # -- the State Manager database user
 #          value: "key_rotation_reader"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
+#          # The State Manager database username secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
+#        # Database password, empty values instructs the chart to use the default settings configured for the associated persistent storage
+#        password:
+#          # -- the State Manager database user
+#          value: ""
+#          # The State Manager database password secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
 #        # Connection pool configuration for the State Manager
 #        connectionPool:
 #          # -- maximum connection pool size
@@ -1546,8 +1617,26 @@ workers:
 #        username:
 #          # -- the State Manager database user
 #          value: "flow_status"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
+#          # The State Manager database username secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
+#        # Database password, empty values instructs the chart to use the default settings configured for the associated persistent storage
+#        password:
+#          # -- the State Manager database user
+#          value: ""
+#          # The State Manager database password secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
 #        # Connection pool configuration for the State Manager
 #        connectionPool:
 #          # -- maximum connection pool size
@@ -1671,7 +1760,6 @@ workers:
       requests: {}
       # -- the CPU/memory resource limits for the P2P link manager worker containers
       limits: {}
-
     stateManager:
 #      # Runtime configuration settings for the State Manager used to interact with 'p2pSession' states
 #      p2pSession:
@@ -1681,8 +1769,25 @@ workers:
 #        username:
 #          # -- the State Manager database user
 #          value: "p2p_session"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
+#        # Database password, empty values instructs the chart to use the default settings configured for the associated persistent storage
+#        password:
+#          # -- the State Manager database user
+#          value: ""
+#          # The State Manager database password secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
 #        # Connection pool configuration for the State Manager
 #        connectionPool:
 #          # -- maximum connection pool size
@@ -1748,7 +1853,6 @@ workers:
           keepAliveTimeSeconds: 0
           # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
           validationTimeoutSeconds: 5
-
     # P2P link manager worker Kafka configuration
     kafka:
       # if kafka.sasl.enabled, the credentials to connect to Kafka with for the P2P link manager worker
@@ -1987,7 +2091,6 @@ workers:
       keepaliveTimeSeconds: 0
       # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
       validationTimeoutSeconds: 5
-
     stateManager:
 #      # Runtime configuration settings for the State Manager used to interact with 'tokenPoolCache' states
 #      tokenPoolCache:
@@ -1997,8 +2100,25 @@ workers:
 #        username:
 #          # -- the State Manager database user
 #          value: "token_pool_cache"
-#        # Database password, 'null' value instructs the chart to use the default settings configured for the associated persistent storage
-#        password: null
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
+#        # Database password, empty values instructs the chart to use the default settings configured for the associated persistent storage
+#        password:
+#          # -- the State Manager database user
+#          value: ""
+#          # The State Manager database password secret configuration; used in preference to value if name is set
+#          valueFrom:
+#            # The State Manager database password secret key reference
+#            secretKeyRef:
+#              # -- the State Manager database password secret name
+#              name: ""
+#              # -- the State Manager database password secret key
+#              key: ""
 #        # Connection pool configuration for the State Manager
 #        connectionPool:
 #          # -- maximum connection pool size
@@ -2064,7 +2184,6 @@ workers:
           keepAliveTimeSeconds: 0
           # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
           validationTimeoutSeconds: 5
-
     # token selection worker Kafka configuration
     kafka:
       # if kafka.sasl.enabled, the credentials to connect to Kafka with for the token selection worker
@@ -2159,7 +2278,6 @@ workers:
       keepaliveTimeSeconds: 0
       # -- maximum time (in seconds) that the pool will wait for a connection to be validated as alive
       validationTimeoutSeconds: 5
-
     # uniqueness worker Kafka configuration
     kafka:
       # if kafka.sasl.enabled, the credentials to connect to Kafka with for the uniqueness worker


### PR DESCRIPTION
Update Helm templates (Secret creation and Database bootstrap) to
support new deployment model on which state types can be isolated and
workers are allowed to access more than a single State Manager instance.
Changes introduced by this commit are backward compatible with the
existing schema, comments were added so that the relevant code can be
entirely removed once the new deployment model is fully rolled out.
