### PR TITLE
CORE-6393: Fix function names for client generated swagger definition

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -18,7 +18,7 @@ import net.corda.rest.response.ResponseEntity
  * Key Rotation API consists of endpoints to request a key rotation operation and to check the status of such operation.
  */
 @HttpRestResource(
-    name = "Key Rotation API",
+    name = "Key Rotation",
     description = "Contains operations related to rotation of the master, cluster-level and vNode wrapping keys.",
     path = "wrappingkey",
     minVersion = RestApiVersion.C5_2

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowClassRestResource.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowClassRestResource.kt
@@ -3,12 +3,12 @@ package net.corda.flow.rest.v1
 import net.corda.flow.rest.v1.types.response.StartableFlowsResponse
 import net.corda.rest.RestResource
 import net.corda.rest.annotations.HttpGET
-import net.corda.rest.annotations.RestPathParameter
 import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestPathParameter
 
 /** Rest operations for getting flow information from a vNode. */
 @HttpRestResource(
-    name = "Flow Info API",
+    name = "Flow Info",
     description = "The Flow Info API consists of a number of endpoints used to find out which flows can be invoked " +
             "using the Flow Management API for a given identity.",
     path = "flowclass"

--- a/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowRestResource.kt
+++ b/components/flow/flow-rest-resource-service/src/main/kotlin/net/corda/flow/rest/v1/FlowRestResource.kt
@@ -17,7 +17,7 @@ import net.corda.rest.response.ResponseEntity
 
 /** Rest operations for flow management. */
 @HttpRestResource(
-    name = "Flow Management API",
+    name = "Flow Management",
     description = "The Flow Management API consists of a number of endpoints used to interact with flows.",
     path = "flow"
 )

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificateRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificateRestResource.kt
@@ -16,7 +16,7 @@ import net.corda.rest.annotations.RestPathParameter
  * authority (CA).
  */
 @HttpRestResource(
-    name = "Certificate API",
+    name = "Certificate",
     description = "The Certificates API consists of endpoints used to work with certificates and related operations. " +
         "The API allows you to import a certificate chain, and generate a certificate signing request (CSR) to be" +
         " submitted to a certificate authority (CA).",

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificatesRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificatesRestResource.kt
@@ -21,7 +21,7 @@ import net.corda.rest.annotations.RestPathParameter
  */
 @Deprecated("Deprecated in favour of CertificateRestResource")
 @HttpRestResource(
-    name = "Certificates API",
+    name = "Certificates",
     description = "The Certificates API consists of endpoints used to work with certificates and related operations. " +
         "The API allows you to import a certificate chain, and generate a certificate signing request (CSR) to be" +
         " submitted to a certificate authority (CA).",

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
@@ -13,7 +13,7 @@ import net.corda.rest.annotations.RestPathParameter
  * assigned to the specified tenant.
  */
 @HttpRestResource(
-    name = "HSM API",
+    name = "HSM",
     description = "The HSM API consists of endpoints used to work with Hardware Security Modules (HSM) for securely storing keys.",
     path = "hsm"
 )

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/KeyRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/KeyRestResource.kt
@@ -16,7 +16,7 @@ import net.corda.rest.annotations.RestQueryParameter
  * key pairs owned by a tenant, generate a key pair for a tenant, and retrieve a tenant's public key in PEM format.
  */
 @HttpRestResource(
-    name = "Key Management API",
+    name = "Key Management",
     description = "The Keys Management API consists of endpoints used to manage public and private key pairs. The API" +
         " allows you to list scheme codes which are supported by the associated HSM integration, retrieve" +
         " information about key pairs owned by a tenant, generate a key pair for a tenant, and retrieve a tenant's" +

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/KeysRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/KeysRestResource.kt
@@ -21,7 +21,7 @@ import net.corda.rest.annotations.RestQueryParameter
  */
 @Deprecated("Deprecated in favour of KeyRestResource")
 @HttpRestResource(
-    name = "Keys Management API",
+    name = "Keys Management",
     description = "The Keys Management API consists of endpoints used to manage public and private key pairs. The API" +
         " allows you to list scheme codes which are supported by the associated HSM integration, retrieve" +
         " information about key pairs owned by a tenant, generate a key pair for a tenant, and retrieve a tenant's" +

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMAdminRestResource.kt
@@ -13,7 +13,7 @@ import net.corda.rest.annotations.RestPathParameter
  * may be displaying unexpected behaviour. This API should only be used by the MGM and under exceptional circumstances.
  */
 @HttpRestResource(
-    name = "MGM Admin API",
+    name = "MGM Admin",
     description = "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership " +
         "groups. A membership group is a logical grouping of a number of Corda Identities to communicate and " +
         "transact with one another with a specific set of CorDapps. The API allows the MGM to perform actions " +

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MGMRestResource.kt
@@ -26,7 +26,7 @@ import net.corda.rest.annotations.RestQueryParameter
  * The API allows you to generate the group policy for a membership group, required for new members to join the group.
  */
 @HttpRestResource(
-    name = "MGM API",
+    name = "MGM",
     description = "The MGM API consists of a number of endpoints used to manage membership groups. A membership group" +
         " is a logical grouping of a number of Corda Identities to communicate and transact with one another with" +
         " a specific set of CorDapps. The API allows you to generate the group policy for a membership group," +

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MemberLookupRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MemberLookupRestResource.kt
@@ -15,7 +15,7 @@ import net.corda.rest.annotations.RestQueryParameter
  * you to retrieve a list of active and pending members in the membership group.
  */
 @HttpRestResource(
-    name = "Member Lookup API",
+    name = "Member Lookup",
     description = "The Member Lookup API consists of endpoints used to look up information related to membership groups.",
     path = "members"
 )

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MemberRegistrationRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/MemberRegistrationRestResource.kt
@@ -17,7 +17,7 @@ import net.corda.rest.annotations.RestPathParameter
  * for a holding identity, and check the status of a previously created registration request.
  */
 @HttpRestResource(
-    name = "Member Registration API",
+    name = "Member Registration",
     description = "The Member Registration API consists of a number of endpoints which manage holding identities'" +
         " participation in membership groups. To participate in a membership group, the holding identity is" +
         " required to make a registration request that needs to be approved by the MGM for that group." +

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/NetworkRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/NetworkRestResource.kt
@@ -12,7 +12,7 @@ import net.corda.rest.annotations.RestPathParameter
  * you to set up a holding identity on the network and configure properties required for P2P messaging.
  */
 @HttpRestResource(
-    name = "Network API",
+    name = "Network",
     description = "The Network API consists of endpoints which manage the setup of holding identities in P2P networks.",
     path = "network"
 )

--- a/components/rest-gateway-comp/src/main/kotlin/net/corda/components/rest/endpoints/impl/HelloRestResourceImpl.kt
+++ b/components/rest-gateway-comp/src/main/kotlin/net/corda/components/rest/endpoints/impl/HelloRestResourceImpl.kt
@@ -14,7 +14,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 @HttpRestResource(
-    name = "Hello Rest API",
+    name = "Hello Rest",
     description = "The Hello Rest API is used to test interactions via the " +
         "Rest API. It verifies that a call to Rest can be made, and that the identity of the user making the " +
         "call can be recognized. RBAC permissions are checked and the call is successfully processed by " +

--- a/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/ConfigRestResource.kt
+++ b/libs/configuration/configuration-endpoints/src/main/kotlin/net/corda/libs/configuration/endpoints/v1/ConfigRestResource.kt
@@ -1,20 +1,20 @@
 package net.corda.libs.configuration.endpoints.v1
 
-import net.corda.rest.RestResource
-import net.corda.rest.annotations.HttpGET
-import net.corda.rest.annotations.HttpPUT
-import net.corda.rest.annotations.RestPathParameter
-import net.corda.rest.annotations.ClientRequestBodyParameter
-import net.corda.rest.annotations.HttpRestResource
-import net.corda.rest.exception.ResourceNotFoundException
-import net.corda.rest.response.ResponseEntity
 import net.corda.libs.configuration.endpoints.v1.types.GetConfigResponse
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigResponse
+import net.corda.rest.RestResource
+import net.corda.rest.annotations.ClientRequestBodyParameter
+import net.corda.rest.annotations.HttpGET
+import net.corda.rest.annotations.HttpPUT
+import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestPathParameter
+import net.corda.rest.exception.ResourceNotFoundException
+import net.corda.rest.response.ResponseEntity
 
 /** Rest operations for cluster configuration management. */
 @HttpRestResource(
-    name = "Configuration API",
+    name = "Configuration",
     description = "The Configuration API consists of a number of endpoints used to manage the configuration of Corda clusters.",
     path = "config"
 )

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/PermissionEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/permission/PermissionEndpoint.kt
@@ -18,7 +18,7 @@ import net.corda.rest.response.ResponseEntity
  * Permission endpoint exposes functionality for management of Permissions in the RBAC permission system.
  */
 @HttpRestResource(
-    name = "RBAC Permission API",
+    name = "RBAC Permission",
     description = "The RBAC Permission API consists of a number of endpoints enabling permissions management in the " +
         "RBAC (role-based access control) permission system. You can get details of specified permissions " +
         "and create new permissions.",

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/RoleEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/role/RoleEndpoint.kt
@@ -17,7 +17,7 @@ import net.corda.rest.response.ResponseEntity
  * Role endpoint exposes HTTP operations for management of Roles in the RBAC permission system.
  */
 @HttpRestResource(
-    name = "RBAC Role API",
+    name = "RBAC Role",
     description = "The RBAC Role API consists of a number of endpoints enabling role management in the RBAC " +
         "(role-based access control) permission system. You can get all roles in the system, " +
         "create new roles and add and delete permissions from roles.",

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/user/UserEndpoint.kt
@@ -20,7 +20,7 @@ import net.corda.rest.response.ResponseEntity
  * User endpoint exposes HTTP endpoints for management of Users in the RBAC permission system.
  */
 @HttpRestResource(
-    name = "RBAC User API",
+    name = "RBAC User",
     description = "The RBAC User API consists of a number of endpoints enabling user management in the RBAC " +
         "(role-based access control) permission system. You can get details of specified users, create new users, " +
         "assign roles to users and remove roles from users.",

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.models.responses.ApiResponses
 import io.swagger.v3.oas.models.tags.Tag
 import net.corda.rest.HttpFileUpload
 import net.corda.rest.annotations.RestApiVersion
+import net.corda.rest.annotations.retrieveApiVersionsSet
 import net.corda.rest.server.impl.apigen.models.Endpoint
 import net.corda.rest.server.impl.apigen.models.EndpointMethod
 import net.corda.rest.server.impl.apigen.models.EndpointParameter
@@ -64,7 +65,7 @@ internal fun List<Resource>.toOpenAPI(
                 apiVersion
             )
         )
-        tags.add(resource.toTag())
+        tags.add(resource.toTag(apiVersion))
     }
     val paths = Paths().apply { swaggerPathInfos.toSortedMap().forEach { addPathItem(it.key, it.value) } }
     val schemas =
@@ -281,10 +282,12 @@ private fun Class<*>.isNull(): Boolean {
         .also { log.trace { "Invoke isNull on class: ${this.name} returned $it." } }
 }
 
-private fun Resource.toTag(): Tag {
+private fun Resource.toTag(apiVersion: RestApiVersion): Tag {
     log.trace { "Map resource: ${this.name} to OpenApi Tag." }
+    val newName = if (retrieveApiVersionsSet(RestApiVersion.C5_0, RestApiVersion.C5_2).contains(apiVersion)) name else name.removeSuffix(" API")
+
     return Tag()
-        .name(name)
+        .name(newName)
         .description(description)
         .also { log.trace { "Map resource: \"${this.name}\" to OpenApi Tag: \"$it\" completed." } }
 }
@@ -293,6 +296,8 @@ private fun Resource.getPathToPathItems(
     schemaModelProvider: SchemaModelProvider,
     apiVersion: RestApiVersion
 ): Map<String, PathItem> {
+    val newName = if (retrieveApiVersionsSet(RestApiVersion.C5_0, RestApiVersion.C5_2).contains(apiVersion)) name else name.removeSuffix(" API")
+
     log.trace { "Map resource: \"${this.name}\" to Map of Path to PathItem." }
     return endpoints.filter { apiVersion in it.apiVersions }
         .groupBy { joinResourceAndEndpointPaths(path, it.path).toOpenApiPath() }.map {
@@ -303,7 +308,7 @@ private fun Resource.getPathToPathItems(
             val fullPath = it.key
 
             fullPath to PathItem().also { pathItem ->
-                val tagName = singletonList(name)
+                val tagName = singletonList(newName)
                 getEndpoint?.let {
                     pathItem.get(getEndpoint.toOperation(fullPath, schemaModelProvider).tags(tagName))
                 }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/openapi/ResourceToOpenApiSpecMapper.kt
@@ -284,7 +284,15 @@ private fun Class<*>.isNull(): Boolean {
 
 private fun Resource.toTag(apiVersion: RestApiVersion): Tag {
     log.trace { "Map resource: ${this.name} to OpenApi Tag." }
-    val newName = if (retrieveApiVersionsSet(RestApiVersion.C5_0, RestApiVersion.C5_2).contains(apiVersion)) name else name.removeSuffix(" API")
+    val newName = if (retrieveApiVersionsSet(
+            RestApiVersion.C5_0,
+            RestApiVersion.C5_2
+        ).contains(apiVersion)
+    ) {
+        name
+    } else {
+        name.removeSuffix(" API")
+    }
 
     return Tag()
         .name(newName)
@@ -296,7 +304,15 @@ private fun Resource.getPathToPathItems(
     schemaModelProvider: SchemaModelProvider,
     apiVersion: RestApiVersion
 ): Map<String, PathItem> {
-    val newName = if (retrieveApiVersionsSet(RestApiVersion.C5_0, RestApiVersion.C5_2).contains(apiVersion)) name else name.removeSuffix(" API")
+    val newName = if (retrieveApiVersionsSet(
+            RestApiVersion.C5_0,
+            RestApiVersion.C5_2
+        ).contains(apiVersion)
+    ) {
+        name
+    } else {
+        name.removeSuffix(" API")
+    }
 
     log.trace { "Map resource: \"${this.name}\" to Map of Path to PathItem." }
     return endpoints.filter { apiVersion in it.apiVersions }

--- a/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiUploadRestResource.kt
+++ b/libs/virtual-node/cpi-upload-endpoints/src/main/kotlin/net/corda/libs/cpiupload/endpoints/v1/CpiUploadRestResource.kt
@@ -1,15 +1,15 @@
 package net.corda.libs.cpiupload.endpoints.v1
 
-import net.corda.rest.RestResource
 import net.corda.rest.HttpFileUpload
-import net.corda.rest.annotations.HttpGET
-import net.corda.rest.annotations.RestPathParameter
-import net.corda.rest.annotations.HttpPOST
+import net.corda.rest.RestResource
 import net.corda.rest.annotations.ClientRequestBodyParameter
+import net.corda.rest.annotations.HttpGET
+import net.corda.rest.annotations.HttpPOST
 import net.corda.rest.annotations.HttpRestResource
+import net.corda.rest.annotations.RestPathParameter
 
 @HttpRestResource(
-    name = "CPI API",
+    name = "CPI",
     description = "The CPI API consists of a number of endpoints used to manage Corda Package Installer (CPI) " +
             "files in the Corda cluster.",
     path = "cpi"

--- a/libs/virtual-node/virtual-node-endpoints-maintenance/src/main/kotlin/net/corda/libs/virtualnode/maintenance/endpoints/v1/VirtualNodeMaintenanceRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints-maintenance/src/main/kotlin/net/corda/libs/virtualnode/maintenance/endpoints/v1/VirtualNodeMaintenanceRestResource.kt
@@ -13,7 +13,7 @@ import net.corda.rest.annotations.RestPathParameter
  * Some of them could be highly disruptive, so great care should be taken when using them.
  */
 @HttpRestResource(
-    name = "Virtual Node Maintenance API",
+    name = "Virtual Node Maintenance",
     description = "The Virtual Node Maintenance API consists of a series of endpoints used for virtual node management." +
         "Warning: Using these endpoints could be highly disruptive, so great care should be taken when using them.",
     path = "maintenance/virtualnode"

--- a/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
+++ b/libs/virtual-node/virtual-node-endpoints/src/main/kotlin/net/corda/libs/virtualnode/endpoints/v1/VirtualNodeRestResource.kt
@@ -22,7 +22,7 @@ import net.corda.rest.response.ResponseEntity
 
 /** Rest operations for virtual node management. */
 @HttpRestResource(
-    name = "Virtual Node API",
+    name = "Virtual Node",
     description = "The Virtual Nodes API consists of a number of endpoints to manage virtual nodes.",
     path = "virtualnode"
 )

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v1.json
@@ -12,64 +12,64 @@
     "basicAuth" : [ ]
   } ],
   "tags" : [ {
-    "name" : "CPI API",
+    "name" : "CPI",
     "description" : "The CPI API consists of a number of endpoints used to manage Corda Package Installer (CPI) files in the Corda cluster."
   }, {
-    "name" : "Certificates API",
+    "name" : "Certificates",
     "description" : "The Certificates API consists of endpoints used to work with certificates and related operations. The API allows you to import a certificate chain, and generate a certificate signing request (CSR) to be submitted to a certificate authority (CA)."
   }, {
-    "name" : "Configuration API",
+    "name" : "Configuration",
     "description" : "The Configuration API consists of a number of endpoints used to manage the configuration of Corda clusters."
   }, {
-    "name" : "Flow Info API",
+    "name" : "Flow Info",
     "description" : "The Flow Info API consists of a number of endpoints used to find out which flows can be invoked using the Flow Management API for a given identity."
   }, {
-    "name" : "Flow Management API",
+    "name" : "Flow Management",
     "description" : "The Flow Management API consists of a number of endpoints used to interact with flows."
   }, {
-    "name" : "HSM API",
+    "name" : "HSM",
     "description" : "The HSM API consists of endpoints used to work with Hardware Security Modules (HSM) for securely storing keys."
   }, {
-    "name" : "Hello Rest API",
+    "name" : "Hello Rest",
     "description" : "The Hello Rest API is used to test interactions via the Rest API. It verifies that a call to Rest can be made, and that the identity of the user making the call can be recognized. RBAC permissions are checked and the call is successfully processed by the HTTP-Rest worker."
   }, {
-    "name" : "Keys Management API",
+    "name" : "Keys Management",
     "description" : "The Keys Management API consists of endpoints used to manage public and private key pairs. The API allows you to list scheme codes which are supported by the associated HSM integration, retrieve information about key pairs owned by a tenant, generate a key pair for a tenant, and retrieve a tenant's public key in PEM format."
   }, {
-    "name" : "MGM API",
+    "name" : "MGM",
     "description" : "The MGM API consists of a number of endpoints used to manage membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows you to generate the group policy for a membership group, required for new members to join the group."
   }, {
-    "name" : "MGM Admin API",
+    "name" : "MGM Admin",
     "description" : "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows the MGM to perform actions such as force decline registration requests which may be displaying unexpected behaviour. This API should only be used by the MGM under exceptional circumstances."
   }, {
-    "name" : "Member Lookup API",
+    "name" : "Member Lookup",
     "description" : "The Member Lookup API consists of endpoints used to look up information related to membership groups."
   }, {
-    "name" : "Member Registration API",
+    "name" : "Member Registration",
     "description" : "The Member Registration API consists of a number of endpoints which manage holding identities' participation in membership groups. To participate in a membership group, the holding identity is required to make a registration request that needs to be approved by the MGM for that group. This API allows you to start the registration process for a holding identity, and check the status of a previously created registration request."
   }, {
-    "name" : "Network API",
+    "name" : "Network",
     "description" : "The Network API consists of endpoints which manage the setup of holding identities in P2P networks."
   }, {
-    "name" : "RBAC Permission API",
+    "name" : "RBAC Permission",
     "description" : "The RBAC Permission API consists of a number of endpoints enabling permissions management in the RBAC (role-based access control) permission system. You can get details of specified permissions and create new permissions."
   }, {
-    "name" : "RBAC Role API",
+    "name" : "RBAC Role",
     "description" : "The RBAC Role API consists of a number of endpoints enabling role management in the RBAC (role-based access control) permission system. You can get all roles in the system, create new roles and add and delete permissions from roles."
   }, {
-    "name" : "RBAC User API",
+    "name" : "RBAC User",
     "description" : "The RBAC User API consists of a number of endpoints enabling user management in the RBAC (role-based access control) permission system. You can get details of specified users, create new users, assign roles to users and remove roles from users."
   }, {
-    "name" : "Virtual Node API",
+    "name" : "Virtual Node",
     "description" : "The Virtual Nodes API consists of a number of endpoints to manage virtual nodes."
   }, {
-    "name" : "Virtual Node Maintenance API",
+    "name" : "Virtual Node Maintenance",
     "description" : "The Virtual Node Maintenance API consists of a series of endpoints used for virtual node management.Warning: Using these endpoints could be highly disruptive, so great care should be taken when using them."
   } ],
   "paths" : {
     "/certificates/cluster/{usage}" : {
       "get" : {
-        "tags" : [ "Certificates API" ],
+        "tags" : [ "Certificates" ],
         "description" : "This method gets the certificate chain aliases for a cluster.",
         "operationId" : "get_certificates_cluster__usage_",
         "parameters" : [ {
@@ -110,7 +110,7 @@
         }
       },
       "put" : {
-        "tags" : [ "Certificates API" ],
+        "tags" : [ "Certificates" ],
         "description" : "This method imports a certificate chain for a cluster.",
         "operationId" : "put_certificates_cluster__usage_",
         "parameters" : [ {
@@ -170,7 +170,7 @@
     },
     "/certificates/cluster/{usage}/{alias}" : {
       "get" : {
-        "tags" : [ "Certificates API" ],
+        "tags" : [ "Certificates" ],
         "description" : "This method gets the certificate chain in PEM format for a cluster.",
         "operationId" : "get_certificates_cluster__usage___alias_",
         "parameters" : [ {
@@ -220,7 +220,7 @@
     },
     "/certificates/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Certificates API" ],
+        "tags" : [ "Certificates" ],
         "description" : "",
         "operationId" : "get_certificates_getprotocolversion",
         "parameters" : [ ],
@@ -249,7 +249,7 @@
     },
     "/certificates/vnode/{holdingidentityid}/{usage}" : {
       "get" : {
-        "tags" : [ "Certificates API" ],
+        "tags" : [ "Certificates" ],
         "description" : "This method gets the certificate chain aliases for a virtual node.",
         "operationId" : "get_certificates_vnode__holdingidentityid___usage_",
         "parameters" : [ {
@@ -301,7 +301,7 @@
         }
       },
       "put" : {
-        "tags" : [ "Certificates API" ],
+        "tags" : [ "Certificates" ],
         "description" : "This method imports a certificate chain for a virtual node.",
         "operationId" : "put_certificates_vnode__holdingidentityid___usage_",
         "parameters" : [ {
@@ -372,7 +372,7 @@
     },
     "/certificates/vnode/{holdingidentityid}/{usage}/{alias}" : {
       "get" : {
-        "tags" : [ "Certificates API" ],
+        "tags" : [ "Certificates" ],
         "description" : "This method gets the certificate chain in PEM format for a virtual node.",
         "operationId" : "get_certificates_vnode__holdingidentityid___usage___alias_",
         "parameters" : [ {
@@ -433,7 +433,7 @@
     },
     "/certificates/{tenantid}/{keyid}" : {
       "post" : {
-        "tags" : [ "Certificates API" ],
+        "tags" : [ "Certificates" ],
         "description" : "This method enables you to generate a certificate signing request (CSR) for a tenant.",
         "operationId" : "post_certificates__tenantid___keyid_",
         "parameters" : [ {
@@ -494,7 +494,7 @@
     },
     "/config" : {
       "put" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "This method updates a section of the cluster configuration.",
         "operationId" : "put_config",
         "parameters" : [ ],
@@ -531,7 +531,7 @@
     },
     "/config/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "",
         "operationId" : "get_config_getprotocolversion",
         "parameters" : [ ],
@@ -560,7 +560,7 @@
     },
     "/config/{section}" : {
       "get" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "This method returns the 'active' configuration for the given section, in both the 'raw' format and with defaults applied.",
         "operationId" : "get_config__section_",
         "parameters" : [ {
@@ -597,7 +597,7 @@
     },
     "/cpi" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "The GET method returns a list of all CPIs uploaded to the cluster.",
         "operationId" : "get_cpi",
         "parameters" : [ ],
@@ -621,7 +621,7 @@
         }
       },
       "post" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "This method uses the POST method to upload a Corda Package Installer (CPI) file to the Corda cluster.",
         "operationId" : "post_cpi",
         "parameters" : [ ],
@@ -667,7 +667,7 @@
     },
     "/cpi/getprotocolversion" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "",
         "operationId" : "get_cpi_getprotocolversion",
         "parameters" : [ ],
@@ -696,7 +696,7 @@
     },
     "/cpi/status/{id}" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "The status endpoint uses the GET method to return status information for the CPI upload with the given request ID.",
         "operationId" : "get_cpi_status__id_",
         "parameters" : [ {
@@ -733,7 +733,7 @@
     },
     "/flow/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "",
         "operationId" : "get_flow_getprotocolversion",
         "parameters" : [ ],
@@ -762,7 +762,7 @@
     },
     "/flow/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method returns an array containing the statuses of all flows running for a specified holding identity. An empty array is returned if there are no flows running.",
         "operationId" : "get_flow__holdingidentityshorthash_",
         "parameters" : [ {
@@ -797,7 +797,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method starts a new instance for the specified flow for the specified holding identity.",
         "operationId" : "post_flow__holdingidentityshorthash_",
         "parameters" : [ {
@@ -845,7 +845,7 @@
     },
     "/flow/{holdingidentityshorthash}/{clientrequestid}" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method gets the current status of the specified flow instance.",
         "operationId" : "get_flow__holdingidentityshorthash___clientrequestid_",
         "parameters" : [ {
@@ -893,7 +893,7 @@
     },
     "/flow/{holdingidentityshorthash}/{clientrequestid}/result" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method gets the result of the specified flow instance execution.",
         "operationId" : "get_flow__holdingidentityshorthash___clientrequestid__result",
         "parameters" : [ {
@@ -941,7 +941,7 @@
     },
     "/flowclass/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Flow Info API" ],
+        "tags" : [ "Flow Info" ],
         "description" : "",
         "operationId" : "get_flowclass_getprotocolversion",
         "parameters" : [ ],
@@ -970,7 +970,7 @@
     },
     "/flowclass/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Flow Info API" ],
+        "tags" : [ "Flow Info" ],
         "description" : "This method gets all flows that can be used by the specified holding identity.",
         "operationId" : "get_flowclass__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1007,7 +1007,7 @@
     },
     "/hello" : {
       "post" : {
-        "tags" : [ "Hello Rest API" ],
+        "tags" : [ "Hello Rest" ],
         "description" : "This method produces a greeting phrase for the addressee.",
         "operationId" : "post_hello",
         "parameters" : [ {
@@ -1046,7 +1046,7 @@
     },
     "/hello/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Hello Rest API" ],
+        "tags" : [ "Hello Rest" ],
         "description" : "",
         "operationId" : "get_hello_getprotocolversion",
         "parameters" : [ ],
@@ -1075,7 +1075,7 @@
     },
     "/hsm/getprotocolversion" : {
       "get" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "",
         "operationId" : "get_hsm_getprotocolversion",
         "parameters" : [ ],
@@ -1104,7 +1104,7 @@
     },
     "/hsm/soft/{tenantid}/{category}" : {
       "post" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "This method enables you to assign a soft HSM to the tenant for the specified category.",
         "operationId" : "post_hsm_soft__tenantid___category_",
         "parameters" : [ {
@@ -1152,7 +1152,7 @@
     },
     "/hsm/{tenantid}/{category}" : {
       "get" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "This method retrieves information on the HSM of the specified category assigned to the tenant.",
         "operationId" : "get_hsm__tenantid___category_",
         "parameters" : [ {
@@ -1200,7 +1200,7 @@
     },
     "/keys/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Keys Management API" ],
+        "tags" : [ "Keys Management" ],
         "description" : "",
         "operationId" : "get_keys_getprotocolversion",
         "parameters" : [ ],
@@ -1229,7 +1229,7 @@
     },
     "/keys/{tenantid}" : {
       "get" : {
-        "tags" : [ "Keys Management API" ],
+        "tags" : [ "Keys Management" ],
         "description" : "This method retrieves information about a list of key pairs belonging to a tenant.",
         "operationId" : "get_keys__tenantid_",
         "parameters" : [ {
@@ -1386,7 +1386,7 @@
     },
     "/keys/{tenantid}/alias/{alias}/category/{hsmcategory}/scheme/{scheme}" : {
       "post" : {
-        "tags" : [ "Keys Management API" ],
+        "tags" : [ "Keys Management" ],
         "description" : "This method generates a new key pair for a tenant.",
         "operationId" : "post_keys__tenantid__alias__alias__category__hsmcategory__scheme__scheme_",
         "parameters" : [ {
@@ -1456,7 +1456,7 @@
     },
     "/keys/{tenantid}/schemes/{hsmcategory}" : {
       "get" : {
-        "tags" : [ "Keys Management API" ],
+        "tags" : [ "Keys Management" ],
         "description" : "This method retrieves a list of supported key schemes for a specified tenant and HSM category.",
         "operationId" : "get_keys__tenantid__schemes__hsmcategory_",
         "parameters" : [ {
@@ -1510,7 +1510,7 @@
     },
     "/keys/{tenantid}/{keyid}" : {
       "get" : {
-        "tags" : [ "Keys Management API" ],
+        "tags" : [ "Keys Management" ],
         "description" : "This method retrieves a tenant's public key in PEM format.",
         "operationId" : "get_keys__tenantid___keyid_",
         "parameters" : [ {
@@ -1560,7 +1560,7 @@
     },
     "/maintenance/virtualnode/forcecpiupload" : {
       "post" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "Even if CPI with the same metadata has already been uploaded, this endpoint will overwrite the previously stored CPI record. This operation also purges any sandboxes running an overwritten version of a CPI. This action can take some time to process, therefore it is performed asynchronously.",
         "operationId" : "post_maintenance_virtualnode_forcecpiupload",
         "parameters" : [ ],
@@ -1606,7 +1606,7 @@
     },
     "/maintenance/virtualnode/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "",
         "operationId" : "get_maintenance_virtualnode_getprotocolversion",
         "parameters" : [ ],
@@ -1635,7 +1635,7 @@
     },
     "/maintenance/virtualnode/{virtualnodeshortid}/vault-schema/force-resync" : {
       "post" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "Rollback the virtual node database for the given virtual node short ID. Then apply current CPI migrations. This operation is destructive and will result in user vault data being deleted, but will not have any effect on system tables.",
         "operationId" : "post_maintenance_virtualnode__virtualnodeshortid__vault_schema_force_resync",
         "parameters" : [ {
@@ -1665,7 +1665,7 @@
     },
     "/members/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "",
         "operationId" : "get_members_getprotocolversion",
         "parameters" : [ ],
@@ -1694,7 +1694,7 @@
     },
     "/members/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "This method retrieves a list of all active and pending members in the membership group.",
         "operationId" : "get_members__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1811,7 +1811,7 @@
     },
     "/members/{holdingidentityshorthash}/group-parameters" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "This method retrieves the group parameters of the membership group.",
         "operationId" : "get_members__holdingidentityshorthash__group_parameters",
         "parameters" : [ {
@@ -1848,7 +1848,7 @@
     },
     "/membership/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "",
         "operationId" : "get_membership_getprotocolversion",
         "parameters" : [ ],
@@ -1877,7 +1877,7 @@
     },
     "/membership/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method checks the statuses of all registration requests for a specified holding identity.",
         "operationId" : "get_membership__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1917,7 +1917,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method starts the registration process for a holding identity.",
         "operationId" : "post_membership__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1965,7 +1965,7 @@
     },
     "/membership/{holdingidentityshorthash}/{registrationrequestid}" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method checks the status of the specified registration request for a holding identity.",
         "operationId" : "get_membership__holdingidentityshorthash___registrationrequestid_",
         "parameters" : [ {
@@ -2013,7 +2013,7 @@
     },
     "/mgm/getprotocolversion" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm_getprotocolversion",
         "parameters" : [ ],
@@ -2042,7 +2042,7 @@
     },
     "/mgm/{holdingidentityshorthash}/activate" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This endpoint enables you to activate a previously suspended member. The v1 version of this endpoint is deprecated in favour of later versions. Later versions mandate that the serial number is specified in the request body.",
         "operationId" : "post_mgm__holdingidentityshorthash__activate",
         "parameters" : [ {
@@ -2083,7 +2083,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the set of rules the group is currently configured with",
         "operationId" : "get_mgm__holdingidentityshorthash__approval_rules",
         "parameters" : [ {
@@ -2123,7 +2123,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API adds a rule to the set of group approval rules.",
         "operationId" : "post_mgm__holdingidentityshorthash__approval_rules",
         "parameters" : [ {
@@ -2171,7 +2171,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/preauth" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the set of rules the group is currently configured with for registration request with a pre-auth token.",
         "operationId" : "get_mgm__holdingidentityshorthash__approval_rules_preauth",
         "parameters" : [ {
@@ -2211,7 +2211,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API adds a rule to the set of group approval rules for registrations including a pre-auth token.",
         "operationId" : "post_mgm__holdingidentityshorthash__approval_rules_preauth",
         "parameters" : [ {
@@ -2259,7 +2259,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/preauth/{ruleid}" : {
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API deletes a group approval rule for registrations including a pre-auth token.",
         "operationId" : "delete_mgm__holdingidentityshorthash__approval_rules_preauth__ruleid_",
         "parameters" : [ {
@@ -2300,7 +2300,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/{ruleid}" : {
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API deletes a previously added group approval rule.",
         "operationId" : "delete_mgm__holdingidentityshorthash__approval_rules__ruleid_",
         "parameters" : [ {
@@ -2341,7 +2341,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approve/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__approve__requestid_",
         "parameters" : [ {
@@ -2382,7 +2382,7 @@
     },
     "/mgm/{holdingidentityshorthash}/decline/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__decline__requestid_",
         "parameters" : [ {
@@ -2443,7 +2443,7 @@
     },
     "/mgm/{holdingidentityshorthash}/info" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the group policy from the MGM required to join the membership group.",
         "operationId" : "get_mgm__holdingidentityshorthash__info",
         "parameters" : [ {
@@ -2482,7 +2482,7 @@
     },
     "/mgm/{holdingidentityshorthash}/mutual-tls/allowed-client-certificate-subjects" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API list the allowed  client certificates subjects to be used in mutual TLS connections.",
         "operationId" : "get_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects",
         "parameters" : [ {
@@ -2525,7 +2525,7 @@
     },
     "/mgm/{holdingidentityshorthash}/mutual-tls/allowed-client-certificate-subjects/{subject}" : {
       "put" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API allows a client certificate with a given subject to be used in mutual TLS connections.",
         "operationId" : "put_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects__subject_",
         "parameters" : [ {
@@ -2564,7 +2564,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API disallows a client certificate with a given subject to be used in mutual TLS connections.",
         "operationId" : "delete_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects__subject_",
         "parameters" : [ {
@@ -2605,7 +2605,7 @@
     },
     "/mgm/{holdingidentityshorthash}/preauthtoken" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm__holdingidentityshorthash__preauthtoken",
         "parameters" : [ {
@@ -2674,7 +2674,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__preauthtoken",
         "parameters" : [ {
@@ -2721,7 +2721,7 @@
     },
     "/mgm/{holdingidentityshorthash}/preauthtoken/revoke/{preauthtokenid}" : {
       "put" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "put_mgm__holdingidentityshorthash__preauthtoken_revoke__preauthtokenid_",
         "parameters" : [ {
@@ -2785,7 +2785,7 @@
     },
     "/mgm/{holdingidentityshorthash}/registrations" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm__holdingidentityshorthash__registrations",
         "parameters" : [ {
@@ -2849,7 +2849,7 @@
     },
     "/mgm/{holdingidentityshorthash}/suspend" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "The suspend endpoint enables you to suspend a member. The v1 version of this endpoint is deprecated in favour of later versions. Later versions mandate that the serial number is specified in the request body.",
         "operationId" : "post_mgm__holdingidentityshorthash__suspend",
         "parameters" : [ {
@@ -2890,7 +2890,7 @@
     },
     "/mgmadmin/getprotocolversion" : {
       "get" : {
-        "tags" : [ "MGM Admin API" ],
+        "tags" : [ "MGM Admin" ],
         "description" : "",
         "operationId" : "get_mgmadmin_getprotocolversion",
         "parameters" : [ ],
@@ -2919,7 +2919,7 @@
     },
     "/network/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Network API" ],
+        "tags" : [ "Network" ],
         "description" : "",
         "operationId" : "get_network_getprotocolversion",
         "parameters" : [ ],
@@ -2948,7 +2948,7 @@
     },
     "/network/setup/{holdingidentityshorthash}" : {
       "put" : {
-        "tags" : [ "Network API" ],
+        "tags" : [ "Network" ],
         "description" : "This method configures a holding identity as a network participant by setting properties required for P2P messaging.",
         "operationId" : "put_network_setup__holdingidentityshorthash_",
         "parameters" : [ {
@@ -2989,7 +2989,7 @@
     },
     "/permission" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method returns permissions which satisfy supplied query criteria.",
         "operationId" : "get_permission",
         "parameters" : [ {
@@ -3074,7 +3074,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method creates a new permission.",
         "operationId" : "post_permission",
         "parameters" : [ ],
@@ -3111,7 +3111,7 @@
     },
     "/permission/bulk" : {
       "post" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method creates a set of permissions and optionally assigns them to the existing roles.",
         "operationId" : "post_permission_bulk",
         "parameters" : [ ],
@@ -3148,7 +3148,7 @@
     },
     "/permission/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "",
         "operationId" : "get_permission_getprotocolversion",
         "parameters" : [ ],
@@ -3177,7 +3177,7 @@
     },
     "/permission/{id}" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method returns the permission associated with the specified ID.",
         "operationId" : "get_permission__id_",
         "parameters" : [ {
@@ -3214,7 +3214,7 @@
     },
     "/role" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method returns an array with information about all roles in the permission system.",
         "operationId" : "get_role",
         "parameters" : [ ],
@@ -3243,7 +3243,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "The method creates a new role in the RBAC permission system.",
         "operationId" : "post_role",
         "parameters" : [ ],
@@ -3280,7 +3280,7 @@
     },
     "/role/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "",
         "operationId" : "get_role_getprotocolversion",
         "parameters" : [ ],
@@ -3309,7 +3309,7 @@
     },
     "/role/{id}" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method gets the details of a role specified by its ID.",
         "operationId" : "get_role__id_",
         "parameters" : [ {
@@ -3346,7 +3346,7 @@
     },
     "/role/{roleid}/permission/{permissionid}" : {
       "put" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method adds the specified permission to the specified role.",
         "operationId" : "put_role__roleid__permission__permissionid_",
         "parameters" : [ {
@@ -3392,7 +3392,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method removes the specified permission from the specified role.",
         "operationId" : "delete_role__roleid__permission__permissionid_",
         "parameters" : [ {
@@ -3440,7 +3440,7 @@
     },
     "/user" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method returns a user based on the specified login name.",
         "operationId" : "get_user",
         "parameters" : [ {
@@ -3475,7 +3475,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method creates a new user.",
         "operationId" : "post_user",
         "parameters" : [ ],
@@ -3512,7 +3512,7 @@
     },
     "/user/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "",
         "operationId" : "get_user_getprotocolversion",
         "parameters" : [ ],
@@ -3541,7 +3541,7 @@
     },
     "/user/{loginname}/permissionsummary" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method returns a summary of the user's permissions.",
         "operationId" : "get_user__loginname__permissionsummary",
         "parameters" : [ {
@@ -3578,7 +3578,7 @@
     },
     "/user/{loginname}/role/{roleid}" : {
       "put" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method assigns a specified role to a specified user.",
         "operationId" : "put_user__loginname__role__roleid_",
         "parameters" : [ {
@@ -3624,7 +3624,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method removes the specified role from the specified user.",
         "operationId" : "delete_user__loginname__role__roleid_",
         "parameters" : [ {
@@ -3672,7 +3672,7 @@
     },
     "/virtualnode" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method lists all virtual nodes in the cluster.",
         "operationId" : "get_virtualnode",
         "parameters" : [ ],
@@ -3696,7 +3696,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method creates a new virtual node.",
         "operationId" : "post_virtualnode",
         "parameters" : [ ],
@@ -3733,7 +3733,7 @@
     },
     "/virtualnode/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "",
         "operationId" : "get_virtualnode_getprotocolversion",
         "parameters" : [ ],
@@ -3762,7 +3762,7 @@
     },
     "/virtualnode/status/{requestid}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the VirtualNodeOperationStatus for a given operation request id.",
         "operationId" : "get_virtualnode_status__requestid_",
         "parameters" : [ {
@@ -3799,7 +3799,7 @@
     },
     "/virtualnode/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the VirtualNodeInfo for a given Holding Identity ShortHash.",
         "operationId" : "get_virtualnode__holdingidentityshorthash_",
         "parameters" : [ {
@@ -3836,7 +3836,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/cpi/{targetcpifilechecksum}" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method upgrades a virtual node's CPI.",
         "operationId" : "put_virtualnode__virtualnodeshortid__cpi__targetcpifilechecksum_",
         "parameters" : [ {
@@ -3884,7 +3884,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/state/{newstate}" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method updates the state of a new virtual node to one of the pre-defined values.",
         "operationId" : "put_virtualnode__virtualnodeshortid__state__newstate_",
         "parameters" : [ {
@@ -5543,4 +5543,3 @@
     }
   }
 }
-

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
@@ -12,64 +12,64 @@
     "basicAuth" : [ ]
   } ],
   "tags" : [ {
-    "name" : "CPI API",
+    "name" : "CPI",
     "description" : "The CPI API consists of a number of endpoints used to manage Corda Package Installer (CPI) files in the Corda cluster."
   }, {
-    "name" : "Certificate API",
+    "name" : "Certificate",
     "description" : "The Certificates API consists of endpoints used to work with certificates and related operations. The API allows you to import a certificate chain, and generate a certificate signing request (CSR) to be submitted to a certificate authority (CA)."
   }, {
-    "name" : "Configuration API",
+    "name" : "Configuration",
     "description" : "The Configuration API consists of a number of endpoints used to manage the configuration of Corda clusters."
   }, {
-    "name" : "Flow Info API",
+    "name" : "Flow Info",
     "description" : "The Flow Info API consists of a number of endpoints used to find out which flows can be invoked using the Flow Management API for a given identity."
   }, {
-    "name" : "Flow Management API",
+    "name" : "Flow Management",
     "description" : "The Flow Management API consists of a number of endpoints used to interact with flows."
   }, {
-    "name" : "HSM API",
+    "name" : "HSM",
     "description" : "The HSM API consists of endpoints used to work with Hardware Security Modules (HSM) for securely storing keys."
   }, {
-    "name" : "Hello Rest API",
+    "name" : "Hello Rest",
     "description" : "The Hello Rest API is used to test interactions via the Rest API. It verifies that a call to Rest can be made, and that the identity of the user making the call can be recognized. RBAC permissions are checked and the call is successfully processed by the HTTP-Rest worker."
   }, {
-    "name" : "Key Management API",
+    "name" : "Key Management",
     "description" : "The Keys Management API consists of endpoints used to manage public and private key pairs. The API allows you to list scheme codes which are supported by the associated HSM integration, retrieve information about key pairs owned by a tenant, generate a key pair for a tenant, and retrieve a tenant's public key in PEM format."
   }, {
-    "name" : "MGM API",
+    "name" : "MGM",
     "description" : "The MGM API consists of a number of endpoints used to manage membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows you to generate the group policy for a membership group, required for new members to join the group."
   }, {
-    "name" : "MGM Admin API",
+    "name" : "MGM Admin",
     "description" : "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows the MGM to perform actions such as force decline registration requests which may be displaying unexpected behaviour. This API should only be used by the MGM under exceptional circumstances."
   }, {
-    "name" : "Member Lookup API",
+    "name" : "Member Lookup",
     "description" : "The Member Lookup API consists of endpoints used to look up information related to membership groups."
   }, {
-    "name" : "Member Registration API",
+    "name" : "Member Registration",
     "description" : "The Member Registration API consists of a number of endpoints which manage holding identities' participation in membership groups. To participate in a membership group, the holding identity is required to make a registration request that needs to be approved by the MGM for that group. This API allows you to start the registration process for a holding identity, and check the status of a previously created registration request."
   }, {
-    "name" : "Network API",
+    "name" : "Network",
     "description" : "The Network API consists of endpoints which manage the setup of holding identities in P2P networks."
   }, {
-    "name" : "RBAC Permission API",
+    "name" : "RBAC Permission",
     "description" : "The RBAC Permission API consists of a number of endpoints enabling permissions management in the RBAC (role-based access control) permission system. You can get details of specified permissions and create new permissions."
   }, {
-    "name" : "RBAC Role API",
+    "name" : "RBAC Role",
     "description" : "The RBAC Role API consists of a number of endpoints enabling role management in the RBAC (role-based access control) permission system. You can get all roles in the system, create new roles and add and delete permissions from roles."
   }, {
-    "name" : "RBAC User API",
+    "name" : "RBAC User",
     "description" : "The RBAC User API consists of a number of endpoints enabling user management in the RBAC (role-based access control) permission system. You can get details of specified users, create new users, assign roles to users and remove roles from users."
   }, {
-    "name" : "Virtual Node API",
+    "name" : "Virtual Node",
     "description" : "The Virtual Nodes API consists of a number of endpoints to manage virtual nodes."
   }, {
-    "name" : "Virtual Node Maintenance API",
+    "name" : "Virtual Node Maintenance",
     "description" : "The Virtual Node Maintenance API consists of a series of endpoints used for virtual node management.Warning: Using these endpoints could be highly disruptive, so great care should be taken when using them."
   } ],
   "paths" : {
     "/certificate/cluster/{usage}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain aliases for a cluster.",
         "operationId" : "get_certificate_cluster__usage_",
         "parameters" : [ {
@@ -110,7 +110,7 @@
         }
       },
       "put" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method imports a certificate chain for a cluster.",
         "operationId" : "put_certificate_cluster__usage_",
         "parameters" : [ {
@@ -170,7 +170,7 @@
     },
     "/certificate/cluster/{usage}/{alias}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain in PEM format for a cluster.",
         "operationId" : "get_certificate_cluster__usage___alias_",
         "parameters" : [ {
@@ -220,7 +220,7 @@
     },
     "/certificate/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "",
         "operationId" : "get_certificate_getprotocolversion",
         "parameters" : [ ],
@@ -249,7 +249,7 @@
     },
     "/certificate/vnode/{holdingidentityid}/{usage}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain aliases for a virtual node.",
         "operationId" : "get_certificate_vnode__holdingidentityid___usage_",
         "parameters" : [ {
@@ -301,7 +301,7 @@
         }
       },
       "put" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method imports a certificate chain for a virtual node.",
         "operationId" : "put_certificate_vnode__holdingidentityid___usage_",
         "parameters" : [ {
@@ -372,7 +372,7 @@
     },
     "/certificate/vnode/{holdingidentityid}/{usage}/{alias}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain in PEM format for a virtual node.",
         "operationId" : "get_certificate_vnode__holdingidentityid___usage___alias_",
         "parameters" : [ {
@@ -433,7 +433,7 @@
     },
     "/certificate/{tenantid}/{keyid}" : {
       "post" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method enables you to generate a certificate signing request (CSR) for a tenant.",
         "operationId" : "post_certificate__tenantid___keyid_",
         "parameters" : [ {
@@ -494,7 +494,7 @@
     },
     "/config" : {
       "put" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "This method updates a section of the cluster configuration.",
         "operationId" : "put_config",
         "parameters" : [ ],
@@ -531,7 +531,7 @@
     },
     "/config/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "",
         "operationId" : "get_config_getprotocolversion",
         "parameters" : [ ],
@@ -560,7 +560,7 @@
     },
     "/config/{section}" : {
       "get" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "This method returns the 'active' configuration for the given section, in both the 'raw' format and with defaults applied.",
         "operationId" : "get_config__section_",
         "parameters" : [ {
@@ -597,7 +597,7 @@
     },
     "/cpi" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "The GET method returns a list of all CPIs uploaded to the cluster.",
         "operationId" : "get_cpi",
         "parameters" : [ ],
@@ -621,7 +621,7 @@
         }
       },
       "post" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "This method uses the POST method to upload a Corda Package Installer (CPI) file to the Corda cluster.",
         "operationId" : "post_cpi",
         "parameters" : [ ],
@@ -667,7 +667,7 @@
     },
     "/cpi/getprotocolversion" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "",
         "operationId" : "get_cpi_getprotocolversion",
         "parameters" : [ ],
@@ -696,7 +696,7 @@
     },
     "/cpi/status/{id}" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "The status endpoint uses the GET method to return status information for the CPI upload with the given request ID.",
         "operationId" : "get_cpi_status__id_",
         "parameters" : [ {
@@ -733,7 +733,7 @@
     },
     "/flow/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "",
         "operationId" : "get_flow_getprotocolversion",
         "parameters" : [ ],
@@ -762,7 +762,7 @@
     },
     "/flow/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method returns an array containing the statuses of all flows running for a specified holding identity. An empty array is returned if there are no flows running.",
         "operationId" : "get_flow__holdingidentityshorthash_",
         "parameters" : [ {
@@ -797,7 +797,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method starts a new instance for the specified flow for the specified holding identity.",
         "operationId" : "post_flow__holdingidentityshorthash_",
         "parameters" : [ {
@@ -845,7 +845,7 @@
     },
     "/flow/{holdingidentityshorthash}/{clientrequestid}" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method gets the current status of the specified flow instance.",
         "operationId" : "get_flow__holdingidentityshorthash___clientrequestid_",
         "parameters" : [ {
@@ -893,7 +893,7 @@
     },
     "/flow/{holdingidentityshorthash}/{clientrequestid}/result" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method gets the result of the specified flow instance execution.",
         "operationId" : "get_flow__holdingidentityshorthash___clientrequestid__result",
         "parameters" : [ {
@@ -941,7 +941,7 @@
     },
     "/flowclass/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Flow Info API" ],
+        "tags" : [ "Flow Info" ],
         "description" : "",
         "operationId" : "get_flowclass_getprotocolversion",
         "parameters" : [ ],
@@ -970,7 +970,7 @@
     },
     "/flowclass/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Flow Info API" ],
+        "tags" : [ "Flow Info" ],
         "description" : "This method gets all flows that can be used by the specified holding identity.",
         "operationId" : "get_flowclass__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1007,7 +1007,7 @@
     },
     "/hello" : {
       "post" : {
-        "tags" : [ "Hello Rest API" ],
+        "tags" : [ "Hello Rest" ],
         "description" : "This method produces a greeting phrase for the addressee.",
         "operationId" : "post_hello",
         "parameters" : [ {
@@ -1046,7 +1046,7 @@
     },
     "/hello/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Hello Rest API" ],
+        "tags" : [ "Hello Rest" ],
         "description" : "",
         "operationId" : "get_hello_getprotocolversion",
         "parameters" : [ ],
@@ -1075,7 +1075,7 @@
     },
     "/hsm/getprotocolversion" : {
       "get" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "",
         "operationId" : "get_hsm_getprotocolversion",
         "parameters" : [ ],
@@ -1104,7 +1104,7 @@
     },
     "/hsm/soft/{tenantid}/{category}" : {
       "post" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "This method enables you to assign a soft HSM to the tenant for the specified category.",
         "operationId" : "post_hsm_soft__tenantid___category_",
         "parameters" : [ {
@@ -1152,7 +1152,7 @@
     },
     "/hsm/{tenantid}/{category}" : {
       "get" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "This method retrieves information on the HSM of the specified category assigned to the tenant.",
         "operationId" : "get_hsm__tenantid___category_",
         "parameters" : [ {
@@ -1200,7 +1200,7 @@
     },
     "/key/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "",
         "operationId" : "get_key_getprotocolversion",
         "parameters" : [ ],
@@ -1229,7 +1229,7 @@
     },
     "/key/{tenantid}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves information about a list of key pairs belonging to a tenant.",
         "operationId" : "get_key__tenantid_",
         "parameters" : [ {
@@ -1386,7 +1386,7 @@
     },
     "/key/{tenantid}/alias/{alias}/category/{hsmcategory}/scheme/{scheme}" : {
       "post" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method generates a new key pair for a tenant.",
         "operationId" : "post_key__tenantid__alias__alias__category__hsmcategory__scheme__scheme_",
         "parameters" : [ {
@@ -1456,7 +1456,7 @@
     },
     "/key/{tenantid}/schemes/{hsmcategory}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves a list of supported key schemes for a specified tenant and HSM category.",
         "operationId" : "get_key__tenantid__schemes__hsmcategory_",
         "parameters" : [ {
@@ -1510,7 +1510,7 @@
     },
     "/key/{tenantid}/{keyid}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves a tenant's public key in PEM format.",
         "operationId" : "get_key__tenantid___keyid_",
         "parameters" : [ {
@@ -1560,7 +1560,7 @@
     },
     "/maintenance/virtualnode/forcecpiupload" : {
       "post" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "Even if CPI with the same metadata has already been uploaded, this endpoint will overwrite the previously stored CPI record. This operation also purges any sandboxes running an overwritten version of a CPI. This action can take some time to process, therefore it is performed asynchronously.",
         "operationId" : "post_maintenance_virtualnode_forcecpiupload",
         "parameters" : [ ],
@@ -1606,7 +1606,7 @@
     },
     "/maintenance/virtualnode/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "",
         "operationId" : "get_maintenance_virtualnode_getprotocolversion",
         "parameters" : [ ],
@@ -1635,7 +1635,7 @@
     },
     "/maintenance/virtualnode/{virtualnodeshortid}/vault-schema/force-resync" : {
       "post" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "Rollback the virtual node database for the given virtual node short ID. Then apply current CPI migrations. This operation is destructive and will result in user vault data being deleted, but will not have any effect on system tables.",
         "operationId" : "post_maintenance_virtualnode__virtualnodeshortid__vault_schema_force_resync",
         "parameters" : [ {
@@ -1665,7 +1665,7 @@
     },
     "/members/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "",
         "operationId" : "get_members_getprotocolversion",
         "parameters" : [ ],
@@ -1694,7 +1694,7 @@
     },
     "/members/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "This method retrieves a list of all active and pending members in the membership group.",
         "operationId" : "get_members__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1811,7 +1811,7 @@
     },
     "/members/{holdingidentityshorthash}/group-parameters" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "This method retrieves the group parameters of the membership group.",
         "operationId" : "get_members__holdingidentityshorthash__group_parameters",
         "parameters" : [ {
@@ -1848,7 +1848,7 @@
     },
     "/membership/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "",
         "operationId" : "get_membership_getprotocolversion",
         "parameters" : [ ],
@@ -1877,7 +1877,7 @@
     },
     "/membership/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method checks the statuses of all registration requests for a specified holding identity.",
         "operationId" : "get_membership__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1917,7 +1917,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method starts the registration process for a holding identity.",
         "operationId" : "post_membership__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1965,7 +1965,7 @@
     },
     "/membership/{holdingidentityshorthash}/{registrationrequestid}" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method checks the status of the specified registration request for a holding identity.",
         "operationId" : "get_membership__holdingidentityshorthash___registrationrequestid_",
         "parameters" : [ {
@@ -2013,7 +2013,7 @@
     },
     "/mgm/getprotocolversion" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm_getprotocolversion",
         "parameters" : [ ],
@@ -2042,7 +2042,7 @@
     },
     "/mgm/{holdingidentityshorthash}/activate" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This endpoint enables you to activate a previously suspended member.",
         "operationId" : "post_mgm__holdingidentityshorthash__activate",
         "parameters" : [ {
@@ -2083,7 +2083,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the set of rules the group is currently configured with",
         "operationId" : "get_mgm__holdingidentityshorthash__approval_rules",
         "parameters" : [ {
@@ -2123,7 +2123,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API adds a rule to the set of group approval rules.",
         "operationId" : "post_mgm__holdingidentityshorthash__approval_rules",
         "parameters" : [ {
@@ -2171,7 +2171,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/preauth" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the set of rules the group is currently configured with for registration request with a pre-auth token.",
         "operationId" : "get_mgm__holdingidentityshorthash__approval_rules_preauth",
         "parameters" : [ {
@@ -2211,7 +2211,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API adds a rule to the set of group approval rules for registrations including a pre-auth token.",
         "operationId" : "post_mgm__holdingidentityshorthash__approval_rules_preauth",
         "parameters" : [ {
@@ -2259,7 +2259,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/preauth/{ruleid}" : {
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API deletes a group approval rule for registrations including a pre-auth token.",
         "operationId" : "delete_mgm__holdingidentityshorthash__approval_rules_preauth__ruleid_",
         "parameters" : [ {
@@ -2300,7 +2300,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/{ruleid}" : {
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API deletes a previously added group approval rule.",
         "operationId" : "delete_mgm__holdingidentityshorthash__approval_rules__ruleid_",
         "parameters" : [ {
@@ -2341,7 +2341,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approve/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__approve__requestid_",
         "parameters" : [ {
@@ -2382,7 +2382,7 @@
     },
     "/mgm/{holdingidentityshorthash}/decline/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__decline__requestid_",
         "parameters" : [ {
@@ -2443,7 +2443,7 @@
     },
     "/mgm/{holdingidentityshorthash}/group-parameters" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API allows you to make changes to the group parameters by submitting an updated version of the group parameters.",
         "operationId" : "post_mgm__holdingidentityshorthash__group_parameters",
         "parameters" : [ {
@@ -2491,7 +2491,7 @@
     },
     "/mgm/{holdingidentityshorthash}/info" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the group policy from the MGM required to join the membership group.",
         "operationId" : "get_mgm__holdingidentityshorthash__info",
         "parameters" : [ {
@@ -2530,7 +2530,7 @@
     },
     "/mgm/{holdingidentityshorthash}/mutual-tls/allowed-client-certificate-subjects" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API list the allowed  client certificates subjects to be used in mutual TLS connections.",
         "operationId" : "get_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects",
         "parameters" : [ {
@@ -2573,7 +2573,7 @@
     },
     "/mgm/{holdingidentityshorthash}/mutual-tls/allowed-client-certificate-subjects/{subject}" : {
       "put" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API allows a client certificate with a given subject to be used in mutual TLS connections.",
         "operationId" : "put_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects__subject_",
         "parameters" : [ {
@@ -2612,7 +2612,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API disallows a client certificate with a given subject to be used in mutual TLS connections.",
         "operationId" : "delete_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects__subject_",
         "parameters" : [ {
@@ -2653,7 +2653,7 @@
     },
     "/mgm/{holdingidentityshorthash}/preauthtoken" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm__holdingidentityshorthash__preauthtoken",
         "parameters" : [ {
@@ -2722,7 +2722,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__preauthtoken",
         "parameters" : [ {
@@ -2769,7 +2769,7 @@
     },
     "/mgm/{holdingidentityshorthash}/preauthtoken/revoke/{preauthtokenid}" : {
       "put" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "put_mgm__holdingidentityshorthash__preauthtoken_revoke__preauthtokenid_",
         "parameters" : [ {
@@ -2833,7 +2833,7 @@
     },
     "/mgm/{holdingidentityshorthash}/registrations" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm__holdingidentityshorthash__registrations",
         "parameters" : [ {
@@ -2897,7 +2897,7 @@
     },
     "/mgm/{holdingidentityshorthash}/suspend" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "The suspend endpoint enables you to suspend a member.",
         "operationId" : "post_mgm__holdingidentityshorthash__suspend",
         "parameters" : [ {
@@ -2938,7 +2938,7 @@
     },
     "/mgmadmin/getprotocolversion" : {
       "get" : {
-        "tags" : [ "MGM Admin API" ],
+        "tags" : [ "MGM Admin" ],
         "description" : "",
         "operationId" : "get_mgmadmin_getprotocolversion",
         "parameters" : [ ],
@@ -2967,7 +2967,7 @@
     },
     "/mgmadmin/{holdingidentityshorthash}/force-decline/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM Admin API" ],
+        "tags" : [ "MGM Admin" ],
         "description" : "This method enables you to force decline an in-progress registration request that may be stuck or displaying some other unexpected behaviour.",
         "operationId" : "post_mgmadmin__holdingidentityshorthash__force_decline__requestid_",
         "parameters" : [ {
@@ -3008,7 +3008,7 @@
     },
     "/network/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Network API" ],
+        "tags" : [ "Network" ],
         "description" : "",
         "operationId" : "get_network_getprotocolversion",
         "parameters" : [ ],
@@ -3037,7 +3037,7 @@
     },
     "/network/setup/{holdingidentityshorthash}" : {
       "put" : {
-        "tags" : [ "Network API" ],
+        "tags" : [ "Network" ],
         "description" : "This method configures a holding identity as a network participant by setting properties required for P2P messaging.",
         "operationId" : "put_network_setup__holdingidentityshorthash_",
         "parameters" : [ {
@@ -3078,7 +3078,7 @@
     },
     "/permission" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method returns permissions which satisfy supplied query criteria.",
         "operationId" : "get_permission",
         "parameters" : [ {
@@ -3163,7 +3163,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method creates a new permission.",
         "operationId" : "post_permission",
         "parameters" : [ ],
@@ -3200,7 +3200,7 @@
     },
     "/permission/bulk" : {
       "post" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method creates a set of permissions and optionally assigns them to the existing roles.",
         "operationId" : "post_permission_bulk",
         "parameters" : [ ],
@@ -3237,7 +3237,7 @@
     },
     "/permission/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "",
         "operationId" : "get_permission_getprotocolversion",
         "parameters" : [ ],
@@ -3266,7 +3266,7 @@
     },
     "/permission/{id}" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method returns the permission associated with the specified ID.",
         "operationId" : "get_permission__id_",
         "parameters" : [ {
@@ -3303,7 +3303,7 @@
     },
     "/role" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method returns an array with information about all roles in the permission system.",
         "operationId" : "get_role",
         "parameters" : [ ],
@@ -3332,7 +3332,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "The method creates a new role in the RBAC permission system.",
         "operationId" : "post_role",
         "parameters" : [ ],
@@ -3369,7 +3369,7 @@
     },
     "/role/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "",
         "operationId" : "get_role_getprotocolversion",
         "parameters" : [ ],
@@ -3398,7 +3398,7 @@
     },
     "/role/{id}" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method gets the details of a role specified by its ID.",
         "operationId" : "get_role__id_",
         "parameters" : [ {
@@ -3435,7 +3435,7 @@
     },
     "/role/{roleid}/permission/{permissionid}" : {
       "put" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method adds the specified permission to the specified role.",
         "operationId" : "put_role__roleid__permission__permissionid_",
         "parameters" : [ {
@@ -3481,7 +3481,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method removes the specified permission from the specified role.",
         "operationId" : "delete_role__roleid__permission__permissionid_",
         "parameters" : [ {
@@ -3529,7 +3529,7 @@
     },
     "/user" : {
       "post" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method creates a new user.",
         "operationId" : "post_user",
         "parameters" : [ ],
@@ -3566,7 +3566,7 @@
     },
     "/user/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "",
         "operationId" : "get_user_getprotocolversion",
         "parameters" : [ ],
@@ -3595,7 +3595,7 @@
     },
     "/user/{loginname}" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method returns a user based on the specified login name.",
         "operationId" : "get_user__loginname_",
         "parameters" : [ {
@@ -3632,7 +3632,7 @@
     },
     "/user/{loginname}/permissionsummary" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method returns a summary of the user's permissions.",
         "operationId" : "get_user__loginname__permissionsummary",
         "parameters" : [ {
@@ -3669,7 +3669,7 @@
     },
     "/user/{loginname}/role/{roleid}" : {
       "put" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method assigns a specified role to a specified user.",
         "operationId" : "put_user__loginname__role__roleid_",
         "parameters" : [ {
@@ -3715,7 +3715,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method removes the specified role from the specified user.",
         "operationId" : "delete_user__loginname__role__roleid_",
         "parameters" : [ {
@@ -3763,7 +3763,7 @@
     },
     "/virtualnode" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method lists all virtual nodes in the cluster.",
         "operationId" : "get_virtualnode",
         "parameters" : [ ],
@@ -3787,7 +3787,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method creates a new virtual node.",
         "operationId" : "post_virtualnode",
         "parameters" : [ ],
@@ -3824,7 +3824,7 @@
     },
     "/virtualnode/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "",
         "operationId" : "get_virtualnode_getprotocolversion",
         "parameters" : [ ],
@@ -3853,7 +3853,7 @@
     },
     "/virtualnode/status/{requestid}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the VirtualNodeOperationStatus for a given operation request id.",
         "operationId" : "get_virtualnode_status__requestid_",
         "parameters" : [ {
@@ -3890,7 +3890,7 @@
     },
     "/virtualnode/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the VirtualNodeInfo for a given Holding Identity ShortHash.",
         "operationId" : "get_virtualnode__holdingidentityshorthash_",
         "parameters" : [ {
@@ -3927,7 +3927,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/cpi/{targetcpifilechecksum}" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method upgrades a virtual node's CPI.",
         "operationId" : "put_virtualnode__virtualnodeshortid__cpi__targetcpifilechecksum_",
         "parameters" : [ {
@@ -3986,7 +3986,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/state/{newstate}" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method updates the state of a new virtual node to one of the pre-defined values.",
         "operationId" : "put_virtualnode__virtualnodeshortid__state__newstate_",
         "parameters" : [ {
@@ -4109,7 +4109,6 @@
             "example" : "string"
           },
           "status" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "IN_PROGRESS",
             "enum" : [ "ACCEPTED", "IN_PROGRESS", "SUCCEEDED", "FAILED", "ABORTED" ]
@@ -4389,7 +4388,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -4629,7 +4627,6 @@
       },
       "GenerateCsrWrapperRequest" : {
         "required" : [ "x500Name" ],
-        "type" : "object",
         "properties" : {
           "contextMap" : {
             "type" : "object",
@@ -4924,7 +4921,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -4968,7 +4964,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -5005,7 +5000,6 @@
             "example" : "string"
           },
           "status" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "REVOKED",
             "enum" : [ "AVAILABLE", "REVOKED", "CONSUMED", "AUTO_INVALIDATED" ]
@@ -5174,7 +5168,6 @@
             "example" : "2022-06-24T10:15:30Z"
           },
           "registrationStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "SENT_TO_MGM",
             "enum" : [ "NEW", "SENT_TO_MGM", "RECEIVED_BY_MGM", "STARTED_PROCESSING_BY_MGM", "PENDING_MEMBER_VERIFICATION", "PENDING_MANUAL_APPROVAL", "PENDING_AUTO_APPROVAL", "DECLINED", "INVALID", "FAILED", "APPROVED" ]
@@ -5271,7 +5264,6 @@
             "example" : "string"
           },
           "inactiveResponseType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "IGNORE",
             "enum" : [ "ERROR", "IGNORE" ]
@@ -5576,19 +5568,16 @@
             "$ref" : "#/components/schemas/RouteConfiguration"
           },
           "flowOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "flowP2pOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "flowStartOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
@@ -5617,7 +5606,6 @@
             "example" : "string"
           },
           "vaultDbOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -12,67 +12,67 @@
     "basicAuth" : [ ]
   } ],
   "tags" : [ {
-    "name" : "CPI API",
+    "name" : "CPI",
     "description" : "The CPI API consists of a number of endpoints used to manage Corda Package Installer (CPI) files in the Corda cluster."
   }, {
-    "name" : "Certificate API",
+    "name" : "Certificate",
     "description" : "The Certificates API consists of endpoints used to work with certificates and related operations. The API allows you to import a certificate chain, and generate a certificate signing request (CSR) to be submitted to a certificate authority (CA)."
   }, {
-    "name" : "Configuration API",
+    "name" : "Configuration",
     "description" : "The Configuration API consists of a number of endpoints used to manage the configuration of Corda clusters."
   }, {
-    "name" : "Flow Info API",
+    "name" : "Flow Info",
     "description" : "The Flow Info API consists of a number of endpoints used to find out which flows can be invoked using the Flow Management API for a given identity."
   }, {
-    "name" : "Flow Management API",
+    "name" : "Flow Management",
     "description" : "The Flow Management API consists of a number of endpoints used to interact with flows."
   }, {
-    "name" : "HSM API",
+    "name" : "HSM",
     "description" : "The HSM API consists of endpoints used to work with Hardware Security Modules (HSM) for securely storing keys."
   }, {
-    "name" : "Hello Rest API",
+    "name" : "Hello Rest",
     "description" : "The Hello Rest API is used to test interactions via the Rest API. It verifies that a call to Rest can be made, and that the identity of the user making the call can be recognized. RBAC permissions are checked and the call is successfully processed by the HTTP-Rest worker."
   }, {
-    "name" : "Key Management API",
+    "name" : "Key Management",
     "description" : "The Keys Management API consists of endpoints used to manage public and private key pairs. The API allows you to list scheme codes which are supported by the associated HSM integration, retrieve information about key pairs owned by a tenant, generate a key pair for a tenant, and retrieve a tenant's public key in PEM format."
   }, {
-    "name" : "Key Rotation API",
+    "name" : "Key Rotation",
     "description" : "Contains operations related to rotation of the master, cluster-level and vNode wrapping keys."
   }, {
-    "name" : "MGM API",
+    "name" : "MGM",
     "description" : "The MGM API consists of a number of endpoints used to manage membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows you to generate the group policy for a membership group, required for new members to join the group."
   }, {
-    "name" : "MGM Admin API",
+    "name" : "MGM Admin",
     "description" : "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows the MGM to perform actions such as force decline registration requests which may be displaying unexpected behaviour. This API should only be used by the MGM under exceptional circumstances."
   }, {
-    "name" : "Member Lookup API",
+    "name" : "Member Lookup",
     "description" : "The Member Lookup API consists of endpoints used to look up information related to membership groups."
   }, {
-    "name" : "Member Registration API",
+    "name" : "Member Registration",
     "description" : "The Member Registration API consists of a number of endpoints which manage holding identities' participation in membership groups. To participate in a membership group, the holding identity is required to make a registration request that needs to be approved by the MGM for that group. This API allows you to start the registration process for a holding identity, and check the status of a previously created registration request."
   }, {
-    "name" : "Network API",
+    "name" : "Network",
     "description" : "The Network API consists of endpoints which manage the setup of holding identities in P2P networks."
   }, {
-    "name" : "RBAC Permission API",
+    "name" : "RBAC Permission",
     "description" : "The RBAC Permission API consists of a number of endpoints enabling permissions management in the RBAC (role-based access control) permission system. You can get details of specified permissions and create new permissions."
   }, {
-    "name" : "RBAC Role API",
+    "name" : "RBAC Role",
     "description" : "The RBAC Role API consists of a number of endpoints enabling role management in the RBAC (role-based access control) permission system. You can get all roles in the system, create new roles and add and delete permissions from roles."
   }, {
-    "name" : "RBAC User API",
+    "name" : "RBAC User",
     "description" : "The RBAC User API consists of a number of endpoints enabling user management in the RBAC (role-based access control) permission system. You can get details of specified users, create new users, assign roles to users and remove roles from users."
   }, {
-    "name" : "Virtual Node API",
+    "name" : "Virtual Node",
     "description" : "The Virtual Nodes API consists of a number of endpoints to manage virtual nodes."
   }, {
-    "name" : "Virtual Node Maintenance API",
+    "name" : "Virtual Node Maintenance",
     "description" : "The Virtual Node Maintenance API consists of a series of endpoints used for virtual node management.Warning: Using these endpoints could be highly disruptive, so great care should be taken when using them."
   } ],
   "paths" : {
     "/certificate/cluster/{usage}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain aliases for a cluster.",
         "operationId" : "get_certificate_cluster__usage_",
         "parameters" : [ {
@@ -113,7 +113,7 @@
         }
       },
       "put" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method imports a certificate chain for a cluster.",
         "operationId" : "put_certificate_cluster__usage_",
         "parameters" : [ {
@@ -173,7 +173,7 @@
     },
     "/certificate/cluster/{usage}/{alias}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain in PEM format for a cluster.",
         "operationId" : "get_certificate_cluster__usage___alias_",
         "parameters" : [ {
@@ -223,7 +223,7 @@
     },
     "/certificate/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "",
         "operationId" : "get_certificate_getprotocolversion",
         "parameters" : [ ],
@@ -252,7 +252,7 @@
     },
     "/certificate/vnode/{holdingidentityid}/{usage}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain aliases for a virtual node.",
         "operationId" : "get_certificate_vnode__holdingidentityid___usage_",
         "parameters" : [ {
@@ -304,7 +304,7 @@
         }
       },
       "put" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method imports a certificate chain for a virtual node.",
         "operationId" : "put_certificate_vnode__holdingidentityid___usage_",
         "parameters" : [ {
@@ -375,7 +375,7 @@
     },
     "/certificate/vnode/{holdingidentityid}/{usage}/{alias}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain in PEM format for a virtual node.",
         "operationId" : "get_certificate_vnode__holdingidentityid___usage___alias_",
         "parameters" : [ {
@@ -436,7 +436,7 @@
     },
     "/certificate/{tenantid}/{keyid}" : {
       "post" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method enables you to generate a certificate signing request (CSR) for a tenant.",
         "operationId" : "post_certificate__tenantid___keyid_",
         "parameters" : [ {
@@ -497,7 +497,7 @@
     },
     "/config" : {
       "put" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "This method updates a section of the cluster configuration.",
         "operationId" : "put_config",
         "parameters" : [ ],
@@ -534,7 +534,7 @@
     },
     "/config/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "",
         "operationId" : "get_config_getprotocolversion",
         "parameters" : [ ],
@@ -563,7 +563,7 @@
     },
     "/config/{section}" : {
       "get" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "This method returns the 'active' configuration for the given section, in both the 'raw' format and with defaults applied.",
         "operationId" : "get_config__section_",
         "parameters" : [ {
@@ -600,7 +600,7 @@
     },
     "/cpi" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "The GET method returns a list of all CPIs uploaded to the cluster.",
         "operationId" : "get_cpi",
         "parameters" : [ ],
@@ -624,7 +624,7 @@
         }
       },
       "post" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "This method uses the POST method to upload a Corda Package Installer (CPI) file to the Corda cluster.",
         "operationId" : "post_cpi",
         "parameters" : [ ],
@@ -670,7 +670,7 @@
     },
     "/cpi/getprotocolversion" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "",
         "operationId" : "get_cpi_getprotocolversion",
         "parameters" : [ ],
@@ -699,7 +699,7 @@
     },
     "/cpi/status/{id}" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "The status endpoint uses the GET method to return status information for the CPI upload with the given request ID.",
         "operationId" : "get_cpi_status__id_",
         "parameters" : [ {
@@ -736,7 +736,7 @@
     },
     "/flow/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "",
         "operationId" : "get_flow_getprotocolversion",
         "parameters" : [ ],
@@ -765,7 +765,7 @@
     },
     "/flow/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method returns an array containing the statuses of all flows for a specified holding identity, for a particular flow processing status if specified. An empty array is returned if there are no flows.",
         "operationId" : "get_flow__holdingidentityshorthash_",
         "parameters" : [ {
@@ -811,7 +811,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method starts a new instance for the specified flow for the specified holding identity.",
         "operationId" : "post_flow__holdingidentityshorthash_",
         "parameters" : [ {
@@ -859,7 +859,7 @@
     },
     "/flow/{holdingidentityshorthash}/{clientrequestid}" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method gets the current status of the specified flow instance.",
         "operationId" : "get_flow__holdingidentityshorthash___clientrequestid_",
         "parameters" : [ {
@@ -907,7 +907,7 @@
     },
     "/flow/{holdingidentityshorthash}/{clientrequestid}/result" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method gets the result of the specified flow instance execution.",
         "operationId" : "get_flow__holdingidentityshorthash___clientrequestid__result",
         "parameters" : [ {
@@ -955,7 +955,7 @@
     },
     "/flowclass/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Flow Info API" ],
+        "tags" : [ "Flow Info" ],
         "description" : "",
         "operationId" : "get_flowclass_getprotocolversion",
         "parameters" : [ ],
@@ -984,7 +984,7 @@
     },
     "/flowclass/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Flow Info API" ],
+        "tags" : [ "Flow Info" ],
         "description" : "This method gets all flows that can be used by the specified holding identity.",
         "operationId" : "get_flowclass__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1021,7 +1021,7 @@
     },
     "/hello" : {
       "post" : {
-        "tags" : [ "Hello Rest API" ],
+        "tags" : [ "Hello Rest" ],
         "description" : "This method produces a greeting phrase for the addressee.",
         "operationId" : "post_hello",
         "parameters" : [ {
@@ -1060,7 +1060,7 @@
     },
     "/hello/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Hello Rest API" ],
+        "tags" : [ "Hello Rest" ],
         "description" : "",
         "operationId" : "get_hello_getprotocolversion",
         "parameters" : [ ],
@@ -1089,7 +1089,7 @@
     },
     "/hsm/getprotocolversion" : {
       "get" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "",
         "operationId" : "get_hsm_getprotocolversion",
         "parameters" : [ ],
@@ -1118,7 +1118,7 @@
     },
     "/hsm/soft/{tenantid}/{category}" : {
       "post" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "This method enables you to assign a soft HSM to the tenant for the specified category.",
         "operationId" : "post_hsm_soft__tenantid___category_",
         "parameters" : [ {
@@ -1166,7 +1166,7 @@
     },
     "/hsm/{tenantid}/{category}" : {
       "get" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "This method retrieves information on the HSM of the specified category assigned to the tenant.",
         "operationId" : "get_hsm__tenantid___category_",
         "parameters" : [ {
@@ -1214,7 +1214,7 @@
     },
     "/key/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "",
         "operationId" : "get_key_getprotocolversion",
         "parameters" : [ ],
@@ -1243,7 +1243,7 @@
     },
     "/key/{tenantid}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves information about a list of key pairs belonging to a tenant.",
         "operationId" : "get_key__tenantid_",
         "parameters" : [ {
@@ -1400,7 +1400,7 @@
     },
     "/key/{tenantid}/alias/{alias}/category/{hsmcategory}/scheme/{scheme}" : {
       "post" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method generates a new key pair for a tenant.",
         "operationId" : "post_key__tenantid__alias__alias__category__hsmcategory__scheme__scheme_",
         "parameters" : [ {
@@ -1470,7 +1470,7 @@
     },
     "/key/{tenantid}/schemes/{hsmcategory}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves a list of supported key schemes for a specified tenant and HSM category.",
         "operationId" : "get_key__tenantid__schemes__hsmcategory_",
         "parameters" : [ {
@@ -1524,7 +1524,7 @@
     },
     "/key/{tenantid}/{keyid}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves a tenant's public key in PEM format.",
         "operationId" : "get_key__tenantid___keyid_",
         "parameters" : [ {
@@ -1574,7 +1574,7 @@
     },
     "/maintenance/virtualnode/forcecpiupload" : {
       "post" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "Even if CPI with the same metadata has already been uploaded, this endpoint will overwrite the previously stored CPI record. This operation also purges any sandboxes running an overwritten version of a CPI. This action can take some time to process, therefore it is performed asynchronously.",
         "operationId" : "post_maintenance_virtualnode_forcecpiupload",
         "parameters" : [ ],
@@ -1620,7 +1620,7 @@
     },
     "/maintenance/virtualnode/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "",
         "operationId" : "get_maintenance_virtualnode_getprotocolversion",
         "parameters" : [ ],
@@ -1649,7 +1649,7 @@
     },
     "/maintenance/virtualnode/{virtualnodeshortid}/vault-schema/force-resync" : {
       "post" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "Rollback the virtual node database for the given virtual node short ID. Then apply current CPI migrations. This operation is destructive and will result in user vault data being deleted, but will not have any effect on system tables.",
         "operationId" : "post_maintenance_virtualnode__virtualnodeshortid__vault_schema_force_resync",
         "parameters" : [ {
@@ -1679,7 +1679,7 @@
     },
     "/members/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "",
         "operationId" : "get_members_getprotocolversion",
         "parameters" : [ ],
@@ -1708,7 +1708,7 @@
     },
     "/members/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "This method retrieves a list of all active and pending members in the membership group.",
         "operationId" : "get_members__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1825,7 +1825,7 @@
     },
     "/members/{holdingidentityshorthash}/group-parameters" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "This method retrieves the group parameters of the membership group.",
         "operationId" : "get_members__holdingidentityshorthash__group_parameters",
         "parameters" : [ {
@@ -1862,7 +1862,7 @@
     },
     "/membership/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "",
         "operationId" : "get_membership_getprotocolversion",
         "parameters" : [ ],
@@ -1891,7 +1891,7 @@
     },
     "/membership/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method checks the statuses of all registration requests for a specified holding identity.",
         "operationId" : "get_membership__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1931,7 +1931,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method starts the registration process for a holding identity.",
         "operationId" : "post_membership__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1979,7 +1979,7 @@
     },
     "/membership/{holdingidentityshorthash}/{registrationrequestid}" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method checks the status of the specified registration request for a holding identity.",
         "operationId" : "get_membership__holdingidentityshorthash___registrationrequestid_",
         "parameters" : [ {
@@ -2027,7 +2027,7 @@
     },
     "/mgm/getprotocolversion" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm_getprotocolversion",
         "parameters" : [ ],
@@ -2056,7 +2056,7 @@
     },
     "/mgm/{holdingidentityshorthash}/activate" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This endpoint enables you to activate a previously suspended member.",
         "operationId" : "post_mgm__holdingidentityshorthash__activate",
         "parameters" : [ {
@@ -2097,7 +2097,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the set of rules the group is currently configured with",
         "operationId" : "get_mgm__holdingidentityshorthash__approval_rules",
         "parameters" : [ {
@@ -2137,7 +2137,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API adds a rule to the set of group approval rules.",
         "operationId" : "post_mgm__holdingidentityshorthash__approval_rules",
         "parameters" : [ {
@@ -2185,7 +2185,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/preauth" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the set of rules the group is currently configured with for registration request with a pre-auth token.",
         "operationId" : "get_mgm__holdingidentityshorthash__approval_rules_preauth",
         "parameters" : [ {
@@ -2225,7 +2225,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API adds a rule to the set of group approval rules for registrations including a pre-auth token.",
         "operationId" : "post_mgm__holdingidentityshorthash__approval_rules_preauth",
         "parameters" : [ {
@@ -2273,7 +2273,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/preauth/{ruleid}" : {
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API deletes a group approval rule for registrations including a pre-auth token.",
         "operationId" : "delete_mgm__holdingidentityshorthash__approval_rules_preauth__ruleid_",
         "parameters" : [ {
@@ -2314,7 +2314,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/{ruleid}" : {
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API deletes a previously added group approval rule.",
         "operationId" : "delete_mgm__holdingidentityshorthash__approval_rules__ruleid_",
         "parameters" : [ {
@@ -2355,7 +2355,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approve/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__approve__requestid_",
         "parameters" : [ {
@@ -2396,7 +2396,7 @@
     },
     "/mgm/{holdingidentityshorthash}/decline/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__decline__requestid_",
         "parameters" : [ {
@@ -2457,7 +2457,7 @@
     },
     "/mgm/{holdingidentityshorthash}/group-parameters" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API allows you to make changes to the group parameters by submitting an updated version of the group parameters.",
         "operationId" : "post_mgm__holdingidentityshorthash__group_parameters",
         "parameters" : [ {
@@ -2505,7 +2505,7 @@
     },
     "/mgm/{holdingidentityshorthash}/info" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the group policy from the MGM required to join the membership group.",
         "operationId" : "get_mgm__holdingidentityshorthash__info",
         "parameters" : [ {
@@ -2544,7 +2544,7 @@
     },
     "/mgm/{holdingidentityshorthash}/mutual-tls/allowed-client-certificate-subjects" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API list the allowed  client certificates subjects to be used in mutual TLS connections.",
         "operationId" : "get_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects",
         "parameters" : [ {
@@ -2587,7 +2587,7 @@
     },
     "/mgm/{holdingidentityshorthash}/mutual-tls/allowed-client-certificate-subjects/{subject}" : {
       "put" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API allows a client certificate with a given subject to be used in mutual TLS connections.",
         "operationId" : "put_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects__subject_",
         "parameters" : [ {
@@ -2626,7 +2626,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API disallows a client certificate with a given subject to be used in mutual TLS connections.",
         "operationId" : "delete_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects__subject_",
         "parameters" : [ {
@@ -2667,7 +2667,7 @@
     },
     "/mgm/{holdingidentityshorthash}/preauthtoken" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm__holdingidentityshorthash__preauthtoken",
         "parameters" : [ {
@@ -2736,7 +2736,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__preauthtoken",
         "parameters" : [ {
@@ -2783,7 +2783,7 @@
     },
     "/mgm/{holdingidentityshorthash}/preauthtoken/revoke/{preauthtokenid}" : {
       "put" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "put_mgm__holdingidentityshorthash__preauthtoken_revoke__preauthtokenid_",
         "parameters" : [ {
@@ -2847,7 +2847,7 @@
     },
     "/mgm/{holdingidentityshorthash}/registrations" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm__holdingidentityshorthash__registrations",
         "parameters" : [ {
@@ -2911,7 +2911,7 @@
     },
     "/mgm/{holdingidentityshorthash}/suspend" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "The suspend endpoint enables you to suspend a member.",
         "operationId" : "post_mgm__holdingidentityshorthash__suspend",
         "parameters" : [ {
@@ -2952,7 +2952,7 @@
     },
     "/mgmadmin/getprotocolversion" : {
       "get" : {
-        "tags" : [ "MGM Admin API" ],
+        "tags" : [ "MGM Admin" ],
         "description" : "",
         "operationId" : "get_mgmadmin_getprotocolversion",
         "parameters" : [ ],
@@ -2981,7 +2981,7 @@
     },
     "/mgmadmin/{holdingidentityshorthash}/force-decline/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM Admin API" ],
+        "tags" : [ "MGM Admin" ],
         "description" : "This method enables you to force decline an in-progress registration request that may be stuck or displaying some other unexpected behaviour.",
         "operationId" : "post_mgmadmin__holdingidentityshorthash__force_decline__requestid_",
         "parameters" : [ {
@@ -3022,7 +3022,7 @@
     },
     "/network/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Network API" ],
+        "tags" : [ "Network" ],
         "description" : "",
         "operationId" : "get_network_getprotocolversion",
         "parameters" : [ ],
@@ -3051,7 +3051,7 @@
     },
     "/network/setup/{holdingidentityshorthash}" : {
       "put" : {
-        "tags" : [ "Network API" ],
+        "tags" : [ "Network" ],
         "description" : "This method configures a holding identity as a network participant by setting properties required for P2P messaging.",
         "operationId" : "put_network_setup__holdingidentityshorthash_",
         "parameters" : [ {
@@ -3092,7 +3092,7 @@
     },
     "/permission" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method returns permissions which satisfy supplied query criteria.",
         "operationId" : "get_permission",
         "parameters" : [ {
@@ -3177,7 +3177,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method creates a new permission.",
         "operationId" : "post_permission",
         "parameters" : [ ],
@@ -3214,7 +3214,7 @@
     },
     "/permission/bulk" : {
       "post" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method creates a set of permissions and optionally assigns them to the existing roles.",
         "operationId" : "post_permission_bulk",
         "parameters" : [ ],
@@ -3251,7 +3251,7 @@
     },
     "/permission/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "",
         "operationId" : "get_permission_getprotocolversion",
         "parameters" : [ ],
@@ -3280,7 +3280,7 @@
     },
     "/permission/{id}" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method returns the permission associated with the specified ID.",
         "operationId" : "get_permission__id_",
         "parameters" : [ {
@@ -3317,7 +3317,7 @@
     },
     "/role" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method returns an array with information about all roles in the permission system.",
         "operationId" : "get_role",
         "parameters" : [ ],
@@ -3346,7 +3346,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "The method creates a new role in the RBAC permission system.",
         "operationId" : "post_role",
         "parameters" : [ ],
@@ -3383,7 +3383,7 @@
     },
     "/role/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "",
         "operationId" : "get_role_getprotocolversion",
         "parameters" : [ ],
@@ -3412,7 +3412,7 @@
     },
     "/role/{id}" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method gets the details of a role specified by its ID.",
         "operationId" : "get_role__id_",
         "parameters" : [ {
@@ -3449,7 +3449,7 @@
     },
     "/role/{roleid}/permission/{permissionid}" : {
       "put" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method adds the specified permission to the specified role.",
         "operationId" : "put_role__roleid__permission__permissionid_",
         "parameters" : [ {
@@ -3495,7 +3495,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method removes the specified permission from the specified role.",
         "operationId" : "delete_role__roleid__permission__permissionid_",
         "parameters" : [ {
@@ -3543,7 +3543,7 @@
     },
     "/user" : {
       "post" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method creates a new user.",
         "operationId" : "post_user",
         "parameters" : [ ],
@@ -3580,7 +3580,7 @@
     },
     "/user/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "",
         "operationId" : "get_user_getprotocolversion",
         "parameters" : [ ],
@@ -3609,7 +3609,7 @@
     },
     "/user/otheruserpassword" : {
       "post" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method updates another user's password, only usable by admin.",
         "operationId" : "post_user_otheruserpassword",
         "parameters" : [ ],
@@ -3646,7 +3646,7 @@
     },
     "/user/selfpassword" : {
       "post" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method updates a users own password.",
         "operationId" : "post_user_selfpassword",
         "parameters" : [ ],
@@ -3692,7 +3692,7 @@
     },
     "/user/{loginname}" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method returns a user based on the specified login name.",
         "operationId" : "get_user__loginname_",
         "parameters" : [ {
@@ -3729,7 +3729,7 @@
     },
     "/user/{loginname}/permissionsummary" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method returns a summary of the user's permissions.",
         "operationId" : "get_user__loginname__permissionsummary",
         "parameters" : [ {
@@ -3766,7 +3766,7 @@
     },
     "/user/{loginname}/role/{roleid}" : {
       "put" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method assigns a specified role to a specified user.",
         "operationId" : "put_user__loginname__role__roleid_",
         "parameters" : [ {
@@ -3812,7 +3812,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method removes the specified role from the specified user.",
         "operationId" : "delete_user__loginname__role__roleid_",
         "parameters" : [ {
@@ -3860,7 +3860,7 @@
     },
     "/virtualnode" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method lists all virtual nodes in the cluster.",
         "operationId" : "get_virtualnode",
         "parameters" : [ ],
@@ -3884,7 +3884,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method creates a new virtual node.",
         "operationId" : "post_virtualnode",
         "parameters" : [ ],
@@ -3921,7 +3921,7 @@
     },
     "/virtualnode/create/db/crypto" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the Crypto SQL needed for intention to create a virtual node.",
         "operationId" : "get_virtualnode_create_db_crypto",
         "parameters" : [ ],
@@ -3949,7 +3949,7 @@
     },
     "/virtualnode/create/db/uniqueness" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the Uniqueness SQL needed for intention to create a virtual node.",
         "operationId" : "get_virtualnode_create_db_uniqueness",
         "parameters" : [ ],
@@ -3977,7 +3977,7 @@
     },
     "/virtualnode/create/db/vault/{cpichecksum}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the Vault SQL needed for intention to create a virtual node and latest uploaded CPI.",
         "operationId" : "get_virtualnode_create_db_vault__cpichecksum_",
         "parameters" : [ {
@@ -4016,7 +4016,7 @@
     },
     "/virtualnode/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "",
         "operationId" : "get_virtualnode_getprotocolversion",
         "parameters" : [ ],
@@ -4045,7 +4045,7 @@
     },
     "/virtualnode/status/{requestid}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the VirtualNodeOperationStatus for a given operation request id.",
         "operationId" : "get_virtualnode_status__requestid_",
         "parameters" : [ {
@@ -4082,7 +4082,7 @@
     },
     "/virtualnode/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the VirtualNodeInfo for a given Holding Identity ShortHash.",
         "operationId" : "get_virtualnode__holdingidentityshorthash_",
         "parameters" : [ {
@@ -4119,7 +4119,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/cpi/{targetcpifilechecksum}" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method upgrades a virtual node's CPI.",
         "operationId" : "put_virtualnode__virtualnodeshortid__cpi__targetcpifilechecksum_",
         "parameters" : [ {
@@ -4178,7 +4178,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/db" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method updates virtual node connection strings.",
         "operationId" : "put_virtualnode__virtualnodeshortid__db",
         "parameters" : [ {
@@ -4226,7 +4226,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/db/vault/{newcpichecksum}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the SQL needed to update the virtual node's CPI",
         "operationId" : "get_virtualnode__virtualnodeshortid__db_vault__newcpichecksum_",
         "parameters" : [ {
@@ -4276,7 +4276,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/state/{newstate}" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method updates the state of a new virtual node to one of the pre-defined values.",
         "operationId" : "put_virtualnode__virtualnodeshortid__state__newstate_",
         "parameters" : [ {
@@ -4324,7 +4324,7 @@
     },
     "/wrappingkey/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Key Rotation API" ],
+        "tags" : [ "Key Rotation" ],
         "description" : "",
         "operationId" : "get_wrappingkey_getprotocolversion",
         "parameters" : [ ],
@@ -4353,7 +4353,7 @@
     },
     "/wrappingkey/rotation/{tenantid}" : {
       "get" : {
-        "tags" : [ "Key Rotation API" ],
+        "tags" : [ "Key Rotation" ],
         "description" : "This method gets the status of the latest key rotation for [tenantId].",
         "operationId" : "get_wrappingkey_rotation__tenantid_",
         "parameters" : [ {
@@ -4388,7 +4388,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Key Rotation API" ],
+        "tags" : [ "Key Rotation" ],
         "description" : "This method enables to rotate master wrapping key or all wrapping keys for tenantId (holding identity ID or cluster-level tenant).",
         "operationId" : "post_wrappingkey_rotation__tenantid_",
         "parameters" : [ {
@@ -4567,7 +4567,6 @@
       },
       "ChangeOtherUserPasswordWrapperRequest" : {
         "required" : [ "password", "username" ],
-        "type" : "object",
         "properties" : {
           "password" : {
             "type" : "string",
@@ -5281,15 +5280,9 @@
         }
       },
       "KeyRotationStatusResponse" : {
-        "required" : [ "rotationInitiatedTimestamp", "lastUpdatedTimestamp", "rotatedKeyStatus", "status", "tenantId" ],
+        "required" : [ "lastUpdatedTimestamp", "rotatedKeyStatus", "rotationInitiatedTimestamp", "status", "tenantId" ],
         "type" : "object",
         "properties" : {
-          "rotationInitiatedTimestamp" : {
-            "type" : "string",
-            "format" : "datetime",
-            "nullable" : false,
-            "example" : "2022-06-24T10:15:30Z"
-          },
           "lastUpdatedTimestamp" : {
             "type" : "string",
             "format" : "datetime",
@@ -5314,6 +5307,12 @@
               },
               "example" : "No example available for this type"
             }
+          },
+          "rotationInitiatedTimestamp" : {
+            "type" : "string",
+            "format" : "datetime",
+            "nullable" : false,
+            "example" : "2022-06-24T10:15:30Z"
           },
           "status" : {
             "type" : "string",

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
@@ -12,67 +12,67 @@
     "basicAuth" : [ ]
   } ],
   "tags" : [ {
-    "name" : "CPI API",
+    "name" : "CPI",
     "description" : "The CPI API consists of a number of endpoints used to manage Corda Package Installer (CPI) files in the Corda cluster."
   }, {
-    "name" : "Certificate API",
+    "name" : "Certificate",
     "description" : "The Certificates API consists of endpoints used to work with certificates and related operations. The API allows you to import a certificate chain, and generate a certificate signing request (CSR) to be submitted to a certificate authority (CA)."
   }, {
-    "name" : "Configuration API",
+    "name" : "Configuration",
     "description" : "The Configuration API consists of a number of endpoints used to manage the configuration of Corda clusters."
   }, {
-    "name" : "Flow Info API",
+    "name" : "Flow Info",
     "description" : "The Flow Info API consists of a number of endpoints used to find out which flows can be invoked using the Flow Management API for a given identity."
   }, {
-    "name" : "Flow Management API",
+    "name" : "Flow Management",
     "description" : "The Flow Management API consists of a number of endpoints used to interact with flows."
   }, {
-    "name" : "HSM API",
+    "name" : "HSM",
     "description" : "The HSM API consists of endpoints used to work with Hardware Security Modules (HSM) for securely storing keys."
   }, {
-    "name" : "Hello Rest API",
+    "name" : "Hello Rest",
     "description" : "The Hello Rest API is used to test interactions via the Rest API. It verifies that a call to Rest can be made, and that the identity of the user making the call can be recognized. RBAC permissions are checked and the call is successfully processed by the HTTP-Rest worker."
   }, {
-    "name" : "Key Management API",
+    "name" : "Key Management",
     "description" : "The Keys Management API consists of endpoints used to manage public and private key pairs. The API allows you to list scheme codes which are supported by the associated HSM integration, retrieve information about key pairs owned by a tenant, generate a key pair for a tenant, and retrieve a tenant's public key in PEM format."
   }, {
-    "name" : "Key Rotation API",
+    "name" : "Key Rotation",
     "description" : "Contains operations related to rotation of the master, cluster-level and vNode wrapping keys."
   }, {
-    "name" : "MGM API",
+    "name" : "MGM",
     "description" : "The MGM API consists of a number of endpoints used to manage membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows you to generate the group policy for a membership group, required for new members to join the group."
   }, {
-    "name" : "MGM Admin API",
+    "name" : "MGM Admin",
     "description" : "The MGM Admin API consists of endpoints used to carry out administrative tasks on membership groups. A membership group is a logical grouping of a number of Corda Identities to communicate and transact with one another with a specific set of CorDapps. The API allows the MGM to perform actions such as force decline registration requests which may be displaying unexpected behaviour. This API should only be used by the MGM under exceptional circumstances."
   }, {
-    "name" : "Member Lookup API",
+    "name" : "Member Lookup",
     "description" : "The Member Lookup API consists of endpoints used to look up information related to membership groups."
   }, {
-    "name" : "Member Registration API",
+    "name" : "Member Registration",
     "description" : "The Member Registration API consists of a number of endpoints which manage holding identities' participation in membership groups. To participate in a membership group, the holding identity is required to make a registration request that needs to be approved by the MGM for that group. This API allows you to start the registration process for a holding identity, and check the status of a previously created registration request."
   }, {
-    "name" : "Network API",
+    "name" : "Network",
     "description" : "The Network API consists of endpoints which manage the setup of holding identities in P2P networks."
   }, {
-    "name" : "RBAC Permission API",
+    "name" : "RBAC Permission",
     "description" : "The RBAC Permission API consists of a number of endpoints enabling permissions management in the RBAC (role-based access control) permission system. You can get details of specified permissions and create new permissions."
   }, {
-    "name" : "RBAC Role API",
+    "name" : "RBAC Role",
     "description" : "The RBAC Role API consists of a number of endpoints enabling role management in the RBAC (role-based access control) permission system. You can get all roles in the system, create new roles and add and delete permissions from roles."
   }, {
-    "name" : "RBAC User API",
+    "name" : "RBAC User",
     "description" : "The RBAC User API consists of a number of endpoints enabling user management in the RBAC (role-based access control) permission system. You can get details of specified users, create new users, assign roles to users and remove roles from users."
   }, {
-    "name" : "Virtual Node API",
+    "name" : "Virtual Node",
     "description" : "The Virtual Nodes API consists of a number of endpoints to manage virtual nodes."
   }, {
-    "name" : "Virtual Node Maintenance API",
+    "name" : "Virtual Node Maintenance",
     "description" : "The Virtual Node Maintenance API consists of a series of endpoints used for virtual node management.Warning: Using these endpoints could be highly disruptive, so great care should be taken when using them."
   } ],
   "paths" : {
     "/certificate/cluster/{usage}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain aliases for a cluster.",
         "operationId" : "get_certificate_cluster__usage_",
         "parameters" : [ {
@@ -113,7 +113,7 @@
         }
       },
       "put" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method imports a certificate chain for a cluster.",
         "operationId" : "put_certificate_cluster__usage_",
         "parameters" : [ {
@@ -173,7 +173,7 @@
     },
     "/certificate/cluster/{usage}/{alias}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain in PEM format for a cluster.",
         "operationId" : "get_certificate_cluster__usage___alias_",
         "parameters" : [ {
@@ -223,7 +223,7 @@
     },
     "/certificate/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "",
         "operationId" : "get_certificate_getprotocolversion",
         "parameters" : [ ],
@@ -252,7 +252,7 @@
     },
     "/certificate/vnode/{holdingidentityid}/{usage}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain aliases for a virtual node.",
         "operationId" : "get_certificate_vnode__holdingidentityid___usage_",
         "parameters" : [ {
@@ -304,7 +304,7 @@
         }
       },
       "put" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method imports a certificate chain for a virtual node.",
         "operationId" : "put_certificate_vnode__holdingidentityid___usage_",
         "parameters" : [ {
@@ -375,7 +375,7 @@
     },
     "/certificate/vnode/{holdingidentityid}/{usage}/{alias}" : {
       "get" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method gets the certificate chain in PEM format for a virtual node.",
         "operationId" : "get_certificate_vnode__holdingidentityid___usage___alias_",
         "parameters" : [ {
@@ -436,7 +436,7 @@
     },
     "/certificate/{tenantid}/{keyid}" : {
       "post" : {
-        "tags" : [ "Certificate API" ],
+        "tags" : [ "Certificate" ],
         "description" : "This method enables you to generate a certificate signing request (CSR) for a tenant.",
         "operationId" : "post_certificate__tenantid___keyid_",
         "parameters" : [ {
@@ -497,7 +497,7 @@
     },
     "/config" : {
       "put" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "This method updates a section of the cluster configuration.",
         "operationId" : "put_config",
         "parameters" : [ ],
@@ -534,7 +534,7 @@
     },
     "/config/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "",
         "operationId" : "get_config_getprotocolversion",
         "parameters" : [ ],
@@ -563,7 +563,7 @@
     },
     "/config/{section}" : {
       "get" : {
-        "tags" : [ "Configuration API" ],
+        "tags" : [ "Configuration" ],
         "description" : "This method returns the 'active' configuration for the given section, in both the 'raw' format and with defaults applied.",
         "operationId" : "get_config__section_",
         "parameters" : [ {
@@ -600,7 +600,7 @@
     },
     "/cpi" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "The GET method returns a list of all CPIs uploaded to the cluster.",
         "operationId" : "get_cpi",
         "parameters" : [ ],
@@ -624,7 +624,7 @@
         }
       },
       "post" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "This method uses the POST method to upload a Corda Package Installer (CPI) file to the Corda cluster.",
         "operationId" : "post_cpi",
         "parameters" : [ ],
@@ -670,7 +670,7 @@
     },
     "/cpi/getprotocolversion" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "",
         "operationId" : "get_cpi_getprotocolversion",
         "parameters" : [ ],
@@ -699,7 +699,7 @@
     },
     "/cpi/status/{id}" : {
       "get" : {
-        "tags" : [ "CPI API" ],
+        "tags" : [ "CPI" ],
         "description" : "The status endpoint uses the GET method to return status information for the CPI upload with the given request ID.",
         "operationId" : "get_cpi_status__id_",
         "parameters" : [ {
@@ -736,7 +736,7 @@
     },
     "/flow/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "",
         "operationId" : "get_flow_getprotocolversion",
         "parameters" : [ ],
@@ -765,7 +765,7 @@
     },
     "/flow/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method returns an array containing the statuses of all flows for a specified holding identity, for a particular flow processing status if specified. An empty array is returned if there are no flows.",
         "operationId" : "get_flow__holdingidentityshorthash_",
         "parameters" : [ {
@@ -811,7 +811,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method starts a new instance for the specified flow for the specified holding identity.",
         "operationId" : "post_flow__holdingidentityshorthash_",
         "parameters" : [ {
@@ -859,7 +859,7 @@
     },
     "/flow/{holdingidentityshorthash}/{clientrequestid}" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method gets the current status of the specified flow instance.",
         "operationId" : "get_flow__holdingidentityshorthash___clientrequestid_",
         "parameters" : [ {
@@ -907,7 +907,7 @@
     },
     "/flow/{holdingidentityshorthash}/{clientrequestid}/result" : {
       "get" : {
-        "tags" : [ "Flow Management API" ],
+        "tags" : [ "Flow Management" ],
         "description" : "This method gets the result of the specified flow instance execution.",
         "operationId" : "get_flow__holdingidentityshorthash___clientrequestid__result",
         "parameters" : [ {
@@ -955,7 +955,7 @@
     },
     "/flowclass/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Flow Info API" ],
+        "tags" : [ "Flow Info" ],
         "description" : "",
         "operationId" : "get_flowclass_getprotocolversion",
         "parameters" : [ ],
@@ -984,7 +984,7 @@
     },
     "/flowclass/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Flow Info API" ],
+        "tags" : [ "Flow Info" ],
         "description" : "This method gets all flows that can be used by the specified holding identity.",
         "operationId" : "get_flowclass__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1021,7 +1021,7 @@
     },
     "/hello" : {
       "post" : {
-        "tags" : [ "Hello Rest API" ],
+        "tags" : [ "Hello Rest" ],
         "description" : "This method produces a greeting phrase for the addressee.",
         "operationId" : "post_hello",
         "parameters" : [ {
@@ -1060,7 +1060,7 @@
     },
     "/hello/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Hello Rest API" ],
+        "tags" : [ "Hello Rest" ],
         "description" : "",
         "operationId" : "get_hello_getprotocolversion",
         "parameters" : [ ],
@@ -1089,7 +1089,7 @@
     },
     "/hsm/getprotocolversion" : {
       "get" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "",
         "operationId" : "get_hsm_getprotocolversion",
         "parameters" : [ ],
@@ -1118,7 +1118,7 @@
     },
     "/hsm/soft/{tenantid}/{category}" : {
       "post" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "This method enables you to assign a soft HSM to the tenant for the specified category.",
         "operationId" : "post_hsm_soft__tenantid___category_",
         "parameters" : [ {
@@ -1166,7 +1166,7 @@
     },
     "/hsm/{tenantid}/{category}" : {
       "get" : {
-        "tags" : [ "HSM API" ],
+        "tags" : [ "HSM" ],
         "description" : "This method retrieves information on the HSM of the specified category assigned to the tenant.",
         "operationId" : "get_hsm__tenantid___category_",
         "parameters" : [ {
@@ -1214,7 +1214,7 @@
     },
     "/key/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "",
         "operationId" : "get_key_getprotocolversion",
         "parameters" : [ ],
@@ -1243,7 +1243,7 @@
     },
     "/key/{tenantid}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves information about a list of key pairs belonging to a tenant.",
         "operationId" : "get_key__tenantid_",
         "parameters" : [ {
@@ -1400,7 +1400,7 @@
     },
     "/key/{tenantid}/alias/{alias}/category/{hsmcategory}/scheme/{scheme}" : {
       "post" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method generates a new key pair for a tenant.",
         "operationId" : "post_key__tenantid__alias__alias__category__hsmcategory__scheme__scheme_",
         "parameters" : [ {
@@ -1470,7 +1470,7 @@
     },
     "/key/{tenantid}/schemes/{hsmcategory}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves a list of supported key schemes for a specified tenant and HSM category.",
         "operationId" : "get_key__tenantid__schemes__hsmcategory_",
         "parameters" : [ {
@@ -1524,7 +1524,7 @@
     },
     "/key/{tenantid}/{keyid}" : {
       "get" : {
-        "tags" : [ "Key Management API" ],
+        "tags" : [ "Key Management" ],
         "description" : "This method retrieves a tenant's public key in PEM format.",
         "operationId" : "get_key__tenantid___keyid_",
         "parameters" : [ {
@@ -1574,7 +1574,7 @@
     },
     "/maintenance/virtualnode/forcecpiupload" : {
       "post" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "Even if CPI with the same metadata has already been uploaded, this endpoint will overwrite the previously stored CPI record. This operation also purges any sandboxes running an overwritten version of a CPI. This action can take some time to process, therefore it is performed asynchronously.",
         "operationId" : "post_maintenance_virtualnode_forcecpiupload",
         "parameters" : [ ],
@@ -1620,7 +1620,7 @@
     },
     "/maintenance/virtualnode/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "",
         "operationId" : "get_maintenance_virtualnode_getprotocolversion",
         "parameters" : [ ],
@@ -1649,7 +1649,7 @@
     },
     "/maintenance/virtualnode/{virtualnodeshortid}/vault-schema/force-resync" : {
       "post" : {
-        "tags" : [ "Virtual Node Maintenance API" ],
+        "tags" : [ "Virtual Node Maintenance" ],
         "description" : "Rollback the virtual node database for the given virtual node short ID. Then apply current CPI migrations. This operation is destructive and will result in user vault data being deleted, but will not have any effect on system tables.",
         "operationId" : "post_maintenance_virtualnode__virtualnodeshortid__vault_schema_force_resync",
         "parameters" : [ {
@@ -1679,7 +1679,7 @@
     },
     "/members/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "",
         "operationId" : "get_members_getprotocolversion",
         "parameters" : [ ],
@@ -1708,7 +1708,7 @@
     },
     "/members/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "This method retrieves a list of all active and pending members in the membership group.",
         "operationId" : "get_members__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1825,7 +1825,7 @@
     },
     "/members/{holdingidentityshorthash}/group-parameters" : {
       "get" : {
-        "tags" : [ "Member Lookup API" ],
+        "tags" : [ "Member Lookup" ],
         "description" : "This method retrieves the group parameters of the membership group.",
         "operationId" : "get_members__holdingidentityshorthash__group_parameters",
         "parameters" : [ {
@@ -1862,7 +1862,7 @@
     },
     "/membership/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "",
         "operationId" : "get_membership_getprotocolversion",
         "parameters" : [ ],
@@ -1891,7 +1891,7 @@
     },
     "/membership/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method checks the statuses of all registration requests for a specified holding identity.",
         "operationId" : "get_membership__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1931,7 +1931,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method starts the registration process for a holding identity.",
         "operationId" : "post_membership__holdingidentityshorthash_",
         "parameters" : [ {
@@ -1979,7 +1979,7 @@
     },
     "/membership/{holdingidentityshorthash}/{registrationrequestid}" : {
       "get" : {
-        "tags" : [ "Member Registration API" ],
+        "tags" : [ "Member Registration" ],
         "description" : "This method checks the status of the specified registration request for a holding identity.",
         "operationId" : "get_membership__holdingidentityshorthash___registrationrequestid_",
         "parameters" : [ {
@@ -2027,7 +2027,7 @@
     },
     "/mgm/getprotocolversion" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm_getprotocolversion",
         "parameters" : [ ],
@@ -2056,7 +2056,7 @@
     },
     "/mgm/{holdingidentityshorthash}/activate" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This endpoint enables you to activate a previously suspended member.",
         "operationId" : "post_mgm__holdingidentityshorthash__activate",
         "parameters" : [ {
@@ -2097,7 +2097,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the set of rules the group is currently configured with",
         "operationId" : "get_mgm__holdingidentityshorthash__approval_rules",
         "parameters" : [ {
@@ -2137,7 +2137,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API adds a rule to the set of group approval rules.",
         "operationId" : "post_mgm__holdingidentityshorthash__approval_rules",
         "parameters" : [ {
@@ -2185,7 +2185,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/preauth" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the set of rules the group is currently configured with for registration request with a pre-auth token.",
         "operationId" : "get_mgm__holdingidentityshorthash__approval_rules_preauth",
         "parameters" : [ {
@@ -2225,7 +2225,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API adds a rule to the set of group approval rules for registrations including a pre-auth token.",
         "operationId" : "post_mgm__holdingidentityshorthash__approval_rules_preauth",
         "parameters" : [ {
@@ -2273,7 +2273,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/preauth/{ruleid}" : {
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API deletes a group approval rule for registrations including a pre-auth token.",
         "operationId" : "delete_mgm__holdingidentityshorthash__approval_rules_preauth__ruleid_",
         "parameters" : [ {
@@ -2314,7 +2314,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approval/rules/{ruleid}" : {
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API deletes a previously added group approval rule.",
         "operationId" : "delete_mgm__holdingidentityshorthash__approval_rules__ruleid_",
         "parameters" : [ {
@@ -2355,7 +2355,7 @@
     },
     "/mgm/{holdingidentityshorthash}/approve/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__approve__requestid_",
         "parameters" : [ {
@@ -2396,7 +2396,7 @@
     },
     "/mgm/{holdingidentityshorthash}/decline/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__decline__requestid_",
         "parameters" : [ {
@@ -2457,7 +2457,7 @@
     },
     "/mgm/{holdingidentityshorthash}/group-parameters" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API allows you to make changes to the group parameters by submitting an updated version of the group parameters.",
         "operationId" : "post_mgm__holdingidentityshorthash__group_parameters",
         "parameters" : [ {
@@ -2505,7 +2505,7 @@
     },
     "/mgm/{holdingidentityshorthash}/info" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API retrieves the group policy from the MGM required to join the membership group.",
         "operationId" : "get_mgm__holdingidentityshorthash__info",
         "parameters" : [ {
@@ -2544,7 +2544,7 @@
     },
     "/mgm/{holdingidentityshorthash}/mutual-tls/allowed-client-certificate-subjects" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API list the allowed  client certificates subjects to be used in mutual TLS connections.",
         "operationId" : "get_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects",
         "parameters" : [ {
@@ -2587,7 +2587,7 @@
     },
     "/mgm/{holdingidentityshorthash}/mutual-tls/allowed-client-certificate-subjects/{subject}" : {
       "put" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API allows a client certificate with a given subject to be used in mutual TLS connections.",
         "operationId" : "put_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects__subject_",
         "parameters" : [ {
@@ -2626,7 +2626,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "This API disallows a client certificate with a given subject to be used in mutual TLS connections.",
         "operationId" : "delete_mgm__holdingidentityshorthash__mutual_tls_allowed_client_certificate_subjects__subject_",
         "parameters" : [ {
@@ -2667,7 +2667,7 @@
     },
     "/mgm/{holdingidentityshorthash}/preauthtoken" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm__holdingidentityshorthash__preauthtoken",
         "parameters" : [ {
@@ -2736,7 +2736,7 @@
         }
       },
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "post_mgm__holdingidentityshorthash__preauthtoken",
         "parameters" : [ {
@@ -2783,7 +2783,7 @@
     },
     "/mgm/{holdingidentityshorthash}/preauthtoken/revoke/{preauthtokenid}" : {
       "put" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "put_mgm__holdingidentityshorthash__preauthtoken_revoke__preauthtokenid_",
         "parameters" : [ {
@@ -2847,7 +2847,7 @@
     },
     "/mgm/{holdingidentityshorthash}/registrations" : {
       "get" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "",
         "operationId" : "get_mgm__holdingidentityshorthash__registrations",
         "parameters" : [ {
@@ -2911,7 +2911,7 @@
     },
     "/mgm/{holdingidentityshorthash}/suspend" : {
       "post" : {
-        "tags" : [ "MGM API" ],
+        "tags" : [ "MGM" ],
         "description" : "The suspend endpoint enables you to suspend a member.",
         "operationId" : "post_mgm__holdingidentityshorthash__suspend",
         "parameters" : [ {
@@ -2952,7 +2952,7 @@
     },
     "/mgmadmin/getprotocolversion" : {
       "get" : {
-        "tags" : [ "MGM Admin API" ],
+        "tags" : [ "MGM Admin" ],
         "description" : "",
         "operationId" : "get_mgmadmin_getprotocolversion",
         "parameters" : [ ],
@@ -2981,7 +2981,7 @@
     },
     "/mgmadmin/{holdingidentityshorthash}/force-decline/{requestid}" : {
       "post" : {
-        "tags" : [ "MGM Admin API" ],
+        "tags" : [ "MGM Admin" ],
         "description" : "This method enables you to force decline an in-progress registration request that may be stuck or displaying some other unexpected behaviour.",
         "operationId" : "post_mgmadmin__holdingidentityshorthash__force_decline__requestid_",
         "parameters" : [ {
@@ -3022,7 +3022,7 @@
     },
     "/network/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Network API" ],
+        "tags" : [ "Network" ],
         "description" : "",
         "operationId" : "get_network_getprotocolversion",
         "parameters" : [ ],
@@ -3051,7 +3051,7 @@
     },
     "/network/setup/{holdingidentityshorthash}" : {
       "put" : {
-        "tags" : [ "Network API" ],
+        "tags" : [ "Network" ],
         "description" : "This method configures a holding identity as a network participant by setting properties required for P2P messaging.",
         "operationId" : "put_network_setup__holdingidentityshorthash_",
         "parameters" : [ {
@@ -3092,7 +3092,7 @@
     },
     "/permission" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method returns permissions which satisfy supplied query criteria.",
         "operationId" : "get_permission",
         "parameters" : [ {
@@ -3177,7 +3177,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method creates a new permission.",
         "operationId" : "post_permission",
         "parameters" : [ ],
@@ -3214,7 +3214,7 @@
     },
     "/permission/bulk" : {
       "post" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method creates a set of permissions and optionally assigns them to the existing roles.",
         "operationId" : "post_permission_bulk",
         "parameters" : [ ],
@@ -3251,7 +3251,7 @@
     },
     "/permission/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "",
         "operationId" : "get_permission_getprotocolversion",
         "parameters" : [ ],
@@ -3280,7 +3280,7 @@
     },
     "/permission/{id}" : {
       "get" : {
-        "tags" : [ "RBAC Permission API" ],
+        "tags" : [ "RBAC Permission" ],
         "description" : "This method returns the permission associated with the specified ID.",
         "operationId" : "get_permission__id_",
         "parameters" : [ {
@@ -3317,7 +3317,7 @@
     },
     "/role" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method returns an array with information about all roles in the permission system.",
         "operationId" : "get_role",
         "parameters" : [ ],
@@ -3346,7 +3346,7 @@
         }
       },
       "post" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "The method creates a new role in the RBAC permission system.",
         "operationId" : "post_role",
         "parameters" : [ ],
@@ -3383,7 +3383,7 @@
     },
     "/role/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "",
         "operationId" : "get_role_getprotocolversion",
         "parameters" : [ ],
@@ -3412,7 +3412,7 @@
     },
     "/role/{id}" : {
       "get" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method gets the details of a role specified by its ID.",
         "operationId" : "get_role__id_",
         "parameters" : [ {
@@ -3449,7 +3449,7 @@
     },
     "/role/{roleid}/permission/{permissionid}" : {
       "put" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method adds the specified permission to the specified role.",
         "operationId" : "put_role__roleid__permission__permissionid_",
         "parameters" : [ {
@@ -3495,7 +3495,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "RBAC Role API" ],
+        "tags" : [ "RBAC Role" ],
         "description" : "This method removes the specified permission from the specified role.",
         "operationId" : "delete_role__roleid__permission__permissionid_",
         "parameters" : [ {
@@ -3543,7 +3543,7 @@
     },
     "/user" : {
       "post" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method creates a new user.",
         "operationId" : "post_user",
         "parameters" : [ ],
@@ -3580,7 +3580,7 @@
     },
     "/user/getprotocolversion" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "",
         "operationId" : "get_user_getprotocolversion",
         "parameters" : [ ],
@@ -3609,7 +3609,7 @@
     },
     "/user/otheruserpassword" : {
       "post" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method updates another user's password, only usable by admin.",
         "operationId" : "post_user_otheruserpassword",
         "parameters" : [ ],
@@ -3646,7 +3646,7 @@
     },
     "/user/selfpassword" : {
       "post" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method updates a users own password.",
         "operationId" : "post_user_selfpassword",
         "parameters" : [ ],
@@ -3692,7 +3692,7 @@
     },
     "/user/{loginname}" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method returns a user based on the specified login name.",
         "operationId" : "get_user__loginname_",
         "parameters" : [ {
@@ -3729,7 +3729,7 @@
     },
     "/user/{loginname}/permissionsummary" : {
       "get" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method returns a summary of the user's permissions.",
         "operationId" : "get_user__loginname__permissionsummary",
         "parameters" : [ {
@@ -3766,7 +3766,7 @@
     },
     "/user/{loginname}/role/{roleid}" : {
       "put" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method assigns a specified role to a specified user.",
         "operationId" : "put_user__loginname__role__roleid_",
         "parameters" : [ {
@@ -3812,7 +3812,7 @@
         }
       },
       "delete" : {
-        "tags" : [ "RBAC User API" ],
+        "tags" : [ "RBAC User" ],
         "description" : "This method removes the specified role from the specified user.",
         "operationId" : "delete_user__loginname__role__roleid_",
         "parameters" : [ {
@@ -3860,7 +3860,7 @@
     },
     "/virtualnode" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method lists all virtual nodes in the cluster.",
         "operationId" : "get_virtualnode",
         "parameters" : [ ],
@@ -3884,7 +3884,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method creates a new virtual node.",
         "operationId" : "post_virtualnode",
         "parameters" : [ ],
@@ -3921,7 +3921,7 @@
     },
     "/virtualnode/create/db/crypto" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the Crypto SQL needed for intention to create a virtual node.",
         "operationId" : "get_virtualnode_create_db_crypto",
         "parameters" : [ ],
@@ -3949,7 +3949,7 @@
     },
     "/virtualnode/create/db/uniqueness" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the Uniqueness SQL needed for intention to create a virtual node.",
         "operationId" : "get_virtualnode_create_db_uniqueness",
         "parameters" : [ ],
@@ -3977,7 +3977,7 @@
     },
     "/virtualnode/create/db/vault/{cpichecksum}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the Vault SQL needed for intention to create a virtual node and latest uploaded CPI.",
         "operationId" : "get_virtualnode_create_db_vault__cpichecksum_",
         "parameters" : [ {
@@ -4016,7 +4016,7 @@
     },
     "/virtualnode/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "",
         "operationId" : "get_virtualnode_getprotocolversion",
         "parameters" : [ ],
@@ -4045,7 +4045,7 @@
     },
     "/virtualnode/status/{requestid}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the VirtualNodeOperationStatus for a given operation request id.",
         "operationId" : "get_virtualnode_status__requestid_",
         "parameters" : [ {
@@ -4082,7 +4082,7 @@
     },
     "/virtualnode/{holdingidentityshorthash}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the VirtualNodeInfo for a given Holding Identity ShortHash.",
         "operationId" : "get_virtualnode__holdingidentityshorthash_",
         "parameters" : [ {
@@ -4119,7 +4119,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/cpi/{targetcpifilechecksum}" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method upgrades a virtual node's CPI.",
         "operationId" : "put_virtualnode__virtualnodeshortid__cpi__targetcpifilechecksum_",
         "parameters" : [ {
@@ -4178,7 +4178,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/db" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method updates virtual node connection strings.",
         "operationId" : "put_virtualnode__virtualnodeshortid__db",
         "parameters" : [ {
@@ -4226,7 +4226,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/db/vault/{newcpichecksum}" : {
       "get" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method returns the SQL needed to update the virtual node's CPI",
         "operationId" : "get_virtualnode__virtualnodeshortid__db_vault__newcpichecksum_",
         "parameters" : [ {
@@ -4276,7 +4276,7 @@
     },
     "/virtualnode/{virtualnodeshortid}/state/{newstate}" : {
       "put" : {
-        "tags" : [ "Virtual Node API" ],
+        "tags" : [ "Virtual Node" ],
         "description" : "This method updates the state of a new virtual node to one of the pre-defined values.",
         "operationId" : "put_virtualnode__virtualnodeshortid__state__newstate_",
         "parameters" : [ {
@@ -4324,7 +4324,7 @@
     },
     "/wrappingkey/getprotocolversion" : {
       "get" : {
-        "tags" : [ "Key Rotation API" ],
+        "tags" : [ "Key Rotation" ],
         "description" : "",
         "operationId" : "get_wrappingkey_getprotocolversion",
         "parameters" : [ ],
@@ -4353,7 +4353,7 @@
     },
     "/wrappingkey/rotation/{tenantid}" : {
       "get" : {
-        "tags" : [ "Key Rotation API" ],
+        "tags" : [ "Key Rotation" ],
         "description" : "This method gets the status of the latest key rotation for [tenantId].",
         "operationId" : "get_wrappingkey_rotation__tenantid_",
         "parameters" : [ {
@@ -4388,7 +4388,7 @@
         }
       },
       "post" : {
-        "tags" : [ "Key Rotation API" ],
+        "tags" : [ "Key Rotation" ],
         "description" : "This method enables to rotate master wrapping key or all wrapping keys for tenantId (holding identity ID or cluster-level tenant).",
         "operationId" : "post_wrappingkey_rotation__tenantid_",
         "parameters" : [ {
@@ -4567,7 +4567,6 @@
       },
       "ChangeOtherUserPasswordWrapperRequest" : {
         "required" : [ "password", "username" ],
-        "type" : "object",
         "properties" : {
           "password" : {
             "type" : "string",


### PR DESCRIPTION
- Remove "API" from RestResource names. This changes the class name for the generated client from `VirtualNodeAPIApi` to `VirtualNodeApi`
- Update swaggerBaselines