### PR TITLE
CORE-18095 Merge worker start-up log lines

### DIFF
--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
@@ -17,6 +17,7 @@ import org.osgi.framework.FrameworkUtil
 import org.slf4j.Logger
 import picocli.CommandLine
 import java.io.InputStream
+import java.lang.StringBuilder
 import java.lang.management.ManagementFactory
 import kotlin.math.absoluteValue
 import kotlin.random.Random
@@ -219,31 +220,34 @@ class WorkerHelpers {
          * Logs info about Worker startup process, including info from current process and [PlatformInfoProvider].
          */
         fun Logger.loggerStartupInfo(platformInfoProvider: PlatformInfoProvider) {
-            info("LocalWorkerPlatformVersion ${platformInfoProvider.localWorkerPlatformVersion}")
-            info("LocalWorkerSoftwareVersion ${platformInfoProvider.localWorkerSoftwareVersion}")
+            val startupInfoBuilder = StringBuilder()
+            val ls = System.lineSeparator()
+            startupInfoBuilder.append("LocalWorkerPlatformVersion ${platformInfoProvider.localWorkerPlatformVersion}$ls")
+            startupInfoBuilder.append("LocalWorkerSoftwareVersion ${platformInfoProvider.localWorkerSoftwareVersion}$ls")
 
             val processHandle = ProcessHandle.current()
             val processInfo = processHandle.info()
-            info("PID: ${processHandle.pid()}")
-            info("Command: ${processInfo.command().orElse("Null")}")
+            startupInfoBuilder.append("PID: ${processHandle.pid()}$ls")
+            startupInfoBuilder.append("Command: ${processInfo.command().orElse("Null")}$ls")
 
             val arguments = processInfo.arguments()
             if (arguments.isPresent) {
                 arguments.get().map { arg ->
                     SENSITIVE_ARGS.firstOrNull { arg.trim().startsWith(it) }
                         .let { prefix -> if (prefix == null) arg else "$prefix=[REDACTED]" }
-                }.forEachIndexed { i, redactedArg -> info("argument $i, $redactedArg") }
+                }.forEachIndexed { i, redactedArg -> startupInfoBuilder.append("argument $i, $redactedArg$ls") }
             } else {
-                info("arguments: Null")
+                startupInfoBuilder.append("arguments: Null$ls")
             }
 
-            info("User: ${processInfo.user().orElse("Null")}")
-            info("StartInstant: ${if (processInfo.startInstant().isPresent) processInfo.startInstant().get() else "Null"}")
-            info("TotalCpuDuration: ${if (processInfo.totalCpuDuration().isPresent) processInfo.totalCpuDuration().get() else "Null"}")
+            startupInfoBuilder.append("User: ${processInfo.user().orElse("Null")}$ls")
+            startupInfoBuilder.append("StartInstant: ${if (processInfo.startInstant().isPresent) processInfo.startInstant().get() else "Null"}$ls")
+            startupInfoBuilder.append("TotalCpuDuration: ${if (processInfo.totalCpuDuration().isPresent) processInfo.totalCpuDuration().get() else "Null"}$ls")
 
             val mxBeanInfo = ManagementFactory.getRuntimeMXBean()
-            info("classpath: ${mxBeanInfo.classPath}")
-            info("VM ${mxBeanInfo.vmName} ${mxBeanInfo.vmVendor} ${mxBeanInfo.vmVersion}")
+            startupInfoBuilder.append("classpath: ${mxBeanInfo.classPath}$ls")
+            startupInfoBuilder.append("VM ${mxBeanInfo.vmName} ${mxBeanInfo.vmVendor} ${mxBeanInfo.vmVersion}")
+            info(startupInfoBuilder.toString())
         }
     }
 }

--- a/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
+++ b/applications/workers/worker-common/src/main/kotlin/net/corda/applications/workers/workercommon/WorkerHelpers.kt
@@ -241,8 +241,10 @@ class WorkerHelpers {
             }
 
             startupInfoBuilder.append("User: ${processInfo.user().orElse("Null")}$ls")
-            startupInfoBuilder.append("StartInstant: ${if (processInfo.startInstant().isPresent) processInfo.startInstant().get() else "Null"}$ls")
-            startupInfoBuilder.append("TotalCpuDuration: ${if (processInfo.totalCpuDuration().isPresent) processInfo.totalCpuDuration().get() else "Null"}$ls")
+            val startInstant = if (processInfo.startInstant().isPresent) processInfo.startInstant().get() else "Null"
+            startupInfoBuilder.append("StartInstant: $startInstant$ls")
+            val totalCpuDuration = if (processInfo.totalCpuDuration().isPresent) processInfo.totalCpuDuration().get() else "Null"
+            startupInfoBuilder.append("TotalCpuDuration: $totalCpuDuration$ls")
 
             val mxBeanInfo = ManagementFactory.getRuntimeMXBean()
             startupInfoBuilder.append("classpath: ${mxBeanInfo.classPath}$ls")


