### PR TITLE
CORE-19027: State Types - Helm Worker Changes

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -259,20 +259,9 @@ spec:
             {{- include "corda.cryptoDbPasswordEnv" . | nindent 12 }}
             {{/* Bootstrap State Manager Databases */}}
             {{- range $stateType, $stateTypeConfig  := .Values.stateManager -}}
-            {{-   $databaseFound := false -}}
-            {{-   $connectionSettings := dict -}}
             {{-   $storageId := $stateTypeConfig.storageId -}}
             {{-   $storagePartition := $stateTypeConfig.partition -}}
-            {{/*  -- Ensure that every state type has an associated database storage configured */}}
-            {{-   range $.Values.databases -}}
-            {{-     if eq .name $storageId -}}
-            {{-       $databaseFound = true -}}
-            {{-       $connectionSettings = . -}}
-            {{-     end -}}
-            {{-   end -}}
-            {{-   if not $databaseFound -}}
-            {{-     fail ( printf "Undefined persistent storage '%s' detected at stateManager.%s.storageId" $storageId $stateType ) -}}
-            {{-   end -}}
+            {{-   $connectionSettings := fromYaml ( include "corda.db.configuration" ( list $ $storageId ( printf "stateManager.%s.storageId" $stateType ) ) ) -}}
             {{/*  -- Check whether bootstrap is enabled for the database storage associated to the state type */}}
             {{-   range $bootCredentials := $.Values.bootstrap.db.databases -}}
             {{-     if eq .name $storageId -}}
@@ -281,7 +270,7 @@ spec:
             {{-           $stateManagerSettings := ( index $workerConfig "stateManager" ) -}}
             {{/*          -- State Manager configured for the worker, generate the required database boostrap template */}}
             {{-           if and $stateManagerSettings ( index $stateManagerSettings $stateType ) -}}
-            {{-             include "corda.stateManagerDatabaseBootstrap" ( list $ $stateType $workerName $storagePartition $connectionSettings ( index $stateManagerSettings $stateType ) $bootCredentials ) -}}
+            {{-             include "corda.sm.db.bootstrapContainers" ( list $ $stateType $workerName $storagePartition $connectionSettings ( index $stateManagerSettings $stateType ) $bootCredentials ) -}}
             {{-           end -}}
             {{-         end -}}
             {{-     end -}}

