### PR TITLE
CORE-19588: warn if class not found during AMQP deserialisation 

### DIFF
--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeLoader.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeLoader.kt
@@ -46,6 +46,7 @@ class ClassTypeLoader: TypeLoader {
             try {
                 identifier to cache.computeIfAbsent(identifier) { identifier.getLocalType(sandboxGroup, metadata) }
             } catch (ex: ClassNotFoundException) {
+                logger.warn("ClassNotFound ${ex.message} loading type for looking for ${identifier.prettyPrint()}")
                 null
             }
         }.toMap()

--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeLoader.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/model/TypeLoader.kt
@@ -46,7 +46,7 @@ class ClassTypeLoader: TypeLoader {
             try {
                 identifier to cache.computeIfAbsent(identifier) { identifier.getLocalType(sandboxGroup, metadata) }
             } catch (ex: ClassNotFoundException) {
-                logger.warn("ClassNotFound ${ex.message} loading type for looking for ${identifier.prettyPrint()}")
+                logger.warn("Class not found while looking for ${identifier.prettyPrint(false)}: ${ex.message}", ex)
                 null
             }
         }.toMap()


### PR DESCRIPTION
This is intended to provide more clues for field support, since it's not always obvious what's going on when classes can't be resolved during serialisation. We assume that this won't happen in working code.