### PR TITLE
CORE-20006: Increase logging when vNode state change is successful

### DIFF
--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -562,7 +562,7 @@ internal class VirtualNodeRestResourceImpl(
         val resp = tryWithExceptionHandling(logger, "Update vNode state") {
             sendAndReceive(rpcRequest)
         }
-        logger.debug { "Received response to update for $virtualNodeShortId to $newState by $actor" }
+        logger.info("Received response to update for $virtualNodeShortId to $newState by $actor")
 
         return when (val resolvedResponse = resp.responseType) {
             is VirtualNodeStateChangeResponse -> {


### PR DESCRIPTION
This changes one of the logs to be info level rather than debug when a vNode's state is changed. This should help understand flakey tests involving maintenance mode better. 