### PR TITLE
CORE-19579: Close Vault DDL DataSource when getting update schema SQL

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeSchemaHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/asyncoperation/handlers/VirtualNodeSchemaHandler.kt
@@ -56,9 +56,9 @@ internal class VirtualNodeSchemaHandler(
                         ) ?: throw VirtualNodeDbException("Unable to fetch virtual node info")
 
                         val cpkChangeLogs = getCpkChangeLogs(em, virtualNodeSchemaRequest.cpiChecksum)
-                        val connectionVNodeVault =
-                            dbConnectionManager.createDatasource(virtualNodeInfo.vaultDdlConnectionId!!).connection
-                        buildCpkSqlWithStringWriter(cpkChangeLogs, connectionVNodeVault)
+                        dbConnectionManager.createDatasource(virtualNodeInfo.vaultDdlConnectionId!!).use {
+                            buildCpkSqlWithStringWriter(cpkChangeLogs, it.connection)
+                        }
                     }
                 } else {
                     throw IllegalArgumentException("Illegal argument combination for VirtualNodeSchemaRequest")


### PR DESCRIPTION
Closes the vault ddl datasource that was causing a connection leak when using REST endpoint to get update schema SQL