### PR TITLE
CORE-19731: Rename cluster utils method for key rotation to keep it consistent with other naming

### DIFF
--- a/.ci/JenkinsfileCommentRebuild
+++ b/.ci/JenkinsfileCommentRebuild
@@ -5,6 +5,6 @@ import static com.r3.build.BuildControl.cancelQueuedJobByName
 cancelQueuedJobByName(env.JOB_NAME)
 
 githubCommentBuildTests(
-    branch: 'release/5.3',
+    branch: 'PR-482',
     chartVersion: '^5.3.0-alpha',
 )

--- a/.ci/JenkinsfileCommentRebuild
+++ b/.ci/JenkinsfileCommentRebuild
@@ -5,6 +5,6 @@ import static com.r3.build.BuildControl.cancelQueuedJobByName
 cancelQueuedJobByName(env.JOB_NAME)
 
 githubCommentBuildTests(
-    branch: 'PR-482',
+    branch: 'release/5.3',
     chartVersion: '^5.3.0-alpha',
 )

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -232,7 +232,7 @@ fun ClusterInfo.whenNoKeyExists(
  *   @param expectedHttpStatusCode Status code that should be displayed when the API is hit,
  *   helps to validate both positive or negative scenarios.
  */
-fun ClusterInfo.rotateCryptoUnmanagedWrappingKeys(
+fun ClusterInfo.rotateCryptoWrappingKeys(
     tenantId: String,
     expectedHttpStatusCode: Int
 ) = cluster {


### PR DESCRIPTION
[E2E test repo PR](https://github.com/corda/corda-e2e-tests/pull/482)