### PR TITLE
CORE-19519 persist transaction signatures

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -80,4 +80,6 @@ interface UtxoPersistenceService {
         transactionId: String,
         groupIndex: Int
     ): List<MerkleProofDto>
+
+    fun persistTransactionSignatures(id: String, signatures: List<ByteArray>, startingIndex: Int)
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -271,7 +271,6 @@ class UtxoPersistenceServiceImpl(
             serializationService.deserialize<DigitalSignatureAndMetadata>(it)
         }
         entityManagerFactory.transaction { em ->
-            System.nanoTime()
             // Insert the Transactions signatures
             digitalSignatureAndMetadatas.forEachIndexed { index, digitalSignatureAndMetadata ->
                 repository.persistTransactionSignature(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 class UtxoPersistenceServiceImpl(
     private val entityManagerFactory: EntityManagerFactory,
     private val repository: UtxoRepository,
@@ -271,7 +271,7 @@ class UtxoPersistenceServiceImpl(
             serializationService.deserialize<DigitalSignatureAndMetadata>(it)
         }
         entityManagerFactory.transaction { em ->
-            val startTime = System.nanoTime()
+            System.nanoTime()
             // Insert the Transactions signatures
             digitalSignatureAndMetadatas.forEachIndexed { index, digitalSignatureAndMetadata ->
                 repository.persistTransactionSignature(
@@ -282,9 +282,6 @@ class UtxoPersistenceServiceImpl(
                     nowUtc
                 )
             }
-            CordaMetrics.Metric.Ledger.PersistenceTxExecutionTime
-                .builder().withTag(CordaMetrics.Tag.OperationName, "signatures")
-                .build().record(Duration.ofNanos(System.nanoTime() - startTime))
         }
     }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -11,6 +11,7 @@ import net.corda.data.ledger.persistence.PersistMerkleProofIfDoesNotExist
 import net.corda.data.ledger.persistence.PersistSignedGroupParametersIfDoNotExist
 import net.corda.data.ledger.persistence.PersistTransaction
 import net.corda.data.ledger.persistence.PersistTransactionIfDoesNotExist
+import net.corda.data.ledger.persistence.PersistTransactionSignatures
 import net.corda.data.ledger.persistence.ResolveStateRefs
 import net.corda.data.ledger.persistence.UpdateTransactionStatus
 import net.corda.data.persistence.FindWithNamedQuery
@@ -30,6 +31,7 @@ import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoPersistMerkle
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoPersistSignedGroupParametersIfDoNotExistRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoPersistTransactionIfDoesNotExistRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoPersistTransactionRequestHandler
+import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoPersistTransactionSignaturesRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoResolveStateRefsRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoUpdateTransactionStatusRequestHandler
 import net.corda.persistence.common.ResponseFactory
@@ -125,6 +127,14 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
                     externalEventResponseFactory,
                     serializationService,
                     persistenceService
+                )
+            }
+            is PersistTransactionSignatures -> {
+                UtxoPersistTransactionSignaturesRequestHandler(
+                    req,
+                    externalEventContext,
+                    persistenceService,
+                    externalEventResponseFactory
                 )
             }
             is UpdateTransactionStatus -> {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionSignaturesRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionSignaturesRequestHandler.kt
@@ -1,0 +1,33 @@
+package net.corda.ledger.persistence.utxo.impl.request.handlers
+
+import net.corda.data.KeyValuePairList
+import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.data.ledger.persistence.PersistTransactionSignatures
+import net.corda.data.persistence.EntityResponse
+import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
+import net.corda.ledger.persistence.common.RequestHandler
+import net.corda.ledger.persistence.utxo.UtxoPersistenceService
+import net.corda.messaging.api.records.Record
+
+class UtxoPersistTransactionSignaturesRequestHandler(
+    private val persistTransactionSignatures: PersistTransactionSignatures,
+    private val externalEventContext: ExternalEventContext,
+    private val persistenceService: UtxoPersistenceService,
+    private val externalEventResponseFactory: ExternalEventResponseFactory
+) : RequestHandler {
+
+    override fun execute(): List<Record<*, *>> {
+        persistenceService.persistTransactionSignatures(
+            persistTransactionSignatures.id,
+            persistTransactionSignatures.signatures.map { it.array() },
+            persistTransactionSignatures.startingIndex
+        )
+
+        return listOf(
+            externalEventResponseFactory.success(
+                externalEventContext,
+                EntityResponse(emptyList(), KeyValuePairList(emptyList()), null)
+            )
+        )
+    }
+}

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -94,7 +94,7 @@ class UtxoFinalityFlowV1(
         sendTransactionAndDependenciesToCounterparties(transferAdditionalSignatures)
         val (transaction, signaturesReceivedFromSessions, startingIndex, signatures) = receiveSignaturesAndAddToTransaction()
         verifyAllReceivedSignatures(transaction, signaturesReceivedFromSessions)
-        persistTransactionWithCounterpartySignatures(transaction.id, startingIndex, signatures)
+        persistCounterpartySignatures(transaction.id, startingIndex, signatures)
 
         if (transferAdditionalSignatures) {
             sendUnseenSignaturesToCounterparties(transaction, signaturesReceivedFromSessions)
@@ -185,13 +185,6 @@ class UtxoFinalityFlowV1(
         }
     }
 
-    private data class TransactionAndReceivedSignatures(
-        val transaction: UtxoSignedTransactionInternal,
-        val sessionsToSignatures: Map<FlowSession, List<DigitalSignatureAndMetadata>>,
-        val indexOfNewSignatures: Int,
-        val orderedNewSignatures: List<DigitalSignatureAndMetadata>
-    )
-
     @Suppress("MaxLineLength")
     @Suspendable
     private fun receiveSignaturesAndAddToTransaction(): TransactionAndReceivedSignatures {
@@ -273,7 +266,7 @@ class UtxoFinalityFlowV1(
     }
 
     @Suspendable
-    private fun persistTransactionWithCounterpartySignatures(
+    private fun persistCounterpartySignatures(
         id: SecureHash,
         startingIndex: Int,
         signatures: List<DigitalSignatureAndMetadata>
@@ -411,4 +404,11 @@ class UtxoFinalityFlowV1(
     private fun sendNotarySignaturesToCounterparties(notarySignatures: List<DigitalSignatureAndMetadata>) {
         flowMessaging.sendAll(Payload.Success(notarySignatures), sessions.toSet())
     }
+
+    private data class TransactionAndReceivedSignatures(
+        val transaction: UtxoSignedTransactionInternal,
+        val sessionsToSignatures: Map<FlowSession, List<DigitalSignatureAndMetadata>>,
+        val indexOfNewSignatures: Int,
+        val orderedNewSignatures: List<DigitalSignatureAndMetadata>
+    )
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -168,13 +168,6 @@ class UtxoReceiveFinalityFlowV1(
         }
     }
 
-    private data class InitialTransactionPayload(
-        val initialTransaction: UtxoSignedTransactionInternal,
-        val transferAdditionalSignatures: Boolean,
-        val inputStateAndRefs: List<StateAndRef<*>>,
-        val referenceStateAndRefs: List<StateAndRef<*>>
-    )
-
     @Suspendable
     private fun verifyDependencies(
         filteredTransactionsAndSignatures: List<FilteredTransactionAndSignatures>,
@@ -309,12 +302,6 @@ class UtxoReceiveFinalityFlowV1(
         return transaction to Payload.Success(mySignatures)
     }
 
-    private data class TransactionAndReceivedSignatures(
-        val transaction: UtxoSignedTransactionInternal,
-        val indexOfNewSignatures: Int,
-        val orderedNewSignatures: List<DigitalSignatureAndMetadata>
-    )
-
     @Suspendable
     private fun receiveSignaturesAndAddToTransaction(transaction: UtxoSignedTransactionInternal): TransactionAndReceivedSignatures {
         val initialSignaturesSize = transaction.signatures.size
@@ -398,4 +385,17 @@ class UtxoReceiveFinalityFlowV1(
             log.debug("Recorded transaction with all parties' and the notary's signature ${notarizedTransaction.id}")
         }
     }
+
+    private data class InitialTransactionPayload(
+        val initialTransaction: UtxoSignedTransactionInternal,
+        val transferAdditionalSignatures: Boolean,
+        val inputStateAndRefs: List<StateAndRef<*>>,
+        val referenceStateAndRefs: List<StateAndRef<*>>
+    )
+
+    private data class TransactionAndReceivedSignatures(
+        val transaction: UtxoSignedTransactionInternal,
+        val indexOfNewSignatures: Int,
+        val orderedNewSignatures: List<DigitalSignatureAndMetadata>
+    )
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
@@ -12,6 +12,7 @@ enum class LedgerPersistenceMetricOperationName {
     PersistSignedGroupParametersIfDoNotExist,
     PersistTransaction,
     PersistTransactionIfDoesNotExist,
+    PersistTransactionSignatures,
     ResolveStateRefs,
     UpdateTransactionStatus,
     PersistMerkleProofIfDoesNotExist

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.persistence
 
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedLedgerTransaction
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
@@ -146,4 +147,7 @@ interface UtxoLedgerPersistenceService {
         groupIndex: Int,
         merkleProof: MerkleProof
     )
+
+    @Suspendable
+    fun persistTransactionSignatures(id: SecureHash, startingIndex: Int, signatures: List<DigitalSignatureAndMetadata>)
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -259,11 +259,17 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun persistTransactionSignatures(id: SecureHash, startingIndex: Int, signatures: List<DigitalSignatureAndMetadata>) {
-        return recordSuspendable({ ledgerPersistenceFlowTimer(LedgerPersistenceMetricOperationName.PersistTransactionSignatures) }) @Suspendable {
+        return recordSuspendable(
+            { ledgerPersistenceFlowTimer(LedgerPersistenceMetricOperationName.PersistTransactionSignatures) }
+        ) @Suspendable {
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     PersistTransactionSignaturesExternalEventFactory::class.java,
-                    PersistTransactionSignaturesParameters(id.toString(), startingIndex, signatures.map { serializationService.serialize(it).bytes })
+                    PersistTransactionSignaturesParameters(
+                        id.toString(),
+                        startingIndex,
+                        signatures.map { serializationService.serialize(it).bytes }
+                    )
                 )
             }
         }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/PersistTransactionSignaturesExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/PersistTransactionSignaturesExternalEventFactory.kt
@@ -1,0 +1,30 @@
+package net.corda.ledger.utxo.flow.impl.persistence.external.events
+
+import net.corda.data.ledger.persistence.PersistTransactionSignatures
+import net.corda.flow.external.events.factory.ExternalEventFactory
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import java.nio.ByteBuffer
+import java.time.Clock
+
+@Component(service = [ExternalEventFactory::class])
+class PersistTransactionSignaturesExternalEventFactory :
+    AbstractUtxoLedgerExternalEventFactory<PersistTransactionSignaturesParameters> {
+    @Activate
+    constructor() : super()
+    constructor(clock: Clock) : super(clock)
+
+    override fun createRequest(parameters: PersistTransactionSignaturesParameters): Any {
+        return PersistTransactionSignatures(
+            parameters.id,
+            parameters.startingIndex,
+            parameters.signatures.map { ByteBuffer.wrap(it) }
+        )
+    }
+}
+
+data class PersistTransactionSignaturesParameters(
+    val id: String,
+    val startingIndex: Int,
+    val signatures: List<ByteArray>
+)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -292,6 +292,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
         whenever(txAfterBobSignature.addSignature(signatureNotary)).thenReturn(notarizedTx)
@@ -317,7 +318,11 @@ class UtxoFinalityFlowV1Test {
         verify(txAfterBobSignature).addSignature(signatureNotary)
 
         verify(persistenceService).persist(initialTx, TransactionStatus.UNVERIFIED, emptyList())
-        verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.UNVERIFIED, emptyList())
+        verify(persistenceService).persistTransactionSignatures(
+            TX_ID,
+            1,
+            listOf(signatureAlice2, signatureBob)
+        )
         verify(persistenceService).persist(notarizedTx, TransactionStatus.VERIFIED, listOf(0))
 
         verify(flowMessaging).receiveAllMap(
@@ -373,6 +378,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
 
@@ -402,7 +408,11 @@ class UtxoFinalityFlowV1Test {
         verify(txAfterBobSignature, never()).addSignature(signatureNotary)
 
         verify(persistenceService).persist(initialTx, TransactionStatus.UNVERIFIED)
-        verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            TX_ID,
+            1,
+            listOf(signatureAlice2, signatureBob)
+        )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.INVALID)
 
@@ -467,6 +477,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
 
@@ -495,7 +506,11 @@ class UtxoFinalityFlowV1Test {
         verify(txAfterBobSignature, never()).addSignature(signatureNotary)
 
         verify(persistenceService).persist(initialTx, TransactionStatus.UNVERIFIED)
-        verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            TX_ID,
+            1,
+            listOf(signatureAlice2, signatureBob)
+        )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.INVALID), any())
 
@@ -559,6 +574,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
         whenever(txAfterBobSignature.addSignature(invalidNotarySignature)).thenReturn(notarizedTx)
@@ -585,7 +601,11 @@ class UtxoFinalityFlowV1Test {
         verify(txAfterBobSignature, never()).addSignature(invalidNotarySignature)
 
         verify(persistenceService).persist(initialTx, TransactionStatus.UNVERIFIED)
-        verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            TX_ID,
+            1,
+            listOf(signatureAlice2, signatureBob)
+        )
         verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.INVALID)
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
 
@@ -643,6 +663,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
 
@@ -669,7 +690,11 @@ class UtxoFinalityFlowV1Test {
         verify(txAfterBobSignature, never()).addSignature(signatureNotary)
 
         verify(persistenceService).persist(initialTx, TransactionStatus.UNVERIFIED)
-        verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            TX_ID,
+            1,
+            listOf(signatureAlice2, signatureBob)
+        )
         verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.INVALID)
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
 
@@ -730,6 +755,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterBobSignature.signatures).thenReturn(listOf(signatureAlice1, signatureAlice2, signatureBob))
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
@@ -754,7 +780,11 @@ class UtxoFinalityFlowV1Test {
         verify(txAfterBobSignature, never()).addSignature(signatureNotary)
 
         verify(persistenceService).persist(initialTx, TransactionStatus.UNVERIFIED)
-        verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            TX_ID,
+            1,
+            listOf(signatureAlice2, signatureBob)
+        )
         verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.INVALID)
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
 
@@ -805,6 +835,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice1Signature = mock<UtxoSignedTransactionInternal>()
         whenever(initialTx.addSignature(signatureAlice1)).thenReturn(txAfterAlice1Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterBobSignature.signatures).thenReturn(listOf(signatureAlice1, signatureAlice2, signatureBob))
         whenever(txAfterAlice1Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
@@ -826,7 +857,11 @@ class UtxoFinalityFlowV1Test {
         verify(txAfterAlice1Signature).addSignature(signatureBob)
 
         verify(persistenceService).persist(initialTx, TransactionStatus.UNVERIFIED)
-        verify(persistenceService).persist(txAfterBobSignature, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            TX_ID,
+            1,
+            listOf(signatureBob)
+        )
         verify(persistenceService).persist(notarizedTx, TransactionStatus.VERIFIED)
 
         verify(flowMessaging).receiveAllMap(
@@ -1146,6 +1181,7 @@ class UtxoFinalityFlowV1Test {
 
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(initialTx.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
         whenever(txAfterBobSignature.addSignature(signatureNotary)).thenReturn(notarizedTx)
 
@@ -1199,6 +1235,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
         whenever(txAfterBobSignature.addSignature(signatureNotary)).thenReturn(notarizedTx)
@@ -1259,6 +1296,7 @@ class UtxoFinalityFlowV1Test {
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
         whenever(txAfterBobSignature.addSignature(signatureNotary)).thenReturn(notarizedTx)
 
@@ -1317,6 +1355,7 @@ class UtxoFinalityFlowV1Test {
         val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
         whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
         val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
         whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
         whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
         whenever(txAfterBobSignature.addSignature(signatureNotary)).thenReturn(notarizedTx)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -203,7 +203,12 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(signedTransaction).addMissingSignatures()
 
         verify(signedTransactionWithOwnKeys).addSignature(signature3)
-        verify(persistenceService, times(2)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            2,
+            listOf()
+        )
         verify(persistenceService).persist(notarizedTransaction, TransactionStatus.VERIFIED)
         verify(session).send(Payload.Success(listOf(signature1, signature2)))
     }
@@ -274,7 +279,12 @@ class UtxoReceiveFinalityFlowV1Test {
             .hasMessageContaining("No notary signature received for transaction:")
 
         verify(signedTransaction).addMissingSignatures()
-        verify(persistenceService, times(2)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            2,
+            listOf()
+        )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(signedTransactionWithOwnKeys, TransactionStatus.INVALID)
         verify(session).send(Payload.Success(listOf(signature1, signature2)))
@@ -296,7 +306,12 @@ class UtxoReceiveFinalityFlowV1Test {
             .hasMessageContaining("notarization error")
 
         verify(signedTransaction).addMissingSignatures()
-        verify(persistenceService, times(2)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            2,
+            listOf()
+        )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(signedTransactionWithOwnKeys, TransactionStatus.INVALID)
         verify(session).send(Payload.Success(listOf(signature1, signature2)))
@@ -313,7 +328,12 @@ class UtxoReceiveFinalityFlowV1Test {
             .hasMessageContaining("notarization error")
 
         verify(signedTransaction).addMissingSignatures()
-        verify(persistenceService, times(2)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            2,
+            listOf()
+        )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.INVALID), any())
         verify(session).send(Payload.Success(listOf(signature1, signature2)))
@@ -334,7 +354,12 @@ class UtxoReceiveFinalityFlowV1Test {
             .hasMessageContaining("Verifying notary signature failed!!")
 
         verify(signedTransaction).addMissingSignatures()
-        verify(persistenceService, times(2)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            2,
+            listOf()
+        )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(signedTransactionWithOwnKeys, TransactionStatus.INVALID)
         verify(session).send(Payload.Success(listOf(signature1, signature2)))
@@ -356,7 +381,12 @@ class UtxoReceiveFinalityFlowV1Test {
             .hasMessageContaining("Notary's signature has not been created by the transaction's notary.")
 
         verify(signedTransaction).addMissingSignatures()
-        verify(persistenceService, times(2)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            2,
+            listOf()
+        )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(signedTransactionWithOwnKeys, TransactionStatus.INVALID)
         verify(session).send(Payload.Success(listOf(signature1, signature2)))
@@ -381,7 +411,12 @@ class UtxoReceiveFinalityFlowV1Test {
 
         verify(signedTransaction).addMissingSignatures()
         verify(signedTransactionWith1Key, never()).addMissingSignatures()
-        verify(persistenceService, times(2)).persist(signedTransactionWith1Key, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransactionWith1Key, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            1,
+            listOf()
+        )
         verify(persistenceService).persist(notarizedTransaction, TransactionStatus.VERIFIED)
         verify(session).send(Payload.Success(listOf(signature1)))
     }
@@ -446,7 +481,12 @@ class UtxoReceiveFinalityFlowV1Test {
 
         verify(signedTransaction).addMissingSignatures()
         verify(session).send(Payload.Success(emptyList<DigitalSignatureAndMetadata>()))
-        verify(persistenceService, times(2)).persist(signedTransaction, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransaction, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            1,
+            listOf()
+        )
         verify(persistenceService).persist(notarizedTransaction, TransactionStatus.VERIFIED)
     }
 
@@ -555,7 +595,12 @@ class UtxoReceiveFinalityFlowV1Test {
         callReceiveFinalityFlow()
 
         verify(session, times(1)).receive(List::class.java)
-        verify(persistenceService, times(2)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            2,
+            listOf()
+        )
     }
 
     @Test


### PR DESCRIPTION
Implement PersistTransactionSignatures to avoid persisting the whole transaction again when only signatures have been added.

API: https://github.com/corda/corda-api/pull/1479