### PR TITLE
CORE-20190 Notary server exception correction

### DIFF
--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
@@ -120,7 +120,7 @@ class ContractVerifyingNotaryServerFlowImpl() : ResponderFlow {
                 is NotaryException -> e
                 // [IllegalArgumentException]s are thrown if a transaction does not pass our correctness checks.
                 is IllegalArgumentException -> NotaryExceptionTransactionVerificationFailure("$genericMessage. Cause: ${e.message}")
-                else -> NotaryExceptionGeneral("$genericMessage. Please contact notary operator for further details.")
+                else -> NotaryExceptionGeneral("$genericMessage. Please contact notary operator for further details.", null)
             }
             session.send(NotarizationResponse(emptyList(), notaryException))
         }

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/main/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImpl.kt
@@ -114,22 +114,15 @@ class ContractVerifyingNotaryServerFlowImpl() : ResponderFlow {
 
             session.send(uniquenessResult.toNotarizationResponse(initialTransactionDetails.id, signature))
         } catch (e: Exception) {
-            logger.warn("Error while processing request from client. Cause: $e ${e.stackTraceToString()}")
-            val exception =
-                if (e is NotaryException) {
-                    e
-                } else {
-                    NotaryExceptionGeneral(
-                        "General error: Error during notarization. Cause: ${e.message}",
-                        null
-                    )
-                }
-            session.send(
-                NotarizationResponse(
-                    emptyList(),
-                    exception
-                )
-            )
+            logger.warn("Error while processing request from client", e)
+            val genericMessage = "Error while processing request from client"
+            val notaryException = when (e) {
+                is NotaryException -> e
+                // [IllegalArgumentException]s are thrown if a transaction does not pass our correctness checks.
+                is IllegalArgumentException -> NotaryExceptionTransactionVerificationFailure("$genericMessage. Cause: ${e.message}")
+                else -> NotaryExceptionGeneral("$genericMessage. Please contact notary operator for further details.")
+            }
+            session.send(NotarizationResponse(emptyList(), notaryException))
         }
     }
 

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
@@ -249,7 +249,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat(responseFromServer.first().signatures).isEmpty()
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
         assertThat((responseError as NotaryExceptionGeneral).message)
-            .contains("The publicKeys do not have any private counterparts available.")
+            .contains("Error while processing request from client. Please contact notary operator for further details")
     }
 
     @ParameterizedTest
@@ -321,7 +321,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         assertThat(responseError).isNotNull
         assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
         assertThat((responseError as NotaryExceptionGeneral).message)
-            .contains("Error during notarization. Cause: Uniqueness checker cannot be reached")
+            .contains("Error while processing request from client. Please contact notary operator for further details")
     }
 
     @ParameterizedTest
@@ -434,9 +434,9 @@ class ContractVerifyingNotaryServerFlowImplTest {
 
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
-        assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
-        assertThat((responseError as NotaryExceptionGeneral).message)
-            .contains("Error during notarization. Cause: DUMMY ERROR")
+        assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
+        assertThat((responseError as NotaryExceptionTransactionVerificationFailure).message)
+            .contains("Error while processing request from client. Cause: DUMMY ERROR")
     }
 
     @ParameterizedTest
@@ -479,8 +479,8 @@ class ContractVerifyingNotaryServerFlowImplTest {
 
         val responseError = responseFromServer.first().error
         assertThat(responseError).isNotNull
-        assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
-        assertThat((responseError as NotaryExceptionGeneral).message)
+        assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
+        assertThat((responseError as NotaryExceptionTransactionVerificationFailure).message)
             .contains("does not match the notary service represented by this notary virtual node")
     }
 
@@ -669,7 +669,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
             when (notarizationType) {
                 NotarizationType.WRITE -> {
                     on { requestUniquenessCheckWrite(any(), any(), any(), any(), any(), any(), any()) } doThrow
-                        IllegalArgumentException("Uniqueness checker cannot be reached")
+                        RuntimeException("Uniqueness checker cannot be reached")
                     on { requestUniquenessCheckRead(any(), any(), any(), any()) } doThrow
                         RuntimeException("Wrong uniqueness check type method called")
                 }
@@ -677,7 +677,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
                     on { requestUniquenessCheckWrite(any(), any(), any(), any(), any(), any(), any()) } doThrow
                         RuntimeException("Wrong uniqueness check type method called")
                     on { requestUniquenessCheckRead(any(), any(), any(), any()) } doThrow
-                        IllegalArgumentException("Uniqueness checker cannot be reached")
+                        RuntimeException("Uniqueness checker cannot be reached")
                 }
             }
         }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -110,19 +110,15 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
 
             session.send(uniquenessResult.toNotarizationResponse(txDetails.id, signature))
         } catch (e: Exception) {
-            logger.warn("Error while processing request from client. Cause: $e ${e.stackTraceToString()}")
+            logger.warn("Error while processing request from client", e)
             val genericMessage = "Error while processing request from client"
             val notaryException = when (e) {
                 is NotaryException -> e
+                // [IllegalArgumentException]s are thrown if a transaction does not pass our correctness checks.
                 is IllegalArgumentException -> NotaryExceptionTransactionVerificationFailure("$genericMessage. Cause: ${e.message}")
                 else -> NotaryExceptionGeneral("$genericMessage. Please contact notary operator for further details.")
             }
-            session.send(
-                NotarizationResponse(
-                    emptyList(),
-                    notaryException
-                )
-            )
+            session.send(NotarizationResponse(emptyList(), notaryException))
         }
     }
 

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -1,8 +1,8 @@
 package com.r3.corda.notary.plugin.nonvalidating.server
 
 import com.r3.corda.notary.plugin.common.NotarizationResponse
