### PR TITLE
CORE-19749: Write "start requested" status to state manager

### DIFF
--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImpl.kt
@@ -40,7 +40,6 @@ import net.corda.rest.messagebus.MessageBusUtils.tryWithExceptionHandling
 import net.corda.rest.response.ResponseEntity
 import net.corda.rest.security.CURRENT_REST_CONTEXT
 import net.corda.schema.Schemas.Flow.FLOW_MAPPER_START
-import net.corda.schema.Schemas.Flow.FLOW_STATUS_TOPIC
 import net.corda.tracing.TraceTag
 import net.corda.tracing.addTraceContextToRecord
 import net.corda.tracing.trace
@@ -205,8 +204,9 @@ class FlowRestResourceImpl @Activate constructor(
                         getKeyForStartEvent(status.key, holdingIdentityShortHash), startEvent
                     )
                 ),
-                Record(FLOW_STATUS_TOPIC, status.key, status),
             )
+
+            flowStatusLookupService.storeStatus(status)
 
             val batchFuture = try {
                 tryWithExceptionHandling(

--- a/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/FlowStatusLookupServiceImplTest.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/FlowStatusLookupServiceImplTest.kt
@@ -71,7 +71,6 @@ class FlowStatusLookupServiceImplTest {
     private val mockSubscription = mock<Subscription<Any, Any>>()
     private lateinit var flowStatusLookupService: FlowStatusLookupServiceImpl
 
-    private val bootConfig = mock<SmartConfig>()
     private val messagingConfig = mock<SmartConfig> {
         whenever(it.getInt(INSTANCE_ID)).thenReturn(2)
         whenever(it.getConfig(ConfigKeys.STATE_MANAGER_CONFIG)).thenReturn(mock())
@@ -79,16 +78,9 @@ class FlowStatusLookupServiceImplTest {
     private val stateManagerConfig = mock<SmartConfig>()
     private val restConfig = mock<SmartConfig>()
 
-    private val configs = mapOf(
-        ConfigKeys.BOOT_CONFIG to bootConfig,
-        ConfigKeys.MESSAGING_CONFIG to messagingConfig,
-        ConfigKeys.STATE_MANAGER_CONFIG to stateManagerConfig,
-        ConfigKeys.REST_CONFIG to restConfig
-    )
-
     companion object {
-        const val ALICE_X500 = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
-        const val BOB_X500 = "CN=Bob, O=Bob Corp, L=LDN, C=GB"
+        private const val ALICE_X500 = "CN=Alice, O=Alice Corp, L=LDN, C=GB"
+        private const val BOB_X500 = "CN=Bob, O=Bob Corp, L=LDN, C=GB"
 
         val FLOW_KEY_1 = FlowKey("a1", HoldingIdentity(ALICE_X500, "c1"))
         val FLOW_KEY_2 = FlowKey("a2", HoldingIdentity(BOB_X500, "c2"))
@@ -179,9 +171,9 @@ class FlowStatusLookupServiceImplTest {
          */
         abstract inner class ContentTests {
             protected val flowStatus1 = FlowStatus(
-                FlowStatusLookupServiceImplTest.FLOW_KEY_1,
+                FLOW_KEY_1,
                 FlowInitiatorType.RPC,
-                FlowStatusLookupServiceImplTest.FLOW_KEY_1.id,
+                FLOW_KEY_1.id,
                 "FlowClassName",
                 FlowStates.START_REQUESTED,
                 null,

--- a/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/FlowStatusLookupServiceImplTest.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/FlowStatusLookupServiceImplTest.kt
@@ -224,9 +224,6 @@ class FlowStatusLookupServiceImplTest {
                 flowStatusLookupService.storeStatus(flowStatus1)
             }
         }
-
     }
-
-
 }
 

--- a/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImplTest.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/test/kotlin/net/corda/flow/rest/impl/v1/FlowRestResourceImplTest.kt
@@ -327,6 +327,7 @@ class FlowRestResourceImplTest {
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(cpiInfoReadService, times(1)).get(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, times(1)).storeStatus(any())
         verify(messageFactory, times(1)).createStartFlowEvent(any(), any(), any(), any(), platformPropertiesCaptor.capture())
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(publisher, times(1)).batchPublish(any())
@@ -360,6 +361,7 @@ class FlowRestResourceImplTest {
         verify(virtualNodeInfoReadService, never()).getByHoldingIdentityShortHash(any())
         verify(cpiInfoReadService, never()).get(any())
         verify(flowStatusLookupService, never()).getStatus(any(), any())
+        verify(flowStatusLookupService, never()).storeStatus(any())
         verify(messageFactory, never()).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, never()).createStartFlowStatus(any(), any(), any())
         verify(publisher, never()).publish(any())
@@ -377,6 +379,7 @@ class FlowRestResourceImplTest {
         }
 
         verify(flowStatusLookupService, never()).getStatus(any(), any())
+        verify(flowStatusLookupService, never()).storeStatus(any())
         verify(messageFactory, never()).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, never()).createStartFlowStatus(any(), any(), any())
         verify(publisher, never()).publish(any())
@@ -395,6 +398,7 @@ class FlowRestResourceImplTest {
         }
 
         verify(flowStatusLookupService, never()).getStatus(any(), any())
+        verify(flowStatusLookupService, never()).storeStatus(any())
         verify(messageFactory, never()).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, never()).createStartFlowStatus(any(), any(), any())
         verify(publisher, never()).publish(any())
@@ -413,6 +417,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, never()).storeStatus(any())
         verify(cpiInfoReadService, times(0)).get(any())
         verify(messageFactory, times(0)).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, times(0)).createStartFlowStatus(any(), any(), any())
@@ -433,6 +438,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, never()).storeStatus(any())
         verify(cpiInfoReadService, atLeastOnce()).get(any())
         verify(messageFactory, never()).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, never()).createStartFlowStatus(any(), any(), any())
@@ -452,6 +458,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, times(1)).storeStatus(any())
         verify(messageFactory, times(1)).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(publisher, times(1)).batchPublish(any())
