### PR TITLE
ES-1931: Ensure we publish a Kafka flavour image of the combined worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@ronanb/ES-1931/create-kafka-combined-worker-docker-image') _
+@Library('corda-shared-build-pipeline-steps@5.2') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.2') _
+@Library('corda-shared-build-pipeline-steps@ronanb/ES-1931/create-kafka-combined-worker-docker-image') _
 
 cordaPipelineKubernetesAgent(
     dailyBuildCron: 'H H/6 * * *',

--- a/buildSrc/src/main/groovy/corda.docker-app.gradle
+++ b/buildSrc/src/main/groovy/corda.docker-app.gradle
@@ -72,4 +72,8 @@ tasks.register('publishOSGiImage', DeployableContainerBuilder) {
     if (project.hasProperty('workerBaseImageTag')) {
         baseImageTag = workerBaseImageTag
     }
+
+    if (project.hasProperty('customImageName')) {
+        overrideContainerName = customImageName
+    }
 }


### PR DESCRIPTION
Expose the value `overrideContainerName` via the gradle `publishOSGiImage` task. This change adds the ability for a user or automation to override the container name at build time. Ultimately, this gives us the ability to publish a kafka-enabled version of the combined worker, which will be named `corda-os-combined-worker-kafka`. By default, this will not affect local publishing or existing CI publishing for other workers, a specific pipeline stage will leverage this, see the associated PR linked below.

**Associated pipeline changes:**
https://github.com/corda/corda-shared-build-pipeline-steps/pull/1595

**Log output from publishing:**
_Normal combined worker_
` Publishing 'corda-os-docker-dev.software.r3.com/corda-os-combined-worker:5.2.0.0-alpha-1707337007665'`
_kafak combined worker_ 
`Publishing 'corda-os-docker-dev.software.r3.com/corda-os-combined-worker-kafka:5.2.0.0-alpha-1707337007665' 
`

 


