### PR TITLE
CORE-19544: Key Rotation REST calls are not throwing error if tenantId is passed as an empty string

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -259,10 +259,9 @@ class KeyRotationRestResourceImpl @Activate constructor(
             }
         }
 
-        if (tenantId.isEmpty()) throw InvalidInputDataException(
+        if (tenantId.isEmpty() || tenantId.isBlank()) throw InvalidInputDataException(
             "Cannot start key rotation. TenantId is not specified."
         )
-
 
         return if (tenantId == MASTER_WRAPPING_KEY_ROTATION_IDENTIFIER) {
             doKeyRotation(publishRequests = { publishToKafka!!.publish(it) })

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -182,6 +182,10 @@ class KeyRotationRestResourceImpl @Activate constructor(
             "State manager for key rotation is not initialised."
         }
 
+        if (tenantId.isEmpty() || tenantId.isBlank()) throw InvalidInputDataException(
+            "Cannot retrieve key rotation status. TenantId is not specified."
+        )
+
         when (tenantId) {
             MASTER_WRAPPING_KEY_ROTATION_IDENTIFIER -> { // do unmanaged key rotation status
                 val records = stateManager.findByMetadataMatchingAll(


### PR DESCRIPTION
We already checked if tenantId is empty, but we also need to check if it's blank to prevent empty string input.