### PR TITLE
CORE-19501: Handle only the last message for each session

### DIFF
--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImplTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImplTest.kt
@@ -87,7 +87,7 @@ class StatefulSessionManagerImplTest {
                             "encryptionKeyId" to "encryptionKeyId",
                             "encryptionTenant" to "encryptionTenant",
                             "status" to "SentResponderHello",
-                            "expiry" to 2000000L,
+                            "expiry" to 20000000L,
                         ),
                     )
                     on { key } doReturn "stateKey"
@@ -120,14 +120,14 @@ class StatefulSessionManagerImplTest {
                         "groupId" to "group ID",
                         "lastSendTimestamp" to 50L,
                         "status" to "SentResponderHello",
-                        "expiry" to 1000L,
+                        "expiry" to 20000000L,
                     ),
                 )
 
                 on { key } doReturn "stateKey"
             }
             val sessionIdentity = "id"
-            whenever(stateManager.get(listOf(sessionIdentity))).doReturn(
+            whenever(stateManager.get(argThat { contains(sessionIdentity) })).doReturn(
                 mapOf(
                     sessionIdentity to state,
                 ),
@@ -190,7 +190,7 @@ class StatefulSessionManagerImplTest {
                 it.value
             }
 
-            verify(stateManager, times(1)).get(listOf(sessionIdentity))
+            verify(stateManager, times(1)).get(any())
         }
     }
 
@@ -212,7 +212,7 @@ class StatefulSessionManagerImplTest {
                 on { key } doReturn "stateKey"
             }
             val sessionIdentity = "id"
-            whenever(stateManager.get(listOf(sessionIdentity))).doReturn(
+            whenever(stateManager.get(any())).doReturn(
                 mapOf(
                     sessionIdentity to state,
                 ),

--- a/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/StateManager.kt
+++ b/libs/state-manager/state-manager-api/src/main/kotlin/net/corda/libs/statemanager/api/StateManager.kt
@@ -27,6 +27,8 @@ interface StateManager : Lifecycle {
      * Control is only returned to the caller once all [states] that were successfully created have been fully
      * persisted and replicas of the underlying persistent storage, if any, are synced.
      *
+     * If the [states] contains more than one state with the same key, an exception will be thrown.
+     *
      * @param states Collection of states to be persisted.
      * @return Collection of keys for all those states that could not be persisted on the underlying persistent storage.
      */

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
@@ -17,7 +17,6 @@ import net.corda.libs.statemanager.impl.metrics.MetricsRecorder.OperationType.UP
 import net.corda.libs.statemanager.impl.repository.StateRepository
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.slf4j.LoggerFactory
 import java.util.UUID
 
@@ -80,7 +79,7 @@ class StateManagerImpl(
             it.value.size > 1
         }.keys
         if (duplicateStatesKeys.isNotEmpty()) {
-            throw CordaRuntimeException(
+            throw IllegalArgumentException(
                 "Could not create two states with the same key." +
                     " Trying to create more than one state for keys: $duplicateStatesKeys")
         }

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/StateManagerImpl.kt
@@ -80,8 +80,9 @@ class StateManagerImpl(
         }.keys
         if (duplicateStatesKeys.isNotEmpty()) {
             throw IllegalArgumentException(
-                "Could not create two states with the same key." +
-                    " Trying to create more than one state for keys: $duplicateStatesKeys")
+                "Creating multiple states with the same key is not supported," +
+                    " duplicated keys found: $duplicateStatesKeys"
+            )
         }
 
         return metricsRecorder.recordProcessingTime(CREATE) {

--- a/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
@@ -7,10 +7,12 @@ import net.corda.libs.statemanager.impl.metrics.MetricsRecorder
 import net.corda.libs.statemanager.impl.metrics.MetricsRecorderImpl
 import net.corda.libs.statemanager.impl.repository.StateRepository
 import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -46,6 +48,21 @@ class StateManagerImplTest {
             .whenever(stateRepository).create(connection, listOf(stateOne, stateTwo))
         assertThat(stateManager.create(listOf(stateOne, stateTwo))).isEmpty()
         verify(stateRepository).create(connection, listOf(stateOne, stateTwo))
+    }
+
+    @Test
+    fun `create throws an error if two states with the same key are created`() {
+        val states = listOf(
+            stateOne,
+            stateTwo,
+            stateOne,
+        )
+
+        val exception = assertThrows<CordaRuntimeException> {
+            stateManager.create(states)
+        }
+
+        assertThat(exception).hasMessageContaining("Could not create two states with the same key.")
     }
 
     @Test

--- a/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
@@ -7,7 +7,6 @@ import net.corda.libs.statemanager.impl.metrics.MetricsRecorder
 import net.corda.libs.statemanager.impl.metrics.MetricsRecorderImpl
 import net.corda.libs.statemanager.impl.repository.StateRepository
 import net.corda.lifecycle.LifecycleCoordinatorFactory
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
@@ -58,7 +57,7 @@ class StateManagerImplTest {
             stateOne,
         )
 
-        val exception = assertThrows<CordaRuntimeException> {
+        val exception = assertThrows<IllegalArgumentException> {
             stateManager.create(states)
         }
 

--- a/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
+++ b/libs/state-manager/state-manager-db-impl/src/test/kotlin/net/corda/libs/statemanager/impl/StateManagerImplTest.kt
@@ -8,10 +8,10 @@ import net.corda.libs.statemanager.impl.metrics.MetricsRecorderImpl
 import net.corda.libs.statemanager.impl.repository.StateRepository
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.entry
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -57,11 +57,10 @@ class StateManagerImplTest {
             stateOne,
         )
 
-        val exception = assertThrows<IllegalArgumentException> {
+        assertThatThrownBy {
             stateManager.create(states)
-        }
-
-        assertThat(exception).hasMessageContaining("Could not create two states with the same key.")
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Creating multiple states with the same key is not supported")
     }
 
     @Test


### PR DESCRIPTION
When the link manager takes too long to pick up a session message (like the `InitiatorHelloMessage`), it will be resent, and the session manager will need to address two session messages from the same session.

With this change, we will only treat the last message for each session.