### PR TITLE
CORE-19896 timestamp check in query

### DIFF
--- a/components/flow/flow-service/build.gradle
+++ b/components/flow/flow-service/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation "co.paralleluniverse:quasar-core-osgi:$quasarVersion"
     implementation "com.esotericsoftware:kryo:$kryoVersion"
     implementation libs.jackson.module.kotlin
+    implementation libs.jackson.datatype.jsr310
 
     testImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
     testImplementation libs.jackson.module.kotlin

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.state.impl
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePair
@@ -46,7 +47,7 @@ class FlowCheckpointImpl(
     }
 
     private companion object {
-        val objectMapper = ObjectMapper().registerKotlinModule()
+        val objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
     }
 
     private val pipelineStateManager = PipelineStateManager(checkpoint.pipelineState)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl
 
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.pipeline.sessions.protocol.FlowProtocolStore
@@ -71,7 +72,8 @@ class UtxoLedgerServiceImpl @Activate constructor(
     @Reference(service = ExternalEventExecutor::class) private val externalEventExecutor: ExternalEventExecutor,
     @Reference(service = ResultSetFactory::class) private val resultSetFactory: ResultSetFactory,
     @Reference(service = UtxoLedgerTransactionVerificationService::class)
-    private val transactionVerificationService: UtxoLedgerTransactionVerificationService
+    private val transactionVerificationService: UtxoLedgerTransactionVerificationService,
+    @Reference(service = FlowCheckpointService::class) private val flowCheckpointService: FlowCheckpointService,
 ) : UtxoLedgerService, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
