### PR TITLE
CORE-19621: Rename createdTimestamp to rotationInitiatedTimestamp

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
@@ -8,7 +8,7 @@ import java.time.Instant
  * @param tenantId Either a holding identity ID, the value 'master' for master wrapping key or one of the values
 *          'p2p', 'rest', 'crypto' for corresponding cluster-level tenant.
  * @param status Overall status of the key rotation. Either In Progress or Done.
- * @param createdTimestamp Timestamp of then the key rotation request was received.
+ * @param rotationInitiatedTimestamp Timestamp of then the key rotation request was received.
  * @param lastUpdatedTimestamp The last updated timestamp.
  * @param rotatedKeyStatus Number of keys needs rotating grouped by tenantId or wrapping key.
  */
@@ -16,7 +16,7 @@ import java.time.Instant
 data class KeyRotationStatusResponse(
     val tenantId: String,
     val status: String,
-    val createdTimestamp: Instant,
+    val rotationInitiatedTimestamp: Instant,
     val lastUpdatedTimestamp: Instant,
     val rotatedKeyStatus: List<Pair<String, RotatedKeysStatus>>,
 )

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
@@ -8,7 +8,7 @@ import java.time.Instant
  * @param tenantId Either a holding identity ID, the value 'master' for master wrapping key or one of the values
 *          'p2p', 'rest', 'crypto' for corresponding cluster-level tenant.
  * @param status Overall status of the key rotation. Either In Progress or Done.
- * @param rotationInitiatedTimestamp Timestamp of then the key rotation request was received.
+ * @param rotationInitiatedTimestamp Timestamp of when the key rotation request was received.
  * @param lastUpdatedTimestamp The last updated timestamp.
  * @param rotatedKeyStatus Number of keys needs rotating grouped by tenantId or wrapping key.
  */

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -5281,10 +5281,10 @@
         }
       },
       "KeyRotationStatusResponse" : {
-        "required" : [ "createdTimestamp", "lastUpdatedTimestamp", "rotatedKeyStatus", "status", "tenantId" ],
+        "required" : [ "rotationInitiatedTimestamp", "lastUpdatedTimestamp", "rotatedKeyStatus", "status", "tenantId" ],
         "type" : "object",
         "properties" : {
-          "createdTimestamp" : {
+          "rotationInitiatedTimestamp" : {
             "type" : "string",
             "format" : "datetime",
             "nullable" : false,


### PR DESCRIPTION
The name of the field `createdTimestamp` can cause confusion about what it refers to, so this PR renames it to `rotationInitiatedTimestamp`