### PR TITLE
CORE-19910: Remove default second key from bootstrapping and startup

### DIFF
--- a/charts/corda-lib/templates/_bootstrap.tpl
+++ b/charts/corda-lib/templates/_bootstrap.tpl
@@ -255,7 +255,7 @@ spec:
               java -Dpf4j.pluginsDir=/opt/override/plugins -Dlog4j2.debug=false -jar /opt/override/cli.jar initial-config create-crypto-config \
                 --salt "${SALT}" --passphrase "${PASSPHRASE}" \
               {{- if (((.Values).config).vault).url }}
-                -t "VAULT" --vault-path "cryptosecrets" -n 2 -ks "salt" -kp "passphrase" -ks "salt2" -kp "passphrase2" \
+                -t "VAULT" --vault-path "cryptosecrets" -n 1 -ks "salt" -kp "passphrase" \
               {{- end }}
                 -l /tmp
           workingDir: /tmp

--- a/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/CryptoConfigSubcommand.kt
+++ b/tools/plugins/initial-config/src/main/kotlin/net/corda/cli/plugin/initialconfig/CryptoConfigSubcommand.kt
@@ -65,9 +65,9 @@ class CryptoConfigSubcommand : Runnable {
 
     @CommandLine.Option(
         names = ["-n", "--number-of-unmanaged-root-wrapping-keys"],
-        description = ["Number of unmanaged root wrapping keys. There must be at least 1, default is 2."]
+        description = ["Number of unmanaged root wrapping keys. There must be at least 1, default is 1."]
     )
-    var numberOfUnmanagedWrappingKeys: Int = 2
+    var numberOfUnmanagedWrappingKeys: Int = 1
 
     @CommandLine.Option(
         names = ["-l", "--location"],

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -119,7 +119,6 @@ class TestInitialConfigPluginCrypto {
                 "--vault-path", "cryptosecrets",
                 "--key-salt", "salt",
                 "--key-passphrase", "passphrase",
-                "--number-of-unmanaged-root-wrapping-keys", "1"
             )
         }
         assertThat(outText).startsWith(expectedPrefix)
@@ -152,6 +151,7 @@ class TestInitialConfigPluginCrypto {
                 "--key-passphrase", "passphrase",
                 "--key-salt", "salt2",
                 "--key-passphrase", "passphrase2",
+                "--number-of-unmanaged-root-wrapping-keys", "2"
             )
         }
         assertThat(outText).startsWith(expectedPrefix)
@@ -169,23 +169,6 @@ class TestInitialConfigPluginCrypto {
             assertThat(key1.getValue("passphrase").render()).contains("vaultPath")
             assertThat(key1.getValue("passphrase")).isNotEqualTo((key2.getValue("passphrase")))
         }
-    }
-    @Test
-    fun `Should fail to create vault initial crypto configuration with insufficient keys specified`() {
-        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
-        val app = InitialConfigPlugin.PluginEntryPoint()
-        val outText = SystemLambda.tapSystemErrNormalized {
-            CommandLine(
-                app
-            ).setColorScheme(colorScheme).execute(
-                "create-crypto-config",
-                "-t", "VAULT",
-                "--vault-path", "cryptosecrets",
-                "--key-salt", "salt",
-                "--key-passphrase", "passphrase",
-            )
-        }
-        assertThat(outText).contains("Not enough vault wrapping key salt keys passed in")
     }
 
     private fun assertGeneratedJson(json: String, wrappingKeyAssert: (ConfigList, SmartConfigFactory) -> Unit) {

--- a/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
+++ b/tools/plugins/initial-config/src/test/kotlin/net/corda/cli/plugin/initialconfig/TestInitialConfigPluginCrypto.kt
@@ -171,6 +171,25 @@ class TestInitialConfigPluginCrypto {
         }
     }
 
+    @Test
+    fun `Should fail to create vault initial crypto configuration with insufficient keys specified`() {
+        val colorScheme = CommandLine.Help.ColorScheme.Builder().ansi(CommandLine.Help.Ansi.OFF).build()
+        val app = InitialConfigPlugin.PluginEntryPoint()
+        val outText = SystemLambda.tapSystemErrNormalized {
+            CommandLine(
+                app
+            ).setColorScheme(colorScheme).execute(
+                "create-crypto-config",
+                "-t", "VAULT",
+                "--vault-path", "cryptosecrets",
+                "--key-salt", "salt",
+                "--key-passphrase", "passphrase",
+                "--number-of-unmanaged-root-wrapping-keys", "2"
+            )
+        }
+        assertThat(outText).contains("Not enough vault wrapping key salt keys passed in")
+    }
+
     private fun assertGeneratedJson(json: String, wrappingKeyAssert: (ConfigList, SmartConfigFactory) -> Unit) {
         val smartConfigFactory = SmartConfigFactory.createWith(
             ConfigFactory.parseString(


### PR DESCRIPTION
The bootstrapping of corda automatically adds 2 master wrapping keys, which was added for testing purposes. We now have e2e testing scripts that add their own keys, so this is no longer necessary