### PR TITLE
CORE-19717: Backchain privacy unit testing in receive finality flow

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -847,16 +847,12 @@ class UtxoReceiveFinalityFlowV1Test {
         whenever(session.receive(List::class.java)).thenReturn(listOf(signature3))
         whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
 
-        val listOfFtxAndSigs = listOf(filteredTxAndSig, filteredTxAndSig2)
-        listOfFtxAndSigs.forEach {
-            whenever(it.verifyFilteredTransactionAndSignatures(notaryInfo, notarySignatureVerificationService))
-                .thenThrow(CordaRuntimeException("verifying filtered transactions and signatures failed!"))
-        }
+        whenever(filteredTransaction.verify()).thenThrow(CordaRuntimeException("verifying filtered transactions verification failed!"))
 
         assertThatThrownBy { callReceiveFinalityFlow() }
 
         // assert persisting filtered transactions and signatures never happened since they are invalid.
-        verify(persistenceService, never()).persistFilteredTransactionsAndSignatures(listOfFtxAndSigs)
+        verify(persistenceService, never()).persistFilteredTransactionsAndSignatures(listOf(filteredTxAndSig, filteredTxAndSig2))
     }
 
     private fun callReceiveFinalityFlow(validator: UtxoTransactionValidator = UtxoTransactionValidator { }) {

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/factory/impl/FilteredTransactionFactoryImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/factory/impl/FilteredTransactionFactoryImpl.kt
@@ -97,7 +97,7 @@ class FilteredTransactionFactoryImpl @Activate constructor(
         parameters: ComponentGroupFilterParameters
     ): FilteredComponentGroup {
         val componentGroupIndex = parameters.componentGroupIndex
-        val componentGroup = wireTransaction.getComponentGroupList(componentGroupIndex)
+        val componentGroupFromWire = wireTransaction.getComponentGroupList(componentGroupIndex)
 
         val componentGroupMerkleTreeDigestProvider = wireTransaction.metadata.getComponentGroupMerkleTreeDigestProvider(
             wireTransaction.privacySalt,
@@ -114,7 +114,7 @@ class FilteredTransactionFactoryImpl @Activate constructor(
             is AuditProof<*> -> {
                 val skipFiltering = componentGroupIndex == 0
 
-                val filteredComponents = componentGroup
+                val filteredComponentsFromWireComponentGroup = componentGroupFromWire
                     .mapIndexed { index, component -> index to component }
                     .filter { (index, component) ->
                         if (skipFiltering) {
@@ -136,8 +136,8 @@ class FilteredTransactionFactoryImpl @Activate constructor(
                         }
                     }
                 wireTransaction.componentMerkleTrees[componentGroupIndex]!!.let { merkleTree ->
-                    if (filteredComponents.isEmpty()) {
-                        if (componentGroup.isEmpty()) {
+                    if (filteredComponentsFromWireComponentGroup.isEmpty()) {
+                        if (componentGroupFromWire.isEmpty()) {
                             // If the unfiltered component group is empty, we return the proof of the marker.
                             merkleTree.createAuditProof(listOf(0))
                         } else {
@@ -145,7 +145,7 @@ class FilteredTransactionFactoryImpl @Activate constructor(
                             componentGroupMerkleTreeSizeProofProvider.getSizeProof(merkleTree.leaves)
                         }
                     } else {
-                        merkleTree.createAuditProof(filteredComponents.map { it.first })
+                        merkleTree.createAuditProof(filteredComponentsFromWireComponentGroup.map { it.first })
                     }
                 }
             }

--- a/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/factory/impl/FilteredTransactionFactoryImpl.kt
+++ b/libs/ledger/ledger-common-data/src/main/kotlin/net/corda/ledger/common/data/transaction/filtered/factory/impl/FilteredTransactionFactoryImpl.kt
@@ -97,7 +97,7 @@ class FilteredTransactionFactoryImpl @Activate constructor(
         parameters: ComponentGroupFilterParameters
     ): FilteredComponentGroup {
         val componentGroupIndex = parameters.componentGroupIndex
-        val componentGroupFromWire = wireTransaction.getComponentGroupList(componentGroupIndex)
+        val componentGroup = wireTransaction.getComponentGroupList(componentGroupIndex)
 
         val componentGroupMerkleTreeDigestProvider = wireTransaction.metadata.getComponentGroupMerkleTreeDigestProvider(
             wireTransaction.privacySalt,
@@ -114,7 +114,7 @@ class FilteredTransactionFactoryImpl @Activate constructor(
             is AuditProof<*> -> {
                 val skipFiltering = componentGroupIndex == 0
 
-                val filteredComponentsFromWireComponentGroup = componentGroupFromWire
+                val filteredComponents = componentGroup
                     .mapIndexed { index, component -> index to component }
                     .filter { (index, component) ->
                         if (skipFiltering) {
@@ -136,8 +136,8 @@ class FilteredTransactionFactoryImpl @Activate constructor(
                         }
                     }
                 wireTransaction.componentMerkleTrees[componentGroupIndex]!!.let { merkleTree ->
-                    if (filteredComponentsFromWireComponentGroup.isEmpty()) {
-                        if (componentGroupFromWire.isEmpty()) {
+                    if (filteredComponents.isEmpty()) {
+                        if (componentGroup.isEmpty()) {
                             // If the unfiltered component group is empty, we return the proof of the marker.
                             merkleTree.createAuditProof(listOf(0))
                         } else {
@@ -145,7 +145,7 @@ class FilteredTransactionFactoryImpl @Activate constructor(
                             componentGroupMerkleTreeSizeProofProvider.getSizeProof(merkleTree.leaves)
                         }
                     } else {
-                        merkleTree.createAuditProof(filteredComponentsFromWireComponentGroup.map { it.first })
+                        merkleTree.createAuditProof(filteredComponents.map { it.first })
                     }
                 }
             }


### PR DESCRIPTION
- enabled receive finality flow test
- edited a test case to make more sense
- added test cases that covers of [Acceptance Criteria](https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4767776883/Contract+Verifying+Acceptance+Criteria):
  - _The receive finality rejects transactions if input/ref filtered txs don’t match input/ref StateRefs_
  - _The receive finality rejects transactions if input/ref filtered tx aren’t part of a valid Merkle proof_ 