### PR TITLE
CORE-6319: Improve HTTPApiException

### DIFF
--- a/components/configuration/configuration-rest-resource-service-impl/src/main/kotlin/net/corda/configuration/rest/impl/exception/ConfigException.kt
+++ b/components/configuration/configuration-rest-resource-service-impl/src/main/kotlin/net/corda/configuration/rest/impl/exception/ConfigException.kt
@@ -15,7 +15,7 @@ class ConfigException(
     config: String
 ) : HttpApiException(
     responseCode = ResponseCode.INTERNAL_SERVER_ERROR,
-    message = "Config Version Error",
+    title = "Config Version Error",
     details = mapOf(
         "schemaVersion" to "${schemaVersion.majorVersion}.${schemaVersion.minorVersion}",
         "config" to config
@@ -33,7 +33,7 @@ class ConfigVersionConflictException(
     config: String
 ) : HttpApiException(
     responseCode = ResponseCode.CONFLICT,
-    message = "Wrong Config Version",
+    title = "Wrong Config Version",
     details = mapOf(
         "schemaVersion" to "${schemaVersion.majorVersion}.${schemaVersion.minorVersion}",
         "config" to config

--- a/components/configuration/configuration-rest-resource-service-impl/src/main/kotlin/net/corda/configuration/rest/impl/exception/ConfigException.kt
+++ b/components/configuration/configuration-rest-resource-service-impl/src/main/kotlin/net/corda/configuration/rest/impl/exception/ConfigException.kt
@@ -2,6 +2,7 @@ package net.corda.configuration.rest.impl.exception
 
 import net.corda.data.config.ConfigurationSchemaVersion
 import net.corda.rest.ResponseCode
+import net.corda.rest.exception.ExceptionDetails
 import net.corda.rest.exception.HttpApiException
 
 /**
@@ -31,9 +32,10 @@ class ConfigVersionConflictException(
     config: String
 ) : HttpApiException(
     responseCode = ResponseCode.CONFLICT,
-    message = "$errorType: $errorMessage",
+    message = "Wrong Config Version",
     details = mapOf(
         "schemaVersion" to "${schemaVersion.majorVersion}.${schemaVersion.minorVersion}",
         "config" to config
-    )
+    ),
+    exceptionDetails = ExceptionDetails(errorType, errorMessage)
 )

--- a/components/configuration/configuration-rest-resource-service-impl/src/main/kotlin/net/corda/configuration/rest/impl/exception/ConfigException.kt
+++ b/components/configuration/configuration-rest-resource-service-impl/src/main/kotlin/net/corda/configuration/rest/impl/exception/ConfigException.kt
@@ -14,13 +14,14 @@ class ConfigException(
     schemaVersion: ConfigurationSchemaVersion,
     config: String
 ) : HttpApiException(
-        responseCode = ResponseCode.INTERNAL_SERVER_ERROR,
-        message = "$errorType: $errorMessage",
-        details = mapOf(
-            "schemaVersion" to "${schemaVersion.majorVersion}.${schemaVersion.minorVersion}",
-            "config" to config
-        )
-    )
+    responseCode = ResponseCode.INTERNAL_SERVER_ERROR,
+    message = "Config Version Error",
+    details = mapOf(
+        "schemaVersion" to "${schemaVersion.majorVersion}.${schemaVersion.minorVersion}",
+        "config" to config
+    ),
+    exceptionDetails = ExceptionDetails(errorType, errorMessage)
+)
 
 /**
  * Incorrect version for config update.

--- a/components/configuration/configuration-rest-resource-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/ConfigRestResourceImplTests.kt
+++ b/components/configuration/configuration-rest-resource-service-impl/src/test/kotlin/net/corda/configuration/rest/impl/ConfigRestResourceImplTests.kt
@@ -1,6 +1,5 @@
 package net.corda.configuration.rest.impl
 
-import java.util.concurrent.CompletableFuture
 import net.corda.configuration.read.ConfigurationGetService
 import net.corda.configuration.rest.impl.exception.ConfigRestResourceException
 import net.corda.configuration.rest.impl.v1.ConfigRestResourceImpl
@@ -9,12 +8,6 @@ import net.corda.data.config.Configuration
 import net.corda.data.config.ConfigurationManagementRequest
 import net.corda.data.config.ConfigurationManagementResponse
 import net.corda.data.config.ConfigurationSchemaVersion
-import net.corda.rest.JsonObject
-import net.corda.rest.ResponseCode
-import net.corda.rest.exception.HttpApiException
-import net.corda.rest.response.ResponseEntity
-import net.corda.rest.security.CURRENT_REST_CONTEXT
-import net.corda.rest.security.RestAuthContext
 import net.corda.libs.configuration.SmartConfigImpl
 import net.corda.libs.configuration.endpoints.v1.ConfigRestResource
 import net.corda.libs.configuration.endpoints.v1.types.ConfigSchemaVersion
@@ -26,6 +19,12 @@ import net.corda.libs.configuration.validation.ConfigurationValidator
 import net.corda.libs.configuration.validation.ConfigurationValidatorFactory
 import net.corda.messaging.api.publisher.RPCSender
 import net.corda.messaging.api.publisher.factory.PublisherFactory
+import net.corda.rest.JsonObject
+import net.corda.rest.ResponseCode
+import net.corda.rest.exception.HttpApiException
+import net.corda.rest.response.ResponseEntity
+import net.corda.rest.security.CURRENT_REST_CONTEXT
+import net.corda.rest.security.RestAuthContext
 import net.corda.v5.base.versioning.Version
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -36,6 +35,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.CompletableFuture
 
 data class TestJsonObject(override val escapedJson: String = "") : JsonObject
 
@@ -183,7 +183,7 @@ class ConfigRestResourceImplTests {
             configRPCOps.updateConfig(req)
         }
 
-        assertEquals("ErrorType: ErrorMessage.", e.message)
+        assertEquals("Config Version Error", e.message)
         assertEquals(ResponseCode.INTERNAL_SERVER_ERROR, e.responseCode)
     }
 

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificateRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/CertificateRestResourceImpl.kt
@@ -159,7 +159,7 @@ class CertificateRestResourceImpl @Activate constructor(
             } else {
                 val message = "$name is not a valid domain name or IP address"
                 throw InvalidInputDataException(
-                    message = message,
+                    title = message,
                     details = mapOf("subjectAlternativeNames" to message),
                 )
             }

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMAdminRestResourceImpl.kt
@@ -104,7 +104,7 @@ class MGMAdminRestResourceImpl @Activate constructor(
             } catch (e: MemberNotAnMgmException) {
                 throw InvalidInputDataException(
                     details = mapOf("holdingIdentityShortHash" to holdingIdentityShortHash),
-                    message = "Member with holding identity $holdingIdentityShortHash is not an MGM.",
+                    title = "Member with holding identity $holdingIdentityShortHash is not an MGM.",
                 )
             } catch (e: CordaRPCAPIPartitionException) {
                 throw ServiceUnavailableException("Could not perform operation for $holdingIdentityShortHash: Repartition Event!")

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -57,7 +57,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.UUID
+import java.util.*
 import java.util.regex.PatternSyntaxException
 import javax.persistence.PessimisticLockException
 import net.corda.data.membership.preauth.PreAuthToken as AvroPreAuthToken
@@ -735,7 +735,7 @@ class MGMRestResourceImpl internal constructor(
         private fun notAnMgmError(holdingIdentityShortHash: String): Nothing =
             throw InvalidInputDataException(
                 details = mapOf("holdingIdentityShortHash" to holdingIdentityShortHash),
-                message = "Member with holding identity $holdingIdentityShortHash is not an MGM.",
+                title = "Member with holding identity $holdingIdentityShortHash is not an MGM.",
             )
 
         private fun parsePreAuthTokenId(preAuthTokenId: String): UUID {
@@ -744,7 +744,7 @@ class MGMRestResourceImpl internal constructor(
             } catch (e: IllegalArgumentException) {
                 throw InvalidInputDataException(
                     details = mapOf("preAuthTokenId" to preAuthTokenId),
-                    message = "tokenId is not a valid pre auth token."
+                    title = "tokenId is not a valid pre auth token."
                 )
             }
         }
@@ -755,7 +755,7 @@ class MGMRestResourceImpl internal constructor(
             } catch (e: IllegalArgumentException) {
                 throw InvalidInputDataException(
                     details = mapOf(keyName to x500Name),
-                    message = "$keyName is not a valid X500 name: ${e.message}",
+                    title = "$keyName is not a valid X500 name: ${e.message}",
                 )
             }
         }
@@ -793,7 +793,7 @@ class MGMRestResourceImpl internal constructor(
         private fun verifyMutualTlsIsRunning() {
             if (TlsType.getClusterType(configurationGetService::getSmartConfig) != TlsType.MUTUAL) {
                 throw BadRequestException(
-                    message = "This cluster is configure to use one way TLS. Mutual TLS APIs can not be called.",
+                    title = "This cluster is configure to use one way TLS. Mutual TLS APIs can not be called.",
                 )
             }
         }

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MGMRestResourceImpl.kt
@@ -57,7 +57,7 @@ import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.util.*
+import java.util.UUID
 import java.util.regex.PatternSyntaxException
 import javax.persistence.PessimisticLockException
 import net.corda.data.membership.preauth.PreAuthToken as AvroPreAuthToken

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MembershipRestUtils.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MembershipRestUtils.kt
@@ -1,7 +1,7 @@
 package net.corda.membership.impl.rest.v1
 
 import net.corda.rest.exception.InvalidInputDataException
-import java.util.*
+import java.util.UUID
 
 internal fun parseRegistrationRequestId(requestId: String): UUID {
     return try {

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MembershipRestUtils.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/MembershipRestUtils.kt
@@ -1,7 +1,7 @@
 package net.corda.membership.impl.rest.v1
 
 import net.corda.rest.exception.InvalidInputDataException
-import java.util.UUID
+import java.util.*
 
 internal fun parseRegistrationRequestId(requestId: String): UUID {
     return try {
@@ -9,7 +9,7 @@ internal fun parseRegistrationRequestId(requestId: String): UUID {
     } catch (e: IllegalArgumentException) {
         throw InvalidInputDataException(
             details = mapOf("registrationRequestId" to requestId),
-            message = "'$requestId' is not a valid registration request ID."
+            title = "'$requestId' is not a valid registration request ID."
         )
     }
 }

--- a/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/deprecated/CertificatesRestResourceImpl.kt
+++ b/components/membership/membership-rest-impl/src/main/kotlin/net/corda/membership/impl/rest/v1/deprecated/CertificatesRestResourceImpl.kt
@@ -169,7 +169,7 @@ class CertificatesRestResourceImpl @Activate constructor(
             } else {
                 val message = "$name is not a valid domain name or IP address"
                 throw InvalidInputDataException(
-                    message = message,
+                    title = message,
                     details = mapOf("subjectAlternativeNames" to message),
                 )
             }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapper.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapper.kt
@@ -48,10 +48,15 @@ internal object HttpExceptionMapper {
     }
 
     private fun HttpApiException.asHttpResponseException(): HttpResponseException {
-        val fullDetails = details + mapOf(
-            exceptionDetails!!.cause.let { "cause" to it },
-            exceptionDetails!!.reason.let { "reason" to it }
-        )
+        val fullDetails = when {
+            exceptionDetails?.cause.isNullOrBlank() || exceptionDetails?.reason.isNullOrBlank() -> details
+            else -> {
+                details + mapOf(
+                    exceptionDetails!!.cause.let { "cause" to it },
+                    exceptionDetails!!.reason.let { "reason" to it }
+                )
+            }
+        }
         return HttpResponseException(responseCode.statusCode, message, fullDetails)
     }
 }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapper.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapper.kt
@@ -48,6 +48,10 @@ internal object HttpExceptionMapper {
     }
 
     private fun HttpApiException.asHttpResponseException(): HttpResponseException {
-        return HttpResponseException(responseCode.statusCode, message, details)
+        val fullDetails = details + mapOf(
+            exceptionDetails!!.cause.let { "cause" to it },
+            exceptionDetails!!.reason.let { "reason" to it }
+        )
+        return HttpResponseException(responseCode.statusCode, message, fullDetails)
     }
 }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapper.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapper.kt
@@ -57,6 +57,6 @@ internal object HttpExceptionMapper {
                 )
             }
         }
-        return HttpResponseException(responseCode.statusCode, message, fullDetails)
+        return HttpResponseException(responseCode.statusCode, title, fullDetails)
     }
 }

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapperTest.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapperTest.kt
@@ -28,7 +28,7 @@ class HttpExceptionMapperTest {
 
     @Test
     fun `map to response BadRequestException with title, details and exceptionDetails`() {
-        val e = BadRequestException("Invalid id.", mapOf("abc" to "def"), ExceptionDetails("BadRequestException","Exception reason"))
+        val e = BadRequestException("Invalid id.", mapOf("abc" to "def"), ExceptionDetails("BadRequestException", "Exception reason"))
 
         val response = HttpExceptionMapper.mapToResponse(e)
 
@@ -74,7 +74,10 @@ class HttpExceptionMapperTest {
 
     @Test
     fun `map to response NotAuthenticatedException with title and exceptionDetails`() {
-        val e = NotAuthenticatedException("auth failed", exceptionDetails = ExceptionDetails("NotAuthenticatedException", "Exception reason"))
+        val e = NotAuthenticatedException(
+            "auth failed",
+            exceptionDetails = ExceptionDetails("NotAuthenticatedException", "Exception reason")
+        )
 
         val response = HttpExceptionMapper.mapToResponse(e)
 
@@ -98,7 +101,11 @@ class HttpExceptionMapperTest {
 
     @Test
     fun `test InternalServerException response`() {
-        val e = InternalServerException("message", mapOf("detail" to "someinfo"), ExceptionDetails("InternalServerException", "Exception reason"))
+        val e = InternalServerException(
+            "message",
+            mapOf("detail" to "someinfo"),
+            ExceptionDetails("InternalServerException", "Exception reason")
+        )
 
         val response = HttpExceptionMapper.mapToResponse(e)
 
@@ -112,7 +119,11 @@ class HttpExceptionMapperTest {
 
     @Test
     fun `test InvalidInputDataException response`() {
-        val e = InvalidInputDataException("title", mapOf("detail" to "someinfo"), ExceptionDetails("InvalidInputDataException", "Exception reason"))
+        val e = InvalidInputDataException(
+            "title",
+            mapOf("detail" to "someinfo"),
+            ExceptionDetails("InvalidInputDataException", "Exception reason")
+        )
 
         val response = HttpExceptionMapper.mapToResponse(e)
 

--- a/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapperTest.kt
+++ b/libs/rest/rest-server-impl/src/test/kotlin/net/corda/rest/server/impl/internal/HttpExceptionMapperTest.kt
@@ -1,17 +1,23 @@
 package net.corda.rest.server.impl.internal
 
 import net.corda.rest.exception.BadRequestException
+import net.corda.rest.exception.ExceptionDetails
 import net.corda.rest.exception.ForbiddenException
 import net.corda.rest.exception.InternalServerException
+import net.corda.rest.exception.InvalidInputDataException
+import net.corda.rest.exception.InvalidStateChangeException
 import net.corda.rest.exception.NotAuthenticatedException
+import net.corda.rest.exception.OperationNotAllowedException
+import net.corda.rest.exception.ResourceAlreadyExistsException
 import net.corda.rest.exception.ResourceNotFoundException
+import net.corda.rest.exception.ServiceUnavailableException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class HttpExceptionMapperTest {
 
     @Test
-    fun `map to response BadRequestException with message`() {
+    fun `map to response BadRequestException with title`() {
         val e = BadRequestException("Invalid id.")
 
         val response = HttpExceptionMapper.mapToResponse(e)
@@ -21,15 +27,17 @@ class HttpExceptionMapperTest {
     }
 
     @Test
-    fun `map to response BadRequestException with message and details`() {
-        val e = BadRequestException("Invalid id.", mapOf("abc" to "def"))
+    fun `map to response BadRequestException with title, details and exceptionDetails`() {
+        val e = BadRequestException("Invalid id.", mapOf("abc" to "def"), ExceptionDetails("BadRequestException","Exception reason"))
 
         val response = HttpExceptionMapper.mapToResponse(e)
 
         assertEquals(400, response.status)
         assertEquals("Invalid id.", response.message)
-        assertEquals(1, response.details.size)
+        assertEquals(3, response.details.size)
         assertEquals("def", response.details["abc"])
+        assertEquals("BadRequestException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
     }
 
     @Test
@@ -43,13 +51,15 @@ class HttpExceptionMapperTest {
     }
 
     @Test
-    fun `map to response ForbiddenException with message`() {
-        val e = ForbiddenException("mess")
+    fun `map to response ForbiddenException with title and exceptionDetails`() {
+        val e = ForbiddenException("mess", exceptionDetails = ExceptionDetails("ForbiddenException", "Exception reason"))
 
         val response = HttpExceptionMapper.mapToResponse(e)
 
         assertEquals(403, response.status)
         assertEquals("mess", response.message)
+        assertEquals("ForbiddenException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
     }
 
     @Test
@@ -63,34 +73,106 @@ class HttpExceptionMapperTest {
     }
 
     @Test
-    fun `map to response NotAuthenticatedException with message`() {
-        val e = NotAuthenticatedException("auth failed")
+    fun `map to response NotAuthenticatedException with title and exceptionDetails`() {
+        val e = NotAuthenticatedException("auth failed", exceptionDetails = ExceptionDetails("NotAuthenticatedException", "Exception reason"))
 
         val response = HttpExceptionMapper.mapToResponse(e)
 
         assertEquals(401, response.status)
         assertEquals("auth failed", response.message)
+        assertEquals("NotAuthenticatedException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
     }
 
     @Test
     fun `test ResourceNotFoundException response`() {
-        val e = ResourceNotFoundException("User", "userlogin123")
+        val e = ResourceNotFoundException("User", "userlogin123", ExceptionDetails("ResourceNotFoundException", "Exception reason"))
 
         val response = HttpExceptionMapper.mapToResponse(e)
 
         assertEquals(404, response.status)
         assertEquals("User 'userlogin123' not found.", response.message)
+        assertEquals("ResourceNotFoundException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
     }
 
     @Test
     fun `test InternalServerException response`() {
-        val e = InternalServerException("message", mapOf("detail" to "someinfo"))
+        val e = InternalServerException("message", mapOf("detail" to "someinfo"), ExceptionDetails("InternalServerException", "Exception reason"))
 
         val response = HttpExceptionMapper.mapToResponse(e)
 
         assertEquals(500, response.status)
         assertEquals("message", response.message)
-        assertEquals(1, response.details.size)
+        assertEquals(3, response.details.size)
         assertEquals("someinfo", response.details["detail"])
+        assertEquals("InternalServerException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
+    }
+
+    @Test
+    fun `test InvalidInputDataException response`() {
+        val e = InvalidInputDataException("title", mapOf("detail" to "someinfo"), ExceptionDetails("InvalidInputDataException", "Exception reason"))
+
+        val response = HttpExceptionMapper.mapToResponse(e)
+
+        assertEquals(400, response.status)
+        assertEquals("title", response.message)
+        assertEquals(3, response.details.size)
+        assertEquals("someinfo", response.details["detail"])
+        assertEquals("InvalidInputDataException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
+    }
+
+    @Test
+    fun `test InvalidStateChangeException response`() {
+        val e = InvalidStateChangeException("title", ExceptionDetails("InvalidStateChangeException", "Exception reason"))
+
+        val response = HttpExceptionMapper.mapToResponse(e)
+
+        assertEquals(409, response.status)
+        assertEquals("title", response.message)
+        assertEquals(2, response.details.size)
+        assertEquals("InvalidStateChangeException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
+    }
+
+    @Test
+    fun `test OperationNotAllowedException response`() {
+        val e = OperationNotAllowedException("title", ExceptionDetails("OperationNotAllowedException", "Exception reason"))
+
+        val response = HttpExceptionMapper.mapToResponse(e)
+
+        assertEquals(405, response.status)
+        assertEquals("title", response.message)
+        assertEquals(2, response.details.size)
+        assertEquals("OperationNotAllowedException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
+    }
+
+    @Test
+    fun `test ResourceAlreadyExistsException response`() {
+        val e = ResourceAlreadyExistsException("title", ExceptionDetails("ResourceAlreadyExistsException", "Exception reason"))
+
+        val response = HttpExceptionMapper.mapToResponse(e)
+
+        assertEquals(409, response.status)
+        assertEquals("title", response.message)
+        assertEquals(2, response.details.size)
+        assertEquals("ResourceAlreadyExistsException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
+    }
+
+    @Test
+    fun `test ServiceUnavailableException response`() {
+        val e = ServiceUnavailableException("title", ExceptionDetails("ServiceUnavailableException", "Exception reason"))
+
+        val response = HttpExceptionMapper.mapToResponse(e)
+
+        assertEquals(503, response.status)
+        assertEquals("title", response.message)
+        assertEquals(2, response.details.size)
+        assertEquals("ServiceUnavailableException", response.details["cause"])
+        assertEquals("Exception reason", response.details["reason"])
     }
 }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/BadRequestException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/BadRequestException.kt
@@ -5,11 +5,17 @@ import net.corda.rest.ResponseCode
 /**
  * Indicates the request was syntactically bad or contained invalid input data and the request could not be serviced.
  *
- * @param message the response message
+ * @param title the response title
  * @param details additional problem details
+ * @param exceptionDetails contains cause and reason
  */
-class BadRequestException(message: String, details: Map<String, String> = emptyMap()) : HttpApiException(
+class BadRequestException(
+    title: String,
+    details: Map<String, String> = emptyMap(),
+    exceptionDetails: ExceptionDetails? = null
+) : HttpApiException(
     ResponseCode.BAD_REQUEST,
-    message,
-    details
+    title,
+    details,
+    exceptionDetails
 )

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/ForbiddenException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/ForbiddenException.kt
@@ -7,8 +7,13 @@ import net.corda.rest.ResponseCode
  *
  * If the authorization logic wants to hide the fact authorization failed, a [ResourceNotFoundException] can be thrown instead.
  */
-class ForbiddenException(message: String = "User not authorized.", details: Map<String, String> = emptyMap()) : HttpApiException(
+class ForbiddenException(
+    title: String = "User not authorized.",
+    details: Map<String, String> = emptyMap(),
+    exceptionDetails: ExceptionDetails? = null
+) : HttpApiException(
     ResponseCode.FORBIDDEN,
-    message,
-    details
+    title,
+    details,
+    exceptionDetails
 )

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/HttpApiException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/HttpApiException.kt
@@ -9,15 +9,16 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
  * Inherit from this class and override the status code to create a HTTP response with a certain status code ([ResponseCode.statusCode]).
  *
  * @param responseCode HTTP error response code
- * @param message the response message
+ * @param title the response title
  * @param details additional problem details
+ * @param exceptionDetails contains cause and reason
  */
 abstract class HttpApiException(
     val responseCode: ResponseCode,
-    override val message: String,
+    val title: String,
     val details: Map<String, String> = emptyMap(),
     val exceptionDetails: ExceptionDetails? = null
-) : CordaRuntimeException(message)
+) : CordaRuntimeException(title)
 
 data class ExceptionDetails(
     val cause: String,

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/HttpApiException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/HttpApiException.kt
@@ -15,5 +15,11 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 abstract class HttpApiException(
     val responseCode: ResponseCode,
     override val message: String,
-    val details: Map<String, String> = emptyMap()
+    val details: Map<String, String> = emptyMap(),
+    val exceptionDetails: ExceptionDetails? = null
 ) : CordaRuntimeException(message)
+
+data class ExceptionDetails(
+    val cause: String,
+    val reason: String
+)

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InternalServerException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InternalServerException.kt
@@ -5,14 +5,17 @@ import net.corda.rest.ResponseCode
 /**
  * The server encountered an internal error which prevented it from fulfilling the request.
  *
- * @param message the response message
+ * @param title the response title
  * @param details additional problem details
+ * @param exceptionDetails contains cause and reason
  */
 class InternalServerException(
-    message: String = "Internal server error.",
-    details: Map<String, String> = emptyMap()
+    title: String = "Internal server error.",
+    details: Map<String, String> = emptyMap(),
+    exceptionDetails: ExceptionDetails? = null
 ) : HttpApiException(
     ResponseCode.INTERNAL_SERVER_ERROR,
-    message,
-    details
+    title,
+    details,
+    exceptionDetails
 )

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InternalServerException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InternalServerException.kt
@@ -10,9 +10,11 @@ import net.corda.rest.ResponseCode
  */
 class InternalServerException(
     message: String = "Internal server error.",
-    details: Map<String, String> = emptyMap()
+    details: Map<String, String> = emptyMap(),
+    exceptionDetails: ExceptionDetails? = null
 ) : HttpApiException(
     ResponseCode.INTERNAL_SERVER_ERROR,
     message,
-    details
+    details,
+    exceptionDetails
 )

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InternalServerException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InternalServerException.kt
@@ -10,11 +10,9 @@ import net.corda.rest.ResponseCode
  */
 class InternalServerException(
     message: String = "Internal server error.",
-    details: Map<String, String> = emptyMap(),
-    exceptionDetails: ExceptionDetails? = null
+    details: Map<String, String> = emptyMap()
 ) : HttpApiException(
     ResponseCode.INTERNAL_SERVER_ERROR,
     message,
-    details,
-    exceptionDetails
+    details
 )

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InvalidInputDataException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InvalidInputDataException.kt
@@ -5,11 +5,17 @@ import net.corda.rest.ResponseCode
 /**
  * The server validation of request data failed, the server could not complete the request because validation on the user's input failed.
  *
- * @param message the response message
+ * @param title the response title
  * @param details additional problem details
+ * @param exceptionDetails contains cause and reason
  */
-class InvalidInputDataException(message: String = "Invalid input data.", details: Map<String, String> = emptyMap()) : HttpApiException(
+class InvalidInputDataException(
+    title: String = "Invalid input data.",
+    details: Map<String, String> = emptyMap(),
+    exceptionDetails: ExceptionDetails? = null
+) : HttpApiException(
     ResponseCode.BAD_REQUEST,
-    message,
-    details
+    title,
+    details,
+    exceptionDetails
 )

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InvalidStateChangeException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/InvalidStateChangeException.kt
@@ -5,6 +5,8 @@ import net.corda.rest.ResponseCode
 /**
  * Indicates a requested state change matches the resources current state
  *
- * @param message the exception message
+ * @param title the exception title
+ * @param exceptionDetails contains cause and reason
  */
-class InvalidStateChangeException(message: String) : HttpApiException(ResponseCode.CONFLICT, message)
+class InvalidStateChangeException(title: String, exceptionDetails: ExceptionDetails? = null) :
+    HttpApiException(ResponseCode.CONFLICT, title, exceptionDetails = exceptionDetails)

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/NotAuthenticatedException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/NotAuthenticatedException.kt
@@ -5,9 +5,14 @@ import net.corda.rest.ResponseCode
 /**
  * User authentication has failed.
  */
-class NotAuthenticatedException(message: String = "User authentication failed.", details: Map<String, String> = emptyMap()) :
+class NotAuthenticatedException(
+    title: String = "User authentication failed.",
+    details: Map<String, String> = emptyMap(),
+    exceptionDetails: ExceptionDetails? = null
+) :
     HttpApiException(
         ResponseCode.NOT_AUTHENTICATED,
-        message,
-        details
+        title,
+        details,
+        exceptionDetails
     )

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/OperationNotAllowedException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/OperationNotAllowedException.kt
@@ -5,6 +5,8 @@ import net.corda.rest.ResponseCode
 /**
  * Indicates a requested resource is in an incompatible state with the request.
  *
- * @param message the exception message
+ * @param title the exception title
+ * @param exceptionDetails contains cause and reason
  */
-class OperationNotAllowedException(message: String) : HttpApiException(ResponseCode.METHOD_NOT_ALLOWED, message)
+class OperationNotAllowedException(title: String, exceptionDetails: ExceptionDetails? = null) :
+    HttpApiException(ResponseCode.METHOD_NOT_ALLOWED, title, exceptionDetails = exceptionDetails)

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/ResourceAlreadyExistsException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/ResourceAlreadyExistsException.kt
@@ -5,12 +5,18 @@ import net.corda.rest.ResponseCode
 /**
  * Indicates a requested resource already exists within the system
  *
- * @param message the exception message
+ * @param title the exception title
+ * @param exceptionDetails contains cause and reason
  */
-class ResourceAlreadyExistsException(message: String) : HttpApiException(ResponseCode.CONFLICT, message) {
+class ResourceAlreadyExistsException(title: String, exceptionDetails: ExceptionDetails? = null) :
+    HttpApiException(ResponseCode.CONFLICT, title, exceptionDetails = exceptionDetails) {
     /**
      * @param resource The resource which already exists
      * @param id The ID of the resource.
      */
-    constructor(resource: Any, id: String) : this("$resource '$id' already exists.")
+    constructor(
+        resource: Any,
+        id: String,
+        exceptionDetails: ExceptionDetails? = null
+    ) : this("$resource '$id' already exists.", exceptionDetails)
 }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/ResourceNotFoundException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/ResourceNotFoundException.kt
@@ -5,12 +5,18 @@ import net.corda.rest.ResponseCode
 /**
  * Indicates a requested resource does not exist.
  *
- * @param message the exception message
+ * @param title the exception title
+ * @param exceptionDetails contains cause and reason
  */
-class ResourceNotFoundException(message: String) : HttpApiException(ResponseCode.RESOURCE_NOT_FOUND, message) {
+class ResourceNotFoundException(title: String, exceptionDetails: ExceptionDetails? = null) :
+    HttpApiException(ResponseCode.RESOURCE_NOT_FOUND, title, exceptionDetails = exceptionDetails) {
     /**
      * @param resource The resource which could not be found.
      * @param id The ID of the resource.
      */
-    constructor(resource: Any, id: String) : this("$resource '$id' not found.")
+    constructor(
+        resource: Any,
+        id: String,
+        exceptionDetails: ExceptionDetails? = null
+    ) : this("$resource '$id' not found.", exceptionDetails)
 }

--- a/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/ServiceUnavailableException.kt
+++ b/libs/rest/rest/src/main/kotlin/net/corda/rest/exception/ServiceUnavailableException.kt
@@ -5,12 +5,18 @@ import net.corda.rest.ResponseCode
 /**
  * Indicates a requested resource is unavailable.
  *
- * @param message the exception message
+ * @param title the exception title
+ * @param exceptionDetails contains cause and reason
  */
-class ServiceUnavailableException(message: String) : HttpApiException(ResponseCode.SERVICE_UNAVAILABLE, message) {
+class ServiceUnavailableException(title: String, exceptionDetails: ExceptionDetails? = null) :
+    HttpApiException(ResponseCode.SERVICE_UNAVAILABLE, title, exceptionDetails = exceptionDetails) {
     /**
      * @param resource The resource which is unavailable.
      * @param id The ID of the resource.
      */
-    constructor(resource: Any, id: String) : this("$resource '$id' is unavailable.")
+    constructor(
+        resource: Any,
+        id: String,
+        exceptionDetails: ExceptionDetails? = null
+    ) : this("$resource '$id' is unavailable.", exceptionDetails)
 }


### PR DESCRIPTION
- Add ExceptionDetails to HTTPApiException to allow for users to pass in a cause and reason
- Make title more explicit so stacktraces are less likely to be passed into it by the user
- Add tests for exceptions with exceptionDetails

The old response body when updating a config with the wrong version:
```
{
    "title": "net.corda.libs.configuration.exception.WrongConfigVersionException: New configuration represented by {\"section\": \"corda.rest\", \"config\": \"{\\\"context\\\":{\\\"description\\\":\\\"new3\\\"}}\", \"schemaVersion\": {\"majorVersion\": 1, \"minorVersion\": 0}, \"updateActor\": \"admin\", \"version\": 3} couldn't be written to the database. Cause: net.corda.libs.configuration.exception.WrongConfigVersionException: The request specified a version of 3, but the current version in the database is 0. These versions must match to update the cluster configuration.",
    "status": 409,
    "details": {"schemaVersion":"1.0","config":"{\"context\":{\"description\":\"new3\"}}"}
}
```

The new response body:
```
{
    "title": "Wrong Config Version",
    "status": 409,
    "details": {"schemaVersion":"1.0","config":"{\"context\":{\"description\":\"new3\"}}","cause":"net.corda.libs.configuration.exception.WrongConfigVersionException","reason":"New configuration represented by {\"section\": \"corda.rest\", \"config\": \"{\\\"context\\\":{\\\"description\\\":\\\"new3\\\"}}\", \"schemaVersion\": {\"majorVersion\": 1, \"minorVersion\": 0}, \"updateActor\": \"admin\", \"version\": 3} couldn't be written to the database. Cause: net.corda.libs.configuration.exception.WrongConfigVersionException: The request specified a version of 3, but the current version in the database is 0. These versions must match to update the cluster configuration."}
}
```

Green E2E build: https://ci02.dev.r3.com/job/Corda5/job/corda5-e2e-tests/job/release%2F5.3/139/