### PR TITLE
CORE-19559: Change create vNode DB connection strings to nested objects

### DIFF
--- a/components/virtual-node/virtual-node-rest-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-rest-service-impl/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:messaging:messaging')
     implementation project(':libs:membership:membership-common')
-    implementation project(':libs:rest:json-serialization')
     implementation project(':libs:utilities')
     implementation project(':libs:platform-info')
     implementation 'net.corda:corda-avro-schema'
@@ -37,4 +36,6 @@ dependencies {
     implementation 'net.corda:corda-topic-schema'
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation libs.slf4j.api
+
+    testImplementation project(':libs:rest:json-serialization')
 }

--- a/components/virtual-node/virtual-node-rest-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-rest-service-impl/build.gradle
@@ -8,6 +8,7 @@ description "Virtual Node REST Resource Implementation"
 ext.cordaEnableFormatting = true
 
 dependencies {
+
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 
@@ -27,6 +28,7 @@ dependencies {
     implementation project(':libs:lifecycle:lifecycle')
     implementation project(':libs:messaging:messaging')
     implementation project(':libs:membership:membership-common')
+    implementation project(':libs:rest:json-serialization')
     implementation project(':libs:utilities')
     implementation project(':libs:platform-info')
     implementation 'net.corda:corda-avro-schema'

--- a/components/virtual-node/virtual-node-rest-service-impl/build.gradle
+++ b/components/virtual-node/virtual-node-rest-service-impl/build.gradle
@@ -8,7 +8,6 @@ description "Virtual Node REST Resource Implementation"
 ext.cordaEnableFormatting = true
 
 dependencies {
-
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:org.osgi.service.component.annotations'
 

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/RequestFactory.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/RequestFactory.kt
@@ -1,16 +1,16 @@
 package net.corda.virtualnode.rest.factories
 
 import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.virtualnode.HoldingIdentity
 
 internal interface RequestFactory {
-    fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity
+    fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequestType): HoldingIdentity
 
     fun createVirtualNodeRequest(
         holdingIdentity: HoldingIdentity,
-        request: CreateVirtualNodeRequest
+        request: CreateVirtualNodeRequestType
     ): VirtualNodeAsynchronousRequest
 
     fun updateVirtualNodeDbRequest(

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/RequestFactory.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/RequestFactory.kt
@@ -2,15 +2,23 @@ package net.corda.virtualnode.rest.factories
 
 import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.virtualnode.HoldingIdentity
 
 internal interface RequestFactory {
-    fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity
+    fun createHoldingIdentityDeprecated(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity
+
+    fun createHoldingIdentity(groupId: String, request: JsonCreateVirtualNodeRequest): HoldingIdentity
+
+    fun createVirtualNodeRequestDeprecated(
+        holdingIdentity: HoldingIdentity,
+        request: CreateVirtualNodeRequest
+    ): VirtualNodeAsynchronousRequest
 
     fun createVirtualNodeRequest(
         holdingIdentity: HoldingIdentity,
-        request: CreateVirtualNodeRequest
+        request: JsonCreateVirtualNodeRequest
     ): VirtualNodeAsynchronousRequest
 
     fun updateVirtualNodeDbRequest(

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/RequestFactory.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/RequestFactory.kt
@@ -7,11 +7,11 @@ import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.virtualnode.HoldingIdentity
 
 internal interface RequestFactory {
-    fun createHoldingIdentityDeprecated(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity
+    fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity
 
     fun createHoldingIdentity(groupId: String, request: JsonCreateVirtualNodeRequest): HoldingIdentity
 
-    fun createVirtualNodeRequestDeprecated(
+    fun createVirtualNodeRequest(
         holdingIdentity: HoldingIdentity,
         request: CreateVirtualNodeRequest
     ): VirtualNodeAsynchronousRequest

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/RequestFactory.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/RequestFactory.kt
@@ -2,23 +2,15 @@ package net.corda.virtualnode.rest.factories
 
 import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.virtualnode.HoldingIdentity
 
 internal interface RequestFactory {
     fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity
 
-    fun createHoldingIdentity(groupId: String, request: JsonCreateVirtualNodeRequest): HoldingIdentity
-
     fun createVirtualNodeRequest(
         holdingIdentity: HoldingIdentity,
         request: CreateVirtualNodeRequest
-    ): VirtualNodeAsynchronousRequest
-
-    fun createVirtualNodeRequest(
-        holdingIdentity: HoldingIdentity,
-        request: JsonCreateVirtualNodeRequest
     ): VirtualNodeAsynchronousRequest
 
     fun updateVirtualNodeDbRequest(

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
@@ -18,7 +18,7 @@ internal class RequestFactoryImpl(
     private val restContextProvider: RestContextProvider,
     private val clock: Clock
 ) : RequestFactory {
-    override fun createHoldingIdentityDeprecated(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity {
+    override fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity {
         return HoldingIdentity(MemberX500Name.parse(request.x500Name), groupId)
     }
 
@@ -26,7 +26,7 @@ internal class RequestFactoryImpl(
         return HoldingIdentity(MemberX500Name.parse(request.x500Name), groupId)
     }
 
-    override fun createVirtualNodeRequestDeprecated(
+    override fun createVirtualNodeRequest(
         holdingIdentity: HoldingIdentity,
         request: CreateVirtualNodeRequest
     ): VirtualNodeAsynchronousRequest {

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
@@ -4,7 +4,8 @@ import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
 import net.corda.data.virtualnode.VirtualNodeDbConnectionUpdateRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.DeprecatedCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.rest.security.RestContextProvider
 import net.corda.utilities.time.Clock
@@ -22,10 +23,6 @@ internal class RequestFactoryImpl(
         return HoldingIdentity(MemberX500Name.parse(request.x500Name), groupId)
     }
 
-    override fun createHoldingIdentity(groupId: String, request: JsonCreateVirtualNodeRequest): HoldingIdentity {
-        return HoldingIdentity(MemberX500Name.parse(request.x500Name), groupId)
-    }
-
     override fun createVirtualNodeRequest(
         holdingIdentity: HoldingIdentity,
         request: CreateVirtualNodeRequest
@@ -36,34 +33,26 @@ internal class RequestFactoryImpl(
             this.request = VirtualNodeCreateRequest().apply {
                 this.holdingId = holdingIdentity.toAvro()
                 this.cpiFileChecksum = request.cpiFileChecksum
-                this.vaultDdlConnection = request.vaultDdlConnection
-                this.vaultDmlConnection = request.vaultDmlConnection
-                this.cryptoDdlConnection = request.cryptoDdlConnection
-                this.cryptoDmlConnection = request.cryptoDmlConnection
-                this.uniquenessDdlConnection = request.uniquenessDdlConnection
-                this.uniquenessDmlConnection = request.uniquenessDmlConnection
                 this.updateActor = restContextProvider.principal
-            }
-        }
-    }
+                when (request) {
+                    is DeprecatedCreateVirtualNodeRequest -> {
+                        this.vaultDdlConnection = request.vaultDdlConnection
+                        this.vaultDmlConnection = request.vaultDmlConnection
+                        this.cryptoDdlConnection = request.cryptoDdlConnection
+                        this.cryptoDmlConnection = request.cryptoDmlConnection
+                        this.uniquenessDdlConnection = request.uniquenessDdlConnection
+                        this.uniquenessDmlConnection = request.uniquenessDmlConnection
+                    }
 
-    override fun createVirtualNodeRequest(
-        holdingIdentity: HoldingIdentity,
-        request: JsonCreateVirtualNodeRequest
-    ): VirtualNodeAsynchronousRequest {
-        return VirtualNodeAsynchronousRequest().apply {
-            this.requestId = holdingIdentity.shortHash.toString()
-            this.timestamp = clock.instant()
-            this.request = VirtualNodeCreateRequest().apply {
-                this.holdingId = holdingIdentity.toAvro()
-                this.cpiFileChecksum = request.cpiFileChecksum
-                this.vaultDdlConnection = request.vaultDdlConnection?.escapedJson
-                this.vaultDmlConnection = request.vaultDmlConnection?.escapedJson
-                this.cryptoDdlConnection = request.cryptoDdlConnection?.escapedJson
-                this.cryptoDmlConnection = request.cryptoDmlConnection?.escapedJson
-                this.uniquenessDdlConnection = request.uniquenessDdlConnection?.escapedJson
-                this.uniquenessDmlConnection = request.uniquenessDmlConnection?.escapedJson
-                this.updateActor = restContextProvider.principal
+                    is JsonCreateVirtualNodeRequest -> {
+                        this.vaultDdlConnection = request.vaultDdlConnection?.escapedJson
+                        this.vaultDmlConnection = request.vaultDmlConnection?.escapedJson
+                        this.cryptoDdlConnection = request.cryptoDdlConnection?.escapedJson
+                        this.cryptoDmlConnection = request.cryptoDmlConnection?.escapedJson
+                        this.uniquenessDdlConnection = request.uniquenessDdlConnection?.escapedJson
+                        this.uniquenessDmlConnection = request.uniquenessDmlConnection?.escapedJson
+                    }
+                }
             }
         }
     }

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
@@ -4,6 +4,7 @@ import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
 import net.corda.data.virtualnode.VirtualNodeDbConnectionUpdateRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.rest.security.RestContextProvider
 import net.corda.utilities.time.Clock
@@ -11,20 +12,44 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.rest.factories.RequestFactory
 import net.corda.virtualnode.toAvro
-import java.util.*
+import java.util.UUID
 
 internal class RequestFactoryImpl(
     private val restContextProvider: RestContextProvider,
     private val clock: Clock
 ) : RequestFactory {
-
-    override fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity {
+    override fun createHoldingIdentityDeprecated(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity {
         return HoldingIdentity(MemberX500Name.parse(request.x500Name), groupId)
+    }
+
+    override fun createHoldingIdentity(groupId: String, request: JsonCreateVirtualNodeRequest): HoldingIdentity {
+        return HoldingIdentity(MemberX500Name.parse(request.x500Name), groupId)
+    }
+
+    override fun createVirtualNodeRequestDeprecated(
+        holdingIdentity: HoldingIdentity,
+        request: CreateVirtualNodeRequest
+    ): VirtualNodeAsynchronousRequest {
+        return VirtualNodeAsynchronousRequest().apply {
+            this.requestId = holdingIdentity.shortHash.toString()
+            this.timestamp = clock.instant()
+            this.request = VirtualNodeCreateRequest().apply {
+                this.holdingId = holdingIdentity.toAvro()
+                this.cpiFileChecksum = request.cpiFileChecksum
+                this.vaultDdlConnection = request.vaultDdlConnection
+                this.vaultDmlConnection = request.vaultDmlConnection
+                this.cryptoDdlConnection = request.cryptoDdlConnection
+                this.cryptoDmlConnection = request.cryptoDmlConnection
+                this.uniquenessDdlConnection = request.uniquenessDdlConnection
+                this.uniquenessDmlConnection = request.uniquenessDmlConnection
+                this.updateActor = restContextProvider.principal
+            }
+        }
     }
 
     override fun createVirtualNodeRequest(
         holdingIdentity: HoldingIdentity,
-        request: CreateVirtualNodeRequest
+        request: JsonCreateVirtualNodeRequest
     ): VirtualNodeAsynchronousRequest {
         return VirtualNodeAsynchronousRequest().apply {
             this.requestId = holdingIdentity.shortHash.toString()

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
@@ -32,12 +32,12 @@ internal class RequestFactoryImpl(
             this.request = VirtualNodeCreateRequest().apply {
                 this.holdingId = holdingIdentity.toAvro()
                 this.cpiFileChecksum = request.cpiFileChecksum
-                this.vaultDdlConnection = request.vaultDdlConnection
-                this.vaultDmlConnection = request.vaultDmlConnection
-                this.cryptoDdlConnection = request.cryptoDdlConnection
-                this.cryptoDmlConnection = request.cryptoDmlConnection
-                this.uniquenessDdlConnection = request.uniquenessDdlConnection
-                this.uniquenessDmlConnection = request.uniquenessDmlConnection
+                this.vaultDdlConnection = request.vaultDdlConnection?.escapedJson
+                this.vaultDmlConnection = request.vaultDmlConnection?.escapedJson
+                this.cryptoDdlConnection = request.cryptoDdlConnection?.escapedJson
+                this.cryptoDmlConnection = request.cryptoDmlConnection?.escapedJson
+                this.uniquenessDdlConnection = request.uniquenessDdlConnection?.escapedJson
+                this.uniquenessDmlConnection = request.uniquenessDmlConnection?.escapedJson
                 this.updateActor = restContextProvider.principal
             }
         }

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImpl.kt
@@ -3,9 +3,9 @@ package net.corda.virtualnode.rest.factories.impl
 import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
 import net.corda.data.virtualnode.VirtualNodeDbConnectionUpdateRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.DeprecatedCreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.rest.security.RestContextProvider
 import net.corda.utilities.time.Clock
@@ -19,13 +19,13 @@ internal class RequestFactoryImpl(
     private val restContextProvider: RestContextProvider,
     private val clock: Clock
 ) : RequestFactory {
-    override fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequest): HoldingIdentity {
+    override fun createHoldingIdentity(groupId: String, request: CreateVirtualNodeRequestType): HoldingIdentity {
         return HoldingIdentity(MemberX500Name.parse(request.x500Name), groupId)
     }
 
     override fun createVirtualNodeRequest(
         holdingIdentity: HoldingIdentity,
-        request: CreateVirtualNodeRequest
+        request: CreateVirtualNodeRequestType
     ): VirtualNodeAsynchronousRequest {
         return VirtualNodeAsynchronousRequest().apply {
             this.requestId = holdingIdentity.shortHash.toString()
@@ -35,7 +35,7 @@ internal class RequestFactoryImpl(
                 this.cpiFileChecksum = request.cpiFileChecksum
                 this.updateActor = restContextProvider.principal
                 when (request) {
-                    is DeprecatedCreateVirtualNodeRequest -> {
+                    is CreateVirtualNodeRequest -> {
                         this.vaultDdlConnection = request.vaultDdlConnection
                         this.vaultDmlConnection = request.vaultDmlConnection
                         this.cryptoDdlConnection = request.cryptoDdlConnection

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -275,7 +275,7 @@ internal class VirtualNodeRestResourceImpl(
     ): ResponseEntity<AsyncResponse> {
         "Deprecated, please use next version where forceUpgrade is passed as a query parameter.".let { msg ->
             logger.warn(msg)
-            return ResponseEntity.okButDeprecated(doUpgradeVirtualNode(virtualNodeShortId, targetCpiFileChecksum, false), msg)
+            return ResponseEntity.acceptedButDeprecated(doUpgradeVirtualNode(virtualNodeShortId, targetCpiFileChecksum, false), msg)
         }
     }
 
@@ -502,7 +502,7 @@ internal class VirtualNodeRestResourceImpl(
 
         "Deprecated, please use next version where non-escaped JSON strings can be passed in the body parameter.".let { msg ->
             logger.warn(msg)
-            return ResponseEntity.okButDeprecated(AsyncResponse(asyncRequest.requestId), msg)
+            return ResponseEntity.acceptedButDeprecated(AsyncResponse(asyncRequest.requestId), msg)
         }
     }
 

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -29,8 +29,8 @@ import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationBadReques
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundException
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.DeprecatedCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
@@ -476,14 +476,14 @@ internal class VirtualNodeRestResourceImpl(
     /**
      * Publishes a virtual node create request onto the message bus.
      *
-     * @property CreateVirtualNodeRequest contains the data we want to use to construct our virtual node
+     * @property DeprecatedCreateVirtualNodeRequest contains the data we want to use to construct our virtual node
      * @throws InvalidInputDataException if the request in invalid.
      * @throws InternalServerException if the requested CPI has invalid metadata.
      * @throws ServiceUnavailableException is thrown if the component isn't running.
      * @return [ResponseEntity] containing the request ID for the create virtual node request.
      */
     @Deprecated("Deprecated in favour of `createVirtualNode()`")
-    override fun createVirtualNodeDeprecated(request: CreateVirtualNodeRequest): ResponseEntity<AsyncResponse> {
+    override fun createVirtualNodeDeprecated(request: DeprecatedCreateVirtualNodeRequest): ResponseEntity<AsyncResponse> {
         val groupId = virtualNodeValidationService.validateAndGetGroupId(request)
 
         val holdingIdentity = requestFactory.createHoldingIdentity(groupId, request)
@@ -509,7 +509,7 @@ internal class VirtualNodeRestResourceImpl(
     /**
      * Publishes a virtual node create request onto the message bus.
      *
-     * @property JsonCreateVirtualNodeRequest contains the data we want to use to construct our virtual node as a JSON object
+     * @property JsonCreateVirtualNodeRequest contains the data we want to use to construct our virtual node
      * @throws InvalidInputDataException if the request in invalid.
      * @throws InternalServerException if the requested CPI has invalid metadata.
      * @throws ServiceUnavailableException is thrown if the component isn't running.

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -29,8 +29,8 @@ import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationBadReques
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundException
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.DeprecatedCreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
@@ -476,14 +476,14 @@ internal class VirtualNodeRestResourceImpl(
     /**
      * Publishes a virtual node create request onto the message bus.
      *
-     * @property DeprecatedCreateVirtualNodeRequest contains the data we want to use to construct our virtual node
+     * @property CreateVirtualNodeRequest contains the data we want to use to construct our virtual node
      * @throws InvalidInputDataException if the request in invalid.
      * @throws InternalServerException if the requested CPI has invalid metadata.
      * @throws ServiceUnavailableException is thrown if the component isn't running.
      * @return [ResponseEntity] containing the request ID for the create virtual node request.
      */
     @Deprecated("Deprecated in favour of `createVirtualNode()`")
-    override fun createVirtualNodeDeprecated(request: DeprecatedCreateVirtualNodeRequest): ResponseEntity<AsyncResponse> {
+    override fun createVirtualNodeDeprecated(request: CreateVirtualNodeRequest): ResponseEntity<AsyncResponse> {
         val groupId = virtualNodeValidationService.validateAndGetGroupId(request)
 
         val holdingIdentity = requestFactory.createHoldingIdentity(groupId, request)

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -484,13 +484,13 @@ internal class VirtualNodeRestResourceImpl(
      */
     @Deprecated("Deprecated in favour of `createVirtualNode()`")
     override fun createVirtualNodeDeprecated(request: CreateVirtualNodeRequest): ResponseEntity<AsyncResponse> {
-        val groupId = virtualNodeValidationService.validateAndGetGroupIdDeprecated(request)
+        val groupId = virtualNodeValidationService.validateAndGetGroupId(request)
 
-        val holdingIdentity = requestFactory.createHoldingIdentityDeprecated(groupId, request)
+        val holdingIdentity = requestFactory.createHoldingIdentity(groupId, request)
 
         virtualNodeValidationService.validateVirtualNodeDoesNotExist(holdingIdentity)
 
-        val asyncRequest = requestFactory.createVirtualNodeRequestDeprecated(holdingIdentity, request)
+        val asyncRequest = requestFactory.createVirtualNodeRequest(holdingIdentity, request)
 
         sendAsync(asyncRequest.requestId, asyncRequest)
 
@@ -509,7 +509,7 @@ internal class VirtualNodeRestResourceImpl(
     /**
      * Publishes a virtual node create request onto the message bus.
      *
-     * @property CreateVirtualNodeRequest contains the data we want to use to construct our virtual node
+     * @property JsonCreateVirtualNodeRequest contains the data we want to use to construct our virtual node as a JSON object
      * @throws InvalidInputDataException if the request in invalid.
      * @throws InternalServerException if the requested CPI has invalid metadata.
      * @throws ServiceUnavailableException is thrown if the component isn't running.

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -30,6 +30,7 @@ import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundE
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
@@ -483,13 +484,13 @@ internal class VirtualNodeRestResourceImpl(
      */
     @Deprecated("Deprecated in favour of `createVirtualNode()`")
     override fun createVirtualNodeDeprecated(request: CreateVirtualNodeRequest): ResponseEntity<AsyncResponse> {
-        val groupId = virtualNodeValidationService.validateAndGetGroupId(request)
+        val groupId = virtualNodeValidationService.validateAndGetGroupIdDeprecated(request)
 
-        val holdingIdentity = requestFactory.createHoldingIdentity(groupId, request)
+        val holdingIdentity = requestFactory.createHoldingIdentityDeprecated(groupId, request)
 
         virtualNodeValidationService.validateVirtualNodeDoesNotExist(holdingIdentity)
 
-        val asyncRequest = requestFactory.createVirtualNodeRequest(holdingIdentity, request)
+        val asyncRequest = requestFactory.createVirtualNodeRequestDeprecated(holdingIdentity, request)
 
         sendAsync(asyncRequest.requestId, asyncRequest)
 
@@ -514,7 +515,7 @@ internal class VirtualNodeRestResourceImpl(
      * @throws ServiceUnavailableException is thrown if the component isn't running.
      * @return [ResponseEntity] containing the request ID for the create virtual node request.
      */
-    override fun createVirtualNode(request: CreateVirtualNodeRequest): ResponseEntity<AsyncResponse> {
+    override fun createVirtualNode(request: JsonCreateVirtualNodeRequest): ResponseEntity<AsyncResponse> {
         val groupId = virtualNodeValidationService.validateAndGetGroupId(request)
 
         val holdingIdentity = requestFactory.createHoldingIdentity(groupId, request)

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/VirtualNodeValidationService.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/VirtualNodeValidationService.kt
@@ -2,14 +2,12 @@ package net.corda.virtualnode.rest.impl.validation
 
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 
 internal interface VirtualNodeValidationService {
     fun validateVirtualNodeDoesNotExist(holdingIdentity: HoldingIdentity)
     fun validateAndGetGroupId(request: CreateVirtualNodeRequest): String
-    fun validateAndGetGroupId(request: JsonCreateVirtualNodeRequest): String
     fun validateAndGetVirtualNode(virtualNodeShortId: String): VirtualNodeInfo
     fun validateAndGetCpiByChecksum(cpiFileChecksum: String): CpiMetadata
     fun validateCpiUpgradePrerequisites(currentCpi: CpiMetadata, upgradeCpi: CpiMetadata)

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/VirtualNodeValidationService.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/VirtualNodeValidationService.kt
@@ -8,7 +8,7 @@ import net.corda.virtualnode.VirtualNodeInfo
 
 internal interface VirtualNodeValidationService {
     fun validateVirtualNodeDoesNotExist(holdingIdentity: HoldingIdentity)
-    fun validateAndGetGroupIdDeprecated(request: CreateVirtualNodeRequest): String
+    fun validateAndGetGroupId(request: CreateVirtualNodeRequest): String
     fun validateAndGetGroupId(request: JsonCreateVirtualNodeRequest): String
     fun validateAndGetVirtualNode(virtualNodeShortId: String): VirtualNodeInfo
     fun validateAndGetCpiByChecksum(cpiFileChecksum: String): CpiMetadata

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/VirtualNodeValidationService.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/VirtualNodeValidationService.kt
@@ -2,12 +2,14 @@ package net.corda.virtualnode.rest.impl.validation
 
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 
 internal interface VirtualNodeValidationService {
     fun validateVirtualNodeDoesNotExist(holdingIdentity: HoldingIdentity)
-    fun validateAndGetGroupId(request: CreateVirtualNodeRequest): String
+    fun validateAndGetGroupIdDeprecated(request: CreateVirtualNodeRequest): String
+    fun validateAndGetGroupId(request: JsonCreateVirtualNodeRequest): String
     fun validateAndGetVirtualNode(virtualNodeShortId: String): VirtualNodeInfo
     fun validateAndGetCpiByChecksum(cpiFileChecksum: String): CpiMetadata
     fun validateCpiUpgradePrerequisites(currentCpi: CpiMetadata, upgradeCpi: CpiMetadata)

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/VirtualNodeValidationService.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/VirtualNodeValidationService.kt
@@ -1,13 +1,13 @@
 package net.corda.virtualnode.rest.impl.validation
 
 import net.corda.libs.packaging.core.CpiMetadata
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
 
 internal interface VirtualNodeValidationService {
     fun validateVirtualNodeDoesNotExist(holdingIdentity: HoldingIdentity)
-    fun validateAndGetGroupId(request: CreateVirtualNodeRequest): String
+    fun validateAndGetGroupId(request: CreateVirtualNodeRequestType): String
     fun validateAndGetVirtualNode(virtualNodeShortId: String): VirtualNodeInfo
     fun validateAndGetCpiByChecksum(cpiFileChecksum: String): CpiMetadata
     fun validateCpiUpgradePrerequisites(currentCpi: CpiMetadata, upgradeCpi: CpiMetadata)

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
@@ -21,7 +21,7 @@ import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.rest.impl.validation.VirtualNodeValidationService
-import java.util.UUID
+import java.util.*
 
 internal class VirtualNodeValidationServiceImpl(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
@@ -94,19 +94,19 @@ internal class VirtualNodeValidationServiceImpl(
                 }
             }
             is JsonCreateVirtualNodeRequest -> {
-                if (request.vaultDdlConnection.toString().isNotBlank() && request.vaultDmlConnection.toString().isBlank()) {
+                if (request.vaultDdlConnection != null && request.vaultDmlConnection == null) {
                     throw InvalidInputDataException(
                         "If Vault DDL connection is provided, Vault DML connection needs to be provided as well."
                     )
                 }
 
-                if (request.cryptoDdlConnection.toString().isNotBlank() && request.cryptoDmlConnection.toString().isBlank()) {
+                if (request.cryptoDdlConnection != null && request.cryptoDmlConnection == null) {
                     throw InvalidInputDataException(
                         "If Crypto DDL connection is provided, Crypto DML connection needs to be provided as well."
                     )
                 }
 
-                if (request.uniquenessDdlConnection.toString().isNotBlank() && request.uniquenessDmlConnection.toString().isBlank()) {
+                if (request.uniquenessDdlConnection != null && request.uniquenessDmlConnection == null) {
                     throw InvalidInputDataException(
                         "If Uniqueness DDL connection is provided, Uniqueness DML connection needs to be provided as well."
                     )

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
@@ -21,7 +21,7 @@ import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.rest.impl.validation.VirtualNodeValidationService
-import java.util.UUID
+import java.util.*
 
 internal class VirtualNodeValidationServiceImpl(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
@@ -117,7 +117,7 @@ internal class VirtualNodeValidationServiceImpl(
 
     @Suppress("ThrowsCount")
     private fun doValidateAndGetGroupId(request: CreateVirtualNodeRequest): String {
-        when (request) {
+        return when (request) {
             is DeprecatedCreateVirtualNodeRequest, is JsonCreateVirtualNodeRequest -> {
                 try {
                     MemberX500Name.parse(request.x500Name)
@@ -153,7 +153,7 @@ internal class VirtualNodeValidationServiceImpl(
                 }
 
                 // generate a group ID when creating a virtual node for an MGM default group.
-                return if (groupId == GroupPolicyConstants.PolicyValues.Root.MGM_DEFAULT_GROUP_ID) {
+                if (groupId == GroupPolicyConstants.PolicyValues.Root.MGM_DEFAULT_GROUP_ID) {
                     UUID.randomUUID().toString()
                 } else {
                     groupId

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
@@ -20,7 +20,7 @@ import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.rest.impl.validation.VirtualNodeValidationService
-import java.util.*
+import java.util.UUID
 
 internal class VirtualNodeValidationServiceImpl(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
@@ -35,7 +35,7 @@ internal class VirtualNodeValidationServiceImpl(
         }
     }
 
-    override fun validateAndGetGroupIdDeprecated(request: CreateVirtualNodeRequest): String {
+    override fun validateAndGetGroupId(request: CreateVirtualNodeRequest): String {
         try {
             MemberX500Name.parse(request.x500Name)
         } catch (e: Exception) {

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
@@ -21,7 +21,7 @@ import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.rest.impl.validation.VirtualNodeValidationService
-import java.util.*
+import java.util.UUID
 
 internal class VirtualNodeValidationServiceImpl(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
@@ -5,6 +5,7 @@ import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.ShortHashException
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants
 import net.corda.membership.lib.grouppolicy.GroupPolicyParseException
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
@@ -19,7 +20,7 @@ import net.corda.virtualnode.OperationalStatus
 import net.corda.virtualnode.VirtualNodeInfo
 import net.corda.virtualnode.read.VirtualNodeInfoReadService
 import net.corda.virtualnode.rest.impl.validation.VirtualNodeValidationService
-import java.util.UUID
+import java.util.*
 
 internal class VirtualNodeValidationServiceImpl(
     private val virtualNodeInfoReadService: VirtualNodeInfoReadService,
@@ -34,7 +35,7 @@ internal class VirtualNodeValidationServiceImpl(
         }
     }
 
-    override fun validateAndGetGroupId(request: CreateVirtualNodeRequest): String {
+    override fun validateAndGetGroupIdDeprecated(request: CreateVirtualNodeRequest): String {
         try {
             MemberX500Name.parse(request.x500Name)
         } catch (e: Exception) {
@@ -64,6 +65,64 @@ internal class VirtualNodeValidationServiceImpl(
         }
 
         if (!request.uniquenessDdlConnection.isNullOrBlank() && request.uniquenessDmlConnection.isNullOrBlank()) {
+            throw InvalidInputDataException(
+                "If Uniqueness DDL connection is provided, Uniqueness DML connection needs to be provided as well."
+            )
+        }
+
+        val cpiMeta = cpiInfoReadService.getAll()
+            .firstOrNull { it.fileChecksum.toHexString().substring(0, 12) == cpiFileChecksum }
+            ?: throw InvalidInputDataException(
+                "No CPI metadata found for checksum '$cpiFileChecksum'."
+            )
+
+        val groupPolicyJson = cpiMeta.groupPolicy
+            ?: throw InternalServerException("Group policy is missing from CPI metadata '$cpiFileChecksum'")
+
+        val groupId = try {
+            GroupPolicyParser.groupIdFromJson(groupPolicyJson)
+        } catch (e: GroupPolicyParseException) {
+            throw InternalServerException("Could not find group ID in CPI policy data '$groupPolicyJson'")
+        }
+
+        // generate a group ID when creating a virtual node for an MGM default group.
+        return if (groupId == GroupPolicyConstants.PolicyValues.Root.MGM_DEFAULT_GROUP_ID) {
+            UUID.randomUUID().toString()
+        } else {
+            groupId
+        }
+    }
+
+    override fun validateAndGetGroupId(request: JsonCreateVirtualNodeRequest): String {
+        try {
+            MemberX500Name.parse(request.x500Name)
+        } catch (e: Exception) {
+            throw InvalidInputDataException(
+                "X500 name \"${request.x500Name}\" could not be parsed. Cause: ${e.message}"
+            )
+        }
+
+        val cpiFileChecksum = request.cpiFileChecksum
+
+        if (!validCpi.matches(cpiFileChecksum)) {
+            throw InvalidInputDataException(
+                "CPI file checksum value '$cpiFileChecksum' is invalid, expecting 12 digit hex value"
+            )
+        }
+
+        if (request.vaultDdlConnection.toString().isNotBlank() && request.vaultDmlConnection.toString().isBlank()) {
+            throw InvalidInputDataException(
+                "If Vault DDL connection is provided, Vault DML connection needs to be provided as well."
+            )
+        }
+
+        if (request.cryptoDdlConnection.toString().isNotBlank() && request.cryptoDmlConnection.toString().isBlank()) {
+            throw InvalidInputDataException(
+                "If Crypto DDL connection is provided, Crypto DML connection needs to be provided as well."
+            )
+        }
+
+        if (request.uniquenessDdlConnection.toString().isNotBlank() && request.uniquenessDmlConnection.toString().isBlank()) {
             throw InvalidInputDataException(
                 "If Uniqueness DDL connection is provided, Uniqueness DML connection needs to be provided as well."
             )

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImpl.kt
@@ -4,9 +4,9 @@ import net.corda.cpiinfo.read.CpiInfoReadService
 import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.ShortHashException
 import net.corda.libs.packaging.core.CpiMetadata
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.DeprecatedCreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.JsonCreateVirtualNodeRequest
 import net.corda.membership.lib.grouppolicy.GroupPolicyConstants
 import net.corda.membership.lib.grouppolicy.GroupPolicyParseException
 import net.corda.membership.lib.grouppolicy.GroupPolicyParser
@@ -36,7 +36,7 @@ internal class VirtualNodeValidationServiceImpl(
         }
     }
 
-    override fun validateAndGetGroupId(request: CreateVirtualNodeRequest): String {
+    override fun validateAndGetGroupId(request: CreateVirtualNodeRequestType): String {
         return doValidateAndGetGroupId(request)
     }
 
@@ -72,9 +72,9 @@ internal class VirtualNodeValidationServiceImpl(
     }
 
     @Suppress("ThrowsCount")
-    private fun validateConnectionParams(request: CreateVirtualNodeRequest) {
+    private fun validateConnectionParams(request: CreateVirtualNodeRequestType) {
         when (request) {
-            is DeprecatedCreateVirtualNodeRequest -> {
+            is CreateVirtualNodeRequest -> {
                 if (!request.vaultDdlConnection.isNullOrBlank() && request.vaultDmlConnection.isNullOrBlank()) {
                     throw InvalidInputDataException(
                         "If Vault DDL connection is provided, Vault DML connection needs to be provided as well."
@@ -116,9 +116,9 @@ internal class VirtualNodeValidationServiceImpl(
     }
 
     @Suppress("ThrowsCount")
-    private fun doValidateAndGetGroupId(request: CreateVirtualNodeRequest): String {
+    private fun doValidateAndGetGroupId(request: CreateVirtualNodeRequestType): String {
         return when (request) {
-            is DeprecatedCreateVirtualNodeRequest, is JsonCreateVirtualNodeRequest -> {
+            is CreateVirtualNodeRequest, is JsonCreateVirtualNodeRequest -> {
                 try {
                     MemberX500Name.parse(request.x500Name)
                 } catch (e: Exception) {

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
@@ -10,7 +10,7 @@ import net.corda.data.virtualnode.VirtualNodeOperationStatusResponse
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundException
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.rest.asynchronous.v1.AsyncOperationStatus
@@ -40,7 +40,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
-import java.util.UUID
+import java.util.*
 import net.corda.data.virtualnode.VirtualNodeOperationStatus as AvroVirtualNodeOperationStatus
 
 class VirtualNodeRestResourceImplTest {
@@ -92,7 +92,7 @@ class VirtualNodeRestResourceImplTest {
     fun `create virtual node`() {
         val groupId = "grp1"
         val requestId = "r1"
-        val request = CreateVirtualNodeRequest(
+        val request = JsonCreateVirtualNodeRequest(
             "",
             "checkSum",
             null,

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
@@ -10,7 +10,7 @@ import net.corda.data.virtualnode.VirtualNodeOperationStatusResponse
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundException
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.JsonCreateVirtualNodeRequest
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.rest.asynchronous.v1.AsyncOperationStatus

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
@@ -10,7 +10,7 @@ import net.corda.data.virtualnode.VirtualNodeOperationStatusResponse
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.libs.virtualnode.common.exception.VirtualNodeOperationNotFoundException
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.rest.asynchronous.v1.AsyncOperationStatus

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/v1/VirtualNodeRestResourceImplTest.kt
@@ -40,7 +40,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import net.corda.data.virtualnode.VirtualNodeOperationStatus as AvroVirtualNodeOperationStatus
 
 class VirtualNodeRestResourceImplTest {

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImplTest.kt
@@ -2,7 +2,7 @@ package net.corda.virtualnode.rest.factories.impl
 
 import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.JsonCreateVirtualNodeRequest
 import net.corda.rest.json.serialization.JsonObjectAsString
 import net.corda.rest.security.RestContextProvider
 import net.corda.utilities.time.Clock

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImplTest.kt
@@ -2,7 +2,7 @@ package net.corda.virtualnode.rest.factories.impl
 
 import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
 import net.corda.rest.json.serialization.JsonObjectAsString
 import net.corda.rest.security.RestContextProvider
 import net.corda.utilities.time.Clock

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/factories/impl/RequestFactoryImplTest.kt
@@ -2,7 +2,8 @@ package net.corda.virtualnode.rest.factories.impl
 
 import net.corda.data.virtualnode.VirtualNodeAsynchronousRequest
 import net.corda.data.virtualnode.VirtualNodeCreateRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
+import net.corda.rest.json.serialization.JsonObjectAsString
 import net.corda.rest.security.RestContextProvider
 import net.corda.utilities.time.Clock
 import net.corda.v5.base.types.MemberX500Name
@@ -26,7 +27,7 @@ class RequestFactoryImplTest {
         val alice = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
         val groupId = "g1"
 
-        val request = CreateVirtualNodeRequest(
+        val request = JsonCreateVirtualNodeRequest(
             alice,
             "cpics",
             null,
@@ -56,15 +57,15 @@ class RequestFactoryImplTest {
         val uniquenessDdlConnection = "uddl"
         val uniquenessDmlConnection = "udml"
 
-        val request = CreateVirtualNodeRequest(
+        val request = JsonCreateVirtualNodeRequest(
             alice,
             cpiChecksum,
-            vaultDdlConnection,
-            vaultDmlConnection,
-            cryptoDdlConnection,
-            cryptoDmlConnection,
-            uniquenessDdlConnection,
-            uniquenessDmlConnection,
+            JsonObjectAsString(vaultDdlConnection),
+            JsonObjectAsString(vaultDmlConnection),
+            JsonObjectAsString(cryptoDdlConnection),
+            JsonObjectAsString(cryptoDmlConnection),
+            JsonObjectAsString(uniquenessDdlConnection),
+            JsonObjectAsString(uniquenessDmlConnection),
         )
 
         val holdingIdentity = HoldingIdentity(MemberX500Name.parse(alice), groupId)

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
@@ -6,12 +6,13 @@ import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.parseSecureHash
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.rest.exception.BadRequestException
 import net.corda.rest.exception.InternalServerException
 import net.corda.rest.exception.InvalidInputDataException
 import net.corda.rest.exception.ResourceAlreadyExistsException
 import net.corda.rest.exception.ResourceNotFoundException
+import net.corda.rest.json.serialization.JsonObjectAsString
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.OperationalStatus
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.Instant
-import java.util.UUID
+import java.util.*
 
 class VirtualNodeValidationServiceImplTest {
     private val now = Instant.now()
@@ -272,16 +273,16 @@ class VirtualNodeValidationServiceImplTest {
         cryptoDmlConnection: String? = "cddl",
         uniquenessDdlConnection: String? = "uddl",
         uniquenessDmlConnection: String? = "udml"
-    ): CreateVirtualNodeRequest {
-        return CreateVirtualNodeRequest(
+    ): JsonCreateVirtualNodeRequest {
+        return JsonCreateVirtualNodeRequest(
             x500Name,
             cpiShortFileChecksum,
-            vaultDdlConnection,
-            vaultDmlConnection,
-            cryptoDdlConnection,
-            cryptoDmlConnection,
-            uniquenessDdlConnection,
-            uniquenessDmlConnection,
+            vaultDdlConnection?.let { JsonObjectAsString(it) },
+            vaultDmlConnection?.let { JsonObjectAsString(it) },
+            cryptoDdlConnection?.let { JsonObjectAsString(it) },
+            cryptoDmlConnection?.let { JsonObjectAsString(it) },
+            uniquenessDdlConnection?.let { JsonObjectAsString(it) },
+            uniquenessDmlConnection?.let { JsonObjectAsString(it) },
         )
     }
 }

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 
 class VirtualNodeValidationServiceImplTest {
     private val now = Instant.now()

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
@@ -6,7 +6,7 @@ import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.parseSecureHash
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
 import net.corda.rest.exception.BadRequestException
 import net.corda.rest.exception.InternalServerException
 import net.corda.rest.exception.InvalidInputDataException

--- a/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/test/kotlin/net/corda/virtualnode/rest/impl/validation/impl/VirtualNodeValidationServiceImplTest.kt
@@ -6,7 +6,7 @@ import net.corda.crypto.core.ShortHash
 import net.corda.crypto.core.parseSecureHash
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.libs.packaging.core.CpiMetadata
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.JsonCreateVirtualNodeRequest
 import net.corda.rest.exception.BadRequestException
 import net.corda.rest.exception.InternalServerException
 import net.corda.rest.exception.InvalidInputDataException

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/response/ResponseEntity.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/response/ResponseEntity.kt
@@ -55,5 +55,8 @@ class ResponseEntity<T : Any?>(
         fun <T : Any?> okButDeprecated(responseBody: T, msg: String): ResponseEntity<T> {
             return ResponseEntity(ResponseCode.OK, responseBody, mapOf("Warning" to "299 - $msg"))
         }
+        fun <T : Any?> acceptedButDeprecated(responseBody: T, msg: String): ResponseEntity<T> {
+            return ResponseEntity(ResponseCode.ACCEPTED, responseBody, mapOf("Warning" to "299 - $msg"))
+        }
     }
 }

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -38,7 +38,7 @@ interface VirtualNodeRestResource : RestResource {
         title = "Create virtual node",
         description = "This method creates a new virtual node.",
         responseDescription = "The details of the created virtual node.",
-        maxVersion = RestApiVersion.C5_2
+        maxVersion = RestApiVersion.C5_1
     )
     fun createVirtualNodeDeprecated(
         @ClientRequestBodyParameter(description = "Details of the virtual node to be created")
@@ -54,7 +54,7 @@ interface VirtualNodeRestResource : RestResource {
         title = "Create virtual node",
         description = "This method creates a new virtual node.",
         responseDescription = "The details of the created virtual node.",
-        minVersion = RestApiVersion.C5_3
+        minVersion = RestApiVersion.C5_2
     )
     fun createVirtualNode(
         @ClientRequestBodyParameter(description = "Details of the virtual node to be created")

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -3,6 +3,7 @@ package net.corda.libs.virtualnode.endpoints.v1
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
 import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
@@ -57,7 +58,7 @@ interface VirtualNodeRestResource : RestResource {
     )
     fun createVirtualNode(
         @ClientRequestBodyParameter(description = "Details of the virtual node to be created")
-        request: CreateVirtualNodeRequest
+        request: JsonCreateVirtualNodeRequest
     ): ResponseEntity<AsyncResponse>
 
     /**

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -1,8 +1,8 @@
 package net.corda.libs.virtualnode.endpoints.v1
 
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.DeprecatedCreateVirtualNodeRequest
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
@@ -42,7 +42,7 @@ interface VirtualNodeRestResource : RestResource {
     )
     fun createVirtualNodeDeprecated(
         @ClientRequestBodyParameter(description = "Details of the virtual node to be created")
-        request: DeprecatedCreateVirtualNodeRequest
+        request: CreateVirtualNodeRequest
     ): ResponseEntity<AsyncResponse>
 
     /**

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -32,10 +32,28 @@ interface VirtualNodeRestResource : RestResource {
      *
      * @throws `HttpApiException` If the request returns an exceptional response.
      */
+    @Deprecated("Deprecated in favour of `createVirtualNode()`")
     @HttpPOST(
         title = "Create virtual node",
         description = "This method creates a new virtual node.",
-        responseDescription = "The details of the created virtual node."
+        responseDescription = "The details of the created virtual node.",
+        maxVersion = RestApiVersion.C5_2
+    )
+    fun createVirtualNodeDeprecated(
+        @ClientRequestBodyParameter(description = "Details of the virtual node to be created")
+        request: CreateVirtualNodeRequest
+    ): ResponseEntity<AsyncResponse>
+
+    /**
+     * Requests the creation of a virtual node.
+     *
+     * @throws `HttpApiException` If the request returns an exceptional response.
+     */
+    @HttpPOST(
+        title = "Create virtual node",
+        description = "This method creates a new virtual node.",
+        responseDescription = "The details of the created virtual node.",
+        minVersion = RestApiVersion.C5_3
     )
     fun createVirtualNode(
         @ClientRequestBodyParameter(description = "Details of the virtual node to be created")

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -1,9 +1,9 @@
 package net.corda.libs.virtualnode.endpoints.v1
 
 import net.corda.libs.virtualnode.endpoints.v1.types.ChangeVirtualNodeStateResponse
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.DeprecatedCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.HoldingIdentity
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.UpdateVirtualNodeDbRequest
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodeInfo
 import net.corda.libs.virtualnode.endpoints.v1.types.VirtualNodes
@@ -42,7 +42,7 @@ interface VirtualNodeRestResource : RestResource {
     )
     fun createVirtualNodeDeprecated(
         @ClientRequestBodyParameter(description = "Details of the virtual node to be created")
-        request: CreateVirtualNodeRequest
+        request: DeprecatedCreateVirtualNodeRequest
     ): ResponseEntity<AsyncResponse>
 
     /**

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -38,7 +38,7 @@ interface VirtualNodeRestResource : RestResource {
         title = "Create virtual node",
         description = "This method creates a new virtual node.",
         responseDescription = "The details of the created virtual node.",
-        maxVersion = RestApiVersion.C5_1
+        maxVersion = RestApiVersion.C5_2
     )
     fun createVirtualNodeDeprecated(
         @ClientRequestBodyParameter(description = "Details of the virtual node to be created")
@@ -54,7 +54,7 @@ interface VirtualNodeRestResource : RestResource {
         title = "Create virtual node",
         description = "This method creates a new virtual node.",
         responseDescription = "The details of the created virtual node.",
-        minVersion = RestApiVersion.C5_2
+        minVersion = RestApiVersion.C5_3
     )
     fun createVirtualNode(
         @ClientRequestBodyParameter(description = "Details of the virtual node to be created")

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/CreateVirtualNodeRequest.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/CreateVirtualNodeRequest.kt
@@ -8,35 +8,40 @@ import net.corda.rest.JsonObject
  * @param x500Name The X500 name for the new virtual node.
  * @param cpiFileChecksum The checksum of the CPI file.
  */
-data class CreateVirtualNodeRequest(
-    val x500Name: String,
-    var cpiFileChecksum: String,
-    val vaultDdlConnection: String?,
-    val vaultDmlConnection: String?,
-    val cryptoDdlConnection: String?,
-    val cryptoDmlConnection: String?,
-    val uniquenessDdlConnection: String?,
-    val uniquenessDmlConnection: String?
-) {
-    init {
-        // Whilst checksum can be expressed with either upper or lower case characters and has the same logical meaning,
-        // all the cache keys using uppercase representation of CPI checksum, therefore early during processing cycle
-        // on REST server, it would make sense to switch to uppercase.
-        cpiFileChecksum = cpiFileChecksum.uppercase()
-    }
-}
+sealed class CreateVirtualNodeRequest {
+    abstract val cpiFileChecksum: String
+    abstract val x500Name: String
 
-data class JsonCreateVirtualNodeRequest(
-    val x500Name: String,
-    var cpiFileChecksum: String,
-    val vaultDdlConnection: JsonObject?,
-    val vaultDmlConnection: JsonObject?,
-    val cryptoDdlConnection: JsonObject?,
-    val cryptoDmlConnection: JsonObject?,
-    val uniquenessDdlConnection: JsonObject?,
-    val uniquenessDmlConnection: JsonObject?
-) {
-    init {
-        cpiFileChecksum = cpiFileChecksum.uppercase()
+    data class DeprecatedCreateVirtualNodeRequest(
+        override val x500Name: String,
+        override var cpiFileChecksum: String,
+        val vaultDdlConnection: String?,
+        val vaultDmlConnection: String?,
+        val cryptoDdlConnection: String?,
+        val cryptoDmlConnection: String?,
+        val uniquenessDdlConnection: String?,
+        val uniquenessDmlConnection: String?
+    ) : CreateVirtualNodeRequest() {
+        init {
+            // Whilst checksum can be expressed with either upper or lower case characters and has the same logical meaning,
+            // all the cache keys using uppercase representation of CPI checksum, therefore early during processing cycle
+            // on REST server, it would make sense to switch to uppercase.
+            cpiFileChecksum = cpiFileChecksum.uppercase()
+        }
+    }
+
+    data class JsonCreateVirtualNodeRequest(
+        override val x500Name: String,
+        override var cpiFileChecksum: String,
+        val vaultDdlConnection: JsonObject?,
+        val vaultDmlConnection: JsonObject?,
+        val cryptoDdlConnection: JsonObject?,
+        val cryptoDmlConnection: JsonObject?,
+        val uniquenessDdlConnection: JsonObject?,
+        val uniquenessDmlConnection: JsonObject?
+    ) : CreateVirtualNodeRequest() {
+        init {
+            cpiFileChecksum = cpiFileChecksum.uppercase()
+        }
     }
 }

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/CreateVirtualNodeRequest.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/CreateVirtualNodeRequest.kt
@@ -11,6 +11,24 @@ import net.corda.rest.JsonObject
 data class CreateVirtualNodeRequest(
     val x500Name: String,
     var cpiFileChecksum: String,
+    val vaultDdlConnection: String?,
+    val vaultDmlConnection: String?,
+    val cryptoDdlConnection: String?,
+    val cryptoDmlConnection: String?,
+    val uniquenessDdlConnection: String?,
+    val uniquenessDmlConnection: String?
+) {
+    init {
+        // Whilst checksum can be expressed with either upper or lower case characters and has the same logical meaning,
+        // all the cache keys using uppercase representation of CPI checksum, therefore early during processing cycle
+        // on REST server, it would make sense to switch to uppercase.
+        cpiFileChecksum = cpiFileChecksum.uppercase()
+    }
+}
+
+data class JsonCreateVirtualNodeRequest(
+    val x500Name: String,
+    var cpiFileChecksum: String,
     val vaultDdlConnection: JsonObject?,
     val vaultDmlConnection: JsonObject?,
     val cryptoDdlConnection: JsonObject?,
@@ -19,9 +37,6 @@ data class CreateVirtualNodeRequest(
     val uniquenessDmlConnection: JsonObject?
 ) {
     init {
-        // Whilst checksum can be expressed with either upper or lower case characters and has the same logical meaning,
-        // all the cache keys using uppercase representation of CPI checksum, therefore early during processing cycle
-        // on REST server, it would make sense to switch to uppercase.
         cpiFileChecksum = cpiFileChecksum.uppercase()
     }
 }

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/CreateVirtualNodeRequest.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/CreateVirtualNodeRequest.kt
@@ -1,7 +1,9 @@
 package net.corda.libs.virtualnode.endpoints.v1.types
 
+import net.corda.rest.JsonObject
+
 /**
- * The data object sent via HTTP to request the creation of a virtual node.
+ * The data object sent via REST to request the creation of a virtual node.
  *
  * @param x500Name The X500 name for the new virtual node.
  * @param cpiFileChecksum The checksum of the CPI file.
@@ -9,12 +11,12 @@ package net.corda.libs.virtualnode.endpoints.v1.types
 data class CreateVirtualNodeRequest(
     val x500Name: String,
     var cpiFileChecksum: String,
-    val vaultDdlConnection: String?,
-    val vaultDmlConnection: String?,
-    val cryptoDdlConnection: String?,
-    val cryptoDmlConnection: String?,
-    val uniquenessDdlConnection: String?,
-    val uniquenessDmlConnection: String?
+    val vaultDdlConnection: JsonObject?,
+    val vaultDmlConnection: JsonObject?,
+    val cryptoDdlConnection: JsonObject?,
+    val cryptoDmlConnection: JsonObject?,
+    val uniquenessDdlConnection: JsonObject?,
+    val uniquenessDmlConnection: JsonObject?
 ) {
     init {
         // Whilst checksum can be expressed with either upper or lower case characters and has the same logical meaning,

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/CreateVirtualNodeRequestType.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/types/CreateVirtualNodeRequestType.kt
@@ -8,11 +8,11 @@ import net.corda.rest.JsonObject
  * @param x500Name The X500 name for the new virtual node.
  * @param cpiFileChecksum The checksum of the CPI file.
  */
-sealed class CreateVirtualNodeRequest {
+sealed class CreateVirtualNodeRequestType {
     abstract val cpiFileChecksum: String
     abstract val x500Name: String
 
-    data class DeprecatedCreateVirtualNodeRequest(
+    data class CreateVirtualNodeRequest(
         override val x500Name: String,
         override var cpiFileChecksum: String,
         val vaultDdlConnection: String?,
@@ -21,7 +21,7 @@ sealed class CreateVirtualNodeRequest {
         val cryptoDmlConnection: String?,
         val uniquenessDdlConnection: String?,
         val uniquenessDmlConnection: String?
-    ) : CreateVirtualNodeRequest() {
+    ) : CreateVirtualNodeRequestType() {
         init {
             // Whilst checksum can be expressed with either upper or lower case characters and has the same logical meaning,
             // all the cache keys using uppercase representation of CPI checksum, therefore early during processing cycle
@@ -39,7 +39,7 @@ sealed class CreateVirtualNodeRequest {
         val cryptoDmlConnection: JsonObject?,
         val uniquenessDdlConnection: JsonObject?,
         val uniquenessDmlConnection: JsonObject?
-    ) : CreateVirtualNodeRequest() {
+    ) : CreateVirtualNodeRequestType() {
         init {
             cpiFileChecksum = cpiFileChecksum.uppercase()
         }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -3893,7 +3893,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/JsonCreateVirtualNodeRequest"
+                "$ref" : "#/components/schemas/CreateVirtualNodeRequest"
               }
             }
           },
@@ -4865,6 +4865,53 @@
         },
         "description" : "\n                Details of the user to be created with the following parameters:\n                enabled: If true, the user account is enabled; false, the account is disabled\n                fullName: The full name for the new user\n                initialPassword: The initial password for the new user; \n                    the value can be null for Single Sign On (SSO) users\n                loginName: The login name for the new user\n                parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n                passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire"
       },
+      "CreateVirtualNodeRequest" : {
+        "required" : [ "cpiFileChecksum", "x500Name" ],
+        "type" : "object",
+        "properties" : {
+          "cpiFileChecksum" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          },
+          "cryptoDdlConnection" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "string"
+          },
+          "cryptoDmlConnection" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "string"
+          },
+          "uniquenessDdlConnection" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "string"
+          },
+          "uniquenessDmlConnection" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "string"
+          },
+          "vaultDdlConnection" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "string"
+          },
+          "vaultDmlConnection" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "string"
+          },
+          "x500Name" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          }
+        },
+        "description" : "Details of the virtual node to be created"
+      },
       "FlowResultResponse" : {
         "required" : [ "flowStatus", "holdingIdentityShortHash", "timestamp" ],
         "type" : "object",
@@ -5168,137 +5215,6 @@
             "example" : "string"
           }
         }
-      },
-      "JsonCreateVirtualNodeRequest" : {
-        "required" : [ "cpiFileChecksum", "x500Name" ],
-        "type" : "object",
-        "properties" : {
-          "cpiFileChecksum" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          },
-          "cryptoDdlConnection" : {
-            "description" : "Can be any value - string, number, boolean, array or object.",
-            "nullable" : true,
-            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
-            "anyOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "number"
-            }, {
-              "type" : "integer",
-              "format" : "int32"
-            }, {
-              "type" : "boolean"
-            }, {
-              "type" : "array"
-            }, {
-              "type" : "object"
-            } ]
-          },
-          "cryptoDmlConnection" : {
-            "description" : "Can be any value - string, number, boolean, array or object.",
-            "nullable" : true,
-            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
-            "anyOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "number"
-            }, {
-              "type" : "integer",
-              "format" : "int32"
-            }, {
-              "type" : "boolean"
-            }, {
-              "type" : "array"
-            }, {
-              "type" : "object"
-            } ]
-          },
-          "uniquenessDdlConnection" : {
-            "description" : "Can be any value - string, number, boolean, array or object.",
-            "nullable" : true,
-            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
-            "anyOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "number"
-            }, {
-              "type" : "integer",
-              "format" : "int32"
-            }, {
-              "type" : "boolean"
-            }, {
-              "type" : "array"
-            }, {
-              "type" : "object"
-            } ]
-          },
-          "uniquenessDmlConnection" : {
-            "description" : "Can be any value - string, number, boolean, array or object.",
-            "nullable" : true,
-            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
-            "anyOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "number"
-            }, {
-              "type" : "integer",
-              "format" : "int32"
-            }, {
-              "type" : "boolean"
-            }, {
-              "type" : "array"
-            }, {
-              "type" : "object"
-            } ]
-          },
-          "vaultDdlConnection" : {
-            "description" : "Can be any value - string, number, boolean, array or object.",
-            "nullable" : true,
-            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
-            "anyOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "number"
-            }, {
-              "type" : "integer",
-              "format" : "int32"
-            }, {
-              "type" : "boolean"
-            }, {
-              "type" : "array"
-            }, {
-              "type" : "object"
-            } ]
-          },
-          "vaultDmlConnection" : {
-            "description" : "Can be any value - string, number, boolean, array or object.",
-            "nullable" : true,
-            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
-            "anyOf" : [ {
-              "type" : "string"
-            }, {
-              "type" : "number"
-            }, {
-              "type" : "integer",
-              "format" : "int32"
-            }, {
-              "type" : "boolean"
-            }, {
-              "type" : "array"
-            }, {
-              "type" : "object"
-            } ]
-          },
-          "x500Name" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          }
-        },
-        "description" : "Details of the virtual node to be created"
       },
       "KeyMetaData" : {
         "required" : [ "alias", "created", "hsmCategory", "keyId", "scheme" ],

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -3893,7 +3893,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CreateVirtualNodeRequest"
+                "$ref" : "#/components/schemas/JsonCreateVirtualNodeRequest"
               }
             }
           },
@@ -4865,53 +4865,6 @@
         },
         "description" : "\n                Details of the user to be created with the following parameters:\n                enabled: If true, the user account is enabled; false, the account is disabled\n                fullName: The full name for the new user\n                initialPassword: The initial password for the new user; \n                    the value can be null for Single Sign On (SSO) users\n                loginName: The login name for the new user\n                parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n                passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire"
       },
-      "CreateVirtualNodeRequest" : {
-        "required" : [ "cpiFileChecksum", "x500Name" ],
-        "type" : "object",
-        "properties" : {
-          "cpiFileChecksum" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          },
-          "cryptoDdlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "cryptoDmlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "uniquenessDdlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "uniquenessDmlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "vaultDdlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "vaultDmlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "x500Name" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          }
-        },
-        "description" : "Details of the virtual node to be created"
-      },
       "FlowResultResponse" : {
         "required" : [ "flowStatus", "holdingIdentityShortHash", "timestamp" ],
         "type" : "object",
@@ -5215,6 +5168,137 @@
             "example" : "string"
           }
         }
+      },
+      "JsonCreateVirtualNodeRequest" : {
+        "required" : [ "cpiFileChecksum", "x500Name" ],
+        "type" : "object",
+        "properties" : {
+          "cpiFileChecksum" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          },
+          "cryptoDdlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "cryptoDmlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "uniquenessDdlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "uniquenessDmlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "vaultDdlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "vaultDmlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "x500Name" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          }
+        },
+        "description" : "Details of the virtual node to be created"
       },
       "KeyMetaData" : {
         "required" : [ "alias", "created", "hsmCategory", "keyId", "scheme" ],

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
@@ -3893,7 +3893,7 @@
           "content" : {
             "application/json" : {
               "schema" : {
-                "$ref" : "#/components/schemas/CreateVirtualNodeRequest"
+                "$ref" : "#/components/schemas/JsonCreateVirtualNodeRequest"
               }
             }
           },
@@ -4865,53 +4865,6 @@
         },
         "description" : "\n                Details of the user to be created with the following parameters:\n                enabled: If true, the user account is enabled; false, the account is disabled\n                fullName: The full name for the new user\n                initialPassword: The initial password for the new user; \n                    the value can be null for Single Sign On (SSO) users\n                loginName: The login name for the new user\n                parentGroup: An optional identifier of the user group for the new user to be included;\n                    value of null means that the user will belong to the root group\n                passwordExpiry: The date and time when the password should expire, specified as an ISO-8601 string;\n                    value of null means that the password does not expire"
       },
-      "CreateVirtualNodeRequest" : {
-        "required" : [ "cpiFileChecksum", "x500Name" ],
-        "type" : "object",
-        "properties" : {
-          "cpiFileChecksum" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          },
-          "cryptoDdlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "cryptoDmlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "uniquenessDdlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "uniquenessDmlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "vaultDdlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "vaultDmlConnection" : {
-            "type" : "string",
-            "nullable" : true,
-            "example" : "string"
-          },
-          "x500Name" : {
-            "type" : "string",
-            "nullable" : false,
-            "example" : "string"
-          }
-        },
-        "description" : "Details of the virtual node to be created"
-      },
       "FlowResultResponse" : {
         "required" : [ "flowStatus", "holdingIdentityShortHash", "timestamp" ],
         "type" : "object",
@@ -5216,6 +5169,137 @@
           }
         }
       },
+      "JsonCreateVirtualNodeRequest" : {
+        "required" : [ "cpiFileChecksum", "x500Name" ],
+        "type" : "object",
+        "properties" : {
+          "cpiFileChecksum" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          },
+          "cryptoDdlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "cryptoDmlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "uniquenessDdlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "uniquenessDmlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "vaultDdlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "vaultDmlConnection" : {
+            "description" : "Can be any value - string, number, boolean, array or object.",
+            "nullable" : true,
+            "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}",
+            "anyOf" : [ {
+              "type" : "string"
+            }, {
+              "type" : "number"
+            }, {
+              "type" : "integer",
+              "format" : "int32"
+            }, {
+              "type" : "boolean"
+            }, {
+              "type" : "array"
+            }, {
+              "type" : "object"
+            } ]
+          },
+          "x500Name" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "string"
+          }
+        },
+        "description" : "Details of the virtual node to be created"
+      },
       "KeyMetaData" : {
         "required" : [ "alias", "created", "hsmCategory", "keyId", "scheme" ],
         "type" : "object",
@@ -5281,15 +5365,9 @@
         }
       },
       "KeyRotationStatusResponse" : {
-        "required" : [ "rotationInitiatedTimestamp", "lastUpdatedTimestamp", "rotatedKeyStatus", "status", "tenantId" ],
+        "required" : [ "lastUpdatedTimestamp", "rotatedKeyStatus", "rotationInitiatedTimestamp", "status", "tenantId" ],
         "type" : "object",
         "properties" : {
-          "rotationInitiatedTimestamp" : {
-            "type" : "string",
-            "format" : "datetime",
-            "nullable" : false,
-            "example" : "2022-06-24T10:15:30Z"
-          },
           "lastUpdatedTimestamp" : {
             "type" : "string",
             "format" : "datetime",
@@ -5314,6 +5392,12 @@
               },
               "example" : "No example available for this type"
             }
+          },
+          "rotationInitiatedTimestamp" : {
+            "type" : "string",
+            "format" : "datetime",
+            "nullable" : false,
+            "example" : "2022-06-24T10:15:30Z"
           },
           "status" : {
             "type" : "string",

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -413,6 +413,70 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
     fun getUpdateSchemaSql(virtualNodeShortHash: String, newCpiChecksum: String) =
         get("/api/$REST_API_VERSION_PATH/virtualnode/$virtualNodeShortHash/db/vault/$newCpiChecksum")
 
+    private data class DeprecatedVNodeCreateBody(
+        val cpiFileChecksum: String,
+        val x500Name: String,
+        val cryptoDdlConnection: String?,
+        val cryptoDmlConnection: String?,
+        val uniquenessDdlConnection: String?,
+        val uniquenessDmlConnection: String?,
+        val vaultDdlConnection: String?,
+        val vaultDmlConnection: String?
+    )
+
+    private fun deprecatedVNodeBody(
+        cpiHash: String,
+        x500Name: String,
+        cryptoDdlConnection: String?,
+        cryptoDmlConnection: String?,
+        uniquenessDdlConnection: String?,
+        uniquenessDmlConnection: String?,
+        vaultDdlConnection: String?,
+        vaultDmlConnection: String?
+    ): String {
+        val body = DeprecatedVNodeCreateBody(
+            cpiHash,
+            x500Name,
+            cryptoDdlConnection,
+            cryptoDmlConnection,
+            uniquenessDdlConnection,
+            uniquenessDmlConnection,
+            vaultDdlConnection,
+            vaultDmlConnection
+        )
+        return jacksonObjectMapper().writeValueAsString(body)
+    }
+
+    data class ExternalDBConnectionParams(
+        val cryptoDdlConnection: String? = null,
+        val cryptoDmlConnection: String? = null,
+        val uniquenessDdlConnection: String? = null,
+        val uniquenessDmlConnection: String? = null,
+        val vaultDdlConnection: String? = null,
+        val vaultDmlConnection: String? = null
+    )
+
+    /** Creates a virtual node with the deprecated method */
+    @Suppress("LongParameterList", "unused")
+    fun deprecatedVNodeCreate(
+        cpiHash: String,
+        x500Name: String,
+        externalDBConnectionParams: ExternalDBConnectionParams? = null
+    ) =
+        post(
+            "/api/$REST_API_VERSION_PATH/virtualnode",
+            deprecatedVNodeBody(
+                cpiHash,
+                x500Name,
+                externalDBConnectionParams?.cryptoDdlConnection,
+                externalDBConnectionParams?.cryptoDmlConnection,
+                externalDBConnectionParams?.uniquenessDdlConnection,
+                externalDBConnectionParams?.uniquenessDmlConnection,
+                externalDBConnectionParams?.vaultDdlConnection,
+                externalDBConnectionParams?.vaultDmlConnection
+            )
+        )
+
     /** Create a virtual node */
     @Suppress("LongParameterList")
     fun vNodeCreate(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -35,12 +35,12 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
     private data class VNodeCreateBody(
         val cpiFileChecksum: String,
         val x500Name: String,
-        val cryptoDdlConnection: String?,
-        val cryptoDmlConnection: String?,
-        val uniquenessDdlConnection: String?,
-        val uniquenessDmlConnection: String?,
-        val vaultDdlConnection: String?,
-        val vaultDmlConnection: String?
+        val cryptoDdlConnection: JsonNode?,
+        val cryptoDmlConnection: JsonNode?,
+        val uniquenessDdlConnection: JsonNode?,
+        val uniquenessDmlConnection: JsonNode?,
+        val vaultDdlConnection: JsonNode?,
+        val vaultDmlConnection: JsonNode?
     )
 
     private data class VNodeChangeConnectionStringsBody(
@@ -50,15 +50,6 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
         val uniquenessDmlConnection: JsonNode?,
         val vaultDdlConnection: JsonNode?,
         val vaultDmlConnection: JsonNode?
-    )
-
-    data class ExternalDBConnectionParams(
-        val cryptoDdlConnection: String? = null,
-        val cryptoDmlConnection: String? = null,
-        val uniquenessDdlConnection: String? = null,
-        val uniquenessDmlConnection: String? = null,
-        val vaultDdlConnection: String? = null,
-        val vaultDmlConnection: String? = null
     )
 
     data class JsonExternalDBConnectionParams(
@@ -254,12 +245,12 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
     private fun vNodeBody(
         cpiHash: String,
         x500Name: String,
-        cryptoDdlConnection: String?,
-        cryptoDmlConnection: String?,
-        uniquenessDdlConnection: String?,
-        uniquenessDmlConnection: String?,
-        vaultDdlConnection: String?,
-        vaultDmlConnection: String?
+        cryptoDdlConnection: JsonNode?,
+        cryptoDmlConnection: JsonNode?,
+        uniquenessDdlConnection: JsonNode?,
+        uniquenessDmlConnection: JsonNode?,
+        vaultDdlConnection: JsonNode?,
+        vaultDmlConnection: JsonNode?
     ): String {
         val body = VNodeCreateBody(
             cpiHash,
@@ -427,7 +418,7 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
     fun vNodeCreate(
         cpiHash: String,
         x500Name: String,
-        externalDBConnectionParams: ExternalDBConnectionParams? = null
+        externalDBConnectionParams: JsonExternalDBConnectionParams? = null
     ) =
         post(
             "/api/$REST_API_VERSION_PATH/virtualnode",

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -465,7 +465,7 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
         externalDBConnectionParams: ExternalDBConnectionParams? = null
     ) =
         post(
-            "/api/${RestApiVersion.C5_2}/virtualnode",
+            "/api/${RestApiVersion.C5_2.versionPath}/virtualnode",
             deprecatedVNodeBody(
                 cpiHash,
                 x500Name,

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -424,6 +424,7 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
         val vaultDmlConnection: String?
     )
 
+    @Suppress("LongParameterList")
     private fun deprecatedVNodeBody(
         cpiHash: String,
         x500Name: String,

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -465,7 +465,7 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
         externalDBConnectionParams: ExternalDBConnectionParams? = null
     ) =
         post(
-            "/api/$REST_API_VERSION_PATH/virtualnode",
+            "/api/${RestApiVersion.C5_2}/virtualnode",
             deprecatedVNodeBody(
                 cpiHash,
                 x500Name,

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -52,7 +52,7 @@ import java.net.URI
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.cert.CertificateFactory
-import java.util.*
+import java.util.Date
 
 @Suppress("TooManyFunctions")
 abstract class BaseOnboard : Runnable, RestCommand() {

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -19,7 +19,7 @@ import net.corda.libs.configuration.endpoints.v1.types.ConfigSchemaVersion
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
 import net.corda.libs.cpiupload.endpoints.v1.CpiUploadRestResource
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
 import net.corda.membership.rest.v1.CertificatesRestResource
 import net.corda.membership.rest.v1.HsmRestResource
 import net.corda.membership.rest.v1.KeysRestResource
@@ -182,7 +182,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
     protected abstract val registrationContext: Map<String, Any?>
 
     private fun createVirtualNode(): String {
-        val request = CreateVirtualNodeRequest(
+        val request = JsonCreateVirtualNodeRequest(
             x500Name = name,
             cpiFileChecksum = cpiFileChecksum,
             vaultDdlConnection = null,

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -19,7 +19,7 @@ import net.corda.libs.configuration.endpoints.v1.types.ConfigSchemaVersion
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
 import net.corda.libs.cpiupload.endpoints.v1.CpiUploadRestResource
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
-import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequestType.JsonCreateVirtualNodeRequest
 import net.corda.membership.rest.v1.CertificatesRestResource
 import net.corda.membership.rest.v1.HsmRestResource
 import net.corda.membership.rest.v1.KeysRestResource
@@ -52,7 +52,7 @@ import java.net.URI
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.cert.CertificateFactory
-import java.util.Date
+import java.util.*
 
 @Suppress("TooManyFunctions")
 abstract class BaseOnboard : Runnable, RestCommand() {

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -19,7 +19,7 @@ import net.corda.libs.configuration.endpoints.v1.types.ConfigSchemaVersion
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
 import net.corda.libs.cpiupload.endpoints.v1.CpiUploadRestResource
 import net.corda.libs.virtualnode.endpoints.v1.VirtualNodeRestResource
-import net.corda.libs.virtualnode.endpoints.v1.types.JsonCreateVirtualNodeRequest
+import net.corda.libs.virtualnode.endpoints.v1.types.CreateVirtualNodeRequest.JsonCreateVirtualNodeRequest
 import net.corda.membership.rest.v1.CertificatesRestResource
 import net.corda.membership.rest.v1.HsmRestResource
 import net.corda.membership.rest.v1.KeysRestResource


### PR DESCRIPTION
- Add new version of createVirtualNode endpoint that uses nested objects for 5.3+ and deprecate old one
- Add new CreateVirtualNodeRequest type so both endpoints can be used
- Update E2E tests to use new endpoint and add new test to use old endpoint: [CORE-19559: Change create vNode DB connection strings to nested objects #462](https://github.com/corda/corda-e2e-tests/pull/462)

Green E2E test build with updated tests: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda5-e2e-tests/detail/PR-462/25/pipeline/