### PR TITLE
CORE-19538: Avoid reusing the same name for the coordinator name in the in-memory messaging emulation

### DIFF
--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/RPCSenderImpl.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/RPCSenderImpl.kt
@@ -12,8 +12,8 @@ import net.corda.messaging.emulation.rpc.RPCTopicService
 class RPCSenderImpl<REQUEST, RESPONSE>(
     private val rpcConfig: RPCConfig<REQUEST, RESPONSE>,
     private val rpcTopicService: RPCTopicService,
-    private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    private val clientIdCounter: String
+    lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    clientIdCounter: String
 ) : RPCSender<REQUEST, RESPONSE> {
 
     private var running = false

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/factory/CordaPublisherFactory.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/publisher/factory/CordaPublisherFactory.kt
@@ -16,7 +16,7 @@ import net.corda.messaging.emulation.topic.service.TopicService
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * In-memory implementation for Publisher Factory.
@@ -31,6 +31,9 @@ class CordaPublisherFactory @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : PublisherFactory {
+    private companion object {
+        val instanceIndex = AtomicInteger()
+    }
 
     override fun createPublisher(
         publisherConfig: PublisherConfig,
@@ -47,7 +50,7 @@ class CordaPublisherFactory @Activate constructor(
             rpcConfig,
             rpcTopicService,
             lifecycleCoordinatorFactory,
-            UUID.randomUUID().toString()
+            instanceIndex.incrementAndGet().toString(),
         )
     }
 

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/compacted/InMemoryCompactedSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/compacted/InMemoryCompactedSubscription.kt
@@ -20,8 +20,8 @@ class InMemoryCompactedSubscription<K : Any, V : Any>(
     private val subscriptionConfig: SubscriptionConfig,
     internal val processor: CompactedProcessor<K, V>,
     private val topicService: TopicService,
-    private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    private val clientIdCounter: String
+    lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    clientIdCounter: String
 ) : CompactedSubscription<K, V> {
 
     private val knownValues = ConcurrentHashMap<K, V>()

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/durable/DurableSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/durable/DurableSubscription.kt
@@ -21,8 +21,8 @@ internal class DurableSubscription<K : Any, V : Any>(
     private val processor: DurableProcessor<K, V>,
     internal val partitionAssignmentListener: PartitionAssignmentListener?,
     private val topicService: TopicService,
-    private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    private val instanceId: Int
+    lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    instanceId: Int
 ) : Subscription<K, V> {
     companion object {
         private val log = LoggerFactory.getLogger(this::class.java.enclosingClass)

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/eventlog/EventLogSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/eventlog/EventLogSubscription.kt
@@ -31,7 +31,7 @@ class EventLogSubscription<K : Any, V : Any>(
     internal val partitionAssignmentListener: PartitionAssignmentListener?,
     internal val topicService: TopicService,
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    private val instanceId: Int
+    instanceId: Int
 ) : Subscription<K, V> {
 
     companion object {

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/factory/InMemSubscriptionFactory.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/factory/InMemSubscriptionFactory.kt
@@ -25,13 +25,12 @@ import net.corda.messaging.emulation.subscription.pubsub.PubSubSubscription
 import net.corda.messaging.emulation.subscription.rpc.RPCSubscriptionImpl
 import net.corda.messaging.emulation.subscription.stateandevent.InMemoryStateAndEventSubscription
 import net.corda.messaging.emulation.topic.service.TopicService
-import net.corda.schema.configuration.BootConfig.INSTANCE_ID
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
-import java.util.UUID
 import net.corda.messaging.api.processor.SyncRPCProcessor
 import net.corda.messaging.api.subscription.config.SyncRPCConfig
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * In memory implementation of the Subscription Factory.
@@ -45,6 +44,9 @@ class InMemSubscriptionFactory @Activate constructor(
     @Reference(service = LifecycleCoordinatorFactory::class)
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory
 ) : SubscriptionFactory {
+    private companion object {
+        val instanceIndex = AtomicInteger()
+    }
 
     override fun <K : Any, V : Any> createPubSubSubscription(
         subscriptionConfig: SubscriptionConfig,
@@ -56,7 +58,7 @@ class InMemSubscriptionFactory @Activate constructor(
             processor,
             topicService,
             lifecycleCoordinatorFactory,
-            UUID.randomUUID().toString()
+            instanceIndex.incrementAndGet().toString(),
         )
     }
 
@@ -72,7 +74,7 @@ class InMemSubscriptionFactory @Activate constructor(
             partitionAssignmentListener,
             topicService,
             lifecycleCoordinatorFactory,
-            messagingConfig.getInt(INSTANCE_ID)
+            instanceIndex.incrementAndGet(),
         )
     }
 
@@ -86,7 +88,7 @@ class InMemSubscriptionFactory @Activate constructor(
             processor,
             topicService,
             lifecycleCoordinatorFactory,
-            UUID.randomUUID().toString()
+            instanceIndex.incrementAndGet().toString()
         )
     }
 
@@ -102,7 +104,7 @@ class InMemSubscriptionFactory @Activate constructor(
             stateAndEventListener,
             topicService,
             lifecycleCoordinatorFactory,
-            messagingConfig.getInt(INSTANCE_ID)
+            instanceIndex.incrementAndGet()
         )
     }
 
@@ -118,7 +120,7 @@ class InMemSubscriptionFactory @Activate constructor(
             partitionAssignmentListener,
             topicService,
             lifecycleCoordinatorFactory,
-            messagingConfig.getInt(INSTANCE_ID)
+            instanceIndex.incrementAndGet()
         )
     }
 
@@ -132,7 +134,7 @@ class InMemSubscriptionFactory @Activate constructor(
             rpcTopicService,
             responderProcessor,
             lifecycleCoordinatorFactory,
-            UUID.randomUUID().toString()
+            instanceIndex.incrementAndGet().toString(),
         )
     }
 

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/pubsub/PubSubSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/pubsub/PubSubSubscription.kt
@@ -29,7 +29,7 @@ class PubSubSubscription<K : Any, V : Any>(
     private val processor: PubSubProcessor<K, V>,
     private val topicService: TopicService,
     private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    private val clientIdCounter: String
+    clientIdCounter: String
 ) : Subscription<K, V> {
 
     companion object {

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/rpc/RPCSubscriptionImpl.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/rpc/RPCSubscriptionImpl.kt
@@ -12,8 +12,8 @@ class RPCSubscriptionImpl<REQUEST, RESPONSE>(
     private val rpcConfig: RPCConfig<REQUEST, RESPONSE>,
     private val rpcTopicService: RPCTopicService,
     private val responderProcessor: RPCResponderProcessor<REQUEST, RESPONSE>,
-    private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    private val clientIdCounter: String
+    lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    clientIdCounter: String
 ) : RPCSubscription<REQUEST, RESPONSE> {
 
     private var running = false

--- a/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/stateandevent/InMemoryStateAndEventSubscription.kt
+++ b/testing/p2p/inmemory-messaging-impl/src/main/kotlin/net/corda/messaging/emulation/subscription/stateandevent/InMemoryStateAndEventSubscription.kt
@@ -19,8 +19,8 @@ class InMemoryStateAndEventSubscription<K : Any, S : Any, E : Any>(
     internal val processor: StateAndEventProcessor<K, S, E>,
     internal val stateAndEventListener: StateAndEventListener<K, S>?,
     internal val topicService: TopicService,
-    private val lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
-    private val instanceId: Int
+    lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    instanceId: Int
 ) :
     StateAndEventSubscription<K, S, E> {
 


### PR DESCRIPTION
Looks like the issue is with:
```
[2024-02-01T03:47:34.674Z]     [INFO] 03:47:16.644 [lifecycle-coordinator-25] impl.LifecycleProcessor. - inbound_message_processor_group-link.in-subscription-tile-55 Lifecycle: An error occurred during the processing of event RegistrationStatusChangeEvent(registration=Registration(registeringCoordinator=inbound_message_processor_group-link.in-subscription-tile-55,coordinators=net.corda.membership.read.MembershipGroupReaderProvider), status=UP) by a lifecycle coordinator: A coordinator with name inbound_message_processor_group-EventLogSubscription-link.in-1 has already been registered. Triggering user event handling. {}
[2024-02-01T03:47:34.675Z]     net.corda.lifecycle.registry.LifecycleRegistryException: A coordinator with name inbound_message_processor_group-EventLogSubscription-link.in-1 has already been registered
[2024-02-01T03:47:34.675Z]     	at net.corda.lifecycle.impl.registry.LifecycleRegistryImpl.registerCoordinator(LifecycleRegistryImpl.kt:64)
[2024-02-01T03:47:34.675Z]     	at net.corda.lifecycle.impl.LifecycleCoordinatorFactoryImpl.internalCreateCoordinator(LifecycleCoordinatorFactoryImpl.kt:47)
[2024-02-01T03:47:34.675Z]     	at net.corda.lifecycle.impl.LifecycleCoordinatorFactoryImpl.createCoordinator(LifecycleCoordinatorFactoryImpl.kt:30)
[2024-02-01T03:47:34.675Z]     	at net.corda.lifecycle.LifecycleCoordinatorFactory.createCoordinator(LifecycleCoordinatorFactory.kt:44)
[2024-02-01T03:47:34.675Z]     	at net.corda.messaging.emulation.subscription.eventlog.EventLogSubscription.<init>(EventLogSubscription.kt:43)
[2024-02-01T03:47:34.675Z]     	at net.corda.messaging.emulation.subscription.factory.InMemSubscriptionFactory.createEventLogSubscription(InMemSubscriptionFactory.kt:115)
[2024-02-01T03:47:34.675Z]     	at net.corda.p2p.linkmanager.inbound.InboundLinkManager$inboundMessageSubscription$1.invoke(InboundLinkManager.kt:30)
[2024-02-01T03:47:34.675Z]     	at net.corda.p2p.linkmanager.inbound.InboundLinkManager$inboundMessageSubscription$1.invoke(InboundLinkManager.kt:29)
[2024-02-01T03:47:34.675Z]     	at net.corda.lifecycle.impl.LifecycleProcessor$addManagedResource$1.invoke(LifecycleProcessor.kt:270)
[2024-02-01T03:47:34.675Z]     	at net.corda.lifecycle.impl.LifecycleProcessor$addManagedResource$1.invoke(LifecycleProcessor.kt:268)
[2024-02-01T03:47:34.675Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.addManagedResource$lambda$19(LifecycleProcessor.kt:268)
[2024-02-01T03:47:34.676Z]     	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1940)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.addManagedResource(LifecycleProcessor.kt:268)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.impl.LifecycleCoordinatorImpl.createManagedResource(LifecycleCoordinatorImpl.kt:224)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase.createAndStartSubscription(SubscriptionDominoTileBase.kt:119)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase.statusChanged(SubscriptionDominoTileBase.kt:166)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase.access$statusChanged(SubscriptionDominoTileBase.kt:43)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase$EventHandler.processEvent(SubscriptionDominoTileBase.kt:147)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.runUserEventHandler(LifecycleProcessor.kt:241)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.processEvent(LifecycleProcessor.kt:137)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.processEvents(LifecycleProcessor.kt:64)
[2024-02-01T03:47:34.676Z]     	at net.corda.lifecycle.impl.LifecycleCoordinatorImpl.processEvents(LifecycleCoordinatorImpl.kt:98)
[2024-02-01T03:47:34.676Z]     	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[2024-02-01T03:47:34.676Z]     	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[2024-02-01T03:47:34.676Z]     	at java.base/java.lang.Thread.run(Thread.java:833)
[2024-02-01T03:47:34.677Z]     [ERROR] 03:47:16.644 [lifecycle-coordinator-25] impl.LifecycleProcessor. - inbound_message_processor_group-link.in-subscription-tile-55 Lifecycle: An unhandled error was encountered while processing RegistrationStatusChangeEvent(registration=Registration(registeringCoordinator=inbound_message_processor_group-link.in-subscription-tile-55,coordinators=net.corda.membership.read.MembershipGroupReaderProvider), status=UP) in a lifecycle coordinator: A coordinator with name inbound_message_processor_group-EventLogSubscription-link.in-1 has already been registered. This coordinator will now shut down. {}
[2024-02-01T03:47:34.677Z]     net.corda.lifecycle.registry.LifecycleRegistryException: A coordinator with name inbound_message_processor_group-EventLogSubscription-link.in-1 has already been registered
[2024-02-01T03:47:34.677Z]     	at net.corda.lifecycle.impl.registry.LifecycleRegistryImpl.registerCoordinator(LifecycleRegistryImpl.kt:64)
[2024-02-01T03:47:34.677Z]     	at net.corda.lifecycle.impl.LifecycleCoordinatorFactoryImpl.internalCreateCoordinator(LifecycleCoordinatorFactoryImpl.kt:47)
[2024-02-01T03:47:34.677Z]     	at net.corda.lifecycle.impl.LifecycleCoordinatorFactoryImpl.createCoordinator(LifecycleCoordinatorFactoryImpl.kt:30)
[2024-02-01T03:47:34.677Z]     	at net.corda.lifecycle.LifecycleCoordinatorFactory.createCoordinator(LifecycleCoordinatorFactory.kt:44)
[2024-02-01T03:47:34.677Z]     	at net.corda.messaging.emulation.subscription.eventlog.EventLogSubscription.<init>(EventLogSubscription.kt:43)
[2024-02-01T03:47:34.677Z]     	at net.corda.messaging.emulation.subscription.factory.InMemSubscriptionFactory.createEventLogSubscription(InMemSubscriptionFactory.kt:115)
[2024-02-01T03:47:34.678Z]     	at net.corda.p2p.linkmanager.inbound.InboundLinkManager$inboundMessageSubscription$1.invoke(InboundLinkManager.kt:30)
[2024-02-01T03:47:34.678Z]     	at net.corda.p2p.linkmanager.inbound.InboundLinkManager$inboundMessageSubscription$1.invoke(InboundLinkManager.kt:29)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.impl.LifecycleProcessor$addManagedResource$1.invoke(LifecycleProcessor.kt:270)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.impl.LifecycleProcessor$addManagedResource$1.invoke(LifecycleProcessor.kt:268)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.addManagedResource$lambda$19(LifecycleProcessor.kt:268)
[2024-02-01T03:47:34.678Z]     	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1940)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.addManagedResource(LifecycleProcessor.kt:268)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.impl.LifecycleCoordinatorImpl.createManagedResource(LifecycleCoordinatorImpl.kt:224)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase.createAndStartSubscription(SubscriptionDominoTileBase.kt:119)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase.statusChanged(SubscriptionDominoTileBase.kt:166)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase.access$statusChanged(SubscriptionDominoTileBase.kt:43)
[2024-02-01T03:47:34.678Z]     	at net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase$EventHandler.processEvent(SubscriptionDominoTileBase.kt:147)
[2024-02-01T03:47:34.679Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.runUserEventHandler(LifecycleProcessor.kt:241)
[2024-02-01T03:47:34.679Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.processEvent(LifecycleProcessor.kt:137)
[2024-02-01T03:47:34.679Z]     	at net.corda.lifecycle.impl.LifecycleProcessor.processEvents(LifecycleProcessor.kt:64)
[2024-02-01T03:47:34.679Z]     	at net.corda.lifecycle.impl.LifecycleCoordinatorImpl.processEvents(LifecycleCoordinatorImpl.kt:98)
[2024-02-01T03:47:34.679Z]     	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[2024-02-01T03:47:34.679Z]     	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[2024-02-01T03:47:34.679Z]     	at java.base/java.lang.Thread.run(Thread.java:833)
```
This is because we are running the test in parallel, and the first coordinator was not closed before the second one is created.

With this change, each coordinator will receive a unique name.