### PR TITLE
CORE-19303 - on sync rpc processing failures, set whatever checkpoint we have

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowTimeoutTaskProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowTimeoutTaskProcessor.kt
@@ -82,7 +82,7 @@ class FlowTimeoutTaskProcessor(
         // Flows timed out by the messaging layer + sessions timed out
         stateManager.findByMetadataMatchingAny(
             listOf(
-                // Time out signaled by the messaging layer
+                // Failure or time out signaled by the messaging layer
                 MetadataFilter(PROCESSING_FAILURE, Operation.Equals, true),
                 // Session expired
                 MetadataFilter(STATE_META_SESSION_EXPIRY_KEY, Operation.LesserThan, now().epochSecond),

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessorSyncEventsIntermittentException.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/processor/EventProcessorSyncEventsIntermittentException.kt
@@ -1,0 +1,17 @@
+package net.corda.messaging.mediator.processor
+
+import net.corda.messaging.api.processor.StateAndEventProcessor
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+/**
+ * This exception indicates an intermittent exception happened during processing of synchronous events.
+ *
+ * It contains a partially processed state that can be used for cleanup purposes and marked as failed.
+ *
+ * @param partiallyProcessedState the state with accumulated changes before processing failure
+ * @param cause the throwable that caused the exception
+ */
+class EventProcessorSyncEventsIntermittentException(
+    val partiallyProcessedState: StateAndEventProcessor.State<*>?,
+    cause: Throwable
+) : CordaRuntimeException(cause.message, cause)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
@@ -107,7 +107,7 @@ class EventProcessorTest {
     }
 
     @Test
-    fun `when rpc client fails, with partially created state, null input state, the output contains partially created state and processing failure`() {
+    fun `sync processing fails with partially created state, the output contains this state with processing failure`() {
         val mergedState = mock<State>()
         val mockState = mock<State>()
         val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), null))
@@ -134,7 +134,7 @@ class EventProcessorTest {
     }
 
     @Test
-    fun `when rpc client fails, with null inputState, null processingState, an empty state is output with processing failure`() {
+    fun `sync processing fails with no state, an empty state is output with processing failure`() {
         val mockedState = mock<State>()
         val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), null))
 
@@ -158,7 +158,7 @@ class EventProcessorTest {
     }
 
     @Test
-    fun `when rpc client fails on second loop, with null input state and no partially created state on second loop, it uses current processor state with processing failure`() {
+    fun `sync processing fails on second loop and uses current processor state with processing failure`() {
         val input = mapOf("key" to EventProcessingInput("key", getStringRecords(2, "key"), null))
         val firstLoopUpdatedState = mock<StateAndEventProcessor.State<String>>()
         val mergedState = mock<State>()

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/processor/EventProcessorTest.kt
@@ -15,6 +15,7 @@ import net.corda.messaging.api.processor.StateAndEventProcessor.Response
 import net.corda.messaging.api.records.Record
 import net.corda.messaging.getStringRecords
 import net.corda.messaging.mediator.StateManagerHelper
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -38,9 +40,10 @@ class EventProcessorTest {
     private lateinit var stateAndEventProcessor: StateAndEventProcessor<String, String, String>
     private lateinit var eventProcessor: EventProcessor<String, String, String>
 
-    private val state1: State = mock()
+    private val inputState1: State = mock()
     private val asyncMessage: String = "ASYNC_PAYLOAD"
     private val syncMessage: String = "SYNC_PAYLOAD"
+    private val updatedProcessingState = StateAndEventProcessor.State("bar", null)
 
     @BeforeEach
     @Suppress("unchecked_cast")
@@ -64,7 +67,8 @@ class EventProcessorTest {
 
         whenever(stateAndEventProcessor.onNext(anyOrNull(), any())).thenAnswer {
             Response(
-                StateAndEventProcessor.State("bar", null), listOf(
+                updatedProcessingState,
+                listOf(
                     Record("", "key", asyncMessage),
                     Record("", "key", syncMessage)
                 )
@@ -91,7 +95,7 @@ class EventProcessorTest {
             }
         }
         whenever(client.send(any())).thenReturn(MediatorMessage(syncMessage))
-        val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), state1))
+        val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), inputState1))
         eventProcessor.processEvents(input)
 
         verify(stateManagerHelper, times(1)).deserializeValue(any())
@@ -103,17 +107,76 @@ class EventProcessorTest {
     }
 
     @Test
-    fun `when the rpc client fails to send a message, a state is output with the correct metadata key filled in`() {
+    fun `when rpc client fails, with partially created state, null input state, the output contains partially created state and processing failure`() {
+        val mergedState = mock<State>()
+        val mockState = mock<State>()
+        val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), null))
 
