### PR TITLE
CORE-19664: Add default pool config when creating vNode with external connection strings

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -90,10 +90,6 @@ internal class VirtualNodeDbFactoryImpl(
         val usingClusterDb = dmlConfig.isNullOrBlank()
         val noUniquenessDb = dbType == UNIQUENESS && dmlConfig == "none"
 
-        println(ddlConfig)
-        println(dmlConfig)
-        println(virtualNodesDdlPoolConfig)
-
         val dbConnections =
             if (usingClusterDb) {
                 mapOf(
@@ -145,20 +141,22 @@ internal class VirtualNodeDbFactoryImpl(
         config: String
     ): DbConnectionImpl {
         with(dbType) {
-            var smartConfig = config.toSmartConfig()
-            if (!config.contains("\"pool\":")) {
+            val smartConfig = config.toSmartConfig()
+            val smartConfigWithPool = if (!config.contains("\"pool\":")) {
                 val virtualNodePoolConfig = smartConfigFactory.create(
                     when (dbPrivilege) {
                         DDL -> virtualNodesDdlPoolConfig
                         DML -> virtualNodesDmlPoolConfig
                     }
                 )
-                smartConfig = createVirtualNodePoolConfig(smartConfig, virtualNodePoolConfig)
+                createVirtualNodePoolConfig(smartConfig, virtualNodePoolConfig)
+            } else {
+                config.toSmartConfig()
             }
             return DbConnectionImpl(
                 getConnectionName(holdingIdentityShortHash),
                 dbPrivilege,
-                smartConfig,
+                smartConfigWithPool,
                 getConnectionDescription(dbPrivilege, holdingIdentityShortHash)
             )
         }

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -255,14 +255,14 @@ private fun createVirtualNodePoolConfig(
     val maxPoolSize = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_POOL_MAX_SIZE)
     var configWithPool = config.withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(maxPoolSize))
 
-    configWithPool = if (virtualNodePoolConfig.hasPath(VirtualNodeDatasourceConfig.VNODE_POOL_MIN_SIZE)) {
+    if (virtualNodePoolConfig.hasPath(VirtualNodeDatasourceConfig.VNODE_POOL_MIN_SIZE)) {
         val minPoolSize = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_POOL_MIN_SIZE)
-        configWithPool.withValue(
+        configWithPool = configWithPool.withValue(
             DatabaseConfig.DB_POOL_MIN_SIZE,
             ConfigValueFactory.fromAnyRef(minPoolSize)
         )
-    } else {
-        configWithPool.withoutPath(DatabaseConfig.DB_POOL_MIN_SIZE)
+    } else if (configWithPool.hasPath(DatabaseConfig.DB_POOL_MIN_SIZE)) {
+        configWithPool = configWithPool.withoutPath(DatabaseConfig.DB_POOL_MIN_SIZE)
     }
 
     val idleTimeout = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_POOL_IDLE_TIMEOUT_SECONDS)

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeDbFactoryImpl.kt
@@ -90,6 +90,10 @@ internal class VirtualNodeDbFactoryImpl(
         val usingClusterDb = dmlConfig.isNullOrBlank()
         val noUniquenessDb = dbType == UNIQUENESS && dmlConfig == "none"
 
+        println(ddlConfig)
+        println(dmlConfig)
+        println(virtualNodesDdlPoolConfig)
+
         val dbConnections =
             if (usingClusterDb) {
                 mapOf(
@@ -141,10 +145,20 @@ internal class VirtualNodeDbFactoryImpl(
         config: String
     ): DbConnectionImpl {
         with(dbType) {
+            var smartConfig = config.toSmartConfig()
+            if (!config.contains("\"pool\":")) {
+                val virtualNodePoolConfig = smartConfigFactory.create(
+                    when (dbPrivilege) {
+                        DDL -> virtualNodesDdlPoolConfig
+                        DML -> virtualNodesDmlPoolConfig
+                    }
+                )
+                smartConfig = createVirtualNodePoolConfig(smartConfig, virtualNodePoolConfig)
+            }
             return DbConnectionImpl(
                 getConnectionName(holdingIdentityShortHash),
                 dbPrivilege,
-                config.toSmartConfig(),
+                smartConfig,
                 getConnectionDescription(dbPrivilege, holdingIdentityShortHash)
             )
         }
@@ -236,22 +250,44 @@ private fun createVirtualNodeDbConfig(
     }
     config = config.withValue(DatabaseConfig.JDBC_URL, ConfigValueFactory.fromAnyRef(jdbcUrl))
 
+    config = createVirtualNodePoolConfig(config, virtualNodePoolConfig)
+
+    return config
+}
+
+private fun createVirtualNodePoolConfig(
+    config: SmartConfig,
+    virtualNodePoolConfig: SmartConfig
+): SmartConfig {
     val maxPoolSize = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_POOL_MAX_SIZE)
-    config = config.withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(maxPoolSize))
+    var configWithPool = config.withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(maxPoolSize))
 
     if (virtualNodePoolConfig.hasPath(VirtualNodeDatasourceConfig.VNODE_POOL_MIN_SIZE)) {
         val minPoolSize = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_POOL_MIN_SIZE)
-        config = config.withValue(DatabaseConfig.DB_POOL_MIN_SIZE, ConfigValueFactory.fromAnyRef(minPoolSize))
+        configWithPool =
+            configWithPool.withValue(DatabaseConfig.DB_POOL_MIN_SIZE, ConfigValueFactory.fromAnyRef(minPoolSize))
     }
 
     val idleTimeout = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_POOL_IDLE_TIMEOUT_SECONDS)
-    config = config.withValue(DatabaseConfig.DB_POOL_IDLE_TIMEOUT_SECONDS, ConfigValueFactory.fromAnyRef(idleTimeout))
+    configWithPool = configWithPool.withValue(
+        DatabaseConfig.DB_POOL_IDLE_TIMEOUT_SECONDS,
+        ConfigValueFactory.fromAnyRef(idleTimeout)
+    )
     val maxLifetime = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_POOL_MAX_LIFETIME_SECONDS)
-    config = config.withValue(DatabaseConfig.DB_POOL_MAX_LIFETIME_SECONDS, ConfigValueFactory.fromAnyRef(maxLifetime))
+    configWithPool = configWithPool.withValue(
+        DatabaseConfig.DB_POOL_MAX_LIFETIME_SECONDS,
+        ConfigValueFactory.fromAnyRef(maxLifetime)
+    )
     val keepaliveTime = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_POOL_KEEPALIVE_TIME_SECONDS)
-    config = config.withValue(DatabaseConfig.DB_POOL_KEEPALIVE_TIME_SECONDS, ConfigValueFactory.fromAnyRef(keepaliveTime))
+    configWithPool = configWithPool.withValue(
+        DatabaseConfig.DB_POOL_KEEPALIVE_TIME_SECONDS,
+        ConfigValueFactory.fromAnyRef(keepaliveTime)
+    )
     val validationTimeout = virtualNodePoolConfig.getInt(VirtualNodeDatasourceConfig.VNODE_VALIDATION_TIMEOUT_SECONDS)
-    config = config.withValue(DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT_SECONDS, ConfigValueFactory.fromAnyRef(validationTimeout))
+    configWithPool = configWithPool.withValue(
+        DatabaseConfig.DB_POOL_VALIDATION_TIMEOUT_SECONDS,
+        ConfigValueFactory.fromAnyRef(validationTimeout)
+    )
 
-    return config
+    return configWithPool
 }

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -135,7 +135,6 @@ class VirtualNodeDbFactoryImplTest {
         )
 
         val vaultDdlConfig = dbs[VirtualNodeDbType.VAULT]?.dbConnections?.get(DbPrivilege.DDL)?.config!!
