### PR TITLE
ES-1914: updated Corda Helm chart schema

### DIFF
--- a/.ci/e2eTests/corda-eks.yaml
+++ b/.ci/e2eTests/corda-eks.yaml
@@ -5,6 +5,8 @@ bootstrap:
   db:
     clientImage:
       registry: docker-remotes.software.r3.com
+  commonPodLabels:
+    sidecar.istio.io/inject: !!str false # explicitly disable Istio integration from bootstrap pods
 
 resources:
   requests:
@@ -13,3 +15,6 @@ resources:
   limits:
     memory: "1250Mi"
     cpu: "1000m"
+
+commonPodLabels:
+  sidecar.istio.io/inject: !!str true # explicitly enable Istio integration from all Corda pods

--- a/.ci/e2eTests/prereqs-eks.yaml
+++ b/.ci/e2eTests/prereqs-eks.yaml
@@ -30,6 +30,6 @@ postgresql:
       requests:
         memory: 256Mi
         cpu: 300m
-      limits:  
+      limits:
         memory: 512Mi
         cpu: 600m

--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -66,6 +66,7 @@ spec:
     metadata:
       labels:
         {{- include "corda.selectorLabels" . | nindent 8 }}
+        {{- include "corda.commonBootstrapPodLabels" . | nindent 8 }}
     spec:
       {{- include "corda.imagePullSecrets" . | indent 6 }}
       {{- include "corda.tolerations" . | nindent 6 }}
@@ -131,6 +132,7 @@ spec:
     metadata:
       labels:
         {{- include "corda.selectorLabels" . | nindent 8 }}
+        {{- include "corda.commonBootstrapPodLabels" . | nindent 8 }}
     spec:
       {{- include "corda.imagePullSecrets" . | indent 6 }}
       {{- include "corda.tolerations" $ | indent 6 }}
@@ -372,6 +374,7 @@ spec:
     metadata:
       labels:
         {{- include "corda.selectorLabels" . | nindent 8 }}
+        {{- include "corda.commonBootstrapPodLabels" . | nindent 8 }}
     spec:
       {{- include "corda.imagePullSecrets" . | indent 6 }}
       {{- include "corda.tolerations" . | indent 6 }}
@@ -522,6 +525,7 @@ spec:
     metadata:
       labels:
         {{- include "corda.selectorLabels" . | nindent 8 }}
+        {{- include "corda.commonBootstrapPodLabels" . | nindent 8 }}
     spec:
       {{- include "corda.imagePullSecrets" . | indent 6 }}
       {{- include "corda.tolerations" . | indent 6 }}

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -63,6 +63,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Custom labels for bootstrap pods
+*/}}
+{{- define  "corda.commonBootstrapPodLabels" -}}
+{{- with .Values.bootstrap.commonPodLabels }}
+{{- . | toYaml }}
+{{- end }}
+{{- end }}
+
+{{/*
+Custom labels for deployments pods
+*/}}
+{{- define  "corda.workerCommonPodLabels" -}}
+{{- with .Values.commonPodLabels }}
+{{- . | toYaml }}
+{{- end }}
+{{- end }}
+
+{{/*
 Image pull secrets
 */}}
 {{- define  "corda.imagePullSecrets" -}}
@@ -521,7 +539,7 @@ metadata:
   annotations:
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook": pre-install
-{{- if $options.cleanup }}   
+{{- if $options.cleanup }}
     "helm.sh/hook-delete-policy": hook-succeeded
 {{- end }}
   labels:

--- a/charts/corda-lib/templates/_nginx.tpl
+++ b/charts/corda-lib/templates/_nginx.tpl
@@ -230,6 +230,7 @@ spec:
     metadata:
       labels:
         {{- include "corda.nginxLabels" ( list . $workerName ) | nindent 8 }}
+        {{- include "corda.workerCommonPodLabels" . | nindent 8 }}
       {{- with .Values.annotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/corda-lib/templates/_sidecar.tpl
+++ b/charts/corda-lib/templates/_sidecar.tpl
@@ -1,0 +1,21 @@
+{{/*
+ Create an Istio Sidecar for the rest worker
+ */}}
+{{- define "corda.istioRestWorkerSidecar" -}}
+{{- if .Capabilities.APIVersions.Has "networking.istio.io/v1beta1/Sidecar" -}}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Sidecar
+metadata:
+  name: https
+spec:
+  workloadSelector:
+    labels:
+      {{- include "corda.workerSelectorLabels" ( list . "rest" ) | nindent 6 }}
+  ingress:
+    - port:
+        number: {{ .Values.workers.rest.service.port }}
+        protocol: HTTPS
+        name: https
+{{- end -}}
+{{- end -}}

--- a/charts/corda-lib/templates/_sidecar.tpl
+++ b/charts/corda-lib/templates/_sidecar.tpl
@@ -16,7 +16,7 @@ metadata:
 spec:
   workloadSelector:
     labels:
-      {{- include "corda.workerSelectorLabels" ( list . $workerName ) | nindent 6 }}
+      {{- include "corda.workerSelectorLabels" ( list . $worker ) | nindent 6 }}
   ingress:
     - port:
         number: {{ $port }}

--- a/charts/corda-lib/templates/_sidecar.tpl
+++ b/charts/corda-lib/templates/_sidecar.tpl
@@ -3,18 +3,23 @@
  */}}
 {{- define "corda.istioRestWorkerSidecar" -}}
 {{- if .Capabilities.APIVersions.Has "networking.istio.io/v1beta1/Sidecar" -}}
