### PR TITLE
CORE-19557 Account for suffixes in metric filtering

### DIFF
--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -568,6 +568,17 @@ metadata:
 spec:
   podMetricsEndpoints:
   - port: monitor
+    metricRelabelings:
+    {{- with .Values.metrics.keepNames }}
+    - sourceLabels:
+      - "__name__"
+      regex: {{ join "|" . | quote }}
+      action: "keep"
+    {{- end }}
+    {{- with .Values.metrics.dropLabels }}
+    - regex: {{ join "|" . | quote }}
+      action: "labeldrop"
+    {{- end }}
   jobLabel: {{ $.Release.Name }}-{{ include "corda.name" . }}
   selector:
     matchLabels:

--- a/libs/metrics/build.gradle
+++ b/libs/metrics/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
+    implementation libs.micrometer.registry.prometheus
 
     api(libs.micrometer.core) {
         // we don't need these in classpath, so excluding them to reduce dependencies.


### PR DESCRIPTION
The regular expressions that we're using for `keepNames` are those copied across from the pod monitor. These are the metric names as seen by Prometheus (and the end user) and include the type-specific suffixes such as `_count` or `_bucket`. In Micrometer, the point at which we're filtering is the point at which the metrics are being added to the registry, and all we have is the base metric name (e.g. `corda_db_reconciliation_run_time_seconds`).

We could modify the regular expression to just use the base metric name, but then we'd lose the previous ability to distinguish whether histogram (`_bucket`) metrics are to be included. Consequently, this PR takes the approach of coding into the filtering logic knowledge of the suffixes that exist for each metric type, and enabling the metric if any of the possible suffixes are included by the regexp. Similarly, histogram metrics are only left enabled if the `_bucket` suffix exists for the metric.

As only some of the child metrics may be covered by the regular expression, the filter is also added back to the pod monitor. The regexp might, for example, request just `_count` for a summary metric. Corda will still generate `_sum` but this will then be filtered out by Prometheus.