--- a/charts/corda-lib/templates/_database.tpl
+++ b/charts/corda-lib/templates/_database.tpl
@@ -1,0 +1,66 @@
+{{/*
+    Database Related Templates / Helpers
+*/}}
+
+
+{{/*
+    Default Name for Secrets Containing Bootstrap Database Credentials
+    The resulting secret name is "chartName-bootstrap-databaseName-db"
+*/}}
+{{- define "corda.db.bootstrapCredentialsSecretName" -}}
+{{- $ := index . 0 -}}
+{{- $dbName := index . 1 -}}
+{{ printf "%s-bootstrap-%s-db" ( include "corda.fullname" $ ) $dbName }}
+{{- end -}}
+
+
+{{/*
+    Default Name for Secrets Containing Database Credentials
+    The resulting secret name is "chartName-runtime-databaseName-db"
+*/}}
+{{- define "corda.db.runtimeCredentialsSecretName" -}}
+{{- $ := index . 0 -}}
+{{- $dbName := index . 1 -}}
+{{ printf "%s-runtime-%s-db" ( include "corda.fullname" $ ) $dbName }}
+{{- end -}}
+
+
+{{/*
+    Generate Java Database Connectivity URL From a 'database' Structure
+*/}}
+{{- define "corda.db.connectionUrl" -}}
+jdbc:{{- .type -}}://{{- required ( printf "Must specify a host for database '%s'" .name ) .host -}}:{{- .port -}}/{{- .name -}}
+{{- end -}}
+
+
+{{/*
+    Generate Java Database Connectivity Driver Class Name From a 'database' Type (already validated in JSON schema)
+*/}}
+{{- define "corda.db.driverClassName" -}}
+{{- if eq .type "postgresql" -}}
+{{-   printf "org.postgresql.Driver" -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+    Iterate through configured platform databases and return the one matching the requested 'storageId'.
+    If a database with the requested 'storageId' can not be found, immediately fail the rendering process.
+*/}}
+{{- define "corda.db.configuration" -}}
+{{- $ := index . 0 -}}
+{{- $dbName := index . 1 -}}
+{{- $reference := index . 2 -}}
+{{- $databaseFound := false -}}
+{{- $defaultDatabaseConfig := dict -}}
+{{- range $.Values.databases -}}
+{{-   if eq .name $dbName -}}
+{{-     $databaseFound = true -}}
+{{-     $defaultDatabaseConfig = . -}}
+{{-   end -}}
+{{- end -}}
+{{- if not $databaseFound -}}
+{{-   fail ( printf "Undefined persistent storage '%s' detected at %s" $dbName $reference ) -}}
+{{- end -}}
+{{ $defaultDatabaseConfig | toYaml }}
+{{- end -}}

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -6,6 +6,13 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+    Transform the given string input into kebab case
+*/}}
+{{- define "corda.kebabCase" -}}
+{{ . | kebabcase | replace "p-2p" "p2p" }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/corda-lib/templates/_stateManagerV2.tpl
+++ b/charts/corda-lib/templates/_stateManagerV2.tpl
@@ -207,7 +207,7 @@
 {{- $ := index . 0 -}}
 {{- $workerName := index . 1 -}}
 {{- $workerConfig := index . 2 -}}
-{{- range $stateType, $runtimeSettings  := $workerConfig.stateManager }}
+{{- range $stateType, $runtimeSettings := $workerConfig.stateManager }}
 {{-   $volumeName := include "corda.sm.runtimeCredentialsVolumeName" $stateType }}
 {{-   $stateTypeRootConfig := ( index $.Values.stateManager $stateType ) }}
 {{-   $connectionSettings := fromYaml ( include "corda.db.configuration" ( list $ $stateTypeRootConfig.storageId ( printf "stateManager.%s.storageId" $stateType ) ) ) }}
@@ -291,7 +291,7 @@
 {{- $workerKebabCase := include "corda.kebabCase" $workerName -}}
 {{- with index . 0 }}
 - name: {{ ( printf "generate-%s-runtime-configuration" $workerKebabCase ) | quote }}
-  image: {{ include "corda.bootstrapCliImage" $ }}
+  image: {{ include "corda.workerImage" ( list $ $workerConfig ) }}
   imagePullPolicy: {{ $.Values.imagePullPolicy }}
   {{- include "corda.containerSecurityContext" $ | nindent 2 }}
   command: [ 'sh', '-c', '-e' ]

--- a/charts/corda-lib/templates/_stateManagerV2.tpl
+++ b/charts/corda-lib/templates/_stateManagerV2.tpl
@@ -316,7 +316,7 @@
                 "driver": {{ include "corda.db.driverClassName" $connectionSettings | quote }}
               },
               "pool": {
-              {{- if $stateTypeRuntimeConfig.connectionPool.minSize }}
+              {{- if not ( kindIs "invalid" $stateTypeRuntimeConfig.connectionPool.minSize ) }}
                 "minSize": {{ $stateTypeRuntimeConfig.connectionPool.minSize }},
               {{- end }}
                 "maxSize": {{ $stateTypeRuntimeConfig.connectionPool.maxSize -}},

--- a/charts/corda-lib/templates/_stateManagerV2.tpl
+++ b/charts/corda-lib/templates/_stateManagerV2.tpl
@@ -1,45 +1,31 @@
 {{/*
     State Manager Named Templates
-    Kept in an isolated file for easier maintenance and development.
     TODO-[CORE-19372]: rename this file to _stateManager.tpl (and remove the old one _stateManager.tpl).
 */}}
 
 
 {{/*
-    Transform the given string input into kebab case
+    Checks whether there's at least one state type configured under the specified 'workerConfig'
 */}}
-{{- define "corda.kebabCase" -}}
-{{ . | kebabcase | replace "p-2p" "p2p" }}
+{{- define "corda.sm.required" -}}
+{{- $ := index . 0 -}}
+{{- $workerConfig := index . 1 -}}
+{{- $stateManagerV2 := false -}}
+{{- range $stateType, $stateTypeConfig  := $.Values.stateManager }}
+{{-   $stateManagerSettings := ( index $workerConfig "stateManager" ) -}}
+{{-   if and $stateManagerSettings ( index $stateManagerSettings $stateType ) -}}
+{{-     $stateManagerV2 = true -}}
+{{-   end -}}
 {{- end }}
-
-
-{{/*
-    Default Name for Secrets Containing Bootstrap Database Credentials
-    The resulting secret name is "chartName-bootstrap-databaseName-db"
-*/}}
-{{- define "corda.defaultDatabaseBootstrapCredentialsSecretName" -}}
-{{- $ := index . 0 -}}
-{{- $dbName := index . 1 -}}
-{{ printf "%s-bootstrap-%s-db" ( include "corda.fullname" $ ) $dbName }}
+{{- $stateManagerV2 -}}
 {{- end -}}
 
 
 {{/*
-    Default Name for Secrets Containing Database Credentials
-    The resulting secret name is "chartName-runtime-databaseName-db"
-*/}}
-{{- define "corda.defaultDatabaseRuntimeCredentialsSecretName" -}}
-{{- $ := index . 0 -}}
-{{- $dbName := index . 1 -}}
-{{ printf "%s-runtime-%s-db" ( include "corda.fullname" $ ) $dbName }}
-{{- end -}}
-
-
-{{/*
-    Name for Secrets Containing State Manager Runtime Credentials (custom, defined at the worker level)
+    Name for Secrets Containing State Manager Runtime Credentials (defined at the worker level)
     The resulting secret name is "chartName-runtime-workerNameKebabCase-stateTypeKebabCase-db"
 */}}
-{{- define "corda.stateManagerDefaultRuntimeSecretName" -}}
+{{- define "corda.sm.runtimeCredentialsSecretName" -}}
 {{- $ := index . 0 -}}
 {{- $stateType := index . 1 -}}
 {{- $workerName := index . 2 -}}
@@ -48,9 +34,16 @@
 
 
 {{/*
-    Environment variables to be used when bootstrapping state manager databases (BOOT_PG_USERNAME and BOOT_PG_PASSWORD)
+    Name for Volumes Containing State Manager Runtime Credentials (defined at the worker level)
 */}}
-{{- define "corda.stateManagerDatabaseBootstrapEnvironment" -}}
+{{- define "corda.sm.runtimeCredentialsVolumeName" -}}
+{{ printf "%s-volume" ( include "corda.kebabCase" . ) }}
+{{- end -}}
+
+{{/*
+    Environment variables (BOOT_PG_USERNAME and BOOT_PG_PASSWORD) to be used when bootstrapping state manager databases
+*/}}
+{{- define "corda.sm.db.bootstrapEnvironment" -}}
 {{- $ := index . 0 -}}
 {{- $dbName := index . 1 -}}
 {{- $bootstrapSettings := index . 2 -}}
@@ -61,7 +54,7 @@
       name: {{ $bootstrapSettings.username.valueFrom.secretKeyRef.name | quote }}
       key: {{ required ( printf "Must specify username.valueFrom.secretKeyRef.key for database '%s'" $dbName ) $bootstrapSettings.username.valueFrom.secretKeyRef.key | quote }}
       {{-   else }}
-      name: {{ include "corda.defaultDatabaseBootstrapCredentialsSecretName" ( list $ $dbName ) | quote }}
+      name: {{ include "corda.db.bootstrapCredentialsSecretName" ( list $ $dbName ) | quote }}
       key: "username"
       {{-   end }}
 - name: BOOT_PG_PASSWORD
@@ -71,7 +64,7 @@
       name: {{ $bootstrapSettings.password.valueFrom.secretKeyRef.name | quote }}
       key: {{ required ( printf "Must specify password.valueFrom.secretKeyRef.key for database '%s'" $dbName ) $bootstrapSettings.password.valueFrom.secretKeyRef.key | quote }}
       {{-   else }}
-      name: {{ include "corda.defaultDatabaseBootstrapCredentialsSecretName" ( list $ $dbName ) | quote }}
+      name: {{ include "corda.db.bootstrapCredentialsSecretName" ( list $ $dbName ) | quote }}
       key: "password"
       {{-   end }}
 {{- end -}}
@@ -85,7 +78,7 @@
         - Default, set at the root "databases" level through a kubernetes secret provided by the user.
         - Default, set at the root "databases" level through a plain value provided by the user (transformed into a Secret by the chart)
 */}}
