### PR TITLE
CORE-20167 exceptions from public bundles

### DIFF
--- a/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableSerializer.kt
+++ b/libs/serialization/serialization-amqp/src/main/kotlin/net/corda/internal/serialization/amqp/custom/ThrowableSerializer.kt
@@ -69,7 +69,8 @@ class ThrowableSerializer(
     @Suppress("NestedBlockDepth")
     override fun fromProxy(proxy: ThrowableProxy, context: SerializationContext): Throwable {
         try {
-            val clazz = context.currentSandboxGroup().loadClassFromMainBundles(proxy.exceptionClass)
+            val clazz = context.currentSandboxGroup().loadClassFromPublicBundles(proxy.exceptionClass) ?:
+                context.currentSandboxGroup().loadClassFromMainBundles(proxy.exceptionClass)
 
             // If it is a CordaRuntimeException, we can seek any constructor and then set the properties
             // Otherwise we just make a CordaRuntimeException


### PR DESCRIPTION
Change the ThrowableSerializer to consisder public bundles as well as main bundles and the system bundle when trying to deserialize an exception.