### PR TITLE
CORE-19401: Increase timeout in the consumer processor

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessor.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/ConsumerProcessor.kt
@@ -47,7 +47,7 @@ class ConsumerProcessor<K : Any, S : Any, E : Any>(
     private val stateManagerHelper: StateManagerHelper<S>
 ) {
     private companion object {
-        private const val EVENT_PROCESSING_TIMEOUT_MILLIS = 30000L // 30 seconds
+        private const val EVENT_PROCESSING_TIMEOUT_MILLIS = 120000L // 120 seconds
     }
 
     private val log = LoggerFactory.getLogger("${this.javaClass.name}-${config.name}")


### PR DESCRIPTION
### Problem description

The event mediator includes a timeout in the consumer processor to minimize the risk of timing out the consumer from the consumer group. In some circumstances it seems this timeout is too short (in particular when resolving large backchains, but also in some parallel processing scenarios).

### Solution

Increase this timeout to two minutes.

This is a workaround solution. Increasing the timeout makes it more likely that slow processing can result in being timed out the consumer group. However, this should be much rarer than a flow taking longer than its allotted time, and in the current code this is the situation that should be avoided. A more fully-fledged solution would tie processing time to individual flow execution (rather than a group of flows) and remove the coupling between Kafka consumer group timeout and processing timeout.

