### PR TITLE
CORE-19478 Remove custom partitioning from inbound gateway

### DIFF
--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -231,10 +231,14 @@ internal class InboundMessageHandler(
             logger.warn("No partitions exist for session ($sessionId), discarding the message and returning an error.")
             HttpResponseStatus.GONE
         } else {
-            // this is simplistic (stateless) load balancing amongst the partitions owned by the LM that "hosts" the session.
-            val selectedPartition = partitions.random()
             val record = Record(LINK_IN_TOPIC, sessionId, p2pMessage)
-            p2pInPublisher.publishToPartition(listOf(selectedPartition to record))
+            if (commonComponents.features.useStatefulSessionManager) {
+                p2pInPublisher.publish(listOf(record))
+            } else {
+                // this is simplistic (stateless) load balancing amongst the partitions owned by the LM that "hosts" the session.
+                val selectedPartition = partitions.random()
+                p2pInPublisher.publishToPartition(listOf(selectedPartition to record))
+            }
             HttpResponseStatus.OK
         }
     }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
@@ -744,26 +744,4 @@ class InboundMessageHandlerTest {
         verify(p2pInPublisher.constructed().first())
             .publish(any())
     }
-
-    @Test
-    fun `when useStatefulSessionManager is false, custom partitioning for inbound session messages is turned on`() {
-        whenever(sessionPartitionMapper.constructed().first().getPartitions(any())).doReturn(listOf(1, 2, 3))
-        setRunning()
-        val msgId = "msg-id"
-        val gatewayMessage = GatewayMessage(msgId, authenticatedP2PDataMessage(""))
-        whenever(avroSchemaRegistry.deserialize<GatewayMessage>(ByteBuffer.wrap(serialisedMessage))).thenReturn(gatewayMessage)
-
-        handler.onRequest(
-            writer,
-            HttpRequest(
-                source = InetSocketAddress("www.r3.com", 1231),
-                payload = serialisedMessage,
-                destination = InetSocketAddress("www.r3.com", 344),
-            )
-
-        )
-
-        verify(p2pInPublisher.constructed().first())
-            .publishToPartition(any())
-    }
 }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandlerTest.kt
@@ -743,5 +743,7 @@ class InboundMessageHandlerTest {
 
         verify(p2pInPublisher.constructed().first())
             .publish(any())
+        verify(sessionPartitionMapper.constructed().first(), never())
+            .getPartitions(any())
     }
 }

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/flags/Features.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/flags/Features.kt
@@ -2,5 +2,5 @@ package net.corda.utilities.flags
 
 class Features {
     val enableP2PGatewayToLinkManagerOverHttp = false
-    val useStatefulSessionManager = false
+    val useStatefulSessionManager = true
 }

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/flags/Features.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/flags/Features.kt
@@ -2,5 +2,5 @@ package net.corda.utilities.flags
 
 class Features {
     val enableP2PGatewayToLinkManagerOverHttp = false
-    val useStatefulSessionManager = true
+    val useStatefulSessionManager = false
 }


### PR DESCRIPTION
Turn off custom partitioning for publishing inbound session messages in the Gateway, when the shared sessions feature is enabled.

Build with feature enabled - [link](https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-runtime-os/detail/PR-5549/1/pipeline)