### PR TITLE
ES-1837: Add Postgres JDBC driver into Combined Worker docker image

### DIFF
--- a/applications/workers/release/combined-worker/build.gradle
+++ b/applications/workers/release/combined-worker/build.gradle
@@ -58,6 +58,20 @@ dependencies {
     // drivers "org.ops4j.pax.jdbc:pax-jdbc-oracle:1.5.3"
     // drivers "com.oracle.database.jdbc:ojdbc10WRAPPED-AS-A-BUNDLE:19.15.0.0"
 
+    // This puts the jdbc driver into the docker image in the /opt/jdbc-driver folder
+    // this folder can contain many jdbc drivers (and DataSourceFactory provider bundles).
+    // Postgres doesn't need a DataSourceFactory provider bundle (e.g. pax-jdbc), because
+    // the postgres devs have written their own and it's in this jar (PGDataSourceFactory).
+    dockerImageJdbc libs.postgresql.jdbc
+
+    // If we were to do this for a different database that is *not natively an OSGi bundle*
+    // we would need the wrapped OSGi bundle version and the pax-jdbc loader, i.e.
+    //
+    // dockerImageJdbc "org.ops4j.pax.jdbc:pax-jdbc-VENDOR:1.5.3"
+    // dockerImageJdbc "com.VENDOR.database.jdbc:vendor-jdbc-WRAPPED-AS-A-BUNDLE:$vendorVersion"
+    //
+    // NOTE: PLEASE MAKE SURE NOT TO PUBLISH A DOCKER IMAGE PUBLICLY WITH THESE WRAPPED DRIVERS,
+    //             UNLESS ABSOLUTELY SURE WE CAN DISTRIBUTE IT!!
 
     implementation platform("net.corda:corda-api:$cordaApiVersion")
     implementation project(':applications:workers:worker-common')


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/ES-1837?focusedCommentId=288220
Add the JDBC driver into the Combined Worker docker image to avoid users having to mount it.
Am I correct to leave the "drivers" dependency above this, as it's used as part of the "download" task?
Copied over the warning comments too, happy to remove if you think otherwise