### PR TITLE
CORE-18597 Allow for reasons to be set for Stop Lifecycle Events

### DIFF
--- a/components/configuration/configuration-rest-resource-service-impl/src/main/kotlin/net/corda/configuration/rest/impl/v1/ConfigRestResourceImpl.kt
+++ b/components/configuration/configuration-rest-resource-service-impl/src/main/kotlin/net/corda/configuration/rest/impl/v1/ConfigRestResourceImpl.kt
@@ -120,7 +120,7 @@ internal class ConfigRestResourceImpl @Activate constructor(
                     when (event.status) {
                         LifecycleStatus.ERROR -> {
                             coordinator.closeManagedResources(setOf(CONFIG_HANDLE))
-                            coordinator.postEvent(StopEvent(errored = true))
+                            coordinator.postEvent(StopEvent(errored = true, reason = "Coordinator stopped. RegistrationStatusChangeEvent with status ERROR received in ConfigRestResourceImpl."))
                         }
                         LifecycleStatus.UP -> {
                             // Receive updates to the RPC and Messaging config

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/PublisherWithDominoLogicBase.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/PublisherWithDominoLogicBase.kt
@@ -38,7 +38,7 @@ open class PublisherWithDominoLogicBase<T: AutoCloseable>(
         override val managedChildren: Collection<NamedLifecycle> = emptySet()
 
         override fun close() {
-            coordinator.postEvent(StopEvent())
+            coordinator.postEvent(StopEvent(reason = "Coordinator stopped. Domino tile closed."))
             coordinator.close()
         }
 

--- a/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/PermissionStorageReaderService.kt
+++ b/components/permissions/permission-storage-reader-service/src/main/kotlin/net/corda/permissions/storage/reader/PermissionStorageReaderService.kt
@@ -57,6 +57,6 @@ class PermissionStorageReaderService @Activate constructor(
     }
 
     override fun stop() {
-        coordinator.postEvent(StopEvent())
+        coordinator.postEvent(StopEvent(reason = "Coordinator stopped in PermissionStorageReaderService."))
     }
 }

--- a/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/PermissionStorageWriterService.kt
+++ b/components/permissions/permission-storage-writer-service/src/main/kotlin/net/corda/permissions/storage/writer/PermissionStorageWriterService.kt
@@ -58,6 +58,6 @@ class PermissionStorageWriterService @Activate constructor(
     }
 
     override fun stop() {
-        coordinator.postEvent(StopEvent())
+        coordinator.postEvent(StopEvent(reason = "Coordinator stopped in PermissionStorageWriterService."))
     }
 }

--- a/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
+++ b/components/rbac-security-manager-service/src/main/kotlin/net/corda/components/rbac/RBACSecurityManagerService.kt
@@ -87,7 +87,7 @@ class RBACSecurityManagerService @Activate constructor(
                         downTransition()
                     }
                     LifecycleStatus.ERROR -> {
-                        coordinator.postEvent(StopEvent(true))
+                        coordinator.postEvent(StopEvent(errored = true, reason = "Coordinator stopped. RegistrationStatusChangeEvent with status ERROR received."))
                     }
                 }
             }

--- a/components/rest-gateway-comp/src/main/kotlin/net/corda/components/rest/internal/RestGatewayEventHandler.kt
+++ b/components/rest-gateway-comp/src/main/kotlin/net/corda/components/rest/internal/RestGatewayEventHandler.kt
@@ -134,7 +134,7 @@ internal class RestGatewayEventHandler(
                     }
                     LifecycleStatus.ERROR -> {
                         log.info("Registration received ERROR status. Stopping the REST Gateway.")
-                        coordinator.postEvent(StopEvent(true))
+                        coordinator.postEvent(StopEvent(errored = true, reason = "Coordinator stopped. RegistrationStatusChangeEvent with status ERROR received."))
                     }
                 }
             }

