### PR TITLE
CORE-19695 Handle duplicate signed and filtered transactions

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -797,8 +797,8 @@ class UtxoPersistenceServiceImplTest {
         entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
             assertThat(transaction).isNotNull
-            assertThat(transaction.field<String>("status")).isEqualTo("D")
             assertThat(transaction.field<Boolean>("isFiltered")).isTrue()
+            assertThat(transaction.field<String>("status")).isEqualTo("D")
             assertThat(transaction.field<Instant>("created")).isEqualTo(createdTimestamp)
         }
     }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -74,8 +74,29 @@ interface UtxoRepository {
         account: String,
         timestamp: Instant,
         status: TransactionStatus,
+        metadataHash: String
+    )
+
+    /** Persists unverified transaction (operation is idempotent) */
+    @Suppress("LongParameterList")
+    fun persistUnverifiedTransaction(
+        entityManager: EntityManager,
+        id: String,
+        privacySalt: ByteArray,
+        account: String,
+        timestamp: Instant,
         metadataHash: String,
-        isFiltered: Boolean
+    )
+
+    /** Persists unverified transaction (operation is idempotent) */
+    @Suppress("LongParameterList")
+    fun persistFilteredTransaction(
+        entityManager: EntityManager,
+        id: String,
+        privacySalt: ByteArray,
+        account: String,
+        timestamp: Instant,
+        metadataHash: String,
     )
 
     /** Persists transaction metadata (operation is idempotent) */

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -24,7 +24,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
             INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash, FALSE)
             ON CONFLICT(id) DO
-            UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated, is_filtered = EXCLUDED.is_filtered
+            UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated, is_filtered = FALSE
             WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT')
                 OR (utxo_transaction.status = '$VERIFIED' AND utxo_transaction.is_filtered = TRUE)
             """
@@ -46,7 +46,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
             INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (:id, :privacySalt, :accountId, :createdAt, '$VERIFIED', :updatedAt, :metadataHash, TRUE)
             ON CONFLICT(id) DO
-            UPDATE SET updated = EXCLUDED.updated, is_filtered = EXCLUDED.is_filtered
+            UPDATE SET updated = EXCLUDED.updated, is_filtered = TRUE
             WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT') AND utxo_transaction.is_filtered = FALSE
             """
             .trimIndent()

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -46,7 +46,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
             INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (:id, :privacySalt, :accountId, :createdAt, '$VERIFIED', :updatedAt, :metadataHash, TRUE)
             ON CONFLICT(id) DO
-            UPDATE SET updated = EXCLUDED.updated, is_filtered = TRUE
+            UPDATE SET is_filtered = TRUE
             WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT') AND utxo_transaction.is_filtered = FALSE
             """
             .trimIndent()

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -22,11 +22,33 @@ class PostgresUtxoQueryProvider @Activate constructor(
     override val persistTransaction: String
         get() = """
             INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
-                VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash, :isFiltered)
+                VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash, FALSE)
             ON CONFLICT(id) DO
-                UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated, is_filtered = EXCLUDED.is_filtered
+            UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated, is_filtered = EXCLUDED.is_filtered
             WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT')
