### PR TITLE
CORE-19896: remove future timestamp check

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -59,11 +59,7 @@ class VaultNamedParameterizedQueryImpl<T>(
 
     @Suspendable
     override fun execute(): PagedQuery.ResultSet<T> {
-        getCreatedTimestampLimit()?.let {
-            require(it <= clock.instant()) {
-                "Timestamp limit must not be in the future."
-            }
-        } ?: setCreatedTimestampLimit(clock.instant())
+        getCreatedTimestampLimit() ?: setCreatedTimestampLimit(clock.instant())
 
         val resultSet = resultSetFactory.create(
             parameters,
@@ -90,8 +86,6 @@ class VaultNamedParameterizedQueryImpl<T>(
     }
 
     override fun setCreatedTimestampLimit(timestampLimit: Instant): VaultNamedParameterizedQuery<T> {
-        require(timestampLimit <= Instant.now()) { "Timestamp limit must not be in the future." }
-
         parameters[TIMESTAMP_LIMIT_PARAM_NAME] = timestampLimit
         return this
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -8,7 +8,6 @@ import net.corda.ledger.utxo.flow.impl.persistence.external.events.VaultNamedQue
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.utilities.days
 import net.corda.utilities.time.Clock
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.application.persistence.PagedQuery.ResultSet
@@ -90,13 +89,6 @@ class VaultNamedParameterizedQueryImplTest {
     @Test
     fun `setLimit cannot be zero`() {
         assertThatThrownBy { query.setLimit(0) }.isInstanceOf(IllegalArgumentException::class.java)
-    }
-
-    @Test
-    fun `cannot set timestamp limit to a future date`() {
-        assertThatThrownBy { query.setCreatedTimestampLimit(Instant.now().plusMillis(1.days.toMillis())) }
-            .isInstanceOf(IllegalArgumentException::class.java)
-            .hasStackTraceContaining("Timestamp limit must not be in the future.")
     }
 
     @Test


### PR DESCRIPTION
This PR removes a check whether the incoming timestamp is future time to prove timestamps in different queries have time skew.