--- a/components/virtual-node/virtual-node-rest-maintenance-impl/src/main/kotlin/net/corda/libs/virtualnode/maintenance/rest/impl/v1/VirtualNodeMaintenanceRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-maintenance-impl/src/main/kotlin/net/corda/libs/virtualnode/maintenance/rest/impl/v1/VirtualNodeMaintenanceRestResourceImpl.kt
@@ -101,7 +101,7 @@ class VirtualNodeMaintenanceRestResourceImpl @Activate constructor(
                 when (event.status) {
                     LifecycleStatus.ERROR -> {
                         coordinator.closeManagedResources(setOf(CONFIG_HANDLE))
-                        coordinator.postEvent(StopEvent(errored = true))
+                        coordinator.postEvent(StopEvent(errored = true, reason = "Coordinator stopped. RegistrationStatusChangeEvent with status ERROR received."))
                     }
 
                     LifecycleStatus.UP -> {

--- a/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
+++ b/components/virtual-node/virtual-node-rest-service-impl/src/main/kotlin/net/corda/virtualnode/rest/impl/v1/VirtualNodeRestResourceImpl.kt
@@ -166,7 +166,7 @@ internal class VirtualNodeRestResourceImpl(
                 when (event.status) {
                     LifecycleStatus.ERROR -> {
                         coordinator.closeManagedResources(setOf(CONFIG_HANDLE))
-                        coordinator.postEvent(StopEvent(errored = true))
+                        coordinator.postEvent(StopEvent(errored = true, reason = "Coordinator stopped. RegistrationStatusChangeEvent with status ERROR received."))
                     }
 
                     LifecycleStatus.UP -> {

--- a/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeWriteEventHandler.kt
+++ b/components/virtual-node/virtual-node-write-service-impl/src/main/kotlin/net/corda/virtualnode/write/db/impl/VirtualNodeWriteEventHandler.kt
@@ -102,7 +102,7 @@ internal class VirtualNodeWriteEventHandler(
                             )
                         )
                 }
-                ERROR -> coordinator.postEvent(StopEvent(errored = true))
+                ERROR -> coordinator.postEvent(StopEvent(errored = true, reason = "Coordinator stopped. Registering for config updates failed."))
                 else -> Unit
             }
         }

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
@@ -271,7 +271,7 @@ class LifecycleCoordinatorImpl(
     override fun close() {
         if (_isClosed.compareAndSet(false, true)) {
             logger.trace { "$name: Closing coordinator" }
-            postInternalEvent(StopEvent())
+            postInternalEvent(StopEvent(reason = "Coordinator closed."))
             postInternalEvent(CloseCoordinator())
         }
     }

--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
@@ -164,11 +164,17 @@ internal class LifecycleProcessor(
         logger.debug { "Processing stop event for ${coordinator.name}" }
         if (state.isRunning) {
             state.isRunning = false
-            val (newStatus, reason) = if (event.errored) {
-                Pair(LifecycleStatus.ERROR, ERRORED_REASON)
+            // use stop event reason if present instead of default
+            val newStatus = if (event.errored) {
+                LifecycleStatus.ERROR
             } else {
-                Pair(LifecycleStatus.DOWN, STOPPED_REASON)
+                LifecycleStatus.DOWN
             }
+
+            val reason = event.reason.ifEmpty {
+                STOPPED_REASON
+            }
+
             try {
                 updateStatus(coordinator, newStatus, reason)
             } catch (e: LifecycleRegistryException) {

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleProcessorTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleProcessorTest.kt
@@ -181,6 +181,14 @@ class LifecycleProcessorTest {
     }
 
     @Test
+    fun `stop event posted with a set reason`() {
+        val state = LifecycleStateManager(5)
+        val processor = LifecycleProcessor(NAME, state, mock(), mock()) { _, _ -> }
+        state.postEvent(StopEvent(errored = false, "Coordinator stopped."))
+        process(processor)
+    }
+
+    @Test
     fun `batching delivers the right number of events to the processor`() {
         val state = LifecycleStateManager(2)
         state.isRunning = true

--- a/libs/lifecycle/lifecycle/src/main/kotlin/net/corda/lifecycle/LifecycleEvents.kt
+++ b/libs/lifecycle/lifecycle/src/main/kotlin/net/corda/lifecycle/LifecycleEvents.kt
@@ -40,8 +40,10 @@ class StartEvent : LifecycleEvent
  *
  * @param errored Flag indicating if this stop event happened due to an error occurring. Used internally to set the
  *                coordinator status correctly.
+ *
+ * @param reason The reason why the coordinator was stopped.
  */
-data class StopEvent(val errored: Boolean = false) : LifecycleEvent
+data class StopEvent(val errored: Boolean = false, val reason: String = "") : LifecycleEvent
 
 /**
  * An event delivered after a scheduled timer has fired.


### PR DESCRIPTION
Added `reason` property to StopEvent. I changed the `processStopEvent` so that instead of always using the default reason values it uses the `event.reason` whenever available. I added reasons for each use case of StopEvent.