### PR TITLE
CORE-19639 Include notary name in baseline builder

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoBaselinedTransactionBuilder.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoBaselinedTransactionBuilder.kt
@@ -208,7 +208,8 @@ class UtxoBaselinedTransactionBuilder private constructor(
      */
     fun diff(): UtxoTransactionBuilderContainer =
         UtxoTransactionBuilderContainer(
-            if (baselineTransactionBuilder.getNotaryName() == null) notaryName else null,
+            // We can include this as we have a check later to make sure that notary name haven't changed
+            notaryName,
             if (baselineTransactionBuilder.timeWindow == null) timeWindow else null,
             commands.drop(baselineTransactionBuilder.commands.size),
             signatories - baselineTransactionBuilder.signatories.toSet(),

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactionbuilder/v1/SendTransactionBuilderDiffFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactionbuilder/v1/SendTransactionBuilderDiffFlowV1Test.kt
@@ -23,6 +23,7 @@ import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionAndS
 import net.corda.v5.membership.NotaryInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
@@ -105,6 +106,7 @@ class SendTransactionBuilderDiffFlowV1Test {
     }
 
     @Test
+    @Disabled("No longer relevant as notary always needs to be provided")
     fun `called with old notary and a different new notary sends back a builder without notary`() {
         whenever(originalTransactionalBuilder.getNotaryName()).thenReturn(anotherNotaryX500Name)
         whenever(currentTransactionBuilder.notaryName).thenReturn(notaryX500Name)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoBaselinedTransactionBuilderDiffTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoBaselinedTransactionBuilderDiffTest.kt
@@ -44,11 +44,11 @@ class UtxoBaselinedTransactionBuilderDiffTest : UtxoLedgerTest() {
     }
 
     @Test
-    fun `diff - notary does not get set when original is not null`() {
+    fun `diff - notary always gets set`() {
         val result =
             UtxoBaselinedTransactionBuilder(utxoTransactionBuilder.setNotary(notaryX500Name) as UtxoTransactionBuilderInternal)
                 .diff()
-        assertNull(result.getNotaryName())
+        assertEquals(notaryX500Name, result.getNotaryName())
     }
 
     @Test


### PR DESCRIPTION
Since notary name is mandatory in all builders now we need to include it in the baseline builder's `diff` function.