-                OR (utxo_transaction.status = '$VERIFIED' AND utxo_transaction.is_filtered = true)"""
+                OR (utxo_transaction.status = '$VERIFIED' AND utxo_transaction.is_filtered = TRUE)
+            """
+            .trimIndent()
+
+    override val persistUnverifiedTransaction: String
+        get() = """
+            INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
+                VALUES (:id, :privacySalt, :accountId, :createdAt, '$UNVERIFIED', :updatedAt, :metadataHash, FALSE)
+            ON CONFLICT(id) DO
+            UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated
+            WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT')
+                OR (utxo_transaction.status = '$VERIFIED' AND utxo_transaction.is_filtered = TRUE)
+            """
+            .trimIndent()
+
+    override val persistFilteredTransaction: String
+        get() = """
+            INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
+                VALUES (:id, :privacySalt, :accountId, :createdAt, '$VERIFIED', :updatedAt, :metadataHash, TRUE)
+            ON CONFLICT(id) DO
+            UPDATE SET updated = EXCLUDED.updated, is_filtered = EXCLUDED.is_filtered
+            WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT') AND utxo_transaction.is_filtered = FALSE
+            """
             .trimIndent()
 
     override val persistTransactionMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -488,8 +488,6 @@ class UtxoPersistenceServiceImpl(
 
                 val nowUtc = utcClock.instant()
 
-                val metadata = filteredTransaction.metadata as TransactionMetadataInternal
-
                 // 1. Get the metadata bytes from the 0th component group merkle proof and create the hash
                 val metadataBytes = filteredTransaction.filteredComponentGroups[0]
                     ?.merkleProof
@@ -500,6 +498,8 @@ class UtxoPersistenceServiceImpl(
                 requireNotNull(metadataBytes) {
                     "Could not find metadata in the filtered transaction with id: ${filteredTransaction.id}"
                 }
+
+                val metadata = filteredTransaction.metadata as TransactionMetadataInternal
 
                 val metadataHash = sandboxDigestService.hash(
                     metadataBytes,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -57,6 +57,16 @@ interface UtxoQueryProvider {
     val persistTransaction: String
 
     /**
+     * @property persistUnverifiedTransaction SQL text for [UtxoRepositoryImpl.persistUnverifiedTransaction].
+     */
+    val persistUnverifiedTransaction: String
+
+    /**
+     * @property persistFilteredTransaction SQL text for [UtxoRepositoryImpl.persistFilteredTransaction].
+     */
+    val persistFilteredTransaction: String
+
+    /**
      * @property persistTransactionMetadata SQL text for [UtxoRepositoryImpl.persistTransactionMetadata].
      */
     val persistTransactionMetadata: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -191,7 +191,6 @@ class UtxoRepositoryImpl(
         timestamp: Instant,
         status: TransactionStatus,
         metadataHash: String,
-        isFiltered: Boolean
     ) {
         entityManager.createNativeQuery(queryProvider.persistTransaction)
             .setParameter("id", id)
@@ -201,7 +200,46 @@ class UtxoRepositoryImpl(
             .setParameter("status", status.value)
             .setParameter("updatedAt", timestamp)
             .setParameter("metadataHash", metadataHash)
-            .setParameter("isFiltered", isFiltered)
+            .executeUpdate()
+            .logResult("transaction [$id]")
+    }
+
+    override fun persistUnverifiedTransaction(
+        entityManager: EntityManager,
+        id: String,
+        privacySalt: ByteArray,
+        account: String,
+        timestamp: Instant,
+        metadataHash: String,
+    ) {
+        entityManager.createNativeQuery(queryProvider.persistUnverifiedTransaction)
+            .setParameter("id", id)
+            .setParameter("privacySalt", privacySalt)
+            .setParameter("accountId", account)
+            .setParameter("createdAt", timestamp)
+            .setParameter("updatedAt", timestamp)
+            .setParameter("metadataHash", metadataHash)
+            .executeUpdate()
+            .logResult("transaction [$id]")
+    }
+
+    override fun persistFilteredTransaction(
+        entityManager: EntityManager,
+        id: String,
+        privacySalt: ByteArray,
+        account: String,
+        timestamp: Instant,
+        metadataHash: String
+    ) {
+        val rs =  entityManager.createNativeQuery("select * from utxo_transaction where id = :id").setParameter("id", id).resultList
+        println(rs)
+        entityManager.createNativeQuery(queryProvider.persistFilteredTransaction)
+            .setParameter("id", id)
+            .setParameter("privacySalt", privacySalt)
+            .setParameter("accountId", account)
+            .setParameter("createdAt", timestamp)
+            .setParameter("updatedAt", timestamp)
+            .setParameter("metadataHash", metadataHash)
             .executeUpdate()
             .logResult("transaction [$id]")
     }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -231,8 +231,6 @@ class UtxoRepositoryImpl(
         timestamp: Instant,
         metadataHash: String
     ) {
-        val rs =  entityManager.createNativeQuery("select * from utxo_transaction where id = :id").setParameter("id", id).resultList
-        println(rs)
         entityManager.createNativeQuery(queryProvider.persistFilteredTransaction)
             .setParameter("id", id)
             .setParameter("privacySalt", privacySalt)

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
@@ -55,7 +55,7 @@ class UtxoPersistenceServiceImplTest {
             persistedJsonStrings[txId] = customRepresentation
         }
 
-        on { persistTransaction(any(), any(), any(), any(), any(), any(), any(), any()) } doAnswer {}
+        on { persistTransaction(any(), any(), any(), any(), any(), any(), any()) } doAnswer {}
         on { persistTransactionComponents(any(), any(), any(), any()) } doAnswer {}
     }
     private val mockDigestService = mock<DigestService> {

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -23,11 +23,37 @@ class HsqldbUtxoQueryProvider @Activate constructor(
     override val persistTransaction: String
         get() = """
             MERGE INTO {h-schema}utxo_transaction AS ut
-            USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), :status, CAST(:updatedAt AS TIMESTAMP), :metadataHash, :isFiltered)
+            USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), :status, CAST(:updatedAt AS TIMESTAMP), :metadataHash, FALSE)
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
             ON x.id = ut.id
-            WHEN MATCHED AND (ut.status in ('$UNVERIFIED', '$DRAFT') OR (ut.status = '$VERIFIED' AND ut.is_filtered = true)) 
-            THEN UPDATE SET ut.status = x.status, ut.updated = x.updated, ut.is_filtered = x.is_filtered
+            WHEN MATCHED AND ((ut.status = '$UNVERIFIED' or ut.status = '$DRAFT') OR (ut.status = '$VERIFIED' AND ut.is_filtered = TRUE)) 
+            THEN UPDATE SET ut.status = x.status, ut.updated = x.updated, ut.is_filtered = FALSE
+            WHEN NOT MATCHED THEN
+                INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
+                VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""
+            .trimIndent()
+
+    override val persistUnverifiedTransaction: String
+        get() = """
+            MERGE INTO {h-schema}utxo_transaction AS ut
+            USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), '$UNVERIFIED', CAST(:updatedAt AS TIMESTAMP), :metadataHash, FALSE)
+                AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
+            ON x.id = ut.id
+            WHEN MATCHED AND ((ut.status = '$UNVERIFIED' or ut.status = '$DRAFT') OR (ut.status = '$VERIFIED' AND ut.is_filtered = TRUE))
+            THEN UPDATE SET ut.status = x.status, ut.updated = x.updated
+            WHEN NOT MATCHED THEN
+                INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
+                VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""
+            .trimIndent()
+
+    override val persistFilteredTransaction: String
+        get() = """
+            MERGE INTO {h-schema}utxo_transaction AS ut
+            USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), '$VERIFIED', CAST(:updatedAt AS TIMESTAMP), :metadataHash, TRUE)
+                AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
+            ON x.id = ut.id
+            WHEN MATCHED AND ((ut.status = '$UNVERIFIED' OR ut.status = '$DRAFT') AND ut.is_filtered = FALSE)
+            THEN UPDATE SET ut.updated = x.updated, ut.is_filtered = TRUE
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -53,7 +53,7 @@ class HsqldbUtxoQueryProvider @Activate constructor(
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
             ON x.id = ut.id
             WHEN MATCHED AND ((ut.status = '$UNVERIFIED' OR ut.status = '$DRAFT') AND ut.is_filtered = FALSE)
-            THEN UPDATE SET ut.updated = x.updated, ut.is_filtered = TRUE
+            THEN UPDATE ut.is_filtered = TRUE
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""


### PR DESCRIPTION
Support having unverified and filtered transactions existing for the same transaction simultaneously. In this case, the `status` would be `U` and `is_filtered = true`. The filtered transaction would be used until the transaction status switches to  `V`.

Fix HSQLDB queries that don't seem to use the `IN` SQL clause correctly. Switching to `=` and `OR` worked.