### PR TITLE
ES-1908 Filter metrics in Corda

### DIFF
--- a/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
+++ b/applications/workers/release/combined-worker/src/main/kotlin/net/corda/applications/workers/combined/CombinedWorker.kt
@@ -191,7 +191,12 @@ class CombinedWorker @Activate constructor(
             config.factory,
         ).run()
 
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
         configureTracing("Combined Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)
 

--- a/applications/workers/release/crypto-worker/src/main/kotlin/net/corda/applications/workers/crypto/CryptoWorker.kt
+++ b/applications/workers/release/crypto-worker/src/main/kotlin/net/corda/applications/workers/crypto/CryptoWorker.kt
@@ -71,7 +71,12 @@ class CryptoWorker @Activate constructor(
         if (params.hsmId.isBlank()) {
             throw IllegalStateException("Please specify which HSM the worker must handle, like --hsm-id SOFT")
         }
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("Crypto Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
+++ b/applications/workers/release/db-worker/src/main/kotlin/net/corda/applications/workers/db/DBWorker.kt
@@ -69,7 +69,12 @@ class DBWorker @Activate constructor(
         val params = getParams(args, DBWorkerParams())
 
         if (printHelpOrVersion(params.defaultParams, DBWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("DB Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/flow-mapper-worker/src/main/kotlin/net.corda.applications.workers.flow.mapper/FlowMapperWorker.kt
+++ b/applications/workers/release/flow-mapper-worker/src/main/kotlin/net.corda.applications.workers.flow.mapper/FlowMapperWorker.kt
@@ -66,7 +66,12 @@ class FlowMapperWorker @Activate constructor(
 
         val params = getParams(args, FlowMapperWorkerParams())
         if (printHelpOrVersion(params.defaultParams, FlowMapperWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("Flow Mapper Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
+++ b/applications/workers/release/flow-worker/src/main/kotlin/net/corda/applications/workers/flow/FlowWorker.kt
@@ -70,7 +70,12 @@ class FlowWorker @Activate constructor(
         val params = getParams(args, FlowWorkerParams())
 
         if (printHelpOrVersion(params.defaultParams, FlowWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("Flow Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/member-worker/src/main/kotlin/net/corda/applications/workers/member/MemberWorker.kt
+++ b/applications/workers/release/member-worker/src/main/kotlin/net/corda/applications/workers/member/MemberWorker.kt
@@ -59,7 +59,12 @@ class MemberWorker @Activate constructor(
 
         val params = getParams(args, MemberWorkerParams())
         if (printHelpOrVersion(params.defaultParams, MemberWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("Member Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/p2p-gateway-worker/src/main/kotlin/net.corda.applications.workers.p2p.gateway/GatewayWorker.kt
+++ b/applications/workers/release/p2p-gateway-worker/src/main/kotlin/net.corda.applications.workers.p2p.gateway/GatewayWorker.kt
@@ -57,7 +57,12 @@ class GatewayWorker @Activate constructor(
 
         val params = WorkerHelpers.getParams(args, GatewayWorkerParams())
         if (WorkerHelpers.printHelpOrVersion(params.defaultParams, this::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("P2P Gateway Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/p2p-link-manager-worker/src/main/kotlin/net.corda.applications.workers.p2p.linkmanager/LinkManagerWorker.kt
+++ b/applications/workers/release/p2p-link-manager-worker/src/main/kotlin/net.corda.applications.workers.p2p.linkmanager/LinkManagerWorker.kt
@@ -57,7 +57,12 @@ class LinkManagerWorker @Activate constructor(
 
         val params = WorkerHelpers.getParams(args, LinkManagerWorkerParams())
         if (WorkerHelpers.printHelpOrVersion(params.defaultParams, this::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("P2P Link Manager Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/persistence-worker/src/main/kotlin/net/corda/applications/workers/db/PersistenceWorker.kt
+++ b/applications/workers/release/persistence-worker/src/main/kotlin/net/corda/applications/workers/db/PersistenceWorker.kt
@@ -64,7 +64,12 @@ class PersistenceWorker @Activate constructor(
 
         val params = getParams(args, PersistenceWorkerParams())
         if (printHelpOrVersion(params.defaultParams, PersistenceWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("Persistence Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/rest-worker/src/main/kotlin/net/corda/applications/workers/rest/RestWorker.kt
+++ b/applications/workers/release/rest-worker/src/main/kotlin/net/corda/applications/workers/rest/RestWorker.kt
@@ -69,7 +69,12 @@ class RestWorker @Activate constructor(
         val params = getParams(args, RestWorkerParams())
         params.validate()
         if (printHelpOrVersion(params.defaultParams, RestWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("REST Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/token-selection-worker/src/main/kotlin/net/corda/applications/workers/token/selection/TokenSelectionWorker.kt
+++ b/applications/workers/release/token-selection-worker/src/main/kotlin/net/corda/applications/workers/token/selection/TokenSelectionWorker.kt
@@ -63,7 +63,12 @@ class TokenSelectionWorker @Activate constructor(
 
         val params = getParams(args, TokenSelectionWorkerParams())
         if (printHelpOrVersion(params.defaultParams, TokenSelectionWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("Token selection Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/uniqueness-worker/src/main/kotlin/net/corda/applications/workers/uniqueness/UniquenessWorker.kt
+++ b/applications/workers/release/uniqueness-worker/src/main/kotlin/net/corda/applications/workers/uniqueness/UniquenessWorker.kt
@@ -64,7 +64,12 @@ class UniquenessWorker @Activate constructor(
 
         val params = getParams(args, UniquenessWorkerParams())
         if (printHelpOrVersion(params.defaultParams, UniquenessWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("Uniqueness Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/release/verification-worker/src/main/kotlin/net/corda/applications/workers/verification/VerificationWorker.kt
+++ b/applications/workers/release/verification-worker/src/main/kotlin/net/corda/applications/workers/verification/VerificationWorker.kt
@@ -66,7 +66,12 @@ class VerificationWorker @Activate constructor(
 
         val params = getParams(args, VerificationWorkerParams())
         if (printHelpOrVersion(params.defaultParams, VerificationWorker::class.java, shutDownService)) return
-        Metrics.configure(webServer, this.javaClass.simpleName)
+        Metrics.configure(
+            webServer,
+            this.javaClass.simpleName,
+            params.defaultParams.metricsKeepNames?.toRegex(),
+            params.defaultParams.metricsDropLabels?.toRegex()
+        )
         Health.configure(webServer, lifecycleRegistry)
 
         configureTracing("Verification Worker", params.defaultParams.zipkinTraceUrl, params.defaultParams.traceSamplesPerSecond)

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/DefaultWorkerParams.kt
@@ -67,6 +67,14 @@ class DefaultWorkerParams(healthPortOverride: Int = WORKER_SERVER_PORT) {
             "defaults to 1 sample per second. Set to \"unlimited\" to record all samples"])
     var traceSamplesPerSecond: String? = null
 
+    @Option(names = ["--metrics-keep-names"], description = ["A regular expression for the names of metrics that " +
+            "Corda should keep; if unspecified, defaults to keeping all metrics"])
+    var metricsKeepNames: String? = null
+
+    @Option(names = ["--metrics-drop-labels"], description = ["A regular expression for the names of metric labels " +
+            "that Corda should drop; if unspecified, defaults to keeping all labels"])
+    var metricsDropLabels: String? = null
+
     // todo CORE-19372 remove this CLI arg, it will be replaced with config file
     @Option(
         names = ["--${BootConfig.BOOT_STATE_MANAGER}"],

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/Metrics.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/Metrics.kt
@@ -21,9 +21,9 @@ import org.slf4j.LoggerFactory
 object Metrics {
     private val logger = LoggerFactory.getLogger(Metrics::class.java)
     private val prometheusRegistry: PrometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-    fun configure(webServer: WebServer, name: String) {
+    fun configure(webServer: WebServer, name: String, keepNames: Regex?, dropLabels: Regex?) {
         logger.info("Creating Prometheus metric registry")
-        CordaMetrics.configure(name, prometheusRegistry)
+        CordaMetrics.configure(name, prometheusRegistry, keepNames, dropLabels)
 
         ClassLoaderMetrics().bindTo(CordaMetrics.registry)
         JvmMemoryMetrics().bindTo(CordaMetrics.registry)

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -561,17 +561,6 @@ metadata:
 spec:
   podMetricsEndpoints:
   - port: monitor
-    metricRelabelings:
-    {{- with .Values.metrics.podMonitor.keepNames }}
-    - sourceLabels:
-      - "__name__"
-      regex: {{ join "|" . | quote }}
-      action: "keep"
-    {{- end }}
-    {{- with .Values.metrics.podMonitor.dropLabels }}
-    - regex: {{ join "|" . | quote }}
-      action: "labeldrop"
-    {{- end }}
   jobLabel: {{ $.Release.Name }}-{{ include "corda.name" . }}
   selector:
     matchLabels:

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -351,6 +351,12 @@ spec:
           {{- if $.Values.tracing.samplesPerSecond }}
           - "--trace-samples-per-second={{ $.Values.tracing.samplesPerSecond }}"
           {{- end }}
+          {{- with $.Values.metrics.keepNames }}
+          - "--metrics-keep-names={{ join "|" . }}"
+          {{- end }}
+          {{- with $.Values.metrics.dropLabels }}
+          - "--metrics-drop-labels={{ join "|" . }}"
+          {{- end }}
           {{- if $optionalArgs.servicesAccessed }}
           {{- range $worker := $optionalArgs.servicesAccessed }}
           - "--serviceEndpoint={{ include "corda.getWorkerEndpoint" (dict "context" $ "worker" $worker) }}"

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -500,6 +500,24 @@
                         true
                     ]
                 },
+                "keepNames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "regex"
+                    },
+                    "title": "A list of regular expressions for the names of metrics that Corda should keep; if empty, all metrics are kept",
+                    "examples": [[ "jvm_.*" ]]
+                },
+                "dropLabels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "regex"
+                    },
+                    "title": "A list of regular expressions for labels that Corda should drop across all metrics; if empty, all labels are kept",
+                    "examples": [[ "virtualnode_destination" ]]
+                },
                 "podMonitor": {
                     "type": "object",
                     "default": {},
@@ -527,24 +545,6 @@
                                 ]
                             },
                             "examples": [{}]
-                        },
-                        "keepNames": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "format": "regex"
-                            },
-                            "title": "A list of regular expressions for the names of metrics that Prometheus should keep; if empty, all metrics are kept",
-                            "examples": [[ "jvm_.*" ]]
-                        },
-                        "dropLabels": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "format": "regex"
-                            },
-                            "title": "A list of regular expressions for labels that Prometheus should drop across all metrics; if empty, all labels are kept",
-                            "examples": [[ "virtualnode_destination" ]]
                         }
                     },
                     "examples": [

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -96,9 +96,7 @@ metrics:
     - "jvm_.*"
     - "process_cpu_usage"
   # -- A list of regular expressions for labels that Corda should drop across all metrics; if empty, all labels are kept
-  dropLabels:
-    - "virtualnode_destination"
-    - "virtualnode_source"
+  dropLabels: []
   # -- Pod monitor configuration for scraping metrics. Please note that the corresponding CRD must exist in the environment
   podMonitor:
     # -- Enable pod monitor creation to identify endpoints to scrape

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -72,39 +72,39 @@ logging:
 metrics:
   # -- enable scraping of worker metrics through Prometheus annotations
   scrape: true
+  # -- A list of regular expressions for the names of metrics that Corda should keep; if empty, all metrics are kept
+  keepNames:
+    - "corda_rpc_http_response_time_seconds_(count|sum|max)"
+    - "corda_token_selection_execution_time_seconds_(count|sum|max)"
+    - "corda_token_selection_db_execution_time_seconds_(count|sum|max)"
+    - "corda_flow_execution_time_seconds_(count|sum|max)"
+    - "corda_http_server_request_time_seconds_(count|sum|max)"
+    - "corda_p2p_gateway_inbound_request_time_seconds_(count|sum|max)"
+    - "corda_p2p_gateway_outbound_request_time_seconds_(count|sum|max)"
+    - "corda_p2p_gateway_outbound_tls_connections_total"
+    - "corda_p2p_message_outbound_total"
+    - "corda_p2p_message_outbound_replayed_total"
+    - "corda_p2p_message_outbound_latency_seconds_(count|sum|max)"
+    - "corda_p2p_message_inbound_total"
+    - "corda_p2p_session_outbound_total"
+    - "corda_p2p_session_inbound_total"
+    - "corda_membership_actions_handler_time_seconds_(count|sum|max)"
+    - "corda_consumer_poll_time_seconds_(count|sum|max)"
+    - "corda_messaging_commit_time_seconds_(count|sum|max)"
+    - "corda_messaging_processor_time_seconds_(count|sum|max)"
+    - "corda_taskmanager_.*"
+    - "jvm_.*"
+    - "process_cpu_usage"
+  # -- A list of regular expressions for labels that Corda should drop across all metrics; if empty, all labels are kept
+  dropLabels:
+    - "virtualnode_destination"
+    - "virtualnode_source"
   # -- Pod monitor configuration for scraping metrics. Please note that the corresponding CRD must exist in the environment
   podMonitor:
     # -- Enable pod monitor creation to identify endpoints to scrape
     enabled: false
     # -- Labels that can be used so PodMonitor is discovered by Prometheus
     labels: {}
-    # -- A list of regular expressions for the names of metrics that Prometheus should keep; if empty, all metrics are kept
-    keepNames:
-      - "corda_rpc_http_response_time_seconds_(count|sum|max)"
-      - "corda_token_selection_execution_time_seconds_(count|sum|max)"
-      - "corda_token_selection_db_execution_time_seconds_(count|sum|max)"
-      - "corda_flow_execution_time_seconds_(count|sum|max)"
-      - "corda_http_server_request_time_seconds_(count|sum|max)"
-      - "corda_p2p_gateway_inbound_request_time_seconds_(count|sum|max)"
-      - "corda_p2p_gateway_outbound_request_time_seconds_(count|sum|max)"
-      - "corda_p2p_gateway_outbound_tls_connections_total"
-      - "corda_p2p_message_outbound_total"
-      - "corda_p2p_message_outbound_replayed_total"
-      - "corda_p2p_message_outbound_latency_seconds_(count|sum|max)"
-      - "corda_p2p_message_inbound_total"
-      - "corda_p2p_session_outbound_total"
-      - "corda_p2p_session_inbound_total"
-      - "corda_membership_actions_handler_time_seconds_(count|sum|max)"
-      - "corda_consumer_poll_time_seconds_(count|sum|max)"
-      - "corda_messaging_commit_time_seconds_(count|sum|max)"
-      - "corda_messaging_processor_time_seconds_(count|sum|max)"
-      - "corda_taskmanager_.*"
-      - "jvm_.*"
-      - "process_cpu_usage"
-    # -- A list of regular expressions for labels that Prometheus should drop across all metrics; if empty, all labels are kept
-    dropLabels:
-      - "virtualnode_destination"
-      - "virtualnode_source"
 
 # Distributed tracing configuration
 tracing:

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -1,6 +1,5 @@
 package net.corda.metrics
 
-import io.micrometer.core.instrument.Tag as micrometerTag
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.Gauge
@@ -19,6 +18,7 @@ import java.nio.file.Path
 import java.util.function.Supplier
 import java.util.function.ToDoubleFunction
 import java.util.function.ToLongFunction
+import io.micrometer.core.instrument.Tag as micrometerTag
 
 
 object CordaMetrics {
@@ -932,9 +932,11 @@ object CordaMetrics {
      *
      * @param workerType Type of Worker, will be tagged to each metric.
      * @param registry Registry instance
+     * @param keepNames Regular expression of metric names to keep
+     * @param dropLabels Regular expression of metric labels to drop
      */
-    fun configure(workerType: String, registry: MeterRegistry) {
-        this.registry.add(registry).config()
+    fun configure(workerType: String, registry: MeterRegistry, keepNames: Regex?, dropLabels: Regex?) {
+        val config = this.registry.add(registry).config()
             .commonTags(Tag.WorkerType.value, workerType)
             .meterFilter(object : MeterFilter {
                 override fun map(id: Meter.Id): Meter.Id {
@@ -952,6 +954,20 @@ object CordaMetrics {
                     }
                 }
             })
+        if (keepNames != null) {
+            config.meterFilter(MeterFilter.denyUnless {
+                registry.config().namingConvention().name(it.name, it.type, it.baseUnit).matches(keepNames)
+            })
+        }
+        if (dropLabels != null) {
+            config.meterFilter(object : MeterFilter {
+                override fun map(id: Meter.Id): Meter.Id {
+                    return id.replaceTags(id.tags.filter {
+                        !registry.config().namingConvention().tagKey(it.key).matches(dropLabels)
+                    })
+                }
+            })
+        }
     }
 
     private fun timer(name: String, tags: Iterable<micrometerTag>): Timer {

--- a/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/AllTestsCordaMetrics.kt
+++ b/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/AllTestsCordaMetrics.kt
@@ -19,7 +19,7 @@ class AllTestsCordaMetrics(
     constructor(workerType: String) : this(workerType, SimpleMeterRegistry())
 
     override fun beforeAll(ctx: ExtensionContext) {
-        CordaMetrics.configure(workerType, registry)
+        CordaMetrics.configure(workerType, registry, null, null)
         assertEquals(1, CordaMetrics.registry.registries.size)
     }
 

--- a/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/EachTestCordaMetrics.kt
+++ b/testing/test-utilities/src/main/kotlin/net/corda/test/util/metrics/EachTestCordaMetrics.kt
@@ -18,7 +18,7 @@ class EachTestCordaMetrics(
     constructor(workerType: String) : this(workerType, SimpleMeterRegistry())
 
     override fun beforeEach(ctx: ExtensionContext) {
-        CordaMetrics.configure(workerType, registry)
+        CordaMetrics.configure(workerType, registry, null, null)
         assertEquals(1, CordaMetrics.registry.registries.size)
     }
 


### PR DESCRIPTION
Move metric filtering from pod monitor to Corda to avoid issues with growth in unused metrics and data loss when dropping labels.