### PR TITLE
CORE-19631: Fix State Manager Timestamp Filter

### DIFF
--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/AbstractQueryProvider.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/AbstractQueryProvider.kt
@@ -6,8 +6,11 @@ import net.corda.libs.statemanager.impl.model.v1.StateColumns.METADATA_COLUMN
 import net.corda.libs.statemanager.impl.model.v1.StateColumns.MODIFIED_TIME_COLUMN
 import net.corda.libs.statemanager.impl.model.v1.StateColumns.VALUE_COLUMN
 import net.corda.libs.statemanager.impl.model.v1.StateColumns.VERSION_COLUMN
+import java.util.TimeZone
 
 abstract class AbstractQueryProvider : QueryProvider {
+    override val timeZone: TimeZone
+        get() = TimeZone.getTimeZone("UTC")
 
     override fun findStatesByKey(size: Int) =
         """

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/PostgresQueryProvider.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/PostgresQueryProvider.kt
@@ -13,7 +13,7 @@ class PostgresQueryProvider : AbstractQueryProvider() {
 
     override fun createStates(size: Int): String = """
         WITH data ($KEY_COLUMN, $VALUE_COLUMN, $VERSION_COLUMN, $METADATA_COLUMN, $MODIFIED_TIME_COLUMN) as (
-            VALUES ${List(size) { "(?, ?, ?, CAST(? AS JSONB), CURRENT_TIMESTAMP AT TIME ZONE 'UTC')" }.joinToString(",")}
+            VALUES ${List(size) { "(?, ?, ?, CAST(? AS JSONB), CURRENT_TIMESTAMP AT TIME ZONE '${timeZone.id}')" }.joinToString(",")}
         )
         INSERT INTO $STATE_MANAGER_TABLE
         SELECT * FROM data d
@@ -31,7 +31,7 @@ class PostgresQueryProvider : AbstractQueryProvider() {
                 $VALUE_COLUMN = temp.value, 
                 $VERSION_COLUMN = s.$VERSION_COLUMN + 1, 
                 $METADATA_COLUMN = CAST(temp.metadata as JSONB), 
-                $MODIFIED_TIME_COLUMN = CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+                $MODIFIED_TIME_COLUMN = CURRENT_TIMESTAMP AT TIME ZONE '${timeZone.id}'
             FROM
             (
                 VALUES ${List(size) { "(?, ?, ?, ?)" }.joinToString(",")}

--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/QueryProvider.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/QueryProvider.kt
@@ -1,6 +1,7 @@
 package net.corda.libs.statemanager.impl.repository.impl
 
 import net.corda.libs.statemanager.api.MetadataFilter
+import java.util.TimeZone
 
 /**
  * Provider for SQL queries executed by [StateRepositoryImpl].
@@ -9,6 +10,8 @@ import net.corda.libs.statemanager.api.MetadataFilter
  * the relevant implementation instead.
  */
 interface QueryProvider {
+
+    val timeZone: TimeZone
 
     fun createStates(size: Int): String
 


### PR DESCRIPTION
Fix state manager implementation so that the time zone used when
filtering by timestamps is the same used when persisting or updating
states ("UTC").
