### PR TITLE
CORE-19662 scheduled job calls the wrong state manager API when filtering

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowCheckpointTerminationTaskProcessor.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/maintenance/FlowCheckpointTerminationTaskProcessor.kt
@@ -65,7 +65,7 @@ class FlowCheckpointTerminationTaskProcessor(
 
     private fun getExpiredStateIds(): List<String> {
         val windowExpiry = clock.instant() - Duration.ofMillis(checkpointTerminationTimeMilliseconds)
-        val states = stateManager.findUpdatedBetweenWithMetadataMatchingAny(
+        val states = stateManager.findUpdatedBetweenWithMetadataMatchingAll(
             IntervalFilter(Instant.EPOCH, windowExpiry),
             listOf(
                 MetadataFilter(STATE_TYPE, Operation.Equals, Checkpoint::class.java.name),


### PR DESCRIPTION
The query should match all filters, not just any