### PR TITLE
CORE-19350 - Disable vnode labels for p2p metrics

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ cordaPipelineKubernetesAgent(
     publishPreTestImage: true,
     publishHelmChart: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
-    runE2eTests: true,
+    runE2eTests: false,
     combinedWorkere2eTests: true,
     // allow publishing artifacts to S3 bucket
     publishToMavenS3Repository: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ cordaPipelineKubernetesAgent(
     publishPreTestImage: true,
     publishHelmChart: true,
     e2eTestName: 'corda-runtime-os-e2e-tests',
-    runE2eTests: false,
+    runE2eTests: true,
     combinedWorkere2eTests: true,
     // allow publishing artifacts to S3 bucket
     publishToMavenS3Repository: true,

--- a/applications/tools/p2p-test/app-simulator/scripts/corda-eks.metrics.yaml
+++ b/applications/tools/p2p-test/app-simulator/scripts/corda-eks.metrics.yaml
@@ -9,6 +9,4 @@ metrics:
     labels:
       release: observability
     keepNames: [ ]
-    dropLabels:
-      - "virtualnode_destination"
-      - "virtualnode_source"
+    dropLabels: []

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
@@ -134,8 +134,6 @@ internal class DeliveryTracker(
 
         private fun recordReplaysMetric(message: AuthenticatedMessage) {
             CordaMetrics.Metric.OutboundMessageReplayCount.builder()
-                .withTag(CordaMetrics.Tag.SourceVirtualNode, message.header.source.x500Name)
-                .withTag(CordaMetrics.Tag.DestinationVirtualNode, message.header.destination.x500Name)
                 .withTag(CordaMetrics.Tag.MembershipGroup, message.header.source.groupId)
                 .build().increment()
         }
@@ -201,8 +199,6 @@ internal class DeliveryTracker(
                 val deliveryLatency = Duration.between(originalProcessingTime, Instant.now())
                 val header = state.message.message.header
                 CordaMetrics.Metric.OutboundMessageDeliveryLatency.builder()
-                    .withTag(CordaMetrics.Tag.SourceVirtualNode, header.source.x500Name)
-                    .withTag(CordaMetrics.Tag.DestinationVirtualNode, header.destination.x500Name)
                     .withTag(CordaMetrics.Tag.MembershipGroup, header.source.groupId)
                     .withTag(CordaMetrics.Tag.MessagingSubsystem, header.subsystem)
                     .build().record(deliveryLatency)
@@ -211,8 +207,6 @@ internal class DeliveryTracker(
             private fun recordTtlExpiredMetric(state: AuthenticatedMessageDeliveryState) {
                 val header = state.message.message.header
                 CordaMetrics.Metric.OutboundMessageTtlExpired.builder()
-                    .withTag(CordaMetrics.Tag.SourceVirtualNode, header.source.x500Name)
-                    .withTag(CordaMetrics.Tag.DestinationVirtualNode, header.destination.x500Name)
                     .withTag(CordaMetrics.Tag.MembershipGroup, header.source.groupId)
                     .withTag(CordaMetrics.Tag.MessagingSubsystem, header.subsystem)
                     .build().increment()

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -137,7 +137,7 @@ internal class InboundMessageProcessor(
                     is ResponderHelloMessage -> {
                         val partitionsAssigned = inboundAssignmentListener.getCurrentlyAssignedPartitions()
                         if (partitionsAssigned.isNotEmpty()) {
-                            recordOutboundSessionMessagesMetric(response.header.sourceIdentity, response.header.destinationIdentity)
+                            recordOutboundSessionMessagesMetric(response.header.sourceIdentity)
                             TraceableItem(
                                 listOf(
                                     Record(Schemas.P2P.LINK_OUT_TOPIC, LinkManager.generateKey(), response),
@@ -159,7 +159,7 @@ internal class InboundMessageProcessor(
                         }
                     }
                     else -> {
-                        recordOutboundSessionMessagesMetric(response.header.sourceIdentity, response.header.destinationIdentity)
+                        recordOutboundSessionMessagesMetric(response.header.sourceIdentity)
                         TraceableItem(
                             listOf(Record(Schemas.P2P.LINK_OUT_TOPIC, LinkManager.generateKey(), response)),
                             traceableMessage.originalRecord

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -300,7 +300,7 @@ internal class InboundMessageProcessor(
             when (val innerMessage = it.message) {
                 is HeartbeatMessage -> {
                     logger.debug { "Processing heartbeat message from session $sessionId" }
-                    recordInboundHeartbeatMessagesMetric(counterparties.counterpartyId, counterparties.ourId)
+                    recordInboundHeartbeatMessagesMetric(counterparties.counterpartyId)
                     makeAckMessageForHeartbeatMessage(counterparties, session)?.let { ack -> messages.add(ack) }
                 }
                 is AuthenticatedMessageAndKey -> {

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
@@ -81,18 +81,14 @@ private fun recordInboundMessagesMetric(group: String?, subsystem: String, messa
     builder.build().increment()
 }
 
-fun recordOutboundSessionTimeoutMetric(source: HoldingIdentity, destination: HoldingIdentity) {
+fun recordOutboundSessionTimeoutMetric(source: HoldingIdentity) {
     CordaMetrics.Metric.OutboundSessionTimeoutCount.builder()
-        .withTag(CordaMetrics.Tag.SourceVirtualNode, source.x500Name.toString())
-        .withTag(CordaMetrics.Tag.DestinationVirtualNode, destination.x500Name.toString())
         .withTag(CordaMetrics.Tag.MembershipGroup, source.groupId)
         .build().increment()
 }
 
-fun recordInboundSessionTimeoutMetric(source: HoldingIdentity, destination: HoldingIdentity?) {
+fun recordInboundSessionTimeoutMetric(source: HoldingIdentity) {
     CordaMetrics.Metric.InboundSessionTimeoutCount.builder()
-        .withTag(CordaMetrics.Tag.SourceVirtualNode, source.x500Name.toString())
-        .withTag(CordaMetrics.Tag.DestinationVirtualNode, destination?.x500Name?.toString() ?: NOT_APPLICABLE_TAG_VALUE)
         .withTag(CordaMetrics.Tag.MembershipGroup, source.groupId)
         .build().increment()
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/metrics/MetricsHelpers.kt
@@ -13,38 +13,35 @@ const val HEARTBEAT_MESSAGE = "HeartbeatMessage"
 
 fun recordOutboundMessagesMetric(message: AuthenticatedMessage) {
     message.header.let {
-        recordOutboundMessagesMetric(it.source.x500Name, it.destination.x500Name, it.source.groupId,
+        recordOutboundMessagesMetric(it.source.groupId,
             it.subsystem, message::class.java.simpleName)
     }
 }
 
 fun recordOutboundMessagesMetric(message: OutboundUnauthenticatedMessage) {
     message.header.let {
-        recordOutboundMessagesMetric(it.source.x500Name, it.destination.x500Name, it.source.groupId,
+        recordOutboundMessagesMetric(it.source.groupId,
             it.subsystem, message::class.java.simpleName)
     }
 }
 
-fun recordOutboundSessionMessagesMetric(sourceVnode: HoldingIdentity, destinationVnode: HoldingIdentity) {
-    recordOutboundMessagesMetric(sourceVnode.x500Name.toString(), destinationVnode.x500Name.toString(), sourceVnode.groupId,
+fun recordOutboundSessionMessagesMetric(sourceVnode: HoldingIdentity) {
+    recordOutboundMessagesMetric(sourceVnode.groupId,
         P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
 }
 
-fun recordOutboundHeartbeatMessagesMetric(sourceVnode: HoldingIdentity, destinationVnode: HoldingIdentity) {
-    recordOutboundMessagesMetric(sourceVnode.x500Name.toString(), destinationVnode.x500Name.toString(), sourceVnode.groupId,
+fun recordOutboundHeartbeatMessagesMetric(sourceVnode: HoldingIdentity) {
+    recordOutboundMessagesMetric(sourceVnode.groupId,
         P2P_SUBSYSTEM, HEARTBEAT_MESSAGE)
 }
 
-fun recordOutboundSessionMessagesMetric(sourceVnode: net.corda.data.identity.HoldingIdentity,
-                                        destinationVnode: net.corda.data.identity.HoldingIdentity) {
-    recordOutboundMessagesMetric(sourceVnode.x500Name, destinationVnode.x500Name, sourceVnode.groupId,
+fun recordOutboundSessionMessagesMetric(sourceVnode: net.corda.data.identity.HoldingIdentity) {
+    recordOutboundMessagesMetric(sourceVnode.groupId,
         P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
 }
 
-fun recordOutboundMessagesMetric(source: String, dest: String, group: String, subsystem: String, messageType: String) {
+fun recordOutboundMessagesMetric(group: String, subsystem: String, messageType: String) {
     CordaMetrics.Metric.OutboundMessageCount.builder()
-        .withTag(CordaMetrics.Tag.SourceVirtualNode, source)
-        .withTag(CordaMetrics.Tag.DestinationVirtualNode, dest)
         .withTag(CordaMetrics.Tag.MembershipGroup, group)
         .withTag(CordaMetrics.Tag.MessagingSubsystem, subsystem)
         .withTag(CordaMetrics.Tag.MessageType, messageType)
@@ -53,33 +50,27 @@ fun recordOutboundMessagesMetric(source: String, dest: String, group: String, su
 
 fun recordInboundMessagesMetric(message: AuthenticatedMessage) {
     message.header.let {
-        recordInboundMessagesMetric(it.source.x500Name, it.destination.x500Name, it.source.groupId,
-            it.subsystem, message::class.java.simpleName)
+        recordInboundMessagesMetric(it.source.groupId, it.subsystem, message::class.java.simpleName)
     }
 }
 
 fun recordInboundMessagesMetric(message: InboundUnauthenticatedMessage) {
-    recordInboundMessagesMetric(null, null, null,
-        message.header.subsystem, message::class.java.simpleName)
+    recordInboundMessagesMetric(null, message.header.subsystem, message::class.java.simpleName)
 }
 
 fun recordInboundSessionMessagesMetric(datapoints: Int = 1) {
     repeat(datapoints) {
-        recordInboundMessagesMetric(null, null, null, P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
+        recordInboundMessagesMetric(null, P2P_SUBSYSTEM, SESSION_MESSAGE_TYPE)
     }
 }
 
-fun recordInboundHeartbeatMessagesMetric(sourceVnode: HoldingIdentity,
-                                         destinationVnode: HoldingIdentity) {
-    recordInboundMessagesMetric(sourceVnode.x500Name.toString(), destinationVnode.x500Name.toString(),
-        destinationVnode.groupId, P2P_SUBSYSTEM, HEARTBEAT_MESSAGE)
+fun recordInboundHeartbeatMessagesMetric(destinationVnode: HoldingIdentity) {
+    recordInboundMessagesMetric(destinationVnode.groupId, P2P_SUBSYSTEM, HEARTBEAT_MESSAGE)
 }
 
-private fun recordInboundMessagesMetric(source: String?, dest: String?, group: String?, subsystem: String, messageType: String) {
+private fun recordInboundMessagesMetric(group: String?, subsystem: String, messageType: String) {
     val builder = CordaMetrics.Metric.InboundMessageCount.builder()
     listOf(
-        CordaMetrics.Tag.SourceVirtualNode to source,
-        CordaMetrics.Tag.DestinationVirtualNode to dest,
         CordaMetrics.Tag.MembershipGroup to group,
         CordaMetrics.Tag.MessagingSubsystem to subsystem,
         CordaMetrics.Tag.MessageType to messageType,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -81,7 +81,7 @@ internal class OutboundMessageProcessor(
                 emptyList()
             } else {
                 state.messages.forEach {
-                    recordOutboundSessionMessagesMetric(state.sessionCounterparties.ourId, state.sessionCounterparties.counterpartyId)
+                    recordOutboundSessionMessagesMetric(state.sessionCounterparties.ourId)
                 }
                 state.messages.flatMap {
                     listOf(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -1284,7 +1284,7 @@ internal class SessionManagerImpl(
         private fun tearDownOutboundSession(counterparties: SessionCounterparties, sessionId: String) {
             destroyOutboundSession(counterparties, sessionId)
             trackedOutboundSessions.remove(sessionId)
-            recordOutboundSessionTimeoutMetric(counterparties.ourId, counterparties.counterpartyId)
+            recordOutboundSessionTimeoutMetric(counterparties.ourId)
         }
 
         private fun scheduleOutboundSessionTimeout(
@@ -1323,7 +1323,7 @@ internal class SessionManagerImpl(
                 )
                 destroyInboundSession(sessionId)
                 trackedInboundSessions.remove(sessionId)
-                recordInboundSessionTimeoutMetric(source, destination)
+                recordInboundSessionTimeoutMetric(source)
             } else {
                 scheduleInboundSessionTimeout(sessionId, source, destination, Duration.ofMillis(sessionTimeoutMs - timeSinceLastReceived))
             }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/SessionManagerImpl.kt
@@ -1466,7 +1466,7 @@ internal class SessionManagerImpl(
                     if (error != null) {
                         logger.warn("An exception was thrown when sending a heartbeat message.\nException:", error)
                     } else {
-                        recordOutboundHeartbeatMessagesMetric(source, dest)
+                        recordOutboundHeartbeatMessagesMetric(source)
                     }
                 }
             }

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -797,11 +797,6 @@ object CordaMetrics {
         SourceVirtualNode("virtualnode.source"),
 
         /**
-         * The destination virtual node in peer-to-peer communication.
-         */
-        DestinationVirtualNode("virtualnode.destination"),
-
-        /**
          * The ledger type.
          */
         LedgerType("ledger.type"),


### PR DESCRIPTION
## Changes
Removing the labels for source & destination vnode at the source (worker). Otherwise, when one is using `dropLabels` in the helm charts, these are filtered out but when that leads to multiple timeseries that are the same for the same time range one of them is kept and the rest dropped (see "Reduce labels" section [here](https://grafana.com/blog/2022/10/20/how-to-manage-high-cardinality-metrics-in-prometheus-and-kubernetes/#3-begin-optimizing-metrics)). In this case, this was leading to under-reporting of message data by a few orders of magnitude in cases where there were a lot of virtual nodes with roughly the same traffic.

## Testing
Tested by running the large network tests with the latest 5.2 release branch and this code.
Before (data and heartbeat messages):
![before_data_messages](https://github.com/corda/corda-runtime-os/assets/6065016/3f6367cb-72cd-499c-b89a-0246fbc2ad4e)

![before_heartbeat_messages](https://github.com/corda/corda-runtime-os/assets/6065016/e9695b24-d83e-4a58-8f33-ba74e747d17b)

After:
<img width="1128" alt="after_data_messages" src="https://github.com/corda/corda-runtime-os/assets/6065016/a41044e6-a2cf-4c06-a037-86069c85f308">

<img width="1129" alt="after_heartbeat_messages" src="https://github.com/corda/corda-runtime-os/assets/6065016/08b44720-009b-4def-87ec-57e7f85feb30">
