### PR TITLE
CORE-20046 - flow fiber cache invalidate on get

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -20,6 +20,7 @@ import org.osgi.service.component.annotations.Reference
 import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
 
 @Suppress("unused")
 @Component(service = [FlowFiberCache::class])
@@ -41,7 +42,7 @@ class FlowFiberCacheImpl @Activate constructor(
 
     private data class FiberCacheValue(val fiber: FlowFiber, val suspendCount: Int)
 
-    private val cache: Cache<FlowKey, FiberCacheValue> = CacheFactoryImpl().build(
+    private val cache: Cache<FlowKey, AtomicReference<FiberCacheValue>> = CacheFactoryImpl().build(
         "flow-fiber-cache",
         Caffeine.newBuilder()
             .maximumSize(maximumSize)
@@ -73,13 +74,13 @@ class FlowFiberCacheImpl @Activate constructor(
     override fun put(key: FlowKey, suspendCount: Int, fiber: FlowFiber) {
         checkIfThreadInterrupted("Interrupted thread prevented from writing into flow fiber cache with flow key $key")
 
-        cache.put(key, FiberCacheValue(fiber, suspendCount))
+        cache.put(key, AtomicReference(FiberCacheValue(fiber, suspendCount)))
     }
 
     override fun get(key: FlowKey, suspendCount: Int, sandboxGroupId: UUID): FlowFiber? {
         checkIfThreadInterrupted("Interrupted thread prevented from getting from flow fiber cache for key $key suspendCount $suspendCount")
 
-        val fiberCacheEntry = cache.asMap().remove(key)
+        val fiberCacheEntry = cache.getIfPresent(key)?.getAndSet(null)
         return if (null == fiberCacheEntry) {
             logger.info("Fiber not found in cache: ${key.id}")
             null
@@ -123,7 +124,7 @@ class FlowFiberCacheImpl @Activate constructor(
     // Yuk ... adding this to support the existing integration test.
     //  I don't think we should have integration tests knowing about the internals of the cache.
     internal fun findInCache(holdingId: HoldingIdentity, flowId: String): FlowFiber? {
-        return cache.getIfPresent(FlowKey(flowId, holdingId))?.fiber
+        return cache.getIfPresent(FlowKey(flowId, holdingId))?.get()?.fiber
     }
 
     private fun checkIfThreadInterrupted(msg: String) {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/cache/impl/FlowFiberCacheImpl.kt
@@ -79,7 +79,7 @@ class FlowFiberCacheImpl @Activate constructor(
     override fun get(key: FlowKey, suspendCount: Int, sandboxGroupId: UUID): FlowFiber? {
         checkIfThreadInterrupted("Interrupted thread prevented from getting from flow fiber cache for key $key suspendCount $suspendCount")
 
-        val fiberCacheEntry = cache.getIfPresent(key)
+        val fiberCacheEntry = cache.asMap().remove(key)
         return if (null == fiberCacheEntry) {
             logger.info("Fiber not found in cache: ${key.id}")
             null
@@ -96,7 +96,6 @@ class FlowFiberCacheImpl @Activate constructor(
                 // fiber we are going to need another one bound to the new sandbox instead.
                 logger.info("Fiber found in cache but for wrong sandbox group id")
             }
-            cache.invalidate(key)
             null
         }
     }


### PR DESCRIPTION
**Problem description**

A flow with the following code cannot be interrupted using `future.cancel()` as there is no blocking operation call to give opportunity to interrupt the thread:
```
        while (counter < 100000000000) {
            counter++
        }
```
If this flow has initiated a session to receive a message, and on receiving the message then hangs in this while loop, the thread will still be running the fiber while the retry thread comes along to re-process the received session event. Thus, the "Not new or suspended" error message.

**Solution**

Remove from flow fiber cache when getting from the cache. The retry thread will deserialize the checkpoint rather than using the cache, if the hanging thread later continues, it won't be able to overwrite the fiber as its thread has flag `isInterrupted=true` and we already have an interrupted validation check in the `FlowFiberCache.put()` method.