### PR TITLE
CORE-19973 - State Manager Create fix.

### DIFF
--- a/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/PostgresQueryProvider.kt
+++ b/libs/state-manager/state-manager-db-impl/src/main/kotlin/net/corda/libs/statemanager/impl/repository/impl/PostgresQueryProvider.kt
@@ -17,10 +17,7 @@ class PostgresQueryProvider : AbstractQueryProvider() {
         )
         INSERT INTO $STATE_MANAGER_TABLE
         SELECT * FROM data d
-        WHERE NOT EXISTS (
-            SELECT 1 FROM $STATE_MANAGER_TABLE t
-            WHERE t.$KEY_COLUMN = d.$KEY_COLUMN
-        )
+        ON CONFLICT DO NOTHING
         RETURNING $STATE_MANAGER_TABLE.$KEY_COLUMN;
     """.trimIndent()
 


### PR DESCRIPTION
Change the State Manager Create function to use `ON CONFLICT DO NOTHING` instead of a subselect to avoid duplicate key inserts.

Previously, the implementation used a sub-select query to avoid inserting duplicate rows, but this does not guard against multiple DB sessions trying the same insert as the SELECT can be "dirty".