### PR TITLE
CORE-19953 Retry unknown notary errors in finality

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -360,7 +360,6 @@ class UtxoPersistenceServiceImpl(
 
             // Mark inputs as consumed
             if (transaction.status == TransactionStatus.VERIFIED) {
-
                 repository.persistVisibleTransactionOutputs(
                     em,
                     transactionIdString,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -34,6 +34,7 @@ import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.data.transaction.toMerkleProof
 import net.corda.libs.packaging.hash
+import net.corda.metrics.CordaMetrics
 import net.corda.orm.utils.transaction
 import net.corda.utilities.serialization.deserialize
 import net.corda.utilities.time.Clock
@@ -55,6 +56,7 @@ import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.v5.ledger.utxo.query.json.ContractStateVaultJsonFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import java.time.Duration
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 
@@ -356,15 +358,16 @@ class UtxoPersistenceServiceImpl(
 
             repository.persistTransactionSources(em, transactionIdString, consumedTransactionSources + referenceTransactionSources)
 
-            repository.persistVisibleTransactionOutputs(
-                em,
-                transactionIdString,
-                nowUtc,
-                visibleTransactionOutputs
-            )
-
             // Mark inputs as consumed
             if (transaction.status == TransactionStatus.VERIFIED) {
+
+                repository.persistVisibleTransactionOutputs(
+                    em,
+                    transactionIdString,
+                    nowUtc,
+                    visibleTransactionOutputs
+                )
+
                 val inputStateRefs = transaction.getConsumedStateRefs()
                 if (inputStateRefs.isNotEmpty()) {
                     repository.markTransactionVisibleStatesConsumed(
@@ -543,6 +546,8 @@ class UtxoPersistenceServiceImpl(
                     nowUtc
                 )
 
+                val startTime = System.nanoTime()
+
                 val topLevelTransactionMerkleProof = createTransactionMerkleProof(
                     filteredTransaction.id.toString(),
                     TOP_LEVEL_MERKLE_PROOF_GROUP_INDEX,
@@ -575,6 +580,11 @@ class UtxoPersistenceServiceImpl(
                     }
                     TransactionMerkleProofToPersist(proof, leaves, components)
                 }
+
+                CordaMetrics.Metric.Ledger.FilteredTransactionComputationTime
+                    .builder()
+                    .build()
+                    .record(Duration.ofNanos(System.nanoTime() - startTime))
 
                 // 6. Persist the top level and component group merkle proofs
                 // No need to persist the leaf data for the top level merkle proof as we can reconstruct that

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -34,7 +34,6 @@ import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
 import net.corda.ledger.utxo.data.transaction.WrappedUtxoWireTransaction
 import net.corda.ledger.utxo.data.transaction.toMerkleProof
 import net.corda.libs.packaging.hash
-import net.corda.metrics.CordaMetrics
 import net.corda.orm.utils.transaction
 import net.corda.utilities.serialization.deserialize
 import net.corda.utilities.time.Clock
@@ -56,7 +55,6 @@ import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.v5.ledger.utxo.query.json.ContractStateVaultJsonFactory
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.time.Duration
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 
@@ -545,8 +543,6 @@ class UtxoPersistenceServiceImpl(
                     nowUtc
                 )
 
-                val startTime = System.nanoTime()
-
                 val topLevelTransactionMerkleProof = createTransactionMerkleProof(
                     filteredTransaction.id.toString(),
                     TOP_LEVEL_MERKLE_PROOF_GROUP_INDEX,
@@ -579,11 +575,6 @@ class UtxoPersistenceServiceImpl(
                     }
                     TransactionMerkleProofToPersist(proof, leaves, components)
                 }
-
-                CordaMetrics.Metric.Ledger.FilteredTransactionComputationTime
-                    .builder()
-                    .build()
-                    .record(Duration.ofNanos(System.nanoTime() - startTime))
 
                 // 6. Persist the top level and component group merkle proofs
                 // No need to persist the leaf data for the top level merkle proof as we can reconstruct that

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
@@ -321,12 +321,13 @@ class UtxoPersistenceServiceImplTest {
             actual = persisted.value.json
         )
     }
+
     private fun createMockTransaction(producedStates: Map<Int, StateAndRef<ContractState>>): UtxoTransactionReader {
         return mock {
             on { getConsumedStateRefs() } doReturn emptyList()
             on { rawGroupLists } doReturn listOf(listOf("{}".toByteArray()))
             on { visibleStatesIndexes } doReturn listOf(0)
-            on { status } doReturn TransactionStatus.UNVERIFIED
+            on { status } doReturn TransactionStatus.VERIFIED
             on { signatures } doReturn emptyList()
             on { id } doReturn randomSecureHash()
             on { privacySalt } doReturn mockPrivacySalt

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -273,8 +273,8 @@ class UtxoFinalityFlowV1(
             // `log.trace {}` and `log.debug {}` are not used in this method due to a Quasar issue.
             if (log.isTraceEnabled) {
                 log.trace(
-                    "Notarizing transaction $transactionId using pluggable notary client flow of ${notarizationFlow::class.java.name} with " +
-                            "notary $notary, attempt number $attemptNumber"
+                    "Notarizing transaction $transactionId using pluggable notary client flow of ${notarizationFlow::class.java.name} " +
+                        "with notary $notary, attempt number $attemptNumber"
                 )
             }
             flowEngine.subFlow(notarizationFlow)

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -56,6 +56,7 @@ import net.corda.v5.membership.NotaryInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -72,6 +73,7 @@ import java.security.PublicKey
 import java.time.Instant
 
 @Suppress("MaxLineLength")
+@Disabled
 class UtxoFinalityFlowV1Test {
 
     private companion object {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1Test.kt
@@ -56,7 +56,6 @@ import net.corda.v5.membership.NotaryInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -67,13 +66,13 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.timeout
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import java.time.Instant
 
 @Suppress("MaxLineLength")
-@Disabled
 class UtxoFinalityFlowV1Test {
 
     private companion object {
@@ -442,7 +441,104 @@ class UtxoFinalityFlowV1Test {
     }
 
     @Test
-    fun `receiving valid signatures over a transaction then non-permanent failing notarization throws, but does not invalidate tx`() {
+    fun `receiving NotaryExceptionUnknown when notarizing retries notarization until it succeeds`() {
+        whenever(initialTx.getMissingSignatories()).thenReturn(
+            setOf(
+                publicKeyAlice1,
+                publicKeyAlice2,
+                publicKeyBob
+            )
+        )
+
+        whenever(
+            flowMessaging.receiveAllMap(
+                mapOf(
+                    sessionAlice to Payload::class.java,
+                    sessionBob to Payload::class.java
+                )
+            )
+        ).thenReturn(
+            mapOf(
+                sessionAlice to Payload.Success(
+                    listOf(
+                        signatureAlice1,
+                        signatureAlice2
+                    )
+                ),
+                sessionBob to Payload.Success(
+                    listOf(
+                        signatureBob
+                    )
+                )
+            )
+        )
+
+        val txAfterAlice1Signature = mock<UtxoSignedTransactionInternal>()
+        whenever(initialTx.addSignature(signatureAlice1)).thenReturn(txAfterAlice1Signature)
+        val txAfterAlice2Signature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterAlice1Signature.addSignature(signatureAlice2)).thenReturn(txAfterAlice2Signature)
+        val txAfterBobSignature = mock<UtxoSignedTransactionInternal>()
+        whenever(txAfterBobSignature.id).thenReturn(TX_ID)
+        whenever(txAfterBobSignature.notaryName).thenReturn(notaryX500Name)
+        whenever(txAfterAlice2Signature.addSignature(signatureBob)).thenReturn(txAfterBobSignature)
+        whenever(txAfterBobSignature.addSignature(signatureNotary)).thenReturn(notarizedTx)
+
+        whenever(txAfterBobSignature.signatures).thenReturn(listOf(signatureAlice1, signatureAlice2, signatureBob))
+        whenever(notarizedTx.outputStateAndRefs).thenReturn(listOf(stateAndRef))
+
+        @CordaSerializable
+        class TestNotaryExceptionNonFatal(
+            errorText: String,
+            txId: SecureHash? = null
+        ) : NotaryExceptionUnknown(errorText, txId)
+
+        val e = TestNotaryExceptionNonFatal("notarization error")
+
+        whenever(flowEngine.subFlow(pluggableNotaryClientFlow))
+            .thenThrow(e, e, e, e)
+            .thenReturn(listOf(signatureNotary))
+
+        whenever(visibilityChecker.containsMySigningKeys(listOf(publicKeyAlice1))).thenReturn(true)
+        whenever(visibilityChecker.containsMySigningKeys(listOf(publicKeyBob))).thenReturn(true)
+
+        callFinalityFlow(initialTx, listOf(sessionAlice, sessionBob))
+
+        verify(initialTx).verifySignatorySignature(eq(signatureAlice1))
+        verify(txAfterAlice1Signature).verifySignatorySignature(eq(signatureAlice2))
+        verify(txAfterAlice2Signature).verifySignatorySignature(eq(signatureBob))
+
+        verify(initialTx).addSignature(signatureAlice1)
+        verify(txAfterAlice1Signature).addSignature(signatureAlice2)
+        verify(txAfterAlice2Signature).addSignature(signatureBob)
+        verify(txAfterBobSignature).addSignature(signatureNotary)
+
+        verify(persistenceService).persist(initialTx, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            TX_ID,
+            1,
+            listOf(signatureAlice2, signatureBob)
+        )
+        verify(persistenceService).persist(any(), eq(TransactionStatus.VERIFIED), any())
+        verify(persistenceService, never()).persist(any(), eq(TransactionStatus.INVALID), any())
+
+        verify(flowMessaging).receiveAllMap(
+            mapOf(
+                sessionAlice to Payload::class.java,
+                sessionBob to Payload::class.java
+            )
+        )
+        verify(flowMessaging).sendAllMap(
+            mapOf(
+                sessionAlice to listOf(signatureBob),
+                sessionBob to listOf(signatureAlice1, signatureAlice2)
+            )
+        )
+        verify(flowEngine, times(5)).subFlow(pluggableNotaryClientFlow)
+        verify(flowMessaging).sendAll(eq(Payload.Success(listOf(signatureNotary))), any())
+    }
+
+    @Test
+    fun `receiving CordaRuntimeException when notarizing fails the flow but does not mark the transaction as invalid`() {
         whenever(initialTx.getMissingSignatories()).thenReturn(
             setOf(
                 publicKeyAlice1,
@@ -485,18 +581,11 @@ class UtxoFinalityFlowV1Test {
 
         whenever(txAfterBobSignature.signatures).thenReturn(listOf(signatureAlice1, signatureAlice2, signatureBob))
 
-        @CordaSerializable
-        class TestNotaryExceptionNonFatal(
-            errorText: String,
-            txId: SecureHash? = null
-        ) : NotaryExceptionUnknown(errorText, txId)
+        val e = CordaRuntimeException("notarization error")
 
-        whenever(flowEngine.subFlow(pluggableNotaryClientFlow))
-            .thenThrow(TestNotaryExceptionNonFatal("notarization error"))
+        whenever(flowEngine.subFlow(pluggableNotaryClientFlow)).thenThrow(e)
 
-        assertThatThrownBy { callFinalityFlow(initialTx, listOf(sessionAlice, sessionBob)) }
-            .isInstanceOf(CordaRuntimeException::class.java)
-            .hasMessage("Unable to notarize transaction <Unknown>: notarization error")
+        assertThatThrownBy { callFinalityFlow(initialTx, listOf(sessionAlice, sessionBob)) }.isEqualTo(e)
 
         verify(initialTx).verifySignatorySignature(eq(signatureAlice1))
         verify(txAfterAlice1Signature).verifySignatorySignature(eq(signatureAlice2))
@@ -531,7 +620,7 @@ class UtxoFinalityFlowV1Test {
         verify(flowMessaging, never()).sendAll(eq(Payload.Success(listOf(signatureNotary))), any())
         verify(flowMessaging).sendAll(
             Payload.Failure<List<DigitalSignatureAndMetadata>>(
-                "Notarization failed with Unable to notarize transaction <Unknown>: notarization error.",
+                "Notarization failed with ${e.message}.",
                 FinalityNotarizationFailureType.UNKNOWN.value
             ),
             sessions

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
@@ -304,25 +304,17 @@ class BatchedUniquenessCheckerImpl(
                         }
                         // Input state conflict check
                         inputStateConflicts.isNotEmpty() -> {
+                            val conflicts = inputStateConflicts.map { stateDetailsCache[it]!! }
                             log.info("Request for transaction ${request.txId} failed due to conflicting " +
-                                    "input states $inputStateConflicts")
-                            handleRejectedRequest(
-                                request,
-                                UniquenessCheckErrorInputStateConflictImpl(
-                                    inputStateConflicts.map { stateDetailsCache[it]!! }
-                                )
-                            )
+                                    "input states $conflicts")
+                            handleRejectedRequest(request, UniquenessCheckErrorInputStateConflictImpl(conflicts))
                         }
                         // Reference state conflict check
                         referenceStateConflicts.isNotEmpty() -> {
+                            val conflicts = referenceStateConflicts.map { stateDetailsCache[it]!! }
                             log.info("Request for transaction ${request.txId} failed due to conflicting " +
-                                    "reference states $referenceStateConflicts")
-                            handleRejectedRequest(
-                                request,
-                                UniquenessCheckErrorReferenceStateConflictImpl(
-                                    referenceStateConflicts.map { stateDetailsCache[it]!! }
-                                )
-                            )
+                                    "reference states $conflicts")
+                            handleRejectedRequest(request, UniquenessCheckErrorReferenceStateConflictImpl(conflicts))
                         }
                         // Time window check
                         !isTimeWindowValid(

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -457,6 +457,8 @@ object CordaMetrics {
 
         object Ledger {
 
+            object FilteredTransactionComputationTime : Metric<Timer>("ledger.persistence.filtered.comp.time", CordaMetrics::timer)
+
             /**
              * The time taken by transaction verification from the flow side.
              */

--- a/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
+++ b/libs/metrics/src/main/kotlin/net/corda/metrics/CordaMetrics.kt
@@ -457,8 +457,6 @@ object CordaMetrics {
 
         object Ledger {
 
-            object FilteredTransactionComputationTime : Metric<Timer>("ledger.persistence.filtered.comp.time", CordaMetrics::timer)
-
             /**
              * The time taken by transaction verification from the flow side.
              */

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
@@ -115,9 +115,9 @@ class ContractVerifyingNotaryServerFlowImpl() : ResponderFlow {
 
             session.send(uniquenessResult.toNotarizationResponse(initialTransactionDetails.id, signature))
         } catch (e: Exception) {
-            logger.warn("Error while processing request from client. Cause: $e ${e.stackTraceToString()}")
+            logger.warn("Error while processing request from client", e)
             val exception =
-                if (e is NotaryException) e else NotaryExceptionGeneral("Error during notarization. Cause: ${e.message}")
+                if (e is NotaryException) e else NotaryExceptionGeneral("Error during notarization")
             session.send(
                 NotarizationResponse(
                     emptyList(),

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
@@ -241,8 +241,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat(responseError).isNotNull
         assertThat(responseFromServer.first().signatures).isEmpty()
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
-        assertThat((responseError as NotaryExceptionGeneral).errorText)
-            .contains("The publicKeys do not have any private counterparts available.")
+        assertThat((responseError as NotaryExceptionGeneral).errorText).isEqualTo("Error during notarization")
     }
 
     @Test
@@ -302,8 +301,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
-        assertThat((responseError as NotaryExceptionGeneral).errorText)
-            .contains("Error during notarization. Cause: Uniqueness checker cannot be reached")
+        assertThat((responseError as NotaryExceptionGeneral).errorText).isEqualTo("Error during notarization")
     }
 
     @Test
@@ -400,8 +398,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
-        assertThat((responseError as NotaryExceptionGeneral).errorText)
-            .contains("Error during notarization. Cause: DUMMY ERROR")
+        assertThat((responseError as NotaryExceptionGeneral).errorText).isEqualTo("Error during notarization")
     }
 
     @Test
@@ -439,8 +436,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
-        assertThat((responseError as NotaryExceptionGeneral).errorText)
-            .contains("does not match the notary service represented by this notary virtual node")
+        assertThat((responseError as NotaryExceptionGeneral).errorText).isEqualTo("Error during notarization")
     }
 
     @Test

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -113,8 +113,8 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
 
             session.send(uniquenessResult.toNotarizationResponse(txDetails.id, signature))
         } catch (e: Exception) {
-            logger.warn("Error while processing request from client. Cause: $e ${e.stackTraceToString()}")
-            val genericMessage = "Error while processing request from client. "
+            logger.warn("Error while processing request from client", e)
+            val genericMessage = "Error during notarization. "
             val additionalMessage =
                 when (e) {
                     is InvalidBackchainFlagException -> "Cause: ${e.message}"

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -103,7 +103,7 @@ class NonValidatingNotaryServerFlowImplTest {
             assertThat(responseFromServer.first().signatures).isEmpty()
             assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
             assertThat((responseError as NotaryExceptionGeneral).errorText)
-                .contains("Error while processing request from client")
+                .contains("Error during notarization")
         }
     }
 
@@ -148,7 +148,7 @@ class NonValidatingNotaryServerFlowImplTest {
             assertThat(responseError).isNotNull
             assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
             assertThat((responseError as NotaryExceptionGeneral).errorText)
-                .contains("Error while processing request from client")
+                .contains("Error during notarization")
         }
     }
 
@@ -181,7 +181,7 @@ class NonValidatingNotaryServerFlowImplTest {
             assertThat(responseError).isNotNull
             assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
             assertThat((responseError as NotaryExceptionGeneral).errorText).contains(
-                "Error while processing request from client"
+                "Error during notarization"
             )
         }
     }
@@ -197,7 +197,7 @@ class NonValidatingNotaryServerFlowImplTest {
             assertThat(responseError).isNotNull
             assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
             assertThat((responseError as NotaryExceptionGeneral).errorText).contains(
-                "Error while processing request from client"
+                "Error during notarization"
             )
         }
     }
@@ -213,7 +213,7 @@ class NonValidatingNotaryServerFlowImplTest {
             assertThat(responseError).isNotNull
             assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
             assertThat((responseError as NotaryExceptionGeneral).errorText).contains(
-                "Error while processing request from client"
+                "Error during notarization"
             )
         }
     }
@@ -233,7 +233,7 @@ class NonValidatingNotaryServerFlowImplTest {
             assertThat(responseError).isNotNull
             assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
             assertThat((responseError as NotaryExceptionGeneral).errorText).contains(
-                "Error while processing request from client"
+                "Error during notarization"
             )
         }
     }
@@ -250,7 +250,7 @@ class NonValidatingNotaryServerFlowImplTest {
             assertThat(responseError).isNotNull
             assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
             assertThat((responseError as NotaryExceptionGeneral).errorText)
-                .contains("Error while processing request from client")
+                .contains("Error during notarization")
         }
     }
 
@@ -286,7 +286,7 @@ class NonValidatingNotaryServerFlowImplTest {
             assertThat(responseError).isNotNull
             assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
             assertThat((responseError as NotaryExceptionGeneral).errorText)
-                .contains("Error while processing request from client")
+                .contains("Error during notarization")
         }
     }
 


### PR DESCRIPTION
Retry `NotaryExceptionUnknown` indefinitely in `UtxoFinalityFlowV1`.

`NotaryExceptionUnknown` represents transient errors from the notary, therefore trying again should eventually succeed.

This was needed due to connection errors during notarisation causing flows to fail. Furthermore, the failing notarisation calls were actually successfully committing their database transactions that consumed states, which caused the ledger to go out of sync as finality didn't complete correctly.

This change also includes a few tidy up changes to logs and persisting visible states.