### PR TITLE
CORE-19563: Remove check that previous key rotation has finished

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -40,7 +40,6 @@ import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.records.Record
 import net.corda.rest.PluggableRestResource
-import net.corda.rest.exception.ForbiddenException
 import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.exception.ResourceNotFoundException
 import net.corda.rest.messagebus.MessageBusUtils.tryWithExceptionHandling

--- a/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
+++ b/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
@@ -184,7 +184,7 @@ class KeyRotationRestResourceTest {
     fun `start key rotation event throws when state manager is not initialised`() {
         val keyRotationRestResource =
             createKeyRotationRestResource(initialiseKafkaPublisher = true, initialiseStateManager = false)
-        assertThrows<IllegalStateException> {
+        assertThrows<InternalServerException> {
             keyRotationRestResource.startKeyRotation(tenantId)
         }
         verify(publishToKafka, never()).publish(any())

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -61,6 +61,9 @@ class CryptoRekeyBusProcessor(
 
         events.mapNotNull { it.timestamp to it.value }.forEach { (timestamp, request) ->
             try {
+                check(stateManager.isRunning) {
+                    "State manager for key rotation is not initialised."
+                }
                 processEvent(request, timestamp)
             } catch (ex: Exception) {
                 logger.warn("A KeyRotationRequest event could not be processed:", ex)
@@ -76,10 +79,6 @@ class CryptoRekeyBusProcessor(
     ) {
         logger.debug("processing $request")
         require(request != null)
-
-        check(stateManager.isRunning) {
-            "State manager for key rotation is not initialised."
-        }
 
         when (request.managedKey) {
             KeyType.UNMANAGED -> {

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -43,7 +43,7 @@ class CryptoRekeyBusProcessor(
     private val wrappingRepositoryFactory: WrappingRepositoryFactory,
     private val signingRepositoryFactory: SigningRepositoryFactory,
     private val rekeyPublisher: Publisher,
-    private val stateManagerInit: StateManager?,
+    private val stateManager: StateManager,
     cordaAvroSerializationFactory: CordaAvroSerializationFactory,
     private val defaultUnmanagedWrappingKeyName: String,
 ) : DurableProcessor<String, KeyRotationRequest> {
@@ -55,10 +55,6 @@ class CryptoRekeyBusProcessor(
     override val valueClass = KeyRotationRequest::class.java
     private val unmanagedKeyStatusSerializer = cordaAvroSerializationFactory.createAvroSerializer<UnmanagedKeyStatus>()
     private val managedKeyStatusSerializer = cordaAvroSerializationFactory.createAvroSerializer<ManagedKeyStatus>()
-    private val stateManager: StateManager
-        get() = checkNotNull(stateManagerInit) {
-            "State manager for key rotation is not initialised."
-        }
 
     @Suppress("NestedBlockDepth")
     override fun onNext(events: List<Record<String, KeyRotationRequest>>): List<Record<*, *>> {

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -78,11 +78,8 @@ class CryptoRekeyBusProcessor(
         logger.debug("processing $request")
         require(request != null)
 
-        try {
-            stateManager.isRunning
-        } catch (_: IllegalStateException) {
-            logger.info("State Manager is not initialised, ignoring")
-            return
+        check(stateManager.isRunning) {
+            "State manager for key rotation is not initialised."
         }
 
         when (request.managedKey) {

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -28,7 +28,6 @@ import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Crypto.REWRAP_MESSAGE_TOPIC
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import org.slf4j.LoggerFactory
-import java.lang.IllegalStateException
 import java.time.Instant
 import java.util.UUID
 

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -29,7 +29,7 @@ private const val REWRAP_KEYS_OPERATION_NAME = "rewrapKeys"
 @Suppress("LongParameterList")
 class CryptoRewrapBusProcessor(
     val cryptoService: CryptoService,
-    private val stateManager: StateManager?,
+    private val stateManager: StateManager,
     private val cordaAvroSerializationFactory: CordaAvroSerializationFactory,
     private val defaultUnmanagedWrappingKeyName: String,
 ) : DurableProcessor<String, IndividualKeyRotationRequest> {

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
@@ -162,6 +162,7 @@ class CryptoRekeyBusProcessorTests {
         stateManager = mock<StateManager>() {
             on { create(stateManagerCreateCapture.capture()) } doReturn emptySet()
             on { delete(stateManagerDeleteCapture.capture()) } doReturn emptyMap()
+            on { isRunning } doReturn true
         }
 
         cryptoRekeyBusProcessor = CryptoRekeyBusProcessor(
@@ -311,7 +312,7 @@ class CryptoRekeyBusProcessorTests {
             wrappingRepositoryFactory,
             signingRepositoryFactory,
             rewrapPublisher,
-            mock(),
+            stateManager,
             cordaAvroSerializationFactory,
             defaultMasterWrappingKeyAlias
         )

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessorTests.kt
@@ -47,7 +47,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -260,7 +259,7 @@ class CryptoRekeyBusProcessorTests {
         }.toMap()
 
         // first return is empty map, so we pass ongoing rotation detection
-        `when`(stateManager.findByMetadataMatchingAll(any())).thenReturn(simulatedExistingStateMap)
+        whenever(stateManager.findByMetadataMatchingAll(any())).thenReturn(simulatedExistingStateMap)
         cryptoRekeyBusProcessor.onNext(listOf(getUnmanagedKeyRotationKafkaRecord()))
         verify(stateManager, times(1)).delete(any())
 
@@ -496,7 +495,7 @@ class CryptoRekeyBusProcessorTests {
         }.toMap()
 
         // first return is empty map, so we pass ongoing rotation detection
-        `when`(stateManager.findByMetadataMatchingAll(any())).thenReturn(simulatedExistingStateMap)
+        whenever(stateManager.findByMetadataMatchingAll(any())).thenReturn(simulatedExistingStateMap)
         cryptoRekeyBusProcessor.onNext(listOf(getManagedKeyRotationKafkaRecord(tenantId = tenantId)))
         verify(stateManager, times(1)).delete(any())
 


### PR DESCRIPTION
This PR removes the check that a previous key rotation had finished in both unmanaged and managed key rotations. Additionally, it adds a check that the state manager is active, which would previously throw an error as a side effect of checking the previous rotation status. Technically, the check in `KeyRotationRestResource` will throw the error from trying to access `stateManager.isRunning`, but I have written the code to throw the same error that is thrown by the failed attempt at accessing it.