-{{- define "corda.stateManagerDatabaseRuntimeEnvironment" -}}
+{{- define "corda.sm.db.runtimeEnvironment" -}}
 {{- $ := index . 0 -}}
 {{- $dbName := index . 1 -}}
 {{- $stateType := index . 2 -}}
@@ -99,13 +92,13 @@
       name: {{ $runtimeSettings.username.valueFrom.secretKeyRef.name | quote }}
       key: {{ required ( printf "Must specify workers.%s.stateManager.%s.username.valueFrom.secretKeyRef.key" $workerName $stateType ) $runtimeSettings.username.valueFrom.secretKeyRef.key | quote }}
       {{-   else if $runtimeSettings.username.value }}
-      name: {{ include "corda.stateManagerDefaultRuntimeSecretName" ( list $ $stateType $workerName ) | quote }}
+      name: {{ include "corda.sm.runtimeCredentialsSecretName" ( list $ $stateType $workerName ) | quote }}
       key: "username"
       {{-   else if $defaultSettings.username.valueFrom.secretKeyRef.name }}
       name: {{ $defaultSettings.username.valueFrom.secretKeyRef.name | quote }}
       key: {{ required ( printf "Must specify username.valueFrom.secretKeyRef.key for database '%s'" $dbName ) $defaultSettings.username.valueFrom.secretKeyRef.key | quote }}
       {{-   else  }}
