### PR TITLE
CORE-19913: Fix time parsing error by using Instant instead of Date

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -284,7 +284,7 @@ fun ClusterInfo.getTime(
             condition { it.code == ResponseCode.OK.statusCode }
         }
     }.headers.single { it.first == "Date" }.second
-)
+).toInstant()
 
 private fun <T> Semaphore.runWith(block: () -> T): T {
     this.acquire()


### PR DESCRIPTION
The way that Instant converts to string can cause issues when parsing as it strips milliseconds off if they're 0 so we use Instant for comparisons instead.

Paired with https://github.com/corda/corda-e2e-tests/pull/518