### PR TITLE
CORE-16539 - Added clearer error message for port problem

### DIFF
--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/ComplexDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/ComplexDominoTile.kt
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory
  */
 @Suppress("LongParameterList", "TooManyFunctions")
 class ComplexDominoTile(
-    componentName: String,
+    private val componentName: String,
     coordinatorFactory: LifecycleCoordinatorFactory,
     private val onStart: (() -> Unit)? = null,
     private val onClose: (() -> Unit)? = null,
@@ -228,7 +228,8 @@ class ComplexDominoTile(
                             logger.warn("Config error ${event.configUpdateResult.e}")
                             stopResources()
                             updateState(StoppedDueToBadConfig, event.configUpdateResult.e.message)
-                            logger.warn("Component has been stopped.")
+                            logger.warn("Component $componentName has been stopped. " +
+                                    "Due to: ${event.configUpdateResult.e.message}")
                         }
                         ConfigUpdateResult.NoUpdate -> {
                             logger.info("Config applied with no update.")

--- a/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/ComplexDominoTileTest.kt
+++ b/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/ComplexDominoTileTest.kt
@@ -390,8 +390,10 @@ class ComplexDominoTileTest {
             val tile = tile()
             tile.start()
 
+            val expMsg = "Bad config"
             configurationHandler.firstValue.onNewConfiguration(setOf(key), mapOf(key to config))
-            outerConfigUpdateResult!!.completeExceptionally(RuntimeException("Bad config"))
+            outerConfigUpdateResult!!.completeExceptionally(RuntimeException(expMsg))
+            verify(coordinator).updateStatus(LifecycleStatus.DOWN, expMsg)
 
             assertThat(tile.isRunning).isFalse
             configurationHandler.firstValue.onNewConfiguration(setOf(key), mapOf(key to config))

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServer.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServer.kt
@@ -27,8 +27,6 @@ internal class ReconfigurableHttpServer(
     private val listener: RequestListener,
     private val commonComponents: CommonComponents,
     private val dynamicCertificateSubjectStore: DynamicCertificateSubjectStore,
-    // added for unit testing
-    private val overrideHttpServer: HttpServer? = null
 ) : LifecycleWithDominoTile {
 
     private data class ServerKey(
@@ -107,13 +105,13 @@ internal class ReconfigurableHttpServer(
                                             "${serverConfiguration.hostAddress}:${serverConfiguration.hostPort}$urlPath",
                                 )
                             }
-                            (overrideHttpServer ?: HttpServer(
+                            HttpServer(
                                 listener,
                                 newConfiguration.maxRequestSize,
                                 serverConfiguration,
                                 commonComponents.dynamicKeyStore.serverKeyStore,
                                 mutualTlsTrustManager,
-                            )).also {
+                            ).also {
                                 try {
                                     it.start()
                                 } catch (e: BindException) {

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServerTest.kt
@@ -30,7 +30,6 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import java.net.BindException
 import java.net.InetSocketAddress
 
 class ReconfigurableHttpServerTest {
@@ -260,22 +259,5 @@ class ReconfigurableHttpServerTest {
             )
 
         assertThat(future).isCompletedWithValue(Unit)
-    }
-
-    @Test
-    fun `applyNewConfiguration completes exceptionally when address is already in use`() {
-        val server = mock<HttpServer> {
-            on { start() } doAnswer { throw BindException("Address already in use") }
-        }
-        ReconfigurableHttpServer(
-            lifecycleCoordinatorFactory,
-            configurationReaderService,
-            listener,
-            commonComponents,
-            mock(),
-            server,
-        )
-        val future = configHandler.applyNewConfiguration(configuration, null, resourcesHolder)
-        assertThat(future).isCompletedExceptionally
     }
 }

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/ReconfigurableHttpServerTest.kt
@@ -30,6 +30,7 @@ import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.net.BindException
 import java.net.InetSocketAddress
 
 class ReconfigurableHttpServerTest {
@@ -259,5 +260,22 @@ class ReconfigurableHttpServerTest {
             )
 
         assertThat(future).isCompletedWithValue(Unit)
+    }
+
+    @Test
+    fun `applyNewConfiguration completes exceptionally when address is already in use`() {
+        val server = mock<HttpServer> {
+            on { start() } doAnswer { throw BindException("Address already in use") }
+        }
+        ReconfigurableHttpServer(
+            lifecycleCoordinatorFactory,
+            configurationReaderService,
+            listener,
+            commonComponents,
+            mock(),
+            server,
+        )
+        val future = configHandler.applyNewConfiguration(configuration, null, resourcesHolder)
+        assertThat(future).isCompletedExceptionally
     }
 }


### PR DESCRIPTION
When BindException was thrown we were not stating which host and port should be available and able to listen.
We only had stated that the component went down in the reason message and haven't provided any details. Example:
`"ReconfigurableHttpServer-1":{"name":{"componentName":"ReconfigurableHttpServer","instanceId":"1"},"status":"DOWN","reason":"Status has changed to DOWN"}`
I've added the exception message to be shown.
After testing, the log message was:
```
2024-02-15 14:52:43.592 [lifecycle-coordinator-1] WARN  ReconfigurableHttpServer-1 {} - Config error net.corda.v5.base.exceptions.CordaRuntimeException: Failed to connect on '0.0.0.0:8080' address. Please make sure the required address is not in use and could be accessed.
2024-02-15 14:52:43.592 [lifecycle-coordinator-1] INFO  ReconfigurableHttpServer-1 {} - Stopping resources
2024-02-15 14:52:43.592 [lifecycle-coordinator-1] INFO  ReconfigurableHttpServer-1 {} - State updated from Created to StoppedDueToBadConfig
2024-02-15 14:52:43.592 [lifecycle-coordinator-1] WARN  ReconfigurableHttpServer-1 {} - Component ReconfigurableHttpServer has been stopped. Due to: Failed to connect on '0.0.0.0:8080' address. Please make sure the required address is not in use and could be accessed.
```
And the status became:
```
"ReconfigurableHttpServer-1":{"name":{"componentName":"ReconfigurableHttpServer","instanceId":"1"},"status":"DOWN","reason":"Failed to connect on '0.0.0.0:8080' address. Please make sure the required address is not in use and could be accessed."}
```
