### PR TITLE
CORE-19577 - disable pooling for crypto ops

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImplTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImplTests.kt
@@ -39,7 +39,6 @@ class SigningRepositoryImplTests {
             verify(dbConnectionManager, times(2)).getOrCreateEntityManagerFactory(CordaDb.Crypto, DbPrivilege.DML)
             verifyNoMoreInteractions(dbConnectionManager)
         }
-        verify(entityManagerFactory, times(0)).close()
     }
 
     private fun makeMockSigningRepository(

--- a/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImplTests.kt
+++ b/components/crypto/crypto-softhsm-impl/src/test/kotlin/net/corda/crypto/softhsm/impl/SigningRepositoryImplTests.kt
@@ -10,12 +10,14 @@ import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
+import java.util.UUID
 import javax.persistence.EntityManagerFactory
 
 class SigningRepositoryImplTests {
@@ -23,7 +25,7 @@ class SigningRepositoryImplTests {
     @Suppress("MaxLineLength")
     @Test
     fun `Appropriate use of DB connection manager that sets up DML connection when creating signing repository for Crypto tenant and P2P`() {
-        // Arguably this is really tessting getEntityManagerFactory so should be moved to a new test class
+        // Arguably this is really testing getEntityManagerFactory so should be moved to a new test class
         val entityManagerFactory = mock<EntityManagerFactory>()
         val dbConnectionManager = mock<DbConnectionManager> {
             on { getOrCreateEntityManagerFactory(any<CordaDb>(), any()) } doReturn entityManagerFactory
@@ -63,7 +65,7 @@ class SigningRepositoryImplTests {
         }
         val dbConnectionManager = mock<DbConnectionManager> {
             on { getOrCreateEntityManagerFactory(any<CordaDb>(), any()) } doReturn mock()
-            on { createEntityManagerFactory(any(), any(), any()) } doReturn ownedEntityManagerFactory
+            on { getOrCreateEntityManagerFactory(any<UUID>(), any(), any()) } doReturn ownedEntityManagerFactory
         }
         val virtualNodeInfoReadService = mock<VirtualNodeInfoReadService> {
             on { getByHoldingIdentityShortHash(any()) } doReturn virtualNodeInfo
@@ -102,7 +104,7 @@ class SigningRepositoryImplTests {
         ).use {
             verify(ownedEntityManagerFactory, times(0)).close()
         } // try shorter, ShortHash bombs
-        verify(dbConnectionManager).createEntityManagerFactory(any(), any(), any())
+        verify(dbConnectionManager).getOrCreateEntityManagerFactory(any(), any(), eq(false))
         verifyNoMoreInteractions(dbConnectionManager)
         verify(sharedEntityManagerFactory, times(0)).close()
         verify(ownedEntityManagerFactory, times(1)).close()

--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionOps.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbConnectionOps.kt
@@ -109,6 +109,8 @@ interface DbConnectionOps {
     /**
      * Get an instance of [EntityManagerFactory] for the named [db] from cache or create one if necessary.
      *
+     * Callers of this function do not need to close the returned EMF. Doing so is a no-op.
+     *
      * @param db Name of the DB to use.
      * @param privilege [DbPrivilege] required (DML or DDL).
      * @return [EntityManagerFactory] from cache, or created on demand.
@@ -119,6 +121,8 @@ interface DbConnectionOps {
 
     /**
      * Get an instance of [EntityManagerFactory] for the connection ID. Use cache or create one if necessary.
+     *
+     * Callers of this function do not need to close the returned EMF. Doing so is a no-op.
      *
      * @param name name for the connection to be used.
      * @param privilege [DbPrivilege] required (DML or DDL).
@@ -133,6 +137,7 @@ interface DbConnectionOps {
 
     /**
      * Create an [EntityManagerFactory] for a given connection ID.
+     * NOTE: to be deprecated - use getOrCreateEntityManagerFactory(db: CordaDb, privilege: DbPrivilege) instead
      *
      * A new EMF should be created and implementations of this class should not cache it.
      *


### PR DESCRIPTION
* Move the "close no-op" change to the central component.
* Change the crypto library to cache EMFs but in return not use connection pooling.