### PR TITLE
ES-2066 Adjust resource requests/limits

### DIFF
--- a/.ci/e2eTests/corda-eks.yaml
+++ b/.ci/e2eTests/corda-eks.yaml
@@ -7,14 +7,37 @@ bootstrap:
       registry: docker-remotes.software.r3.com
   commonPodLabels:
     sidecar.istio.io/inject: !!str false # explicitly disable Istio integration from bootstrap pods
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "512Mi"
 
 resources:
   requests:
-    memory: "620Mi"
-    cpu: "500m"
-  limits:
-    memory: "1250Mi"
+    memory: "768Mi"
     cpu: "1000m"
+  limits:
+    memory: "768Mi"
+
+workers:
+  db:
+    resources:
+      requests:
+        memory: "1Gi"
+      limits:
+        memory: "1Gi"
+  flow:
+    resources:
+      requests:
+        memory: "1Gi"
+      limits:
+        memory: "1Gi"
+
 
 commonPodLabels:
   sidecar.istio.io/inject: !!str true # explicitly enable Istio integration from all Corda pods
+
+annotations:
+  cluster-autoscaler.kubernetes.io/safe-to-evict: "false"

--- a/.ci/e2eTests/prereqs-eks.yaml
+++ b/.ci/e2eTests/prereqs-eks.yaml
@@ -13,23 +13,50 @@ kafka:
     allow.everyone.if.no.acl.found=true
     super.users=User:controller_user
   controller:
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+    podAntiAffinityPreset: hard
     replicaCount: 7
     startupProbe:
       enabled: true
-  resources:
-    requests:
-      memory: 780Mi
-      cpu: 1000m
-    limits:
-      memory: 1600Mi
-      cpu: 1000m
+    resources:
+      requests:
+        memory: 1536Mi
+        cpu: 1000m
+      limits:
+        memory: 1536Mi
+  metrics:
+    jmx:
+      resources:
+        requests:
+          memory: 128Mi
+          cpu: 150m
+        limits:
+          memory: 128Mi
+    kafka:
+      resources:
+        requests:
+          memory: 32Mi
+          cpu: 100m
+        limits:
+          memory: 32Mi
 
 postgresql:
   primary:
+    extendedConfiguration: |
+      max_connections = 500
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     resources:
       requests:
-        memory: 256Mi
-        cpu: 300m
+        memory: 128Mi
+        cpu: 250m
       limits:
-        memory: 512Mi
-        cpu: 600m
+        memory: 128Mi
+  metrics:
+    resources:
+      requests:
+        memory: 32Mi
+        cpu: 100m
+      limits:
+        memory: 64Mi

--- a/.ci/e2eTests/prereqs-eks.yaml
+++ b/.ci/e2eTests/prereqs-eks.yaml
@@ -49,10 +49,10 @@ postgresql:
       cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
     resources:
       requests:
-        memory: 128Mi
+        memory: 256Mi
         cpu: 250m
       limits:
-        memory: 128Mi
+        memory: 256Mi
   metrics:
     resources:
       requests:

--- a/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckLimits.kt
+++ b/tools/plugins/preinstall/src/main/kotlin/net/corda/cli/plugins/preinstall/CheckLimits.kt
@@ -100,26 +100,37 @@ class CheckLimits : Callable<Int>, PluginContext() {
             }
 
             if (requests?.cpu != null || limits?.cpu != null) {
-                if (requests?.cpu == null || limits?.cpu == null) {
-                    report.addEntry(ReportEntry("${name.uppercase()} cpu resources contains both a request and a limit", false))
-                    return
-                }
-                report.addEntry(ReportEntry("${name.uppercase()} cpu resources contains both a request and a limit", true))
-                logger.info("${name.uppercase()} CPU: \n\t request - ${requests.cpu}\n\t limit - ${limits.cpu}")
-                val limit: Double = parseCpuString(limits.cpu!!)
-                val request: Double = parseCpuString(requests.cpu!!)
+                logger.info("${name.uppercase()} CPU: \n\t request - ${requests?.cpu ?: "unset"}\n\t limit - ${limits?.cpu ?: "unset"}")
+                val limit: Double? = if (limits?.cpu == null) null else parseCpuString(limits.cpu!!)
+                val request: Double? = if (requests?.cpu == null) null else parseCpuString(requests.cpu!!)
                 report.addEntry(ReportEntry("Parse \"$name\" cpu resource strings", true))
 
-                if (limit >= request) {
-                    report.addEntry(ReportEntry("$name cpu requests do not exceed limits", true))
-                } else {
-                    report.addEntry(ReportEntry("$name cpu requests do not exceed limits", false,
-                        ResourceLimitsExceededException("Request ($requests.cpu!!) is greater than it's limit ($limits.cpu!!)")))
+                if (limit != null && request != null) {
+                    checkRequestsNotGreaterThanLimits(limit, request, name, requests, limits)
                 }
             }
 
         } catch(e: IllegalArgumentException) {
             report.addEntry(ReportEntry("Parse \"$name\" cpu resource strings", false, e))
+        }
+    }
+
+    private fun checkRequestsNotGreaterThanLimits(
+        limit: Double,
+        request: Double,
+        name: String,
+        requests: ResourceValues?,
+        limits: ResourceValues?
+    ) {
+        if (limit >= request) {
+            report.addEntry(ReportEntry("$name cpu requests do not exceed limits", true))
+        } else {
+            report.addEntry(
+                ReportEntry(
+                    "$name cpu requests do not exceed limits", false,
+                    ResourceLimitsExceededException("Request ($requests.cpu!!) is greater than it's limit ($limits.cpu!!)")
+                )
+            )
         }
     }
 


### PR DESCRIPTION
Ensures that all resources deployed as part of an E2E test have defined memory requests/limits and CPU requests. No CPU limits have been defined (i.e. pods can burst to use any additional available CPU on the nodes). CPU usage seems pretty variable from one run to the next. I suspect it is dependent on whether the metric polling picks up the initial spike on creation (given the short length of the runs, this can influence the p95 used for recommendations).

The preinstall check needed modifying to allow specifying CPU requests without limits.