### PR TITLE
CORE-19834 Update missing transaction in backchain resolution message

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainSenderFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainSenderFlowV1.kt
@@ -53,13 +53,13 @@ class TransactionBackchainSenderFlowV1(
                             ?: run {
                                 log.warn(
                                     "Transaction $id does not exist locally when requested during backchain resolution. A filtered " +
-                                            "transaction might exist for the same id or the transaction has been deleted locally. " +
-                                            "Sending a backchain containing a filtered transaction suggests incorrect mixing of states " +
-                                            "and transactions in enhanced privacy and non-enhanced privacy mode."
+                                        "transaction might exist for the same id or the transaction has been deleted locally. " +
+                                        "Sending a backchain containing a filtered transaction suggests incorrect mixing of states " +
+                                        "and transactions in enhanced privacy and non-enhanced privacy mode."
                                 )
                                 throw CordaRuntimeException(
                                     "Transaction $id does not exist locally when requested during backchain resolution. A filtered " +
-                                            "transaction might exist for the same id or the transaction has been deleted locally."
+                                        "transaction might exist for the same id or the transaction has been deleted locally."
                                 )
                             }
                     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainSenderFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainSenderFlowV1.kt
@@ -50,7 +50,18 @@ class TransactionBackchainSenderFlowV1(
                 is TransactionBackchainRequestV1.Get -> {
                     val transactions = request.transactionIds.map { id ->
                         utxoLedgerPersistenceService.findSignedTransaction(id)
-                            ?: throw CordaRuntimeException("Requested transaction does not exist locally")
+                            ?: run {
+                                log.warn(
+                                    "Transaction $id does not exist locally when requested during backchain resolution. A filtered " +
+                                            "transaction might exist for the same id or the transaction has been deleted locally. " +
+                                            "Sending a backchain containing a filtered transaction suggests incorrect mixing of states " +
+                                            "and transactions in enhanced privacy and non-enhanced privacy mode."
+                                )
+                                throw CordaRuntimeException(
+                                    "Transaction $id does not exist locally when requested during backchain resolution. A filtered " +
+                                            "transaction might exist for the same id or the transaction has been deleted locally."
+                                )
+                            }
                     }
                     session.send(transactions)
                     log.trace {


### PR DESCRIPTION
Update the error message and add a log line for when a signed transaction is missing during the sending of a transaction backchain. This can occur when a sender has received part of the backchain as a filtered transaction and then tries to send the whole backchain. Upon reaching the filtered transaction in the chain, an error is thrown due to no signed transaction existing.

The error message makes it clearer why this could have happened to users.