+{{- $worker := "rest" }}
+{{- $port := (index .Values.workers $worker).service.port }}
+{{- $workerName := printf "%s-%s-worker" ( include "corda.fullname" $ ) ( include "corda.workerTypeKebabCase" $worker ) }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
-  name: https
+  name: {{ $workerName | quote }}
+  annotations:
+    "helm.sh/hook": pre-install
 spec:
   workloadSelector:
     labels:
-      {{- include "corda.workerSelectorLabels" ( list . "rest" ) | nindent 6 }}
+      {{- include "corda.workerSelectorLabels" ( list . $workerName ) | nindent 6 }}
   ingress:
     - port:
-        number: {{ .Values.workers.rest.service.port }}
+        number: {{ $port }}
         protocol: HTTPS
         name: https
 {{- end -}}

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -145,6 +145,7 @@ spec:
         {{- end }}
       labels:
         {{- include "corda.workerSelectorLabels" ( list $ $worker ) | nindent 8 }}
+        {{- include "corda.workerCommonPodLabels" $ | nindent 8 }}
     spec:
       {{- if and ( not $.Values.dumpHostPath ) ( not .profiling.enabled ) }}
       {{- with $.Values.podSecurityContext }}

--- a/charts/corda/templates/sidecar.yaml
+++ b/charts/corda/templates/sidecar.yaml
@@ -1,16 +1,1 @@
-{{- if .Capabilities.APIVersions.Has "networking.istio.io/v1beta1/Sidecar" -}}
----
-apiVersion: networking.istio.io/v1beta1
-kind: Sidecar
-metadata:
-  name: https
-spec:
-  workloadSelector:
-    labels:
-      {{- include "corda.workerSelectorLabels" ( list . "rest" ) | nindent 6 }}
-  ingress:
-    - port:
-        number: {{ .Values.workers.rest.service.port }}
-        protocol: HTTPS
-        name: https
-{{- end -}}
+{{- include "corda.istioRestWorkerSidecar" . }}

--- a/charts/corda/templates/sidecar.yaml
+++ b/charts/corda/templates/sidecar.yaml
@@ -1,0 +1,16 @@
+{{- if .Capabilities.APIVersions.Has "networking.istio.io/v1beta1/Sidecar" -}}
+---
+apiVersion: networking.istio.io/v1beta1
+kind: Sidecar
+metadata:
+  name: https
+spec:
+  workloadSelector:
+    labels:
+      {{- include "corda.workerSelectorLabels" ( list . "rest" ) | nindent 6 }}
+  ingress:
+    - port:
+        number: {{ .Values.workers.rest.service.port }}
+        protocol: HTTPS
+        name: https
+{{- end -}}

--- a/charts/corda/values.schema.json
+++ b/charts/corda/values.schema.json
@@ -76,6 +76,17 @@
                 ]
             }
         },
+        "commonPodLabels": {
+            "type": "object",
+            "default": {},
+            "title": "extra labels to add to all pods created by deployments",
+            "additionalProperties": {
+                "type": [
+                    "string",
+                    "null"
+                ]
+            }
+        },
         "image": {
             "type": "object",
             "default": {},
@@ -136,12 +147,12 @@
                     ]
                 },
                 "runAsNonRoot": {
-                    "type": "boolean", 
+                    "type": "boolean",
                     "description": "indicates that the container must run as a non-root user",
                     "examples": [
                         true
                     ]
-                }, 
+                },
                 "runAsGroup": {
                     "type": "integer",
                     "title": "specify what group ID that processes will run with",
@@ -164,12 +175,12 @@
                     ]
                 },
                 "procMount": {
-                    "type": "string", 
-                    "description": "denotes the type of proc mount to use for the containers - cannot be set when spec.os.name is windows", 
+                    "type": "string",
+                    "description": "denotes the type of proc mount to use for the containers - cannot be set when spec.os.name is windows",
                     "examples": [
                         "DefaultProcMount"
                     ]
-                }, 
+                },
                 "privileged": {
                     "type": "boolean",
                     "title": "run container in privileged mode",
@@ -185,27 +196,27 @@
                         "add": {
                             "items": {
                                 "type": [
-                                    "string", 
+                                    "string",
                                     "null"
                                 ]
-                            }, 
+                            },
                             "type": [
-                                "array", 
+                                "array",
                                 "null"
-                            ], 
+                            ],
                             "description": "added capabilities"