@@ -204,7 +206,8 @@ class UtxoLedgerServiceImpl @Activate constructor(
             limit = Int.MAX_VALUE,
             offset = 0,
             resultClass,
-            clock
+            clock,
+            flowCheckpointService
         )
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -250,14 +250,16 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
 
     private fun updateTimeInCheckpoint(persistTimeStamp: Instant) {
         @Suppress("deprecation", "removal")
-        java.security.AccessController.doPrivileged(PrivilegedExceptionAction {
-            val previousTimeStamp =
-                flowCheckpointService.getCheckpoint().readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
-            if (previousTimeStamp == null || previousTimeStamp.lastPersistedTimestamp < persistTimeStamp) {
-                flowCheckpointService.getCheckpoint()
-                    .writeCustomState(UtxoLedgerLastPersistedTimestamp(persistTimeStamp))
+        java.security.AccessController.doPrivileged(
+            PrivilegedExceptionAction {
+                val previousTimeStamp =
+                    flowCheckpointService.getCheckpoint().readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
+                if (previousTimeStamp == null || previousTimeStamp.lastPersistedTimestamp < persistTimeStamp) {
+                    flowCheckpointService.getCheckpoint()
+                        .writeCustomState(UtxoLedgerLastPersistedTimestamp(persistTimeStamp))
+                }
             }
-        })
+        )
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -65,6 +65,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import java.security.PrivilegedExceptionAction
 import java.security.PublicKey
 import java.time.Instant
 
@@ -248,11 +249,15 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
     }
 
     private fun updateTimeInCheckpoint(persistTimeStamp: Instant) {
-        val previousTimeStamp =
-            flowCheckpointService.getCheckpoint().readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
-        if (previousTimeStamp == null || previousTimeStamp.lastPersistedTimestamp < persistTimeStamp) {
-            flowCheckpointService.getCheckpoint().writeCustomState(UtxoLedgerLastPersistedTimestamp(persistTimeStamp))
-        }
+        @Suppress("deprecation", "removal")
+        java.security.AccessController.doPrivileged(PrivilegedExceptionAction {
+            val previousTimeStamp =
+                flowCheckpointService.getCheckpoint().readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
+            if (previousTimeStamp == null || previousTimeStamp.lastPersistedTimestamp < persistTimeStamp) {
+                flowCheckpointService.getCheckpoint()
+                    .writeCustomState(UtxoLedgerLastPersistedTimestamp(persistTimeStamp))
+            }
+        })
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -88,10 +88,10 @@ class VaultNamedParameterizedQueryImpl<T>(
         return resultSet
     }
 
-    private fun getNowOrLatestAsOfLastPersistence(): Instant{
-        return clock.instant().let{ now ->
+    private fun getNowOrLatestAsOfLastPersistence(): Instant {
+        return clock.instant().let { now ->
             flowCheckpointService.getCheckpoint().readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
-                ?.lastPersistedTimestamp?.let{prev ->
+                ?.lastPersistedTimestamp?.let { prev ->
                     if (now < prev) prev else now
                 } ?: now
         }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -79,7 +79,7 @@ class UtxoLedgerPersistenceServiceImplTest {
         private val future = now.plusSeconds(1)
 
         @JvmStatic
-        private fun provideTimeArguments(): Array<TimeArguments>{
+        private fun provideTimeArguments(): Array<TimeArguments> {
             return arrayOf(
                 TimeArguments(null, now),
                 TimeArguments(past, now),
@@ -103,8 +103,6 @@ class UtxoLedgerPersistenceServiceImplTest {
     private val stateAndRefCache = mock<StateAndRefCache>()
     private val flowCheckpointService = mock<FlowCheckpointService>()
     private val flowCheckpoint = mock<FlowCheckpoint>()
-
-
 
     private val notaryServiceKey = mock<CompositeKey>()
     private val publicKeyNotaryVNode1 = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x01)) }
@@ -131,7 +129,6 @@ class UtxoLedgerPersistenceServiceImplTest {
             flowCheckpointService
         )
 
-
         whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
         whenever(
             externalEventExecutor.execute(
@@ -153,7 +150,7 @@ class UtxoLedgerPersistenceServiceImplTest {
         whenever(notaryServiceKey.isFulfilledBy(publicKeyNotaryVNode2)).thenReturn(true)
     }
 
-    data class TimeArguments( val previousPersist: Instant?, val verifyPutWith: Instant?)
+    data class TimeArguments(val previousPersist: Instant?, val verifyPutWith: Instant?)
 
     @ParameterizedTest
     @MethodSource("provideTimeArguments")
@@ -165,7 +162,7 @@ class UtxoLedgerPersistenceServiceImplTest {
         whenever(transaction.signatures).thenReturn(mock())
 
         whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
-            .then{ args.previousPersist?.let{UtxoLedgerLastPersistedTimestamp(it)}}
+            .then { args.previousPersist?.let { UtxoLedgerLastPersistedTimestamp(it) } }
 
         assertThat(
             utxoLedgerPersistenceService.persist(

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -4,7 +4,9 @@ import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.crypto.core.parseSecureHash
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.flow.state.FlowCheckpoint
 import net.corda.internal.serialization.SerializedBytesImpl
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
@@ -15,6 +17,7 @@ import net.corda.ledger.common.flow.transaction.TransactionSignatureServiceInter
 import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoComponentGroup
 import net.corda.ledger.utxo.data.transaction.UtxoFilteredTransactionAndSignaturesImpl
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerLastPersistedTimestamp
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionImpl
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerTransactionInternal
 import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
@@ -52,6 +55,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -68,6 +73,21 @@ class UtxoLedgerPersistenceServiceImplTest {
     private companion object {
         private val byteBuffer = ByteBuffer.wrap("bytes".toByteArray())
         private val serializedBytes = SerializedBytesImpl<Any>(byteBuffer.array())
+
+        private val now = Instant.ofEpochSecond(3600)
+        private val past = now.minusSeconds(1)
+        private val future = now.plusSeconds(1)
+
+        @JvmStatic
+        private fun provideTimeArguments(): Array<TimeArguments>{
+            return arrayOf(
+                TimeArguments(null, now),
+                TimeArguments(past, now),
+                TimeArguments(future, null),
+                TimeArguments(now, null)
+
+            )
+        }
     }
 
     private val externalEventExecutor = mock<ExternalEventExecutor>()
@@ -81,6 +101,10 @@ class UtxoLedgerPersistenceServiceImplTest {
     private val virtualNodeContext = mock<VirtualNodeContext>()
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     private val stateAndRefCache = mock<StateAndRefCache>()
+    private val flowCheckpointService = mock<FlowCheckpointService>()
+    private val flowCheckpoint = mock<FlowCheckpoint>()
+
+
 
     private val notaryServiceKey = mock<CompositeKey>()
     private val publicKeyNotaryVNode1 = mock<PublicKey>().also { whenever(it.encoded).thenReturn(byteArrayOf(0x01)) }
@@ -103,8 +127,10 @@ class UtxoLedgerPersistenceServiceImplTest {
             utxoSignedTransactionFactory,
             utxoFilteredTransactionFactory,
             notarySignatureVerificationService,
-            stateAndRefCache
+            stateAndRefCache,
+            flowCheckpointService
         )
+
 
         whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
         whenever(
@@ -119,19 +145,27 @@ class UtxoLedgerPersistenceServiceImplTest {
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
         whenever(stateAndRefCache.putAll(any())).doAnswer {}
 
+        whenever(flowCheckpointService.getCheckpoint()).thenReturn(flowCheckpoint)
+
         // Composite key containing both of the notary VNode keys
         whenever(notaryServiceKey.leafKeys).thenReturn(setOf(publicKeyNotaryVNode1, publicKeyNotaryVNode2))
         whenever(notaryServiceKey.isFulfilledBy(publicKeyNotaryVNode1)).thenReturn(true)
         whenever(notaryServiceKey.isFulfilledBy(publicKeyNotaryVNode2)).thenReturn(true)
     }
 
-    @Test
-    fun `persist executes successfully`() {
-        val expectedObj = mock<Instant>()
+    data class TimeArguments( val previousPersist: Instant?, val verifyPutWith: Instant?)
+
+    @ParameterizedTest
+    @MethodSource("provideTimeArguments")
+    fun `persist executes successfully and updates timestamp in flow checkpoing when required`(args: TimeArguments) {
+        val expectedObj = now
         whenever(serializationService.deserialize<Instant>(any<ByteArray>(), any())).thenReturn(expectedObj)
         val transaction = mock<UtxoSignedTransactionInternal>()
         whenever(transaction.wireTransaction).thenReturn(mock())
         whenever(transaction.signatures).thenReturn(mock())
+
+        whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
+            .then{ args.previousPersist?.let{UtxoLedgerLastPersistedTimestamp(it)}}
 
         assertThat(
             utxoLedgerPersistenceService.persist(
@@ -143,6 +177,9 @@ class UtxoLedgerPersistenceServiceImplTest {
         verify(serializationService).serialize(any<Any>())
         verify(serializationService).deserialize<Instant>(any<ByteArray>(), any())
         assertThat(argumentCaptor.firstValue).isEqualTo(PersistTransactionExternalEventFactory::class.java)
+        args.verifyPutWith?.let {
+            verify(flowCheckpoint).writeCustomState(UtxoLedgerLastPersistedTimestamp(it))
+        }
     }
 
     @Test

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -1,8 +1,11 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.persistence.query.StableResultSetExecutor
+import net.corda.flow.state.FlowCheckpoint
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerLastPersistedTimestamp
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.ALICE_X500_HOLDING_IDENTITY
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.VaultNamedQueryExternalEventFactory
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
@@ -17,10 +20,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
@@ -29,10 +35,24 @@ class VaultNamedParameterizedQueryImplTest {
 
     private companion object {
         const val TIMESTAMP_LIMIT_PARAM_NAME = "Corda_TimestampLimit"
-        val now: Instant = Instant.now().minusSeconds(10)
-        val later: Instant = Instant.now().minusSeconds(10)
+        val customTimestamp: Instant = Instant.ofEpochSecond(1200)
+        val now: Instant = Instant.ofEpochSecond(3600)
+        val future: Instant = now.plusSeconds(2)
+        val past: Instant = now.minusSeconds(1)
         val results = listOf("A", "B")
+
+
+        @JvmStatic
+        private fun getTimeArguments() : Array<TimeArguments> = arrayOf(
+            TimeArguments(null, now),
+            TimeArguments(now, now),
+            TimeArguments(past, now),
+            TimeArguments(future, future)
+        )
+
     }
+
+    data class TimeArguments(val checkpointValue: Instant?, val expectedValue: Instant)
 
     private val externalEventExecutor = mock<ExternalEventExecutor>()
     private val sandbox = mock<SandboxGroupContext>()
@@ -43,6 +63,8 @@ class VaultNamedParameterizedQueryImplTest {
     private val clock = mock<Clock>()
     private val resultSetExecutorCaptor = argumentCaptor<StableResultSetExecutor<Any>>()
     private val mapCaptor = argumentCaptor<Map<String, Any>>()
+    private val flowCheckpointService = mock<FlowCheckpointService>()
+    private val flowCheckpoint = mock<FlowCheckpoint>()
 
     private val query = VaultNamedParameterizedQueryImpl(
         externalEventExecutor = externalEventExecutor,
@@ -53,17 +75,21 @@ class VaultNamedParameterizedQueryImplTest {
         limit = 1,
         offset = 0,
         resultClass = Any::class.java,
-        clock = clock
+        clock = clock,
+        flowCheckpointService = flowCheckpointService
     )
 
     @BeforeEach
     fun beforeEach() {
         whenever(resultSetFactory.create(mapCaptor.capture(), any(), any(), resultSetExecutorCaptor.capture())).thenReturn(resultSet)
         whenever(resultSet.next()).thenReturn(results)
-        whenever(clock.instant()).thenReturn(later)
+        whenever(clock.instant()).thenReturn(now)
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
+        whenever(flowCheckpointService.getCheckpoint()).thenReturn(flowCheckpoint)
+        whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
+            .thenReturn(null)
     }
 
     @Test
@@ -96,21 +122,30 @@ class VaultNamedParameterizedQueryImplTest {
         val parameterNameOne = "one"
         val parameterOne = "param one"
         query.setParameter(parameterNameOne, parameterOne)
-        query.setCreatedTimestampLimit(now)
+        query.setCreatedTimestampLimit(customTimestamp)
 
         query.execute()
-        assertThat(mapCaptor.firstValue).containsAllEntriesOf(mapOf(parameterNameOne to parameterOne, TIMESTAMP_LIMIT_PARAM_NAME to now))
+        verify(flowCheckpointService, never()).getCheckpoint()
+        assertThat(mapCaptor.firstValue).containsAllEntriesOf(mapOf(parameterNameOne to parameterOne, TIMESTAMP_LIMIT_PARAM_NAME to customTimestamp))
     }
 
-    @Test
-    fun `execute sets the timestamp limit to now if not set when there are no other parameters`() {
+    @ParameterizedTest
+    @MethodSource("getTimeArguments")
+    fun `execute sets the timestamp limit to now or the future if in the context if not set when there are no other parameters`(args: TimeArguments) {
+        whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
+            .thenReturn(args.checkpointValue?.let{UtxoLedgerLastPersistedTimestamp(it)})
         query.execute()
         verify(clock).instant()
-        assertThat(mapCaptor.firstValue).containsExactlyEntriesOf(mapOf(TIMESTAMP_LIMIT_PARAM_NAME to later))
+        assertThat(mapCaptor.firstValue).containsExactlyEntriesOf(mapOf(TIMESTAMP_LIMIT_PARAM_NAME to args.expectedValue))
     }
 
-    @Test
-    fun `execute sets the timestamp limit to now if not set when there are other parameters`() {
+
+
+    @ParameterizedTest
+    @MethodSource("getTimeArguments")
+    fun `execute sets the timestamp limit to now  or the future if in the context if not set when there are other parameters`(args: TimeArguments) {
+        whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
+            .thenReturn(args.checkpointValue?.let{UtxoLedgerLastPersistedTimestamp(it)})
         val parameterNameOne = "one"
         val parameterOne = "param one"
         query.setParameter(parameterNameOne, parameterOne)
@@ -119,7 +154,7 @@ class VaultNamedParameterizedQueryImplTest {
         assertThat(mapCaptor.firstValue).containsExactlyEntriesOf(
             mapOf(
                 parameterNameOne to parameterOne,
-                TIMESTAMP_LIMIT_PARAM_NAME to later
+                TIMESTAMP_LIMIT_PARAM_NAME to args.expectedValue
             )
         )
     }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -41,15 +41,13 @@ class VaultNamedParameterizedQueryImplTest {
         val past: Instant = now.minusSeconds(1)
         val results = listOf("A", "B")
 
-
         @JvmStatic
-        private fun getTimeArguments() : Array<TimeArguments> = arrayOf(
+        private fun getTimeArguments(): Array<TimeArguments> = arrayOf(
             TimeArguments(null, now),
             TimeArguments(now, now),
             TimeArguments(past, now),
             TimeArguments(future, future)
         )
-
     }
 
     data class TimeArguments(val checkpointValue: Instant?, val expectedValue: Instant)
@@ -126,26 +124,30 @@ class VaultNamedParameterizedQueryImplTest {
 
         query.execute()
         verify(flowCheckpointService, never()).getCheckpoint()
-        assertThat(mapCaptor.firstValue).containsAllEntriesOf(mapOf(parameterNameOne to parameterOne, TIMESTAMP_LIMIT_PARAM_NAME to customTimestamp))
+        assertThat(
+            mapCaptor.firstValue
+        ).containsAllEntriesOf(mapOf(parameterNameOne to parameterOne, TIMESTAMP_LIMIT_PARAM_NAME to customTimestamp))
     }
 
     @ParameterizedTest
     @MethodSource("getTimeArguments")
-    fun `execute sets the timestamp limit to now or the future if in the context if not set when there are no other parameters`(args: TimeArguments) {
+    fun `execute sets the timestamp limit to now or the future if in the context if not set when there are no other parameters`(
+        args: TimeArguments
+    ) {
         whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
-            .thenReturn(args.checkpointValue?.let{UtxoLedgerLastPersistedTimestamp(it)})
+            .thenReturn(args.checkpointValue?.let { UtxoLedgerLastPersistedTimestamp(it) })
         query.execute()
         verify(clock).instant()
         assertThat(mapCaptor.firstValue).containsExactlyEntriesOf(mapOf(TIMESTAMP_LIMIT_PARAM_NAME to args.expectedValue))
     }
 
-
-
     @ParameterizedTest
     @MethodSource("getTimeArguments")
-    fun `execute sets the timestamp limit to now  or the future if in the context if not set when there are other parameters`(args: TimeArguments) {
+    fun `execute sets the timestamp limit to now  or the future if in the context if not set when there are other parameters`(
+        args: TimeArguments
+    ) {
         whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
-            .thenReturn(args.checkpointValue?.let{UtxoLedgerLastPersistedTimestamp(it)})
+            .thenReturn(args.checkpointValue?.let { UtxoLedgerLastPersistedTimestamp(it) })
         val parameterNameOne = "one"
         val parameterOne = "param one"
         query.setParameter(parameterNameOne, parameterOne)

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoLedgerLastPersistedTimestamp.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoLedgerLastPersistedTimestamp.kt
@@ -1,0 +1,9 @@
+package net.corda.ledger.utxo.data.transaction
+
+import net.corda.v5.base.annotations.CordaSerializable
+import java.time.Instant
+
+@CordaSerializable
+data class UtxoLedgerLastPersistedTimestamp(
+    val lastPersistedTimestamp: Instant
+)

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.test
 
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
@@ -98,7 +99,8 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
         mockNotaryLookup,
         mockExternalEventExecutor,
         mockResultSetFactory,
-        mockUtxoLedgerTransactionVerificationService
+        mockUtxoLedgerTransactionVerificationService,
+        mock<FlowCheckpointService>()
     )
     val utxoSignedTransactionKryoSerializer = UtxoSignedTransactionKryoSerializer(
         serializationServiceWithWireTx,


### PR DESCRIPTION
Whenever persisting a transaction, store the timestamp it was persisted at in the flow checkpoint if it's newer than the one stored there, and when querying without a timestamp (as of now), use the later of the stored one and now. This _shouldn't_ do anything, but clock skew between pods is real.

Co-authored-by: nkovacsx <nandor.kovacs@r3.com>