### PR TITLE
CORE-19558: Fix app simulator script

### DIFF
--- a/applications/tools/p2p-test/app-simulator/charts/app-simulator-db/Chart.lock
+++ b/applications/tools/p2p-test/app-simulator/charts/app-simulator-db/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.13
-digest: sha256:c16bf201546beaa66e177d27f5298b558f9922008b3ab1fc763a0990717c1424
-generated: "2023-05-23T14:20:52.660577+01:00"
+  version: 13.4.1
+digest: sha256:a8797417e2b63d76fa237c5528527ca23021f4b5815299e9ebd891486f95abb8
+generated: "2024-02-12T15:12:47.434307519Z"

--- a/applications/tools/p2p-test/app-simulator/charts/app-simulator-db/values.yaml
+++ b/applications/tools/p2p-test/app-simulator/charts/app-simulator-db/values.yaml
@@ -1,3 +1,8 @@
+global:
+  imageRegistry: docker-remotes.software.r3.com
+  imagePullSecrets:
+    - docker-registry-cred
+
 # values for configuring bitnami/postgres sub-chart.
 postgresql:
   # values configuring the permissions of volumes.

--- a/applications/tools/p2p-test/app-simulator/scripts/corda-eks.metrics.yaml
+++ b/applications/tools/p2p-test/app-simulator/scripts/corda-eks.metrics.yaml
@@ -8,5 +8,3 @@ metrics:
     enabled: true
     labels:
       release: observability
-    keepNames: [ ]
-    dropLabels: []

--- a/applications/tools/p2p-test/app-simulator/scripts/prereqs-eks-large.yaml
+++ b/applications/tools/p2p-test/app-simulator/scripts/prereqs-eks-large.yaml
@@ -1,3 +1,8 @@
+global:
+  imageRegistry: docker-remotes.software.r3.com
+  imagePullSecrets:
+    - docker-registry-cred
+
 kafka:
   resources:
     requests:

--- a/applications/tools/p2p-test/app-simulator/scripts/prereqs-eks-small.yaml
+++ b/applications/tools/p2p-test/app-simulator/scripts/prereqs-eks-small.yaml
@@ -1,3 +1,8 @@
+global:
+  imageRegistry: docker-remotes.software.r3.com
+  imagePullSecrets:
+    - docker-registry-cred
+
 kafka:
   resources:
     requests:


### PR DESCRIPTION
Fix a few issues with the app simulator helm charts:
* Add `imageRegistry: docker-remotes.software.r3.com` when needed.
* Remove the `keepNames` and `dropLabels`.
* Set starting latencies to be valid numbers.
* Save the slowest messages into a report file.