### PR TITLE
CORE-19492 Adding subscription to read from FlowStatus cleanup topic and delete stale FlowStatuses

### DIFF
--- a/processors/rest-processor/src/main/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessor.kt
+++ b/processors/rest-processor/src/main/kotlin/net/corda/processors/rest/FlowStatusCleanupProcessor.kt
@@ -19,6 +19,21 @@ import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * A processor for cleaning up flow status records that are in terminal states and have not been updated within a specified time frame.
+ *
+ * When this processor receives a [ScheduledTaskTrigger] of type [SCHEDULE_TASK_NAME_FLOW_STATUS_CLEANUP], it will poll the StateManager
+ * for all FlowStatus records with a status of [FlowStates.COMPLETED], [FlowStates.FAILED], or [FlowStates.KILLED] which have
+ * not been updated within a configurable time window, specified by [REST_FLOW_STATUS_CLEANUP_TIME_MS] in the REST config.
+ *
+ * The retrieved stale records, if any, are split into batches determined by [batchSize] and sent downstream to the
+ * [FlowStatusDeletionExecutor] for deletion.
+ *
+ * @property config The [SmartConfig] instance used for configuration settings, including the cleanup time.
+ * @property stateManager The [StateManager] instance used for accessing and modifying flow status records.
+ * @property now A lambda function that returns the current [Instant]; this is used to assess FlowStatus staleness.
+ * @property batchSize The number of records per batch that are sent to the downstream [FlowStatusDeletionExecutor].
+ */
 class FlowStatusCleanupProcessor(
     config: SmartConfig,
     private val stateManager: StateManager,

--- a/processors/rest-processor/src/main/kotlin/net/corda/processors/rest/FlowStatusDeletionExecutor.kt
+++ b/processors/rest-processor/src/main/kotlin/net/corda/processors/rest/FlowStatusDeletionExecutor.kt
@@ -1,0 +1,56 @@
+package net.corda.processors.rest
+
+import net.corda.data.rest.ExecuteFlowStatusCleanup
+import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.StateManager
+import net.corda.messaging.api.processor.DurableProcessor
+import net.corda.messaging.api.records.Record
+import net.corda.utilities.debug
+import org.slf4j.LoggerFactory
+
+/**
+ * Executes the deletion of stale flow status records that have been identified by the [FlowStatusCleanupProcessor].
+ *
+ * This executor is triggered by receiving a list of [ExecuteFlowStatusCleanup] events, each containing batches of
+ * stale flow status records. It then attempts to delete these records from the StateManager. If deletion fails for any
+ * of the records, the failed keys are logged but no error is thrown.
+ *
+ * @property stateManager The [StateManager] instance used for accessing and modifying flow status records.
+ */
+class FlowStatusDeletionExecutor(
+    private val stateManager: StateManager
+) : DurableProcessor<String, ExecuteFlowStatusCleanup> {
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
+    override val keyClass: Class<String> = String::class.java
+    override val valueClass: Class<ExecuteFlowStatusCleanup> = ExecuteFlowStatusCleanup::class.java
+
+    override fun onNext(events: List<Record<String, ExecuteFlowStatusCleanup>>): List<Record<*, *>> {
+        events.mapNotNull { it.value }.forEach(::process)
+        return emptyList()
+    }
+
+    private fun process(event: ExecuteFlowStatusCleanup) {
+        logger.debug { "FlowStatus cleanup event received with ${event.records.size} states to delete" }
+
+        if (event.records.isEmpty()) {
+            logger.debug { "FlowStatus cleanup event contained no states to delete." }
+            return
+        }
+
+        val statesToDelete = event.records.map {
+            State(it.key, ByteArray(0), it.version)
+        }
+
+        val failed = stateManager.delete(statesToDelete)
+
+        if (failed.isNotEmpty()) {
+            val failedKeys = failed.keys.joinToString(",")
+            logger.info(
+                "Failed to delete ${failed.size} FlowStatus records when executing cleanup. Failed keys: $failedKeys"
+            )
+        }
+    }
+}

--- a/processors/rest-processor/src/test/kotlin/net/corda/processors/rest/FlowStatusDeletionExecutorTest.kt
+++ b/processors/rest-processor/src/test/kotlin/net/corda/processors/rest/FlowStatusDeletionExecutorTest.kt
@@ -1,0 +1,82 @@
+package net.corda.processors.rest
+
+import net.corda.data.rest.ExecuteFlowStatusCleanup
+import net.corda.data.rest.FlowStatusRecord
+import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.StateManager
+import net.corda.messaging.api.records.Record
+import net.corda.schema.Schemas.Rest.REST_FLOW_STATUS_CLEANUP_TOPIC
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+
+class FlowStatusDeletionExecutorTest {
+    private lateinit var flowStatusDeletionExecutor: FlowStatusDeletionExecutor
+    private lateinit var stateManager: StateManager
+    private lateinit var stateCaptor: KArgumentCaptor<List<State>>
+
+    @BeforeEach
+    fun setup() {
+        stateManager = mock()
+        flowStatusDeletionExecutor = FlowStatusDeletionExecutor(stateManager)
+        stateCaptor = argumentCaptor<List<State>>()
+    }
+
+    @Test
+    fun `onNext with a single ExecuteFlowStatusCleanup record containing 0 keys does not call delete`() {
+        val inputRecords = getCleanupRecords(1, 0)
+        flowStatusDeletionExecutor.onNext(inputRecords)
+
+        verify(stateManager, never()).delete(any())
+    }
+
+    @Test
+    fun `onNext with a single ExecuteFlowStatusCleanup record containing 3 keys calls delete once with 3 keys`() {
+        val inputRecords = getCleanupRecords(1, 3)
+        flowStatusDeletionExecutor.onNext(inputRecords)
+
+        verify(stateManager, times(1)).delete(stateCaptor.capture())
+
+        val capturedStates = stateCaptor.firstValue
+
+        assertThat(capturedStates).hasSize(3)
+        assertThat(capturedStates.map { it.key })
+            .containsExactly("record_key_0", "record_key_1", "record_key_2")
+    }
+
+    @Test
+    fun `onNext with a multiple ExecuteFlowStatusCleanup records calls delete multiple times`() {
+        val inputRecords = getCleanupRecords(3, 3)
+        flowStatusDeletionExecutor.onNext(inputRecords)
+
+        verify(stateManager, times(3)).delete(stateCaptor.capture())
+
+        val allCapturedStates = stateCaptor.allValues
+
+        assertThat(allCapturedStates).hasSize(3)
+        allCapturedStates.forEach { capturedStates ->
+            assertThat(capturedStates.map { it.key }).containsExactly("record_key_0", "record_key_1", "record_key_2")
+        }
+    }
+
+    private fun getFlowStatusRecords(count: Int) =
+        (0 until count).map { i ->
+            FlowStatusRecord("record_key_$i", 0)
+        }
+
+    private fun getCleanupRecords(recordCount: Int, statusCountPerRecord: Int) =
+        (0 until recordCount).map { i ->
+            Record(
+                REST_FLOW_STATUS_CLEANUP_TOPIC,
+                "cleanup_key_$i",
+                ExecuteFlowStatusCleanup(getFlowStatusRecords(statusCountPerRecord))
+            )
+        }
+}


### PR DESCRIPTION
This PR created a new processor, `FlowStatusDeletionExecutor` which is intended to read `ExecuteFlowStatusCleanup` records from the `rest.flow.status.cleanup` topic.

These records contain the fingerprint of a `FlowStatus` record in the `StateManager` (I.e., key and version). For each `FlowStatusRecord` in the `ExecuteFlowStatusCleanup`, we create a dummy `State` object; all of these objects are then passed to the `StateManager::delete()` function to enact a bulk delete.

We retain the version from the original deletion request to preserve optimistic locking in the `StateManager`. If any `FlowStatus` record is updated between the time that it's picked up by the scheduled job and the time that we attempt deletion, deletion for that record will fail. This will be logged, but execution will proceed with no errors.