### PR TITLE
CORE-19774: ensure verifying notary works with a composite key

### DIFF
--- a/testing/ledger/ledger-common-testkit/build.gradle
+++ b/testing/ledger/ledger-common-testkit/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':libs:crypto:cipher-suite')
     implementation project(':libs:crypto:crypto-core')
     implementation project(':libs:ledger:ledger-common-data')
+    implementation project(':libs:crypto:crypto-impl')
     api project(':components:ledger:ledger-common-flow-api')
     api project(':libs:application:application-impl')
     api project(':libs:platform-info')

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/CompositKeyExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/CompositKeyExample.kt
@@ -1,0 +1,14 @@
+package net.corda.ledger.common.testkit
+
+import net.corda.crypto.impl.CompositeKeyProviderImpl
+import net.corda.v5.crypto.CompositeKeyNodeAndWeight
+import java.security.PublicKey
+
+fun generateCompositeKey(publicKeys: Pair<PublicKey, PublicKey>): PublicKey {
+    return CompositeKeyProviderImpl().create(
+        listOf(
+            CompositeKeyNodeAndWeight(publicKeys.first, 2),
+            CompositeKeyNodeAndWeight(publicKeys.second, 1)
+        ), threshold = 2
+    )
+}

--- a/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PublicKeyExample.kt
+++ b/testing/ledger/ledger-common-testkit/src/main/kotlin/net/corda/ledger/common/testkit/PublicKeyExample.kt
@@ -14,3 +14,6 @@ val publicKeyExample: PublicKey = keyPairExample.public
 
 val anotherPublicKeyExample: PublicKey = kpg
     .generateKeyPair().public
+
+fun generatePublicKey(): PublicKey = KeyPairGenerator.getInstance("EC")
+    .also { it.initialize(ECGenParameterSpec("secp256r1")) }.genKeyPair().public


### PR DESCRIPTION
To ensure notaries work with a composite key, I switched public keys and composite keys from mocks to real objects.
I deleted meaningless test cases since I found some of the failed test cases actually are throwing unrelated errors to what the test case is for - the error that was expected in the test cases were actually coming from the composite key not being mocked properly.

This PR ensures that we cover _All of this needs to work with a notary composite key_ of [acceptance criteria](https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4767776883/Contract+Verifying+Acceptance+Criteria)