### PR TITLE
CORE-19746 Fix repeated session replays to unreachable endpoints

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
@@ -64,6 +64,7 @@ import net.corda.data.p2p.crypto.InitiatorHandshakeMessage as AvroInitiatorHands
 import net.corda.data.p2p.crypto.InitiatorHelloMessage as AvroInitiatorHelloMessage
 import net.corda.data.p2p.crypto.ResponderHandshakeMessage as AvroResponderHandshakeMessage
 import net.corda.data.p2p.crypto.ResponderHelloMessage as AvroResponderHelloMessage
+import net.corda.p2p.linkmanager.common.MessageConverter.Companion.createLinkOutMessage
 
 @Suppress("TooManyFunctions", "LongParameterList", "LargeClass")
 internal class StatefulSessionManagerImpl(
@@ -199,7 +200,7 @@ internal class StatefulSessionManagerImpl(
                 }
 
                 OutboundSessionStatus.SentInitiatorHello, OutboundSessionStatus.SentInitiatorHandshake -> {
-                    state.state.replaySessionMessage()?.let { (needed, newState) ->
+                    state.state.replaySessionMessage(state.first.message.message.header.statusFilter)?.let { (needed, newState) ->
                         state.toResultsFirstAndOther(
                             action = UpdateAction(newState),
                             firstState = needed,
@@ -632,12 +633,25 @@ internal class StatefulSessionManagerImpl(
         return NewSessionsNeeded(listOf(message), counterParties) to newState
     }
 
-    private fun State.replaySessionMessage(): Pair<NewSessionsNeeded, State>? {
-        val sessionMessage =
+    private fun State.replaySessionMessage(statusFilter: MembershipStatusFilter): Pair<NewSessionsNeeded, State>? {
+        val previousSessionMessage =
             stateConvertor.toCordaSessionState(
                 this,
                 sessionManagerImpl.revocationCheckerClient::checkRevocation,
             )?.message ?: return null
+        val previousHeader = previousSessionMessage.header
+        val linkOutMessage = membershipGroupReaderProvider.lookup(
+            previousHeader.sourceIdentity.toCorda(),
+            previousHeader.destinationIdentity.toCorda(),
+            statusFilter
+        )?.let {
+            createLinkOutMessage(
+                previousSessionMessage.payload,
+                previousHeader.sourceIdentity.toCorda(),
+                it,
+                previousHeader.destinationNetworkType
+            )
+        } ?: return null
         val outboundMetadata = metadata.toOutbound()
         val updatedMetadata = outboundMetadata.copy(
             commonData = outboundMetadata.commonData.copy(
@@ -652,7 +666,7 @@ internal class StatefulSessionManagerImpl(
                 metadata = updatedMetadata.toMetadata(),
             )
         return NewSessionsNeeded(
-            listOf(updatedMetadata.sessionId to sessionMessage),
+            listOf(updatedMetadata.sessionId to linkOutMessage),
             updatedState.getSessionCounterparties(),
         ) to updatedState
     }


### PR DESCRIPTION
While replaying outbound session messages, we resend messages to the same endpoint. This causes session negotiation to fail in case that endpoint is unreachable. This was causing a QA test to fail, where a member re-registration was attempted with two new endpoints, only one of which was added to the P2P Gateway config. This change reconstructs `LinkOutMessage` while replaying outbound session messages, so that an endpoint is randomly selected from the available list, instead of retrying with the same endpoint.

This has been tested using a multi-cluster e2e test [corda-e2e-tests-multi-cluster-tests](https://ci02.dev.r3.com/job/Corda5/job/corda-e2e-tests-multi-cluster-tests/job/yash%2FCORE-19746/), and [qa-regpack-tests](https://ci02.dev.r3.com/job/QA/job/Craft_Tests/job/qa-regpack-tests/job/CORE-19746-1/).