### PR TITLE
CORE-19506 Support config changes in key rotation

### DIFF
--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/CryptoOperationsTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/CryptoOperationsTests.kt
@@ -647,7 +647,14 @@ class CryptoOperationsTests {
             factory.cryptoService.createWrappingKey("", true, mapOf())
         }
         assertThrows<java.lang.IllegalStateException> {
-            factory.cryptoService.generateKeyPair(tenantId, LEDGER, "key1", null, rsaScheme, mapOf("parentKeyAlias" to ""))
+            factory.cryptoService.generateKeyPair(
+                tenantId,
+                LEDGER,
+                "key1",
+                null,
+                rsaScheme,
+                mapOf("parentKeyAlias" to "")
+            )
         }
     }
 
@@ -655,18 +662,25 @@ class CryptoOperationsTests {
     fun `high level generateKeyPair should throw IllegalStateException when wrapping key is not found`() {
         val alias = UUID.randomUUID().toString()
         val rsaScheme = schemeMetadata.findKeyScheme(RSA_CODE_NAME)
-        val e= assertThrows<IllegalStateException> {
-            factory.cryptoService.generateKeyPair(tenantId, LEDGER, "key1", null, rsaScheme, mapOf("parentKeyAlias" to alias))
+        val e = assertThrows<IllegalStateException> {
+            factory.cryptoService.generateKeyPair(
+                tenantId,
+                LEDGER,
+                "key1",
+                null,
+                rsaScheme,
+                mapOf("parentKeyAlias" to alias)
+            )
         }
         assertThat(e.message).contains("Wrapping key with alias $alias not found")
     }
 
 
-    private fun testWithBadWrappingKeyInfo(info: (TestServicesFactory) -> WrappingKeyInfo): java.lang.IllegalArgumentException {
+    private fun testWithBadWrappingKeyInfo(info: (TestServicesFactory) -> WrappingKeyInfo): IllegalStateException {
         val myFactory = TestServicesFactory()
         val rsaScheme = myFactory.schemeMetadata.findKeyScheme(RSA_CODE_NAME)
         myFactory.wrappingRepository.saveKey(info(myFactory))
-        return assertThrows<java.lang.IllegalArgumentException> {
+        return assertThrows<IllegalStateException> {
             myFactory.cryptoService.generateKeyPair(
                 tenantId,
                 LEDGER,
@@ -679,8 +693,8 @@ class CryptoOperationsTests {
     }
 
     @Test
-    fun `generateKeyPair should throw IllegalArgumentException when key algorithm does not match master key`() {
-        val e= testWithBadWrappingKeyInfo {
+    fun `generateKeyPair should throw IllegalStateException when key algorithm does not match master key`() {
+        val e = testWithBadWrappingKeyInfo {
             WrappingKeyInfo(
                 WRAPPING_KEY_ENCODING_VERSION,
                 it.rootWrappingKey.algorithm + "!",
@@ -694,13 +708,13 @@ class CryptoOperationsTests {
     }
 
     @Test
-    fun `generateKeyPair should throw IllegalArgumentException when encoding version is not recognised`() {
-        val e= testWithBadWrappingKeyInfo {
+    fun `generateKeyPair should throw IllegalStateException when encoding version is not recognised`() {
+        val e = testWithBadWrappingKeyInfo {
             WrappingKeyInfo(
-            WRAPPING_KEY_ENCODING_VERSION + 1,
-            it.secondLevelWrappingKey.algorithm,
-            it.rootWrappingKey.wrap(it.secondLevelWrappingKey),
-            1, "root", "key1"
+                WRAPPING_KEY_ENCODING_VERSION + 1,
+                it.secondLevelWrappingKey.algorithm,
+                it.rootWrappingKey.wrap(it.secondLevelWrappingKey),
+                1, "root", "key1"
             )
         }
         assertThat(e.message).contains("Unknown wrapping key encoding. Expected to be 1")

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -418,7 +418,7 @@ open class SoftCryptoService(
         if (throwOnFailure) {
             throw IllegalStateException(msg)
         } else {
-            logger.info(msg)
+            logger.debug(msg)
             null
         }
     }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoService.kt
@@ -401,7 +401,7 @@ open class SoftCryptoService(
                 } catch (ex: Exception) {
                     throw IllegalStateException(
                         "Could not decrypt wrapping key with alias: ${wrappingKeyInfo.alias} with parent key: " +
-                            "${wrappingKeyInfo.parentKeyAlias} because ${ex.message}, so could not be added to cache."
+                            "${wrappingKeyInfo.parentKeyAlias} because ${ex.message}."
                     )
                 }
             } ?: run {

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceGeneralTests.kt
@@ -83,13 +83,22 @@ class SoftCryptoServiceGeneralTests {
     private val schemeMetadata = CipherSchemeMetadataImpl()
     private val UNSUPPORTED_SIGNATURE_SCHEME = CipherSchemeMetadataProvider().COMPOSITE_KEY_TEMPLATE.makeScheme("BC")
     private val cryptoRepositoryWrapping = TestWrappingRepository()
-    private val sampleWrappingKeyInfo = WrappingKeyInfo(1, "AES", byteArrayOf(), 1, "root", "key1")
+    private val rootWrappingKey = WrappingKeyImpl.generateWrappingKey(schemeMetadata)
+
+    // Crypto service checks for valid decryptable key material before adding to the cache, because the cache holds already
+    // decrypted wrapping keys. So here we wrap the existing rootWrappingKey with itself to achieve this, even though it's
+    // not a sensible real world scenario. It makes the sampleWrappingKeyInfo.keyMaterial decryptable with the root key which
+    // is all that matters.
+    private val sampleWrappingKeyInfo =
+        WrappingKeyInfo(1, "AES", rootWrappingKey.wrap(rootWrappingKey), 1, "root", "key1")
+
     val defaultContext =
         mapOf(CRYPTO_TENANT_ID to UUID.randomUUID().toString(), CRYPTO_CATEGORY to CryptoConsts.Categories.LEDGER)
+
     private val service = makeSoftCryptoService(
         wrappingRepository = cryptoRepositoryWrapping,
         schemeMetadata = schemeMetadata,
-        rootWrappingKey = mock(),
+        rootWrappingKey = rootWrappingKey
     )
 
     companion object {
@@ -298,7 +307,7 @@ class SoftCryptoServiceGeneralTests {
         val exception = assertThrows<CryptoException> {
             cryptoServiceExploding.createWrappingKey("foo", true, emptyMap())
         }
-        assertThat(exception.message).contains("Calling createWrappingKey findKey failed in a potentially recoverable way")
+        assertThat(exception.message).contains("findKey failed in a potentially recoverable way")
     }
 
     @Test
@@ -581,8 +590,10 @@ class SoftCryptoServiceGeneralTests {
         val tenantInfoService = mock<TenantInfoService> {
             on { lookup(eq(tenantId), any()) } doReturn mockAssoicationInfo
         }
-        val cryptoService = makeSoftCryptoService(signingRepository = repo,
-            tenantInfoService = tenantInfoService)
+        val cryptoService = makeSoftCryptoService(
+            signingRepository = repo,
+            tenantInfoService = tenantInfoService
+        )
         var thrown = Assertions.assertThrows(exception::class.java) {
             cryptoService.generateKeyPair(
                 tenantId = tenantId,
@@ -633,7 +644,7 @@ class SoftCryptoServiceGeneralTests {
             signingRepositoryFactory = { repo },
             schemeMetadata = schemeMetadata,
             defaultUnmanagedWrappingKeyName = "root",
-            unmanagedWrappingKeys = mapOf("root" to WrappingKeyImpl.generateWrappingKey(schemeMetadata)),
+            unmanagedWrappingKeys = mapOf("root" to rootWrappingKey),
             digestService = PlatformDigestServiceImpl(schemeMetadata),
             wrappingKeyCache = null,
             privateKeyCache = null,
@@ -666,17 +677,17 @@ class SoftCryptoServiceGeneralTests {
         verify(repo, times(1)).savePrivateKey(
             argThat {
                 key == generatedKey &&
-                        alias == expectedAlias &&
-                        externalId == null &&
-                        keyScheme == scheme
+                    alias == expectedAlias &&
+                    externalId == null &&
+                    keyScheme == scheme
             }
         )
         verify(repo, times(1)).savePrivateKey(
             argThat {
                 key == generatedKey &&
-                        alias == expectedAlias &&
-                        externalId == expectedExternalId &&
-                        keyScheme == scheme
+                    alias == expectedAlias &&
+                    externalId == expectedExternalId &&
+                    keyScheme == scheme
             }
         )
     }
@@ -882,8 +893,6 @@ class SoftCryptoServiceGeneralTests {
     @Test
     fun `can rewrap a managed wrapping key`() {
         cryptoRepositoryWrapping.keys["root"] = sampleWrappingKeyInfo
-        // service has a mock root wrapping key, so we have to make one with a real wrapping key
-        val rootWrappingKey = WrappingKeyImpl.generateWrappingKey(schemeMetadata)
         val rootWrappingKey2 = WrappingKeyImpl.generateWrappingKey(schemeMetadata)
         val myCryptoService = makeSoftCryptoService(
             wrappingRepository = cryptoRepositoryWrapping,

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceOperationsTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SoftCryptoServiceOperationsTests.kt
@@ -71,6 +71,7 @@ class SoftCryptoServiceOperationsTests {
         private val knownWrappingKeyMaterial = rootWrappingKey.wrap(knownWrappingKey)
         private val knownWrappingKeyAlias = UUID.randomUUID().toString()
         private val tenantId = UUID.randomUUID().toString()
+
         //  TODO - reuse these two fixtures?
         private val clusterWrappingRepository = TestWrappingRepository(
             ConcurrentHashMap(
@@ -211,6 +212,7 @@ class SoftCryptoServiceOperationsTests {
                 )
             }
         }
+
         val exception1 = verifySign(softAliasedKeys.getValue(scheme), spec)
         assertThat(exception1.message).contains("Wrapping key with alias")
         val exception2 = verifySign(softFreshKeys.getValue(scheme), spec)
@@ -375,7 +377,11 @@ class SoftCryptoServiceOperationsTests {
     fun `should throw IllegalArgumentException when generating key pair with unsupported key scheme`(aliased: Boolean) {
         val exception = assertThrows<IllegalArgumentException> {
             cryptoService.generateKeyPair(
-                KeyGenerationSpec(UNSUPPORTED_KEY_SCHEME, if (aliased) UUID.randomUUID().toString() else null, knownWrappingKeyAlias),
+                KeyGenerationSpec(
+                    UNSUPPORTED_KEY_SCHEME,
+                    if (aliased) UUID.randomUUID().toString() else null,
+                    knownWrappingKeyAlias
+                ),
                 defaultContext
             )
         }
@@ -497,7 +503,7 @@ class SoftCryptoServiceOperationsTests {
     }
 
     @Test
-    fun `generateKeyPair should throw IllegalArgumentException when encoding version is not recognised`() {
+    fun `generateKeyPair should throw IllegalStateException when encoding version is not recognised`() {
         val alias = UUID.randomUUID().toString()
         clusterWrappingRepository.saveKey(
             WrappingKeyInfo(
@@ -507,7 +513,7 @@ class SoftCryptoServiceOperationsTests {
                 1, rootKeyAlias, alias
             )
         )
-        val exception = assertThrows<IllegalArgumentException> {
+        val exception = assertThrows<IllegalStateException> {
             cryptoService.generateKeyPair(KeyGenerationSpec(rsaScheme, "k1", alias), emptyMap())
         }
         assertThat(exception.message).contains("Unknown wrapping key encoding")
@@ -527,7 +533,7 @@ class SoftCryptoServiceOperationsTests {
                 alias
             )
         )
-        val exception =  assertThrows<IllegalStateException> {
+        val exception = assertThrows<IllegalStateException> {
             cryptoService.generateKeyPair(KeyGenerationSpec(rsaScheme, "key1", alias), emptyMap())
         }
         assertThat(exception.message).contains("Unknown parent key")

--- a/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
+++ b/processors/crypto-processor/src/test/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImplTest.kt
@@ -1,5 +1,6 @@
 package net.corda.processors.crypto.internal
 
+import net.corda.cipher.suite.impl.CipherSchemeMetadataImpl
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.config.impl.ALIAS
 import net.corda.crypto.config.impl.CACHING
@@ -10,6 +11,11 @@ import net.corda.crypto.config.impl.PASSPHRASE
 import net.corda.crypto.config.impl.RETRYING
 import net.corda.crypto.config.impl.SALT
 import net.corda.crypto.config.impl.WRAPPING_KEYS
+import net.corda.crypto.core.aes.WrappingKeyImpl
+import net.corda.crypto.persistence.db.model.WrappingKeyEntity
+import net.corda.crypto.service.impl.bus.CryptoRekeyBusProcessor
+import net.corda.crypto.service.impl.bus.CryptoRewrapBusProcessor
+import net.corda.crypto.service.impl.rpc.CryptoFlowOpsProcessor
 import net.corda.crypto.service.impl.rpc.SessionDecryptionProcessor
 import net.corda.crypto.service.impl.rpc.SessionEncryptionProcessor
 import net.corda.crypto.softhsm.impl.HSMRepositoryImpl
@@ -21,38 +27,60 @@ import net.corda.data.crypto.wire.ops.encryption.request.EncryptRpcCommand
 import net.corda.data.crypto.wire.ops.encryption.response.DecryptionOpsResponse
 import net.corda.data.crypto.wire.ops.encryption.response.EncryptionOpsResponse
 import net.corda.data.crypto.wire.ops.flow.FlowOpsRequest
+import net.corda.data.crypto.wire.ops.key.rotation.IndividualKeyRotationRequest
+import net.corda.data.crypto.wire.ops.key.rotation.KeyRotationRequest
 import net.corda.data.crypto.wire.ops.rpc.RpcOpsRequest
 import net.corda.data.crypto.wire.ops.rpc.RpcOpsResponse
+import net.corda.data.flow.event.FlowEvent
 import net.corda.db.connection.manager.DbConnectionManager
+import net.corda.db.core.DbPrivilege
+import net.corda.db.schema.CordaDb
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.test.impl.LifecycleTest
+import net.corda.messaging.api.publisher.Publisher
+import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.api.subscription.Subscription
+import net.corda.messaging.api.subscription.SubscriptionBase
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.orm.JpaEntitiesRegistry
 import net.corda.processors.crypto.CryptoProcessor
 import net.corda.schema.Schemas
+import net.corda.schema.configuration.ConfigKeys
 import net.corda.schema.configuration.ConfigKeys.CRYPTO_CONFIG
 import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mockConstruction
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.clearInvocations
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.UUID
+import javax.persistence.EntityManager
+import javax.persistence.EntityManagerFactory
+import javax.persistence.TypedQuery
 
 class CryptoProcessorImplTest {
 
     companion object {
+        private const val ALPHA_KEY_NAME = "alpha"
+        private const val ALPHA_KEY_PASSPHRASE = "friend"
+        private const val ALPHA_KEY_SALT = "speak"
+
         // Tempting to use SmartConfig here even from unit tests, but probably better to mock it out
         // since SmartConfig is Corda corda. Or could we use TypeSafeConfig directly heere?
         // TODO remove hard coded strings e.g. "expireAfterAccessMins" and instead use string constants
@@ -80,14 +108,14 @@ class CryptoProcessorImplTest {
                 whenever(it.getConfig("waitBetweenMills")).thenReturn(waitBetweenMillsConfig)
             }
             val wrappingKeysList = listOf(mock<SmartConfig>().also {
-                whenever(it.getString(ALIAS)).thenReturn("alpha")
-                whenever(it.getString(SALT)).thenReturn("speak")
-                whenever(it.getString(PASSPHRASE)).thenReturn("friend")
+                whenever(it.getString(ALIAS)).thenReturn(ALPHA_KEY_NAME)
+                whenever(it.getString(SALT)).thenReturn(ALPHA_KEY_SALT)
+                whenever(it.getString(PASSPHRASE)).thenReturn(ALPHA_KEY_PASSPHRASE)
             })
             val hsmConfig = mock<SmartConfig>().also {
                 whenever(it.getConfigList(eq(WRAPPING_KEYS))).thenReturn(wrappingKeysList)
                 // this must match the ALIAS of the one wrapping key we set up in wrappingKeysList
-                whenever(it.getString(DEFAULT_WRAPPING_KEY)).thenReturn("alpha")
+                whenever(it.getString(DEFAULT_WRAPPING_KEY)).thenReturn(ALPHA_KEY_NAME)
             }
             whenever(it.getConfig(eq(CACHING))).thenReturn(cachingConfig)
             whenever(it.getConfig(eq(RETRYING))).thenReturn(retryingConfig)
@@ -95,16 +123,227 @@ class CryptoProcessorImplTest {
         }
     }
 
+    /**
+     * We have a lot of mock subscriptions to test and in the main we perform the same validation on each of them.
+     * This class helps that without having to write lots of boiler plate code.
+     */
+    class MockSubscriptions {
+        private val subscriptionList = mutableListOf<SubscriptionBase>()
+
+        val keyRotationSubscription =
+            mock<Subscription<String, KeyRotationRequest>>().also { subscriptionList.add(it) }
+        val keyRewrapSubscription =
+            mock<Subscription<String, IndividualKeyRotationRequest>>().also { subscriptionList.add(it) }
+        val flowOpsRpcSubscription =
+            mock<RPCSubscription<FlowOpsRequest, FlowEvent>>().also { subscriptionList.add(it) }
+        val rpcOpsSubscription =
+            mock<RPCSubscription<RpcOpsRequest, RpcOpsResponse>>().also { subscriptionList.add(it) }
+        val encryptionSubscription =
+            mock<RPCSubscription<EncryptRpcCommand, EncryptionOpsResponse>>().also { subscriptionList.add(it) }
+        val decryptionSubscription =
+            mock<RPCSubscription<DecryptRpcCommand, DecryptionOpsResponse>>().also { subscriptionList.add(it) }
+        val hsmRegSubscription =
+            mock<RPCSubscription<HSMRegistrationRequest, HSMRegistrationResponse>>().also { subscriptionList.add(it) }
+
+        init {
+            // Sanity check all subscriptions are in list
+            assertThat(subscriptionList).hasSize(7)
+        }
+
+        /**
+         * Clears invocations, so do any specific subscription verification before calling
+         */
+        fun verifyAllSubscriptionsStarted() {
+            subscriptionList.forEach {
+                verify(it).start()
+                clearInvocations(it)
+            }
+        }
+
+        /**
+         * Clears invocations, so do any specific subscription verification before calling
+         */
+        @SuppressWarnings("SpreadOperator")
+        fun verifyAllSubscriptionsClosedAndRestarted() {
+            inOrder(*subscriptionList.toTypedArray()).also { inOrder ->
+                subscriptionList.forEach {
+                    inOrder.verify(it).close()
+                    inOrder.verify(it).start()
+                    clearInvocations(it)
+                }
+            }
+        }
+    }
+
     @Test
     fun `bus subscriptions created on ConfigChangedEvent, closed and re-created on new ConfigChangedEvent`() {
-        val flowOpsSubscription = mock<Subscription<String, FlowOpsRequest>>()
-        val rpcOpsSubscription = mock<RPCSubscription<RpcOpsRequest, RpcOpsResponse>>()
-        val encryptionSubscription = mock<RPCSubscription<EncryptRpcCommand, EncryptionOpsResponse>>()
-        val decryptionSubscription = mock<RPCSubscription<DecryptRpcCommand, DecryptionOpsResponse>>()
-        val hsmRegSubscription = mock<RPCSubscription<HSMRegistrationRequest, HSMRegistrationResponse>>()
+        val mockSubscriptions = MockSubscriptions()
+        val subscriptionFactory = mockSubscriptionFactory(mockSubscriptions)
+        val mockHsmAssociation = mock<HSMAssociationInfo>()
+        val mockHsmAssociationInfo = mock<HSMAssociationInfo>() {
+            on { masterKeyAlias }.doReturn("masterKeyAlias")
+        }
+        mockConstruction(HSMRepositoryImpl::class.java) { mock, _ ->
+            whenever(mock.findTenantAssociation(any(), any())).doReturn(mockHsmAssociation)
+            whenever(mock.createOrLookupCategoryAssociation(any(), any(), any())).doReturn(mockHsmAssociationInfo)
+        }
+
+        val virtualNodeInfo = mock<VirtualNodeInfo> {
+            on { cryptoDmlConnectionId } doReturn UUID.randomUUID()
+        }
+
+        val mockDbConnectionManager = mockDbConnectionManager()
+
+        // Keep track of any publishers created
+        val publisherList = mutableListOf<Publisher>()
+        val publisherFactory = mock<PublisherFactory>() {
+            on { createPublisher(any(), any()) }.doAnswer {
+                mock<Publisher>().also {
+                    publisherList.add(it)
+                }
+            }
+        }
+
+        LifecycleTest {
+            addDependency<LifecycleCoordinatorFactory>()
+            addDependency<ConfigurationReadService>()
+
+            addDependency<JpaEntitiesRegistry>()
+            addDependency<DbConnectionManager>()
+            addDependency<VirtualNodeInfoReadService>()
+            addDependency<SubscriptionFactory>()
+
+            val cryptoProcessor = CryptoProcessorImpl(
+                coordinatorFactory = coordinatorFactory,
+                configurationReadService = configReadService,
+                jpaEntitiesRegistry = mock(),
+                dbConnectionManager = mockDbConnectionManager,
+                virtualNodeInfoReadService = mock {
+                    on { getByHoldingIdentityShortHash(any()) } doReturn virtualNodeInfo
+                },
+                subscriptionFactory = subscriptionFactory,
+                externalEventResponseFactory = mock(),
+                keyEncodingService = mock(),
+                layeredPropertyMapFactory = mock(),
+                digestService = mock(),
+                schemeMetadata = mock(),
+                publisherFactory = publisherFactory,
+                stateManagerFactory = mock(),
+                cordaAvroSerializationFactory = mock()
+            ).apply {
+                // Must start and pass some sort of boot config
+                start(mock())
+            }
+            cryptoProcessor.lifecycleCoordinator
+        }.run {
+            testClass.start()
+            bringDependenciesUp()
+            verify(configReadService).registerComponentForUpdates(any(), any())
+            verifyIsDown<CryptoProcessor>()
+
+            sendConfigUpdate<CryptoProcessor>(
+                mapOf(
+                    CRYPTO_CONFIG to cryptoConfig, MESSAGING_CONFIG to mock(),
+                    ConfigKeys.STATE_MANAGER_CONFIG to mock()
+                )
+            )
+
+            verifyIsUp<CryptoProcessor>()
+            mockSubscriptions.verifyAllSubscriptionsStarted()
+
+            // We only publish out of the rekey processor, so we should have 1 publisher
+            val originalPublisher = publisherList.single()
+
+            sendConfigUpdate<CryptoProcessor>(
+                mapOf(
+                    CRYPTO_CONFIG to cryptoConfig, MESSAGING_CONFIG to mock(),
+                    ConfigKeys.STATE_MANAGER_CONFIG to mock()
+                )
+            )
+
+            verifyIsUp<CryptoProcessor>()
+
+            // Expect a new publisher per config change
+            assertThat(publisherList).hasSize(2)
+
+            // Check original publisher created was closed on the config change, after the subscription was closed
+            inOrder(originalPublisher, mockSubscriptions.keyRotationSubscription).apply {
+                verify(mockSubscriptions.keyRotationSubscription).close()
+                verify(originalPublisher).close()
+            }
+
+            mockSubscriptions.verifyAllSubscriptionsClosedAndRestarted()
+        }
+    }
+
+    private fun mockDbConnectionManager(): DbConnectionManager {
+        // This is very susceptible to changes in db access, at the moment it is based around the TenantInfoService
+        // ensuring a wrapping key exists when the first call to populate is made, which is done on the first CryptoProcessor
+        // config changes. Our mock is set up to return an existing WrappingKeyEntity as if it exists in the database,
+        // but from then on subsequent attempts to fetch it will come from the crypto service's internal cache.
+        val mockTypedQuery = mock<TypedQuery<*>>()
+        whenever(mockTypedQuery.setParameter(any<String>(), any<Any>())).thenReturn(mockTypedQuery)
+        whenever(mockTypedQuery.setMaxResults(any())).thenReturn(mockTypedQuery)
+        val alphaWrappingKey = WrappingKeyImpl.derive(CipherSchemeMetadataImpl(), ALPHA_KEY_PASSPHRASE, ALPHA_KEY_SALT)
+        // Crypto service checks for valid decryptable key material before adding to the cache, because the cache holds already
+        // decrypted wrapping keys. So here we wrap the alphaWrappingKey with itself to achieve this, even though it's not a
+        // sensible real world scenario. It makes the dummyKeyMaterial decryptable with the alphaWrappingKey key which is all
+        // that matters.
+        val dummyKeyMaterial = alphaWrappingKey.wrap(alphaWrappingKey)
+        whenever(mockTypedQuery.resultList).thenReturn(
+            listOf(
+                WrappingKeyEntity(
+                    id = UUID.randomUUID(),
+                    generation = 1,
+                    alias = "alias",
+                    created = Instant.now(),
+                    rotationDate = LocalDate.parse("9999-12-31").atStartOfDay().toInstant(ZoneOffset.UTC),
+                    encodingVersion = 1,
+                    algorithmName = "AES",
+                    keyMaterial = dummyKeyMaterial,
+                    isParentKeyManaged = false,
+                    parentKeyReference = ALPHA_KEY_NAME
+                )
+            )
+        )
+
+        val mockEntityManager = mock<EntityManager>() {
+            on { createQuery(any<String>(), any<Class<*>>()) }.doReturn(mockTypedQuery)
+        }
+        val mockEntityManagerFactory = mock<EntityManagerFactory>() {
+            on { createEntityManager() }.doReturn(mockEntityManager)
+        }
+        // We are only mocking DbConnectionManager for the initial check that a wrapping key exists, fail the test if
+        // we get multiple calls to create an EMF
+        val mockDbConnectionManager = mock<DbConnectionManager>() {
+            on { getOrCreateEntityManagerFactory(CordaDb.Crypto, DbPrivilege.DML) }.doReturn(
+                mockEntityManagerFactory
+            )
+        }
+        return mockDbConnectionManager
+    }
+
+    private fun mockSubscriptionFactory(mockSubscriptions: MockSubscriptions): SubscriptionFactory {
         val subscriptionFactory = mock<SubscriptionFactory>().also {
-            whenever(it.createDurableSubscription<String, FlowOpsRequest>(any(), any(), any(), anyOrNull()))
-                .thenReturn(flowOpsSubscription)
+
+            whenever(
+                it.createDurableSubscription<String, KeyRotationRequest>(
+                    any(),
+                    any<CryptoRekeyBusProcessor>(),
+                    any(),
+                    anyOrNull()
+                )
+            ).thenReturn(mockSubscriptions.keyRotationSubscription)
+
+            whenever(
+                it.createDurableSubscription<String, IndividualKeyRotationRequest>(
+                    any(),
+                    any<CryptoRewrapBusProcessor>(),
+                    any(),
+                    anyOrNull()
+                )
+            ).thenReturn(mockSubscriptions.keyRewrapSubscription)
+
             whenever(
                 it.createRPCSubscription(
                     eq(
@@ -119,22 +358,22 @@ class CryptoProcessorImplTest {
                     any(),
                     any()
                 )
-            )
-                .thenReturn(rpcOpsSubscription)
+            ).thenReturn(mockSubscriptions.rpcOpsSubscription)
+
             whenever(
                 it.createHttpRPCSubscription(
                     any(),
                     any<SessionDecryptionProcessor>()
                 )
-            )
-                .thenReturn(decryptionSubscription)
+            ).thenReturn(mockSubscriptions.decryptionSubscription)
+
             whenever(
                 it.createHttpRPCSubscription(
                     any(),
                     any<SessionEncryptionProcessor>()
                 )
-            )
-                .thenReturn(encryptionSubscription)
+            ).thenReturn(mockSubscriptions.encryptionSubscription)
+
             whenever(
                 it.createRPCSubscription(
                     eq(
@@ -149,72 +388,15 @@ class CryptoProcessorImplTest {
                     any(),
                     any()
                 )
-            )
-                .thenReturn(hsmRegSubscription)
+            ).thenReturn(mockSubscriptions.hsmRegSubscription)
+
+            whenever(
+                it.createHttpRPCSubscription(
+                    any(),
+                    any<CryptoFlowOpsProcessor>()
+                )
+            ).thenReturn(mockSubscriptions.flowOpsRpcSubscription)
         }
-        val mockHsmAssociation = mock<HSMAssociationInfo>()
-        mockConstruction(HSMRepositoryImpl::class.java) { mock, _ ->
-            whenever(mock.findTenantAssociation(any(), any())).doReturn(mockHsmAssociation)
-
-            LifecycleTest {
-                addDependency<LifecycleCoordinatorFactory>()
-                addDependency<ConfigurationReadService>()
-
-                addDependency<JpaEntitiesRegistry>()
-                addDependency<DbConnectionManager>()
-                addDependency<VirtualNodeInfoReadService>()
-                addDependency<SubscriptionFactory>()
-                val virtualNodeInfo = mock<VirtualNodeInfo> {
-                    on { cryptoDmlConnectionId } doReturn UUID.randomUUID()
-                }
-
-                val cryptoProcessor = CryptoProcessorImpl(
-                    coordinatorFactory = coordinatorFactory,
-                    configurationReadService = configReadService,
-                    jpaEntitiesRegistry = mock(),
-                    dbConnectionManager = mock(),
-                    virtualNodeInfoReadService = mock {
-                        on { getByHoldingIdentityShortHash(any()) } doReturn virtualNodeInfo
-                    },
-                    subscriptionFactory = subscriptionFactory,
-                    externalEventResponseFactory = mock(),
-                    keyEncodingService = mock(),
-                    layeredPropertyMapFactory = mock(),
-                    digestService = mock(),
-                    schemeMetadata = mock(),
-                    publisherFactory = mock(),
-                    stateManagerFactory = mock(),
-                    cordaAvroSerializationFactory = mock())
-                cryptoProcessor.lifecycleCoordinator
-            }.run {
-                testClass.start()
-                bringDependenciesUp()
-                verify(configReadService, times(1)).registerComponentForUpdates(any(), any())
-                verifyIsDown<CryptoProcessor>()
-
-                sendConfigUpdate<CryptoProcessor>(mapOf(CRYPTO_CONFIG to cryptoConfig, MESSAGING_CONFIG to mock()))
-
-                verifyIsUp<CryptoProcessor>()
-                verify(flowOpsSubscription, times(1)).start()
-                verify(rpcOpsSubscription, times(1)).start()
-                verify(decryptionSubscription, times(1)).start()
-                verify(encryptionSubscription, times(1)).start()
-                verify(hsmRegSubscription, times(1)).start()
-
-                sendConfigUpdate<CryptoProcessor>(mapOf(CRYPTO_CONFIG to cryptoConfig, MESSAGING_CONFIG to mock()))
-
-                verify(flowOpsSubscription, times(1)).close()
-                verify(rpcOpsSubscription, times(1)).close()
-                verify(hsmRegSubscription, times(1)).close()
-                verify(decryptionSubscription, times(1)).close()
-                verify(encryptionSubscription, times(1)).close()
-
-                verify(flowOpsSubscription, times(2)).start()
-                verify(rpcOpsSubscription, times(2)).start()
-                verify(hsmRegSubscription, times(2)).start()
-                verify(encryptionSubscription, times(2)).start()
-                verify(hsmRegSubscription, times(2)).start()
-            }
-        }
+        return subscriptionFactory
     }
 }


### PR DESCRIPTION
There existed a test which attmpted to check we could apply config changes to the crypto processor. Unfortunately this test didn't execute because of a typo which must have appeared at some point during the life of the test. This change reinstates execution, however the crypto processor has evovled during key rotation a fair bit and the test needed quite a lot of attention. Once resolved it picked up three bugs:
- The inability to apply a new config as per the ticket which triggered this. That is fixed in `CryptoProcessorImpl` with the use of a new resource which manages the subscription resource and the publisher resource. It ensures in its `close` method the latter is closed before the subscription and this should resolve the problem outlined in the ticket.
- `CryptoProcessorImpl` was erroneously starting the rewrap subscription twice, see line 438
- Whilst debugging the test it was observed the `SoftCryptoService` would not put wrapping keys in the cache when it didn't have to create them, but it would cache them if it did create them. Ironically keys which already existed in the db didn't make it into the cache but new ones did. This was because of repetition with subtle differences in the code between the function which obtained keys and the one which created them if they didn't exist (i.e. the former did caching, the latter sometimes didn't). This PR consolidates this functionality into one function used in both places as the logic is identical. It also includes a test to ensure a call to `createWrappingKey` leaves the key in the cache whether it was created or fetched by this worker.