### PR TITLE
CORE-19401: Modify the consumer API for synchronously committing offsets to take a collection of events

### DIFF
--- a/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
+++ b/libs/messaging/db-message-bus-impl/src/test/kotlin/net/corda/messagebus/db/consumer/DBCordaConsumerImplTest.kt
@@ -6,12 +6,10 @@ import net.corda.messagebus.api.consumer.CordaConsumer
 import net.corda.messagebus.api.consumer.CordaConsumerRecord
 import net.corda.messagebus.api.consumer.CordaOffsetResetStrategy
 import net.corda.messagebus.db.configuration.ResolvedConsumerConfig
-import net.corda.messagebus.db.datamodel.CommittedPositionEntry
 import net.corda.messagebus.db.datamodel.TopicRecordEntry
 import net.corda.messagebus.db.datamodel.TransactionRecordEntry
 import net.corda.messagebus.db.datamodel.TransactionState
 import net.corda.messagebus.db.persistence.DBAccess
-import net.corda.messagebus.db.persistence.DBAccess.Companion.ATOMIC_TRANSACTION
 import net.corda.messagebus.db.serialization.MessageHeaderSerializerImpl
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import org.assertj.core.api.Assertions.assertThat

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -334,10 +334,13 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
         }
     }
 
-    override fun syncCommitOffsets(event: CordaConsumerRecord<K, V>, metaData: String?) {
-        val offsets = mutableMapOf<TopicPartition, OffsetAndMetadata>()
-        val topicPartition = TopicPartition(config.topicPrefix + event.topic, event.partition)
-        offsets[topicPartition] = OffsetAndMetadata(event.offset + 1, metaData)
+    override fun syncCommitOffsets(events: Collection<CordaConsumerRecord<K, V>>, metaData: String?) {
+        val offsets = events.groupBy { event ->
+            TopicPartition(config.topicPrefix + event.topic, event.partition)
+        }.mapValues { (_, partitionEvents) ->
+            val maxOffset = partitionEvents.maxBy { it.offset }
+            OffsetAndMetadata(maxOffset.offset + 1, metaData)
+        }
         var attemptCommit = true
 
         while (attemptCommit) {
@@ -348,17 +351,19 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                 when (ex::class.java) {
                     in fatalExceptions -> {
                         logErrorAndThrowFatalException(
-                            "Error attempting to commitSync offsets for record $event.",
+                            "Error attempting to commitSync offsets for records ${events.joinToString()}.",
                             ex
                         )
                     }
                     in transientExceptions -> {
-                        logWarningAndThrowIntermittentException("Failed to commitSync offsets for record $event.", ex)
+                        logWarningAndThrowIntermittentException(
+                            "Failed to commitSync offsets for records ${events.joinToString()}.", ex
+                        )
                     }
                     else -> {
                         logErrorAndThrowFatalException(
                             "Unexpected error attempting to commitSync offsets " +
-                                    "for record $event.", ex
+                                    "for records ${events.joinToString()}.", ex
                         )
                     }
                 }

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/MockKafkaTestUtils.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/MockKafkaTestUtils.kt
@@ -18,12 +18,9 @@ fun createMockConsumerAndAddRecords(
 ):
         Pair<MockConsumer<Any, Any>, TopicPartition> {
     val topicPartition = TopicPartition(topic, 1)
-    val partitions = mutableListOf(topicPartition)
-    val partitionsBeginningMap = mutableMapOf<TopicPartition, Long>()
-    val partitionsEndMap = mutableMapOf<TopicPartition, Long>()
-
-    partitionsBeginningMap[topicPartition] = 0L
-    partitionsEndMap[topicPartition] = numberOfRecords
+    val partitions = listOf(TopicPartition(topic, 1), TopicPartition(topic, 2))
+    val partitionsBeginningMap = partitions.associateWith { 0L }
+    val partitionsEndMap = partitions.associateWith { numberOfRecords }
 
     val consumer = MockConsumer<Any, Any>(offsetResetStrategy)
     consumer.subscribe(listOf(topic))

--- a/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
+++ b/libs/messaging/message-bus/src/main/kotlin/net/corda/messagebus/api/consumer/CordaConsumer.kt
@@ -152,11 +152,14 @@ interface CordaConsumer<K : Any, V : Any> : AutoCloseable {
     fun syncCommitOffsets()
 
     /**
-     * Synchronously commit the consumer offset for this [event] back to the topic partition.
-     * Record [metaData] about this commit back on the [event] topic.
+     * Synchronously commit the consumer offset for these [events] back to the topic partition.
+     * Record [metaData] about this commit back on the [events] topic.
+     *
+     * For the given set of events, the consumer will determine the latest offset for each partition represented, and
+     * will commit this +1 back as the next offset to process for that partition.
      * @throws CordaMessageAPIFatalException fatal error occurred attempting to commit offsets.
      */
-    fun syncCommitOffsets(event: CordaConsumerRecord<K, V>, metaData: String? = null)
+    fun syncCommitOffsets(events: Collection<CordaConsumerRecord<K, V>>, metaData: String? = null)
 
     /**
      * Get metadata about the partitions for a given topic.


### PR DESCRIPTION
### Problem description

The consumer abstraction provided by the messaging API provides two sync offset commit APIs. The first of these commits the last polled offsets back. The second takes a single event and commits the next offset after that event back.

Typically, events are polled in batches, and so a more frequent use case for the second is to commit the next offset of all events that were polled in the last batch. The API previously did not allow this.

### Solution

Modify the API to take a collection of events.

The events provided are grouped by topic partition, and then the max offset in each group is calculated. The offset committed is the next one after the max offset for each group.