-                        }, 
+                        },
                         "drop": {
                             "items": {
                                 "type": [
-                                    "string", 
+                                    "string",
                                     "null"
                                 ]
-                            }, 
+                            },
                             "type": [
-                                "array", 
+                                "array",
                                 "null"
-                            ], 
+                            ],
                             "description": "removed capabilities"
                         }
                     }
@@ -276,25 +287,25 @@
             "title": "define privilege and access control settings for a pod",
             "properties": {
                 "runAsNonRoot": {
-                    "type": "boolean", 
+                    "type": "boolean",
                     "description": "indicates that the container must run as a non-root user",
                     "examples": [
                         true
                     ]
-                }, 
+                },
                 "fsGroup": {
-                    "type": "integer", 
-                    "description": "a special supplemental group that applies to all containers in a pod", 
+                    "type": "integer",
+                    "description": "a special supplemental group that applies to all containers in a pod",
                     "format": "int64",
                     "examples": [
                         "1000"
                     ]
                 },
                 "fsGroupChangePolicy": {
-                    "type": "string", 
-                    "description": "defines behavior of changing ownership and permission of the volume before being exposed inside Pod", 
+                    "type": "string",
+                    "description": "defines behavior of changing ownership and permission of the volume before being exposed inside Pod",
                     "enum": ["Always", "OnRootMismatch"]
-                }, 
+                },
                 "seccompProfile": {
                     "type": "object",
                     "description": "the seccomp options to use by the containers in this pod - this field cannot be set if spec.os.name is windows",
@@ -380,26 +391,26 @@
                 },
                 "supplementalGroups": {
                     "items": {
-                        "type": "integer", 
+                        "type": "integer",
                         "format": "int64"
-                    }, 
+                    },
                     "type": [
-                        "array", 
+                        "array",
                         "null"
-                    ], 
+                    ],
                     "description": "a list of groups applied to the first process run in each container, in addition to the container's primary GID"
-                }, 
+                },
                 "runAsUser": {
-                    "type": "integer", 
-                    "description": "The UID to run the entrypoint of the container process", 
+                    "type": "integer",
+                    "description": "The UID to run the entrypoint of the container process",
                     "format": "int64",
                     "examples": [
                         "10001"
                     ]
                 },
                 "runAsGroup": {
-                    "type": "integer", 
-                    "description": "The GID to run the entrypoint of the container process", 
+                    "type": "integer",
+                    "description": "The GID to run the entrypoint of the container process",
                     "format": "int64",
                     "examples": [
                         "10002"
@@ -1034,7 +1045,8 @@
                 "kafka",
                 "image",
                 "resources",
-                "nodeSelector"
+                "nodeSelector",
+                "commonPodLabels"
             ],
             "additionalProperties": false,
             "properties": {
@@ -1645,6 +1657,17 @@
                     "examples": [{
                         "enabled": true
                     }]
+                },
+                "commonPodLabels": {
+                    "type": "object",
+                    "default": {},
+                    "title": "extra labels to add to all pods created by bootstrap jobs",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
                 }
             }
         },

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -586,6 +586,7 @@ bootstrap:
 
   # extra labels to add to all pods created by bootstrap jobs
   commonPodLabels: { }
+
 # config service configuration
 config:
   # the configuration for encryption of configuration

--- a/charts/corda/values.yaml
+++ b/charts/corda/values.yaml
@@ -48,6 +48,9 @@ podSecurityContext:
 # -- extra labels to add to all deployed objects
 commonLabels: {}
 
+# extra labels to add to all pods created by deployments
+commonPodLabels: {}
+
 # -- image pull secrets
 imagePullSecrets: []
 
@@ -581,6 +584,8 @@ bootstrap:
   serviceAccount:
     name: ""
 
+  # extra labels to add to all pods created by bootstrap jobs
+  commonPodLabels: { }
 # config service configuration
 config:
   # the configuration for encryption of configuration


### PR DESCRIPTION
* new fields: `bootstrap.commonPodLabels` and `commonPodLabels`
* required to apply relevant Kubernetes labels for enabling or disabling integration with Istio service mesh for specific parts of Corda, deployments
* cosmetic changes in the schema for values.yaml: removed trailing whitespaces
* cosmetic changes in the schema for prereqs-eks.yaml: removed trailing whitespaces
* enabled Istio integration for Corda workers, and disabled for bootstrap pods in E2E tests
* Istio Sidecar is automaticaly created if API is available