### PR TITLE
CORE-19985 Stop bringing coordinator `DOWN` on new config

### DIFF
--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeInfoWriterComponentImpl.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/writer/VirtualNodeInfoWriterComponentImpl.kt
@@ -155,7 +155,6 @@ class VirtualNodeInfoWriterComponentImpl @Activate constructor(
      */
     private fun onConfigChangedEventReceived(coordinator: LifecycleCoordinator, event: ConfigChangedEvent) {
         log.debug { "Creating resources" }
-        coordinator.updateStatus(LifecycleStatus.DOWN)
         lock.withLock {
             publisher?.close()
             publisher = publisherFactory.createPublisher(


### PR DESCRIPTION
## Issue

When the component goes `UP`, then on processing subsequent config change event we take its coordinator to `DOWN` and `UP` again. This was causing the depending reconciler to go `UP` then `DOWN` then `UP` again. This seems to have been causing the issue of staring concurrent reconciliations (for the same data).