### PR TITLE
Dependabot to ignore major and minor versions for 5.2 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       interval: "daily"
     rebase-strategy: "disabled"
+    ignore:
+      - dependency-name: "*"
+        # 5.2 release branch in maintenance mode. Only take patch updates
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
For 5.2 branch, make Dependabot ignore major and minor release versions of dependencies.

** DO NOT FORWARD MERGE! **