### PR TITLE
CORE-19325 - Excluded the endpoints from tracing and removed existing rules which were deemed no longer necessary

### DIFF
--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
@@ -111,8 +111,6 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
     }
 
     private val serverSampler: SamplerFunction<HttpRequest> = HttpRuleSampler.newBuilder()
-        .putRule(and(methodEquals("POST"), pathStartsWith("/api/v5_1/flow")), sampler(samplesPerSecond))
-        .putRule(and(methodEquals("POST"), pathStartsWith("/api/v1/flow")), sampler(samplesPerSecond))
         .putRule(and(methodEquals("GET"), pathStartsWith("/metrics")), Sampler.NEVER_SAMPLE) // Disable tracing for the specified path
         .putRule(pathStartsWith("/"), sampler(samplesPerSecond))
         .build()

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
@@ -112,6 +112,8 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
 
     private val serverSampler: SamplerFunction<HttpRequest> = HttpRuleSampler.newBuilder()
         .putRule(pathStartsWith("/metrics"), Sampler.NEVER_SAMPLE) // Disable tracing for the specified path
+        .putRule(pathStartsWith("/isHealthy"), Sampler.NEVER_SAMPLE) // Disable tracing for the specified path
+        .putRule(pathStartsWith("/status"), Sampler.NEVER_SAMPLE) // Disable tracing for the specified path
         .putRule(pathStartsWith("/"), sampler(samplesPerSecond))
         .build()
 

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
@@ -7,14 +7,12 @@ import brave.baggage.BaggagePropagationConfig
 import brave.baggage.CorrelationScopeConfig
 import brave.context.slf4j.MDCScopeDecorator
 import brave.http.HttpRequest
-import brave.http.HttpRequestMatchers.methodEquals
 import brave.http.HttpRequestMatchers.pathStartsWith
 import brave.http.HttpRequestParser
 import brave.http.HttpRuleSampler
 import brave.http.HttpTracing
 import brave.propagation.B3Propagation
 import brave.propagation.ThreadLocalCurrentTraceContext
-import brave.sampler.Matchers.and
 import brave.sampler.RateLimitingSampler
 import brave.sampler.Sampler
 import brave.sampler.SamplerFunction

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
@@ -35,7 +35,8 @@ import zipkin2.reporter.BytesMessageSender
 import zipkin2.reporter.Reporter
 import zipkin2.reporter.brave.ZipkinSpanHandler
 import zipkin2.reporter.urlconnection.URLConnectionSender
-import java.util.*
+import java.util.EnumSet
+import java.util.Stack
 import java.util.concurrent.ExecutorService
 import java.util.logging.Level
 import java.util.logging.Logger

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
@@ -111,7 +111,7 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
     }
 
     private val serverSampler: SamplerFunction<HttpRequest> = HttpRuleSampler.newBuilder()
-        .putRule(and(methodEquals("GET"), pathStartsWith("/metrics")), Sampler.NEVER_SAMPLE) // Disable tracing for the specified path
+        .putRule(pathStartsWith("/metrics"), Sampler.NEVER_SAMPLE) // Disable tracing for the specified path
         .putRule(pathStartsWith("/"), sampler(samplesPerSecond))
         .build()
 

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
@@ -35,8 +35,7 @@ import zipkin2.reporter.BytesMessageSender
 import zipkin2.reporter.Reporter
 import zipkin2.reporter.brave.ZipkinSpanHandler
 import zipkin2.reporter.urlconnection.URLConnectionSender
-import java.util.EnumSet
-import java.util.Stack
+import java.util.*
 import java.util.concurrent.ExecutorService
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -113,7 +112,7 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
     private val serverSampler: SamplerFunction<HttpRequest> = HttpRuleSampler.newBuilder()
         .putRule(and(methodEquals("POST"), pathStartsWith("/api/v5_1/flow")), sampler(samplesPerSecond))
         .putRule(and(methodEquals("POST"), pathStartsWith("/api/v1/flow")), sampler(samplesPerSecond))
-        .putRule(and(methodEquals("GET"), pathStartsWith("/metrics")), sampler(PerSecond(0))) // Disable tracing for the specified path
+        .putRule(and(methodEquals("GET"), pathStartsWith("/metrics")), Sampler.NEVER_SAMPLE) // Disable tracing for the specified path
         .putRule(pathStartsWith("/"), sampler(samplesPerSecond))
         .build()
 

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveTracingService.kt
@@ -113,7 +113,9 @@ internal class BraveTracingService(serviceName: String, zipkinHost: String?, sam
     private val serverSampler: SamplerFunction<HttpRequest> = HttpRuleSampler.newBuilder()
         .putRule(and(methodEquals("POST"), pathStartsWith("/api/v5_1/flow")), sampler(samplesPerSecond))
         .putRule(and(methodEquals("POST"), pathStartsWith("/api/v1/flow")), sampler(samplesPerSecond))
-        .putRule(pathStartsWith("/"), sampler(samplesPerSecond)).build()
+        .putRule(and(methodEquals("GET"), pathStartsWith("/metrics")), sampler(PerSecond(0))) // Disable tracing for the specified path
+        .putRule(pathStartsWith("/"), sampler(samplesPerSecond))
+        .build()
 
     private val httpTracing by lazy {
         HttpTracing.newBuilder(tracing)


### PR DESCRIPTION
 The endpoint `/metrics` is called by Prometheus regularly which spams the tracing and it does not provide any valuable insights.
The endpoints `/isHealthy` and `/status` have also been excluded from tracing since they do not provide any valuable information.
The rules for `/api/v5_1/flow` and `/api/v1/flow` were removed because during tests enough flows are invoked that ensure that traces related to flows will be sampled.
