### PR TITLE
POC - set DB schema in EntityManagerFactory

### DIFF
--- a/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/DefaultSchemaTest.kt
+++ b/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/DefaultSchemaTest.kt
@@ -42,7 +42,14 @@ class DefaultSchemaTest {
                 r.getString(1)
             }
         }
-
         assertThat(fetch).isEqualTo("Fred")
+
+        // also check we can use a JQL query without specifying schema
+        val queryResult = emf.createEntityManager().use {
+            it.createQuery("select o.name from Owner as o where o.id = :id")
+                .setParameter("id", ownerId)
+                .resultList.first()
+        }
+        assertThat(queryResult).isEqualTo("Fred")
     }
 }

--- a/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/DefaultSchemaTest.kt
+++ b/libs/db/db-orm-impl/src/integrationTest/kotlin/net/corda/orm/impl/DefaultSchemaTest.kt
@@ -1,0 +1,48 @@
+package net.corda.orm.impl
+
+import net.corda.db.testkit.dbutilsimpl.PostgresHelper
+import net.corda.orm.impl.test.entities.Owner
+import net.corda.orm.utils.use
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class DefaultSchemaTest {
+    @Test
+    fun `can persist JPA entity`() {
+        val conf = PostgresHelper().getEntityManagerConfiguration("DefaultSchemaTest")
+        val schema = "custom_schema_${Instant.now().epochSecond}"
+        conf.dataSource.connection.use {
+            it.autoCommit = true
+            it.createStatement().execute("CREATE SCHEMA $schema")
+            it.createStatement().execute("CREATE TABLE $schema.owner(age INT, name VARCHAR, id UUID)")
+        }
+
+        val emf = EntityManagerFactoryFactoryImpl().create(
+            "DefaultSchemaTest",
+            listOf(Owner::class.java),
+            conf,
+            schema
+        )
+
+        val ownerId = UUID.randomUUID()
+        val owner = Owner(ownerId, "Fred", 25)
+
+        emf.createEntityManager().use {
+            it.transaction.begin()
+            it.persist(owner)
+            it.transaction.commit()
+        }
+
+        val fetch = conf.dataSource.connection.use { con ->
+            con.prepareStatement("SELECT name FROM $schema.owner WHERE id = '$ownerId'").use {
+                val r = it.executeQuery()
+                r.next()
+                r.getString(1)
+            }
+        }
+
+        assertThat(fetch).isEqualTo("Fred")
+    }
+}

--- a/libs/db/db-orm-impl/src/main/kotlin/net/corda/orm/impl/EntityManagerFactoryFactoryImpl.kt
+++ b/libs/db/db-orm-impl/src/main/kotlin/net/corda/orm/impl/EntityManagerFactoryFactoryImpl.kt
@@ -4,6 +4,7 @@ import net.corda.db.core.CloseableDataSource
 import net.corda.orm.DdlManage
 import net.corda.orm.EntityManagerConfiguration
 import net.corda.orm.EntityManagerFactoryFactory
+import net.corda.utilities.debug
 import org.hibernate.cfg.AvailableSettings
 import org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl
 import org.hibernate.jpa.boot.internal.PersistenceUnitInfoDescriptor
@@ -12,7 +13,6 @@ import org.osgi.service.component.annotations.Component
 import org.slf4j.LoggerFactory
 import javax.persistence.EntityManagerFactory
 import javax.persistence.spi.PersistenceUnitInfo
-import net.corda.utilities.debug
 
 /**
  * Hibernate implementation of [EntityManagerFactoryFactory]
@@ -55,13 +55,15 @@ class EntityManagerFactoryFactoryImpl(
     override fun create(
         persistenceUnitName: String,
         entities: List<Class<*>>,
-        configuration: EntityManagerConfiguration
+        configuration: EntityManagerConfiguration,
+        defaultSchema: String?
     ): EntityManagerFactory {
         return create(
             persistenceUnitName,
             entities.map(Class<*>::getCanonicalName),
             entities.map(Class<*>::getClassLoader).distinct(),
-            configuration
+            configuration,
+            defaultSchema
         )
     }
 
@@ -70,7 +72,8 @@ class EntityManagerFactoryFactoryImpl(
         persistenceUnitName: String,
         entities: List<String>,
         classLoaders: List<ClassLoader>,
-        configuration: EntityManagerConfiguration
+        configuration: EntityManagerConfiguration,
+        defaultSchema: String?
     ): EntityManagerFactory {
         log.debug { "Creating for $persistenceUnitName" }
 
@@ -87,6 +90,7 @@ class EntityManagerFactoryFactoryImpl(
             //"hibernate.generate_statistics" to true.toString(),
             "javax.persistence.validation.mode" to "none"
         ).toProperties()
+        if(null != defaultSchema) props["hibernate.default_schema"] = defaultSchema
         props[AvailableSettings.CLASSLOADERS] = classLoaders
         props += configuration.extraProperties
 

--- a/libs/db/db-orm/src/main/kotlin/net/corda/orm/EntityManagerFactoryFactory.kt
+++ b/libs/db/db-orm/src/main/kotlin/net/corda/orm/EntityManagerFactoryFactory.kt
@@ -12,12 +12,14 @@ interface EntityManagerFactoryFactory {
      * @param persistenceUnitName
      * @param entities to be managed by the [EntityManagerFactory]
      * @param configuration for the target data source
+     * @param defaultSchema optional default schema to use
      * @return [EntityManagerFactory]
      */
     fun create(
         persistenceUnitName: String,
         entities: List<Class<*>>,
-        configuration: EntityManagerConfiguration
+        configuration: EntityManagerConfiguration,
+        defaultSchema: String? = null
     ): EntityManagerFactory
 
     /**
@@ -27,12 +29,14 @@ interface EntityManagerFactoryFactory {
      * @param classLoaders
      * @param entities
      * @param configuration
+     * @param defaultSchema optional default schema to use
      * @return
      */
     fun create(
         persistenceUnitName: String,
         entities: List<String>,
         classLoaders: List<ClassLoader>,
-        configuration: EntityManagerConfiguration
+        configuration: EntityManagerConfiguration,
+        defaultSchema: String? = null
     ): EntityManagerFactory
 }


### PR DESCRIPTION
POC to prove we can set schema in the EMF, which should allow us to re-use a datasource/pool across EMFs.

This is to support the proposed CORE-19423 epic.