-      name: {{ include "corda.defaultDatabaseRuntimeCredentialsSecretName" ( list $ $dbName ) | quote }}
+      name: {{ include "corda.db.runtimeCredentialsSecretName" ( list $ $dbName ) | quote }}
       key: "username"
       {{-   end }}
 - name: STATE_MANAGER_PASSWORD
@@ -115,20 +108,22 @@
       name: {{ $runtimeSettings.password.valueFrom.secretKeyRef.name | quote }}
       key: {{ required ( printf "Must specify workers.%s.stateManager.%s.password.valueFrom.secretKeyRef.key" $workerName $stateType ) $runtimeSettings.password.valueFrom.secretKeyRef.key | quote }}
       {{-   else if $runtimeSettings.password.value }}
-      name: {{ include "corda.stateManagerDefaultRuntimeSecretName" ( list $ $stateType $workerName ) | quote }}
+      name: {{ include "corda.sm.runtimeCredentialsSecretName" ( list $ $stateType $workerName ) | quote }}
       key: "password"
       {{-   else if $defaultSettings.password.valueFrom.secretKeyRef.name }}
       name: {{ $defaultSettings.password.valueFrom.secretKeyRef.name | quote }}
       key: {{ required ( printf "Must specify password.valueFrom.secretKeyRef.key for database '%s'" $dbName ) $defaultSettings.password.valueFrom.secretKeyRef.key | quote }}
       {{-   else  }}
-      name: {{ include "corda.defaultDatabaseRuntimeCredentialsSecretName" ( list $ $dbName ) | quote }}
+      name: {{ include "corda.db.runtimeCredentialsSecretName" ( list $ $dbName ) | quote }}
       key: "password"
       {{-   end }}
 {{- end -}}
 
 
-{{/* State Manager Containers to Create & Apply Database Schemas Within The Bootstrap Job */}}
-{{- define "corda.stateManagerDatabaseBootstrap" -}}
+{{/*
+    State Manager Containers to Create & Apply Database Schemas Within The Bootstrap Job
+*/}}
+{{- define "corda.sm.db.bootstrapContainers" -}}
 {{- $ := index . 0 -}}
 {{- $stateType := index . 1 -}}
 {{- $workerName := index . 2 -}}
