### PR TITLE
CORE-19845 Tactical fix to stop COMPLETED flows being marked as FAILED

### DIFF
--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/DurableFlowStatusProcessor.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/DurableFlowStatusProcessor.kt
@@ -56,10 +56,8 @@ class DurableFlowStatusProcessor(
         return emptyList()
     }
 
-    private fun getStatus(state: State) : String? {
-        val flowStatus = state.metadata[FLOW_STATUS_METADATA_KEY]
-        return if (flowStatus != null) flowStatus as String else null
-    }
+    private fun getStatus(state: State): String? =
+        state.metadata[FLOW_STATUS_METADATA_KEY] as? String
 
     private fun hasTerminatedStatus(state: State): Boolean {
         val status = getStatus(state)

--- a/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/DurableFlowStatusProcessor.kt
+++ b/components/flow/flow-rest-resource-service-impl/src/main/kotlin/net/corda/flow/rest/impl/DurableFlowStatusProcessor.kt
@@ -63,8 +63,7 @@ class DurableFlowStatusProcessor(
 
     private fun hasTerminatedStatus(state: State): Boolean {
         val status = getStatus(state)
-        val terminatedStatus = status != null && TERMINATED_STATES.contains(FlowStates.valueOf(status))
-        return terminatedStatus || status == null
+        return status != null && TERMINATED_STATES.contains(FlowStates.valueOf(status))
     }
 
     private fun Metadata?.withHoldingIdentityAndStatus(holdingIdentity: HoldingIdentity, flowStatus: FlowStates): Metadata {


### PR DESCRIPTION
For: 5.2.1

**Problem**:
In order to maintain performance of the corda system, deletion of states in the mediator has been moved to after committing offsets in the bus. 

If the system crashes after offsets are committed but before states are deleted or if the delete call fails then the states can be orphaned and will not be deleted immediately. 

This will then result in Checkpoints being picked up by the idle flow scheduled job which will mark the flow as failed even though it has already updated the status to COMPLETED. This job is currently set to trigger every 30 mins This means a flow would be marked as FAILED 30 mins after being marked as COMPLETED.

**Solution**:
One possible solution would be to update the flow status processor which sets the status in the state manager to ignore updates to status when the status is already at  terminal status (FAILED/KILLED/COMPLETED) 

This will not stop the checkpoint state from being picked up by the idle flow processor job. However for COMPLETED flows all sessions are terminated. The only negative impact of running a COMPLETED state through this job inadvertently is the update to Flow Status. No messages will be sent to counterparties. 