@@ -472,6 +479,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, times(1)).storeStatus(any())
         verify(messageFactory, times(1)).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(publisher, times(1)).batchPublish(any())
@@ -490,6 +498,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, times(1)).storeStatus(any())
         verify(messageFactory, times(1)).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(publisher, times(1)).batchPublish(any())
@@ -505,6 +514,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, times(1)).storeStatus(any())
         verify(messageFactory, times(1)).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(publisher, times(1)).batchPublish(any())
@@ -525,6 +535,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, times(1)).storeStatus(any())
         verify(messageFactory, times(1)).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(publisher, times(1)).batchPublish(any())
@@ -540,6 +551,7 @@ class FlowRestResourceImplTest {
 
         verify(virtualNodeInfoReadService, times(1)).getByHoldingIdentityShortHash(any())
         verify(flowStatusLookupService, times(1)).getStatus(any(), any())
+        verify(flowStatusLookupService, times(1)).storeStatus(any())
         verify(messageFactory, times(1)).createStartFlowEvent(any(), any(), any(), any(), any())
         verify(messageFactory, times(1)).createStartFlowStatus(any(), any(), any())
         verify(publisher, times(1)).batchPublish(any())

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/FlowStatusLookupService.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/FlowStatusLookupService.kt
@@ -35,4 +35,12 @@ interface FlowStatusLookupService: Lifecycle {
      * @return A list of flow statuses, or an empty list if none exist.
      * */
     fun getStatusesPerIdentity(holdingIdentity: HoldingIdentity): List<FlowStatus>
+
+    /**
+     * Stores a new status in the state manager.
+     * Intended to allow saving "start requested" stauses from flow start REST handler
+     *
+     * @param status Status to save
+     */
+    fun storeStatus(status: FlowStatus)
 }


### PR DESCRIPTION
Write "start requested" to state manager so all REST workers recognise the flow ID when the start flow request completes.