### PR TITLE
ES-1921: Update CODEOWNERS ensure team leads are tagged on dependency changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@ Jenkinsfile        @corda/blt
 *.gradle           @corda/blt
 gradle/wrapper     @corda/blt
 *.toml             @corda/corda5-team-leads
+gradle.properties  @corda/corda5-team-leads
+gradle/*           @corda/blt
 
 .github/**          @corda/blt
 CODEOWNERS         @corda/blt @corda/corda5-team-leads


### PR DESCRIPTION
Update `CODEOWNERS` file, the below additions were removed in error as part of a previous commit.