### PR TITLE
CORE-19913: Add getTime to ClusterUtils

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -8,6 +8,7 @@ import net.corda.test.util.eventually
 import net.corda.utilities.seconds
 import net.corda.v5.base.types.MemberX500Name
 import org.assertj.core.api.Assertions.assertThat
+import java.text.SimpleDateFormat
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Semaphore
@@ -271,6 +272,19 @@ fun ClusterInfo.getProtocolVersionForKeyRotation(
         condition { it.code == ResponseCode.OK.statusCode }
     }
 }
+
+/**
+ * This method fetches the local time of the corda cluster
+ */
+fun ClusterInfo.getTime(
+) = SimpleDateFormat("EEE,dd MMM yyyy HH:mm:ss zzz").parse(
+    cluster {
+        assertWithRetry {
+            command { get("/api/$REST_API_VERSION_PATH/hello/getprotocolversion") }
+            condition { it.code == ResponseCode.OK.statusCode }
+        }
+    }.headers.single { it.first == "Date" }.second
+)
 
 private fun <T> Semaphore.runWith(block: () -> T): T {
     this.acquire()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -277,8 +277,8 @@ fun ClusterInfo.getProtocolVersionForKeyRotation(
  * This method fetches the local time of the corda cluster
  */
 fun ClusterInfo.getTime(
-) = SimpleDateFormat("EEE,dd MMM yyyy HH:mm:ss zzz").parse(
-    cluster {
+) = SimpleDateFormat("EEE,dd MMM yyyy HH:mm:ss zzz") // RFC 822
+    .parse(cluster {
         assertWithRetry {
             command { get("/api/$REST_API_VERSION_PATH/hello/getprotocolversion") }
             condition { it.code == ResponseCode.OK.statusCode }


### PR DESCRIPTION
The key rotation e2e tests have a race condition where they attempt to get the status of the latest key rotation without checking that it is the correct rotation. This adds a utility function that allows the e2e tests to get the current time of the corda cluster.

Linked with https://github.com/corda/corda-e2e-tests/pull/499