### PR TITLE
CORE-17167: Report URL with 404 error

### DIFF
--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
@@ -93,6 +93,10 @@ class RestServerRequestsTest : RestServerTestBase() {
             password
         )
         assertEquals(HttpStatus.SC_NOT_FOUND, invalidPathResponse.responseStatus)
+        assertEquals(
+            "/api/${apiVersion.versionPath}/invalidPath",
+            (invalidPathResponse.body!!.asMapFromJson()["details"] as Map<*, *>)["url"]
+        )
     }
 
     @Test

--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
@@ -93,10 +93,8 @@ class RestServerRequestsTest : RestServerTestBase() {
             password
         )
         assertEquals(HttpStatus.SC_NOT_FOUND, invalidPathResponse.responseStatus)
-        assertEquals(
-            "/api/${apiVersion.versionPath}/invalidPath",
-            (invalidPathResponse.body!!.asMapFromJson()["details"] as Map<*, *>)["url"]
-        )
+        assertThat((invalidPathResponse.body!!.asMapFromJson()["details"] as Map<*, *>)["url"].toString())
+            .contains("/api/${apiVersion.versionPath}/invalidPath")
     }
 
     @Test

--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerTestBase.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerTestBase.kt
@@ -15,6 +15,6 @@ abstract class RestServerTestBase {
         const val password = FakeSecurityManager.PASSWORD
         val securityManager = FakeSecurityManager()
         val context = RestContext("api", "RestContext test title ", "RestContext test description")
-        val apiVersion = RestApiVersion.C5_0
+        val apiVersion = RestApiVersion.C5_3
     }
 }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -138,14 +138,14 @@ internal class RestServerInternal(
     private fun addExceptionHandlers(app: Javalin) {
         app.exception(NotFoundResponse::class.java) { e, ctx ->
             val detailsWithUrl = e.details.plus("url" to ctx.req.requestURI)
-            commonResultString(NotFoundResponse(details = detailsWithUrl), ctx)
+            commonResult(NotFoundResponse(details = detailsWithUrl), ctx)
         }
         app.exception(HttpResponseException::class.java) { e, ctx ->
-            commonResultString(e, ctx)
+            commonResult(e, ctx)
         }
     }
 
-    private fun commonResultString(e: HttpResponseException, ctx: Context) {
+    private fun commonResult(e: HttpResponseException, ctx: Context) {
         if (ctx.header(Header.ACCEPT)?.contains(ContentType.JSON) == true || ctx.res.contentType == ContentType.JSON) {
             ctx.status(e.status).result(
                 """{

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -137,7 +137,7 @@ internal class RestServerInternal(
 
     private fun addExceptionHandlers(app: Javalin) {
         app.exception(NotFoundResponse::class.java) { e, ctx ->
-            val detailsWithUrl = e.details.plus("url" to ctx.req.requestURI)
+            val detailsWithUrl = e.details.plus("url" to ctx.req.requestURL.toString())
             commonResult(NotFoundResponse(details = detailsWithUrl), ctx)
         }
         app.exception(HttpResponseException::class.java) { e, ctx ->

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/RestServerInternal.kt
@@ -45,7 +45,7 @@ import org.osgi.framework.FrameworkUtil
 import org.osgi.framework.wiring.BundleWiring
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
-import java.util.*
+import java.util.LinkedList
 import javax.servlet.MultipartConfigElement
 
 @Suppress("TooManyFunctions", "TooGenericExceptionThrown", "LongParameterList")


### PR DESCRIPTION
- Add exception handler NotFoundResponse for invalid REST api paths and add the request URL to the details
- Update integration test

New response body for an invalid path:
`body={
    "title": "Not found",
    "status": 404,
    "details": {"url":"https://localhost:8888/api/v5_3/cpi/invalidPath"}
}`

Old response body for an invalid path:
`body={
    "title": "Not found",
    "status": 404,
    "details": {}
}`