### PR TITLE
CORE-18839 - Kafka client upgrade

### DIFF
--- a/components/membership/membership-persistence-service-impl/build.gradle
+++ b/components/membership/membership-persistence-service-impl/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     integrationTestImplementation project(':libs:layered-property-map')
     integrationTestImplementation project(':libs:messaging:topic-admin')
     integrationTestImplementation project(':testing:message-patterns')
-    integrationTestImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    integrationTestImplementation libs.kafka.client
 
     integrationTestRuntimeOnly "com.sun.activation:javax.activation:$activationVersion"
     integrationTestRuntimeOnly "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.framework.extension:$ariesDynamicFrameworkExtensionVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,12 +55,12 @@ hibernateVersion=5.6.15.Final
 jaxbVersion = 2.3.1
 jbossTransactionApiSpecVersion=1.1.1.Final
 jetbrainsAnnotationsVersion=24.0.1
-kafkaClientVersion=3.4.0_1
 # NOTE: Kryo cannot easily be upgraded as it needs a Quasar change.
 #  Check with one of the group leads before changing.
 kryoVersion = 5.5.0
 kryoSerializersVersion = 0.45
 kotlinCoroutinesVersion=1.6.4
+# Liquibase upgrade to 4.20 and 4.21 failed - see CORE-12612 for more details
 # Liquibase upgrade to 4.20 and 4.21 failed - see CORE-12612 for more details
 liquibaseVersion = 4.19.0
 # Needed by Liquibase:
@@ -80,8 +80,6 @@ quasarVersion = 0.9.1_r3-SNAPSHOT
 reflectAsmVersion = 1.11.9
 # Snappy version used for serialization
 snappyVersion=0.4
-# Completely different version of Snappy used in Kafka client
-xerialSnappyVersion=1.1.10.4
 typeSafeConfigVersion=1.4.2
 jsonCanonicalizerVersion=1.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,6 @@ kryoVersion = 5.5.0
 kryoSerializersVersion = 0.45
 kotlinCoroutinesVersion=1.6.4
 # Liquibase upgrade to 4.20 and 4.21 failed - see CORE-12612 for more details
-# Liquibase upgrade to 4.20 and 4.21 failed - see CORE-12612 for more details
 liquibaseVersion = 4.19.0
 # Needed by Liquibase:
 beanutilsVersion=1.9.4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ bouncycastleVersion = "1.77"
 hikariCpVersion = "5.1.0"
 jacksonVersion = "2.16.1"
 micrometerVersion = "1.12.2"
+kafkaClientVersion = "3.6.1_1"
 mssqlDriverVersion = "11.2.3.jre17"
 postgresDriverVersion = "42.7.1"
 
@@ -79,6 +80,7 @@ junit-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.r
 junit-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junitVersion" }
 junit-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitVersion" }
 junit-platform = { group = "org.junit.platform", name = "junit-platform-launcher" }
