### PR TITLE
CORE-19898 Get vault update correct when transactions stored out of order

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -735,7 +735,7 @@ class UtxoPersistenceServiceImplTest {
     }
 
     @Test
-    fun `persist filtered transaction when an unverified signed transaction exists for the same id sets is_filtered to true and override stauts to VERIFIED`() {
+    fun `persist filtered transaction when an unverified signed transaction exists for the same id sets is_filtered to true and leaves the status as UNVERIFIED`() {
         val signatures = createSignatures(Instant.now())
         val signedTransaction = createSignedTransaction(signatures = signatures)
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
@@ -760,7 +760,7 @@ class UtxoPersistenceServiceImplTest {
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
             assertThat(transaction).isNotNull
             assertThat(transaction.field<Boolean>("isFiltered")).isTrue()
-            assertThat(transaction.field<String>("status")).isEqualTo("V")
+            assertThat(transaction.field<String>("status")).isEqualTo("U")
             assertThat(transaction.field<Instant>("created")).isEqualTo(createdTimestamp)
             assertThat(transaction.field<Instant>("updated")).isEqualTo(updatedTimestamp)
         }
@@ -796,7 +796,7 @@ class UtxoPersistenceServiceImplTest {
     }
 
     @Test
-    fun `persist filtered transaction when a draft signed transaction exists for the same id sets is_filtered to true and override the status to VERIFIED`() {
+    fun `persist filtered transaction when a draft signed transaction exists for the same id sets is_filtered to true and leaves the status as DRAFT`() {
         val signatures = createSignatures(Instant.now())
         val signedTransaction = createSignedTransaction(signatures = signatures)
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
@@ -821,7 +821,7 @@ class UtxoPersistenceServiceImplTest {
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
             assertThat(transaction).isNotNull
             assertThat(transaction.field<Boolean>("isFiltered")).isTrue()
-            assertThat(transaction.field<String>("status")).isEqualTo("V")
+            assertThat(transaction.field<String>("status")).isEqualTo("D")
             assertThat(transaction.field<Instant>("created")).isEqualTo(createdTimestamp)
             assertThat(transaction.field<Instant>("updated")).isEqualTo(updatedTimestamp)
         }
@@ -1294,7 +1294,7 @@ class UtxoPersistenceServiceImplTest {
             val transaction = em.find(entityFactory.utxoTransaction, txASignedTransaction.id.toString())
             assertThat(transaction).isNotNull
             assertThat(transaction.field<Boolean>("isFiltered")).isTrue()
-            assertThat(transaction.field<String>("status")).isEqualTo("V")
+            assertThat(transaction.field<String>("status")).isEqualTo("U")
         }
 
         // persist verified signed txB

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -1156,7 +1156,6 @@ class UtxoPersistenceServiceImplTest {
             assertThat(transaction).isNotNull
             assertThat(transaction.field<Boolean>("isFiltered")).isTrue()
             assertThat(transaction.field<String>("status")).isEqualTo("V")
-            transaction.field<Instant>("created") to transaction.field<Instant>("updated")
         }
 
         // persist the subsequent transaction

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -1239,7 +1239,7 @@ class UtxoPersistenceServiceImplTest {
             txASignedTransaction,
             "account",
             UNVERIFIED,
-            emptyList(),
+            emptyList(), // visible states of unverified tx is always empty
             serializer = serializationService
         )
         val txAReaderVerified = TestUtxoTransactionReader(

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -1126,7 +1126,7 @@ class UtxoPersistenceServiceImplTest {
     }
 
     @Test
-    fun `persist verified signed transaction when a filtered transaction exists for the same id and a subsequent transaction has already been persisted`() {
+    fun `persist verified signed transaction consuming a filtered transaction when a filtered transaction for the same id exists for the same id updates states as consumed`() {
         val signatures = createSignatures(Instant.now())
         val signedTransaction = createSignedTransaction(outputStates = defaultVisibleTransactionOutputs, signatures = signatures)
         val filteredTransaction = createFilteredTransaction(signedTransaction, indexes = listOf(0, 1))
@@ -1227,7 +1227,7 @@ class UtxoPersistenceServiceImplTest {
     }
 
     @Test
-    fun `persist verified signed transaction consuming a filtered transaction that exists as an unverified signed transaction in DB`() {
+    fun `persist verified signed transaction consuming a filtered transaction when an unverified signed transaction exists for the same id updates states as consumed`() {
         val signatures = createSignatures(Instant.now())
         val txAIndexes = listOf(0, 1)
         val txASignedTransaction = createSignedTransaction(

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -75,7 +75,7 @@ interface UtxoRepository {
         timestamp: Instant,
         status: TransactionStatus,
         metadataHash: String
-    )
+    ): Boolean
 
     /** Persists unverified transaction (operation is idempotent) */
     @Suppress("LongParameterList")
@@ -98,6 +98,9 @@ interface UtxoRepository {
         timestamp: Instant,
         metadataHash: String,
     )
+
+    /** Updates an existing verified transaction */
+    fun updateTransactionToVerified(entityManager: EntityManager, id: String, timestamp: Instant)
 
     /** Persists transaction metadata (operation is idempotent) */
     fun persistTransactionMetadata(
@@ -223,4 +226,6 @@ interface UtxoRepository {
     )
 
     data class TransactionMerkleProofLeaf(val merkleProofId: String, val leafIndex: Int)
+
+    fun findConsumedTransactionSourcesForTransaction(entityManager: EntityManager, transactionId: String, indexes: List<Int>): List<Int>
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -204,6 +204,8 @@ interface UtxoRepository {
         ids: List<String>
     ): Map<String, UtxoFilteredTransactionDto>
 
+    fun findConsumedTransactionSourcesForTransaction(entityManager: EntityManager, transactionId: String, indexes: List<Int>): List<Int>
+
     data class TransactionComponent(val transactionId: String, val groupIndex: Int, val leafIndex: Int, val leafData: ByteArray)
 
     data class VisibleTransactionOutput(
@@ -226,6 +228,4 @@ interface UtxoRepository {
     )
 
     data class TransactionMerkleProofLeaf(val merkleProofId: String, val leafIndex: Int)
-
-    fun findConsumedTransactionSourcesForTransaction(entityManager: EntityManager, transactionId: String, indexes: List<Int>): List<Int>
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -193,4 +193,21 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
             	)
             WHERE utmp.transaction_id IN (:transactionIds)"""
             .trimIndent()
+
+    override val findConsumedTransactionSourcesForTransaction: String
+        get() = """
+            SELECT utxo_transaction_sources.source_state_idx from {h-schema}utxo_transaction_sources 
+            WHERE source_state_transaction_id = :transactionId 
+            AND group_idx = 6
+            AND source_state_idx in :inputStateIndexes
+        """.trimIndent()
+
+    override val updateTransactionToVerified: String
+        get() = """
+            UPDATE {h-schema}utxo_transaction 
+            SET status = '$VERIFIED', updated = :updatedAt
+            WHERE id = :transactionId
+            AND status in ('$UNVERIFIED', '$DRAFT') 
+            OR (status = $VERIFIED AND is_filtered = TRUE)
+        """.trimIndent()
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -205,9 +205,9 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
     override val updateTransactionToVerified: String
         get() = """
             UPDATE {h-schema}utxo_transaction 
-            SET status = '$VERIFIED', updated = :updatedAt
+            SET status = '$VERIFIED', updated = :updatedAt, is_filtered = FALSE
             WHERE id = :transactionId
             AND status in ('$UNVERIFIED', '$DRAFT') 
-            OR (status = $VERIFIED AND is_filtered = TRUE)
+            OR (status = '$VERIFIED' AND is_filtered = TRUE)
         """.trimIndent()
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -198,7 +198,7 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
         get() = """
             SELECT utxo_transaction_sources.source_state_idx from {h-schema}utxo_transaction_sources 
             WHERE source_state_transaction_id = :transactionId 
-            AND group_idx = 6
+            AND group_idx = ${UtxoComponentGroup.INPUTS.ordinal}
             AND source_state_idx in :inputStateIndexes
         """.trimIndent()
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -24,7 +24,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
                 VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash, FALSE)
             ON CONFLICT(id) DO
             UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated, is_filtered = FALSE
-            WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT') and utxo_transaction.is_filtered = FALSE
+            WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT')
             """
             .trimIndent()
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -24,7 +24,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
                 VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash, FALSE)
             ON CONFLICT(id) DO
             UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated, is_filtered = FALSE
-            WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT')
+            WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT') AND utxo_transaction.is_filtered = FALSE
             """
             .trimIndent()
 
@@ -46,7 +46,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
             INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (:id, :privacySalt, :accountId, :createdAt, '$VERIFIED', :updatedAt, :metadataHash, TRUE)
             ON CONFLICT(id) DO
-            UPDATE SET status = '$VERIFIED', is_filtered = TRUE
+            UPDATE SET is_filtered = TRUE
             WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT') AND utxo_transaction.is_filtered = FALSE
             """
             .trimIndent()

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -46,7 +46,7 @@ class PostgresUtxoQueryProvider @Activate constructor(
             INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (:id, :privacySalt, :accountId, :createdAt, '$VERIFIED', :updatedAt, :metadataHash, TRUE)
             ON CONFLICT(id) DO
-            UPDATE SET is_filtered = TRUE
+            UPDATE SET status = '$VERIFIED', is_filtered = TRUE
             WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT') AND utxo_transaction.is_filtered = FALSE
             """
             .trimIndent()

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -28,8 +28,6 @@ class PostgresUtxoQueryProvider @Activate constructor(
             """
             .trimIndent()
 
-    // add an update query for VERIFIED + is_filtered = false
-
     override val persistUnverifiedTransaction: String
         get() = """
             INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -18,17 +18,17 @@ class PostgresUtxoQueryProvider @Activate constructor(
         LoggerFactory.getLogger(this::class.java).debug { "Activated for ${databaseTypeProvider.databaseType}" }
     }
 
-    // the additional logic will allow repeated filtered transaction inserts to keep updating the table
     override val persistTransaction: String
         get() = """
             INSERT INTO {h-schema}utxo_transaction(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (:id, :privacySalt, :accountId, :createdAt, :status, :updatedAt, :metadataHash, FALSE)
             ON CONFLICT(id) DO
             UPDATE SET status = EXCLUDED.status, updated = EXCLUDED.updated, is_filtered = FALSE
-            WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT')
-                OR (utxo_transaction.status = '$VERIFIED' AND utxo_transaction.is_filtered = TRUE)
+            WHERE utxo_transaction.status in ('$UNVERIFIED', '$DRAFT') and utxo_transaction.is_filtered = FALSE
             """
             .trimIndent()
+
+    // add an update query for VERIFIED + is_filtered = false
 
     override val persistUnverifiedTransaction: String
         get() = """

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -513,7 +513,6 @@ class UtxoPersistenceServiceImpl(
         account: String
     ) {
         entityManagerFactory.transaction { em ->
-
             filteredTransactionsAndSignatures.forEach { (filteredTransaction, signatures) ->
 
                 val nowUtc = utcClock.instant()
@@ -550,7 +549,7 @@ class UtxoPersistenceServiceImpl(
                 )
 
                 // 3. Persist the transaction itself to the utxo_transaction table
-                // if the same id of UNVERIFIED or DRAFT stx exists, override them to VERIFIED ftx
+                // if the same id of UNVERIFIED or DRAFT stx exists, override status to VERIFIED
                 repository.persistFilteredTransaction(
                     em,
                     filteredTransaction.id.toString(),

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -335,18 +335,18 @@ class UtxoPersistenceServiceImpl(
                         transaction.status,
                         metadataHash,
                     )
-            } else {
-                // ignore if incoming transaction is an unverified stx
-                repository.persistUnverifiedTransaction(
-                    em,
-                    transactionIdString,
-                    transaction.privacySalt.bytes,
-                    transaction.account,
-                    nowUtc,
-                    metadataHash
-                )
-                null
-            }
+                } else {
+                    // ignore if the incoming transaction is an unverified stx
+                    repository.persistUnverifiedTransaction(
+                        em,
+                        transactionIdString,
+                        transaction.privacySalt.bytes,
+                        transaction.account,
+                        nowUtc,
+                        metadataHash
+                    )
+                    null
+                }
 
             repository.persistTransactionComponents(
                 em,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -317,18 +317,26 @@ class UtxoPersistenceServiceImpl(
                 requireNotNull(metadata.getCpiMetadata()) { "Metadata without CPI metadata" }.fileChecksum
             )
 
-            val inserted = if (transaction.status != TransactionStatus.UNVERIFIED) {
-                // Insert the Transaction
-                repository.persistTransaction(
-                    em,
-                    transactionIdString,
-                    transaction.privacySalt.bytes,
-                    transaction.account,
-                    nowUtc,
-                    transaction.status,
-                    metadataHash,
-                )
+            val inserted =
+                if (transaction.status != TransactionStatus.UNVERIFIED) {
+                    /**
+                     * Insert the Transaction
+                     * The record will only be inserted when:
+                     * - there is no record exists given txId
+                     * - there is record which is UNVERIFIED stx
+                     * - there is record which is DRAFT stx
+                     * */
+                    repository.persistTransaction(
+                        em,
+                        transactionIdString,
+                        transaction.privacySalt.bytes,
+                        transaction.account,
+                        nowUtc,
+                        transaction.status,
+                        metadataHash,
+                    )
             } else {
+                // ignore if incoming transaction is an unverified stx
                 repository.persistUnverifiedTransaction(
                     em,
                     transactionIdString,
@@ -357,9 +365,10 @@ class UtxoPersistenceServiceImpl(
 
             repository.persistTransactionSources(em, transactionIdString, consumedTransactionSources + referenceTransactionSources)
 
+            // rectify data from U -> V
             if (inserted != null && !inserted) {
-                // inserted != null means the tx in question is not UNVERIFIED
-                // tx not being inserted implies that tx of the same ID exists in the table
+                // inserted != null means the incoming tx is not UNVERIFIED (incoming U is always stx)
+                // tx not being inserted implies that tx of the same ID exists in the table, and need to be rectified
 
                 val indexes = repository.findConsumedTransactionSourcesForTransaction(
                     em,
@@ -384,7 +393,7 @@ class UtxoPersistenceServiceImpl(
                 }
                 repository.updateTransactionToVerified(em, transactionIdString, nowUtc)
             } else {
-                // outputs of UNVERIFIED would be empty
+                // outputs of stx UNVERIFIED would be empty
                 repository.persistVisibleTransactionOutputs(
                     em,
                     transactionIdString,
@@ -549,7 +558,7 @@ class UtxoPersistenceServiceImpl(
                 )
 
                 // 3. Persist the transaction itself to the utxo_transaction table
-                // if the same id of UNVERIFIED or DRAFT stx exists, override status to VERIFIED
+                // if the same id of UNVERIFIED or DRAFT stx exists, leaving the status as it is.
                 repository.persistFilteredTransaction(
                     em,
                     filteredTransaction.id.toString(),

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -121,4 +121,6 @@ interface UtxoQueryProvider {
      * @property findMerkleProofs SQL text for [UtxoRepositoryImpl.findMerkleProofs].
      */
     val findMerkleProofs: String
+    val findConsumedTransactionSourcesForTransaction: String
+    val updateTransactionToVerified: String
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -576,8 +576,6 @@ class UtxoRepositoryImpl(
     }
 
     // select from transaction sources where input states of "previous" transaction are seen as sourceTransactionIds + indexes
-
-
     override fun findConsumedTransactionSourcesForTransaction(
         entityManager: EntityManager,
         transactionId: String,
@@ -586,8 +584,8 @@ class UtxoRepositoryImpl(
         return entityManager.createNativeQuery(queryProvider.findConsumedTransactionSourcesForTransaction)
             .setParameter("transactionId", transactionId)
             .setParameter("inputStateIndexes", indexes)
-            .resultListAsTuples()
-            .map { it.get(0) as Int }
+            .resultList
+            .map { it as Int }
     }
 
     private fun <T> EntityManager.connection(block: (connection: Connection) -> T) {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -191,8 +191,8 @@ class UtxoRepositoryImpl(
         timestamp: Instant,
         status: TransactionStatus,
         metadataHash: String,
-    ) {
-        entityManager.createNativeQuery(queryProvider.persistTransaction)
+    ): Boolean {
+        return entityManager.createNativeQuery(queryProvider.persistTransaction)
             .setParameter("id", id)
             .setParameter("privacySalt", privacySalt)
             .setParameter("accountId", account)
@@ -200,8 +200,7 @@ class UtxoRepositoryImpl(
             .setParameter("status", status.value)
             .setParameter("updatedAt", timestamp)
             .setParameter("metadataHash", metadataHash)
-            .executeUpdate()
-            .logResult("transaction [$id]")
+            .executeUpdate() != 0
     }
 
     override fun persistUnverifiedTransaction(
@@ -242,6 +241,13 @@ class UtxoRepositoryImpl(
             .logResult("transaction [$id]")
     }
 
+    override fun updateTransactionToVerified(entityManager: EntityManager, id: String, timestamp: Instant) {
+        entityManager.createNativeQuery(queryProvider.updateTransactionToVerified)
+            .setParameter("transactionId", id)
+            .setParameter("updatedAt", timestamp)
+            .executeUpdate()
+    }
+
     override fun persistTransactionMetadata(
         entityManager: EntityManager,
         hash: String,
@@ -269,11 +275,11 @@ class UtxoRepositoryImpl(
                 queryProvider.persistTransactionSources,
                 transactionSources
             ) { statement, parameterIndex, transactionSource ->
-                statement.setString(parameterIndex.next(), transactionId)
-                statement.setInt(parameterIndex.next(), transactionSource.group.ordinal)
-                statement.setInt(parameterIndex.next(), transactionSource.index)
-                statement.setString(parameterIndex.next(), transactionSource.sourceTransactionId)
-                statement.setInt(parameterIndex.next(), transactionSource.sourceIndex)
+                statement.setString(parameterIndex.next(), transactionId) // new transaction id
+                statement.setInt(parameterIndex.next(), transactionSource.group.ordinal) // refs or inputs
+                statement.setInt(parameterIndex.next(), transactionSource.index) // index in refs or inputs
+                statement.setString(parameterIndex.next(), transactionSource.sourceTransactionId) // tx state came from
+                statement.setInt(parameterIndex.next(), transactionSource.sourceIndex) // index from tx it came from
             }
         }
     }
@@ -567,6 +573,21 @@ class UtxoRepositoryImpl(
                 signatures = transactionSignatures
             )
         }
+    }
+
+    // select from transaction sources where input states of "previous" transaction are seen as sourceTransactionIds + indexes
+
+
+    override fun findConsumedTransactionSourcesForTransaction(
+        entityManager: EntityManager,
+        transactionId: String,
+        indexes: List<Int>
+    ): List<Int> {
+        return entityManager.createNativeQuery(queryProvider.findConsumedTransactionSourcesForTransaction)
+            .setParameter("transactionId", transactionId)
+            .setParameter("inputStateIndexes", indexes)
+            .resultListAsTuples()
+            .map { it.get(0) as Int }
     }
 
     private fun <T> EntityManager.connection(block: (connection: Connection) -> T) {

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
@@ -55,7 +55,7 @@ class UtxoPersistenceServiceImplTest {
             persistedJsonStrings[txId] = customRepresentation
         }
 
-        on { persistTransaction(any(), any(), any(), any(), any(), any(), any()) } doAnswer {}
+        on { persistTransaction(any(), any(), any(), any(), any(), any(), any()) } doAnswer { true }
         on { persistTransactionComponents(any(), any(), any(), any()) } doAnswer {}
     }
     private val mockDigestService = mock<DigestService> {

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -151,7 +151,7 @@ open class JPABackingStoreImpl @Activate constructor(
                                 //  won't be necessary
                                 if (entityManager.transaction.isActive) {
                                     entityManager.transaction.rollback()
-                                    log.debug { "Rolled back transaction" }
+                                    log.warn("Rolled back transaction")
                                 }
 
                                 CordaMetrics.Metric.UniquenessBackingStoreTransactionErrorCount
@@ -186,7 +186,7 @@ open class JPABackingStoreImpl @Activate constructor(
                                 // triggered.
                                 if (entityManager.transaction.isActive) {
                                     entityManager.transaction.rollback()
-                                    log.debug { "Rolled back transaction" }
+                                    log.warn("Rolled back transaction")
                                 }
 
                                 CordaMetrics.Metric.UniquenessBackingStoreTransactionErrorCount

--- a/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
+++ b/components/uniqueness/backing-store-impl/src/main/kotlin/net/corda/uniqueness/backingstore/impl/JPABackingStoreImpl.kt
@@ -18,7 +18,6 @@ import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateDetailsImpl
 import net.corda.uniqueness.datamodel.impl.UniquenessCheckStateRefImpl
 import net.corda.uniqueness.datamodel.internal.UniquenessCheckRequestInternal
 import net.corda.uniqueness.datamodel.internal.UniquenessCheckTransactionDetailsInternal
-import net.corda.utilities.debug
 import net.corda.v5.application.uniqueness.model.UniquenessCheckError
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 import net.corda.v5.application.uniqueness.model.UniquenessCheckResultFailure

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -26,7 +26,7 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), :status, CAST(:updatedAt AS TIMESTAMP), :metadataHash, FALSE)
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
             ON x.id = ut.id
-            WHEN MATCHED AND ((ut.status = '$UNVERIFIED' or ut.status = '$DRAFT') AND (ut.is_filtered = FALSE)) 
+            WHEN MATCHED AND (ut.status = '$UNVERIFIED' or ut.status = '$DRAFT')
             THEN UPDATE SET ut.status = x.status, ut.updated = x.updated, ut.is_filtered = FALSE
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -26,7 +26,7 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), :status, CAST(:updatedAt AS TIMESTAMP), :metadataHash, FALSE)
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
             ON x.id = ut.id
-            WHEN MATCHED AND ((ut.status = '$UNVERIFIED' or ut.status = '$DRAFT') OR (ut.status = '$VERIFIED' AND ut.is_filtered = TRUE)) 
+            WHEN MATCHED AND ((ut.status = '$UNVERIFIED' or ut.status = '$DRAFT') AND (ut.is_filtered = FALSE)) 
             THEN UPDATE SET ut.status = x.status, ut.updated = x.updated, ut.is_filtered = FALSE
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -26,7 +26,7 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), :status, CAST(:updatedAt AS TIMESTAMP), :metadataHash, FALSE)
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
             ON x.id = ut.id
-            WHEN MATCHED AND (ut.status = '$UNVERIFIED' or ut.status = '$DRAFT')
+            WHEN MATCHED AND ((ut.status = '$UNVERIFIED' or ut.status = '$DRAFT') AND (ut.is_filtered = FALSE)) 
             THEN UPDATE SET ut.status = x.status, ut.updated = x.updated, ut.is_filtered = FALSE
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
@@ -53,7 +53,7 @@ class HsqldbUtxoQueryProvider @Activate constructor(
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
             ON x.id = ut.id
             WHEN MATCHED AND ((ut.status = '$UNVERIFIED' OR ut.status = '$DRAFT') AND ut.is_filtered = FALSE)
-            THEN UPDATE SET ut.status = '$VERIFIED', ut.is_filtered = TRUE
+            THEN UPDATE SET ut.is_filtered = TRUE
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -53,7 +53,7 @@ class HsqldbUtxoQueryProvider @Activate constructor(
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
             ON x.id = ut.id
             WHEN MATCHED AND ((ut.status = '$UNVERIFIED' OR ut.status = '$DRAFT') AND ut.is_filtered = FALSE)
-            THEN UPDATE SET ut.is_filtered = TRUE
+            THEN UPDATE SET ut.status = '$VERIFIED', ut.is_filtered = TRUE
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""


### PR DESCRIPTION
This PR contains:
update `persistTransaction` logic on detect of same id of stx in question already exists which involves:
- correct update on consumed state
- correct update on ftx -> stx
- override unverified stx U -> ftx V 
And an integration test that will prove this logic works as expected.