### PR TITLE
CORE-17351: Add redirect from /swagger/ to /swagger

### DIFF
--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerOpenApiTest.kt
@@ -503,6 +503,15 @@ class RestServerOpenApiTest : RestServerTestBase() {
     }
 
     @Test
+    fun `GET swagger UI with trailing slash in path should return html with reference to swagger json without trailing slash`() {
+        val apiSpec = client.call(GET, WebRequest<Any>("swagger/"))
+        assertEquals(HttpStatus.SC_OK, apiSpec.responseStatus)
+        assertEquals("text/html", apiSpec.headers["Content-Type"])
+        val expected = """url: "/${context.basePath}/${apiVersion.versionPath}/swagger.json""""
+        assertTrue(apiSpec.body!!.contains(expected))
+    }
+
+    @Test
     fun `GET swagger UI dependencies should return non empty result`() {
         val baseClient = TestHttpClientUnirestImpl("http://${restServerSettings.address.host}:${server.port}/")
         val swaggerUIversion = OptionalDependency.SWAGGERUI.version

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/SwaggerUIRenderer.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/SwaggerUIRenderer.kt
@@ -70,7 +70,7 @@ internal class SwaggerUIRenderer(private val configurationProvider: RestServerSe
                     }
                 
                     const ui = SwaggerUIBundle({
-                        url: "${ctx.path().jsonPath()}",
+                        url: "${ctx.path().removeSuffix("/").jsonPath()}",
                         dom_id: "#swagger-ui",
                         deepLinking: true,
                         presets: [SwaggerUIBundle.presets.apis],


### PR DESCRIPTION
`https://localhost:8888/api/REST_API_VERSION/swagger/` throws an error. Updated behaviour so that it 'redirects' to `https://localhost:8888/api/REST_API_VERSION/swagger`

Using the URL with a trailing slash will now redirect to the working URL
<img width="386" alt="Screenshot 2024-03-01 at 09 11 46" src="https://github.com/corda/corda-runtime-os/assets/61285264/7367ea5c-e5e9-4197-bc1b-9854f9d1c340">
