### PR TITLE
CORE-19546 Populate the session cache when a responderHandshakeMessage  is received

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
@@ -329,8 +329,8 @@ internal class StatefulSessionManagerImpl(
                         )
                     }
                 }
-                is AvroInitiatorHelloMessage, is AvroInitiatorHandshakeMessage -> {
-                    result.result.sessionToCache?.let { sessionToCache ->
+                is AvroInitiatorHelloMessage, is AvroInitiatorHandshakeMessage, null -> {
+                    result.result?.sessionToCache?.let { sessionToCache ->
                         val key = result.result.stateAction.state.key
                         cachedOutboundSessions.put(
                             key,


### PR DESCRIPTION
Receiving a responder handshake message is the last step in the handshake. Hence in that case we don't expect to send any response back.