### PR TITLE
CORE-19526: Add tenantId into UnmanagedKeyStatus

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -195,11 +195,11 @@ class KeyRotationRestResourceImpl @Activate constructor(
         val result = mutableListOf<Pair<String, TenantIdWrappingKeysStatus>>()
         records.forEach {
             val state = it.value
-            val keyRotationStatus = checkNotNull(deserializer.deserialize(state.value))
+            val unmanagedKeyRotationStatus = checkNotNull(deserializer.deserialize(state.value))
             result.add(
-                state.metadata[KeyRotationMetadataValues.TENANT_ID].toString() to TenantIdWrappingKeysStatus(
-                    keyRotationStatus.total,
-                    keyRotationStatus.rotatedKeys
+                unmanagedKeyRotationStatus.tenantId to TenantIdWrappingKeysStatus(
+                    unmanagedKeyRotationStatus.total,
+                    unmanagedKeyRotationStatus.rotatedKeys
                 )
             )
             // Get the latest modified time of all the records

--- a/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
+++ b/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
@@ -103,7 +103,7 @@ class KeyRotationRestResourceTest {
         }
 
         deserializer = mock<CordaAvroDeserializer<UnmanagedKeyStatus>> {
-            on { deserialize(any()) } doReturn UnmanagedKeyStatus(oldKeyAlias, newKeyAlias, 10, 5, Instant.now())
+            on { deserialize(any()) } doReturn UnmanagedKeyStatus(oldKeyAlias, newKeyAlias, tenantId, 10, 5, Instant.now())
         }
 
         cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory> {

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -243,6 +243,7 @@ class CryptoRekeyBusProcessor(
             val status = UnmanagedKeyStatus(
                 request.oldParentKeyAlias,
                 request.newParentKeyAlias,
+                tenantId,
                 wrappingKeys.size,
                 0,
                 Instant.ofEpochMilli(timestamp)
@@ -256,7 +257,6 @@ class CryptoRekeyBusProcessor(
                     Metadata(
                         mapOf(
                             KeyRotationMetadataValues.ROOT_KEY_ALIAS to request.oldParentKeyAlias,
-                            KeyRotationMetadataValues.TENANT_ID to tenantId,
                             KeyRotationMetadataValues.STATUS_TYPE to KeyRotationRecordType.KEY_ROTATION,
                             KeyRotationMetadataValues.STATUS to KeyRotationStatus.IN_PROGRESS,
                             KeyRotationMetadataValues.KEY_TYPE to KeyRotationKeyType.UNMANAGED,

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -162,6 +162,7 @@ class CryptoRewrapBusProcessor(
                             UnmanagedKeyStatus(
                                 deserializedStatus.oldParentKeyAlias,
                                 deserializedStatus.newParentKeyAlias,
+                                deserializedStatus.tenantId,
                                 deserializedStatus.total,
                                 deserializedStatus.rotatedKeys + 1,
                                 deserializedStatus.createdTimestamp

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
@@ -193,7 +193,6 @@ class CryptoRekeyBusProcessorTests {
 
         stateManagerCreateCapture.firstValue.forEachIndexed { index, it ->
             assertThat(it.metadata[STATE_TYPE]).isEqualTo(UnmanagedKeyStatus::class.java.name)
-            assertThat(it.metadata[KeyRotationMetadataValues.TENANT_ID]).isEqualTo(allTenants[index])
             assertThat(it.metadata[KeyRotationMetadataValues.STATUS_TYPE]).isEqualTo(KeyRotationRecordType.KEY_ROTATION)
             assertThat(it.metadata[KeyRotationMetadataValues.STATUS]).isEqualTo(KeyRotationStatus.IN_PROGRESS)
             assertThat(it.metadata[KeyRotationMetadataValues.KEY_TYPE]).isEqualTo(KeyRotationKeyType.UNMANAGED)
@@ -209,6 +208,7 @@ class CryptoRekeyBusProcessorTests {
             assertThat(unmanagedKeyStatus).isNotNull()
             assertThat(unmanagedKeyStatus!!.newParentKeyAlias).isEqualTo(newKeyAlias)
             assertThat(unmanagedKeyStatus.oldParentKeyAlias).isEqualTo(oldKeyAlias)
+            assertThat(unmanagedKeyStatus.tenantId).isEqualTo(allTenants[index])
             assertThat(unmanagedKeyStatus.total).isEqualTo(1)
             assertThat(unmanagedKeyStatus.rotatedKeys).isEqualTo(0)
         }

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
@@ -36,6 +36,7 @@ class CryptoRewrapBusProcessorTests {
         on { deserialize(any()) } doReturn UnmanagedKeyStatus(
             OLD_PARENT_KEY_ALIAS,
             NEW_PARENT_KEY_ALIAS,
+            tenantId,
             10,
             5,
             Instant.now()

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.33-beta+
+cordaApiVersion=5.2.0.34-alpha-1706717429795
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.34-alpha-1706717429795
+cordaApiVersion=5.2.0.34-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26


### PR DESCRIPTION
This simplifies future work in returning key rotation status, where we need to differentiate between managed and unmanaged key rotation.

[API PR](https://github.com/corda/corda-api/pull/1478)