@@ -148,14 +143,14 @@
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
           env:
             {{- include "corda.bootstrapCliEnv" . | nindent 12 }}
-            {{- include "corda.stateManagerDatabaseBootstrapEnvironment" ( list $ $dbName $bootstrapSettings ) | nindent 12 }}
+            {{- include "corda.sm.db.bootstrapEnvironment" ( list $ $dbName $bootstrapSettings ) | nindent 12 }}
           command: [ 'sh', '-c', '-e' ]
           args:
             - |
               #!/bin/sh
               set -ev
               echo "Generating Database Specification for Database '{{ $dbName }}'..."
-              JDBC_URL="jdbc:{{- $databaseConfig.type -}}://{{- required ( printf "Must specify a host for database '%s'" $dbName ) $databaseConfig.host -}}:{{- $databaseConfig.port -}}/{{- $dbName -}}"
+              JDBC_URL={{ include "corda.db.connectionUrl" $databaseConfig | quote }}
               mkdir /tmp/database-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }}
               java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar database spec \
                 -s "statemanager" -g "statemanager:{{ $schemaName }}" \
@@ -174,14 +169,14 @@
           {{- include "corda.bootstrapResources" . | nindent 10 }}
           {{- include "corda.containerSecurityContext" . | nindent 10 }}
           env:
-            {{- include "corda.stateManagerDatabaseBootstrapEnvironment" ( list $ $dbName $bootstrapSettings ) | nindent 12 }}
-            {{- include "corda.stateManagerDatabaseRuntimeEnvironment" ( list $ $dbName $stateType $workerName $databaseConfig $runtimeSettings ) | nindent 12 }}
+            {{- include "corda.sm.db.bootstrapEnvironment" ( list $ $dbName $bootstrapSettings ) | nindent 12 }}
+            {{- include "corda.sm.db.runtimeEnvironment" ( list $ $dbName $stateType $workerName $databaseConfig $runtimeSettings ) | nindent 12 }}
           command: [ 'sh', '-c', '-e' ]
           args:
             - |
               #!/bin/sh
               set -ev
-              echo 'Applying State Manager Specification for Database '{{ $dbName }}'..."
+              echo "Applying State Manager Specification for Database '{{ $dbName }}'..."
               export PGPASSWORD="${BOOT_PG_PASSWORD}"
               find /tmp/database-{{ $workerKebabCase }}-{{ $stateTypeKebabCase }} -iname "*.sql" | xargs printf -- ' -f %s' | xargs psql -v ON_ERROR_STOP=1 -h "{{- required ( printf "Must specify a host for database '%s'" $dbName ) $databaseConfig.host -}}" -p "{{- $databaseConfig.port -}}" -U "${BOOT_PG_USERNAME}" --dbname "{{- $dbName -}}"
               echo 'Applying State Manager Specification for {{ $workerName }}... Done!'
@@ -195,9 +190,164 @@
                 ALTER ROLE "${STATE_MANAGER_USERNAME}" SET search_path TO "{{- $schemaName -}}";
               SQL
 
-              echo 'Applying State Manager Specification for Database '{{ $dbName }}'... Done!'
+              echo "Applying State Manager Specification for Database '{{ $dbName }}'... Done!"
           volumeMounts:
             - mountPath: /tmp
               name: temp
 {{- end -}}
