### PR TITLE
CORE-20208 Make persist API calls with deterministic ids

### DIFF
--- a/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v1/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
+++ b/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v1/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
@@ -20,11 +20,10 @@ class SimplePersistenceCheckFlow : ClientStartableFlow {
 
     @Suspendable
     override fun call(requestBody: ClientRequestBody): String {
-        val deduplicationId = UUID.randomUUID().toString()
         val fish = Fish(UUID.randomUUID(), "Floaty", "Black", Owner(UUID.randomUUID(), "alice", 22))
 
         try {
-            persistenceService.persist(deduplicationId, fish)
+            persistenceService.persist("fish1", fish)
         } catch (ex: CordaPersistenceException) {
             return "Could not persist fish"
         }

--- a/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v2/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
+++ b/testing/cpbs/test-cordapp-for-vnode-upgrade-testing-v2/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
@@ -21,11 +21,10 @@ class SimplePersistenceCheckFlow : ClientStartableFlow {
 
     @Suspendable
     override fun call(requestBody: ClientRequestBody): String {
-        val deduplicationId = UUID.randomUUID().toString()
         val dog = Dog(UUID.randomUUID(), "Rex", Instant.now(), "none")
 
         try {
-            persistenceService.persist(deduplicationId, dog)
+            persistenceService.persist("dog1", dog)
         } catch (ex: CordaPersistenceException) {
             return "Could not persist dog"
         }

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RestSmokeTestFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/flow/RestSmokeTestFlow.kt
@@ -130,10 +130,9 @@ class RestSmokeTestFlow : ClientStartableFlow {
 
     @Suspendable
     private fun persistencePersistDogs(input: RestSmokeTestInput): String {
-        val deduplicationId = UUID.randomUUID().toString()
 
         val dogs = getDogIds(input).map { id -> Dog(id, "dog-$id", Instant.now(), "none") }
-        persistenceService.persist(deduplicationId, dogs)
+        persistenceService.persist("multipleDogs1", dogs)
         return "dogs ${dogs.map { it.id }} saved"
     }
 

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/smoketests/virtualnode/SimplePersistenceCheckFlow.kt
@@ -27,12 +27,11 @@ class SimplePersistenceCheckFlow : ClientStartableFlow {
 
     @Suspendable
     override fun call(requestBody: ClientRequestBody): String {
-        val deduplicationId = UUID.randomUUID().toString()
         val id = UUID.randomUUID()
 
         val dog = Dog(id, "Penny", Instant.now(), "Alice")
         try {
-            persistenceService.persist(deduplicationId, dog)
+            persistenceService.persist("Penny1", dog)
         } catch (ex: CordaPersistenceException) {
             log.error("exception $ex")
             return "Could not persist dog"

--- a/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/testflows/PersistenceFlow.kt
+++ b/testing/cpbs/test-cordapp/src/main/kotlin/com/r3/corda/testing/testflows/PersistenceFlow.kt
@@ -33,25 +33,24 @@ class PersistenceFlow : ClientStartableFlow {
     override fun call(requestBody: ClientRequestBody): String {
         log.info("Starting Test Flow...")
         try {
-            val deduplicationIds = List(4) { UUID.randomUUID().toString() }
             val inputs = requestBody.getRequestBodyAs(jsonMarshallingService, TestFlowInput::class.java)
 
-            persistenceService.persist(deduplicationIds[0], 123)
+            persistenceService.persist("entity1", 123)
             persistenceService.remove(123)
 
             val id = UUID.randomUUID()
             val dog = Dog(id, "Penny", Instant.now(), "Alice")
-            persistenceService.persist(deduplicationIds[1], dog)
+            persistenceService.persist("entity2", dog)
             log.info("Persisted Dog: $dog")
 
             val id2 = UUID.randomUUID()
             val dog2 = Dog(id2, "Lenard", Instant.now(), "Alice")
-            persistenceService.persist(deduplicationIds[2], listOf(dog2))
+            persistenceService.persist("entity3", listOf(dog2))
             log.info("Persisted Dog (bulk): $dog2")
 
             if (inputs.throwException) {
                 try {
-                    persistenceService.persist(deduplicationIds[3], dog)
+                    persistenceService.persist("entity4", dog)
                     log.error("Persisted second Dog incorrectly: $dog")
 
                 } catch (e: CordaPersistenceException) {


### PR DESCRIPTION
Currently they are random. This could cause flakiness in tests which rerun fibers