### PR TITLE
CORE-19285 - Fix bug caused by creating instead of updating state when replay happens

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
@@ -833,7 +833,6 @@ internal class StatefulSessionManagerImpl(
                         sessionManagerImpl.revocationCheckerClient::checkRevocation,
                     )
                     val responderHelloToResend = sessionState?.message ?: return null
-                    val session = sessionState.sessionData as? AuthenticationProtocolResponder
                     val newState =
                         State(
                             key = state.key,
@@ -841,7 +840,7 @@ internal class StatefulSessionManagerImpl(
                             version = state.version,
                             metadata = updatedMetadata.toMetadata(),
                         )
-                    Result(responderHelloToResend, UpdateAction(newState), session?.getSession())
+                    Result(responderHelloToResend, UpdateAction(newState), null)
                 } else {
                     null
                 }


### PR DESCRIPTION
Flows were stuck in RUNNING state, because participants were unable to establish sessions.
When the ResponderHello message is lost and an InitiatorHello got replayed by the initiator: the responder side started processing the message again. However, instead of eventually getting past through this step and sending the ResponderHello again, we got into a loop where the processing of the init message failed, because we tried to create new states using same ID, instead of updating the existing state from the first processing.