### PR TITLE
CORE-19738 Hash merkle proof id

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -999,7 +999,8 @@ class UtxoPersistenceServiceImplTest {
 
     @Test
     fun `persist filtered transaction with many outputs`() {
-        val stateIndexes = (0 until 100000).toList()
+        val upperLimit = if (DbUtils.databaseType == DbUtils.DatabaseType.HSQL) 1000 else 100000
+        val stateIndexes = (0 until upperLimit).toList()
         val visibleStateIndexes = stateIndexes - listOf(10, 100, 1000)
         val outputStates = stateIndexes.map { TestContractState1() }
         val signatures = createSignatures(Instant.now())
@@ -1024,7 +1025,8 @@ class UtxoPersistenceServiceImplTest {
 
     @Test
     fun `find filtered transaction with many outputs`() {
-        val stateIndexes = (0 until 10000).toList()
+        val upperLimit = if (DbUtils.databaseType == DbUtils.DatabaseType.HSQL) 1000 else 10000
+        val stateIndexes = (0 until upperLimit).toList()
         val excludedStateIndexes = listOf(10, 100, 1000)
         val visibleStateIndexes = stateIndexes - excludedStateIndexes
         val outputStates = stateIndexes.associateWith { TestContractState1() }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -214,14 +214,13 @@ interface UtxoRepository {
     data class TransactionSignature(val index: Int, val signatureBytes: ByteArray, val publicKeyHash: SecureHash)
 
     data class TransactionMerkleProof(
+        val merkleProofId: String,
         val transactionId: String,
         val groupIndex: Int,
         val treeSize: Int,
         val leafIndexes: List<Int>,
         val leafHashes: List<String>
-    ) {
-        val merkleProofId: String = "$transactionId;$groupIndex;${leafIndexes.joinToString(separator = ",")}"
-    }
+    )
 
     data class TransactionMerkleProofLeaf(val merkleProofId: String, val leafIndex: Int)
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -175,6 +175,7 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
                 utmp.transaction_id,
                 utmp.group_idx,
                 utmp.tree_size,
+                utmp.leaf_indexes,
                 utmp.hashes,
                 utt.privacy_salt,
                 utc.leaf_idx,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -109,8 +109,8 @@ class PostgresUtxoQueryProvider @Activate constructor(
     override val persistMerkleProofs: (batchSize: Int) -> String
         get() = { batchSize ->
             """
-            INSERT INTO utxo_transaction_merkle_proof(merkle_proof_id, transaction_id, group_idx, tree_size, hashes)
-            VALUES ${List(batchSize) { "(?, ?, ?, ?, ?)" }.joinToString(",")}
+            INSERT INTO utxo_transaction_merkle_proof(merkle_proof_id, transaction_id, group_idx, tree_size, leaf_indexes, hashes)
+            VALUES ${List(batchSize) { "(?, ?, ?, ?, ?, ?)" }.joinToString(",")}
             ON CONFLICT DO NOTHING
             """.trimIndent()
         }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -543,7 +543,7 @@ class UtxoPersistenceServiceImpl(
                     nowUtc
                 )
 
-                val topLevelTransactionMerkleProof = UtxoRepository.TransactionMerkleProof(
+                val topLevelTransactionMerkleProof = createTransactionMerkleProof(
                     filteredTransaction.id.toString(),
                     TOP_LEVEL_MERKLE_PROOF_GROUP_INDEX,
                     filteredTransaction.topLevelMerkleProof.treeSize,
@@ -552,7 +552,7 @@ class UtxoPersistenceServiceImpl(
                 )
 
                 val componentGroupTransactionMerkleProofs = filteredTransaction.filteredComponentGroups.map { (groupIndex, groupData) ->
-                    val proof = UtxoRepository.TransactionMerkleProof(
+                    val proof = createTransactionMerkleProof(
                         filteredTransaction.id.toString(),
                         groupIndex,
                         groupData.merkleProof.treeSize,
@@ -724,6 +724,26 @@ class UtxoPersistenceServiceImpl(
                 // 6. Map the transaction id to the filtered transaction object and signatures
                 filteredTransaction.id to Pair(filteredTransaction, ftxDto.signatures)
             }.filterNotNull().toMap()
+    }
+
+    fun createTransactionMerkleProof(
+        transactionId: String,
+        groupIndex: Int,
+        treeSize: Int,
+        leafIndexes: List<Int>,
+        leafHashes: List<String>
+    ): UtxoRepository.TransactionMerkleProof {
+        return UtxoRepository.TransactionMerkleProof(
+            digestService.hash(
+                "$transactionId;$groupIndex;${leafIndexes.joinToString(separator = ",")}".toByteArray(Charsets.UTF_8),
+                DigestAlgorithmName.SHA2_256
+            ).toString(),
+            transactionId,
+            groupIndex,
+            treeSize,
+            leafIndexes,
+            leafHashes
+        )
     }
 
     private data class TransactionMerkleProofToPersist(

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoMerkleProofEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoMerkleProofEntity.kt
@@ -28,6 +28,9 @@ data class UtxoMerkleProofEntity(
     @get:Column(name = "tree_size", nullable = false, updatable = false)
     var treeSize: Int,
 
+    @get:Column(name = "leaf_indexes", nullable = false)
+    var leafIndexes: String,
+
     @get:Column(name = "hashes", nullable = false)
     var hashes: String
 ) {
@@ -41,6 +44,7 @@ data class UtxoMerkleProofEntity(
         if (transactionId != other.transactionId) return false
         if (groupIndex != other.groupIndex) return false
         if (treeSize != other.treeSize) return false
+        if (leafIndexes != other.leafIndexes) return false
         if (hashes != other.hashes) return false
 
         return true
@@ -51,6 +55,7 @@ data class UtxoMerkleProofEntity(
         result = 31 * result + transactionId.hashCode()
         result = 31 * result + groupIndex
         result = 31 * result + treeSize
+        result = 31 * result + leafIndexes.hashCode()
         result = 31 * result + hashes.hashCode()
         return result
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.49-alpha-1708438273680
+cordaApiVersion=5.2.0.49-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.48-beta+
+cordaApiVersion=5.2.0.49-alpha-1708438273680
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -53,7 +53,7 @@ class HsqldbUtxoQueryProvider @Activate constructor(
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
             ON x.id = ut.id
             WHEN MATCHED AND ((ut.status = '$UNVERIFIED' OR ut.status = '$DRAFT') AND ut.is_filtered = FALSE)
-            THEN UPDATE ut.is_filtered = TRUE
+            THEN UPDATE SET ut.is_filtered = TRUE
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -160,14 +160,14 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             MERGE INTO utxo_transaction_merkle_proof AS utmp
             USING (VALUES${
                 List(batchSize) {
-                    "(?, ?, ?, ?, ?)"
+                    "(?, ?, ?, ?, ?, ?)"
                 }.joinToString(",")
             })
-                AS x(merkle_proof_id, transaction_id, group_idx, tree_size, hashes)
+                AS x(merkle_proof_id, transaction_id, group_idx, tree_size, leaf_indexes, hashes)
             ON utmp.merkle_proof_id = x.merkle_proof_id
             WHEN NOT MATCHED THEN
-                INSERT (merkle_proof_id, transaction_id, group_idx, tree_size, hashes)
-                VALUES (x.merkle_proof_id, x.transaction_id, x.group_idx, x.tree_size, x.hashes)
+                INSERT (merkle_proof_id, transaction_id, group_idx, tree_size, leaf_indexes, hashes)
+                VALUES (x.merkle_proof_id, x.transaction_id, x.group_idx, x.tree_size, x.leaf_indexes, x.hashes)
             """.trimIndent()
         }
 


### PR DESCRIPTION
Store the merkle proof id as a hash of
`<transactionId>;<groupIndex>;<leafIndexes>`. The same structure was used before this change, but would easily go over the columns size limit when storing filtered transactions.

Using the hash gives us predictable ids as it is based on computed data rather than any randomisation and also keeps the ids shorter.

As the id contained the leaf indexes which were parsed when read from the database, the content still needed to be preserved in a readable format; a column has been added for `leaf_indexes` to preserve this data.