+{{- end -}}
+
+
+{{/*
+    Volumes Containing State Manager Runtime Credentials for Each State Type Used by The Worker
+    The template defines a single 'volume' per State Type, with two projections pointing to the Secrets where the
+    username and password are configured.
+*/}}
+{{- define "corda.sm.runtimeCredentialVolumes" -}}
+{{- $ := index . 0 -}}
+{{- $workerName := index . 1 -}}
+{{- $workerConfig := index . 2 -}}
+{{- range $stateType, $runtimeSettings  := $workerConfig.stateManager }}
+{{-   $volumeName := include "corda.sm.runtimeCredentialsVolumeName" $stateType }}
+{{-   $stateTypeRootConfig := ( index $.Values.stateManager $stateType ) }}
+{{-   $connectionSettings := fromYaml ( include "corda.db.configuration" ( list $ $stateTypeRootConfig.storageId ( printf "stateManager.%s.storageId" $stateType ) ) ) }}
+- name: {{ $volumeName }}
+  projected:
+    sources:
+      - secret:
+{{-   if $runtimeSettings.username.valueFrom.secretKeyRef.name }}
+          name: {{ $runtimeSettings.username.valueFrom.secretKeyRef.name | quote }}
+          items:
+            - key: {{ required ( printf "Must specify workers.%s.stateManager.%s.username.valueFrom.secretKeyRef.key" $workerName $stateType ) $runtimeSettings.username.valueFrom.secretKeyRef.key | quote }}
+              path: "username"
+{{-   else if $runtimeSettings.username.value }}
+          name: {{ include "corda.sm.runtimeCredentialsSecretName" ( list $ $stateType $workerName ) | quote }}
+          items:
+            - key: "username"
+              path: "username"
+{{-   else if $connectionSettings.username.valueFrom.secretKeyRef.name }}
+          name: {{ $connectionSettings.username.valueFrom.secretKeyRef.name | quote }}
+          items:
+            - key: {{ required ( printf "Must specify username.valueFrom.secretKeyRef.key for database '%s'" $connectionSettings.name ) $connectionSettings.username.valueFrom.secretKeyRef.key | quote }}
+              path: "username"
+{{-   else  }}
+          name: {{ include "corda.db.runtimeCredentialsSecretName" ( list $ $connectionSettings.name ) | quote }}
+          items:
+            - key: "username"
+              path: "username"
+{{-   end }}
+      - secret:
+{{-   if $runtimeSettings.password.valueFrom.secretKeyRef.name }}
+          name: {{ $runtimeSettings.password.valueFrom.secretKeyRef.name | quote }}
+          items:
+            - key: {{ required ( printf "Must specify workers.%s.stateManager.%s.password.valueFrom.secretKeyRef.key" $workerName $stateType ) $runtimeSettings.password.valueFrom.secretKeyRef.key | quote }}
+              path: "password"
+{{-   else if $runtimeSettings.password.value }}
+          name: {{ include "corda.sm.runtimeCredentialsSecretName" ( list $ $stateType $workerName ) | quote }}
+          items:
+            - key: "password"
+              path: "password"
+{{-   else if $connectionSettings.password.valueFrom.secretKeyRef.name }}
+          name: {{ $connectionSettings.password.valueFrom.secretKeyRef.name | quote }}
+          items:
+            - key: {{ required ( printf "Must specify password.valueFrom.secretKeyRef.key for database '%s'" $connectionSettings.name ) $connectionSettings.password.valueFrom.secretKeyRef.key | quote }}
+              path: "password"
+{{-   else  }}
+          name: {{ include "corda.db.runtimeCredentialsSecretName" ( list $ $connectionSettings.name ) | quote }}
+          items:
+            - key: "password"
+              path: "password"
+{{-   end }}
+{{- end }}
+{{- end -}}
+
+
+{{/*
+    Volume Mounts for Each State Type Used by The Worker
+*/}}
+{{- define "corda.sm.runtimeCredentialsVolumeMounts" -}}
+{{- $ := index . 0 -}}
+{{- $workerConfig := index . 1 -}}
+{{- range $stateType, $runtimeSettings := $workerConfig.stateManager }}
+{{-   $volumeName := include "corda.sm.runtimeCredentialsVolumeName" $stateType }}
+- mountPath: "/tmp/{{- $stateType -}}-mount"
+  name: {{ $volumeName | quote }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+
+{{/*
+    State Manager Container to Create Worker Startup Configuration File
+    There is one configuration file generated for each State Type used by the Worker:
+        - Connection settings are obtained from the database configuration.
+        - Connection Pool settings are obtained from the worker runtime configuration.
+        - Credentials are obtained worker runtime configuration and, if not found, from the database configuration.
+*/}}
+{{- define "corda.sm.db.runtimeConfigurationContainer" -}}
+{{- $ := index . 0 -}}
+{{- $workerName := index . 1 -}}
+{{- $workerConfig := index . 2 -}}
+{{- $workerKebabCase := include "corda.kebabCase" $workerName -}}
+{{- with index . 0 }}
+- name: {{ ( printf "generate-%s-runtime-configuration" $workerKebabCase ) | quote }}
+  image: {{ include "corda.bootstrapCliImage" $ }}
+  imagePullPolicy: {{ $.Values.imagePullPolicy }}
+  {{- include "corda.containerSecurityContext" $ | nindent 2 }}
+  command: [ 'sh', '-c', '-e' ]
+  args:
+    - |
+      #!/bin/sh
+      set -ev
+      echo 'Generating State Manger Configuration Settings...'
+
+      {{ range $stateType, $stateTypeRuntimeConfig  := $workerConfig.stateManager }}
+      {{-   $stateTypeRootConfig := ( index $.Values.stateManager $stateType ) -}}
+      {{-   $connectionSettings := fromYaml ( include "corda.db.configuration" ( list $ $stateTypeRootConfig.storageId ( printf "stateManager.%s.storageId" $stateType ) ) ) -}}
+      cat << EOF >> "/work/{{- $stateType -}}-config.json"
+      {
+        "stateManager": {
+          "{{- $stateType -}}": {
+            {{/* TODO-[CORE-19372]: align case with boot schema in corda-api */ -}}
+            "type": "{{- $stateTypeRuntimeConfig.type | upper -}}",
+            "database": {
+              "jdbc": {
+                "url": {{ include "corda.db.connectionUrl" $connectionSettings | quote }},
+                "driver": {{ include "corda.db.driverClassName" $connectionSettings | quote }}
+              },
+              "pool": {
+              {{- if $stateTypeRuntimeConfig.connectionPool.minSize }}
+                "minSize": {{ $stateTypeRuntimeConfig.connectionPool.minSize }},
+              {{- end }}
+                "maxSize": {{ $stateTypeRuntimeConfig.connectionPool.maxSize -}},
+                "idleTimeoutSeconds": {{ $stateTypeRuntimeConfig.connectionPool.idleTimeoutSeconds -}},
+                "maxLifetimeSeconds": {{ $stateTypeRuntimeConfig.connectionPool.maxLifetimeSeconds -}},
+                "keepAliveTimeSeconds": {{ $stateTypeRuntimeConfig.connectionPool.keepAliveTimeSeconds -}},
+                "validationTimeoutSeconds": {{ $stateTypeRuntimeConfig.connectionPool.validationTimeoutSeconds }}
+              },
+              "user": "$(cat /tmp/{{ $stateType }}-mount/username)",
+              "pass": "$(cat /tmp/{{ $stateType }}-mount/password)"
+            }
+          }
+        }
+      }
+      EOF
+      {{ end }}
+      echo 'Generating State Manger Configuration Settings... Done!'
+  volumeMounts:
+    - mountPath: "/work"
+      name: "work"
+      readOnly: false
+  {{- include "corda.sm.runtimeCredentialsVolumeMounts" ( list $ $workerConfig )  | nindent 4 -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+    State Manager Startup Configuration File Parameters
+*/}}
+{{- define "corda.sm.runtimeConfigurationParameters" -}}
+{{-  range $stateType, $stateTypeRuntimeConfig  := .stateManager }}
+- "--values=/work/{{- $stateType -}}-config.json"
+{{- end }}
 {{- end -}}

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -372,7 +372,6 @@ spec:
           {{- range $i, $arg := $optionalArgs.additionalWorkerArgs }}
           - {{ $arg | quote }}
           {{- end -}}
-          {{- $stateManagerV2 := include "corda.sm.required" ( list $ . ) -}}
           {{- if eq $stateManagerV2 "true" }}
           {{-   include "corda.sm.runtimeConfigurationParameters" . | nindent 10 -}}
           {{- end }}
@@ -469,7 +468,6 @@ spec:
             path: {{ $.Values.dumpHostPath }}/{{ $.Release.Namespace }}/
             type: DirectoryOrCreate
         {{- end -}}
-        {{- $stateManagerV2 := include "corda.sm.required" ( list $ . ) -}}
         {{- if eq $stateManagerV2 "true" }}
         {{-   include "corda.sm.runtimeCredentialVolumes" ( list $ $worker . )  | nindent 8 -}}
         {{- end -}}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -15,9 +15,8 @@
             $
             $dbConfig
             ( printf "databases.[%d]" $index )
-            ( include "corda.defaultDatabaseRuntimeCredentialsSecretName" ( list $ $dbConfig.name ) )
+            ( include "corda.db.runtimeCredentialsSecretName" ( list $ $dbConfig.name ) )
             ( dict "username" ( dict ) "password" ( dict ) )
-            ( dict "cleanup" true )
         )
 }}
 {{- end -}}
