### PR TITLE
CORE-19415: Fix issues with stateful session manager, upgrade postgresql version

### DIFF
--- a/applications/tools/p2p-test/app-simulator/charts/app-simulator-db/Chart.yaml
+++ b/applications/tools/p2p-test/app-simulator/charts/app-simulator-db/Chart.yaml
@@ -8,5 +8,5 @@ appVersion: "5.0.0"
 
 dependencies:
   - name: postgresql
-    version: 11.9.13
+    version: 13.4.1
     repository: https://charts.bitnami.com/bitnami

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
@@ -102,14 +102,14 @@ internal class StatefulSessionManagerImpl(
 
         val cachedSessions = getCachedOutboundSessions(keysToMessages)
 
-        val keysNotInCache = (keysToMessages - cachedSessions.keys).keys
+        val notInCache = (keysToMessages - cachedSessions.keys)
         val sessionStates =
-            if (keysNotInCache.isNotEmpty()) {
+            if (notInCache.isNotEmpty()) {
                 sessionExpiryScheduler.checkStatesValidateAndRememberThem(
-                    stateManager.get(keysNotInCache.filterNotNull()),
+                    stateManager.get(notInCache.keys.filterNotNull()),
                 )
                     .let { states ->
-                        keysToMessages.map { (id, items) ->
+                        notInCache.map { (id, items) ->
                             OutboundMessageState(
                                 id,
                                 states[id],
@@ -226,9 +226,11 @@ internal class StatefulSessionManagerImpl(
         if (uuids.isEmpty()) {
             return emptyList()
         }
-        val traceable = uuids.associateBy { getSessionId(it) }
-        val allCached = traceable.mapNotNull { (key, trace) ->
-            getSessionIfCached(key)?.let { key to Pair(trace, it) }
+        val traceable = uuids.groupBy { getSessionId(it) }
+        val allCached = traceable.mapNotNull { (key, traces) ->
+            getSessionIfCached(key)?.let { sessionDirection ->
+                key to (traces to sessionDirection)
+            }
         }.toMap()
         val sessionIdsNotInCache = (traceable - allCached.keys)
         val inboundSessionsFromStateManager = if (sessionIdsNotInCache.isEmpty()) {
@@ -245,14 +247,14 @@ internal class StatefulSessionManagerImpl(
                             sessionManagerImpl.revocationCheckerClient::checkRevocation,
                         ).sessionData as? Session
                     session?.let {
-                        sessionIdsNotInCache[sessionId]?.let {
+                        sessionIdsNotInCache[sessionId]?.let { traceables ->
                             val inboundSession =
                                 SessionManager.SessionDirection.Inbound(
                                     state.toCounterparties(),
                                     session,
                                 )
                             cachedInboundSessions.put(sessionId, inboundSession)
-                            it to inboundSession
+                            traceables to inboundSession
                         }
                     }
                 }
@@ -290,7 +292,11 @@ internal class StatefulSessionManagerImpl(
                 }
         }
 
-        return allCached.values + inboundSessionsFromStateManager + outboundSessionsFromStateManager
+        return (allCached.values + inboundSessionsFromStateManager + outboundSessionsFromStateManager).flatMap {  (traceables, direction) ->
+            traceables.map {
+                it to direction
+            }
+        }
     }
 
     override fun <T> processSessionMessages(


### PR DESCRIPTION
This should fix a few issues:
1. The Bitnami PostgreSQL version is no longer available.
2. The processOutboundMessages retired the cached messages twice.
3. When we called the `getSessionsById` with two messages with the same session, it returned only one.