### PR TITLE
CORE-19592: vNode wrapping key rotation never reports as finished

### DIFF
--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -189,7 +189,8 @@ class CryptoRekeyBusProcessor(
             )
 
             State(
-                // using key's uuid and tenantId as key's alias is not available re-wrap processor
+                // Using wrapping key's uuid and tenantId as SM key because wrapping key's alias is not available
+                // in re-wrap bus processor where we also update SM records.
                 getKeyRotationStatusRecordKey(it.first.toString(), request.tenantId),
                 checkNotNull(managedKeyStatusSerializer.serialize(status)),
                 1,

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -189,7 +189,8 @@ class CryptoRekeyBusProcessor(
             )
 
             State(
-                getKeyRotationStatusRecordKey(wrappingKeyAlias, request.tenantId),
+                // using key's uuid and tenantId as key's alias is not available re-wrap processor
+                getKeyRotationStatusRecordKey(it.first.toString(), request.tenantId),
                 checkNotNull(managedKeyStatusSerializer.serialize(status)),
                 1,
                 Metadata(

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyRotationUtils.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/KeyRotationUtils.kt
@@ -31,6 +31,6 @@ object KeyRotationKeyType {
     const val UNMANAGED: String = "unmanaged"
 }
 
-fun getKeyRotationStatusRecordKey(keyAlias: String, tenantId: String) =
-    keyAlias + tenantId + KeyRotationRecordType.KEY_ROTATION
+fun getKeyRotationStatusRecordKey(keyIdentifier: String, tenantId: String) =
+    keyIdentifier + tenantId + KeyRotationRecordType.KEY_ROTATION
 


### PR DESCRIPTION
When running vNodes wrapping key rotation, it never reported back as finished. The problem was that we stored the record in the state manager using key generated by wrapping key's alias. This alias was never available when we tried to update the record (in RewrapBusProcessor) so we tried to find the record using wrapping key's uuid, which could never worked.

**Change**:
- Use key's uuid opposed to alias as state manager record's key as it's available in both crypto processors dealing with state manager records.