### PR TITLE
CORE-19435 Changing FlowStatusDeletionExecutor record key from UUID to String

### DIFF
--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/FlowStatusCleanupProcessor.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/FlowStatusCleanupProcessor.kt
@@ -58,7 +58,7 @@ class FlowStatusCleanupProcessor(
             getStaleFlowStatuses()
                 .map { FlowStatusRecord(it.key, it.value.version) }
                 .chunked(batchSize)
-                .map { Record(REST_FLOW_STATUS_CLEANUP_TOPIC, UUID.randomUUID(), ExecuteFlowStatusCleanup(it)) }
+                .map { Record(REST_FLOW_STATUS_CLEANUP_TOPIC, UUID.randomUUID().toString(), ExecuteFlowStatusCleanup(it)) }
         } ?: emptyList()
     }
 


### PR DESCRIPTION
Previously, the `key` for Records destined for the `FlowStatusDeletionExecutor` were of type UUID. This was causing serialization issues:

```
2024-02-09 11:45:56.707 [durable processing thread flow.status.cleanup.tasks-scheduled.task.flow.status.processor] WARN  net.corda.messagebus.db.producer.CordaTransactionalDBProducerImpl {} - Failed to send record to topic rest.flow.status.cleanup with key 199c7652-766d-4bf4-87a0-8c53c66e3489
net.corda.messaging.api.exception.CordaMessageAPIFatalException: Failed to serialize key
```
caused by
```
net.corda.v5.base.exceptions.CordaRuntimeException: Could not find fingerprint for class java.util.UUID
```

Changing this to a String fixes the problem, and has been confirmed in manual testing.