### PR TITLE
CORE-14391 - Set an initial status for a `CPI UPLOAD` request

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.3-alpha-1709565175585
+cordaApiVersion=5.3.0.3-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=-5.3.0.3-alpha-1709565175585
+cordaApiVersion=5.3.0.3-alpha-1709565175585
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.3-beta-1709317119341
+cordaApiVersion=-5.3.0.3-alpha-1709565175585
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/CpiUploadManagerImpl.kt
+++ b/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/CpiUploadManagerImpl.kt
@@ -38,7 +38,9 @@ class CpiUploadManagerImpl(
                 futures.forEach { f -> f.get() }
             }
         }
-        return chunkWriter.write(cpiContent)
+        val resp = chunkWriter.write(cpiContent)
+        statusProcessor.status(publisher, resp.requestId, 0, "Upload started")
+        return resp
     }
 
     override fun status(requestId: RequestId): UploadStatus? = statusProcessor.status(requestId)

--- a/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/CpiUploadManagerImpl.kt
+++ b/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/CpiUploadManagerImpl.kt
@@ -39,7 +39,7 @@ class CpiUploadManagerImpl(
             }
         }
         val resp = chunkWriter.write(cpiContent)
-        statusProcessor.status(publisher, resp.requestId, 0, "Upload started")
+        statusProcessor.publishStatus(publisher, resp.requestId, 0, "Upload started")
         return resp
     }
 

--- a/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/UploadStatusProcessor.kt
+++ b/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/UploadStatusProcessor.kt
@@ -61,9 +61,9 @@ class UploadStatusProcessor : CompactedProcessor<UploadStatusKey, UploadStatus> 
 
         publisher.publish(listOf(newRecord))
 
-        // Update the tracker immediately, so we won't send the 400 error, request not found if the user checks for the
-        // upload request status. Keep in mind that the tracker will be updated again
-        // once the request sent is received. This is unavoidable since we want to let other workers
+        // Update the tracker immediately, so we won't send the 400 code error "request id not found", if the user
+        // checks for the upload request status. Keep in mind that the tracker will be updated again
+        // once the status update message that was sent is received. This is unavoidable since we want to let other workers
         // know about this status update.
         updateTracker(newRecord)
     }

--- a/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/UploadStatusProcessor.kt
+++ b/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/UploadStatusProcessor.kt
@@ -52,7 +52,7 @@ class UploadStatusProcessor : CompactedProcessor<UploadStatusKey, UploadStatus> 
         return tracker.status(requestId)
     }
 
-    fun status(publisher: Publisher, requestId: RequestId, sequenceNumber: Int, message: String) {
+    fun publishStatus(publisher: Publisher, requestId: RequestId, sequenceNumber: Int, message: String) {
         val newRecord = Record(
             Schemas.VirtualNode.CPI_UPLOAD_STATUS_TOPIC,
             UploadStatusKey(requestId, sequenceNumber),

--- a/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/UploadStatusProcessor.kt
+++ b/libs/virtual-node/cpi-upload-manager-impl/src/main/kotlin/net/corda/libs/cpiupload/impl/UploadStatusProcessor.kt
@@ -48,7 +48,7 @@ class UploadStatusProcessor : CompactedProcessor<UploadStatusKey, UploadStatus> 
      * @return returns the status of the specified chunk upload request
      */
     fun status(requestId: RequestId): UploadStatus? {
-        log.info("Getting status for $requestId")
+        log.debug("Getting status for $requestId")
         return tracker.status(requestId)
     }
 


### PR DESCRIPTION
Set an initial status for a `CPI UPLOAD` request to decrease the chance of returning `400` code while the request waits in the Kafka queue to be processed by the db worker.

Keep in mind this is only a mitigation. It is still possible that a 400 error code is returned when multiple REST workers are used. This happens because Corda follows the `eventual consistency` pattern.

This PR depends on: https://github.com/corda/corda-api/pull/1541