@@ -62,7 +61,7 @@
               $
               $bootConfig
               ( printf "bootstrap.db.databases.[%d]" $index )
-              ( include "corda.defaultDatabaseBootstrapCredentialsSecretName" ( list $ $bootConfig.name ) )
+              ( include "corda.db.bootstrapCredentialsSecretName" ( list $ $bootConfig.name ) )
               ( dict "username" ( dict ) "password" ( dict ) )
               ( dict "cleanup" true )
           )
@@ -139,16 +138,7 @@
 {{- end }}
 {{/*  State Manager Runtime Connection Secrets */}}
 {{- range $stateType, $stateTypeConfig  := .Values.stateManager -}}
-{{-   $databaseFound := false -}}
-{{-   $storageId := $stateTypeConfig.storageId -}}
-{{-   range $.Values.databases -}}
-{{-     if eq .name $storageId -}}
-{{-       $databaseFound = true -}}
-{{-     end -}}
-{{-   end -}}
-{{-   if not $databaseFound -}}
-{{-     fail ( printf "Undefined persistent storage '%s' detected at stateManager.%s.storageId" $storageId $stateType ) -}}
-{{-   end -}}
+{{-   $connectionSettings := fromYaml ( include "corda.db.configuration" ( list $ $stateTypeConfig.storageId ( printf "stateManager.%s.storageId" $stateType ) ) ) }}
 {{-   range $workerName, $workerConfig := $.Values.workers -}}
 {{-     $runtimeCredentials := ( index $workerConfig "stateManager" ) -}}
 {{-     if and $runtimeCredentials ( index $runtimeCredentials $stateType ) -}}