+kafka-client = { group = "org.apache.servicemix.bundles", name = "org.apache.servicemix.bundles.kafka-clients", version.ref = "kafkaClientVersion" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
 kotlin-stdlib-common = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-common", version.ref = "kotlinVersion" }
 kotlin-stdlib-jdk7 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk7", version.ref = "kotlinVersion" }

--- a/libs/messaging/db-topic-admin-impl/build.gradle
+++ b/libs/messaging/db-topic-admin-impl/build.gradle
@@ -9,13 +9,7 @@ dependencies {
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
-    constraints {
-        implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
-            because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +
-                    'This might be resolved in the future versions of Kafka Client.'
-        }
-    }
+    implementation libs.kafka.client
     implementation "com.typesafe:config:$typeSafeConfigVersion"
     implementation "net.corda:corda-base"
     implementation 'net.corda:corda-db-schema'

--- a/libs/messaging/kafka-message-bus-impl/build.gradle
+++ b/libs/messaging/kafka-message-bus-impl/build.gradle
@@ -29,13 +29,7 @@ dependencies {
     implementation "net.corda:corda-base"
     implementation "net.corda:corda-config-schema"
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
-    constraints {
-        implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
-            because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +
-                    'This might be resolved in the future versions of Kafka Client.'
-        }
-    }
+    implementation libs.kafka.client
 
     implementation "com.typesafe:config:$typeSafeConfigVersion"
 

--- a/libs/messaging/kafka-topic-admin-impl/build.gradle
+++ b/libs/messaging/kafka-topic-admin-impl/build.gradle
@@ -10,13 +10,7 @@ dependencies {
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation "com.typesafe:config:$typeSafeConfigVersion"
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
-    constraints {
-        implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
-            because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +
-                    'This might be resolved in the future versions of Kafka Client.'
-        }
-    }
+    implementation libs.kafka.client
     implementation "net.corda:corda-base"
     implementation project(":libs:messaging:topic-admin")
     implementation project(":libs:utilities")

--- a/libs/messaging/messaging-impl/build.gradle
+++ b/libs/messaging/messaging-impl/build.gradle
@@ -57,5 +57,5 @@ dependencies {
     integrationTestImplementation project(':libs:lifecycle:registry')
     integrationTestImplementation project(':libs:schema-registry:schema-registry-impl')
     integrationTestImplementation project(':libs:messaging:kafka-message-bus-impl')
-    integrationTestImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    integrationTestImplementation libs.kafka.client
 }

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     integrationTestImplementation "com.typesafe:config:$typeSafeConfigVersion"
     integrationTestImplementation "org.osgi:org.osgi.test.junit5:$osgiTestJunit5Version"
     integrationTestImplementation "javax.persistence:javax.persistence-api"
-    integrationTestImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    integrationTestImplementation libs.kafka.client
 
     integrationTestImplementation project(":components:kafka-topic-admin")
     integrationTestImplementation 'net.corda:corda-db-schema'

--- a/tools/plugins/preinstall/build.gradle
+++ b/tools/plugins/preinstall/build.gradle
@@ -35,13 +35,7 @@ dependencies {
         }
     }
     implementation libs.postgresql.jdbc
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
-    constraints {
-        implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
-            because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +
-                    'This might be resolved in the future versions of Kafka Client.'
-        }
-    }
+    implementation libs.kafka.client
 }
 
 cliPlugin {

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     compileOnly platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-topic-schema:$cordaApiVersion"
     implementation libs.kafka.client
+    constraints {
+        implementation(libs.slf4j.v2.api)
+    }
 
     testImplementation libs.bundles.test
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib'

--- a/tools/plugins/topic-config/build.gradle
+++ b/tools/plugins/topic-config/build.gradle
@@ -23,14 +23,7 @@ dependencies {
 
     compileOnly platform("net.corda:corda-api:$cordaApiVersion")
     implementation "net.corda:corda-topic-schema:$cordaApiVersion"
-    implementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
-    constraints {
-        implementation(libs.slf4j.v2.api)
-        implementation("org.xerial.snappy:snappy-java:$xerialSnappyVersion") {
-            because 'Kafka Client uses an older version of Snappy library which is exposed to CVE-2023-34455. ' +
-                    'This might be resolved in the future versions of Kafka Client.'
-        }
-    }
+    implementation libs.kafka.client
 
     testImplementation libs.bundles.test
     testImplementation 'org.jetbrains.kotlin:kotlin-stdlib'
@@ -38,7 +31,7 @@ dependencies {
     testImplementation "net.corda.cli.host:api:$pluginHostVersion"
     testImplementation libs.jackson.module.kotlin
     testImplementation libs.jackson.dataformat.yaml
-    testImplementation "org.apache.servicemix.bundles:org.apache.servicemix.bundles.kafka-clients:$kafkaClientVersion"
+    testImplementation libs.kafka.client
 }
 
 cliPlugin {


### PR DESCRIPTION
Move Kafka Client to version catalog and update to version that doesn't need snappy override.