### PR TITLE
ES-1921: ensure code owners is triggered for toml file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,11 @@ Jenkinsfile        @corda/blt
 
 *.gradle           @corda/blt
 gradle/wrapper     @corda/blt
-*.toml             @corda/corda5-team-leads
 gradle.properties  @corda/corda5-team-leads
 gradle/*           @corda/blt
+*.toml             @corda/corda5-team-leads
 
-.github/**          @corda/blt
+.github/**         @corda/blt
 CODEOWNERS         @corda/blt @corda/corda5-team-leads
 
 # Modules to be audited by REST team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@ Jenkinsfile        @corda/blt
 *.gradle           @corda/blt
 gradle/wrapper     @corda/blt
 gradle.properties  @corda/corda5-team-leads
-gradle/*           @corda/blt
+/gradle/wrapper/   @corda/blt
 *.toml             @corda/corda5-team-leads
 
 .github/**         @corda/blt


### PR DESCRIPTION
from GH docs

` Order is important; the last matching pattern takes the most precedence.`

As a result, we need to move the ordering to ensure we trigger the required code review for toml file changes. 
Add BLT reviews to Gradle wrapper i.e gradle version change 