### PR DESCRIPTION
Before, we had 
```2024-03-01 11:39:26.674 [main] WARN  net.corda.osgi.framework.OSGiFrameworkWrap {} - OSGi bundle bundles/snappy-java-1.1.10.5.jar ID = 346 org.xerial.snappy.snappy-java 1.1.10.5 starting activation time-out after 0 ms.
2024-03-01 11:39:30.836 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - Combined worker starting.
2024-03-01 11:39:30.898 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - LocalWorkerPlatformVersion 50300
2024-03-01 11:39:30.898 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - LocalWorkerSoftwareVersion 5.3.0.0-SNAPSHOT
2024-03-01 11:39:30.901 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - PID: 64332
2024-03-01 11:39:30.901 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - Command: /Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home/bin/java
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 0, -Dco.paralleluniverse.fibers.verifyInstrumentation=true
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 1, -Dfile.encoding=UTF-8
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 2, -jar
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 3, /Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.3.0.0-SNAPSHOT.jar
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 4, --instance-id=0
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 5, -mbus.busType=DATABASE
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 6, -spassphrase=[REDACTED]
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 7, -ssalt=salt
2024-03-01 11:39:30.902 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 8, -spassphrase=[REDACTED]
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 9, -ssalt=salt
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 10, -ddatabase.user=user
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 11, -ddatabase.pass=[REDACTED]
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 12, -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 13, -ddatabase.jdbc.directory=/Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/drivers
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 14, -rtls.crt.path=/Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/tls/rest/server.crt
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 15, -rtls.key.path=/Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/tls/rest/server.key
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - argument 16, -rtls.ca.crt.path=/Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/tls/rest/ca-chain-bundle.crt
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - User: bogdan.paunescu
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - StartInstant: 2024-03-01T09:38:52.264Z
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - TotalCpuDuration: PT49.285567S
2024-03-01 11:39:30.903 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - classpath: /Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.3.0.0-SNAPSHOT.jar
2024-03-01 11:39:30.904 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - VM OpenJDK 64-Bit Server VM Azul Systems, Inc. 17.0.9+8-LTS
2024-03-01 11:39:30.906 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - Quasar's instrumentation verification is enabled
2024-03-01 11:39:32.045 [main] INFO  net.corda.application.dbsetup.PostgresDbSetup {} - Table config.config exists in jdbc:postgresql://localhost:5432/cordacluster?user=postgres&password=password, skipping DB initialisation.

Now we have

2024-03-01 13:00:57.102 [main] WARN  net.corda.osgi.framework.OSGiFrameworkWrap {} - OSGi bundle bundles/snappy-java-1.1.10.5.jar ID = 346 org.xerial.snappy.snappy-java 1.1.10.5 starting activation time-out after 0 ms.
2024-03-01 13:01:01.889 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - Combined worker starting.
2024-03-01 13:01:01.915 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - LocalWorkerPlatformVersion 50300
LocalWorkerSoftwareVersion 5.3.0.0-SNAPSHOT
PID: 8002
Command: /Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home/bin/java
argument 0, -Dco.paralleluniverse.fibers.verifyInstrumentation=true
argument 1, -Dfile.encoding=UTF-8
argument 2, -jar
argument 3, /Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.3.0.0-SNAPSHOT.jar
argument 4, --instance-id=0
argument 5, -mbus.busType=DATABASE
argument 6, -spassphrase=[REDACTED]
argument 7, -ssalt=salt
argument 8, -spassphrase=[REDACTED]
argument 9, -ssalt=salt
argument 10, -ddatabase.user=user
argument 11, -ddatabase.pass=[REDACTED]
argument 12, -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster
argument 13, -ddatabase.jdbc.directory=/Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/drivers
argument 14, -rtls.crt.path=/Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/tls/rest/server.crt
argument 15, -rtls.key.path=/Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/tls/rest/server.key
argument 16, -rtls.ca.crt.path=/Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/tls/rest/ca-chain-bundle.crt
User: bogdan.paunescu
StartInstant: 2024-03-01T11:00:24.109Z
TotalCpuDuration: PT49.245005S
classpath: /Users/bogdan.paunescu/Work/github/corda-runtime-os/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.3.0.0-SNAPSHOT.jar
VM OpenJDK 64-Bit Server VM Azul Systems, Inc. 17.0.9+8-LTS
2024-03-01 13:01:01.916 [main] INFO  net.corda.applications.workers.combined.CombinedWorker {} - Quasar's instrumentation verification is enabled
2024-03-01 13:01:02.378 [main] INFO  net.corda.application.dbsetup.PostgresDbSetup {} - Table config.config exists in jdbc:postgresql://localhost:5432/cordacluster?user=postgres&password=password, skipping DB initialisation.
