### PR TITLE
CORE-17933 Implement fetching filtered transactions and signatures

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -116,7 +116,7 @@ pipeline {
                 }
                 post {
                     always {
-                        junit allowEmptyResults: true, testResults: '**/test-results/**/TEST-*.xml'
+                        junit allowEmptyResults: false, testResults: '**/test-results/**/TEST-*.xml'
                     }
                 }
         }

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -109,7 +109,7 @@ pipeline {
         }
         stage('smoketests') {
                 options {
-                    timeout(time: 100, unit: 'MINUTES')
+                    timeout(time: 30, unit: 'MINUTES')
                 }
                 steps {
                    gradlew('smoketest -PisCombinedWorker=true')

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -109,7 +109,7 @@ pipeline {
         }
         stage('smoketests') {
                 options {
-                    timeout(time: 30, unit: 'MINUTES')
+                    timeout(time: 100, unit: 'MINUTES')
                 }
                 steps {
                    gradlew('smoketest -PisCombinedWorker=true')

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -116,7 +116,7 @@ pipeline {
                 }
                 post {
                     always {
-                        junit allowEmptyResults: false, testResults: '**/test-results/**/TEST-*.xml'
+                        junit allowEmptyResults: true, testResults: '**/test-results/**/TEST-*.xml'
                     }
                 }
         }

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -675,7 +675,7 @@ class UtxoPersistenceServiceImplTest {
 
         assertThat(filteredTxResults).hasSize(1)
 
-        val storedFilteredTransaction = filteredTxResults[filteredTransactionToStore.id.toString()]?.first
+        val storedFilteredTransaction = filteredTxResults[filteredTransactionToStore.id]?.first
 
         assertNotNull(storedFilteredTransaction)
 

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -35,6 +35,8 @@ import net.corda.ledger.persistence.utxo.tests.datamodel.UtxoEntityFactory
 import net.corda.ledger.utxo.data.state.StateAndRefImpl
 import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
+import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup.METADATA
+import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup.NOTARY
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
 import net.corda.ledger.utxo.data.transaction.UtxoTransactionMetadata
@@ -58,6 +60,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
+import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.utxo.Contract
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.EncumbranceGroup
@@ -257,6 +260,56 @@ class UtxoPersistenceServiceImplTest {
         val retval = persistenceService.findSignedLedgerTransaction(transaction.id.toString(), VERIFIED)
 
         assertThat(retval).isEqualTo(null to "U")
+    }
+
+    @Test
+    fun `find filtered transaction and signatures that matches with stateRefs`() {
+        val entityFactory = UtxoEntityFactory(entityManagerFactory)
+        val transactions = listOf(
+            persistTransactionViaEntity(entityFactory, VERIFIED),
+            persistTransactionViaEntity(entityFactory, VERIFIED)
+        )
+
+        val stateRefs = listOf(
+            StateRef(transactions[0].id, 0),
+            StateRef(transactions[1].id, 1),
+        )
+        val txIdToIndexes = stateRefs.groupBy { it.transactionId }
+            .mapValues { (_, stateRefs) -> stateRefs.map { stateRef -> stateRef.index } }
+        val expectedRetval = stateRefs.associate {
+            val indexes = txIdToIndexes[it.transactionId]!!
+            val (wireTransaction, signatures) = persistenceService.findSignedTransaction(it.transactionId.toString(), VERIFIED).first!!
+            val filteredTransaction = filteredTransactionFactory.create(
+                wireTransaction,
+                listOf(
+                    ComponentGroupFilterParameters.AuditProof(
+                        METADATA.ordinal,
+                        TransactionMetadata::class.java,
+                        ComponentGroupFilterParameters.AuditProof.AuditProofPredicate.Content { true }
+                    ),
+                    ComponentGroupFilterParameters.AuditProof(
+                        NOTARY.ordinal,
+                        Any::class.java,
+                        ComponentGroupFilterParameters.AuditProof.AuditProofPredicate.Content { true }
+                    ),
+                    ComponentGroupFilterParameters.AuditProof(
+                        UtxoComponentGroup.OUTPUTS_INFO.ordinal,
+                        UtxoOutputInfoComponent::class.java,
+                        ComponentGroupFilterParameters.AuditProof.AuditProofPredicate.Index(indexes)
+                    ),
+                    ComponentGroupFilterParameters.AuditProof(
+                        UtxoComponentGroup.OUTPUTS.ordinal,
+                        ContractState::class.java,
+                        ComponentGroupFilterParameters.AuditProof.AuditProofPredicate.Index(indexes)
+                    )
+                )
+            )
+            it.transactionId to Pair(filteredTransaction, signatures)
+        }
+
+        val retval = persistenceService.findFilteredTransactionsAndSignatures(stateRefs)
+
+        assertThat(retval).isEqualTo(expectedRetval)
     }
 
     @Test
@@ -672,22 +725,24 @@ class UtxoPersistenceServiceImplTest {
         entityFactory: UtxoEntityFactory,
         status: TransactionStatus = UNVERIFIED,
         inputStateRefs: List<StateRef> = defaultInputStateRefs,
-        referenceStateRefs: List<StateRef> = defaultReferenceStateRefs
-
+        referenceStateRefs: List<StateRef> = defaultReferenceStateRefs,
+        isFiltered: Boolean = false
     ): SignedTransactionContainer {
         val signedTransaction = createSignedTransaction(inputStateRefs = inputStateRefs, referenceStateRefs = referenceStateRefs)
         entityManagerFactory.transaction { em ->
-            em.persist(createTransactionEntity(entityFactory, signedTransaction, status = status))
+            em.persist(createTransactionEntity(entityFactory, signedTransaction, status = status, isFiltered = isFiltered))
         }
         return signedTransaction
     }
 
+    @Suppress("LongParameterList")
     private fun createTransactionEntity(
         entityFactory: UtxoEntityFactory,
         signedTransaction: SignedTransactionContainer,
         account: String = "Account",
         createdTs: Instant = testClock.instant(),
-        status: TransactionStatus = UNVERIFIED
+        status: TransactionStatus = UNVERIFIED,
+        isFiltered: Boolean = false
     ): Any {
         val metadataBytes = signedTransaction.wireTransaction.componentGroupLists[0][0]
         val metadata = entityFactory.createOrFindUtxoTransactionMetadataEntity(
@@ -704,7 +759,8 @@ class UtxoPersistenceServiceImplTest {
             createdTs,
             status.value,
             createdTs,
-            metadata
+            metadata,
+            isFiltered
         ).also { transaction ->
             transaction.field<MutableCollection<Any>>("components").addAll(
                 signedTransaction.wireTransaction.componentGroupLists.flatMapIndexed { groupIndex, componentGroup ->
@@ -763,7 +819,7 @@ class UtxoPersistenceServiceImplTest {
         inputStateRefs: List<StateRef> = defaultInputStateRefs,
         referenceStateRefs: List<StateRef> = defaultReferenceStateRefs
     ): SignedTransactionContainer {
-        val transactionMetadata = utxoTransactionMetadataExample(cpkPackageSeed = seed,)
+        val transactionMetadata = utxoTransactionMetadataExample(cpkPackageSeed = seed)
         val timeWindow = Instant.now().plusMillis(Duration.ofDays(1).toMillis())
         val componentGroupLists: List<List<ByteArray>> = listOf(
             listOf(jsonValidator.canonicalize(jsonMarshallingService.format(transactionMetadata)).toByteArray()),

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/datamodel/UtxoEntityFactory.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/datamodel/UtxoEntityFactory.kt
@@ -22,16 +22,18 @@ class UtxoEntityFactory(private val entityManagerFactory: EntityManagerFactory) 
         created: Instant,
         status: String,
         updated: Instant,
-        utxoTransactionMetadata: Any
+        utxoTransactionMetadata: Any,
+        isFiltered: Boolean = false
     ): Any {
-        return utxoTransaction.constructors.single { it.parameterCount == 7 }.newInstance(
+        return utxoTransaction.constructors.single { it.parameterCount == 8 }.newInstance(
             transactionId,
             privacySalt,
             accountId,
             created,
             status,
             updated,
-            utxoTransactionMetadata
+            utxoTransactionMetadata,
+            isFiltered
         )
     }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
@@ -5,9 +5,12 @@ import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
+import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
 import net.corda.messaging.api.records.Record
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.virtualnode.HoldingIdentity
@@ -37,6 +40,11 @@ interface UtxoOutputRecordFactory {
     ): Record<String, FlowEvent>
 
     fun getPersistTransactionSuccessRecord(
+        externalEventContext: ExternalEventContext
+    ): Record<String, FlowEvent>
+
+    fun getFindFilteredTransactionsAndSignaturesSuccessRecord(
+        filteredTransactionsAndSignatures: Map<SecureHash, Pair<FilteredTransaction?, List<DigitalSignatureAndMetadata>>>,
         externalEventContext: ExternalEventContext
     ): Record<String, FlowEvent>
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -81,4 +81,16 @@ interface UtxoPersistenceService {
     )
 
     fun persistTransactionSignatures(id: String, signatures: List<ByteArray>, startingIndex: Int)
+
+    /**
+     * Retrieve filtered transactions and its signatures with the given a list of state references.
+     *
+     * @param stateRefs The list of [StateRef]
+     *
+     * @return A map of the filtered transaction ID to a pair of a found [FilteredTransaction] and a corresponding signatures.
+     * If a [FilteredTransaction] with a given stateRef ID is not found, it will be null.
+     */
+    fun findFilteredTransactionsAndSignatures(
+        stateRefs: List<StateRef>
+    ): Map<SecureHash, Pair<FilteredTransaction?, List<DigitalSignatureAndMetadata>>>
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoOutputRecordFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoOutputRecordFactoryImpl.kt
@@ -12,13 +12,16 @@ import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey
 import net.corda.data.persistence.EntityResponse
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
+import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
 import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
 import net.corda.messaging.api.records.Record
 import net.corda.persistence.common.ResponseFactory
 import net.corda.schema.Schemas.Services.TOKEN_CACHE_EVENT
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.virtualnode.HoldingIdentity
@@ -90,6 +93,20 @@ class UtxoOutputRecordFactoryImpl(
         )
     }
 
+    override fun getFindFilteredTransactionsAndSignaturesSuccessRecord(
+        filteredTransactionsAndSignatures: Map<SecureHash, Pair<FilteredTransaction?, List<DigitalSignatureAndMetadata>>>,
+        externalEventContext: ExternalEventContext
+    ): Record<String, FlowEvent> {
+        return responseFactory.successResponse(
+            externalEventContext,
+            EntityResponse(
+                listOf(ByteBuffer.wrap(serializationService.serialize(filteredTransactionsAndSignatures).bytes)),
+                KeyValuePairList(emptyList()),
+                null
+            )
+        )
+    }
+
     override fun getStatesSuccessRecord(
         states: List<UtxoVisibleTransactionOutputDto>,
         externalEventContext: ExternalEventContext,
@@ -118,7 +135,10 @@ class UtxoOutputRecordFactoryImpl(
         )
     }
 
-    private fun createPoolKeyRecord(holdingIdentity: HoldingIdentity, stateTokenPair: Pair<StateAndRef<*>, UtxoToken>): TokenPoolCacheKey {
+    private fun createPoolKeyRecord(
+        holdingIdentity: HoldingIdentity,
+        stateTokenPair: Pair<StateAndRef<*>, UtxoToken>
+    ): TokenPoolCacheKey {
         val (stateAndRef, token) = stateTokenPair
         return TokenPoolCacheKey.newBuilder()
             .setShortHolderId(holdingIdentity.shortHash.value)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -12,6 +12,7 @@ import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionMetadataUtils.parseMetadata
 import net.corda.ledger.common.data.transaction.TransactionStatus
+import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
 import net.corda.ledger.common.data.transaction.filtered.FilteredComponentGroup
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.ledger.common.data.transaction.filtered.factory.FilteredTransactionFactory
@@ -26,6 +27,9 @@ import net.corda.ledger.persistence.utxo.UtxoRepository
 import net.corda.ledger.persistence.utxo.UtxoTransactionReader
 import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
+import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup.METADATA
+import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup.NOTARY
+import net.corda.ledger.utxo.data.transaction.UtxoOutputInfoComponent
 import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.data.transaction.toMerkleProof
@@ -44,6 +48,7 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.extensions.merkle.MerkleTreeHashDigestProvider
 import net.corda.v5.crypto.merkle.MerkleProof
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
+import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
@@ -90,6 +95,77 @@ class UtxoPersistenceServiceImpl(
                 null
             } to status
         }
+    }
+
+    override fun findFilteredTransactionsAndSignatures(
+        stateRefs: List<StateRef>,
+    ): Map<SecureHash, Pair<FilteredTransaction?, List<DigitalSignatureAndMetadata>>> {
+        val txIdToIndexesMap = stateRefs.groupBy { it.transactionId }
+            .mapValues { (_, stateRefs) -> stateRefs.map { stateRef -> stateRef.index } }
+
+        // create payload map and make values null by default, if the value of certain filtered tx is null at the end,
+        // it means it's not found. The error will be handled in flow side.
+        val txIdToFilteredTxAndSignature: MutableMap<SecureHash, Pair<FilteredTransaction?, List<DigitalSignatureAndMetadata>>> = stateRefs
+            .groupBy { it.transactionId }
+            .mapValues { (_, _) -> null to emptyList<DigitalSignatureAndMetadata>() }.toMutableMap()
+
+        txIdToIndexesMap.keys.forEach { transactionId ->
+
+            require(txIdToFilteredTxAndSignature.containsKey(transactionId)) { "transaction Id $transactionId is not found." }
+
+            val signedTransactionContainer = findSignedTransaction(transactionId.toString(), TransactionStatus.VERIFIED).first
+            val wireTransaction = signedTransactionContainer?.wireTransaction
+            val signatures = signedTransactionContainer?.signatures ?: emptyList()
+            val indexesOfTxId = requireNotNull(txIdToIndexesMap[transactionId])
+
+            if (wireTransaction != null) {
+                /** filter wire transaction that is equivalent to:
+                 * var filteredTxBuilder = filteredTransactionBuilder
+                 *   .withTimeWindow()
+                 *   .withOutputStates(indexesOfTxId)
+                 *   .withNotary()
+                 */
+                val filteredTransaction = filteredTransactionFactory.create(
+                    wireTransaction,
+                    listOf(
+                        ComponentGroupFilterParameters.AuditProof(
+                            METADATA.ordinal,
+                            TransactionMetadata::class.java,
+                            ComponentGroupFilterParameters.AuditProof.AuditProofPredicate.Content { true }
+                        ),
+                        ComponentGroupFilterParameters.AuditProof(
+                            NOTARY.ordinal,
+                            Any::class.java,
+                            ComponentGroupFilterParameters.AuditProof.AuditProofPredicate.Content { true }
+                        ),
+                        ComponentGroupFilterParameters.AuditProof(
+                            UtxoComponentGroup.OUTPUTS_INFO.ordinal,
+                            UtxoOutputInfoComponent::class.java,
+                            ComponentGroupFilterParameters.AuditProof.AuditProofPredicate.Index(indexesOfTxId)
+                        ),
+                        ComponentGroupFilterParameters.AuditProof(
+                            UtxoComponentGroup.OUTPUTS.ordinal,
+                            ContractState::class.java,
+                            ComponentGroupFilterParameters.AuditProof.AuditProofPredicate.Index(indexesOfTxId)
+                        )
+                    )
+                )
+                txIdToFilteredTxAndSignature[transactionId] = filteredTransaction to signatures
+            }
+        }
+        // filter transaction ids who's filtered tx is null
+        val transactionIdsToFind =
+            txIdToFilteredTxAndSignature.filter { it.value.toList().contains(null) }.keys.map { it.toString() }
+
+        // find from filtered transaction table if there are still unfounded filtered txs
+        val txIdToFilteredTxSignaturePairFromMerkleTable =
+            if (transactionIdsToFind.isNotEmpty()) {
+                findFilteredTransactions(transactionIdsToFind)
+            } else {
+                emptyMap<SecureHash, Pair<FilteredTransaction?, List<DigitalSignatureAndMetadata>>>()
+            }
+
+        return (txIdToFilteredTxAndSignature + txIdToFilteredTxSignaturePairFromMerkleTable).toMap()
     }
 
     override fun findTransactionIdsAndStatuses(
@@ -469,7 +545,7 @@ class UtxoPersistenceServiceImpl(
     @VisibleForTesting
     internal fun findFilteredTransactions(
         ids: List<String>
-    ): Map<String, Pair<FilteredTransaction, List<DigitalSignatureAndMetadata>>> {
+    ): Map<SecureHash, Pair<FilteredTransaction, List<DigitalSignatureAndMetadata>>> {
         return entityManagerFactory.transaction { em ->
             repository.findFilteredTransactions(em, ids)
         }.map { (transactionId, ftxDto) ->
@@ -570,7 +646,7 @@ class UtxoPersistenceServiceImpl(
             )
 
             // 6. Map the transaction id to the filtered transaction object and signatures
-            filteredTransaction.id.toString() to Pair(filteredTransaction, ftxDto.signatures)
+            filteredTransaction.id to Pair(filteredTransaction, ftxDto.signatures)
         }.toMap()
     }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.persistence.utxo.impl
 
+import net.corda.data.ledger.persistence.FindFilteredTransactionsAndSignatures
 import net.corda.data.ledger.persistence.FindSignedGroupParameters
 import net.corda.data.ledger.persistence.FindSignedLedgerTransaction
 import net.corda.data.ledger.persistence.FindTransaction
@@ -21,6 +22,7 @@ import net.corda.ledger.persistence.json.impl.DefaultContractStateVaultJsonFacto
 import net.corda.ledger.persistence.query.execution.impl.VaultNamedQueryExecutorImpl
 import net.corda.ledger.persistence.utxo.UtxoRequestHandlerSelector
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoExecuteNamedQueryHandler
+import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindFilteredTransactionsAndSignaturesRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedGroupParametersRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedLedgerTransactionRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindTransactionIdsAndStatusesRequestHandler
@@ -100,6 +102,14 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
                 UtxoFindUnconsumedStatesByTypeRequestHandler(
                     req,
                     sandbox,
+                    externalEventContext,
+                    persistenceService,
+                    outputRecordFactory
+                )
+            }
+            is FindFilteredTransactionsAndSignatures -> {
+                UtxoFindFilteredTransactionsAndSignaturesRequestHandler(
+                    req,
                     externalEventContext,
                     persistenceService,
                     outputRecordFactory

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindFilteredTransactionsAndSignaturesRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindFilteredTransactionsAndSignaturesRequestHandler.kt
@@ -1,0 +1,34 @@
+package net.corda.ledger.persistence.utxo.impl.request.handlers
+
+import net.corda.crypto.core.SecureHashImpl
+import net.corda.data.flow.event.external.ExternalEventContext
+import net.corda.data.ledger.persistence.FindFilteredTransactionsAndSignatures
+import net.corda.ledger.persistence.common.RequestHandler
+import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
+import net.corda.ledger.persistence.utxo.UtxoPersistenceService
+import net.corda.messaging.api.records.Record
+import net.corda.v5.ledger.utxo.StateRef
+
+class UtxoFindFilteredTransactionsAndSignaturesRequestHandler(
+    private val findFilteredTransactionsAndSignatures: FindFilteredTransactionsAndSignatures,
+    private val externalEventContext: ExternalEventContext,
+    private val persistenceService: UtxoPersistenceService,
+    private val utxoOutputRecordFactory: UtxoOutputRecordFactory
+) : RequestHandler {
+    override fun execute(): List<Record<*, *>> {
+        val filteredTransactionFetchResults = persistenceService.findFilteredTransactionsAndSignatures(
+            findFilteredTransactionsAndSignatures.stateRefs.map {
+                StateRef(
+                    SecureHashImpl(it.transactionId.algorithm, it.transactionId.bytes.array()),
+                    it.index
+                )
+            }
+        )
+        return listOf(
+            utxoOutputRecordFactory.getFindFilteredTransactionsAndSignaturesSuccessRecord(
+                filteredTransactionFetchResults,
+                externalEventContext
+            )
+        )
+    }
+}

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionEntity.kt
@@ -37,6 +37,9 @@ data class UtxoTransactionEntity(
     @get:ManyToOne
     @get:JoinColumn(name = "metadata_hash", nullable = false, updatable = false)
     var metadata: UtxoTransactionMetadataEntity,
+
+    @get:Column(name = "is_filtered", nullable = true)
+    var isFiltered: Boolean = false,
 ) {
     @get:OneToMany(mappedBy = "transaction", cascade = [CascadeType.ALL], orphanRemoval = true)
     var components: MutableList<UtxoTransactionComponentEntity> = mutableListOf()
@@ -54,6 +57,7 @@ data class UtxoTransactionEntity(
         if (!privacySalt.contentEquals(other.privacySalt)) return false
         if (accountId != other.accountId) return false
         if (created != other.created) return false
+        if (isFiltered != other.isFiltered) return false
 
         return true
     }

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.ledger.utxo.flow.impl.transaction.filtered.factory;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/transaction/filtered/package-info.java
+++ b/components/ledger/ledger-utxo-flow/src/main/java/net/corda/ledger/utxo/flow/impl/transaction/filtered/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.ledger.utxo.flow.impl.transaction.filtered;
+
+import org.osgi.annotation.bundle.Export;

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -27,6 +27,7 @@ import net.corda.sandbox.type.UsedByFlow
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.utilities.time.UTCClock
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.flows.FlowEngine
 import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.application.persistence.PagedQuery
@@ -47,6 +48,7 @@ import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionValidator
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
 import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionBuilder
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
@@ -135,6 +137,17 @@ class UtxoLedgerServiceImpl @Activate constructor(
             .setCreatedTimestampLimit(createdTimestampLimit)
             .setLimit(limit)
             .execute() as PagedQuery.ResultSet<StateAndRef<T>>
+    }
+
+    @Suspendable
+    override fun findFilteredTransactionsAndSignatures(
+        signedTransaction: UtxoSignedTransaction
+    ): Map<SecureHash, Map<UtxoFilteredTransaction, List<DigitalSignatureAndMetadata>>> {
+        return utxoLedgerPersistenceService.findFilteredTransactionsAndSignatures(
+            signedTransaction.inputStateRefs + signedTransaction.referenceStateRefs,
+            signedTransaction.notaryKey,
+            signedTransaction.notaryName
+        )
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/FinalityPayload.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality
 
+import net.corda.ledger.utxo.data.transaction.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.v5.base.annotations.ConstructorForDeserialization
 import net.corda.v5.base.annotations.CordaSerializable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -1,18 +1,18 @@
 package net.corda.ledger.utxo.flow.impl.flows.finality.v1
 
 import net.corda.crypto.core.fullId
-import net.corda.crypto.core.fullIdHash
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.flow.transaction.TransactionMissingSignaturesException
 import net.corda.ledger.notary.worker.selection.NotaryVirtualNodeSelectorService
+import net.corda.ledger.utxo.data.transaction.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.PluggableNotaryDetails
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainSenderFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
-import net.corda.ledger.utxo.flow.impl.flows.finality.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
+import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerPersistenceService
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.sandbox.CordaSystemFlow
 import net.corda.utilities.debug
@@ -33,6 +33,7 @@ import net.corda.v5.ledger.notary.plugin.core.NotaryExceptionFatal
 import net.corda.v5.ledger.utxo.NotarySignatureVerificationService
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
 import net.corda.v5.membership.NotaryInfo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -73,6 +74,9 @@ class UtxoFinalityFlowV1(
 
     @CordaInject
     lateinit var notarySignatureVerificationService: NotarySignatureVerificationService
+
+    @CordaInject
+    lateinit var utxoLedgerPersistenceService: UtxoLedgerPersistenceService
 
     @Suspendable
     override fun call(): UtxoSignedTransaction {
@@ -145,43 +149,19 @@ class UtxoFinalityFlowV1(
     @Suspendable
     private fun createFilteredTransactionsAndSignatures(notaryInfo: NotaryInfo): List<FilteredTransactionAndSignatures>? {
         return if (!notaryInfo.isBackchainRequired) {
-            initialTransaction
-                .let { it.inputStateRefs + it.referenceStateRefs }
-                .groupBy { stateRef -> stateRef.transactionId }
-                .mapValues { (_, stateRefs) -> stateRefs.map { stateRef -> stateRef.index } }
-                .map { (transactionId, indexes) ->
-                    val dependency = requireNotNull(utxoLedgerService.findSignedTransaction(transactionId)) {
-                        "Dependent transaction $transactionId does not exist"
-                    }
-                    val newTxNotaryKey = initialTransaction.notaryKey
-                    require(initialTransaction.notaryName == dependency.notaryName) {
-                        "Notary name of filtered transaction \"${dependency.notaryName}\" doesn't match with " +
-                            "notary service of current transaction \"${initialTransaction.notaryName}\""
-                    }
-                    notarySignatureVerificationService.verifyNotarySignatures(
-                        dependency,
-                        initialTransaction.notaryKey,
-                        dependency.signatures,
-                        mutableMapOf()
-                    )
-
-                    val newTxNotaryKeyIds = if (newTxNotaryKey is CompositeKey) {
-                        newTxNotaryKey.leafKeys.toSet()
-                    } else {
-                        setOf(newTxNotaryKey.fullIdHash())
-                    }
-
-                    FilteredTransactionAndSignatures(
-                        utxoLedgerService.filterSignedTransaction(dependency)
-                            .withOutputStates(indexes)
-                            .withNotary()
-                            .withTimeWindow()
-                            .build(),
-                        dependency.signatures.filter { newTxNotaryKeyIds.contains(it.by) }
-                    )
-                }
+            return utxoLedgerService.findFilteredTransactionsAndSignatures(initialTransaction)
+                .toFilteredTransactionsAndSignatures()
         } else {
             null
+        }
+    }
+
+    @Suppress("MaxLineLength")
+    private fun Map<SecureHash, Map<UtxoFilteredTransaction, List<DigitalSignatureAndMetadata>>>.toFilteredTransactionsAndSignatures(): List<FilteredTransactionAndSignatures> {
+        return this.flatMap { (_, ftxAndSigs) ->
+            ftxAndSigs.map {
+                FilteredTransactionAndSignatures(it.key, it.value)
+            }
         }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -25,7 +25,6 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.NotaryLookup
 import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -4,10 +4,10 @@ import net.corda.flow.application.GroupParametersLookupInternal
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
+import net.corda.ledger.utxo.data.transaction.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.backchain.InvalidBackchainException
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
-import net.corda.ledger.utxo.flow.impl.flows.finality.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.flows.finality.addTransactionIdToFlowContext
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/LedgerPersistenceMetricOperationName.kt
@@ -1,7 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
 enum class LedgerPersistenceMetricOperationName {
-
+    FindFilteredTransactionsAndSignatures,
     FindGroupParameters,
     FindSignedLedgerTransactionWithStatus,
     FindTransactionIdsAndStatuses,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -5,9 +5,13 @@ import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedLedgerTransaction
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
+import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
+import java.security.PublicKey
 
 /**
  * [UtxoLedgerPersistenceService] allows to insert and find UTXO signed transactions in the persistent store provided
@@ -83,6 +87,21 @@ interface UtxoLedgerPersistenceService {
         id: SecureHash,
         transactionStatus: TransactionStatus
     ): Pair<UtxoSignedLedgerTransaction?, TransactionStatus>?
+
+    /**
+     * Retrieve a map of transaction id to its corresponding filtered transaction and notary signature.
+     *
+     * @param stateRefs a list of [StateRef]
+     * @param notaryKey an expected notary key of stateRefs
+     * @param notaryName an expected notary name of stateRefs
+     * @return The fetch result in a map of transaction ID to [UtxoFilteredTransaction] and [DigitalSignatureAndMetadata]
+     * */
+    @Suspendable
+    fun findFilteredTransactionsAndSignatures(
+        stateRefs: List<StateRef>,
+        notaryKey: PublicKey,
+        notaryName: MemberX500Name
+    ): Map<SecureHash, Map<UtxoFilteredTransaction, List<DigitalSignatureAndMetadata>>>
 
     /**
      * Persist a [UtxoSignedTransaction] to the store.

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindFilteredTransactionsAndSignaturesExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindFilteredTransactionsAndSignaturesExternalEventFactory.kt
@@ -1,0 +1,36 @@
+package net.corda.ledger.utxo.flow.impl.persistence.external.events
+
+import net.corda.crypto.core.bytes
+import net.corda.data.crypto.SecureHash
+import net.corda.data.ledger.persistence.FindFilteredTransactionsAndSignatures
+import net.corda.flow.external.events.factory.ExternalEventFactory
+import net.corda.v5.ledger.utxo.StateRef
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import java.nio.ByteBuffer
+import java.time.Clock
+
+@Component(service = [ExternalEventFactory::class])
+class FindFilteredTransactionsAndSignaturesExternalEventFactory :
+    AbstractUtxoLedgerExternalEventFactory<FindFilteredTransactionsAndSignaturesParameters> {
+    @Activate
+    constructor() : super()
+    constructor(clock: Clock) : super(clock)
+    override fun createRequest(parameters: FindFilteredTransactionsAndSignaturesParameters): Any {
+        return FindFilteredTransactionsAndSignatures(
+            parameters.stateRefs.map {
+                net.corda.data.ledger.utxo.StateRef(
+                    SecureHash(
+                        it.transactionId.algorithm,
+                        ByteBuffer.wrap(it.transactionId.bytes)
+                    ),
+                    it.index
+                )
+            }
+        )
+    }
+}
+
+data class FindFilteredTransactionsAndSignaturesParameters(
+    val stateRefs: List<StateRef>
+)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -178,8 +178,7 @@ data class UtxoSignedTransactionImpl(
     private fun getPublicKeysToSignatorySignatures(): Map<PublicKey, DigitalSignatureAndMetadata> {
         return signatures.mapNotNull { // We do not care about non-notary/non-signatory keys
             (getSignatoryKeyFromKeyId(it.by) ?: return@mapNotNull null) to it
-        }
-            .toMap()
+        }.toMap()
     }
 
     override fun verifyAttachedNotarySignature() {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactory.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.transaction.filtered.factory
 
+import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.filtered.UtxoFilteredTransactionBuilderInternal
 import net.corda.v5.base.annotations.Suspendable
@@ -24,5 +25,17 @@ interface UtxoFilteredTransactionFactory {
     fun create(
         signedTransaction: UtxoSignedTransactionInternal,
         filteredTransactionBuilder: UtxoFilteredTransactionBuilderInternal
+    ): UtxoFilteredTransaction
+
+    /**
+     * Creates a [UtxoFilteredTransaction].
+     *
+     * @param filteredTransaction The [FilteredTransaction] to build from
+     *
+     * @return A [UtxoFilteredTransaction].
+     */
+    @Suspendable
+    fun create(
+        filteredTransaction: FilteredTransaction
     ): UtxoFilteredTransaction
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/filtered/factory/UtxoFilteredTransactionFactoryImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.transaction.filtered.factory
 
 import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters
 import net.corda.ledger.common.data.transaction.filtered.ComponentGroupFilterParameters.AuditProof.AuditProofPredicate
+import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.ledger.common.data.transaction.filtered.factory.FilteredTransactionFactory
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup.METADATA
@@ -85,6 +86,14 @@ class UtxoFilteredTransactionFactoryImpl @Activate constructor(
                     filteredTransactionBuilder.commands
                 )
             )
+        )
+    }
+
+    @Suspendable
+    override fun create(filteredTransaction: FilteredTransaction): UtxoFilteredTransaction {
+        return UtxoFilteredTransactionImpl(
+            serializationService,
+            filteredTransaction
         )
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -11,11 +11,11 @@ import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
 import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.utxo.data.transaction.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.data.transaction.TransactionVerificationStatus
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.flow.impl.flows.backchain.TransactionBackchainResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
-import net.corda.ledger.utxo.flow.impl.flows.finality.FilteredTransactionAndSignatures
 import net.corda.ledger.utxo.flow.impl.flows.finality.FinalityPayload
 import net.corda.ledger.utxo.flow.impl.groupparameters.verifier.SignedGroupParametersVerifier
 import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerGroupParametersPersistenceService

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -1,5 +1,8 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
+import net.corda.crypto.cipher.suite.SignatureSpecImpl
+import net.corda.crypto.core.DigitalSignatureWithKeyId
+import net.corda.crypto.core.fullIdHash
 import net.corda.crypto.core.parseSecureHash
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.internal.serialization.SerializedBytesImpl
@@ -8,6 +11,7 @@ import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
 import net.corda.ledger.common.data.transaction.TransactionStatus.VERIFIED
 import net.corda.ledger.common.data.transaction.WireTransaction
+import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.ledger.common.flow.transaction.TransactionSignatureServiceInternal
 import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
@@ -17,6 +21,7 @@ import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
 import net.corda.ledger.utxo.flow.impl.cache.StateAndRefCache
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.ALICE_X500_HOLDING_IDENTITY
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.AbstractUtxoLedgerExternalEventFactory
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindFilteredTransactionsAndSignaturesExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.PersistTransactionExternalEventFactory
@@ -26,20 +31,27 @@ import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoLedgerTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
+import net.corda.ledger.utxo.flow.impl.transaction.filtered.factory.UtxoFilteredTransactionFactory
 import net.corda.ledger.utxo.flow.impl.transaction.verifier.NotarySignatureVerificationServiceInternal
+import net.corda.ledger.utxo.testkit.notaryX500Name
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.crypto.DigitalSignatureMetadata
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
+import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
 import net.corda.virtualnode.toCorda
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
@@ -47,6 +59,8 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
+import java.security.PublicKey
+import java.time.Instant
 
 class UtxoLedgerPersistenceServiceImplTest {
 
@@ -61,10 +75,18 @@ class UtxoLedgerPersistenceServiceImplTest {
     private val notarySignatureVerificationService = mock<NotarySignatureVerificationServiceInternal>()
     private val utxoSignedTransactionFactory = mock<UtxoSignedTransactionFactory>()
     private val utxoLedgerTransactionFactory = mock<UtxoLedgerTransactionFactory>()
+    private val utxoFilteredTransactionFactory = mock<UtxoFilteredTransactionFactory>()
     private val sandbox = mock<SandboxGroupContext>()
     private val virtualNodeContext = mock<VirtualNodeContext>()
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     private val stateAndRefCache = mock<StateAndRefCache>()
+
+    private val notaryServiceKey = mock<CompositeKey>()
+    private val publicKeyNotaryVNode1 = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x01)) }
+    private val publicKeyNotaryVNode2 = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x02)) }
+
+    private val signatureNotary1 = digitalSignatureAndMetadata(publicKeyNotaryVNode1, byteArrayOf(1, 2, 6))
+    private val signatureNotary2 = digitalSignatureAndMetadata(publicKeyNotaryVNode2, byteArrayOf(1, 2, 7))
 
     private lateinit var utxoLedgerPersistenceService: UtxoLedgerPersistenceService
 
@@ -78,6 +100,8 @@ class UtxoLedgerPersistenceServiceImplTest {
             serializationService,
             utxoLedgerTransactionFactory,
             utxoSignedTransactionFactory,
+            utxoFilteredTransactionFactory,
+            notarySignatureVerificationService,
             stateAndRefCache
         )
 
@@ -93,6 +117,11 @@ class UtxoLedgerPersistenceServiceImplTest {
         whenever(virtualNodeContext.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
         whenever(stateAndRefCache.putAll(any())).doAnswer {}
+
+        // Composite key containing both of the notary VNode keys
+        whenever(notaryServiceKey.leafKeys).thenReturn(setOf(publicKeyNotaryVNode1, publicKeyNotaryVNode2))
+        whenever(notaryServiceKey.isFulfilledBy(publicKeyNotaryVNode1)).thenReturn(true)
+        whenever(notaryServiceKey.isFulfilledBy(publicKeyNotaryVNode2)).thenReturn(true)
     }
 
     @Test
@@ -234,6 +263,86 @@ class UtxoLedgerPersistenceServiceImplTest {
             .isEqualTo(UtxoSignedLedgerTransactionImpl(ledgerTransaction, signedTransaction))
 
         assertThat(argumentCaptor.firstValue).isEqualTo(FindSignedLedgerTransactionExternalEventFactory::class.java)
+    }
+
+    @Test
+    fun `findFilteredTransactionsAndSignatures executes successfully `() {
+        val testId = parseSecureHash("SHA256:1234567890123456")
+
+        val filteredTransaction = mock<FilteredTransaction>().also {
+            whenever(it.getComponentGroupContent(UtxoComponentGroup.NOTARY.ordinal)).thenReturn(
+                listOf(Pair(1, byteArrayOf(1)))
+            )
+        }
+
+        val filteredTransactionAndSignaturesMapA = mapOf(testId to Pair(filteredTransaction, listOf(signatureNotary1)))
+        val filteredTransactionAndSignaturesMapB = mapOf(testId to Pair(filteredTransaction, listOf(signatureNotary2)))
+
+        whenever(
+            serializationService.deserialize(
+                any<ByteArray>(),
+                eq(Map::class.java)
+            )
+        ).thenReturn(
+            filteredTransactionAndSignaturesMapA,
+            filteredTransactionAndSignaturesMapB,
+            filteredTransactionAndSignaturesMapA,
+            filteredTransactionAndSignaturesMapB
+        )
+
+        val utxoFilteredTransaction = mock<UtxoFilteredTransaction>().also {
+            whenever(it.notaryName).thenReturn(notaryX500Name)
+        }
+
+        whenever(utxoFilteredTransactionFactory.create(filteredTransaction)).thenReturn(utxoFilteredTransaction)
+        whenever(notarySignatureVerificationService.verifyNotarySignatures(any(), any(), any(), any())).then {}
+        val stateRef = mock<StateRef>().also {
+            whenever(it.transactionId).thenReturn(testId)
+        }
+
+        val expectedResultA = mapOf(testId to mapOf(utxoFilteredTransaction to listOf(signatureNotary1)))
+        val expectedResultB = mapOf(testId to mapOf(utxoFilteredTransaction to listOf(signatureNotary2)))
+
+        // assert with notary composite key
+        assertThat(
+            utxoLedgerPersistenceService.findFilteredTransactionsAndSignatures(
+                listOf(stateRef),
+                notaryServiceKey,
+                notaryX500Name
+            )
+        ).isEqualTo(expectedResultA)
+        assertThat(
+            utxoLedgerPersistenceService.findFilteredTransactionsAndSignatures(
+                listOf(stateRef),
+                notaryServiceKey,
+                notaryX500Name
+            )
+        ).isEqualTo(expectedResultB)
+
+        // assert with notary public keys
+        assertThat(
+            utxoLedgerPersistenceService.findFilteredTransactionsAndSignatures(
+                listOf(stateRef),
+                publicKeyNotaryVNode1,
+                notaryX500Name
+            )
+        ).isEqualTo(expectedResultA)
+        assertThat(
+            utxoLedgerPersistenceService.findFilteredTransactionsAndSignatures(
+                listOf(stateRef),
+                publicKeyNotaryVNode2,
+                notaryX500Name
+            )
+        ).isEqualTo(expectedResultB)
+
+        assertThat(argumentCaptor.firstValue).isEqualTo(FindFilteredTransactionsAndSignaturesExternalEventFactory::class.java)
+    }
+
+    private fun digitalSignatureAndMetadata(publicKey: PublicKey, byteArray: ByteArray): DigitalSignatureAndMetadata {
+        return DigitalSignatureAndMetadata(
+            DigitalSignatureWithKeyId(publicKey.fullIdHash(), byteArray),
+            DigitalSignatureMetadata(Instant.now(), SignatureSpecImpl("dummySignatureName"), emptyMap())
+        )
     }
 
     private fun persistIfDoesNotExist(

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.36-alpha-1707162503619
+cordaApiVersion=5.2.0.36-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.36-alpha-1706546440754
+cordaApiVersion=5.2.0.36-alpha-1706893643763
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.36-alpha-1706893643763
+cordaApiVersion=5.2.0.36-alpha-1707162503619
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,7 +41,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.35-beta+
+cordaApiVersion=5.2.0.36-alpha-1706546440754
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -514,7 +514,7 @@ class MerkleTreeTest {
         check(xSubset.size + ySubset.size == leafIndicesCombination.size)
         val xProof = proof.subset(digest, xSubset)
         val yProof = proof.subset(digest, ySubset)
-        val mergedProof = xProof.merge(yProof, digest)
+        val mergedProof = xProof.merge(yProof, digest) as MerkleProofImpl
         val mergedProofText = mergedProof.render(digest)
         assertThat(mergedProofText).isEqualTo(proofText)
     }
@@ -570,7 +570,7 @@ class MerkleTreeTest {
                                            ┗00000003 (calc)    known leaf
         """.trimIndent()
         )
-        val mergedProof = xProof.merge(yProof, trivialHashDigestProvider)
+        val mergedProof = xProof.merge(yProof, trivialHashDigestProvider) as MerkleProofImpl
         val mergedProofText = mergedProof.render(trivialHashDigestProvider)
         assertThat(mergedProofText).isEqualTo(proofText)
     }
@@ -671,7 +671,7 @@ class MerkleTreeTest {
                                                                   ┗00000005 (input 0) filtered      
         """.trimIndent()
         )
-        val proofMerged = proof2.merge(proof3, trivialHashDigestProvider)
+        val proofMerged = proof2.merge(proof3, trivialHashDigestProvider) as MerkleProofImpl
         assertThat(proofMerged.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
             """
                 00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
@@ -724,7 +724,7 @@ class MerkleTreeTest {
                                                                      ┗unknown            filtered
         """.trimIndent()
         )
-        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider)
+        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider) as MerkleProofImpl
         val proofMergedText = proofMerged.render(trivialHashDigestProvider)
         assertThat(proofMergedText).isEqualTo(proof1Text)
     }
@@ -825,7 +825,7 @@ class MerkleTreeTest {
                                                                                                           ┗unknown            filtered
         """.trimIndent()
         )
-        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider)
+        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider) as MerkleProofImpl
         val proofMergedText = proofMerged.render(trivialHashDigestProvider)
         assertThat(proofMergedText).isEqualTo(proof1Text)
     }
@@ -864,7 +864,7 @@ class MerkleTreeTest {
                                               ┗568F8D2A (calc) known leaf
         """.trimIndent()
         )
-        val proofMerged = proofX.merge(proofY, digest)
+        val proofMerged = proofX.merge(proofY, digest) as MerkleProofImpl
         val proofMergedText = proofMerged.render(digest)
         assertThat(proofMergedText).isEqualTo(proof1Text)
     }
@@ -1390,7 +1390,7 @@ class MerkleTreeTest {
         check(xSubset.size + ySubset.size == leafIndicesCombination.size)
         val xProof = proof.subset(defaultHashDigestProvider, xSubset)
         val yProof = proof.subset(defaultHashDigestProvider, ySubset)
-        val mergedProof = xProof.merge(yProof, defaultHashDigestProvider)
+        val mergedProof = xProof.merge(yProof, defaultHashDigestProvider) as MerkleProofImpl
         val mergedProofText = mergedProof.render(defaultHashDigestProvider)
         assertThat(mergedProofText).isEqualTo(proofText)
     }

--- a/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
+++ b/libs/crypto/merkle-impl/src/test/kotlin/net/corda/crypto/merkle/impl/MerkleTreeTest.kt
@@ -514,7 +514,7 @@ class MerkleTreeTest {
         check(xSubset.size + ySubset.size == leafIndicesCombination.size)
         val xProof = proof.subset(digest, xSubset)
         val yProof = proof.subset(digest, ySubset)
-        val mergedProof = xProof.merge(yProof, digest) as MerkleProofImpl
+        val mergedProof = xProof.merge(yProof, digest)
         val mergedProofText = mergedProof.render(digest)
         assertThat(mergedProofText).isEqualTo(proofText)
     }
@@ -570,7 +570,7 @@ class MerkleTreeTest {
                                            ┗00000003 (calc)    known leaf
         """.trimIndent()
         )
-        val mergedProof = xProof.merge(yProof, trivialHashDigestProvider) as MerkleProofImpl
+        val mergedProof = xProof.merge(yProof, trivialHashDigestProvider)
         val mergedProofText = mergedProof.render(trivialHashDigestProvider)
         assertThat(mergedProofText).isEqualTo(proofText)
     }
@@ -671,7 +671,7 @@ class MerkleTreeTest {
                                                                   ┗00000005 (input 0) filtered      
         """.trimIndent()
         )
-        val proofMerged = proof2.merge(proof3, trivialHashDigestProvider) as MerkleProofImpl
+        val proofMerged = proof2.merge(proof3, trivialHashDigestProvider)
         assertThat(proofMerged.render(trivialHashDigestProvider)).isEqualToIgnoringWhitespace(
             """
                 00000612 (calc)┳0000069F (calc)┳00000630 (input 2)┳unknown            filtered
@@ -724,7 +724,7 @@ class MerkleTreeTest {
                                                                      ┗unknown            filtered
         """.trimIndent()
         )
-        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider) as MerkleProofImpl
+        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider)
         val proofMergedText = proofMerged.render(trivialHashDigestProvider)
         assertThat(proofMergedText).isEqualTo(proof1Text)
     }
@@ -825,7 +825,7 @@ class MerkleTreeTest {
                                                                                                           ┗unknown            filtered
         """.trimIndent()
         )
-        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider) as MerkleProofImpl
+        val proofMerged = proofX.merge(proofY, trivialHashDigestProvider)
         val proofMergedText = proofMerged.render(trivialHashDigestProvider)
         assertThat(proofMergedText).isEqualTo(proof1Text)
     }
@@ -864,7 +864,7 @@ class MerkleTreeTest {
                                               ┗568F8D2A (calc) known leaf
         """.trimIndent()
         )
-        val proofMerged = proofX.merge(proofY, digest) as MerkleProofImpl
+        val proofMerged = proofX.merge(proofY, digest)
         val proofMergedText = proofMerged.render(digest)
         assertThat(proofMergedText).isEqualTo(proof1Text)
     }
@@ -1390,7 +1390,7 @@ class MerkleTreeTest {
         check(xSubset.size + ySubset.size == leafIndicesCombination.size)
         val xProof = proof.subset(defaultHashDigestProvider, xSubset)
         val yProof = proof.subset(defaultHashDigestProvider, ySubset)
-        val mergedProof = xProof.merge(yProof, defaultHashDigestProvider) as MerkleProofImpl
+        val mergedProof = xProof.merge(yProof, defaultHashDigestProvider)
         val mergedProofText = mergedProof.render(defaultHashDigestProvider)
         assertThat(mergedProofText).isEqualTo(proofText)
     }

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/FilteredTransactionAndSignatures.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/FilteredTransactionAndSignatures.kt
@@ -1,4 +1,4 @@
-package net.corda.ledger.utxo.flow.impl.flows.finality
+package net.corda.ledger.utxo.data.transaction
 
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.CordaSerializable

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-client/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/client/ContractVerifyingNotaryClientFlowImpl.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-client/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/client/ContractVerifyingNotaryClientFlowImpl.kt
@@ -11,10 +11,11 @@ import net.corda.v5.application.messaging.FlowMessaging
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.types.MemberX500Name
-import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow
 import net.corda.v5.ledger.utxo.UtxoLedgerService
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
 import org.slf4j.LoggerFactory
 
 @InitiatingFlow(protocol = "com.r3.corda.notary.plugin.contractverifying", version = [1])
@@ -88,24 +89,17 @@ class ContractVerifyingNotaryClientFlowImpl(
 
     @Suspendable
     internal fun createPayload(): ContractVerifyingNotarizationPayload {
-        val hashedNotaryKey = digestService.hash(signedTransaction.notaryKey.encoded, DigestAlgorithmName.SHA2_256)
+        val filteredTxAndSignatures = utxoLedgerService.findFilteredTransactionsAndSignatures(signedTransaction)
+            .toFilteredTransactionsAndSignatures()
+        return ContractVerifyingNotarizationPayload(signedTransaction, filteredTxAndSignatures)
+    }
 
-        val filteredDependenciesAndSignatures = signedTransaction.let { it.inputStateRefs + it.referenceStateRefs }
-            .groupBy { stateRef -> stateRef.transactionId }
-            .mapValues { (_, stateRefs) -> stateRefs.map { stateRef -> stateRef.index } }
-            .map { (transactionId, indexes) ->
-                val dependency = requireNotNull(utxoLedgerService.findSignedTransaction(transactionId)) {
-                    "Dependent transaction $transactionId does not exist"
-                }
-                FilteredTransactionAndSignatures(
-                    utxoLedgerService.filterSignedTransaction(dependency)
-                        .withOutputStates(indexes)
-                        .withNotary()
-                        .withTimeWindow()
-                        .build(),
-                    dependency.signatures.filter { hashedNotaryKey == it.by }
-                )
+    private fun Map<SecureHash, Map<UtxoFilteredTransaction, List<DigitalSignatureAndMetadata>>>.toFilteredTransactionsAndSignatures()
+            : List<FilteredTransactionAndSignatures> {
+        return this.flatMap { (_, ftxAndSigs) ->
+            ftxAndSigs.map {
+                FilteredTransactionAndSignatures(it.key, it.value)
             }
-        return ContractVerifyingNotarizationPayload(signedTransaction, filteredDependenciesAndSignatures)
+        }
     }
 }


### PR DESCRIPTION
This PR contains the implementation of `findFilteredTransactionsAndSignatures` API, that fetches filtered transactions of dependencies and its notary signature and using this API in `FinalityFlow` and `ContractVerifyingNotaryClient` based on [this design](https://lucid.app/lucidchart/06502244-3d17-4b34-9e1e-10b9164eb7ff/edit?page=0_0&invitationId=inv_fe70d458-8eef-48b2-b2ac-e96b411ba8b6#)


### Test Result / Plan
**Integration Testing**
I tested the API, whether it finds the correct filtered transactions and signatures from 2 persisted transaction outputs.

**Unit test**
I tested ledger persistence service for finding filtered transactions and signatures given a notary composite key or public keys

**E2E Testing**
I tested using `VerifyingNotaryWithoutBackchain` test in E2E repo and wrote a test case where it asserts correct filtered tx ids fetched using the API
 
<img width="904" alt="image" src="https://github.com/corda/corda-runtime-os/assets/135036209/9f409fc1-9327-4a82-b9d5-1a64bc397181">