### PR TITLE
CORE-19306: POC for async RPC

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/RPCClient.kt
@@ -45,21 +45,21 @@ class RPCClient(
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
-    private val pendingResponses = LinkedList<CompletableFuture<MediatorMessage<*>>>()
+  //  private val requestQueue = LinkedList<Pair<MediatorMessage<*>, CompletableFuture<MediatorMessage<*>>>>()
 
     override fun send(message: MediatorMessage<*>): CompletableFuture<MediatorMessage<*>>? {
         val future = CompletableFuture<MediatorMessage<*>>()
-        pendingResponses.addLast(future)
-        pollPendingResponses(future)
+       // requestQueue.offer(message to future)
         return future
     }
 
-    private fun pollPendingResponses(future: CompletableFuture<MediatorMessage<*>>?, message: MediatorMessage<*>) {
-        if (pendingResponses.isNotEmpty()) {
+    private fun pollPendingResponses(requestQueue: LinkedList<Pair<MediatorMessage<*>, CompletableFuture<MediatorMessage<*>>>>) {
+        while (requestQueue.isNotEmpty()) {
+            val (message, future) = requestQueue.removeFirst()
             try {
-                future.complete(processMessage(message))
+                future!!.complete(processMessage(message))
             } catch (e: Exception) {
-                future.completeExceptionally(handleExceptions(e, message.endpoint()))
+                future!!.completeExceptionally(handleExceptions(e, message.endpoint()))
             }
         }
     }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
@@ -29,4 +29,5 @@ interface MessagingClient : AutoCloseable {
      * @return Computation result, or null if the destination doesn't provide a response.
      * */
     fun send(message: MediatorMessage<*>): CompletableFuture<*>?
+
 }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/MessagingClient.kt
@@ -1,5 +1,7 @@
 package net.corda.messaging.api.mediator
 
+import java.util.concurrent.CompletableFuture
+
 /**
  * Multi-source event mediator messaging client.
  */
@@ -26,5 +28,5 @@ interface MessagingClient : AutoCloseable {
      * @param message The [MediatorMessage] to send.
      * @return Computation result, or null if the destination doesn't provide a response.
      * */
-    fun send(message: MediatorMessage<*>): MediatorMessage<*>?
+    fun send(message: MediatorMessage<*>): CompletableFuture<*>?
 }


### PR DESCRIPTION
RPCClient has a send API and takes a MediatorMessage and waits and blocks until it gets a response back in the form of a MediatorMessage. 

We want to change this, so the RPCClient send will make async sends and will return a CompletableFuture<Result> instead.