### PR TITLE
CORE-19913: Fix bug where unmanaged key rotation could rotate previously rotated keys

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImpl.kt
@@ -66,10 +66,10 @@ class WrappingRepositoryImpl(
         entityManagerFactory.createEntityManager().use {
             it.createQuery(
                 "FROM ${WrappingKeyEntity::class.simpleName} " +
-                        "WHERE (alias, generation) IN (" +
-                            "SELECT alias, MAX(generation) FROM ${WrappingKeyEntity::class.simpleName} " +
-                            "GROUP BY alias" +
-                        ") AND parentKeyReference != :parentKeyAlias",
+                "WHERE (alias, generation) IN (" +
+                    "SELECT alias, MAX(generation) FROM ${WrappingKeyEntity::class.simpleName} " +
+                    "GROUP BY alias" +
+                ") AND parentKeyReference != :parentKeyAlias",
                 WrappingKeyEntity::class.java
             ).setParameter("parentKeyAlias", parentKeyAlias).resultList
                 .map { dao -> dao.toDto() }

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/WrappingRepositoryImpl.kt
@@ -65,13 +65,14 @@ class WrappingRepositoryImpl(
     override fun findKeysNotWrappedByParentKey(parentKeyAlias: String): List<WrappingKeyInfo> =
         entityManagerFactory.createEntityManager().use {
             it.createQuery(
-                "FROM ${WrappingKeyEntity::class.simpleName} AS k WHERE k.parentKeyReference != :parentKeyAlias",
+                "FROM ${WrappingKeyEntity::class.simpleName} " +
+                        "WHERE (alias, generation) IN (" +
+                            "SELECT alias, MAX(generation) FROM ${WrappingKeyEntity::class.simpleName} " +
+                            "GROUP BY alias" +
+                        ") AND parentKeyReference != :parentKeyAlias",
                 WrappingKeyEntity::class.java
             ).setParameter("parentKeyAlias", parentKeyAlias).resultList
                 .map { dao -> dao.toDto() }
-                .groupBy { it.alias } // bucket into aliases
-                .map { it.value.sortedBy { it.generation }.lastOrNull() } // grab only the highest generation per alias
-                .filterNotNull()
         }
 
     override fun getKeyById(id: UUID): WrappingKeyInfo? = entityManagerFactory.createEntityManager().use {


### PR DESCRIPTION
The previous implementation of `WrappingRepositoryImpl.findKeysNotWrappedByParentKey` had a bug where it could find previous generations of a managed wrapping key, which would cause them to be rotated needlessly. This PR fixes that by fetching the highest generation of each key before checking the parent key.