### PR TITLE
CORE-20072 Updating the REST API docs

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -42,7 +42,8 @@ interface KeyRotationRestResource : RestResource {
     )
     fun getKeyRotationStatus(
         @RestPathParameter(description = "Can either be a holding identity ID, the value 'master' for master wrapping " +
-                "key or one of the values 'p2p', 'rest', 'crypto' for corresponding cluster-level services.")
+                "key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' "+
+                "tenant ID does not support key rotation and should not be used.")
         tenantId: String
     ): KeyRotationStatusResponse
 
@@ -67,7 +68,8 @@ interface KeyRotationRestResource : RestResource {
     )
     fun startKeyRotation(
         @RestPathParameter(description = "Can either be a holding identity ID, the value 'master' for master wrapping " +
-                "key or one of the values 'p2p', 'rest', 'crypto' for corresponding cluster-level services.")
+                "key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the" +
+                " 'p2p' tenant ID does not support key rotation and should not be used.")
         tenantId: String
     ): ResponseEntity<KeyRotationResponse>
 }


### PR DESCRIPTION
Updating the REST API docs to reflect the limitations of key rotation for the P2P tenant ID