### PR TITLE
CORE-20065 - Subscription down caused member not found

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -111,6 +111,12 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                     in transientExceptions -> {
                         logWarningAndThrowIntermittentException("Error attempting to poll.", ex)
                     }
+                    in authExceptions -> {
+                        logWarningAndThrowAuthException(
+                            "Authentication error attempting to get end offsets.",
+                            ex
+                        )
+                    }
                     else -> logErrorAndThrowFatalException("Unexpected error attempting to poll.", ex)
                 }
             }
@@ -329,6 +335,12 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                     in transientExceptions -> {
                         logWarningAndThrowIntermittentException("Failed to commitSync offsets.", ex)
                     }
+                    in authExceptions -> {
+                        logWarningAndThrowAuthException(
+                            "Authentication error attempting to get end offsets.",
+                            ex
+                        )
+                    }
                     else -> {
                         logErrorAndThrowFatalException(
                             "Unexpected error attempting to commitSync offsets .", ex
@@ -359,6 +371,12 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                     }
                     in transientExceptions -> {
                         logWarningAndThrowIntermittentException("Failed to commitSync offsets for record $event.", ex)
+                    }
+                    in authExceptions -> {
+                        logWarningAndThrowAuthException(
+                            "Authentication error attempting to get end offsets.",
+                            ex
+                        )
                     }
                     else -> {
                         logErrorAndThrowFatalException(
@@ -444,6 +462,12 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                 in transientExceptions -> {
                     logWarningAndThrowIntermittentException(
                         "Intermittent error attempting to get partitions on topic $topic",
+                        ex
+                    )
+                }
+                in authExceptions -> {
+                    logWarningAndThrowAuthException(
+                        "Authentication error attempting to get end offsets.",
                         ex
                     )
                 }
@@ -539,6 +563,12 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                 in transientExceptions -> {
                     logWarningAndThrowIntermittentException(
                         "Intermittent error attempting to get position.",
+                        ex
+                    )
+                }
+                in authExceptions -> {
+                    logWarningAndThrowAuthException(
+                        "Authentication error attempting to get end offsets.",
                         ex
                     )
                 }
@@ -641,6 +671,13 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
                 in transientExceptions -> {
                     logWarningAndThrowIntermittentException(
                         "Intermittent error attempting to get end offsets.",
+                        ex
+                    )
+                }
+
+                in authExceptions -> {
+                    logWarningAndThrowAuthException(
+                        "Authentication error attempting to get end offsets.",
                         ex
                     )
                 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/CompactedSubscriptionImpl.kt
@@ -105,13 +105,7 @@ internal class CompactedSubscriptionImpl<K : Any, V : Any>(
                     }
 
                     is CordaMessageAPIAuthException -> {
-                        if (attempts < 3) {
-                            log.warn("$errorMsg. Attempts: $attempts. Retrying.", ex)
-                        } else {
-                            log.error("$errorMsg. Fatal error occurred. Closing subscription.", ex)
-                            threadLooper.updateLifecycleStatus(LifecycleStatus.ERROR, errorMsg)
-                            threadLooper.stopLoop()
-                        }
+                        onAuthException(attempts, threadLooper, ex)
                     }
 
                     else -> {
@@ -124,6 +118,16 @@ internal class CompactedSubscriptionImpl<K : Any, V : Any>(
         }
         latestValues?.apply { mapFactory.destroyMap(this) }
         latestValues = null
+    }
+
+    private fun onAuthException(attempts: Int, threadLooper: ThreadLooper, ex: Exception) {
+        if (attempts < 3) {
+            log.warn("$errorMsg. Attempts: $attempts. Retrying.", ex)
+        } else {
+            log.error("$errorMsg. Fatal error occurred. Closing subscription.", ex)
+            threadLooper.updateLifecycleStatus(LifecycleStatus.ERROR, errorMsg)
+            threadLooper.stopLoop()
+        }
     }
 
     private fun onError(bytes: ByteArray) {

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/ExceptionUtils.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/ExceptionUtils.kt
@@ -1,11 +1,32 @@
 package net.corda.messaging.utils
 
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.messaging.api.exception.CordaMessageAPIAuthException
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
+import net.corda.messaging.subscription.ThreadLooper
+import org.slf4j.Logger
 
 object ExceptionUtils {
     val CordaMessageAPIException: Set<Class<out Throwable>> = setOf(
         CordaMessageAPIFatalException::class.java,
-        CordaMessageAPIIntermittentException::class.java
+        CordaMessageAPIAuthException::class.java,
+        CordaMessageAPIIntermittentException::class.java,
     )
+}
+
+fun onAuthException(
+    log: Logger,
+    attempts: Int,
+    threadLooper: ThreadLooper,
+    ex: Exception,
+    errorMsg: String,
+) {
+    if (attempts < 3) {
+        log.warn("$errorMsg Attempts: $attempts. Retrying.", ex)
+    } else {
+        log.error("$errorMsg Fatal error occurred. Closing subscription.", ex)
+        threadLooper.updateLifecycleStatus(LifecycleStatus.ERROR, errorMsg)
+        threadLooper.stopLoop()
+    }
 }

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/exception/CordaMessageAPIExceptions.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/exception/CordaMessageAPIExceptions.kt
@@ -18,6 +18,13 @@ open class CordaMessageAPIIntermittentException(message: String?, exception: Exc
     CordaRuntimeException(message, exception)
 
 /**
+ * Intermittent error during authentication which can be retried a few times.
+ * We will attempt to retry a few times just in case if we face with an intermittent error from kafka side.
+ */
+open class CordaMessageAPIAuthException(message: String?, exception: Exception? = null) :
+    CordaRuntimeException(message, exception)
+
+/**
  * Only thrown from a producer. In this case the error is not fatal in the way [CordaMessageAPIFatalException] is, but
  * the producer must be closed and re-instantiated. Re-using the producer when this is thrown is not an option and
  * results in undefined behaviour. Subclass of [CordaMessageAPIIntermittentException] so if you are resetting the


### PR DESCRIPTION
Resiliency tests were failing, because membership group subscription was down in rest worker, due to:
`{"instant":{"epochSecond":1710217827,"nanoOfSecond":45000000},"thread":"compacted subscription thread MEMBERSHIP_GROUP_READER-membership.members","level":"ERROR","loggerName":"net.corda.messaging.subscription.CompactedSubscriptionImpl-COMPACTED--MEMBERSHIP_GROUP_READER--membership.members--07a6fc33-ed2a-419a-b82d-0fc13a7efa6e","message":"Failed to read records from group MEMBERSHIP_GROUP_READER, topic membership.members. Fatal error occurred. Closing subscription.","thrown":{"message":"Unexpected error attempting to get end offsets.","name":"net.corda.messaging.api.exception.CordaMessageAPIFatalException","extendedStackTrace":"net.corda.messaging.api.exception.CordaMessageAPIFatalException: Unexpected error attempting to get end offsets.\n\tat net.corda.messagebus.kafka.consumer.CordaKafkaConsumerImpl.logErrorAndThrowFatalException(CordaKafkaConsumerImpl.kt:467)\n\tat net.corda.messagebus.kafka.consumer.CordaKafkaConsumerImpl.endOffsets(CordaKafkaConsumerImpl.kt:666)\n\tat net.corda.messaging.subscription.CompactedSubscriptionImpl.pollAndProcessSnapshot(CompactedSubscriptionImpl.kt:133)\n\tat net.corda.messaging.subscription.CompactedSubscriptionImpl.runConsumeLoop(CompactedSubscriptionImpl.kt:95)\n\tat net.corda.messaging.subscription.CompactedSubscriptionImpl.access$runConsumeLoop(CompactedSubscriptionImpl.kt:24)\n\tat net.corda.messaging.subscription.CompactedSubscriptionImpl$threadLooper$1.invoke(CompactedSubscriptionImpl.kt:37)\n\tat net.corda.messaging.subscription.CompactedSubscriptionImpl$threadLooper$1.invoke(CompactedSubscriptionImpl.kt:37)\n\tat net.corda.messaging.subscription.ThreadLooper.runConsumeLoop(ThreadLooper.kt:174)\n\tat net.corda.messaging.subscription.ThreadLooper.access$runConsumeLoop(ThreadLooper.kt:27)\n\tat net.corda.messaging.subscription.ThreadLooper$StoppableThread$start$1$1.invoke(ThreadLooper.kt:106)\n\tat net.corda.messaging.subscription.ThreadLooper$StoppableThread$start$1$1.invoke(ThreadLooper.kt:106)\n\tat kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)\nCaused by: org.apache.kafka.common.errors.SaslAuthenticationException: Authentication failed during authentication due to invalid credentials with SASL mechanism SCRAM-SHA-256\n"},"endOfBatch":false,"loggerFqcn":"org.apache.logging.slf4j.Log4jLogger","threadId":302,"threadPriority":5,"timestamp":"2024-03-12T04:30:27.045Z"}`

The authentication error is there in the kafka logs as well. Only happens once and never seen again. The kafka pod apart from this, seems healthy and it does rebalances and logs messages as usual for other topics.

We are using compacted subscription in this case for the membership group reader. When the error happens we map it to CordaMessageAPIFatalException from which we decide not to try to recover at all. There are some intermittent problems/exceptions from which we try to recover via some re-try attempts.

As a result of this fatal exception we are closing down the subscription and move the lifecycle to ERROR state. From there we all know that due to the bug in lifecycle we go eventually DOWN and never recover instead of re-starting the pod.

I've added a re-try loop which will re-try 3 times in case we get the authentication exception.