+        val updatedState = mock<StateAndEventProcessor.State<String>>()
         whenever(client.send(any())).thenThrow(CordaMessageAPIIntermittentException("baz"))
-        whenever(stateManagerHelper.failStateProcessing(any(), anyOrNull(), any())).thenReturn(mock())
+        whenever(stateAndEventProcessor.onNext(anyOrNull(), any())).thenAnswer {
+            Response(
+                updatedState,
+                listOf(
+                    Record("", "key", syncMessage)
+                )
+            )
+        }
+        whenever(stateManagerHelper.createOrUpdateState(any(), eq(null), eq(updatedState))).thenReturn(mergedState)
+        whenever(stateManagerHelper.failStateProcessing(any(), eq(mergedState), any())).thenReturn(mockState)
 
-        val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), state1))
         val outputMap = eventProcessor.processEvents(input)
 
         val output = outputMap["key"]
         assertEquals(emptyList<MediatorMessage<Any>>(), output?.asyncOutputs)
-        verify(stateManagerHelper).failStateProcessing(any(), anyOrNull(), any())
+        assertThat(output?.stateChangeAndOperation?.outputState).isEqualTo(mockState)
+        assertThat(output?.stateChangeAndOperation).isInstanceOf(StateChangeAndOperation.Create::class.java)
+    }
+
+    @Test
+    fun `when rpc client fails, with null inputState, null processingState, an empty state is output with processing failure`() {
+        val mockedState = mock<State>()
+        val input = mapOf("key" to EventProcessingInput("key", getStringRecords(1, "key"), null))
+
+        whenever(client.send(any())).thenThrow(CordaMessageAPIIntermittentException("baz"))
+        whenever(stateAndEventProcessor.onNext(anyOrNull(), any())).thenAnswer {
+            Response<State>(
+                null,
+                listOf(
+                    Record("", "key", syncMessage)
+                )
+            )
+        }
+        whenever(stateManagerHelper.failStateProcessing(any(), eq(null), any())).thenReturn(mockedState)
+
+        val outputMap = eventProcessor.processEvents(input)
+
+        val output = outputMap["key"]
+        assertEquals(emptyList<MediatorMessage<Any>>(), output?.asyncOutputs)
+        assertThat(output?.stateChangeAndOperation?.outputState).isEqualTo(mockedState)
+        assertThat(output?.stateChangeAndOperation).isInstanceOf(StateChangeAndOperation.Create::class.java)
+    }
+
+    @Test
+    fun `when rpc client fails on second loop, with null input state and no partially created state on second loop, it uses current processor state with processing failure`() {
+        val input = mapOf("key" to EventProcessingInput("key", getStringRecords(2, "key"), null))
+        val firstLoopUpdatedState = mock<StateAndEventProcessor.State<String>>()
+        val mergedState = mock<State>()
+        val mockedState = mock<State>()
+
+        whenever(stateAndEventProcessor.onNext(anyOrNull(), any()))
+            .thenAnswer { Response(firstLoopUpdatedState, emptyList()) }
+            .thenAnswer { Response<String>(null, listOf(Record("", "key", syncMessage))) }
+        whenever(client.send(any())).thenThrow(CordaMessageAPIIntermittentException("baz"))
+        whenever(stateManagerHelper.createOrUpdateState(any(), eq(null), eq(firstLoopUpdatedState))).thenReturn(mergedState)
+        whenever(stateManagerHelper.failStateProcessing(any(), eq(mergedState), any())).thenReturn(mockedState)
+
+        val outputMap = eventProcessor.processEvents(input)
+
+        val output = outputMap["key"]
+        assertEquals(emptyList<MediatorMessage<Any>>(), output?.asyncOutputs)
+        assertThat(output?.stateChangeAndOperation?.outputState).isEqualTo(mockedState)
+        assertThat(output?.stateChangeAndOperation).isInstanceOf(StateChangeAndOperation.Create::class.java)
     }
 
     private fun buildTestConfig() = EventMediatorConfig(


### PR DESCRIPTION
**Problem description**

Some flows are left in `START_REQUESTED` when external event processing fails. When no checkpoint has been written, we write a state with `null` checkpoint and the `PROCESSING_FAILURE` error flag in the metadata.

The cleanup logic in `TimeoutEventCleanupProcessor` ignores this state because the checkpoint is null. Therefore the flow is never cleaned up, no flow status to indicate the failure is published.

**Solution**

We actually have some state accumulated because the flow engine has processed an event, and produced an output. Store this partially updated state, which contains checkpoint. Flag it as `PROCESSING_FAILURE` so it is ignored and not fed back into the processing queue. The cleanup task can now clean this up as it has the checkpoint.