### PR TITLE
ES-2045: Create and use Enums for SDK parameters

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.7-alpha-1711449104065
+cordaApiVersion=5.3.0.7-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.7-beta+
+cordaApiVersion=5.3.0.7-alpha-1711449104065
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/corda-sdk/build.gradle
+++ b/libs/corda-sdk/build.gradle
@@ -17,14 +17,16 @@ dependencies {
     implementation libs.kotlin.stdlib
     implementation project(':libs:configuration:configuration-core')
     implementation project(':libs:configuration:configuration-endpoints')
-    implementation project(':libs:membership:schema-validation')
+    implementation project(':libs:membership:certificates-common')
     implementation project(':libs:membership:membership-common')
+    implementation project(':libs:membership:schema-validation')
     implementation project(':libs:packaging:packaging-verify')
     implementation project(':libs:rest:json-serialization')
     implementation project(':libs:rest:rest-client')
     implementation project(':libs:virtual-node:cpi-upload-endpoints')
     implementation project(':libs:virtual-node:virtual-node-endpoints')
     implementation project(':libs:virtual-node:virtual-node-endpoints-maintenance')
+    implementation 'net.corda:corda-config-schema'
 
     testImplementation libs.bundles.test
     testImplementation project(':testing:test-utilities')

--- a/libs/corda-sdk/src/main/kotlin/net/corda/sdk/config/ClusterConfig.kt
+++ b/libs/corda-sdk/src/main/kotlin/net/corda/sdk/config/ClusterConfig.kt
@@ -7,6 +7,7 @@ import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigResponse
 import net.corda.libs.configuration.exception.WrongConfigVersionException
 import net.corda.rest.ResponseCode
 import net.corda.rest.client.RestClient
+import net.corda.schema.configuration.ConfigKeys.RootConfigKey
 import net.corda.sdk.rest.RestClientUtils.executeWithRetry
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -22,7 +23,7 @@ class ClusterConfig {
      */
     fun getCurrentConfig(
         restClient: RestClient<ConfigRestResource>,
-        configSection: String,
+        configSection: RootConfigKey,
         wait: Duration = 10.seconds
     ): GetConfigResponse {
         return restClient.use { client ->
@@ -31,7 +32,7 @@ class ClusterConfig {
                 operationName = "Get current config $configSection"
             ) {
                 val resource = client.start().proxy
-                resource.get(configSection)
+                resource.get(configSection.value)
             }
         }
     }

--- a/libs/corda-sdk/src/main/kotlin/net/corda/sdk/network/ClientCertificates.kt
+++ b/libs/corda-sdk/src/main/kotlin/net/corda/sdk/network/ClientCertificates.kt
@@ -3,6 +3,8 @@
 
 package net.corda.sdk.network
 
+import net.corda.data.certificates.CertificateUsage
+import net.corda.membership.certificates.CertificateUsageUtils.publicName
 import net.corda.membership.rest.v1.CertificatesRestResource
 import net.corda.membership.rest.v1.MGMRestResource
 import net.corda.membership.rest.v1.types.response.KeyPairIdentifier
@@ -121,14 +123,14 @@ class ClientCertificates {
         alias: String = P2P_TLS_CERTIFICATE_ALIAS,
         wait: Duration = 10.seconds
     ) {
-        uploadCertificate(restClient, certificate, "p2p-tls", alias, wait)
+        uploadCertificate(restClient, certificate, CertificateUsage.P2P_TLS, alias, wait)
     }
 
     /**
      * Upload a given certificate
      * @param restClient of type RestClient<CertificatesRestResource>
      * @param certificate value of the given certificate
-     * @param usage the certificate usage such as p2p-tls or code-signer etc.
+     * @param usage the certificate usage such as p2p-tls or code-signer etc. Underscores are repleaced with hyphens
      * @param alias the unique alias under which the certificate chain will be stored
      * @param wait Duration before timing out, default 10 seconds
      */
@@ -136,7 +138,7 @@ class ClientCertificates {
     fun uploadCertificate(
         restClient: RestClient<CertificatesRestResource>,
         certificate: InputStream,
-        usage: String,
+        usage: CertificateUsage,
         alias: String,
         wait: Duration = 10.seconds
     ) {
@@ -147,7 +149,7 @@ class ClientCertificates {
             ) {
                 val resource = client.start().proxy
                 resource.importCertificateChain(
-                    usage = usage,
+                    usage = usage.publicName,
                     alias = alias,
                     certificates = listOf(
                         HttpFileUpload(

--- a/libs/corda-sdk/src/main/kotlin/net/corda/sdk/network/Keys.kt
+++ b/libs/corda-sdk/src/main/kotlin/net/corda/sdk/network/Keys.kt
@@ -3,6 +3,7 @@
 
 package net.corda.sdk.network
 
+import net.corda.crypto.core.CryptoConsts.Categories.KeyCategory
 import net.corda.membership.rest.v1.HsmRestResource
 import net.corda.membership.rest.v1.KeysRestResource
 import net.corda.membership.rest.v1.types.response.KeyPairIdentifier
@@ -34,16 +35,16 @@ class Keys {
         hsmRestClient: RestClient<HsmRestResource>,
         keysRestClient: RestClient<KeysRestResource>,
         holdingIdentityShortHash: String,
-        category: String,
+        category: KeyCategory,
         scheme: String = ECDSA_SECP256R1_CODE_NAME,
         wait: Duration = 10.seconds
     ): KeyPairIdentifier {
         hsmRestClient.use { hsmClient ->
             executeWithRetry(
                 waitDuration = wait,
-                operationName = "Assign Soft HSM operation for $category"
+                operationName = "Assign Soft HSM operation for ${category.value}"
             ) {
-                hsmClient.start().proxy.assignSoftHsm(holdingIdentityShortHash, category)
+                hsmClient.start().proxy.assignSoftHsm(holdingIdentityShortHash, category.value)
             }
         }
 
@@ -72,19 +73,19 @@ class Keys {
         keysRestClient: RestClient<KeysRestResource>,
         tenantId: String,
         alias: String,
-        category: String,
+        category: KeyCategory,
         scheme: String = ECDSA_SECP256R1_CODE_NAME,
         wait: Duration = 10.seconds
     ): KeyPairIdentifier {
         return keysRestClient.use { keyClient ->
             executeWithRetry(
                 waitDuration = wait,
-                operationName = "Generate key $category"
+                operationName = "Generate key ${category.value}"
             ) {
                 keyClient.start().proxy.generateKeyPair(
                     tenantId,
                     alias,
-                    category,
+                    category.value,
                     scheme,
                 )
             }
@@ -114,7 +115,7 @@ class Keys {
                     skip = 0,
                     take = 20,
                     orderBy = "NONE",
-                    category = "TLS",
+                    category = KeyCategory.TLS_KEY.value,
                     schemeCodeName = null,
                     alias = alias,
                     masterKeyAlias = null,
@@ -143,7 +144,7 @@ class Keys {
             keysRestClient = restClient,
             tenantId = "p2p",
             alias = alias,
-            category = "TLS",
+            category = KeyCategory.TLS_KEY,
             scheme = ECDSA_SECP256R1_CODE_NAME,
             wait = wait
         )

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoConsts.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoConsts.kt
@@ -18,20 +18,22 @@ object CryptoConsts {
         const val PRE_AUTH = "PRE_AUTH"
         const val SESSION_INIT = "SESSION_INIT"
         const val TLS = "TLS"
-        const val JWT_KEY = "JWT_KEY"
+        const val JWT = "JWT_KEY"
         const val ENCRYPTION_SECRET = "ENCRYPTION_SECRET"
 
-        val all: Set<String> = setOf(
-            ACCOUNTS,
-            CI,
-            LEDGER,
-            NOTARY,
-            PRE_AUTH,
-            SESSION_INIT,
-            TLS,
-            JWT_KEY,
-            ENCRYPTION_SECRET,
-        )
+        enum class KeyCategory(val value: String) {
+            ACCOUNTS_KEY(ACCOUNTS),
+            CI_KEY(CI),
+            LEDGER_KEY(LEDGER),
+            NOTARY_KEY(NOTARY),
+            PRE_AUTH_KEY(PRE_AUTH),
+            SESSION_INIT_KEY(SESSION_INIT),
+            TLS_KEY(TLS),
+            JWT_KEY(JWT),
+            ENCRYPTION_SECRET_KEY(ENCRYPTION_SECRET)
+        }
+
+        val all: Set<String> = CryptoConsts.Categories.KeyCategory.values().map { it.value }.toSet()
     }
 
     /**

--- a/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
+++ b/processors/crypto-processor/src/integrationTest/kotlin/net/corda/processors/crypto/tests/CryptoProcessorTests.kt
@@ -428,7 +428,7 @@ class CryptoProcessorTests {
             Arguments.of(CryptoConsts.Categories.LEDGER, vnodeId),
             Arguments.of(CryptoConsts.Categories.TLS, vnodeId),
             Arguments.of(CryptoConsts.Categories.SESSION_INIT, vnodeId),
-            Arguments.of(CryptoConsts.Categories.JWT_KEY, CryptoTenants.REST),
+            Arguments.of(CryptoConsts.Categories.JWT, CryptoTenants.REST),
             Arguments.of(CryptoConsts.Categories.TLS, CryptoTenants.P2P)
         )
 

--- a/tools/plugins/network/build.gradle
+++ b/tools/plugins/network/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation project(':libs:virtual-node:cpi-upload-endpoints')
     implementation project(':libs:virtual-node:virtual-node-endpoints')
     implementation project(':libs:virtual-node:virtual-node-info')
+    implementation 'net.corda:corda-config-schema'
     implementation project(":tools:plugins:package")
     implementation project(':tools:plugins:plugins-rest')
 

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -7,9 +7,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import net.corda.cli.plugins.common.RestCommand
 import net.corda.cli.plugins.packaging.signing.SigningOptions
 import net.corda.crypto.cipher.suite.schemes.RSA_TEMPLATE
+import net.corda.crypto.core.CryptoConsts.Categories.KeyCategory
 import net.corda.crypto.test.certificates.generation.CertificateAuthorityFactory
 import net.corda.crypto.test.certificates.generation.toFactoryDefinitions
 import net.corda.crypto.test.certificates.generation.toPem
+import net.corda.data.certificates.CertificateUsage
 import net.corda.libs.configuration.endpoints.v1.ConfigRestResource
 import net.corda.libs.configuration.endpoints.v1.types.ConfigSchemaVersion
 import net.corda.libs.configuration.endpoints.v1.types.UpdateConfigParameters
@@ -25,6 +27,7 @@ import net.corda.membership.rest.v1.types.request.HostedIdentitySessionKeyAndCer
 import net.corda.membership.rest.v1.types.request.HostedIdentitySetupRequest
 import net.corda.membership.rest.v1.types.response.KeyPairIdentifier
 import net.corda.rest.json.serialization.JsonObjectAsString
+import net.corda.schema.configuration.ConfigKeys.RootConfigKey
 import net.corda.sdk.config.ClusterConfig
 import net.corda.sdk.network.ClientCertificates
 import net.corda.sdk.network.Keys
@@ -152,7 +155,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
         shortHashId
     }
 
-    protected fun assignSoftHsmAndGenerateKey(category: String): KeyPairIdentifier {
+    protected fun assignSoftHsmAndGenerateKey(category: KeyCategory): KeyPairIdentifier {
         val hsmRestClient = createRestClient(
             HsmRestResource::class,
             insecure = insecure,
@@ -179,10 +182,10 @@ abstract class BaseOnboard : Runnable, RestCommand() {
     }
 
     protected val sessionKeyId by lazy {
-        assignSoftHsmAndGenerateKey("SESSION_INIT")
+        assignSoftHsmAndGenerateKey(KeyCategory.SESSION_INIT_KEY)
     }
     protected val ecdhKeyId by lazy {
-        assignSoftHsmAndGenerateKey("PRE_AUTH")
+        assignSoftHsmAndGenerateKey(KeyCategory.PRE_AUTH_KEY)
     }
     protected val certificateSubject by lazy {
         tlsCertificateSubject ?: "O=P2P Certificate, OU=$p2pHosts, L=London, C=GB"
@@ -318,7 +321,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             targetUrl = targetUrl
         )
         val clusterConfig = ClusterConfig()
-        val currentConfig = clusterConfig.getCurrentConfig(restClient, "corda.p2p.gateway", waitDurationSeconds.seconds)
+        val currentConfig = clusterConfig.getCurrentConfig(restClient, RootConfigKey.P2P_GATEWAY, waitDurationSeconds.seconds)
         val rawConfig = currentConfig.configWithDefaults
         val rawConfigJson = json.readTree(rawConfig)
         val sslConfig = rawConfigJson["sslConfig"]
@@ -402,7 +405,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
                 ClientCertificates().uploadCertificate(
                     restClient = restClient,
                     certificate = certificate,
-                    usage = "code-signer",
+                    usage = CertificateUsage.CODE_SIGNER,
                     alias = GRADLE_PLUGIN_DEFAULT_KEY_ALIAS,
                     wait = waitDurationSeconds.seconds
                 )
@@ -414,7 +417,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
                 ClientCertificates().uploadCertificate(
                     restClient = restClient,
                     certificate = certificate,
-                    usage = "code-signer",
+                    usage = CertificateUsage.CODE_SIGNER,
                     alias = "signingkey1-2022",
                     wait = waitDurationSeconds.seconds
                 )

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
@@ -2,6 +2,7 @@ package net.corda.cli.plugins.network
 
 import net.corda.cli.plugins.network.utils.PrintUtils.verifyAndPrintError
 import net.corda.cli.plugins.network.utils.inferCpiName
+import net.corda.crypto.core.CryptoConsts.Categories.KeyCategory
 import net.corda.libs.cpiupload.endpoints.v1.CpiUploadRestResource
 import net.corda.sdk.network.MemberRole
 import net.corda.sdk.network.RegistrationContext
@@ -157,11 +158,11 @@ class OnboardMember : Runnable, BaseOnboard() {
     }
 
     private val ledgerKeyId by lazy {
-        assignSoftHsmAndGenerateKey("LEDGER")
+        assignSoftHsmAndGenerateKey(KeyCategory.LEDGER_KEY)
     }
 
     private val notaryKeyId by lazy {
-        assignSoftHsmAndGenerateKey("NOTARY")
+        assignSoftHsmAndGenerateKey(KeyCategory.NOTARY_KEY)
     }
 
     override val registrationContext by lazy {


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/ES-2045
For the Corda-SDK we're wanting to use explicit types for function parameters instead of passing strings
As I don't want to break the existing API I've added the enum to sit alongside the existing constants, rather than replace them.
Requires Corda-API PR: https://github.com/corda/corda-api/pull/1579
Reminder: will reset the gradle property `cordaApiVersion=5.3.0.7-beta+` once API PR has been merged