### PR TITLE
ES-2029: release prep, ensure all needed artifacts are generated for external publishing

### DIFF
--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/build.gradle
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'corda.common-publishing'
     id 'net.corda.plugins.cordapp-cpk2'
+    id 'corda.javadoc-generation'
 }
 
 ext {

--- a/tools/corda-runtime-gradle-plugin/build.gradle
+++ b/tools/corda-runtime-gradle-plugin/build.gradle
@@ -49,4 +49,17 @@ publishing {
             }
         }
     }
+    if (project.hasProperty('maven.repo.s3')) {
+        repositories {
+            maven {
+                name = 'AWS'
+                url = project.findProperty('maven.repo.s3')
+                credentials(AwsCredentials) {
+                    accessKey "${System.getenv('AWS_ACCESS_KEY_ID')}"
+                    secretKey "${System.getenv('AWS_SECRET_ACCESS_KEY')}"
+                    sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
When carrying out release prep, it was noticed the following issues were present. 

- Missing Java doc for `notary-plugin-contract-verifying-server` this will prevent maven central upload as the system checks for valid javaDoc on anything being uploaded to the platform and throws an error if not present.
- `corda-runtime-gradle-plugin` is missing S3 publishing, in C5 S3 publishing acts as a staging area for maven upload, so this is required before the final release.

No functional change to the application logic is altered in this PR. These are build changes which are prerequisites for the 5.2 release. 