### PR TITLE
CORE-19491 Adding FlowStatusCleanupProcessor for discovering stale FlowStatus records in state storage

### DIFF
--- a/processors/rest-processor/src/main/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessor.kt
+++ b/processors/rest-processor/src/main/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessor.kt
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 
-class FlowStatusCleanupProcessor (
+class FlowStatusCleanupProcessor(
     config: SmartConfig,
     private val stateManager: StateManager,
     private val now: () -> Instant = Instant::now,
@@ -29,7 +29,7 @@ class FlowStatusCleanupProcessor (
         private val logger = LoggerFactory.getLogger(FlowStatusCleanupProcessor::class.java)
         private val TERMINAL_STATES = setOf(FlowStates.COMPLETED, FlowStates.FAILED, FlowStates.KILLED)
         private const val FLOW_STATUS_METADATA_KEY = "flowStatus"
-        private const val BATCH_SIZE = 200
+        private const val BATCH_SIZE = 500
     }
 
     override val keyClass: Class<String> = String::class.java
@@ -41,7 +41,7 @@ class FlowStatusCleanupProcessor (
             logger.trace { "Processing flow status cleanup trigger scheduled at ${trigger.timestamp}" }
 
             getStaleFlowStatuses()
-                .map{ FlowStatusRecord(it.key, it.value.version) }
+                .map { FlowStatusRecord(it.key, it.value.version) }
                 .chunked(batchSize)
                 .map { Record(REST_FLOW_STATUS_CLEANUP_TOPIC, UUID.randomUUID(), ExecuteFlowStatusCleanup(it)) }
         } ?: emptyList()

--- a/processors/rest-processor/src/main/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessor.kt
+++ b/processors/rest-processor/src/main/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessor.kt
@@ -1,0 +1,56 @@
+package net.corda.processors.rest
+
+import net.corda.data.scheduler.ScheduledTaskTrigger
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.statemanager.api.IntervalFilter
+import net.corda.libs.statemanager.api.MetadataFilter
+import net.corda.libs.statemanager.api.Operation
+import net.corda.libs.statemanager.api.StateManager
+import net.corda.messaging.api.processor.DurableProcessor
+import net.corda.messaging.api.records.Record
+import net.corda.utilities.trace
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.UUID
+
+class FlowStatusCleanupProcessor (
+    private val stateManager: StateManager,
+    private val now: () -> Instant = Instant::now,
+    private val batchSize: Int = BATCH_SIZE,
+    config: SmartConfig
+) : DurableProcessor<String, ScheduledTaskTrigger> {
+    companion object {
+        private val logger = LoggerFactory.getLogger(FlowStatusCleanupProcessor::class.java)
+        private const val BATCH_SIZE = 200
+    }
+
+    override val keyClass: Class<String> = String::class.java
+    override val valueClass: Class<ScheduledTaskTrigger> = ScheduledTaskTrigger::class.java
+    private val cleanupTimeMilliseconds = 604800000
+
+    override fun onNext(events: List<Record<String, ScheduledTaskTrigger>>): List<Record<*, *>> {
+        return events.lastOrNull {
+            it.key == "flow-status-cleanup" // replace with const CORE-19490
+        }?.value?.let { trigger ->
+            logger.trace { "Processing trigger scheduled at ${trigger.timestamp}" }
+            val statesToCleanup = staleFlowStatuses().map{ it.key }
+
+            if (statesToCleanup.isEmpty()) {
+                logger.trace { "No FlowStatus records to clean up" }
+                emptyList()
+            } else {
+                logger.trace { "Triggering cleanup of ${statesToCleanup.size} FlowStatus records" }
+
+                statesToCleanup.chunked(batchSize) { batch ->
+                    Record("rest.flow.status.cleanup", UUID.randomUUID(), batch) // replace topic with const CORE-19490
+                }
+            }
+        } ?: emptyList()
+    }
+
+    private fun staleFlowStatuses() =
+        stateManager.findUpdatedBetweenWithMetadataFilter(
+            IntervalFilter(Instant.EPOCH, now().minusMillis(cleanupTimeMilliseconds.toLong())),
+            MetadataFilter("PLACEHOLDER awaiting CORE-19440", Operation.Equals, true)
+        )
+}

--- a/processors/rest-processor/src/test/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessorTest.kt
+++ b/processors/rest-processor/src/test/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessorTest.kt
@@ -49,10 +49,12 @@ class FlowStatusCleanupProcessorTest {
         assertThat(output.size).isEqualTo(1)
         assertThat(output[0].value)
             .isEqualTo(
-                ExecuteFlowStatusCleanup(listOf(
-                    FlowStatusRecord("key0", 0),
-                    FlowStatusRecord("key1", 0),
-                    FlowStatusRecord("key2", 0))
+                ExecuteFlowStatusCleanup(
+                    listOf(
+                        FlowStatusRecord("key0", 0),
+                        FlowStatusRecord("key1", 0),
+                        FlowStatusRecord("key2", 0)
+                    )
                 )
             )
     }
@@ -68,14 +70,18 @@ class FlowStatusCleanupProcessorTest {
         val output = flowStatusCleanupProcessor.onNext(inputRecords)
 
         assertThat(output.size).isEqualTo(2)
-        assertThat(output.map {it.value}).isEqualTo(
+        assertThat(output.map { it.value }).isEqualTo(
             listOf(
-                ExecuteFlowStatusCleanup(listOf(
-                    FlowStatusRecord("key0", 0),
-                    FlowStatusRecord("key1", 0))
+                ExecuteFlowStatusCleanup(
+                    listOf(
+                        FlowStatusRecord("key0", 0),
+                        FlowStatusRecord("key1", 0)
+                    )
                 ),
-                ExecuteFlowStatusCleanup(listOf(
-                    FlowStatusRecord("key2", 0))
+                ExecuteFlowStatusCleanup(
+                    listOf(
+                        FlowStatusRecord("key2", 0)
+                    )
                 )
             )
         )

--- a/processors/rest-processor/src/test/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessorTest.kt
+++ b/processors/rest-processor/src/test/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessorTest.kt
@@ -1,0 +1,92 @@
+package net.corda.processors.rest
+
+import net.corda.data.flow.output.FlowStates
+import net.corda.data.rest.ExecuteFlowStatusCleanup
+import net.corda.data.rest.FlowStatusRecord
+import net.corda.data.scheduler.ScheduledTaskTrigger
+import net.corda.libs.configuration.SmartConfig
+import net.corda.libs.statemanager.api.Metadata
+import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.StateManager
+import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas.ScheduledTask.SCHEDULED_TASK_TOPIC_FLOW_STATUS_PROCESSOR
+import net.corda.schema.Schemas.ScheduledTask.SCHEDULE_TASK_NAME_FLOW_STATUS_CLEANUP
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class FlowStatusCleanupProcessorTest {
+    private lateinit var flowStatusCleanupProcessor: FlowStatusCleanupProcessor
+    private val config: SmartConfig = mock()
+
+    private val inputRecords = listOf(
+        Record(SCHEDULED_TASK_TOPIC_FLOW_STATUS_PROCESSOR, SCHEDULE_TASK_NAME_FLOW_STATUS_CLEANUP, ScheduledTaskTrigger())
+    )
+
+    @Test
+    fun `Test onNext returns an empty list when nothing is returned from the StateManager`() {
+        val stateManager: StateManager = mock {
+            whenever(it.findUpdatedBetweenWithMetadataMatchingAny(any(), any())).thenReturn(emptyMap())
+        }
+
+        flowStatusCleanupProcessor = FlowStatusCleanupProcessor(config, stateManager)
+        val output = flowStatusCleanupProcessor.onNext(inputRecords)
+
+        assertThat(output).isEqualTo(emptyList<Record<*, *>>())
+    }
+
+    @Test
+    fun `Test onNext returns a record containing the expected batch of records`() {
+        val stateManager: StateManager = mock {
+            whenever(it.findUpdatedBetweenWithMetadataMatchingAny(any(), any())).thenReturn(getStates(3))
+        }
+
+        flowStatusCleanupProcessor = FlowStatusCleanupProcessor(config, stateManager)
+        val output = flowStatusCleanupProcessor.onNext(inputRecords)
+
+        assertThat(output.size).isEqualTo(1)
+        assertThat(output[0].value)
+            .isEqualTo(
+                ExecuteFlowStatusCleanup(listOf(
+                    FlowStatusRecord("key0", 0),
+                    FlowStatusRecord("key1", 0),
+                    FlowStatusRecord("key2", 0))
+                )
+            )
+    }
+
+    @Test
+    fun `Test onNext returns multiple batches when the number of records is greater than the configured batch size`() {
+        val stateManager: StateManager = mock {
+            whenever(it.findUpdatedBetweenWithMetadataMatchingAny(any(), any())).thenReturn(getStates(3))
+        }
+
+        flowStatusCleanupProcessor = FlowStatusCleanupProcessor(config, stateManager, batchSize = 2)
+
+        val output = flowStatusCleanupProcessor.onNext(inputRecords)
+
+        assertThat(output.size).isEqualTo(2)
+        assertThat(output.map {it.value}).isEqualTo(
+            listOf(
+                ExecuteFlowStatusCleanup(listOf(
+                    FlowStatusRecord("key0", 0),
+                    FlowStatusRecord("key1", 0))
+                ),
+                ExecuteFlowStatusCleanup(listOf(
+                    FlowStatusRecord("key2", 0))
+                )
+            )
+        )
+    }
+
+    private fun getStates(count: Int, flowState: FlowStates = FlowStates.COMPLETED) =
+        (0 until count).associate { i ->
+            "key$i" to State(
+                key = "key$i",
+                value = "value".toByteArray(),
+                metadata = Metadata(mapOf("flowStatus" to flowState.name))
+            )
+        }
+}


### PR DESCRIPTION
This PR adds a durable subscription which will read from the FlowStatus StateManager database and return all items in states {`COMPLETED`, `FAILED`, `KILLED`} which haven't been updated in a configurable amount of time (default: 7 days). These items are fanned out into batches of 500 and posted into another internal Kafka topic which will be read by a FlowStatus deletion executor that will delete them from the StateManager batch-by-batch.