### PR TITLE
CORE-19461: state for individual rotations complete (CryptoRewrapBusProcessor)

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
@@ -4,6 +4,8 @@ import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.crypto.core.CryptoService
+import net.corda.crypto.core.KeyRotationMetadataValues
+import net.corda.crypto.core.KeyRotationStatus
 import net.corda.data.crypto.wire.ops.key.rotation.IndividualKeyRotationRequest
 import net.corda.data.crypto.wire.ops.key.rotation.KeyType
 import net.corda.data.crypto.wire.ops.key.status.ManagedKeyStatus
@@ -12,9 +14,14 @@ import net.corda.libs.statemanager.api.Metadata
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
 import net.corda.messaging.api.records.Record
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -24,6 +31,21 @@ import java.time.Instant
 import java.util.UUID
 
 class CryptoRewrapBusProcessorTests {
+    private lateinit var unmanagedKeysSerialized: MutableList<UnmanagedKeyStatus>
+    private lateinit var unmanagedSerializer: CordaAvroSerializer<UnmanagedKeyStatus>
+    private lateinit var unmanagedDeserializer: CordaAvroDeserializer<UnmanagedKeyStatus>
+    private lateinit var unmanagedCordaAvroSerializationFactory: CordaAvroSerializationFactory
+    private lateinit var unmanagedCryptoRewrapBusProcessor: CryptoRewrapBusProcessor
+    private lateinit var managedKeysSerialized: MutableList<ManagedKeyStatus>
+    private lateinit var managedSerializer: CordaAvroSerializer<ManagedKeyStatus>
+    private lateinit var managedDeserializer: CordaAvroDeserializer<ManagedKeyStatus>
+    private lateinit var managedCordaAvroSerializationFactory: CordaAvroSerializationFactory
+    private lateinit var cryptoService: CryptoService
+    private lateinit var stateManagerUpdateCapture: KArgumentCaptor<Collection<State>>
+    private lateinit var stateManagerDeleteCapture: KArgumentCaptor<Collection<State>>
+    private lateinit var stateManager: StateManager
+    private lateinit var managedCryptoRewrapBusProcessor: CryptoRewrapBusProcessor
+
     companion object {
         private val tenantId = UUID.randomUUID().toString()
         private const val OLD_PARENT_KEY_ALIAS = "alias1"
@@ -31,63 +53,80 @@ class CryptoRewrapBusProcessorTests {
         private const val WRAPPING_KEY_ALIAS = "alias"
     }
 
-    private val unmanagedSerializer = mock<CordaAvroSerializer<UnmanagedKeyStatus>> {
-        on { serialize(any()) } doReturn byteArrayOf(42)
-    }
-    private val unmanagedDeserializer = mock<CordaAvroDeserializer<UnmanagedKeyStatus>> {
-        on { deserialize(any()) } doReturn UnmanagedKeyStatus(
-            OLD_PARENT_KEY_ALIAS,
-            NEW_PARENT_KEY_ALIAS,
-            tenantId,
-            10,
-            5,
-            Instant.now()
-        )
-    }
-    private val unmanagedCordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
-        on { createAvroSerializer<UnmanagedKeyStatus>() } doReturn unmanagedSerializer
-        on { createAvroDeserializer<UnmanagedKeyStatus>(any(), any()) } doReturn unmanagedDeserializer
-    }
-
-    private val managedSerializer = mock<CordaAvroSerializer<ManagedKeyStatus>> {
-        on { serialize(any()) } doReturn byteArrayOf(42)
-    }
-    private val managedDeserializer = mock<CordaAvroDeserializer<ManagedKeyStatus>> {
-        on { deserialize(any()) } doReturn ManagedKeyStatus(
-            WRAPPING_KEY_ALIAS,
-            10,
-            5,
-            Instant.now()
-        )
-    }
-    private val managedCordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
-        on { createAvroSerializer<ManagedKeyStatus>() } doReturn managedSerializer
-        on { createAvroDeserializer<ManagedKeyStatus>(any(), any()) } doReturn managedDeserializer
-    }
-
-    private val cryptoService: CryptoService = mock<CryptoService> { }
-    private val stateManager = mock<StateManager> {
-        on { get(any()) } doReturn mapOf(
-            OLD_PARENT_KEY_ALIAS + tenantId + "keyRotation" to State(
-                OLD_PARENT_KEY_ALIAS + tenantId + "keyRotation",
-                "random".toByteArray(),
-                0,
-                Metadata(mapOf("status" to "In Progress"))
+    @BeforeEach
+    fun setup() {
+        unmanagedKeysSerialized = mutableListOf()
+        unmanagedSerializer = mock<CordaAvroSerializer<UnmanagedKeyStatus>> {
+            on { serialize(any()) } doAnswer { args ->
+                unmanagedKeysSerialized.add(args.arguments[0] as UnmanagedKeyStatus)
+                byteArrayOf(42)
+            }
+        }
+        unmanagedDeserializer = mock<CordaAvroDeserializer<UnmanagedKeyStatus>> {
+            on { deserialize(any()) } doReturn UnmanagedKeyStatus(
+                OLD_PARENT_KEY_ALIAS,
+                NEW_PARENT_KEY_ALIAS,
+                tenantId,
+                10,
+                5,
+                Instant.now()
             )
+        }
+        unmanagedCordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
+            on { createAvroSerializer<UnmanagedKeyStatus>() } doReturn unmanagedSerializer
+            on { createAvroDeserializer<UnmanagedKeyStatus>(any(), any()) } doReturn unmanagedDeserializer
+        }
+
+        managedKeysSerialized = mutableListOf()
+        managedSerializer = mock<CordaAvroSerializer<ManagedKeyStatus>> {
+            on { serialize(any()) } doAnswer { args ->
+                managedKeysSerialized.add(args.arguments[0] as ManagedKeyStatus)
+                byteArrayOf(42)
+            }
+        }
+        managedDeserializer = mock<CordaAvroDeserializer<ManagedKeyStatus>> {
+            on { deserialize(any()) } doReturn ManagedKeyStatus(
+                WRAPPING_KEY_ALIAS,
+                10,
+                5,
+                Instant.now()
+            )
+        }
+        managedCordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {
+            on { createAvroSerializer<ManagedKeyStatus>() } doReturn managedSerializer
+            on { createAvroDeserializer<ManagedKeyStatus>(any(), any()) } doReturn managedDeserializer
+        }
+
+        cryptoService = mock {
+            on { rewrapAllSigningKeysWrappedBy(any(), any()) } doReturn 5
+        }
+        stateManagerUpdateCapture = argumentCaptor()
+        stateManagerDeleteCapture = argumentCaptor()
+        stateManager = mock<StateManager> {
+            on { get(any()) } doReturn mapOf(
+                OLD_PARENT_KEY_ALIAS + tenantId + "keyRotation" to State(
+                    OLD_PARENT_KEY_ALIAS + tenantId + "keyRotation",
+                    "random".toByteArray(),
+                    0,
+                    Metadata(mapOf(KeyRotationMetadataValues.STATUS to KeyRotationStatus.IN_PROGRESS))
+                )
+            )
+            on { update(stateManagerUpdateCapture.capture()) } doReturn emptyMap()
+            on { delete(stateManagerDeleteCapture.capture()) } doReturn emptyMap()
+        }
+
+        unmanagedCryptoRewrapBusProcessor = CryptoRewrapBusProcessor(
+            cryptoService,
+            stateManager,
+            unmanagedCordaAvroSerializationFactory
+        )
+
+        managedCryptoRewrapBusProcessor = CryptoRewrapBusProcessor(
+            cryptoService,
+            stateManager,
+            managedCordaAvroSerializationFactory
         )
     }
-
-    private val unmanagedCryptoRewrapBusProcessor = CryptoRewrapBusProcessor(
-        cryptoService,
-        stateManager,
-        unmanagedCordaAvroSerializationFactory
-    )
-
-    private val managedCryptoRewrapBusProcessor = CryptoRewrapBusProcessor(
-        cryptoService,
-        stateManager,
-        managedCordaAvroSerializationFactory
-    )
 
     @Test
     fun `unmanaged rewrap calls rewrapWrappingKey in crypto service`() {
@@ -575,5 +614,40 @@ class CryptoRewrapBusProcessorTests {
 
         verify(cryptoService, never()).rewrapWrappingKey(any(), any(), any())
         verify(stateManager, never()).update(any())
+    }
+
+    @Test
+    fun `managed key rotation rewraps all keys and writes state`() {
+        val uuid = UUID.randomUUID()
+        managedCryptoRewrapBusProcessor.onNext(
+            listOf(
+                Record(
+                    "TBC",
+                    UUID.randomUUID().toString(),
+                    IndividualKeyRotationRequest(
+                        UUID.randomUUID().toString(),
+                        tenantId,
+                        null,
+                        null,
+                        null,
+                        uuid.toString(),
+                        KeyType.MANAGED
+                    )
+                )
+            )
+        )
+        verify(stateManager, times(1)).get(any())
+        verify(stateManager, times(1)).update(any())
+
+        assertThat(stateManagerUpdateCapture.firstValue).size().isEqualTo(1)
+        stateManagerUpdateCapture.firstValue.forEachIndexed { index, it ->
+            assertThat(it.metadata[KeyRotationMetadataValues.STATUS]).isEqualTo(KeyRotationStatus.DONE)
+
+            val managedKeyStatus = (managedKeysSerialized[index] as? ManagedKeyStatus)
+            assertThat(managedKeyStatus).isNotNull()
+            assertThat(managedKeyStatus!!.wrappingKeyAlias).isEqualTo(WRAPPING_KEY_ALIAS)
+            assertThat(managedKeyStatus.rotatedKeys).isEqualTo(10)
+            assertThat(managedKeyStatus.total).isEqualTo(10)
+        }
     }
 }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -691,7 +691,7 @@ open class SoftCryptoService(
         return Pair(wrappingKeyUUID, wrappingKey)
     }
 
-    override fun rewrapAllSigningKeysWrappedBy(managedWrappingKeyId: UUID, tenantId: String) {
+    override fun rewrapAllSigningKeysWrappedBy(managedWrappingKeyId: UUID, tenantId: String): Int {
         wrappingRepositoryFactory.create(tenantId).use { wrappingRepo ->
             val oldWrappingKeyInfo = checkNotNull(wrappingRepo.getKeyById(managedWrappingKeyId)) {
                 "Unable to find existing wrapping key with id ${managedWrappingKeyId} for tenantId ${tenantId}"
@@ -703,6 +703,7 @@ open class SoftCryptoService(
             val createdWrappingKey = createWrappingKeyFrom(wrappingRepo, oldWrappingKeyInfo)
             val newWrappingUuid = createdWrappingKey.first
             val newWrappingKeyDecrypted = createdWrappingKey.second
+            var rewrappedKeys = 0
             signingRepositoryFactory.getInstance(tenantId).use { signingRepo ->
                 // Get signing materials which use the old wrapping uuid, passed in as wrappingKeyUuid
                 signingRepo.getKeyMaterials(managedWrappingKeyId).forEach { oldSigningKeyMaterial ->
@@ -712,8 +713,10 @@ open class SoftCryptoService(
                         newSigningKeyMaterial
                     )
                     signingRepo.saveSigningKeyMaterial(newSigningKeyMaterialInfo, newWrappingUuid)
+                    rewrappedKeys++
                 }
             }
+            return rewrappedKeys
         }
     }
 }

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoService.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoService.kt
@@ -353,6 +353,8 @@ interface CryptoService {
      *
      * @param managedWrappingKeyId The managed wrapping key which is being rotated away from
      * @param tenantId The tenant Id which uses the specified wrapping key
+     *
+     * @return The number of keys rewrapped
      */
-    fun rewrapAllSigningKeysWrappedBy(managedWrappingKeyId: UUID, tenantId: String)
+    fun rewrapAllSigningKeysWrappedBy(managedWrappingKeyId: UUID, tenantId: String): Int
 }


### PR DESCRIPTION
This PR handles the state manager updates of managed key rotation. The testing used by the class also had to change how its serializers were generated, as both the strategy used previously and the strategy used in https://github.com/corda/corda-runtime-os/pull/5539 did not work. The previous strategy didn't work with multiple serializer types being returned, as mockito did not allow us to change based on generics, and the strategy used in the linked PR did not allow for the return of multiple deserialisers, so this PR had to switch to having multiple factories, one for managed tests and another for unmanaged tests.