### PR TITLE
CORE-20194 persistence clean up

### DIFF
--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -214,6 +214,7 @@ interface UtxoRepository {
         val customRepresentation: CustomRepresentation,
         val token: UtxoToken?,
         val notaryName: String,
+        val consumed: Instant? = null
     )
 
     data class TransactionSignature(val index: Int, val signatureBytes: ByteArray, val publicKeyHash: SecureHash)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -375,7 +375,11 @@ class UtxoRepositoryImpl(
                 }
 
                 statement.setTimestamp(parameterIndex.next(), Timestamp.from(timestamp))
-                statement.setNull(parameterIndex.next(), Types.TIMESTAMP)
+                if (visibleTransactionOutput.consumed == null) {
+                    statement.setNull(parameterIndex.next(), Types.TIMESTAMP)
+                } else {
+                    statement.setTimestamp(parameterIndex.next(), Timestamp.from(visibleTransactionOutput.consumed))
+                }
                 statement.setString(parameterIndex.next(), visibleTransactionOutput.customRepresentation.json)
             }
         }

--- a/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/test/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImplTest.kt
@@ -326,7 +326,7 @@ class UtxoPersistenceServiceImplTest {
             on { getConsumedStateRefs() } doReturn emptyList()
             on { rawGroupLists } doReturn listOf(listOf("{}".toByteArray()))
             on { visibleStatesIndexes } doReturn listOf(0)
-            on { status } doReturn TransactionStatus.UNVERIFIED
+            on { status } doReturn TransactionStatus.VERIFIED
             on { signatures } doReturn emptyList()
             on { id } doReturn randomSecureHash()
             on { privacySalt } doReturn mockPrivacySalt


### PR DESCRIPTION
Optimise and clean up the persistence code for the out-of-order case. This is an optional improvement for 5.2, it can be merged to 5.3 or 5.2.1 if deemed to risky. It does not change actual functionality.