### PR TITLE
CORE-15061 Fix integer overflow in named query execution

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -336,7 +336,9 @@ class VaultNamedQueryExecutorImpl(
             query.firstResult = offset
             // Getting one more than requested allows us to identify if there are more results to
             // return in a subsequent page
-            query.maxResults = request.limit + 1
+            // CORE-15061 By default the limit will be `Int.MAX_VALUE` and adding +1 to that value
+            // will cause integer to overflow, that's why we need this extra `minOf` here.
+            query.maxResults = minOf(Int.MAX_VALUE-1, request.limit) + 1
 
             query.resultList as List<Tuple>
         }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -338,7 +338,7 @@ class VaultNamedQueryExecutorImpl(
             // return in a subsequent page
             // CORE-15061 By default the limit will be `Int.MAX_VALUE` and adding +1 to that value
             // will cause integer to overflow, that's why we need this extra `minOf` here.
-            query.maxResults = minOf(Int.MAX_VALUE-1, request.limit) + 1
+            query.maxResults = minOf(Int.MAX_VALUE - 1, request.limit) + 1
 
             query.resultList as List<Tuple>
         }
@@ -413,7 +413,7 @@ class VaultNamedQueryExecutorImpl(
             // return in a subsequent page
             // CORE-15061 By default the limit will be `Int.MAX_VALUE` and adding +1 to that value
             // will cause integer to overflow, that's why we need this extra `minOf` here.
-            query.maxResults = minOf(Int.MAX_VALUE-1, request.limit) + 1
+            query.maxResults = minOf(Int.MAX_VALUE - 1, request.limit) + 1
 
             query.resultList as List<Tuple>
         }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/query/execution/impl/VaultNamedQueryExecutorImpl.kt
@@ -411,7 +411,9 @@ class VaultNamedQueryExecutorImpl(
             query.firstResult = request.offset
             // Getting one more than requested allows us to identify if there are more results to
             // return in a subsequent page
-            query.maxResults = request.limit + 1
+            // CORE-15061 By default the limit will be `Int.MAX_VALUE` and adding +1 to that value
+            // will cause integer to overflow, that's why we need this extra `minOf` here.
+            query.maxResults = minOf(Int.MAX_VALUE-1, request.limit) + 1
 
             query.resultList as List<Tuple>
         }


### PR DESCRIPTION
### Overview

By default the limit defaults to `Int.MAX_VALUE` and we add `+1` to that value when fetching the results. This will cause the integer to overflow.