### PR TITLE
CORE-19619: exclude locations quasar persistence worker

### DIFF
--- a/applications/workers/release/persistence-worker/build.gradle
+++ b/applications/workers/release/persistence-worker/build.gradle
@@ -68,5 +68,5 @@ dependencies {
 }
 
 quasar {
-    excludeLocations = [ 'PERSISTENCE/*' ]
+    excludeLocations = [ '*' ]
 }

--- a/applications/workers/release/persistence-worker/build.gradle
+++ b/applications/workers/release/persistence-worker/build.gradle
@@ -66,3 +66,7 @@ dependencies {
     // NOTE: PLEASE MAKE SURE NOT TO PUBLISH A DOCKER IMAGE PUBLICLY WITH THESE WRAPPED DRIVERS,
     //             UNLESS ABSOLUTELY SURE WE CAN DISTRIBUTE IT!!
 }
+
+quasar {
+    excludeLocations = [ 'PERSISTENCE/*' ]
+}


### PR DESCRIPTION
We have a problem with AMQP in the persistence working failing on quasar instrumentation types, so completely disable  instrumentation within the persistence worker.

E2E test run (shows as aborted but all tests have passed so I think it is indicative) https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda5-e2e-tests/detail/release%2F5.2/653/tests
