### PR TITLE
ES-1941 Use in demand for downstream jobs triggered by PRs

### DIFF
--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -19,11 +19,18 @@ PipelineUtils pipelineUtils = new PipelineUtils(this)
 @Field
 GitUtils gitUtils = new GitUtils(this)
 
+@Field
+String agentLabel = 'docker'
+
+if (env.CHANGE_ID || gitUtils.isReleaseTag()) {
+    agentLabel = 'docker-on-demand'
+}
+
 pipeline {
     agent {
         docker {
             image 'build-zulu-openjdk:17'
-            label 'docker'
+            label "${agentLabel}"
             registryUrl 'https://engineering-docker.software.r3.com/'
             registryCredentialsId 'artifactory-credentials'
             args '-v /tmp:/host_tmp '


### PR DESCRIPTION
To ensure stability when running PRs, we will now use on-demand instances. This will prevent the possibility (however slim) that a cloud vendor can revoke a spot instances mid-flight. Also, use on-demand for release tag builds.

This has no functional change on the application code but ensures maximum possible stability on PR gates. 