### PR TITLE
CORE-20257: Get the key ID from list

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -186,7 +186,7 @@ fun ClusterInfo.createKeyFor(
     category: String,
     scheme: String
 ): String = cluster {
-    val keyId = assertWithRetry {
+    assertWithRetry {
         interval(1.seconds)
         command { createKey(tenantId, alias, category, scheme) }
         condition {
@@ -194,14 +194,24 @@ fun ClusterInfo.createKeyFor(
             it.code == 200 || it.code == 409
         }
         failMessage("Failed to create key for holding id '$tenantId'")
-    }.toJson()
-    assertWithRetryIgnoringExceptions {
-        interval(1.seconds)
-        command { getKey(tenantId, keyId["id"].textValue()) }
-        condition { it.code == 200 }
-        failMessage("Failed to get key for holding id '$tenantId' and key id '$keyId'")
     }
-    keyId["id"].textValue()
+    val keys = assertWithRetryIgnoringExceptions {
+        interval(1.seconds)
+        command {
+            getKey(
+                tenantId = tenantId,
+                alias = alias,
+                category = category,
+            )
+        }
+        condition {
+            it.code == 200 &&
+                    it.toJson().isObject &&
+                    !it.toJson().isEmpty
+        }
+        failMessage("Failed to get keys for holding id '$tenantId' and alias '$alias'")
+    }.toJson()
+    keys.fieldNames().next()
 }
 
 private val keyExistsLock = ReentrantLock()


### PR DESCRIPTION
The issue is that when the `createKey` returns 409 (conflict), we can't read the key ID from the returned payload. So, instead of using the key ID from there and then trying to get it to verify it exists, we will list all the keys with that alias and category and use the first key (which should be unique because we are searching by alias).

e2e tests in https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-e2e-tests-multi-cluster-tests/detail/PR-553/1/pipeline