### PR TITLE
CORE-18544: Retry the registration request if the group reader is not ready

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationService.kt
@@ -330,8 +330,9 @@ class DynamicMemberRegistrationService @Activate constructor(
                     }.toWire()
                 )
 
+                // The group reader might not know about the MGM yet.
                 val mgm = groupReader.lookup().firstOrNull { it.isMgm }
-                    ?: throw IllegalArgumentException("Failed to look up MGM information.")
+                    ?: throw NotReadyMembershipRegistrationException("Failed to look up MGM information.")
 
                 val serialInfo = context[SERIAL]?.toLong()
                     ?: previousInfo?.serial
@@ -410,6 +411,8 @@ class DynamicMemberRegistrationService @Activate constructor(
                     "Registration failed. Reason: ${e.message}",
                     e,
                 )
+            } catch (e: NotReadyMembershipRegistrationException) {
+                throw e
             } catch (e: MembershipPersistenceResult.PersistenceRequestException) {
                 registrationLogger.warn("Registration failed.", e)
                 throw NotReadyMembershipRegistrationException("Could not persist request: ${e.message}", e)

--- a/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
+++ b/components/membership/registration-impl/src/test/kotlin/net/corda/membership/impl/registration/dynamic/member/DynamicMemberRegistrationServiceTest.kt
@@ -1133,7 +1133,7 @@ class DynamicMemberRegistrationServiceTest {
             postConfigChangedEvent()
             registrationService.start()
 
-            val exception = assertThrows<InvalidMembershipRegistrationException> {
+            val exception = assertThrows<NotReadyMembershipRegistrationException> {
                 registrationService.register(registrationResultId, member, context)
             }
             assertThat(exception).hasMessageContaining("MGM information")


### PR DESCRIPTION
It seems like the issue is due to the membership worker accepting messages before the group reader is ready. So, when we get the register request, we look for an MGM in the group, but because the group is not prepared, we can't find the MGM and assume that the request is invalid.

This will fail with a not-ready exception, that will enable the membership worker to retry the request a few more times before failing.