### PR TITLE
CORE-20047 Invalidate the flow fiber cache when new partitions are assigned to clear out potentially stale fibers

### DIFF
--- a/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestFlowEventMediatorFactoryImpl.kt
+++ b/components/flow/flow-mapper-service/src/integrationTest/kotlin/net/corda/session/mapper/service/integration/TestFlowEventMediatorFactoryImpl.kt
@@ -64,10 +64,10 @@ class TestFlowEventMediatorFactoryImpl @Activate constructor(
         .messagingConfig(messagingConfig)
         .consumerFactories(
             mediatorConsumerFactoryFactory.createMessageBusConsumerFactory(
-                FLOW_START, CONSUMER_GROUP, messagingConfig
+                FLOW_START, CONSUMER_GROUP, UUID.randomUUID().toString(), messagingConfig
             ),
             mediatorConsumerFactoryFactory.createMessageBusConsumerFactory(
-                FLOW_SESSION, CONSUMER_GROUP, messagingConfig
+                FLOW_SESSION, CONSUMER_GROUP, UUID.randomUUID().toString(), messagingConfig
             ),
         )
         .clientFactories(

--- a/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/messaging/mediator/FlowMapperEventMediatorFactoryImpl.kt
+++ b/components/flow/flow-mapper-service/src/main/kotlin/net/corda/session/mapper/messaging/mediator/FlowMapperEventMediatorFactoryImpl.kt
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 @Component(service = [FlowMapperEventMediatorFactory::class])
 class FlowMapperEventMediatorFactoryImpl @Activate constructor(
@@ -92,9 +93,10 @@ class FlowMapperEventMediatorFactoryImpl @Activate constructor(
         .build()
 
     private fun createMediatorConsumerFactories(messagingConfig: SmartConfig,  bootConfig: SmartConfig): List<MediatorConsumerFactory> {
+        val clientId = "MultiSourceSubscription--$CONSUMER_GROUP--$FLOW_MAPPER_START--${UUID.randomUUID()}"
         val mediatorConsumerFactory: MutableList<MediatorConsumerFactory> = mutableListOf(
             mediatorConsumerFactoryFactory.createMessageBusConsumerFactory(
-                FLOW_MAPPER_START, CONSUMER_GROUP, messagingConfig
+                FLOW_MAPPER_START, CONSUMER_GROUP, clientId, messagingConfig,
             ),
         )
 
@@ -126,11 +128,11 @@ class FlowMapperEventMediatorFactoryImpl @Activate constructor(
     ): List<MediatorConsumerFactory> {
         val mediatorReplicas = bootConfig.getIntOrDefault(configName, 1)
         logger.info("Creating $mediatorReplicas mediator(s) consumer factories for $topicName")
-
         val mediatorConsumerFactory: List<MediatorConsumerFactory> = (1..mediatorReplicas).map {
-                mediatorConsumerFactoryFactory.createMessageBusConsumerFactory(
-                    topicName, CONSUMER_GROUP, messagingConfig
-                )
+            val clientId = "MultiSourceSubscription--$CONSUMER_GROUP--$topicName--${UUID.randomUUID()}"
+            mediatorConsumerFactoryFactory.createMessageBusConsumerFactory(
+                topicName, CONSUMER_GROUP, clientId, messagingConfig
+            )
         }
 
         return mediatorConsumerFactory

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/FlowFiberCache.kt
@@ -23,4 +23,9 @@ interface FlowFiberCache : SandboxedCache {
      * Invalidate and remove a flow fiber from the cache with the given [FlowKey].
      */
     fun remove(key: FlowKey)
+
+    /**
+     * Invalidate and remove all flow fibers from the cache.
+     */
+    fun removeAll()
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -101,6 +101,11 @@ class FlowFiberCacheImpl @Activate constructor(
         cache.invalidate(key)
     }
 
+    override fun removeAll() {
+        cache.invalidateAll()
+        cache.cleanUp()
+    }
+
     override fun remove(virtualNodeContext: VirtualNodeContext) {
         val holdingIdentityToRemove = virtualNodeContext.holdingIdentity.toAvro()
         val keysToInvalidate = cache.asMap().keys.filter { holdingIdentityToRemove == it.identity }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowMediatorRebalanceListener.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/messaging/mediator/FlowMediatorRebalanceListener.kt
@@ -1,0 +1,38 @@
+package net.corda.flow.messaging.mediator
+
+import net.corda.flow.fiber.cache.FlowFiberCache
+import net.corda.messagebus.api.CordaTopicPartition
+import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * Rebalance listener triggered when partitions are assigned or revoked from a flow mediator consumer.
+ * Log the assignment changes and invalidate the flow fiber cache when assigned new partitions to clear out stale fibers.
+ */
+class FlowMediatorRebalanceListener(
+    clientId: String,
+    private val flowFiberCache: FlowFiberCache
+): CordaConsumerRebalanceListener {
+
+
+    val log: Logger = LoggerFactory.getLogger("${this.javaClass.name}-${clientId}")
+
+    /**
+     * When a [partitions] are revoked write to the log.
+     */
+    override fun onPartitionsRevoked(partitions: Collection<CordaTopicPartition>) {
+        val partitionIds = partitions.map { it.partition }.joinToString(",")
+        log.info("Partitions revoked: $partitionIds.")
+    }
+
+    /**
+     * When a [partitions] are assigned write to the log and invalidate the flow fiber cache.
+     * Cache is invalidated, to clear cache of fibers which may be stale.
+     */
+    override fun onPartitionsAssigned(partitions: Collection<CordaTopicPartition>) {
+        flowFiberCache.removeAll()
+        val partitionIds = partitions.map { it.partition }.joinToString(",")
+        log.info("Partitions assigned: $partitionIds. Invalidated flow fiber cache.")
+    }
+}

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
@@ -76,22 +76,22 @@ class FlowFibreCacheTest {
     }
 
     @Test
-    fun `when remove and exists`() {
+    fun `removeAll when data exists`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         val key1 = mock<FlowKey>()
         val key2 = mock<FlowKey>()
         whenever(value1.getSandboxGroupId()).thenReturn(sandboxGroupId1)
-        whenever(value1.getSandboxGroupId()).thenReturn(sandboxGroupId1)
+        whenever(value2.getSandboxGroupId()).thenReturn(sandboxGroupId2)
 
         cache.put(key1, 1, value1)
-        cache.put(key2, 3, value1)
+        cache.put(key2, 3, value2)
         cache.removeAll()
         assertThat(cache.get(this.key1, 1, sandboxGroupId1)).isNull()
-        assertThat(cache.get(this.key1, 3, sandboxGroupId1)).isNull()
+        assertThat(cache.get(this.key2, 3, sandboxGroupId2)).isNull()
     }
 
     @Test
-    fun `removeAll clears cache when data exists`() {
+    fun `removeAll does not throw when no data exists`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         assertDoesNotThrow {
             cache.removeAll()
@@ -99,7 +99,7 @@ class FlowFibreCacheTest {
     }
 
     @Test
-    fun `removeAll does not throw when no data exists`() {
+    fun `removeAll clears cache when data exists`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         cache.put(key1, 1, value1)
         cache.put(key2, 1, value2)

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/fiber/cache/FlowFibreCacheTest.kt
@@ -21,62 +21,93 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class FlowFibreCacheTest {
     private val cacheEviction = mock<CacheEviction>()
-    private val key = mock<FlowKey>()
-    private val value = mock<FlowFiber>()
-    private val sandboxGroupId = UUID.randomUUID()
+    private val key1 = mock<FlowKey>()
+    private val key2 = mock<FlowKey>()
+    private val value1 = mock<FlowFiber>()
+    private val value2 = mock<FlowFiber>()
+    private val sandboxGroupId1 = UUID.randomUUID()
+    private val sandboxGroupId2 = UUID.randomUUID()
 
     @BeforeAll
     fun setup() {
-        whenever(value.getSandboxGroupId()).thenReturn(sandboxGroupId)
+        whenever(value1.getSandboxGroupId()).thenReturn(sandboxGroupId1)
+        whenever(value2.getSandboxGroupId()).thenReturn(sandboxGroupId2)
     }
 
     @Test
     fun `when get and no entry return null`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
-        val entry = cache.get(mock(), 123, sandboxGroupId)
+        val entry = cache.get(mock(), 123, sandboxGroupId1)
         assertThat(entry).isNull()
     }
 
     @Test
     fun `when get and entry wrong version return null and entry evicted`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
-        cache.put(key, 1, value)
-        val entry = cache.get(key, 123, sandboxGroupId)
+        cache.put(key1, 1, value1)
+        val entry = cache.get(key1, 123, sandboxGroupId1)
         assertThat(entry).isNull()
-        assertThat(cache.get(key, 1, sandboxGroupId)).isNull()
+        assertThat(cache.get(key1, 1, sandboxGroupId1)).isNull()
     }
 
     @Test
     fun `when get and entry wrong sandbox group ID return null and entry evicted`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
-        cache.put(key, 1, value)
-        val entry = cache.get(key, 1, UUID.randomUUID())
+        cache.put(key1, 1, value1)
+        val entry = cache.get(key1, 1, UUID.randomUUID())
         assertThat(entry).isNull()
-        assertThat(cache.get(key, 1, sandboxGroupId)).isNull()
+        assertThat(cache.get(key1, 1, sandboxGroupId1)).isNull()
     }
 
     @Test
     fun `when get and entry and version exist and matches sandbox group ID return`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
-        cache.put(key, 1, value)
-        val entry = cache.get(key, 1, sandboxGroupId)
-        assertThat(entry).isSameAs(value)
+        cache.put(key1, 1, value1)
+        val entry = cache.get(key1, 1, sandboxGroupId1)
+        assertThat(entry).isSameAs(value1)
     }
 
     @Test
     fun `when remove and entry does not exist do no throw`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
         assertDoesNotThrow {
-            cache.remove(key)
+            cache.remove(key1)
         }
     }
 
     @Test
     fun `when remove and exists`() {
         val cache = FlowFiberCacheImpl(cacheEviction)
-        cache.put(key, 1, value)
-        cache.remove(key)
-        assertThat(cache.get(key, 1, sandboxGroupId)).isNull()
+        val key1 = mock<FlowKey>()
+        val key2 = mock<FlowKey>()
+        whenever(value1.getSandboxGroupId()).thenReturn(sandboxGroupId1)
+        whenever(value1.getSandboxGroupId()).thenReturn(sandboxGroupId1)
+
+        cache.put(key1, 1, value1)
+        cache.put(key2, 3, value1)
+        cache.removeAll()
+        assertThat(cache.get(this.key1, 1, sandboxGroupId1)).isNull()
+        assertThat(cache.get(this.key1, 3, sandboxGroupId1)).isNull()
+    }
+
+    @Test
+    fun `removeAll clears cache when data exists`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        assertDoesNotThrow {
+            cache.removeAll()
+        }
+    }
+
+    @Test
+    fun `removeAll does not throw when no data exists`() {
+        val cache = FlowFiberCacheImpl(cacheEviction)
+        cache.put(key1, 1, value1)
+        cache.put(key2, 1, value2)
+        assertThat(cache.get(key1, 1, sandboxGroupId1)).isNotNull()
+        assertThat(cache.get(key2, 1, sandboxGroupId2)).isNotNull()
+        cache.removeAll()
+        assertThat(cache.get(key1, 1, sandboxGroupId1)).isNull()
+        assertThat(cache.get(key2, 1, sandboxGroupId2)).isNull()
     }
 
     @Test
@@ -99,7 +130,7 @@ class FlowFibreCacheTest {
         cache.put(key1, 1, mock())
         cache.put(key2, 1, mock())
         cache.remove(vnodeContext)
-        assertThat(cache.get(key1, 1, sandboxGroupId)).isNull()
-        assertThat(cache.get(key2, 1, sandboxGroupId)).isNull()
+        assertThat(cache.get(key1, 1, sandboxGroupId1)).isNull()
+        assertThat(cache.get(key2, 1, sandboxGroupId1)).isNull()
     }
 }

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/FlowEventMediatorFactoryImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/FlowEventMediatorFactoryImplTest.kt
@@ -10,6 +10,7 @@ import net.corda.data.ledger.persistence.LedgerPersistenceRequest
 import net.corda.data.ledger.utxo.token.selection.event.TokenPoolCacheEvent
 import net.corda.data.persistence.EntityRequest
 import net.corda.data.uniqueness.UniquenessCheckRequestAvro
+import net.corda.flow.fiber.cache.FlowFiberCache
 import net.corda.flow.messaging.mediator.FlowEventMediatorFactory
 import net.corda.flow.messaging.mediator.FlowEventMediatorFactoryImpl
 import net.corda.flow.pipeline.factory.FlowEventProcessorFactory
@@ -51,6 +52,7 @@ class FlowEventMediatorFactoryImplTest {
     private val multiSourceEventMediatorFactory = mock<MultiSourceEventMediatorFactory>()
     private val cordaAvroSerializationFactory = mock<CordaAvroSerializationFactory>()
     private val platformInfoProvider = mock<PlatformInfoProvider>()
+    private val flowFiberCache = mock<FlowFiberCache>()
     private val config = mock<SmartConfig>()
 
     val captor = argumentCaptor<EventMediatorConfig<String, Checkpoint, FlowEvent>>()
@@ -71,7 +73,8 @@ class FlowEventMediatorFactoryImplTest {
             messagingClientFactoryFactory,
             multiSourceEventMediatorFactory,
             cordaAvroSerializationFactory,
-            platformInfoProvider
+            platformInfoProvider,
+            flowFiberCache
         )
     }
 

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MediatorConsumerFactoryFactoryImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MediatorConsumerFactoryFactoryImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.messaging.mediator.factory
 
 import net.corda.libs.configuration.SmartConfig
+import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
 import net.corda.messagebus.api.consumer.builder.CordaConsumerBuilder
 import net.corda.messaging.api.mediator.factory.MediatorConsumerFactoryFactory
 import org.osgi.service.component.annotations.Activate
@@ -18,11 +19,15 @@ class MediatorConsumerFactoryFactoryImpl @Activate constructor(
     override fun createMessageBusConsumerFactory(
         topicName: String,
         groupName: String,
-        messageBusConfig: SmartConfig
+        clientId: String,
+        messageBusConfig: SmartConfig,
+        rebalanceListener: CordaConsumerRebalanceListener?
     ) = MessageBusConsumerFactory(
         topicName,
         groupName,
         messageBusConfig,
         cordaConsumerBuilder,
+        clientId,
+        rebalanceListener
     )
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessageBusConsumerFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessageBusConsumerFactory.kt
@@ -4,12 +4,13 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.messagebus.api.configuration.ConsumerConfig
 import net.corda.messagebus.api.constants.ConsumerRoles
 import net.corda.messagebus.api.consumer.CordaConsumer
+import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
 import net.corda.messagebus.api.consumer.builder.CordaConsumerBuilder
 import net.corda.messaging.api.mediator.MediatorConsumer
 import net.corda.messaging.api.mediator.config.MediatorConsumerConfig
 import net.corda.messaging.api.mediator.factory.MediatorConsumerFactory
 import net.corda.messaging.mediator.MessageBusConsumer
-import java.util.UUID
+import net.corda.messaging.subscription.consumer.listener.LoggingConsumerRebalanceListener
 
 /**
  * Factory for creating multi-source event mediator message bus consumers.
@@ -18,19 +19,20 @@ import java.util.UUID
  * @param groupName Consumer group name.
  * @param messageBusConfig Message bus related configuration.
  * @param cordaConsumerBuilder [CordaConsumer] builder.
+ * @param clientId Consumer client Id
+ * @param rebalanceListener Rebalance listener
  */
+@Suppress("LongParameterList")
 class MessageBusConsumerFactory(
     private val topicName: String,
     private val groupName: String,
     private val messageBusConfig: SmartConfig,
     private val cordaConsumerBuilder: CordaConsumerBuilder,
+    private val clientId: String,
+    private val rebalanceListener: CordaConsumerRebalanceListener?
 ): MediatorConsumerFactory {
 
     override fun <K : Any, V : Any> create(config: MediatorConsumerConfig<K, V>): MediatorConsumer<K, V> {
-        val subscriptionType = "MultiSourceSubscription"
-        val uniqueId = UUID.randomUUID().toString()
-        val clientId = "$subscriptionType--$groupName--$topicName--$uniqueId"
-
         val eventConsumerConfig = ConsumerConfig(
             groupName,
             "$clientId-eventConsumer",
@@ -42,7 +44,8 @@ class MessageBusConsumerFactory(
             messageBusConfig,
             config.keyClass,
             config.valueClass,
-            config.onSerializationError
+            config.onSerializationError,
+            rebalanceListener?: LoggingConsumerRebalanceListener(clientId)
         )
 
         return MessageBusConsumer(

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessageBusConsumerFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessageBusConsumerFactory.kt
@@ -4,12 +4,13 @@ import net.corda.libs.configuration.SmartConfig
 import net.corda.messagebus.api.configuration.ConsumerConfig
 import net.corda.messagebus.api.constants.ConsumerRoles
 import net.corda.messagebus.api.consumer.CordaConsumer
+import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
 import net.corda.messagebus.api.consumer.builder.CordaConsumerBuilder
 import net.corda.messaging.api.mediator.MediatorConsumer
 import net.corda.messaging.api.mediator.config.MediatorConsumerConfig
 import net.corda.messaging.api.mediator.factory.MediatorConsumerFactory
 import net.corda.messaging.mediator.MessageBusConsumer
-import java.util.UUID
+import net.corda.messaging.subscription.consumer.listener.LoggingConsumerRebalanceListener
 
 /**
  * Factory for creating multi-source event mediator message bus consumers.
@@ -18,19 +19,19 @@ import java.util.UUID
  * @param groupName Consumer group name.
  * @param messageBusConfig Message bus related configuration.
  * @param cordaConsumerBuilder [CordaConsumer] builder.
+ * @param clientId Consumer client Id
+ * @param rebalanceListener Rebalance listener
  */
 class MessageBusConsumerFactory(
     private val topicName: String,
     private val groupName: String,
     private val messageBusConfig: SmartConfig,
     private val cordaConsumerBuilder: CordaConsumerBuilder,
+    private val clientId: String,
+    private val rebalanceListener: CordaConsumerRebalanceListener?
 ): MediatorConsumerFactory {
 
     override fun <K : Any, V : Any> create(config: MediatorConsumerConfig<K, V>): MediatorConsumer<K, V> {
-        val subscriptionType = "MultiSourceSubscription"
-        val uniqueId = UUID.randomUUID().toString()
-        val clientId = "$subscriptionType--$groupName--$topicName--$uniqueId"
-
         val eventConsumerConfig = ConsumerConfig(
             groupName,
             "$clientId-eventConsumer",
@@ -42,7 +43,8 @@ class MessageBusConsumerFactory(
             messageBusConfig,
             config.keyClass,
             config.valueClass,
-            config.onSerializationError
+            config.onSerializationError,
+            rebalanceListener?: LoggingConsumerRebalanceListener(clientId)
         )
 
         return MessageBusConsumer(

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessageBusConsumerFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessageBusConsumerFactory.kt
@@ -22,6 +22,7 @@ import net.corda.messaging.subscription.consumer.listener.LoggingConsumerRebalan
  * @param clientId Consumer client Id
  * @param rebalanceListener Rebalance listener
  */
+@Suppress("LongParameterList")
 class MessageBusConsumerFactory(
     private val topicName: String,
     private val groupName: String,

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MediatorConsumerFactoryFactoryTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MediatorConsumerFactoryFactoryTest.kt
@@ -24,6 +24,7 @@ class MediatorConsumerFactoryFactoryTest {
         val messageBusConsumerFactory = mediatorConsumerFactoryFactory.createMessageBusConsumerFactory(
             "topic",
             "consumerGroup",
+            "clientId",
             messageBusConfig,
         )
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MessageBusConsumerFactoryTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/mediator/factory/MessageBusConsumerFactoryTest.kt
@@ -28,6 +28,8 @@ class MessageBusConsumerFactoryTest {
             "group",
             messageBusConfig,
             cordaConsumerBuilder,
+            "clientId",
+            mock()
         )
     }
 

--- a/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/factory/MediatorConsumerFactoryFactory.kt
+++ b/libs/messaging/messaging/src/main/kotlin/net/corda/messaging/api/mediator/factory/MediatorConsumerFactoryFactory.kt
@@ -1,6 +1,7 @@
 package net.corda.messaging.api.mediator.factory
 
 import net.corda.libs.configuration.SmartConfig
+import net.corda.messagebus.api.consumer.CordaConsumerRebalanceListener
 
 /**
  * Factory for creating multi-source event mediator consumer factories.
@@ -11,11 +12,15 @@ interface MediatorConsumerFactoryFactory {
      *
      * @param topicName Topic name.
      * @param groupName Consumer group name.
+     * @param clientId Consumer clientId
      * @param messageBusConfig Message bus related configuration.
+     * @param rebalanceListener Message bus rebalance listener
      */
     fun createMessageBusConsumerFactory(
         topicName: String,
         groupName: String,
+        clientId: String,
         messageBusConfig: SmartConfig,
+        rebalanceListener: CordaConsumerRebalanceListener? = null
     ) : MediatorConsumerFactory
 }

--- a/testing/message-patterns/build.gradle
+++ b/testing/message-patterns/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     integrationTestImplementation project(":libs:configuration:configuration-core")
     integrationTestImplementation project(":libs:lifecycle:lifecycle")
     integrationTestImplementation project(":libs:messaging:messaging")
+    integrationTestImplementation project(":libs:messaging:message-bus")
     integrationTestImplementation project(":libs:messaging:messaging-impl")
     integrationTestImplementation project(":libs:messaging:topic-admin")
     integrationTestImplementation project(":libs:schema-registry:schema-registry")

--- a/testing/message-patterns/src/integrationTest/kotlin/net/corda/testing/messaging/integration/subscription/MediatorSubscriptionIntegrationTest.kt
+++ b/testing/message-patterns/src/integrationTest/kotlin/net/corda/testing/messaging/integration/subscription/MediatorSubscriptionIntegrationTest.kt
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.osgi.test.common.annotation.InjectService
 import org.osgi.test.junit5.context.BundleContextExtension
 import org.osgi.test.junit5.service.ServiceExtension
+import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -108,7 +109,7 @@ class MediatorSubscriptionIntegrationTest {
             .messagingConfig(messagingConfig)
             .consumerFactories(
                 mediatorConsumerFactoryFactory.createMessageBusConsumerFactory(
-                    inputTopic, "CONSUMER_GROUP", messagingConfig
+                    inputTopic, "CONSUMER_GROUP", UUID.randomUUID().toString(), messagingConfig
                 )
             )
             .clientFactories(


### PR DESCRIPTION
**Problem**
This PR solves a problem whereby stale Fibers from the FlowFiberCache can be read and used instead of a more recent version of the fiber.

**Scenario**
Flow starts on Pod A which is assigned flow.start topic. Flow reaches the point where it needs to receive from counterparty, puts fiber in cache and then tries to save the checkpoint. This will fail if the task exceeded its timeout. A rebalance occurs. Pod A is assigned the flow.session topic and Pod B is assigned the flow.start topic. Pod B replays the start flow event successfully and writes the state. Flow progresses to the same suspension point and initiates a session with a counterparty successfully.

Counterparty responds with the first message sent to the flow.session topic and is picked up by Pod A.
Pod A has the first vesion of the fiber in its cache which is invalid and reuses it. This then results in an error as the FlowSession ID does not match the message received.

**Solution**
Invalidate the cache on a rebalance to clear out potentially stale fibers in the cache.