@@ -157,9 +147,8 @@
                 $
                 ( index $runtimeCredentials $stateType )
                 ( printf "workers.%s.stateManager.[%s]" $workerName $stateType )
-                ( include "corda.stateManagerDefaultRuntimeSecretName" ( list $ $stateType $workerName ) )
-                ( dict "username" ( dict ) "password" ( dict ) )
-                ( dict "cleanup" true )
+                ( include "corda.sm.runtimeCredentialsSecretName" ( list $ $stateType $workerName ) )
+                ( dict "username" ( dict "required" true ) "password" ( dict "generate" 12 ) )
             )
 }}
 {{-     end -}}

--- a/charts/corda/templates/workers.yaml
+++ b/charts/corda/templates/workers.yaml
@@ -1,3 +1,4 @@
+{{/* TODO-[CORE-19372]: remove stateManagerDbAccess and all references to it */}}
 {{- include "corda.worker" ( list $ .Values.workers.crypto "crypto"
   ( dict "clusterDbAccess" true "stateManagerDbAccess" true "additionalWorkerArgs" ( list "--hsm-id=SOFT" ) )
 ) }}


### PR DESCRIPTION
Update Helm templates (Secret creation and Worker Runtime) to support
new deployment model on which state types can be isolated and workers
are allowed to access more than a single State Manager instance.
Changes introduced by this commit are backward compatible with the
existing schema, comments were added so that the relevant code can be
entirely removed once the new deployment model is fully rolled out.

- Rename templates to better reflect purposes
- Isolate database related templates in "databases.tpl".
- Add reusable template to retrieve and validate databases by name.
