### PR TITLE
CORE-14483 - Log entries generated inside Flow code now have a trace ID in the MDC

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestMethodOrder
-import java.time.Duration
 import java.util.UUID
 
 @Target(AnnotationTarget.FUNCTION)
@@ -69,7 +68,7 @@ class VirtualNodeRestTest : ClusterReadiness by ClusterReadinessChecker() {
     @BeforeAll
     fun setup() {
         // check cluster is ready
-        assertIsReady(Duration.ofMinutes(2), Duration.ofMillis(100))
+     //  assertIsReady(Duration.ofMinutes(2), Duration.ofMillis(100))
     }
 
     @BeforeEach

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestMethodOrder
+import java.time.Duration
 import java.util.UUID
 
 @Target(AnnotationTarget.FUNCTION)
@@ -68,7 +69,7 @@ class VirtualNodeRestTest : ClusterReadiness by ClusterReadinessChecker() {
     @BeforeAll
     fun setup() {
         // check cluster is ready
-     //  assertIsReady(Duration.ofMinutes(2), Duration.ofMillis(100))
+        assertIsReady(Duration.ofMinutes(2), Duration.ofMillis(100))
     }
 
     @BeforeEach

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
@@ -8,11 +8,12 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.membership.read.MembershipGroupReader
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.serialization.checkpoint.NonSerializable
+import net.corda.tracing.TraceContext
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 
 @Suppress("LongParameterList")
-class FlowFiberExecutionContext(
+class `FlowFiberExecutionContext`(
     val flowCheckpoint: FlowCheckpoint,
     val sandboxGroupContext: FlowSandboxGroupContext,
     val holdingIdentity: HoldingIdentity,
@@ -20,7 +21,8 @@ class FlowFiberExecutionContext(
     val currentSandboxGroupContext: CurrentSandboxGroupContext,
     val mdcLoggingData: Map<String, String>,
     val flowMetrics: FlowMetrics,
-    val configs: Map<String, SmartConfig>
+    val configs: Map<String, SmartConfig>,
+    val traceContext: TraceContext? = null
 ) : NonSerializable {
     val memberX500Name: MemberX500Name get() = holdingIdentity.x500Name
     val flowStackService: FlowStack get() = flowCheckpoint.flowStack

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
@@ -22,7 +22,7 @@ class FlowFiberExecutionContext(
     val mdcLoggingData: Map<String, String>,
     val flowMetrics: FlowMetrics,
     val configs: Map<String, SmartConfig>,
-    val traceContext: TraceContext? = null
+    val traceContext: TraceContext
 ) : NonSerializable {
     val memberX500Name: MemberX500Name get() = holdingIdentity.x500Name
     val flowStackService: FlowStack get() = flowCheckpoint.flowStack

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberExecutionContext.kt
@@ -13,7 +13,7 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.virtualnode.HoldingIdentity
 
 @Suppress("LongParameterList")
-class `FlowFiberExecutionContext`(
+class FlowFiberExecutionContext(
     val flowCheckpoint: FlowCheckpoint,
     val sandboxGroupContext: FlowSandboxGroupContext,
     val holdingIdentity: HoldingIdentity,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -67,6 +67,12 @@ class FlowFiberImpl(
 
     @Suspendable
     override fun run() {
+        // This point is the entry point of a Quasar fiber. In order to keep the traceId present in the MDC
+        // the method markInScope must be called. The call must be the first thing to be done to ensure
+        // any generated logs contain the trace id which helps people find the relevant logs when troubleshooting an issue.
+        // Keep in mind the traceId is managed by a third-party library
+        flowFiberExecutionContext?.traceContext?.markInScope()
+
         try {
             setCurrentSandboxGroupContext()
             // Ensure run() does not exit via any means without completing the future, in order not to indefinitely block

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -67,7 +67,7 @@ class FlowFiberImpl(
 
     @Suspendable
     override fun run() {
-        // This point is the entry point of a Quasar fiber. In order to keep the traceId present in the MDC
+        // This is the entry point of a Quasar fiber. In order to keep the traceId present in the MDC
         // the method markInScope must be called. The call must be the first thing to be done to ensure
         // any generated logs contain the trace id which helps people find the relevant logs when troubleshooting an issue.
         // Keep in mind the traceId is managed by a third-party library

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/factory/impl/FlowFiberExecutionContextFactoryImpl.kt
@@ -40,7 +40,8 @@ class FlowFiberExecutionContextFactoryImpl @Activate constructor(
             currentSandboxGroupContext,
             context.mdcProperties,
             context.flowMetrics,
-            context.configs
+            context.configs,
+            context.flowTraceContext
         )
     }
 }

--- a/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
+++ b/components/flow/flow-service/src/test/java/net/corda/flow/application/sessions/FlowSessionImplJavaTest.java
@@ -46,7 +46,8 @@ public class FlowSessionImplJavaTest {
             mock(CurrentSandboxGroupContext.class),
             Map.of(),
             mock(FlowMetrics.class),
-            Map.of()
+            Map.of(),
+            mock()
     );
     private final FlowFiber flowFiber = new FakeFiber(flowFiberExecutionContext);
     private final FlowFiberService flowFiberService = mock(FlowFiberService.class);

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
@@ -59,7 +59,8 @@ class MockFlowFiberService : FlowFiberService {
             currentSandboxGroupContext,
             emptyMap(),
             mock(),
-            emptyMap()
+            emptyMap(),
+            mock()
         )
 
         whenever(flowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/ClientRequestBodyImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/ClientRequestBodyImplTest.kt
@@ -87,7 +87,8 @@ class ClientRequestBodyImplTest {
             mock(),
             emptyMap(),
             mock(),
-            emptyMap()
+            emptyMap(),
+            mock()
         )
         whenever(fiber.getExecutionContext()).thenReturn(executionContext)
         whenever(fiberService.getExecutingFiber()).thenReturn(fiber)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberExecutionContextTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/FlowFiberExecutionContextTest.kt
@@ -18,7 +18,7 @@ class FlowFiberExecutionContextTest {
     @Test
     fun `getMemberX500Name returns x500name parsed from holding identity`() {
         val holdingIdentity = HoldingIdentity(BOB_X500_NAME, "group1")
-        val context = FlowFiberExecutionContext(mock(), mock(), holdingIdentity, mock(), mock(), emptyMap(), mock(), emptyMap())
+        val context = FlowFiberExecutionContext(mock(), mock(), holdingIdentity, mock(), mock(), emptyMap(), mock(), emptyMap(), mock())
         assertThat(context.memberX500Name).isEqualTo(BOB_X500_NAME)
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/runner/FlowRunnerImplTest.kt
@@ -113,7 +113,8 @@ class FlowRunnerImplTest {
             mock(),
             emptyMap(),
             mock(),
-            emptyMap()
+            emptyMap(),
+            mock()
         )
         whenever(virtualNodeInfoReadService.get(any())).thenReturn(getMockVNodeInfo())
         whenever(cpiInfoReadService.get(any())).thenReturn(getMockCpiMetaData())

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ContextUtils.kt
@@ -5,7 +5,6 @@ import io.javalin.http.Context
 import io.javalin.http.ForbiddenResponse
 import io.javalin.http.UnauthorizedResponse
 import net.corda.metrics.CordaMetrics
-import net.corda.rest.authorization.AuthorizationUtils
 import net.corda.rest.authorization.AuthorizingSubject
 import net.corda.rest.exception.HttpApiException
 import net.corda.rest.exception.InvalidInputDataException
@@ -21,6 +20,9 @@ import net.corda.rest.server.impl.internal.ParameterRetrieverFactory
 import net.corda.rest.server.impl.internal.ParametersRetrieverContext
 import net.corda.rest.server.impl.security.RestAuthenticationProvider
 import net.corda.rest.server.impl.security.provider.credentials.CredentialResolver
+import net.corda.utilities.MDC_METHOD
+import net.corda.utilities.MDC_PATH
+import net.corda.utilities.MDC_USER
 import net.corda.utilities.debug
 import net.corda.utilities.trace
 import net.corda.utilities.withMDC
@@ -41,9 +43,9 @@ internal object ContextUtils {
     private fun <T> withMDC(user: String, method: String, path: String, block: () -> T): T {
         return withMDC(
             listOf(
-                AuthorizationUtils.USER_MDC to user,
-                AuthorizationUtils.METHOD_MDC to method,
-                AuthorizationUtils.PATH_MDC to path
+                MDC_USER to user,
+                MDC_METHOD to method,
+                MDC_PATH to path
             ).toMap(),
             block
         )

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/authorization/AuthorizationUtils.kt
@@ -5,10 +5,6 @@ import org.slf4j.LoggerFactory
 object AuthorizationUtils {
     private val log = LoggerFactory.getLogger(AuthorizationUtils::class.java)
 
-    const val USER_MDC = "http.user"
-    const val METHOD_MDC = "http.method"
-    const val PATH_MDC = "http.path"
-
     fun authorize(
         authorizingSubject: AuthorizingSubject,
         resourceAccessString: String,

--- a/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveBaggageFields.kt
+++ b/libs/tracing-impl/src/main/kotlin/net/corda/tracing/brave/BraveBaggageFields.kt
@@ -3,6 +3,6 @@ package net.corda.tracing.brave
 import brave.baggage.BaggageField
 
 object BraveBaggageFields {
-    val REQUEST_ID: BaggageField = BaggageField.create("request_id")
-    val VIRTUAL_NODE_ID: BaggageField = BaggageField.create("vnode_id")
+    val REQUEST_ID: BaggageField = BaggageField.create("request.id")
+    val VIRTUAL_NODE_ID: BaggageField = BaggageField.create("vnode.id")
 }

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
@@ -12,11 +12,13 @@ import java.util.Collections
  * Common MDC properties used across corda.
  */
 const val MDC_CLIENT_ID = "corda.client.id"
-const val MDC_FLOW_ID = "flow.id"
-const val MDC_VNODE_ID = "vnode.id"
-const val MDC_SESSION_EVENT_ID = "session.event.id"
+const val MDC_FLOW_ID = "corda.flow.id"
+const val MDC_VNODE_ID = "corda.vnode.id"
+const val MDC_SESSION_EVENT_ID = "corda.session.event.id"
 const val MDC_EXTERNAL_EVENT_ID = "corda.external.event.id"
-
+const val MDC_USER = "corda.http.user"
+const val MDC_METHOD = "corda.http.method"
+const val MDC_PATH = "corda.http.path"
 const val MDC_LOGGED_PREFIX = "corda.logged"
 
 inline fun <T> logElapsedTime(label: String, logger: Logger, body: () -> T): T {

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
@@ -10,6 +10,8 @@ import java.util.Collections
 
 /**
  * Common MDC properties used across corda.
+ * The name of the MDC properties should be prefixed with `corda.` so we can tell from the logs which MDC values
+ * were set explicitly by corda from those that were set by a third-party library.
  */
 const val MDC_CLIENT_ID = "corda.client.id"
 const val MDC_FLOW_ID = "corda.flow.id"
@@ -119,5 +121,17 @@ fun clearMDC(mdcData: Map<String, String>) {
  * Clear the Log4j logging MDC of all data stored there.
  */
 fun clearMDC() {
-    MDC.clear()
+    // Clear only the MDC properties that are set explicitly by Corda
+    // Some libraries like Brave also manage the MDC properties and those
+    // properties shouldn't be cleared out.
+    MDC.getMDCAdapter().apply {
+        remove(MDC_CLIENT_ID)
+        remove(MDC_FLOW_ID)
+        remove(MDC_VNODE_ID)
+        remove(MDC_SESSION_EVENT_ID)
+        remove(MDC_EXTERNAL_EVENT_ID)
+        remove(MDC_USER)
+        remove(MDC_METHOD)
+        remove(MDC_PATH)
+    }
 }

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/LogUtils.kt
@@ -121,7 +121,7 @@ fun clearMDC(mdcData: Map<String, String>) {
  * Clear the Log4j logging MDC of all data stored there.
  */
 fun clearMDC() {
-    // Clear only the MDC properties that are set explicitly by Corda
+    // Clear only the MDC properties that are explicitly set  by Corda
     // Some libraries like Brave also manage the MDC properties and those
     // properties shouldn't be cleared out.
     MDC.getMDCAdapter().apply {

--- a/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
+++ b/testing/test-serialization/src/main/kotlin/net/corda/internal/serialization/amqp/helper/TestFlowFiberServiceWithSerialization.kt
@@ -63,7 +63,8 @@ class TestFlowFiberServiceWithSerialization(
             currentSandboxGroupContext,
             emptyMap(),
             mock(FlowMetrics::class.java),
-            emptyMap()
+            emptyMap(),
+            mock()
         )
 
         Mockito.`when`(mockFlowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext)


### PR DESCRIPTION
Updated the code so the `traceId` is preserved when logs are generated by the flow. This helps fetching the relevant logs when troubleshooting bugs and reduces the risk of overwhelming Grafana.
Added the `traceContext` to `FlowFiberExecutionContext`.
Replaced the underscore by a dot so the mdc names are consistent in the logs.
The function `LogUtils.clearMDC()` should only clear the properties that are set explicitly by Corda. The MDC properties set by third-party dependencies should not be cleared out.
Renamed the MDC variables in `AuthorizationUtils` to follow the same naming pattern found in `LogUtils`
Moved the MDC variables in `AuthorizationUtils` to `LogUtils` to make it easier to find all MDC related variables.
Added the prefix `corda.` to the MDC related strings so we can tell which ones are set by Corda explicitly.

Example of the logs:
The log line that starts with "Filipe:" is printed by the flow and it now contains the trace id.
![image](https://github.com/corda/corda-runtime-os/assets/6329837/3a48dc2a-3256-45ec-a5e0-f82c5712a8e6)
