### PR TITLE
ES-1828: Gradle plugin deploy CPI with static network

### DIFF
--- a/tools/corda-runtime-gradle-plugin/README.md
+++ b/tools/corda-runtime-gradle-plugin/README.md
@@ -8,6 +8,7 @@ Add the following extension properties
 ```groovy
     cordaRuntimeGradlePlugin {
         combinedWorkerVersion = "5.2.0.0"
+        notaryVersion = "5.2.0.0"
         postgresJdbcVersion = "42.7.1"
         notaryCpiName = "NotaryServer"
         corDappCpiName = "MyCorDapp"

--- a/tools/corda-runtime-gradle-plugin/README.md
+++ b/tools/corda-runtime-gradle-plugin/README.md
@@ -8,7 +8,16 @@ Add the following extension properties
 ```groovy
     cordaRuntimeGradlePlugin {
         combinedWorkerVersion = "5.2.0.0"
-        postgresJdbcVersion = "42.6.0"
+        postgresJdbcVersion = "42.7.1"
+        notaryCpiName = "NotaryServer"
+        corDappCpiName = "MyCorDapp"
+        cpiUploadTimeout = "30000"
+        vnodeRegistrationTimeout = "60000"
+        cordaProcessorTimeout = "300000"
+        workflowsModuleName = "workflows"
+        networkConfigFile = "config/static-network-config.json"
+        r3RootCertFile = "config/r3-ca-key.pem"
+        skipTestsDuringBuildCpis = "false"
         // Only need to supply these if you want to use an unpublished version
         artifactoryUsername = findProperty('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
         artifactoryPassword = findProperty('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')

--- a/tools/corda-runtime-gradle-plugin/build.gradle
+++ b/tools/corda-runtime-gradle-plugin/build.gradle
@@ -17,7 +17,8 @@ repositories {
 }
 
 dependencies {
-    api libs.junit.api
+    implementation libs.unirest.java
+    implementation libs.unirest.objectmapper.jackson
     testImplementation libs.bundles.test
 }
 

--- a/tools/corda-runtime-gradle-plugin/src/integrationTest/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupHelperTests.kt
+++ b/tools/corda-runtime-gradle-plugin/src/integrationTest/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupHelperTests.kt
@@ -12,9 +12,17 @@ class EnvironmentSetupHelperTests {
     @TempDir
     lateinit var tempDir: Path
 
+    private val publicVersion = "5.1.0.0"
+    private val hcVersion = "5.1.0.0-HC15"
+    private val rcVersion = "5.1.0.0-RC03"
+    private val alphaVersion = "5.2.0.0-alpha-1706270718014"
+    private val betaVersion = "5.2.0.0-beta-1706271586528"
+    private val cordaArtifactoryUsername = System.getProperty("cordaArtifactoryUsername")
+    private val cordaArtifactoryPassword = System.getProperty("cordaArtifactoryPassword")
+
     @Test
     fun downloadCombinedWorkerFromGitHub() {
-        val version = "5.1.0.0"
+        val version = publicVersion
         val fileName = "corda-combined-worker-$version.jar"
         val targetFile = File("$tempDir/$fileName")
         EnvironmentSetupHelper().downloadCombinedWorker(
@@ -30,9 +38,7 @@ class EnvironmentSetupHelperTests {
 
     @Test
     fun downloadCombinedWorkerHC() {
-        val username = System.getProperty("cordaArtifactoryUsername")
-        val password = System.getProperty("cordaArtifactoryPassword")
-        val version = "5.1.0.0-HC15"
+        val version = hcVersion
         val fileName = "corda-combined-worker-$version.jar"
         val targetFile = File("$tempDir/$fileName")
         EnvironmentSetupHelper().downloadCombinedWorker(
@@ -40,17 +46,15 @@ class EnvironmentSetupHelperTests {
             version,
             "release-$version",
             targetFile.path,
-            username,
-            password
+            cordaArtifactoryUsername,
+            cordaArtifactoryPassword
         )
         assertTrue(targetFile.exists(), "The HC combined worker file should have been downloaded from Artifactory")
     }
 
     @Test
     fun downloadCombinedWorkerRC() {
-        val username = System.getProperty("cordaArtifactoryUsername")
-        val password = System.getProperty("cordaArtifactoryPassword")
-        val version = "5.1.0.0-RC03"
+        val version = rcVersion
         val fileName = "corda-combined-worker-$version.jar"
         val targetFile = File("$tempDir/$fileName")
         EnvironmentSetupHelper().downloadCombinedWorker(
@@ -58,17 +62,15 @@ class EnvironmentSetupHelperTests {
             version,
             "release-$version",
             targetFile.path,
-            username,
-            password
+            cordaArtifactoryUsername,
+            cordaArtifactoryPassword
         )
         assertTrue(targetFile.exists(), "The RC combined worker file should have been downloaded from Artifactory")
     }
 
     @Test
     fun downloadCombinedWorkerAlpha() {
-        val username = System.getProperty("cordaArtifactoryUsername")
-        val password = System.getProperty("cordaArtifactoryPassword")
-        val version = "5.2.0.0-alpha-1706270718014"
+        val version = alphaVersion
         val fileName = "corda-combined-worker-$version.jar"
         val targetFile = File("$tempDir/$fileName")
         EnvironmentSetupHelper().downloadCombinedWorker(
@@ -76,17 +78,15 @@ class EnvironmentSetupHelperTests {
             version,
             "release-$version",
             targetFile.path,
-            username,
-            password
+            cordaArtifactoryUsername,
+            cordaArtifactoryPassword
         )
         assertTrue(targetFile.exists(), "The alpha combined worker file should have been downloaded from Artifactory")
     }
 
     @Test
     fun downloadCombinedWorkerBeta() {
-        val username = System.getProperty("cordaArtifactoryUsername")
-        val password = System.getProperty("cordaArtifactoryPassword")
-        val version = "5.2.0.0-beta-1706271586528"
+        val version = betaVersion
         val fileName = "corda-combined-worker-$version.jar"
         val targetFile = File("$tempDir/$fileName")
         EnvironmentSetupHelper().downloadCombinedWorker(
@@ -94,20 +94,115 @@ class EnvironmentSetupHelperTests {
             version,
             "release-$version",
             targetFile.path,
-            username,
-            password
+            cordaArtifactoryUsername,
+            cordaArtifactoryPassword
         )
         assertTrue(targetFile.exists(), "The beta combined worker file should have been downloaded from Artifactory")
     }
 
     @Test
     fun unableToDownloadUnpublishedCombinedWorkerWithoutCredentials() {
-        val version = "5.2.0.0-beta-1706271586528"
+        val version = betaVersion
         val fileName = "corda-combined-worker-$version.jar"
         val targetFile = File("$tempDir/$fileName")
         val exception = assertThrows<CordaRuntimeGradlePluginException> {
             EnvironmentSetupHelper().downloadCombinedWorker(
                 fileName,
+                version,
+                "release-$version",
+                targetFile.path,
+                "",
+                ""
+            )
+        }
+        assertTrue(
+            exception.message!!.contains("require a username and password"),
+            "We should not be able to download an unpublished version without credentials"
+        )
+    }
+
+    @Test
+    fun downloadNotaryServerCpbFromGitHub() {
+        val version = publicVersion
+        val fileName = "notary-plugin-non-validating-server-$version-package.cpb"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadNotaryCpb(
+            version,
+            "release-$version",
+            targetFile.path,
+            "",
+            ""
+        )
+        assertTrue(targetFile.exists(), "The notary server cpb file should have been downloaded from GitHub")
+    }
+
+    @Test
+    fun downloadNotaryServerCpbHC() {
+        val version = hcVersion
+        val fileName = "notary-plugin-non-validating-server-$version-package.cpb"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadNotaryCpb(
+            version,
+            "release-$version",
+            targetFile.path,
+            cordaArtifactoryUsername,
+            cordaArtifactoryPassword
+        )
+        assertTrue(targetFile.exists(), "The HC notary server cpb file should have been downloaded from Artifactory")
+    }
+
+    @Test
+    fun downloadNotaryServerCpbRC() {
+        val version = rcVersion
+        val fileName = "notary-plugin-non-validating-server-$version-package.cpb"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadNotaryCpb(
+            version,
+            "release-$version",
+            targetFile.path,
+            cordaArtifactoryUsername,
+            cordaArtifactoryPassword
+        )
+        assertTrue(targetFile.exists(), "The RC notary server cpb file should have been downloaded from Artifactory")
+    }
+
+    @Test
+    fun downloadNotaryServerCpbAlpha() {
+        val version = alphaVersion
+        val fileName = "notary-plugin-non-validating-server-$version-package.cpb"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadNotaryCpb(
+            version,
+            "release-$version",
+            targetFile.path,
+            cordaArtifactoryUsername,
+            cordaArtifactoryPassword
+        )
+        assertTrue(targetFile.exists(), "The alpha notary server cpb file should have been downloaded from Artifactory")
+    }
+
+    @Test
+    fun downloadNotaryServerCpbBeta() {
+        val version = betaVersion
+        val fileName = "notary-plugin-non-validating-server-$version-package.cpb"
+        val targetFile = File("$tempDir/$fileName")
+        EnvironmentSetupHelper().downloadNotaryCpb(
+            version,
+            "release-$version",
+            targetFile.path,
+            cordaArtifactoryUsername,
+            cordaArtifactoryPassword
+        )
+        assertTrue(targetFile.exists(), "The beta notary server cpb file should have been downloaded from Artifactory")
+    }
+
+    @Test
+    fun unableToDownloadUnpublishedNotaryServerCpbWithoutCredentials() {
+        val version = betaVersion
+        val fileName = "notary-plugin-non-validating-server-$version-package.cpb"
+        val targetFile = File("$tempDir/$fileName")
+        val exception = assertThrows<CordaRuntimeGradlePluginException> {
+            EnvironmentSetupHelper().downloadNotaryCpb(
                 version,
                 "release-$version",
                 targetFile.path,

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/CordaRuntimeGradlePlugin.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/CordaRuntimeGradlePlugin.kt
@@ -3,6 +3,8 @@ package net.corda.gradle.plugin
 import net.corda.gradle.plugin.configuration.PluginConfiguration
 import net.corda.gradle.plugin.cordalifecycle.createCordaLifeCycleTasks
 import net.corda.gradle.plugin.cordalifecycle.createPluginEnvSetupTasks
+import net.corda.gradle.plugin.cordapp.createCordappTasks
+import net.corda.gradle.plugin.network.createNetworkTasks
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -13,5 +15,7 @@ class CordaRuntimeGradlePlugin: Plugin<Project> {
         val projectConfig = project.extensions.create(CONFIG_BLOCK_NAME, PluginConfiguration::class.java)
         createPluginEnvSetupTasks(project, projectConfig)
         createCordaLifeCycleTasks(project, projectConfig)
+        createCordappTasks(project, projectConfig)
+        createNetworkTasks(project, projectConfig)
     }
 }

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/ProjectUtils.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/ProjectUtils.kt
@@ -1,6 +1,16 @@
 package net.corda.gradle.plugin
 
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import kong.unirest.HttpResponse
+import kong.unirest.JsonNode
+import kong.unirest.Unirest
+import net.corda.gradle.plugin.configuration.ProjectContext
+import net.corda.gradle.plugin.dtos.VirtualNodeInfoDTO
+import net.corda.gradle.plugin.dtos.VirtualNodesDTO
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
 import java.net.ConnectException
+import java.net.HttpURLConnection
 import java.net.Socket
 import java.time.Duration
 import java.time.Instant
@@ -35,7 +45,7 @@ fun isPortInUse(host: String, port: Int): Boolean {
  * @param timeout time to wait for the operation to complete. Default value is 10 seconds.
  * @param cooldown time to wait between retries. Default value is 1 second.
  * @param block the block of code to execute
- * @throws CsdeException if the operation fails after all retries
+ * @throws Exception if the operation fails after all retries
  */
 fun <R> retry(
     timeout: Duration = Duration.ofMillis(10000),
@@ -58,4 +68,29 @@ fun <R> retry(
             elapsed = Duration.between(start, Instant.now())
         }
     }; throw firstException!!
+}
+
+/**
+ * Gets a list of the virtual nodes which have already been created.
+ * @return a list of the virtual nodes which have already been created.
+ */
+fun getExistingNodes(pc: ProjectContext) : List<VirtualNodeInfoDTO> {
+
+    Unirest.config().verifySsl(false)
+    val mapper = ObjectMapper()
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+    val response: HttpResponse<JsonNode> = Unirest.get(pc.cordaClusterURL + "/api/v1/virtualnode")
+        .basicAuth(pc.cordaRpcUser, pc.cordaRpcPassword)
+        .asJson()
+
+    if (response.status != HttpURLConnection.HTTP_OK) {
+        throw CordaRuntimeGradlePluginException("Failed to get Existing vNodes, response status: " + response.status)
+    }
+
+    return try {
+        mapper.readValue(response.body.toString(), VirtualNodesDTO::class.java).virtualNodes!!
+    } catch (e: Exception) {
+        throw CordaRuntimeGradlePluginException("Failed to get Existing vNodes with exception: $e")
+    }
 }

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/ProjectUtils.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/ProjectUtils.kt
@@ -72,6 +72,7 @@ fun <R> retry(
 
 /**
  * Gets a list of the virtual nodes which have already been created.
+ * @Param the [ProjectContext]
  * @return a list of the virtual nodes which have already been created.
  */
 fun getExistingNodes(pc: ProjectContext) : List<VirtualNodeInfoDTO> {

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/NetworkConfig.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/NetworkConfig.kt
@@ -1,0 +1,27 @@
+package net.corda.gradle.plugin.configuration
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import net.corda.gradle.plugin.dtos.VNode
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import java.io.FileInputStream
+
+/**
+ * Class which reads in a network config file, parses it and exposes the list of VNodes and x500Names required.
+ */
+class NetworkConfig(val configFilePath: String) {
+
+    var vNodes: List<VNode>
+
+    init {
+        val mapper = ObjectMapper()
+        vNodes = try {
+            val fis = FileInputStream(configFilePath)
+            mapper.readValue(fis, object : TypeReference<List<VNode>>(){})
+        } catch (e: Exception) {
+            throw CordaRuntimeGradlePluginException("Failed to read static network configuration file, with exception: $e")
+        }
+    }
+
+    var x500Names = vNodes.map { it.x500Name }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/PluginConfiguration.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/PluginConfiguration.kt
@@ -24,6 +24,9 @@ open class PluginConfiguration @Inject constructor(objects: ObjectFactory) {
     val combinedWorkerVersion: Property<String> = objects.property(String::class.java).convention("5.2.0.0")
 
     @get:Input
+    val notaryVersion: Property<String> = objects.property(String::class.java).convention("5.2.0.0")
+
+    @get:Input
     val postgresJdbcVersion: Property<String> = objects.property(String::class.java).convention("42.7.1")
 
     @get:Input

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/PluginConfiguration.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/PluginConfiguration.kt
@@ -21,10 +21,10 @@ open class PluginConfiguration @Inject constructor(objects: ObjectFactory) {
     val cordaRuntimePluginWorkspaceDir: Property<String> = objects.property(String::class.java).convention("workspace")
 
     @get:Input
-    val combinedWorkerVersion: Property<String> = objects.property(String::class.java).convention("5.0.1.0")
+    val combinedWorkerVersion: Property<String> = objects.property(String::class.java).convention("5.2.0.0")
 
     @get:Input
-    val postgresJdbcVersion: Property<String> = objects.property(String::class.java).convention("42.6.0")
+    val postgresJdbcVersion: Property<String> = objects.property(String::class.java).convention("42.7.1")
 
     @get:Input
     var cordaDbContainerName: Property<String> = objects.property(String::class.java).convention("cordaPostgres")
@@ -43,4 +43,30 @@ open class PluginConfiguration @Inject constructor(objects: ObjectFactory) {
     @get:Input
     val artifactoryPassword: Property<String> = objects.property(String::class.java).convention("")
 
+    @get:Input
+    val notaryCpiName: Property<String> = objects.property(String::class.java).convention("NotaryServer")
+
+    @get:Input
+    val corDappCpiName: Property<String> = objects.property(String::class.java).convention("MyCorDapp")
+
+    @get:Input
+    val cpiUploadTimeout: Property<String> = objects.property(String::class.java).convention("10000")
+
+    @get:Input
+    val vnodeRegistrationTimeout: Property<String> = objects.property(String::class.java).convention("30000")
+
+    @get:Input
+    val cordaProcessorTimeout: Property<String> = objects.property(String::class.java).convention("-1")
+
+    @get:Input
+    val workflowsModuleName: Property<String> = objects.property(String::class.java).convention("workflows")
+
+    @get:Input
+    val networkConfigFile: Property<String> = objects.property(String::class.java).convention("config/static-network-config.json")
+
+    @get:Input
+    val r3RootCertFile: Property<String> = objects.property(String::class.java).convention("config/r3-ca-key.pem")
+
+    @get:Input
+    val skipTestsDuringBuildCpis: Property<String> = objects.property(String::class.java).convention("false")
 }

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/ProjectContext.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/ProjectContext.kt
@@ -24,11 +24,21 @@ class ProjectContext(val project: Project, pluginConfig: PluginConfiguration) {
     val cordaCliBinDir: String = pluginConfig.cordaCliBinDir.get()
     val artifactoryUsername: String = pluginConfig.artifactoryUsername.get()
     val artifactoryPassword: String = pluginConfig.artifactoryPassword.get()
+    val notaryCpiName: String = pluginConfig.notaryCpiName.get()
+    val corDappCpiName: String = pluginConfig.corDappCpiName.get()
+    val cpiUploadTimeout: Long = pluginConfig.cpiUploadTimeout.get().toLong()
+    val vnodeRegistrationTimeout: Long = pluginConfig.vnodeRegistrationTimeout.get().toLong()
+    val cordaProcessorTimeout: Long = pluginConfig.cordaProcessorTimeout.get().toLong()
+    val workflowsModuleName: String = pluginConfig.workflowsModuleName.get()
+    val networkConfigFile: String = pluginConfig.networkConfigFile.get()
+    val r3RootCertFile: String = "${project.rootDir}/${pluginConfig.r3RootCertFile.get()}"
 
     // Set Non user configurable context properties
     val javaBinDir: String = "${System.getProperty("java.home")}/bin"
     val cordaPidCache: String = "$workspaceDir/CordaPIDCache.dat"
     val jdbcDir: String = "$cordaBinDir/jdbcDrivers"
+    val notaryServiceDir: String = "$cordaBinDir/notaryServer"
+    val workflowBuildDir: String = "${project.rootDir}/${workflowsModuleName}/build"
 
     val cordaClusterHost: String = cordaClusterURL.split("://").last().split(":").first()
     val cordaClusterPort: Int = cordaClusterURL.split("://").last().split(":").last().toInt()
@@ -36,6 +46,23 @@ class ProjectContext(val project: Project, pluginConfig: PluginConfiguration) {
     val combinedWorkerFileName: String = "corda-combined-worker-$combinedWorkerVersion.jar"
     val combinedWorkerFilePath: String = "$cordaBinDir/combinedWorker/$combinedWorkerFileName"
     val cordaReleaseBranchName: String = "release-$combinedWorkerVersion"
+    val notaryVersion: String = combinedWorkerVersion
+    val notaryCpbFilePath: String = "$notaryServiceDir/notary-plugin-non-validating-server-$notaryVersion-package.cpb"
+    val notaryCpiFilePath: String = "$workflowBuildDir/$notaryCpiName-${project.version}.cpi"
+    val corDappCpbFilePath: String = "$workflowBuildDir/libs/${workflowsModuleName}-${project.version}-package.cpb"
+    val corDappCpiFilePath: String = "$workflowBuildDir/$corDappCpiName-${project.version}.cpi"
+    val corDappCpiUploadStatusFilePath: String = "$workspaceDir/corDappCpiUploadStatus.json"
+    val notaryCpiUploadStatusFilePath: String = "$workspaceDir/notaryCpiUploadStatus.json"
+
+    val networkConfig: NetworkConfig = NetworkConfig("${project.rootDir}/${networkConfigFile}")
+    val groupPolicyFilePath: String = "${project.rootDir}/$workspaceDir/GroupPolicy.json"
+    val gradleDefaultCertAlias: String = "gradle-plugin-default-key"
+    val gradleDefaultCertFilePath: String = "${project.rootDir}/config/gradle-plugin-default-key.pem"
+    val keystoreAlias: String = "my-signing-key"
+    val keystorePassword: String = "keystore password"
+    val keystoreFilePath: String = "${project.rootDir}/$workspaceDir/signingkeys.pfx"
+    val keystoreCertFilePath: String = "${project.rootDir}/$workspaceDir/signingkey1.pem"
+    val r3RootCertKeyAlias: String = "digicert-ca"
 
     val logger: Logger = project.logger
 }

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/ProjectContext.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/configuration/ProjectContext.kt
@@ -18,6 +18,7 @@ class ProjectContext(val project: Project, pluginConfig: PluginConfiguration) {
     val cordaRpcPassword: String = pluginConfig.cordaRpcPasswd.get()
     val workspaceDir: String = pluginConfig.cordaRuntimePluginWorkspaceDir.get()
     val combinedWorkerVersion: String = pluginConfig.combinedWorkerVersion.get()
+    val notaryVersion: String = pluginConfig.notaryVersion.get()
     val postgresJdbcVersion: String = pluginConfig.postgresJdbcVersion.get()
     val cordaDbContainerName: String =pluginConfig.cordaDbContainerName.get()
     val cordaBinDir: String = pluginConfig.cordaBinDir.get()
@@ -46,7 +47,6 @@ class ProjectContext(val project: Project, pluginConfig: PluginConfiguration) {
     val combinedWorkerFileName: String = "corda-combined-worker-$combinedWorkerVersion.jar"
     val combinedWorkerFilePath: String = "$cordaBinDir/combinedWorker/$combinedWorkerFileName"
     val cordaReleaseBranchName: String = "release-$combinedWorkerVersion"
-    val notaryVersion: String = combinedWorkerVersion
     val notaryCpbFilePath: String = "$notaryServiceDir/notary-plugin-non-validating-server-$notaryVersion-package.cpb"
     val notaryCpiFilePath: String = "$workflowBuildDir/$notaryCpiName-${project.version}.cpi"
     val corDappCpbFilePath: String = "$workflowBuildDir/libs/${workflowsModuleName}-${project.version}-package.cpb"

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleTasks.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/CordaLifecycleTasks.kt
@@ -10,7 +10,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import javax.inject.Inject
 
-const val CLUSTER_TASKS_GROUP = "corda-runtime-plugin"
+const val CLUSTER_TASKS_GROUP = "corda-runtime-plugin-local-environment"
 const val START_CORDA_TASK_NAME = "startCorda"
 const val STOP_CORDA_TASK_NAME = "stopCorda"
 const val STOP_CORDA_AND_CLEAN_TASK_NAME = "stopCordaAndCleanWorkspace"

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordalifecycle/EnvironmentSetupHelper.kt
@@ -1,5 +1,6 @@
 package net.corda.gradle.plugin.cordalifecycle
 
+import kong.unirest.Unirest
 import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
 import java.io.File
 import java.net.Authenticator
@@ -32,11 +33,79 @@ class EnvironmentSetupHelper {
         }
     }
 
-    private fun nameContainsRcOrHc(combinedWorkerFileName: String) : Boolean {
+    fun downloadNotaryCpb(
+        notaryCpbVersion: String,
+        cordaReleaseVersion: String,
+        targetFilePath: String,
+        artifactoryUsername: String,
+        artifactoryPassword: String
+    ) {
+        val url = if (nameContainsRcOrHc(notaryCpbVersion) || nameContainsAlphaOrBeta(notaryCpbVersion)) {
+            setupAuthentication(artifactoryUsername, artifactoryPassword)
+            URL(
+                "https://software.r3.com/artifactory/corda-os-maven/com/r3/corda/notary/plugin/nonvalidating/" +
+                        "notary-plugin-non-validating-server/$notaryCpbVersion/" +
+                        "notary-plugin-non-validating-server-$notaryCpbVersion-package.cpb"
+            )
+        } else URL(
+            "https://github.com/corda/corda-runtime-os/releases/download/$cordaReleaseVersion/" +
+                    "notary-plugin-non-validating-server-$notaryCpbVersion-package.cpb"
+        )
+        if (!File(targetFilePath).exists()) {
+            File(targetFilePath).parentFile.mkdirs()
+            url.openStream().use { Files.copy(it, Paths.get(targetFilePath)) }
+        }
+    }
+
+    fun getConfigVersion(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        configSection: String
+    ): Int {
+        return Unirest.get("$cordaClusterURL/api/v1/config/$configSection")
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .asJson()
+            .ifSuccess {}.body.`object`["version"].toString().toInt()
+    }
+
+    @Suppress("LongParameterList")
+    fun sendUpdate(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        configSection: String,
+        configBody: String,
+        configVersion: Int
+    ) {
+        Unirest.put("$cordaClusterURL/api/v1/config")
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .body(
+                """
+                {
+                    "config": {
+                        $configBody
+                    },
+                    "schemaVersion": {
+                        "major": 1,
+                        "minor": 0
+                    },
+                    "section": "$configSection",
+                    "version": $configVersion
+                }
+                """.trimIndent()
+            )
+            .asJson()
+            .ifFailure { response ->
+                throw CordaRuntimeGradlePluginException("Failed to Update Config\n${response.body.`object`["title"]}")
+            }
+    }
+
+    private fun nameContainsRcOrHc(combinedWorkerFileName: String): Boolean {
         return combinedWorkerFileName.contains("-RC") || combinedWorkerFileName.contains("-HC")
     }
 
-    private fun nameContainsAlphaOrBeta(combinedWorkerFileName: String) : Boolean {
+    private fun nameContainsAlphaOrBeta(combinedWorkerFileName: String): Boolean {
         return combinedWorkerFileName.contains("alpha") || combinedWorkerFileName.contains("beta")
     }
 

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/BuildCpiHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/BuildCpiHelper.kt
@@ -1,0 +1,63 @@
+package net.corda.gradle.plugin.cordapp
+
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import java.io.File
+
+class BuildCpiHelper {
+
+    @Suppress("LongParameterList")
+    fun createCPI(
+        javaBinDir: String,
+        cordaCliBinDir: String,
+        groupPolicyFilePath: String,
+        keystoreFilePath: String,
+        keystoreAlias: String,
+        keystorePassword: String,
+        cpbFilePath: String,
+        cpiFilePath: String,
+        cpiName: String,
+        cpiVersion: String,
+    ){
+        // Get Cpb
+        val cpbFile = File(cpbFilePath)
+        if (!cpbFile.exists()) {
+            throw CordaRuntimeGradlePluginException("Cpb file not found at: $cpbFilePath.")
+        }
+        // Clear previous cpi if it exists
+        val cpiFile = File(cpiFilePath)
+        if (cpiFile.exists()) {
+            cpiFile.delete()
+        }
+        // Build and execute command to build cpi
+        val cmdList = mutableListOf<String>()
+
+        cmdList.add("$javaBinDir/java")
+        cmdList.add("-Dpf4j.pluginsDir=$cordaCliBinDir/plugins/")
+        cmdList.add("-jar")
+        cmdList.add("$cordaCliBinDir/corda-cli.jar")
+        cmdList.add("package")
+        cmdList.add("create-cpi")
+        cmdList.add("--cpb")
+        cmdList.add(cpbFile.absolutePath)
+        cmdList.add("--group-policy")
+        cmdList.add(groupPolicyFilePath)
+        cmdList.add("--cpi-name")
+        cmdList.add(cpiName)
+        cmdList.add("--cpi-version")
+        cmdList.add(cpiVersion )
+        cmdList.add("--file")
+        cmdList.add(cpiFilePath)
+        cmdList.add("--keystore")
+        cmdList.add(keystoreFilePath)
+        cmdList.add("--storepass")
+        cmdList.add(keystorePassword)
+        cmdList.add("--key")
+        cmdList.add(keystoreAlias)
+
+        val pb = ProcessBuilder(cmdList)
+        pb.redirectErrorStream(true)
+        val proc = pb.start()
+        proc.inputStream.transferTo(System.out)
+        proc.waitFor()
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/BuildCpiHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/BuildCpiHelper.kt
@@ -21,7 +21,7 @@ class BuildCpiHelper {
         // Get Cpb
         val cpbFile = File(cpbFilePath)
         if (!cpbFile.exists()) {
-            throw CordaRuntimeGradlePluginException("Cpb file not found at: $cpbFilePath.")
+            throw CordaRuntimeGradlePluginException("CPB file not found at: $cpbFilePath.")
         }
         // Clear previous cpi if it exists
         val cpiFile = File(cpiFilePath)

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/BuildCpiHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/BuildCpiHelper.kt
@@ -17,7 +17,7 @@ class BuildCpiHelper {
         cpiFilePath: String,
         cpiName: String,
         cpiVersion: String,
-    ){
+    ) {
         // Get Cpb
         val cpbFile = File(cpbFilePath)
         if (!cpbFile.exists()) {
@@ -29,30 +29,30 @@ class BuildCpiHelper {
             cpiFile.delete()
         }
         // Build and execute command to build cpi
-        val cmdList = mutableListOf<String>()
-
-        cmdList.add("$javaBinDir/java")
-        cmdList.add("-Dpf4j.pluginsDir=$cordaCliBinDir/plugins/")
-        cmdList.add("-jar")
-        cmdList.add("$cordaCliBinDir/corda-cli.jar")
-        cmdList.add("package")
-        cmdList.add("create-cpi")
-        cmdList.add("--cpb")
-        cmdList.add(cpbFile.absolutePath)
-        cmdList.add("--group-policy")
-        cmdList.add(groupPolicyFilePath)
-        cmdList.add("--cpi-name")
-        cmdList.add(cpiName)
-        cmdList.add("--cpi-version")
-        cmdList.add(cpiVersion )
-        cmdList.add("--file")
-        cmdList.add(cpiFilePath)
-        cmdList.add("--keystore")
-        cmdList.add(keystoreFilePath)
-        cmdList.add("--storepass")
-        cmdList.add(keystorePassword)
-        cmdList.add("--key")
-        cmdList.add(keystoreAlias)
+        val cmdList = listOf(
+            "$javaBinDir/java",
+            "-Dpf4j.pluginsDir=$cordaCliBinDir/plugins/",
+            "-jar",
+            "$cordaCliBinDir/corda-cli.jar",
+            "package",
+            "create-cpi",
+            "--cpb",
+            cpbFile.absolutePath,
+            "--group-policy",
+            groupPolicyFilePath,
+            "--cpi-name",
+            cpiName,
+            "--cpi-version",
+            cpiVersion,
+            "--file",
+            cpiFilePath,
+            "--keystore",
+            keystoreFilePath,
+            "--storepass",
+            keystorePassword,
+            "--key",
+            keystoreAlias
+        )
 
         val pb = ProcessBuilder(cmdList)
         pb.redirectErrorStream(true)

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/CordappTasks.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/CordappTasks.kt
@@ -1,3 +1,104 @@
 package net.corda.gradle.plugin.cordapp
 
+import net.corda.gradle.plugin.configuration.PluginConfiguration
+import net.corda.gradle.plugin.configuration.ProjectContext
+import net.corda.gradle.plugin.cordalifecycle.GET_NOTARY_SERVER_CPB_TASK_NAME
+import net.corda.gradle.plugin.cordalifecycle.PROJINIT_TASK_NAME
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
 // Tasks relating to building a CorDapp
+const val CORDAPP_BUILD_GROUP = "corda-runtime-plugin-cordapp"
+const val CREATE_GROUP_POLICY_TASK_NAME = "createGroupPolicy"
+const val CREATE_KEYSTORE_TASK_NAME = "createKeystore"
+const val BUILD_CPIS_TASK_NAME = "buildCpis"
+const val DEPLOY_CPIS_TASK_NAME = "deployCpis"
+const val WORKFLOW_BUILD_TASK_NAME = ":workflows:build"
+
+fun createCordappTasks(project: Project, pluginConfiguration: PluginConfiguration) {
+    project.afterEvaluate {
+        project.tasks.create(CREATE_GROUP_POLICY_TASK_NAME, CreateGroupPolicyTask::class.java) {
+            it.group = CORDAPP_BUILD_GROUP
+            it.dependsOn(PROJINIT_TASK_NAME)
+            it.pluginConfig.set(pluginConfiguration)
+        }
+
+        project.tasks.create(CREATE_KEYSTORE_TASK_NAME, CreateKeystoreTask::class.java) {
+            it.group = CORDAPP_BUILD_GROUP
+            it.dependsOn(CREATE_GROUP_POLICY_TASK_NAME)
+            it.pluginConfig.set(pluginConfiguration)
+        }
+
+        project.tasks.create(BUILD_CPIS_TASK_NAME, BuildCPIsTask::class.java) {
+            it.group = CORDAPP_BUILD_GROUP
+            it.dependsOn(
+                CREATE_KEYSTORE_TASK_NAME,
+                GET_NOTARY_SERVER_CPB_TASK_NAME,
+                getWorkflowsModuleTaskName(pluginConfiguration)
+            )
+            it.pluginConfig.set(pluginConfiguration)
+        }
+
+        project.tasks.create(DEPLOY_CPIS_TASK_NAME, DeployCPIsTask::class.java) {
+            it.group = CORDAPP_BUILD_GROUP
+            it.dependsOn(BUILD_CPIS_TASK_NAME)
+            it.pluginConfig.set(pluginConfiguration)
+        }
+    }
+}
+
+private fun getWorkflowsModuleTaskName(pluginConfiguration: PluginConfiguration): String {
+    var workflowsModuleTaskName = WORKFLOW_BUILD_TASK_NAME.replace("workflows", pluginConfiguration.workflowsModuleName.get())
+    if (pluginConfiguration.skipTestsDuringBuildCpis.get().toBoolean()) {
+        // If we want to skip the tests, we can use the assemble task rather than the build task
+        workflowsModuleTaskName = workflowsModuleTaskName.replace(":build", ":assemble")
+    }
+    return workflowsModuleTaskName
+}
+
+open class CreateGroupPolicyTask @Inject constructor(objects: ObjectFactory): DefaultTask() {
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+
+    @TaskAction
+    fun createGroupPolicy() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        CordappTasksImpl(pc).createGroupPolicy()
+    }
+}
+
+open class CreateKeystoreTask @Inject constructor(objects: ObjectFactory): DefaultTask() {
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+
+    @TaskAction
+    fun createKeystore() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        CordappTasksImpl(pc).createKeyStore()
+    }
+}
+
+open class BuildCPIsTask @Inject constructor(objects: ObjectFactory): DefaultTask() {
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+    @TaskAction
+    fun buildCPIs() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        CordappTasksImpl(pc).buildCPIs()
+    }
+}
+
+open class DeployCPIsTask @Inject constructor(objects: ObjectFactory): DefaultTask() {
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+    @TaskAction
+    fun deployCPIs() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        CordappTasksImpl(pc).deployCPIs()
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/CordappTasksImpl.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/CordappTasksImpl.kt
@@ -1,0 +1,194 @@
+package net.corda.gradle.plugin.cordapp
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import net.corda.gradle.plugin.configuration.ProjectContext
+import net.corda.gradle.plugin.dtos.GroupPolicyDTO
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import java.io.File
+import java.io.FileInputStream
+
+class CordappTasksImpl(var pc: ProjectContext){
+
+    /**
+     * Creates a group Policy based on the network config file and outputs it to the Group Policy json file.
+     */
+    fun createGroupPolicy() {
+        val groupPolicyFile = File(pc.groupPolicyFilePath)
+        val networkConfigFile = File("${pc.project.rootDir}${pc.networkConfig.configFilePath}")
+
+        val pluginsDir = "${pc.cordaCliBinDir}/plugins/"
+
+        if (!groupPolicyFile.exists() || groupPolicyFile.lastModified() < networkConfigFile.lastModified()) {
+
+            pc.logger.quiet("Creating the Group policy.")
+            val configX500Ids = pc.networkConfig.x500Names
+
+            GroupPolicyHelper().createStaticGroupPolicy(
+                groupPolicyFile,
+                configX500Ids,
+                pc.javaBinDir,
+                pluginsDir,
+                pc.cordaCliBinDir
+            )
+        } else {
+            pc.logger.quiet("Group policy up to date.")
+        }
+        validateGroupPolicy()
+    }
+
+    private fun validateGroupPolicy() {
+        val groupPolicyFile = File(pc.groupPolicyFilePath)
+        val groupPolicy = try {
+            val fis = FileInputStream(groupPolicyFile)
+            val mapper = ObjectMapper()
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            mapper.readValue(fis, GroupPolicyDTO::class.java)
+        } catch (e: Exception) {
+            val firstLine = groupPolicyFile.useLines { it.firstOrNull() }
+            if ((firstLine != null) && firstLine.contains("Unable to access jarfile \\S*corda-cli.jar".toRegex())) {
+                throw CordaRuntimeGradlePluginException("Unable to find the Corda CLI, has it been installed?")
+            }
+
+            throw CordaRuntimeGradlePluginException("Failed to read GroupPolicy from group policy file with exception: $e.")
+        }
+        validateGroupPolicyHasAllMembers(groupPolicy)
+    }
+
+    private fun validateGroupPolicyHasAllMembers(groupPolicy: GroupPolicyDTO){
+        val membersNames = groupPolicy.protocolParameters?.staticNetwork?.members?.map { it.name }
+        pc.networkConfig.vNodes.forEach { requiredNode ->
+            if (membersNames?.any { requiredNode.x500Name == it } != true) {
+                throw CordaRuntimeGradlePluginException(
+                    "GroupPolicy File does not contain member ${requiredNode.x500Name} specified in the networkConfigFile"
+                )
+            }
+        }
+    }
+
+    /**
+     * Creates the key pairs and keystore required to sign Cpis.
+     */
+    fun createKeyStore() {
+        val keystoreFile = File(pc.keystoreFilePath)
+        if (!keystoreFile.exists()) {
+            pc.logger.quiet("Creating a keystore and signing certificate.")
+            KeyStoreHelper().generateKeyPair(
+                pc.javaBinDir,
+                pc.keystoreAlias,
+                pc.keystorePassword,
+                pc.keystoreFilePath
+            )
+
+            pc.logger.quiet("Importing default gradle certificate")
+            KeyStoreHelper().importKeystoreCert(
+                pc.javaBinDir,
+                pc.keystorePassword,
+                pc.keystoreFilePath,
+                pc.gradleDefaultCertAlias,
+                pc.gradleDefaultCertFilePath
+            )
+            pc.logger.quiet("Importing R3 signing certificate")
+            KeyStoreHelper().importKeystoreCert(
+                pc.javaBinDir,
+                pc.keystorePassword,
+                pc.keystoreFilePath,
+                pc.r3RootCertKeyAlias,
+                pc.r3RootCertFile
+            )
+            KeyStoreHelper().exportCert(
+                pc.javaBinDir,
+                pc.keystoreAlias,
+                pc.keystoreFilePath,
+                pc.keystoreCertFilePath
+            )
+        } else {
+            pc.logger.quiet("Keystore and signing certificate already created.")
+        }
+    }
+
+    /**
+     * Builds the Cpis for the CordDapp and the Notary
+     */
+    fun buildCPIs() {
+        pc.logger.quiet("Creating ${pc.corDappCpiName} Cpi.")
+        BuildCpiHelper().createCPI(
+            pc.javaBinDir,
+            pc.cordaCliBinDir,
+            pc.groupPolicyFilePath,
+            pc.keystoreFilePath,
+            pc.keystoreAlias,
+            pc.keystorePassword,
+            pc.corDappCpbFilePath,
+            pc.corDappCpiFilePath,
+            pc.corDappCpiName,
+            pc.project.version.toString()
+        )
+        pc.logger.quiet("Creating ${pc.notaryCpiName} Cpi.")
+        BuildCpiHelper().createCPI(
+            pc.javaBinDir,
+            pc.cordaCliBinDir,
+            pc.groupPolicyFilePath,
+            pc.keystoreFilePath,
+            pc.keystoreAlias,
+            pc.keystorePassword,
+            pc.notaryCpbFilePath,
+            pc.notaryCpiFilePath,
+            pc.notaryCpiName,
+            pc.project.version.toString()
+        )
+    }
+
+    /**
+     * Uploads the required certificates and uploads the CorDapp and Notary CPIs
+     */
+    fun deployCPIs() {
+        val helper = DeployCpiHelper()
+        helper.uploadCertificate(
+            pc.cordaClusterURL,
+            pc.cordaRpcUser,
+            pc.cordaRpcPassword,
+            pc.gradleDefaultCertAlias,
+            pc.gradleDefaultCertFilePath
+        )
+        pc.logger.quiet("Certificate '${pc.gradleDefaultCertAlias}' uploaded.")
+        helper.uploadCertificate(
+            pc.cordaClusterURL,
+            pc.cordaRpcUser,
+            pc.cordaRpcPassword,
+            pc.keystoreAlias,
+            pc.keystoreCertFilePath
+        )
+        pc.logger.quiet("Certificate '${pc.keystoreAlias}' uploaded.")
+        helper.uploadCertificate(
+            pc.cordaClusterURL,
+            pc.cordaRpcUser,
+            pc.cordaRpcPassword,
+            pc.r3RootCertKeyAlias,
+            pc.r3RootCertFile
+        )
+        pc.logger.quiet("Certificate '${pc.r3RootCertKeyAlias}' uploaded.")
+        val cpiUploadStatus = helper.uploadCpi(
+            pc.cordaClusterURL,
+            pc.cordaRpcUser,
+            pc.cordaRpcPassword,
+            pc.corDappCpiFilePath,
+            pc.corDappCpiName,
+            pc.project.version.toString(),
+            pc.corDappCpiUploadStatusFilePath,
+            pc.cpiUploadTimeout
+        )
+        pc.logger.quiet("Cpi ${pc.corDappCpiName} uploaded: ${cpiUploadStatus.cpiFileChecksum}")
+        val notaryUploadStatus = helper.uploadCpi(
+            pc.cordaClusterURL,
+            pc.cordaRpcUser,
+            pc.cordaRpcPassword,
+            pc.notaryCpiFilePath,
+            pc.notaryCpiName,
+            pc.project.version.toString(),
+            pc.notaryCpiUploadStatusFilePath,
+            pc.cpiUploadTimeout
+        )
+        pc.logger.quiet("Cpi ${pc.notaryCpiName} uploaded: ${notaryUploadStatus.cpiFileChecksum}")
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/CordappTasksImpl.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/CordappTasksImpl.kt
@@ -8,7 +8,7 @@ import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
 import java.io.File
 import java.io.FileInputStream
 
-class CordappTasksImpl(var pc: ProjectContext){
+class CordappTasksImpl(var pc: ProjectContext) {
 
     /**
      * Creates a group Policy based on the network config file and outputs it to the Group Policy json file.
@@ -55,13 +55,20 @@ class CordappTasksImpl(var pc: ProjectContext){
         validateGroupPolicyHasAllMembers(groupPolicy)
     }
 
-    private fun validateGroupPolicyHasAllMembers(groupPolicy: GroupPolicyDTO){
+    private fun validateGroupPolicyHasAllMembers(groupPolicy: GroupPolicyDTO) {
         val membersNames = groupPolicy.protocolParameters?.staticNetwork?.members?.map { it.name }
-        pc.networkConfig.vNodes.forEach { requiredNode ->
-            if (membersNames?.any { requiredNode.x500Name == it } != true) {
-                throw CordaRuntimeGradlePluginException(
-                    "GroupPolicy File does not contain member ${requiredNode.x500Name} specified in the networkConfigFile"
-                )
+        val requiredNodes = pc.networkConfig.vNodes
+        if (requiredNodes.isNotEmpty() && membersNames == null) {
+            throw CordaRuntimeGradlePluginException(
+                "GroupPolicy File does not contain any members"
+            )
+        } else {
+            requiredNodes.forEach { requiredNode ->
+                if (!membersNames!!.contains(requiredNode.x500Name)) {
+                    throw CordaRuntimeGradlePluginException(
+                        "GroupPolicy File does not contain member ${requiredNode.x500Name} specified in the networkConfigFile"
+                    )
+                }
             }
         }
     }
@@ -108,10 +115,10 @@ class CordappTasksImpl(var pc: ProjectContext){
     }
 
     /**
-     * Builds the Cpis for the CordDapp and the Notary
+     * Builds the CPIs for the CordDapp and the Notary
      */
     fun buildCPIs() {
-        pc.logger.quiet("Creating ${pc.corDappCpiName} Cpi.")
+        pc.logger.quiet("Creating ${pc.corDappCpiName} CPI.")
         BuildCpiHelper().createCPI(
             pc.javaBinDir,
             pc.cordaCliBinDir,
@@ -124,7 +131,7 @@ class CordappTasksImpl(var pc: ProjectContext){
             pc.corDappCpiName,
             pc.project.version.toString()
         )
-        pc.logger.quiet("Creating ${pc.notaryCpiName} Cpi.")
+        pc.logger.quiet("Creating ${pc.notaryCpiName} CPI.")
         BuildCpiHelper().createCPI(
             pc.javaBinDir,
             pc.cordaCliBinDir,
@@ -178,7 +185,7 @@ class CordappTasksImpl(var pc: ProjectContext){
             pc.corDappCpiUploadStatusFilePath,
             pc.cpiUploadTimeout
         )
-        pc.logger.quiet("Cpi ${pc.corDappCpiName} uploaded: ${cpiUploadStatus.cpiFileChecksum}")
+        pc.logger.quiet("CPI ${pc.corDappCpiName} uploaded: ${cpiUploadStatus.cpiFileChecksum}")
         val notaryUploadStatus = helper.uploadCpi(
             pc.cordaClusterURL,
             pc.cordaRpcUser,
@@ -189,6 +196,6 @@ class CordappTasksImpl(var pc: ProjectContext){
             pc.notaryCpiUploadStatusFilePath,
             pc.cpiUploadTimeout
         )
-        pc.logger.quiet("Cpi ${pc.notaryCpiName} uploaded: ${notaryUploadStatus.cpiFileChecksum}")
+        pc.logger.quiet("CPI ${pc.notaryCpiName} uploaded: ${notaryUploadStatus.cpiFileChecksum}")
     }
 }

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/DeployCpiHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/DeployCpiHelper.kt
@@ -1,0 +1,188 @@
+package net.corda.gradle.plugin.cordapp
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import kong.unirest.HttpResponse
+import kong.unirest.JsonNode
+import kong.unirest.Unirest
+import net.corda.gradle.plugin.dtos.CpiUploadResponseDTO
+import net.corda.gradle.plugin.dtos.CpiUploadStatus
+import net.corda.gradle.plugin.dtos.GetCPIsResponseDTO
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import net.corda.gradle.plugin.retry
+import java.io.File
+import java.io.FileOutputStream
+import java.io.PrintStream
+import java.net.HttpURLConnection
+import java.time.Duration
+import java.util.*
+
+class DeployCpiHelper {
+
+    private val mapper = ObjectMapper()
+
+    init {
+        Unirest.config().verifySsl(false)
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    }
+
+
+    fun uploadCertificate(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        certAlias: String,
+        certFilePath: String
+    ) {
+
+        val response = Unirest.put(cordaClusterURL + "/api/v1/certificates/cluster/code-signer")
+            .field("alias", certAlias)
+            .field("certificate", File(certFilePath))
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .asJson()
+
+        // Note, api returns a 204 success code
+        if (response.status != HttpURLConnection.HTTP_NO_CONTENT) {
+            throw CordaRuntimeGradlePluginException(
+                "Upload of certificate '$certAlias' failed with response status: ${response.status} and response body: ${response.body}."
+            )
+        }
+    }
+
+    @Suppress("LongParameterList")
+    fun uploadCpi(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        cpiFilePath: String,
+        cpiName: String,
+        cpiVersion: String,
+        cpiUploadStatusFilePath: String,
+        cpiUploadTimeout: Long
+    ): CpiUploadStatus {
+
+        val response = if (cpiPreviouslyUploaded(
+                    cordaClusterURL,
+                    cordaRpcUser,
+                    cordaRpcPassword,
+                    cpiName,
+                    cpiVersion
+                )
+            ) {
+            Unirest.post("$cordaClusterURL/api/v1/maintenance/virtualnode/forcecpiupload/")
+                .field("upload", File(cpiFilePath))
+                .basicAuth(cordaRpcUser, cordaRpcPassword)
+                .asJson()
+        } else {
+            //pc.logger.quiet("Uploading Cpi '$cpiName' for the first time.")
+
+            Unirest.post(cordaClusterURL + "/api/v1/cpi/")
+                .field("upload", File(cpiFilePath))
+                .basicAuth(cordaRpcUser, cordaRpcPassword)
+                .asJson()
+        }
+        if (response.status == HttpURLConnection.HTTP_OK) {
+            //pc.logger.quiet("Cpi upload requested for cpi '$cpiName'.")
+        } else {
+            throw CordaRuntimeGradlePluginException("Failed to request upload of cpi: '$cpiName'.")
+        }
+
+        val requestId = try {
+            mapper.readValue(response.body.toString(), CpiUploadResponseDTO::class.java).id!!
+        } catch (e: Exception) {
+            throw CordaRuntimeGradlePluginException("Failed to request upload of cpi: '$cpiName'.")
+        }
+
+        val cpiUploadStatus = pollForCpiUpload(
+            cordaClusterURL,
+            cordaRpcUser,
+            cordaRpcPassword,
+            requestId,
+            cpiUploadTimeout
+        )
+        PrintStream(FileOutputStream(cpiUploadStatusFilePath)).print(mapper.writeValueAsString(cpiUploadStatus))
+        return cpiUploadStatus
+    }
+
+    /**
+     * Checks if a Cpi has previously been uploaded by comparing the cpiName and cpiVersion to cpis already uploaded.
+     */
+    private fun cpiPreviouslyUploaded(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        cpiName: String, cpiVersion: String
+    ): Boolean {
+
+        val response: HttpResponse<JsonNode> = Unirest.get("$cordaClusterURL/api/v1/cpi")
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .asJson()
+
+        if (response.status != HttpURLConnection.HTTP_OK) {
+            throw CordaRuntimeGradlePluginException("Failed to check Cpis, response status:  ${response.status}.")
+        }
+
+        try {
+            val cpisResponse: GetCPIsResponseDTO = mapper.readValue(response.body.toString(), GetCPIsResponseDTO::class.java)
+
+            cpisResponse.cpis?.forEach { cpi ->
+                if (Objects.equals(cpi.id!!.cpiName, cpiName) && Objects.equals(cpi.id!!.cpiVersion, cpiVersion)) return true
+            }
+            return false
+        } catch (e: Exception) {
+            throw CordaRuntimeGradlePluginException("Failed to check Cpis with exception: $e.")
+        }
+    }
+
+    /**
+     * Polls to see if a request to upload a Cpi has been successful.
+     * The timeout is controlled by setting the cpiUploadTimeout property
+     */
+    private fun pollForCpiUpload(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        id: String,
+        cpiUploadTimeout: Long
+    ): CpiUploadStatus {
+        var cpiUploadStatus = CpiUploadStatus()
+        retry(timeout = Duration.ofMillis(cpiUploadTimeout)) {
+            cpiUploadStatus = checkCpiUploadStatus(
+                cordaClusterURL,
+                cordaRpcUser,
+                cordaRpcPassword,
+                id
+            )
+        }
+        //pc.logger.quiet("Cpi upload request $id successful.")
+        return cpiUploadStatus
+    }
+
+    /**
+     * Check if a Cpi upload has been successful.
+     */
+    private fun checkCpiUploadStatus(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        id: String
+    ): CpiUploadStatus {
+        var cpiUploadStatus = CpiUploadStatus()
+        Unirest.get(cordaClusterURL + "/api/v1/cpi/status/$id")
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .asJson()
+            .ifSuccess { response ->
+                cpiUploadStatus = mapper.readValue(response.body.toString(), CpiUploadStatus::class.java)
+                if (cpiUploadStatus.status != "OK")
+                    throw CordaRuntimeGradlePluginException(
+                        "Failed to verify Cpi Upload Status, current status: ${cpiUploadStatus.status}."
+                    )
+            }
+            .ifFailure(
+                fun(response: HttpResponse<JsonNode>) {
+                    throw CordaRuntimeGradlePluginException("Failed to get Cpi Upload Status, response status: ${response.status}.")
+                }
+            )
+        return cpiUploadStatus
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/DeployCpiHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/DeployCpiHelper.kt
@@ -74,16 +74,12 @@ class DeployCpiHelper {
                 .basicAuth(cordaRpcUser, cordaRpcPassword)
                 .asJson()
         } else {
-            //pc.logger.quiet("Uploading Cpi '$cpiName' for the first time.")
-
             Unirest.post(cordaClusterURL + "/api/v1/cpi/")
                 .field("upload", File(cpiFilePath))
                 .basicAuth(cordaRpcUser, cordaRpcPassword)
                 .asJson()
         }
-        if (response.status == HttpURLConnection.HTTP_OK) {
-            //pc.logger.quiet("Cpi upload requested for cpi '$cpiName'.")
-        } else {
+        if (response.status != HttpURLConnection.HTTP_OK) {
             throw CordaRuntimeGradlePluginException("Failed to request upload of cpi: '$cpiName'.")
         }
 
@@ -154,7 +150,6 @@ class DeployCpiHelper {
                 id
             )
         }
-        //pc.logger.quiet("Cpi upload request $id successful.")
         return cpiUploadStatus
     }
 

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/DeployCpiHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/DeployCpiHelper.kt
@@ -80,13 +80,13 @@ class DeployCpiHelper {
                 .asJson()
         }
         if (response.status != HttpURLConnection.HTTP_OK) {
-            throw CordaRuntimeGradlePluginException("Failed to request upload of cpi: '$cpiName'.")
+            throw CordaRuntimeGradlePluginException("Failed to request upload of CPI: '$cpiName'.")
         }
 
         val requestId = try {
             mapper.readValue(response.body.toString(), CpiUploadResponseDTO::class.java).id!!
         } catch (e: Exception) {
-            throw CordaRuntimeGradlePluginException("Failed to request upload of cpi: '$cpiName'.")
+            throw CordaRuntimeGradlePluginException("Failed to request upload of CPI: '$cpiName'.", e)
         }
 
         val cpiUploadStatus = pollForCpiUpload(
@@ -101,7 +101,7 @@ class DeployCpiHelper {
     }
 
     /**
-     * Checks if a Cpi has previously been uploaded by comparing the cpiName and cpiVersion to cpis already uploaded.
+     * Checks if a CPI has previously been uploaded by comparing the cpiName and cpiVersion to CPIs already uploaded.
      */
     private fun cpiPreviouslyUploaded(
         cordaClusterURL: String,
@@ -115,7 +115,7 @@ class DeployCpiHelper {
             .asJson()
 
         if (response.status != HttpURLConnection.HTTP_OK) {
-            throw CordaRuntimeGradlePluginException("Failed to check Cpis, response status:  ${response.status}.")
+            throw CordaRuntimeGradlePluginException("Failed to check CPIs, response status:  ${response.status}.")
         }
 
         try {
@@ -126,12 +126,12 @@ class DeployCpiHelper {
             }
             return false
         } catch (e: Exception) {
-            throw CordaRuntimeGradlePluginException("Failed to check Cpis with exception: $e.")
+            throw CordaRuntimeGradlePluginException("Failed to check CPIs with exception: ${e.message}.", e)
         }
     }
 
     /**
-     * Polls to see if a request to upload a Cpi has been successful.
+     * Polls to see if a request to upload a CPI has been successful.
      * The timeout is controlled by setting the cpiUploadTimeout property
      */
     private fun pollForCpiUpload(
@@ -170,12 +170,12 @@ class DeployCpiHelper {
                 cpiUploadStatus = mapper.readValue(response.body.toString(), CpiUploadStatus::class.java)
                 if (cpiUploadStatus.status != "OK")
                     throw CordaRuntimeGradlePluginException(
-                        "Failed to verify Cpi Upload Status, current status: ${cpiUploadStatus.status}."
+                        "CPI Upload Status is not OK, current status:${cpiUploadStatus.status}."
                     )
             }
             .ifFailure(
                 fun(response: HttpResponse<JsonNode>) {
-                    throw CordaRuntimeGradlePluginException("Failed to get Cpi Upload Status, response status: ${response.status}.")
+                    throw CordaRuntimeGradlePluginException("Failed to get CPI Upload Status, response status: ${response.status}.")
                 }
             )
         return cpiUploadStatus

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/GroupPolicyHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/GroupPolicyHelper.kt
@@ -1,0 +1,41 @@
+package net.corda.gradle.plugin.cordapp
+
+import java.io.File
+
+class GroupPolicyHelper {
+
+    fun createStaticGroupPolicy(
+        targetPolicyFile: File,
+        x500Names: List<String?>,
+        javaBinDir: String,
+        pluginsDir: String,
+        cordaCliBinDir: String
+    ) {
+        val cmdList = mutableListOf(
+            "$javaBinDir/java",
+            "-Dpf4j.pluginsDir=$pluginsDir",
+            "-jar",
+            "$cordaCliBinDir/corda-cli.jar",
+            "mgm",
+            "groupPolicy",
+            "--endpoint-protocol=1",
+            "--endpoint=http://localhost:1080"
+        )
+
+        for (id in x500Names) {
+            cmdList.add("--name")
+            cmdList.add(id!!)
+        }
+
+        val pb = ProcessBuilder(cmdList)
+        pb.redirectErrorStream(true)
+        val proc = pb.start()
+
+        proc.inputStream.use { input ->
+            targetPolicyFile.outputStream().use {
+                    output ->
+                input.copyTo(output)
+            }
+        }
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/KeyStoreHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/KeyStoreHelper.kt
@@ -2,6 +2,10 @@ package net.corda.gradle.plugin.cordapp
 
 class KeyStoreHelper {
 
+    private val aliasFlag = "-alias"
+    private val keystoreFlag = "-keystore"
+    private val storepassFlag = "-storepass"
+
     fun generateKeyPair(
         javaBinDir: String,
         keystoreAlias: String,
@@ -11,11 +15,11 @@ class KeyStoreHelper {
         val cmdList = listOf(
             "$javaBinDir/keytool",
             "-genkeypair",
-            "-alias",
+            aliasFlag,
             keystoreAlias,
-            "-keystore",
+            keystoreFlag,
             keystoreFilePath,
-            "-storepass",
+            storepassFlag,
             keystorePassword,
             "-dname",
             "CN=CPI Example - My Signing Key, O=CorpOrgCorp, L=London, C=GB",
@@ -33,19 +37,19 @@ class KeyStoreHelper {
         javaBinDir: String,
         keystorePassword: String,
         keystoreFilePath: String,
-        alias: String,
+        aliasValue: String,
         fileName: String
     ) {
         val cmdList = listOf(
             "$javaBinDir/keytool",
             "-importcert",
-            "-keystore",
+            keystoreFlag,
             keystoreFilePath,
-            "-storepass",
+            storepassFlag,
             keystorePassword,
             "-noprompt",
-            "-alias",
-            alias,
+            aliasFlag,
+            aliasValue,
             "-file",
             fileName
         )
@@ -60,14 +64,14 @@ class KeyStoreHelper {
     ) {
 
         val cmdList = listOf(
-            javaBinDir + "/keytool",
+            "$javaBinDir/keytool",
             "-exportcert",
             "-rfc",
-            "-alias",
+            aliasFlag,
             keystoreAlias,
-            "-keystore",
+            keystoreFlag,
             keystoreFilePath,
-            "-storepass",
+            storepassFlag,
             "keystore password",
             "-file",
             keystoreCertFilePath

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/KeyStoreHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/cordapp/KeyStoreHelper.kt
@@ -1,0 +1,86 @@
+package net.corda.gradle.plugin.cordapp
+
+class KeyStoreHelper {
+
+    fun generateKeyPair(
+        javaBinDir: String,
+        keystoreAlias: String,
+        keystorePassword: String,
+        keystoreFilePath: String
+    ){
+        val cmdList = listOf(
+            "$javaBinDir/keytool",
+            "-genkeypair",
+            "-alias",
+            keystoreAlias,
+            "-keystore",
+            keystoreFilePath,
+            "-storepass",
+            keystorePassword,
+            "-dname",
+            "CN=CPI Example - My Signing Key, O=CorpOrgCorp, L=London, C=GB",
+            "-keyalg",
+            "RSA",
+            "-storetype",
+            "pkcs12",
+            "-validity",
+            "4000"
+        )
+        runCommand(cmdList)
+    }
+
+    fun importKeystoreCert(
+        javaBinDir: String,
+        keystorePassword: String,
+        keystoreFilePath: String,
+        alias: String,
+        fileName: String
+    ) {
+        val cmdList = listOf(
+            "$javaBinDir/keytool",
+            "-importcert",
+            "-keystore",
+            keystoreFilePath,
+            "-storepass",
+            keystorePassword,
+            "-noprompt",
+            "-alias",
+            alias,
+            "-file",
+            fileName
+        )
+        runCommand(cmdList)
+    }
+
+    fun exportCert(
+        javaBinDir: String,
+        keystoreAlias: String,
+        keystoreFilePath: String,
+        keystoreCertFilePath: String
+    ) {
+
+        val cmdList = listOf(
+            javaBinDir + "/keytool",
+            "-exportcert",
+            "-rfc",
+            "-alias",
+            keystoreAlias,
+            "-keystore",
+            keystoreFilePath,
+            "-storepass",
+            "keystore password",
+            "-file",
+            keystoreCertFilePath
+        )
+
+        runCommand(cmdList)
+    }
+
+    private fun runCommand(cmd: List<String>) {
+        val pb = ProcessBuilder(cmd)
+        pb.redirectErrorStream(true)
+        val proc = pb.start()
+        proc.inputStream.transferTo(System.out)
+        proc.waitFor()
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/dtos/DTOs.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/dtos/DTOs.kt
@@ -1,3 +1,75 @@
 package net.corda.gradle.plugin.dtos
 
 // A collection of dataclasses representing objects used by the plugin
+
+data class VNode(
+    var x500Name: String? = null,
+    var cpi: String? = null,
+    var serviceX500Name : String? = null,
+)
+
+data class GroupPolicyDTO(
+    // Note, we only need protocolParameters rather than the full set of properties.
+    var protocolParameters: ProtocolParametersDTO? = null
+)
+
+data class ProtocolParametersDTO(
+    var sessionKeyPolicy: String? = null,
+    var staticNetwork: StaticNetworkDTO? = null
+)
+
+data class StaticNetworkDTO(
+    var members: List<MemberDTO>? = null
+)
+
+data class MemberDTO(
+    var name: String? = null
+)
+
+data class CpiUploadResponseDTO(
+    var id: String? = null
+)
+
+data class GetCPIsResponseDTO(
+    var cpis: List<CpiMetadataDTO>? = null
+)
+
+data class CpiMetadataDTO(
+    // Note, these DTOs don't cover all returned values, just the ones required for the plugin.
+    var cpiFileChecksum: String? = null,
+    var id: CpiIdentifierDTO? = null
+)
+
+data class CpiIdentifierDTO(
+    // Note, these DTOs don't cover all returned values, just the ones required for the plugin
+    var cpiName: String? = null,
+    var cpiVersion: String? = null
+)
+
+data class CpiUploadStatus(
+    var cpiFileChecksum: String? = null,
+    var status: String? = null
+)
+
+data class VirtualNodeInfoDTO(
+    // Note, these DTOs don't cover all returned values, just the ones required for the plugin.
+    var holdingIdentity: HoldingIdentityDTO? = null,
+    var cpiIdentifier: CpiIdentifierDTO? = null
+)
+
+data class VirtualNodesDTO(
+    var virtualNodes: List<VirtualNodeInfoDTO>? = null
+)
+
+data class HoldingIdentityDTO(
+    // Note, these DTOs don't cover all returned values, just the ones required for the plugin.
+    var fullHash: String? = null,
+    var groupId: String? = null,
+    var shortHash: String? = null,
+    var x500Name: String? = null
+)
+
+data class RegistrationRequestProgressDTO(
+    // Note, these DTOs don't cover all returned values, just the ones required for the plugin.
+    var registrationStatus: String? = null
+)

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/NetworkTasks.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/NetworkTasks.kt
@@ -1,3 +1,45 @@
 package net.corda.gradle.plugin.network
 
+import net.corda.gradle.plugin.configuration.PluginConfiguration
+import net.corda.gradle.plugin.configuration.ProjectContext
+import net.corda.gradle.plugin.cordalifecycle.UPDATE_PROCESSOR_TIMEOUT
+import net.corda.gradle.plugin.cordapp.DEPLOY_CPIS_TASK_NAME
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
 // Tasks relating to creating virtual nodes and setting up a network
+
+const val NETWORK_GROUP = "corda-runtime-plugin-network"
+const val VNODE_SETUP_TASK_NAME = "vNodesSetup"
+
+/**
+ * Creates the gradle helper tasks in the network group
+ */
+fun createNetworkTasks(project: Project, pluginConfiguration: PluginConfiguration) {
+    project.afterEvaluate {
+        project.tasks.create(VNODE_SETUP_TASK_NAME, VNodeSetupTask::class.java) {
+            it.group = NETWORK_GROUP
+            it.dependsOn(DEPLOY_CPIS_TASK_NAME)
+            it.pluginConfig.set(pluginConfiguration)
+            it.finalizedBy(UPDATE_PROCESSOR_TIMEOUT)
+        }
+    }
+
+}
+
+open class VNodeSetupTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+    @get:Input
+    val pluginConfig: Property<PluginConfiguration> = objects.property(PluginConfiguration::class.java)
+
+    @TaskAction
+    fun deployCPIs() {
+        val pc = ProjectContext(project, pluginConfig.get())
+        NetworkTasksImpl(pc).createVNodes()
+        NetworkTasksImpl(pc).registerVNodes()
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/NetworkTasksImpl.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/NetworkTasksImpl.kt
@@ -1,0 +1,93 @@
+package net.corda.gradle.plugin.network
+
+import net.corda.gradle.plugin.configuration.ProjectContext
+import net.corda.gradle.plugin.dtos.VNode
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import net.corda.gradle.plugin.getExistingNodes
+import net.corda.gradle.plugin.retry
+import net.corda.gradle.plugin.rpcWait
+import java.time.Duration
+
+class NetworkTasksImpl(var pc: ProjectContext) {
+
+    /**
+     * Creates vnodes specified in the config if they don't already exist.
+     */
+    fun createVNodes() {
+
+        // Represents the list of VNodes as specified in the network Config json file (static-network-config.json)
+        val requiredNodes: List<VNode> = pc.networkConfig.vNodes
+
+        val existingVNodes = getExistingNodes(pc)
+
+        // Check if each required vnode already exist, if not create it.
+        val nodesToCreate = requiredNodes.filter { vn ->
+            !existingVNodes.any { en ->
+                en.holdingIdentity?.x500Name.equals(vn.x500Name) &&
+                        en.cpiIdentifier?.cpiName.equals(vn.cpi)
+            }
+        }
+        nodesToCreate.forEach {
+            val cpiUploadFilePath = if (it.serviceX500Name == null) pc.corDappCpiUploadStatusFilePath else pc.notaryCpiUploadStatusFilePath
+
+            VNodeHelper().createVNode(
+                pc.cordaClusterURL,
+                pc.cordaRpcUser,
+                pc.cordaRpcPassword,
+                it,
+                cpiUploadFilePath
+            )
+            // Check if the virtual node has been created.
+            retry(timeout = Duration.ofMillis(30000)) {
+                getExistingNodes(pc).singleOrNull { knownVNode ->
+                    knownVNode.holdingIdentity?.x500Name.equals(it.x500Name)
+                } ?: throw CordaRuntimeGradlePluginException("Failed to create VNode: ${it.x500Name}")
+            }
+        }
+    }
+
+    /**
+     * Checks if the required virtual nodes have been registered and if not registers them.
+     */
+    fun registerVNodes() {
+        // Represents the list of VNodes as specified in the network Config json file (static-network-config.json)
+        val requiredNodes: List<VNode> = pc.networkConfig.vNodes
+
+        // There appears to be a delay between the successful post /virtualnodes synchronous call and the
+        // vnodes being returned in the GET /virtualnodes call. Putting a thread wait here as a quick fix
+        // as this will move to async mechanism post beta2. see CORE-12153
+        rpcWait(3000)
+
+        val existingNodes = getExistingNodes(pc)
+        val helper = VNodeHelper()
+
+        requiredNodes.forEach { vn ->
+            val match = helper.findMatchingVNodeFromList(existingNodes, vn)
+
+            val shortHash = try {
+                match.holdingIdentity!!.shortHash!!
+            } catch (e: Exception) {
+                throw CordaRuntimeGradlePluginException("Cannot read ShortHash for virtual node '${vn.x500Name}'")
+            }
+
+            if (!helper.checkVNodeIsRegistered(
+                    pc.cordaClusterURL,
+                    pc.cordaRpcUser,
+                    pc.cordaRpcPassword,
+                    shortHash
+                )
+            ) {
+                pc.logger.quiet("Registering vNode: ${vn.x500Name} with shortHash: $shortHash")
+                helper.registerVNode(
+                    pc.cordaClusterURL,
+                    pc.cordaRpcUser,
+                    pc.cordaRpcPassword,
+                    vn,
+                    shortHash,
+                    pc.vnodeRegistrationTimeout
+                )
+                pc.logger.quiet("VNode ${vn.x500Name} with shortHash $shortHash registered.")
+            }
+        }
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/VNodeHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/VNodeHelper.kt
@@ -1,0 +1,220 @@
+package net.corda.gradle.plugin.network
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import kong.unirest.HttpResponse
+import kong.unirest.JsonNode
+import kong.unirest.Unirest
+import net.corda.gradle.plugin.dtos.CpiUploadStatus
+import net.corda.gradle.plugin.dtos.GetCPIsResponseDTO
+import net.corda.gradle.plugin.dtos.RegistrationRequestProgressDTO
+import net.corda.gradle.plugin.dtos.VNode
+import net.corda.gradle.plugin.dtos.VirtualNodeInfoDTO
+import net.corda.gradle.plugin.exception.CordaRuntimeGradlePluginException
+import net.corda.gradle.plugin.retry
+import java.io.FileInputStream
+import java.net.HttpURLConnection
+import java.time.Duration
+import java.util.*
+
+class VNodeHelper {
+
+    private val mapper = ObjectMapper()
+
+    init {
+        Unirest.config().verifySsl(false)
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    }
+
+    fun createVNode(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        vNode: VNode,
+        cpiUploadStatusFilePath: String
+    ) {
+
+        //pc.logger.quiet("Creating virtual node for: ${vNode.x500Name}")
+        val cpiCheckSum = getCpiCheckSum(cpiUploadStatusFilePath)
+
+        if (!checkCpiUploaded(
+                cordaClusterURL,
+                cordaRpcUser,
+                cordaRpcPassword,
+                cpiCheckSum
+            )
+        ) throw CordaRuntimeGradlePluginException("Cpi $cpiCheckSum not uploaded.")
+
+        val response: HttpResponse<JsonNode> = Unirest.post("$cordaClusterURL/api/v1/virtualnode")
+            .body("{ \"request\" : { \"cpiFileChecksum\": \"" + cpiCheckSum + "\", \"x500Name\": \"" + vNode.x500Name + "\" } }")
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .asJson()
+
+        if (response.status != HttpURLConnection.HTTP_ACCEPTED) {
+            throw CordaRuntimeGradlePluginException("Creation of virtual node failed with response status: ${response.status}")
+        }
+
+
+    }
+
+    /**
+     * Reads the latest CPI checksums from file.
+     */
+    private fun getCpiCheckSum(
+        cpiUploadStatusFilePath: String
+    ): String {
+        try {
+            val fis = FileInputStream(cpiUploadStatusFilePath)
+            val statusDTO: CpiUploadStatus = mapper.readValue(fis, CpiUploadStatus::class.java)
+            return statusDTO.cpiFileChecksum!!
+        } catch (e: Exception) {
+            throw CordaRuntimeGradlePluginException("Failed to read CPI checksum from file, with error: $e")
+        }
+    }
+
+    private fun checkCpiUploaded(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        cpiCheckSum: String
+    ): Boolean {
+
+        val response: HttpResponse<JsonNode> = Unirest.get(cordaClusterURL + "/api/v1/cpi")
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .asJson()
+
+        if (response.status != HttpURLConnection.HTTP_OK) {
+            throw CordaRuntimeGradlePluginException("Failed to check cpis, response status: " + response.status)
+        }
+
+        try {
+            val cpisResponse: GetCPIsResponseDTO = mapper.readValue(response.body.toString(), GetCPIsResponseDTO::class.java)
+
+            cpisResponse.cpis?.forEach { cpi ->
+                if (Objects.equals(cpi.cpiFileChecksum, cpiCheckSum)) return true
+            }
+            return false
+        } catch (e: Exception) {
+            throw CordaRuntimeGradlePluginException("Failed to check cpis with exception: $e")
+        }
+    }
+
+    fun findMatchingVNodeFromList(existingNodes: List<VirtualNodeInfoDTO>, requiredNode: VNode): VirtualNodeInfoDTO {
+        val matches = existingNodes.filter { en ->
+            en.holdingIdentity?.x500Name.equals(requiredNode.x500Name) &&
+                    en.cpiIdentifier?.cpiName.equals(requiredNode.cpi)
+        }
+        if (matches.isEmpty()) {
+            throw CordaRuntimeGradlePluginException(
+                "Registration failed because virtual node for '${requiredNode.x500Name}' not found."
+            )
+        } else if (matches.size > 1) {
+            throw CordaRuntimeGradlePluginException(
+                "Registration failed because more than virtual node for '${requiredNode.x500Name}'"
+            )
+        }
+        return matches.single()
+    }
+
+    /**
+     * Registers an individual Vnode
+     */
+    @Suppress("LongParameterList")
+    fun registerVNode(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        vNode: VNode,
+        shortHash: String,
+        vnodeRegistrationTimeout: Long
+    ) {
+        val registrationBody = if (vNode.serviceX500Name == null) {
+            """ 
+            { 
+                "memberRegistrationRequest" : {
+                    "context" : {
+                        "corda.key.scheme" : "CORDA.ECDSA.SECP256R1" 
+                    }
+                }
+            }
+            """.trimIndent()
+        } else {
+            """
+            { 
+                "memberRegistrationRequest" : {
+                    "context" : {
+                        "corda.key.scheme" : "CORDA.ECDSA.SECP256R1",
+                        "corda.roles.0" : "notary",
+                        "corda.notary.service.name" : "${vNode.serviceX500Name}",
+                        "corda.notary.service.flow.protocol.version.0" : "1",
+                        "corda.notary.service.flow.protocol.name" : "com.r3.corda.notary.plugin.nonvalidating"
+                    } 
+                }
+            }
+            """.trimIndent()
+        }
+
+        val response: HttpResponse<JsonNode> = Unirest.post("$cordaClusterURL/api/v1/membership/$shortHash")
+            .body(registrationBody)
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .asJson()
+
+        if (response.status != HttpURLConnection.HTTP_OK) {
+            throw CordaRuntimeGradlePluginException(
+                "Failed to request registration of virtual node $shortHash, response status: ${response.status}"
+            )
+        }
+
+        // Wait until the VNode is registered
+        // The timeout is controlled by setting the vnodeRegistrationTimeout property
+        retry(timeout = Duration.ofMillis(vnodeRegistrationTimeout)) {
+            if (!checkVNodeIsRegistered(
+                    cordaClusterURL,
+                    cordaRpcUser,
+                    cordaRpcPassword,
+                    shortHash
+                )
+            ) {
+                throw CordaRuntimeGradlePluginException("VNode $shortHash not registered.")
+            }
+        }
+    }
+
+    /**
+     * Checks if a virtual node with given shortHash has been registered
+     * @return returns true if the vnode is registered
+     */
+    fun checkVNodeIsRegistered(
+        cordaClusterURL: String,
+        cordaRpcUser: String,
+        cordaRpcPassword: String,
+        shortHash: String
+    ): Boolean {
+
+        val response: HttpResponse<JsonNode> = Unirest.get("$cordaClusterURL/api/v1/membership/$shortHash")
+            .basicAuth(cordaRpcUser, cordaRpcPassword)
+            .asJson()
+
+        if (response.status != HttpURLConnection.HTTP_OK) {
+            return false
+        }
+
+        try {
+            if (!response.body.array.isEmpty) {
+                val requests: List<RegistrationRequestProgressDTO> = mapper.readValue(
+                    response.body.toString(),
+                    object : TypeReference<List<RegistrationRequestProgressDTO>>() {})
+
+                // Returns true if any requests have registrationStatus of "APPROVED"
+                return requests.any { request ->
+                    Objects.equals(request.registrationStatus, "APPROVED")
+                }
+            }
+            // Returns false if array was empty or "APPROVED" wasn't found
+            return false
+        } catch (e: Exception) {
+            throw CordaRuntimeGradlePluginException("Failed to check registration status for $shortHash with exception: $e.")
+        }
+    }
+}

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/VNodeHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/VNodeHelper.kt
@@ -42,7 +42,7 @@ class VNodeHelper {
                 cordaRpcPassword,
                 cpiCheckSum
             )
-        ) throw CordaRuntimeGradlePluginException("Cpi $cpiCheckSum not uploaded.")
+        ) throw CordaRuntimeGradlePluginException("CPI $cpiCheckSum not uploaded.")
 
         val response: HttpResponse<JsonNode> = Unirest.post("$cordaClusterURL/api/v1/virtualnode")
             .body("{ \"request\" : { \"cpiFileChecksum\": \"" + cpiCheckSum + "\", \"x500Name\": \"" + vNode.x500Name + "\" } }")
@@ -81,7 +81,7 @@ class VNodeHelper {
             .asJson()
 
         if (response.status != HttpURLConnection.HTTP_OK) {
-            throw CordaRuntimeGradlePluginException("Failed to check cpis, response status: " + response.status)
+            throw CordaRuntimeGradlePluginException("Failed to check CPIs, response status: " + response.status)
         }
 
         try {
@@ -92,7 +92,7 @@ class VNodeHelper {
             }
             return false
         } catch (e: Exception) {
-            throw CordaRuntimeGradlePluginException("Failed to check cpis with exception: $e")
+            throw CordaRuntimeGradlePluginException("Failed to check CPIs with exception: ${e.message}", e)
         }
     }
 
@@ -107,7 +107,7 @@ class VNodeHelper {
             )
         } else if (matches.size > 1) {
             throw CordaRuntimeGradlePluginException(
-                "Registration failed because more than virtual node for '${requiredNode.x500Name}'"
+                "Registration failed because more than one virtual node for '${requiredNode.x500Name}'"
             )
         }
         return matches.single()
@@ -210,7 +210,7 @@ class VNodeHelper {
             // Returns false if array was empty or "APPROVED" wasn't found
             return false
         } catch (e: Exception) {
-            throw CordaRuntimeGradlePluginException("Failed to check registration status for $shortHash with exception: $e.")
+            throw CordaRuntimeGradlePluginException("Failed to check registration status for $shortHash with exception: ${e.message}.", e)
         }
     }
 }

--- a/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/VNodeHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/main/kotlin/net/corda/gradle/plugin/network/VNodeHelper.kt
@@ -34,8 +34,6 @@ class VNodeHelper {
         vNode: VNode,
         cpiUploadStatusFilePath: String
     ) {
-
-        //pc.logger.quiet("Creating virtual node for: ${vNode.x500Name}")
         val cpiCheckSum = getCpiCheckSum(cpiUploadStatusFilePath)
 
         if (!checkCpiUploaded(
@@ -54,8 +52,6 @@ class VNodeHelper {
         if (response.status != HttpURLConnection.HTTP_ACCEPTED) {
             throw CordaRuntimeGradlePluginException("Creation of virtual node failed with response status: ${response.status}")
         }
-
-
     }
 
     /**


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/ES-1828

Reproduce the heart and soul of the CSDE plugin.
Split some of the functionality so that the gradle/project specific things are in the taskImpl classes, and the "helpers" are pure kotlin: thinking ahead to when we pick up the Corda SDK.

Tested manually:
<img width="1631" alt="Screenshot 2024-01-31 at 15 20 07" src="https://github.com/corda/corda-runtime-os/assets/92731849/94bd4f5e-786a-4b2f-a321-a2fb09ba6838">
