### PR TITLE
CORE-19633 Add corda serializable annotation to ext event parameter class

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindFilteredTransactionsAndSignaturesExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindFilteredTransactionsAndSignaturesExternalEventFactory.kt
@@ -4,6 +4,7 @@ import net.corda.crypto.core.bytes
 import net.corda.data.crypto.SecureHash
 import net.corda.data.ledger.persistence.FindFilteredTransactionsAndSignatures
 import net.corda.flow.external.events.factory.ExternalEventFactory
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.ledger.utxo.StateRef
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -31,6 +32,7 @@ class FindFilteredTransactionsAndSignaturesExternalEventFactory :
     }
 }
 
+@CordaSerializable
 data class FindFilteredTransactionsAndSignaturesParameters(
     val stateRefs: List<StateRef>
 )

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/UpdateTransactionStatusExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/UpdateTransactionStatusExternalEventFactory.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.utxo.flow.impl.persistence.external.events
 import net.corda.data.ledger.persistence.UpdateTransactionStatus
 import net.corda.flow.external.events.factory.ExternalEventFactory
 import net.corda.ledger.common.data.transaction.TransactionStatus
+import net.corda.v5.base.annotations.CordaSerializable
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import java.time.Clock
@@ -18,4 +19,5 @@ class UpdateTransactionStatusExternalEventFactory : AbstractUtxoLedgerExternalEv
     }
 }
 
+@CordaSerializable
 data class UpdateTransactionStatusParameters(val id: String, val transactionStatus: TransactionStatus)


### PR DESCRIPTION
A number of PRs were merged in quick succession which caused conflicts with each other.

External Event Parameters objects must be CordaSerializable. 