-        println(vaultDdlConfig)
         verify(vaultDdlConfig, never()).withValue(eq(DatabaseConfig.JDBC_DRIVER), any())
         verify(vaultDdlConfig).withValue(DatabaseConfig.JDBC_URL, ConfigValueFactory.fromAnyRef(JDBC_URL))
         verify(vaultDdlConfig).withValue(DatabaseConfig.DB_POOL_MAX_SIZE, ConfigValueFactory.fromAnyRef(1))

--- a/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/test/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeDbFactoryImplTest.kt
@@ -156,8 +156,19 @@ class VirtualNodeDbFactoryImplTest {
     }
 
     @Test
+    @Suppress("MaxLineLength")
     fun `createVNodeDbs with custom pool config values in external connection strings creates VNode datasource configuration with default pool values`() {
-        val externalConnectionString = "{\"database\":{\"jdbc\":{\"url\":\"\"},\"pass\":\"\",\"pool\":{\"idleTimeoutSeconds\":999,\"keepaliveTimeSeconds\":999,\"maxLifetimeSeconds\":999,\"max_size\":999,\"min_size\":999,\"validationTimeoutSeconds\":999},\"user\":\"\"}}"
+        val externalConnectionString = """
+            {"database":{"jdbc":{"url":""},"pass":"","user":"",
+            "pool":{
+            "idleTimeoutSeconds":999,
+            "keepaliveTimeSeconds":999,
+            "maxLifetimeSeconds":999,
+            "max_size":999,
+            "min_size":999,
+            "validationTimeoutSeconds":999
+            }}}
+        """.trimIndent()
         val request = VirtualNodeConnectionStrings(
             /* vaultDdlConnection = */
             externalConnectionString,


### PR DESCRIPTION
If the user is creating a virtual node with external connection strings, but doesn't specify the pool config, using that virtual node will cause connections to accumulate.

Refactored config code to allow external connection strings to use the same pool config parameters as a cluster connection