### PR TITLE
CORE-19313: Remove cluster check from TokenSelectionTests

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/TokenSelectionTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/token/selection/TokenSelectionTests.kt
@@ -2,8 +2,6 @@ package net.corda.applications.workers.smoketest.token.selection
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import net.corda.e2etest.utilities.ClusterReadiness
-import net.corda.e2etest.utilities.ClusterReadinessChecker
 import net.corda.e2etest.utilities.DEFAULT_CLUSTER
 import net.corda.e2etest.utilities.REST_FLOW_STATUS_SUCCESS
 import net.corda.e2etest.utilities.TEST_NOTARY_CPB_LOCATION
@@ -23,11 +21,10 @@ import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import java.math.BigDecimal
-import java.time.Duration
 import java.util.UUID
 
 @TestInstance(PER_CLASS)
-class TokenSelectionTests : ClusterReadiness by ClusterReadinessChecker() {
+class TokenSelectionTests {
 
     private companion object {
         const val TEST_CPI_NAME = "ledger-utxo-demo-app"
@@ -84,9 +81,6 @@ class TokenSelectionTests : ClusterReadiness by ClusterReadinessChecker() {
 
     @BeforeAll
     fun beforeAll() {
-        // check cluster is ready
-        assertIsReady(Duration.ofMinutes(2), Duration.ofMillis(100))
-
         DEFAULT_CLUSTER.conditionallyUploadCpiSigningCertificate()
 
         conditionallyUploadCordaPackage(


### PR DESCRIPTION
Remove the cluster health check because...

* Our cluster is expected to work even if some workers report down
* It makes our test sensitive to worker health
* It guarentees failure when there was a chance of success
* It makes the test care about combined worker differences that it would not normally notice