### PR TITLE
CORE-19539 Initial filtered tx coverage and logic fixes

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -29,16 +29,6 @@ interface UtxoPersistenceService {
     fun findSignedTransaction(id: String, transactionStatus: TransactionStatus): Pair<SignedTransactionContainer?, String?>
 
     /**
-     * Find transactions with the given [transactionIds] that are present in the persistence context and return
-     * their IDs and statuses.
-     *
-     * @param transactionIds IDs of transactions to find.
-     *
-     * @return A map of the transaction IDs found and their statuses.
-     */
-    fun findTransactionIdsAndStatuses(transactionIds: List<String>): Map<SecureHash, String>
-
-    /**
      * Find a signed ledger transaction in the persistence context given it's [id] and return it with the status it is stored with. This
      * involves resolving its input and reference state and fetching the transaction's signatures.
      *
@@ -52,11 +42,21 @@ interface UtxoPersistenceService {
      */
     fun findSignedLedgerTransaction(id: String, transactionStatus: TransactionStatus): Pair<SignedLedgerTransactionContainer?, String?>
 
+    /**
+     * Find transactions with the given [transactionIds] that are present in the persistence context and return
+     * their IDs and statuses.
+     *
+     * @param transactionIds IDs of transactions to find.
+     *
+     * @return A map of the transaction IDs found and their statuses.
+     */
+    fun findTransactionIdsAndStatuses(transactionIds: List<String>): Map<SecureHash, String>
+
     fun <T : ContractState> findUnconsumedVisibleStatesByType(stateClass: Class<out T>): List<UtxoVisibleTransactionOutputDto>
 
     fun resolveStateRefs(stateRefs: List<StateRef>): List<UtxoVisibleTransactionOutputDto>
 
-    fun persistTransaction(
+    fun persistSignedTransaction(
         transaction: UtxoTransactionReader,
         utxoTokenMap: Map<StateRef, UtxoToken> = emptyMap()
     ): List<CordaPackageSummary>

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -16,17 +16,23 @@ import javax.persistence.EntityManager
 @Suppress("TooManyFunctions")
 interface UtxoRepository {
 
+    /** Retrieves transaction by [id] */
+    fun findSignedTransaction(
+        entityManager: EntityManager,
+        id: String
+    ): SignedTransactionContainer?
+
+    /** Find filtered transactions with the given [ids] */
+    fun findFilteredTransactions(
+        entityManager: EntityManager,
+        ids: List<String>
+    ): Map<String, UtxoFilteredTransactionDto>
+
     /** Retrieves transaction IDs and their statuses if its ID is included in the [transactionIds] list. */
     fun findTransactionIdsAndStatuses(
         entityManager: EntityManager,
         transactionIds: List<String>
     ): Map<SecureHash, String>
-
-    /** Retrieves transaction by [id] */
-    fun findTransaction(
-        entityManager: EntityManager,
-        id: String
-    ): SignedTransactionContainer?
 
     /** Retrieves transaction component leafs except metadata which is stored separately */
     fun findTransactionComponentLeafs(
@@ -188,10 +194,4 @@ interface UtxoRepository {
         entityManager: EntityManager,
         transactionIds: List<String>
     ): Map<String, List<MerkleProofDto>>
-
-    /** Find filtered transactions with the given [ids] */
-    fun findFilteredTransactions(
-        entityManager: EntityManager,
-        ids: List<String>
-    ): Map<String, UtxoFilteredTransactionDto>
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -189,4 +189,11 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
             	)
             WHERE utmp.transaction_id IN (:transactionIds)"""
             .trimIndent()
+
+    override val findIfTransactionsFiltered: String
+        get() = """
+            SELECT id, is_filtered 
+            FROM {h-schema}utxo_transaction 
+            WHERE id IN (:transactionIds)"""
+            .trimIndent()
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -25,8 +25,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
             ON CONFLICT(id) DO
                 UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated
             WHERE utxo_transaction.status in (EXCLUDED.status, '$UNVERIFIED', '$DRAFT')
-                (AND utxo_transaction.is_filtered = EXCLUDED.is_filtered
-                OR utxo_transaction.is_filtered = true)""" // We  should only overwrite if it's filtered
+                AND utxo_transaction.is_filtered in( EXCLUDED.is_filtered, true)""" // We should only overwrite if it's filtered
             .trimIndent()
 
     override val persistTransactionMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -25,7 +25,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
             ON CONFLICT(id) DO
                 UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated
             WHERE utxo_transaction.status in (EXCLUDED.status, '$UNVERIFIED', '$DRAFT')
-                AND utxo_transaction.is_filtered in( EXCLUDED.is_filtered, true)""" // We should only overwrite if it's filtered
+                AND utxo_transaction.is_filtered IN (EXCLUDED.is_filtered, true)""" // We should only overwrite if it's filtered
             .trimIndent()
 
     override val persistTransactionMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -25,8 +25,8 @@ class PostgresUtxoQueryProvider @Activate constructor(
             ON CONFLICT(id) DO
                 UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated
             WHERE utxo_transaction.status in (EXCLUDED.status, '$UNVERIFIED', '$DRAFT')
-                AND utxo_transaction.is_filtered = EXCLUDED.is_filtered
-                OR utxo_transaction.is_filtered = true""" // We  should only overwrite if it's filtered
+                (AND utxo_transaction.is_filtered = EXCLUDED.is_filtered
+                OR utxo_transaction.is_filtered = true)""" // We  should only overwrite if it's filtered
             .trimIndent()
 
     override val persistTransactionMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -24,7 +24,9 @@ class PostgresUtxoQueryProvider @Activate constructor(
                 VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash, :isFiltered)
             ON CONFLICT(id) DO
                 UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated
-            WHERE utxo_transaction.status in (EXCLUDED.status, '$UNVERIFIED', '$DRAFT')"""
+            WHERE utxo_transaction.status in (EXCLUDED.status, '$UNVERIFIED', '$DRAFT')
+                AND utxo_transaction.is_filtered = EXCLUDED.is_filtered
+                OR utxo_transaction.is_filtered = true""" // We  should only overwrite if it's filtered
             .trimIndent()
 
     override val persistTransactionMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -111,4 +111,9 @@ interface UtxoQueryProvider {
      * @property findMerkleProofs SQL text for [UtxoRepositoryImpl.findMerkleProofs].
      */
     val findMerkleProofs: String
+
+    /**
+     * @property findIfTransactionsFiltered SQL text for [UtxoRepositoryImpl.findIfTransactionsFiltered]
+     */
+    val findIfTransactionsFiltered: String
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionRequestHandler.kt
@@ -37,7 +37,7 @@ constructor(
         val utxoTokenMap = listOfPairsStateAndUtxoToken.associate { it.first.ref to it.second }
 
         // persist the transaction
-        persistenceService.persistTransaction(transaction, utxoTokenMap)
+        persistenceService.persistSignedTransaction(transaction, utxoTokenMap)
 
         // return output records
         return listOf(utxoOutputRecordFactory.getPersistTransactionSuccessRecord(externalEventContext))

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
@@ -115,7 +115,7 @@ class UtxoPersistenceServiceImplTest {
             )
         )
 
-        persistenceService.persistTransaction(tx)
+        persistenceService.persistSignedTransaction(tx)
 
         assertThat(persistedJsonStrings).hasSize(1)
 
@@ -166,7 +166,7 @@ class UtxoPersistenceServiceImplTest {
             )
         )
 
-        singlePersistenceService.persistTransaction(tx)
+        singlePersistenceService.persistSignedTransaction(tx)
 
         assertThat(persistedJsonStrings).hasSize(1)
 
@@ -192,7 +192,7 @@ class UtxoPersistenceServiceImplTest {
             )
         )
 
-        persistenceService.persistTransaction(tx)
+        persistenceService.persistSignedTransaction(tx)
 
         assertThat(persistedJsonStrings).hasSize(1)
         val persisted = persistedJsonStrings.entries.first()
@@ -221,7 +221,7 @@ class UtxoPersistenceServiceImplTest {
             )
         )
 
-        persistenceService.persistTransaction(tx)
+        persistenceService.persistSignedTransaction(tx)
 
         assertThat(persistedJsonStrings).hasSize(1)
         val persisted = persistedJsonStrings.entries.first()
@@ -262,7 +262,7 @@ class UtxoPersistenceServiceImplTest {
             )
         )
 
-        emptyPersistenceService.persistTransaction(tx)
+        emptyPersistenceService.persistSignedTransaction(tx)
 
         assertThat(persistedJsonStrings).hasSize(1)
         val persisted = persistedJsonStrings.entries.first()
@@ -308,7 +308,7 @@ class UtxoPersistenceServiceImplTest {
         )
 
         assertDoesNotThrow {
-            persistenceService.persistTransaction(tx)
+            persistenceService.persistSignedTransaction(tx)
         }
 
         assertThat(persistedJsonStrings).hasSize(1)

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -25,7 +25,7 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             MERGE INTO {h-schema}utxo_transaction AS ut
             USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), :status, CAST(:updatedAt AS TIMESTAMP), :metadataHash, :isFiltered)
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
-            ON x.id = ut.id
+            ON x.id = ut.id AND (x.is_filtered = ut.is_filtered OR ut.is_filtered = true)
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""


### PR DESCRIPTION
- Rename `persistTransaction` to `persistSignedTransaction`
- Rename `findTransaction` to `findSignedTransaction` and add a check that the `is_filtered` column is false
- Add test cases for `persistFilteredTransactions` and `findFilteredTransactions`
- Interface function re-orders and error message rework