### PR TITLE
POC for offset on stable vault queries

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/ResultSetFactoryImpl.kt
@@ -33,18 +33,20 @@ class ResultSetFactoryImpl @Activate constructor(
         return OffsetResultSetImpl(serializationService, getSerializedParameters(parameters), limit, offset, resultClass, resultSetExecutor)
     }
 
-    override fun <R> create(
+    override fun <R> createStable(
         parameters: Map<String, Any?>,
         limit: Int,
+        offset: Int,
         resultClass: Class<R>,
         resultSetExecutor: StableResultSetExecutor<R>
     ): PagedQuery.ResultSet<R> {
         return StableResultSetImpl(
-            serializationService,
-            getSerializedParameters(parameters).toMutableMap(),
-            limit,
-            resultClass,
-            resultSetExecutor)
+            serializationService = serializationService,
+            serializedParameters = getSerializedParameters(parameters).toMutableMap(),
+            limit = limit,
+            offset = offset,
+            resultClass = resultClass,
+            resultSetExecutor = resultSetExecutor)
     }
 
     private fun getSerializedParameters(parameters: Map<String, Any?>): Map<String, ByteBuffer?> {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/StableResultSetImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/persistence/query/StableResultSetImpl.kt
@@ -13,6 +13,7 @@ data class StableResultSetImpl<R> internal constructor(
     private val serializationService: SerializationService,
     private var serializedParameters: MutableMap<String, ByteBuffer?>,
     private var limit: Int,
+    private var offset: Int = 0,
     private val resultClass: Class<R>,
     private val resultSetExecutor: StableResultSetExecutor<R>
 ) : PagedQuery.ResultSet<R> {
@@ -20,7 +21,6 @@ data class StableResultSetImpl<R> internal constructor(
     private var results: List<R> = emptyList()
     private var resumePoint: ByteBuffer? = null
     private var firstExecution = true
-    private var offset: Int = 0
 
     override fun getResults(): List<R> {
         return results

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/ResultSetFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/persistence/query/ResultSetFactoryImplTest.kt
@@ -29,7 +29,10 @@ class ResultSetFactoryImplTest {
     fun `serializes the parameters and creates a stable result set`() {
         whenever(serializationService.serialize(any<Any>())).thenReturn(SerializedBytesImpl(byteArrayOf(1, 2, 3, 4)))
         val parameters = mapOf("A" to 1, "B" to 2, "C" to 3)
-        resultSetFactory.create(parameters, 5,  Any::class.java) { _, _, _ -> StableResultSetExecutor.Results(emptyList(), null, null) }
+        resultSetFactory.createStable(parameters, 5,0,  Any::class.java) {
+
+             _, _, _ -> StableResultSetExecutor.Results(emptyList(),
+            null, null) }
         verify(serializationService).serialize(1)
         verify(serializationService).serialize(2)
         verify(serializationService).serialize(3)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -40,7 +40,9 @@ class VaultNamedParameterizedQueryImpl<T>(
     }
 
     override fun setOffset(offset: Int): VaultNamedParameterizedQuery<T> {
-        throw UnsupportedOperationException("This query does not support offset functionality.")
+        require(offset >= 0 { "Offset cannot be negative"})
+        this.offset = offset
+        return this
     }
 
     override fun setParameter(name: String, value: Any?): VaultNamedParameterizedQuery<T> {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -59,7 +59,9 @@ class VaultNamedParameterizedQueryImplTest {
 
     @BeforeEach
     fun beforeEach() {
-        whenever(resultSetFactory.create(mapCaptor.capture(), any(), any(), resultSetExecutorCaptor.capture())).thenReturn(resultSet)
+        whenever(
+            resultSetFactory.createStable(mapCaptor.capture(), any(), any(), any(), resultSetExecutorCaptor.capture())
+        ).thenReturn(resultSet)
         whenever(resultSet.next()).thenReturn(results)
         whenever(clock.instant()).thenReturn(later)
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
@@ -70,16 +72,16 @@ class VaultNamedParameterizedQueryImplTest {
     @Test
     fun `setLimit updates the limit`() {
         query.execute()
-        verify(resultSetFactory).create(any(), eq(1), any<Class<Any>>(), any())
+        verify(resultSetFactory).createStable(any(), eq(1), any(), any<Class<Any>>(), any())
 
         query.setLimit(10)
         query.execute()
-        verify(resultSetFactory).create(any(), eq(10), any<Class<Any>>(), any())
+        verify(resultSetFactory).createStable(any(), eq(10), any(), any<Class<Any>>(), any())
     }
 
     @Test
-    fun `setOffset is not supported`() {
-        assertThatThrownBy { query.setOffset(10) }.isInstanceOf(UnsupportedOperationException::class.java)
+    fun `setOffset is supported`() {
+        query.setOffset(10)
     }
 
     @Test
@@ -165,7 +167,7 @@ class VaultNamedParameterizedQueryImplTest {
     @Test
     fun `execute creates a result set, gets the next page and returns the result set`() {
         assertThat(query.execute()).isEqualTo(resultSet)
-        verify(resultSetFactory).create(any(), any(), any<Class<Any>>(), any())
+        verify(resultSetFactory).createStable(any(), any(), any(), any<Class<Any>>(), any())
         verify(resultSet).next()
     }
 

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetFactory.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetFactory.kt
@@ -35,15 +35,17 @@ interface ResultSetFactory {
      *
      * @param parameters The parameters of the query.
      * @param limit The limit of the query.
+     * @param offset The offset of the query
      * @param resultClass The return type of the query.
      * @param resultSetExecutor The operation that is executed to retrieve query results.
      *
      * @return A [ResultSet] that retrieves data based on the implementation of [offsetResultSetExecutor].
      */
-    fun <R> create(
+    fun <R> createStable(
         parameters: Map<String, Any?>,
         limit: Int,
+        offset: Int,
         resultClass: Class<R>,
-        resultSetExecutor: StableResultSetExecutor<R>
+        resultSetExecutor: StableResultSetExecutor<R>,
     ): ResultSet<R>
 }

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetFactory.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/persistence/query/ResultSetFactory.kt
@@ -35,7 +35,6 @@ interface ResultSetFactory {
      *
      * @param parameters The parameters of the query.
      * @param limit The limit of the query.
-     * @param offset The offset of the query.
      * @param resultClass The return type of the query.
      * @param resultSetExecutor The operation that is executed to retrieve query results.
      *


### PR DESCRIPTION
Exploring whether we can support offsets on stable (created ordering) custom queries. There will need to be some restrictions e.g. around queries that only touch unconsumed states.