### PR TITLE
CORE-18929 make external event id deterministic based on suspension and invocation count rather than hashcode

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -55,7 +55,7 @@ class FlowCheckpointImpl(
     }
 
     private var deleted = false
-    private val ledgerSaltIncrementor = AtomicInteger(0)
+    private val atomicInMemCounter = AtomicInteger(0)
 
     private val flowInitialisedOnCreation = checkpoint.flowState != null
 
@@ -148,8 +148,8 @@ class FlowCheckpointImpl(
         get() = checkNotNull(flowStateManager)
         { "Attempt to access context before flow state has been created" }.suspendCount
 
-    override val ledgerSaltCounter: Int
-        get() = ledgerSaltIncrementor.getAndIncrement()
+    override val counter: Int
+        get() = atomicInMemCounter.getAndIncrement()
 
     override fun initFlowState(flowStartContext: FlowStartContext, cpkFileHashes: Set<SecureHash>) {
         if (flowStateManager != null) {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/external/events/impl/executor/ExternalEventExecutorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/external/events/impl/executor/ExternalEventExecutorImplTest.kt
@@ -33,11 +33,13 @@ class ExternalEventExecutorImplTest {
 
     private fun initializeMocks(
         flowId: String = testFlowId,
-        suspendCount: Int = 1
+        suspendCount: Int = 1,
+        counter: Int = 1
     ) {
         mockFlowFiberService = MockFlowFiberService()
         whenever(mockFlowFiberService.flowCheckpoint.flowId).thenReturn(flowId)
         whenever(mockFlowFiberService.flowCheckpoint.suspendCount).thenReturn(suspendCount)
+        whenever(mockFlowFiberService.flowCheckpoint.counter).thenReturn(counter)
 
         // Capture arguments (ArgumentCaptor doesn't play nice with suspending functions)
         doAnswer { invocation ->
@@ -58,7 +60,7 @@ class ExternalEventExecutorImplTest {
 
         val expectedRequest = FlowIORequest.ExternalEvent(
             // This is hardcoded, but should be deterministic!
-            "26ec4282-eebc-358d-9ac3-6e32ca1b103b",
+            "5d6010d4-b4b8-31ee-ae36-5771f68a8ca4",
             mockFactoryClass, mockParams, contextProperties
         )
 
@@ -69,7 +71,7 @@ class ExternalEventExecutorImplTest {
     }
 
     @Test
-    fun `Suspending with the same parameters, flowId, and suspensionCount produces the same requestID`() {
+    fun `Suspending with the same counter, flowId, and suspensionCount produces the same requestID`() {
         externalEventExecutorImpl.execute(mockFactoryClass, mockParams)
         externalEventExecutorImpl.execute(mockFactoryClass, mockParams)
 
@@ -78,14 +80,14 @@ class ExternalEventExecutorImplTest {
     }
 
     @Test
-    fun `Suspending with different parameters produces a different requestID`() {
+    fun `Suspending with different counter produces a different requestID`() {
         externalEventExecutorImpl.execute(mockFactoryClass, mockParams)
-        externalEventExecutorImpl.execute(mockFactoryClass, mockParams + mapOf("additional" to "data"))
+        whenever(mockFlowFiberService.flowCheckpoint.counter).thenReturn(2)
+        externalEventExecutorImpl.execute(mockFactoryClass, mockParams)
 
         assertEquals(2, capturedArguments.size)
         assertNotEquals(capturedArguments[0].requestId, capturedArguments[1].requestId)
     }
-
 
     @Test
     fun `Suspending with a different flowId produces a different requestID`() {

--- a/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/PrivacySaltProviderServiceImpl.kt
+++ b/components/ledger/ledger-common-flow/src/main/kotlin/net/corda/ledger/common/flow/impl/transaction/PrivacySaltProviderServiceImpl.kt
@@ -18,7 +18,7 @@ class PrivacySaltProviderServiceImpl @Activate constructor(
         val flowCheckpoint = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint
         val flowID = flowCheckpoint.flowId
         val suspendCount = flowCheckpoint.suspendCount
-        val saltCounter = flowCheckpoint.ledgerSaltCounter
+        val saltCounter = flowCheckpoint.counter
         val input = "$flowID-$suspendCount-$saltCounter"
         return PrivacySaltImpl(input.toByteArray())
     }

--- a/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/PrivacySaltProviderServiceImplTest.kt
+++ b/components/ledger/ledger-common-flow/src/test/kotlin/net/corda/ledger/common/flow/impl/transaction/PrivacySaltProviderServiceImplTest.kt
@@ -18,7 +18,7 @@ internal class PrivacySaltProviderServiceImplTest : CommonLedgerTest() {
 
         whenever(checkpoint.flowId).thenReturn(flowId)
         whenever(checkpoint.suspendCount).thenReturn(suspendCount)
-        whenever(checkpoint.ledgerSaltCounter).thenReturn(ledgerSaltCounter)
+        whenever(checkpoint.counter).thenReturn(ledgerSaltCounter)
     }
 
     @Test
@@ -58,7 +58,7 @@ internal class PrivacySaltProviderServiceImplTest : CommonLedgerTest() {
 
         val ledgerSaltCounter = 2
         val checkpoint = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint
-        whenever(checkpoint.ledgerSaltCounter).thenReturn(ledgerSaltCounter)
+        whenever(checkpoint.counter).thenReturn(ledgerSaltCounter)
 
         val transaction2 = privacySaltProviderService.generatePrivacySalt()
         Assertions.assertThat(transaction1).isNotEqualTo(transaction2)

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
@@ -55,10 +55,9 @@ interface FlowCheckpoint : NonSerializable {
 
     /**
      * In memory counter used to generate unique and deterministic inputs into ledger PrivacySalts
-     * when multiple transactions are created within a single suspension.
-     * This is not saved to the AVRO object. It only needs to be unique per suspension.
+     * and external event ids generated within the same suspension.
      */
-    val ledgerSaltCounter: Int
+    val counter: Int
 
     fun initFlowState(flowStartContext: FlowStartContext, cpkFileHashes: Set<SecureHash>)
 


### PR DESCRIPTION
 make external event id deterministic based on suspension and invocation count rather than hashcode
 
hashcode is non deterministic.

It is not possible to serialize the parameters object as it may contain non serializable data

change the name of the counter to be generic, as it is no longer only incremented in the ledger.

Known issue: If a flow reruns in a non deterministic way and executes a different ext event call it will be detected as a duplicate call