### PR TITLE
CORE-19985 On same reconciliation interval do not update reconciler timer

### DIFF
--- a/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
+++ b/components/reconciliation/reconciliation-impl/src/main/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandler.kt
@@ -180,8 +180,10 @@ internal class ReconcilerEventHandler<K : Any, V : Any>(
     private fun onUpdateIntervalEvent(event: UpdateIntervalEvent, coordinator: LifecycleCoordinator) {
         logger.info("Updating interval to ${event.intervalMs} ms")
         val newIntervalMs = event.intervalMs
-        reconciliationIntervalMs = newIntervalMs
-        coordinator.setTimer(timerKey, newIntervalMs) { ReconcileEvent(it) }
+        if (newIntervalMs != reconciliationIntervalMs) {
+            reconciliationIntervalMs = newIntervalMs
+            coordinator.setTimer(timerKey, newIntervalMs) { ReconcileEvent(it) }
+        }
     }
 
     private fun onStopEvent(coordinator: LifecycleCoordinator) {

--- a/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
+++ b/components/reconciliation/reconciliation-impl/src/test/kotlin/net/corda/reconciliation/impl/ReconcilerEventHandlerTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -55,6 +56,26 @@ internal class ReconcilerEventHandlerTest {
         reconcilerEventHandler.processEvent(updateIntervalEvent, coordinator)
         verify(coordinator).setTimer(eq(reconcilerEventHandler.name), eq(updateIntervalEvent.intervalMs), any())
         assertEquals(updateIntervalEvent.intervalMs, reconcilerEventHandler.reconciliationIntervalMs)
+    }
+
+    @Test
+    fun `on updating reconciliation with same interval does not update timer`() {
+        reconcilerEventHandler =
+            ReconcilerEventHandler(
+                mock(),
+                mock(),
+                mock(),
+                String::class.java,
+                Int::class.java,
+                1000L,
+                forceInitialReconciliation = false,
+            )
+
+        val updateIntervalEvent = ReconcilerEventHandler.UpdateIntervalEvent(1000L)
+        val coordinator = mock<LifecycleCoordinator>()
+
+        reconcilerEventHandler.processEvent(updateIntervalEvent, coordinator)
+        verify(coordinator, times(0)).setTimer(eq(reconcilerEventHandler.name), any(), any())
     }
 
     private val dbRecord = object : VersionedRecord<String, Int> {


### PR DESCRIPTION
## Issue

Updating reconciler's timer task would happen every time the `DBProcessorImpl` would get a new config changed event. However that config changed event might not include an update for the reconciler (i.e. new reconciliation interval), but we would still disrupt the reconciler timer task and start a new one.

## Changes

* Do not update the reconciler's timer task on same reconciliation interval