-import com.r3.corda.notary.plugin.common.NotaryTransactionDetails
 import com.r3.corda.notary.plugin.common.NotaryExceptionTransactionVerificationFailure
+import com.r3.corda.notary.plugin.common.NotaryTransactionDetails
 import com.r3.corda.notary.plugin.common.toNotarizationResponse
 import com.r3.corda.notary.plugin.nonvalidating.api.NonValidatingNotarizationPayload
 import net.corda.v5.application.flows.CordaInject
@@ -17,6 +17,7 @@ import net.corda.v5.base.annotations.VisibleForTesting
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.ledger.common.transaction.TransactionSignatureService
 import net.corda.v5.ledger.notary.plugin.api.NotarizationType
+import net.corda.v5.ledger.notary.plugin.core.NotaryException
 import net.corda.v5.ledger.notary.plugin.core.NotaryExceptionGeneral
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
@@ -115,7 +116,7 @@ class NonValidatingNotaryServerFlowImpl() : ResponderFlow {
                 is NotaryException -> e
                 // [IllegalArgumentException]s are thrown if a transaction does not pass our correctness checks.
                 is IllegalArgumentException -> NotaryExceptionTransactionVerificationFailure("$genericMessage. Cause: ${e.message}")
-                else -> NotaryExceptionGeneral("$genericMessage. Please contact notary operator for further details.")
+                else -> NotaryExceptionGeneral("$genericMessage. Please contact notary operator for further details.", null)
             }
             session.send(NotarizationResponse(emptyList(), notaryException))
         }

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/main/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImpl.kt
@@ -25,7 +25,6 @@ import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
 import net.corda.v5.ledger.utxo.uniqueness.client.LedgerUniquenessCheckerClientService
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import java.lang.IllegalArgumentException
 
 /**
  * The server-side implementation of the non-validating notary logic.

--- a/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-non-validating/notary-plugin-non-validating-server/src/test/kotlin/com/r3/corda/notary/plugin/nonvalidating/server/NonValidatingNotaryServerFlowImplTest.kt
@@ -2,6 +2,7 @@ package com.r3.corda.notary.plugin.nonvalidating.server
 
 import com.r3.corda.notary.plugin.common.NotarizationResponse
 import com.r3.corda.notary.plugin.common.NotaryExceptionReferenceStateUnknown
+import com.r3.corda.notary.plugin.common.NotaryExceptionTransactionVerificationFailure
 import com.r3.corda.notary.plugin.nonvalidating.api.NonValidatingNotarizationPayload
 import net.corda.crypto.core.fullIdHash
 import net.corda.crypto.testkit.SecureHashUtils.randomSecureHash
@@ -333,8 +334,8 @@ class NonValidatingNotaryServerFlowImplTest {
 
             val responseError = responseFromServer.first().error
             assertThat(responseError).isNotNull
-            assertThat(responseError).isInstanceOf(NotaryExceptionGeneral::class.java)
-            assertThat((responseError as NotaryExceptionGeneral).message)
+            assertThat(responseError).isInstanceOf(NotaryExceptionTransactionVerificationFailure::class.java)
+            assertThat((responseError as NotaryExceptionTransactionVerificationFailure).message)
                 .contains("Error while processing request from client")
         }
     }
@@ -476,7 +477,7 @@ class NonValidatingNotaryServerFlowImplTest {
             when (notarizationType) {
                 NotarizationType.WRITE -> {
                     on { requestUniquenessCheckWrite(any(), any(), any(), any(), any(), any(), any()) } doThrow
-                        IllegalArgumentException("Uniqueness checker cannot be reached")
+                        RuntimeException("Uniqueness checker cannot be reached")
                     on { requestUniquenessCheckRead(any(), any(), any(), any()) } doThrow
                         RuntimeException("Wrong uniqueness check type method called")
                 }
@@ -484,7 +485,7 @@ class NonValidatingNotaryServerFlowImplTest {
                     on { requestUniquenessCheckWrite(any(), any(), any(), any(), any(), any(), any()) } doThrow
                         RuntimeException("Wrong uniqueness check type method called")
                     on { requestUniquenessCheckRead(any(), any(), any(), any()) } doThrow
-                        IllegalArgumentException("Uniqueness checker cannot be reached")
+                        RuntimeException("Uniqueness checker cannot be reached")
                 }
             }
         }


### PR DESCRIPTION
`IllegalArgumentException`s that were used for checking the validity of transactions were being turned into `NotaryExceptionGeneral` exceptions, meaning that they were deemed as transient errors and might succeed if retried. However, this is not true, as failing validation will mean that a transaction will always fail the same validation when ran again.

Any `IllegalArgumentException`s are now converted into `NotaryExceptionTransactionVerificationFailure`, which is a fatal notary exception. This is then appropriately handled on the finalizing side of the flows.