### PR TITLE
CORE-19571: Add support for external DB to getOrCreateVirtualNodeFor

### DIFF
--- a/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbAdmin.kt
+++ b/components/db/db-connection-manager/src/main/kotlin/net/corda/db/connection/manager/DbAdmin.kt
@@ -70,9 +70,9 @@ abstract class DbAdmin {
             "GRANT ALL ON SCHEMA $schemaName"
         }
         val sql = """
-            CREATE SCHEMA IF NOT EXISTS $schemaName;
             CREATE USER $user WITH PASSWORD '$password';
             GRANT $user TO current_user;
+            CREATE SCHEMA IF NOT EXISTS $schemaName AUTHORIZATION ${grantee ?: user};
             GRANT USAGE ON SCHEMA $schemaName to $user;
             $permissions TO $user;
             ALTER ROLE "$user" SET search_path TO $schemaName;
@@ -80,6 +80,13 @@ abstract class DbAdmin {
 
         withDbConnection { connection ->
             connection.createStatement().execute(sql)
+            connection.commit()
+        }
+    }
+
+    fun revokeAccessToUser(user: String) {
+        withDbConnection { connection ->
+            connection.createStatement().execute("REVOKE $user FROM current_user;")
             connection.commit()
         }
     }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbImpl.kt
@@ -62,11 +62,18 @@ internal class VirtualNodeDbImpl(
                     }
                     // When DML user is created, it is granted with privileges related to DB objects created by DDL user
                     // (therefore DDL user has to be provided as grantee)
-                    val grantee = if (privilege == DML) dbConnections[DDL]!!.getUser() else null
-                    virtualNodesDbAdmin.createDbAndUser(dbSchema, user, password, privilege, grantee)
+                    virtualNodesDbAdmin.createDbAndUser(
+                        dbSchema,
+                        user,
+                        password,
+                        privilege,
+                        dbConnections[DDL]?.getUser()
+                    )
                 }
             }
         }
+        dbConnections[DDL]?.getUser()?.let(virtualNodesDbAdmin::revokeAccessToUser)
+        dbConnections[DML]?.getUser()?.let(virtualNodesDbAdmin::revokeAccessToUser)
     }
 
     /**

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/tests/VirtualNodeDbImplTest.kt
@@ -132,7 +132,7 @@ class VirtualNodeDbImplTest {
 
         target.createSchemasAndUsers()
 
-        verify(dbAdmin).createDbAndUser(schema, ddlUuser, password, DbPrivilege.DDL, null)
+        verify(dbAdmin).createDbAndUser(schema, ddlUuser, password, DbPrivilege.DDL, ddlUuser)
     }
 
     @Test

--- a/testing/e2e-test-utilities/build.gradle
+++ b/testing/e2e-test-utilities/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation project(':libs:crypto:certificate-generation')
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:crypto:crypto-utils')
+    implementation project(':libs:db:db-core')
     implementation project(':tools:plugins:package')
     implementation project(":testing:packaging-test-utilities")
     implementation project(':testing:test-utilities')

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterInfo.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterInfo.kt
@@ -59,6 +59,13 @@ abstract class ClusterInfo {
 
 }
 
+class ClusterInfoWithExternalDb(clusterInfo: ClusterInfo) : ClusterInfo() {
+    override val id: String = clusterInfo.id
+}
+
+fun ClusterInfo.withExternalDb(): ClusterInfo =
+    ClusterInfoWithExternalDb(this)
+
 /**
  * Data class for data relevant to the REST endpoint information of the E2E test cluster.
  */
@@ -88,6 +95,8 @@ data class P2PEndpointInfo(
 object ClusterAInfo : ClusterInfo() {
     override val id = "A"
 }
+
+val ClusterAWithExternalDbInfo = ClusterAInfo.withExternalDb()
 
 /**
  * Default cluster info for E2E test cluster "B"

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ConnectionParameters.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ConnectionParameters.kt
@@ -1,0 +1,3 @@
+package net.corda.e2etest.utilities.externaldb
+
+data class ConnectionParameters(val jdbc: JDBCString, val user: String, val pass: String)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ConnectionStatementParams.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ConnectionStatementParams.kt
@@ -1,0 +1,16 @@
+package net.corda.e2etest.utilities.externaldb
+
+import net.corda.db.core.DbPrivilege
+
+class ConnectionStatementParams(
+    connectionUsername: String,
+    val privilege: DbPrivilege,
+    currentSchema: String,
+    schemaOwner: String? = null
+) {
+    val schemaOwner: String = (schemaOwner ?: connectionUsername.also {
+        require(privilege == DbPrivilege.DDL) {"DML connections should set schemaOwner"}
+    }).lowercase()
+    val currentSchema: String = currentSchema.lowercase()
+    val connectionUsername: String = connectionUsername.lowercase()
+}

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/DatabaseParameters.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/DatabaseParameters.kt
@@ -1,0 +1,3 @@
+package net.corda.e2etest.utilities.externaldb
+
+data class DatabaseParameters(val database: ConnectionParameters)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ExternalDBConnectionParams.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ExternalDBConnectionParams.kt
@@ -1,0 +1,10 @@
+package net.corda.e2etest.utilities.externaldb
+
+data class ExternalDBConnectionParams(
+    val cryptoDdlConnection: String? = null,
+    val cryptoDmlConnection: String? = null,
+    val uniquenessDdlConnection: String? = null,
+    val uniquenessDmlConnection: String? = null,
+    val vaultDdlConnection: String? = null,
+    val vaultDmlConnection: String? = null
+)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ExternalDbUtil.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ExternalDbUtil.kt
@@ -2,8 +2,6 @@ package net.corda.e2etest.utilities.externaldb
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.sql.DriverManager
 
 class ExternalDbUtil {
@@ -17,13 +15,9 @@ class ExternalDbUtil {
     private var jdbcUrlCreateVNode: String
     private var postgresService: String
 
-    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
-
-
     init {
         // Use Corda combined worker cluster DB default details if there are no external DB details
         if (System.getProperty("postgresDb").isNullOrEmpty()) {
-            logger.info("Running with DB connectivity properties defaulted")
             postgresDb = "cordacluster"
             postgresHost = "localhost"
             postgresPort = "5432"
@@ -34,7 +28,6 @@ class ExternalDbUtil {
             jdbcUrlCreateVNode = jdbcUrl
         } else {
             // Get external DB details
-            logger.info("Running with external DB connectivity properties")
             postgresDb = System.getProperty("postgresDb")
             postgresHost = System.getProperty("postgresHost")
             postgresPort = System.getProperty("postgresPort")

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ExternalDbUtil.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/ExternalDbUtil.kt
@@ -1,0 +1,118 @@
+package net.corda.e2etest.utilities.externaldb
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.sql.DriverManager
+
+class ExternalDbUtil {
+
+    private var postgresDb: String
+    private var postgresHost: String
+    private var postgresPort: String
+    private var postgresUser: String
+    private var postgresPassword: String
+    private var jdbcUrl: String
+    private var jdbcUrlCreateVNode: String
+    private var postgresService: String
+
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+
+    init {
+        // Use Corda combined worker cluster DB default details if there are no external DB details
+        if (System.getProperty("postgresDb").isNullOrEmpty()) {
+            logger.info("Running with DB connectivity properties defaulted")
+            postgresDb = "cordacluster"
+            postgresHost = "localhost"
+            postgresPort = "5432"
+            postgresService = ""
+            postgresUser = "user"
+            postgresPassword = "password"
+            jdbcUrl = createJdbcUrl(postgresHost, postgresPort, postgresDb)
+            jdbcUrlCreateVNode = jdbcUrl
+        } else {
+            // Get external DB details
+            logger.info("Running with external DB connectivity properties")
+            postgresDb = System.getProperty("postgresDb")
+            postgresHost = System.getProperty("postgresHost")
+            postgresPort = System.getProperty("postgresPort")
+            postgresService = System.getProperty("postgresService")
+            postgresUser = System.getProperty("postgresUser")
+            postgresPassword = System.getProperty("postgresPassword")
+            jdbcUrl = createJdbcUrl(postgresHost, postgresPort, postgresDb)
+            jdbcUrlCreateVNode = createJdbcUrl(postgresService, postgresPort, postgresDb)
+        }
+
+    }
+
+    private fun createJdbcUrl(postgresHostname: String, postgresPort: String, postgresDb: String): String =
+        "jdbc:postgresql://$postgresHostname:$postgresPort/$postgresDb"
+
+    private fun runSql(sql: String, connectionUsernameDdl: ConnectionStatementParams? = null, password: String? = null) {
+        val newJdbcUrl: String
+        val connectionUser: String
+        val connectionPassword: String
+        if (connectionUsernameDdl != null && password != null) {
+            newJdbcUrl = "${jdbcUrl}?currentSchema=${connectionUsernameDdl.currentSchema}"
+            connectionUser = connectionUsernameDdl.connectionUsername.lowercase()
+            connectionPassword = password
+        } else {
+            newJdbcUrl = jdbcUrl
+            connectionUser = postgresUser
+            connectionPassword = postgresPassword
+        }
+        DriverManager.getConnection(newJdbcUrl, connectionUser, connectionPassword).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute(sql)
+            }
+        }
+    }
+
+    fun createUsersAndSchemas(connectionUsernames: List<ConnectionStatementParams>, password: String) {
+        connectionUsernames.forEach { connectionStatementParams ->
+            with(connectionStatementParams) {
+                runSql("CREATE USER $connectionUsername WITH PASSWORD '$password';")
+                runSql("ALTER ROLE $connectionUsername SET search_path TO ${currentSchema};")
+                runSql("GRANT $schemaOwner TO current_user;")
+                runSql("CREATE SCHEMA IF NOT EXISTS $currentSchema AUTHORIZATION $schemaOwner;")
+                runSql("GRANT USAGE ON SCHEMA $currentSchema to $connectionUsername;")
+                runSql("ALTER DEFAULT PRIVILEGES FOR ROLE $schemaOwner IN SCHEMA $currentSchema " +
+                        "GRANT SELECT, UPDATE, INSERT, DELETE ON TABLES TO $connectionUsername;")
+            }
+        }
+        connectionUsernames.forEach { runSql("REVOKE ${it.schemaOwner} FROM current_user;") }
+    }
+
+    @Suppress("unused")
+    fun changePassword(connectionUsernames: List<ConnectionStatementParams>, password: String) =
+        connectionUsernames.map { "ALTER USER ${it.connectionUsername} PASSWORD '$password';" }.forEach(::runSql)
+
+
+    private fun mapToExternalDBConnectionParamsJson(
+        connectionUsernames: List<ConnectionStatementParams>,
+        password: String
+    ): List<JsonNode> {
+        // Use Jackson object mapper to create a list of correctly formatted connection strings
+        val mapper = jacksonObjectMapper()
+        return connectionUsernames.map {
+            mapper.valueToTree(
+                DatabaseParameters(
+                    ConnectionParameters(
+                        JDBCString(jdbcUrlCreateVNode),
+                        it.connectionUsername.lowercase(),
+                        password
+                    )
+                )
+            )
+        }
+    }
+
+    fun mapToExternalDBConnectionParams(
+        connectionUsernames: List<ConnectionStatementParams>,
+        password: String
+    ): List<String> {
+        return mapToExternalDBConnectionParamsJson(connectionUsernames, password).map { it.toString() }
+    }
+}

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/JDBCString.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/JDBCString.kt
@@ -1,0 +1,3 @@
+package net.corda.e2etest.utilities.externaldb
+
+data class JDBCString(val url: String)

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/PasswordGenerator.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/externaldb/PasswordGenerator.kt
@@ -1,0 +1,15 @@
+package net.corda.e2etest.utilities.externaldb
+
+import java.security.SecureRandom
+
+class PasswordGenerator {
+    private val passwordLength = 64
+    private val passwordSource = (('0'..'9') + ('A'..'Z') + ('a'..'z')).toCharArray()
+    private val random = SecureRandom()
+
+    fun generatePassword(): CharArray {
+        val password = CharArray(passwordLength)
+        for (i in 0 until passwordLength) password[i] = passwordSource[random.nextInt(passwordSource.size)]
+        return password
+    }
+}


### PR DESCRIPTION
This adds a `withExternalDb()` extension method to `ClusterInfo`. 
When used, any calls to `vNodeCreate` will create the vnode using an external DB with a Corda managed schema.

`vNodeCreate` will create a schema and user accounts on the tests globally configured external DB before creating the vnode.