### PR TITLE
CORE-20228 Increasing test RETRY_TIMEOUT to 12 minutes to allow FlowSpecificTimeoutTests to pass

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -17,7 +17,7 @@ const val SMOKE_TEST_CLASS_NAME = "com.r3.corda.testing.smoketests.flow.RestSmok
 const val REST_FLOW_STATUS_SUCCESS = "COMPLETED"
 const val REST_FLOW_STATUS_FAILED = "FAILED"
 
-// @TODO: reduce timeout to 6 minutes following investigation in CORE-20228 into test slowness
+// Reduce timeout to 6 minutes following investigation in CORE-20228 into test slowness
 //private val RETRY_TIMEOUT = 6.minutes
 private val RETRY_TIMEOUT = 12.minutes
 

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/FlowTestUtils.kt
@@ -17,7 +17,9 @@ const val SMOKE_TEST_CLASS_NAME = "com.r3.corda.testing.smoketests.flow.RestSmok
 const val REST_FLOW_STATUS_SUCCESS = "COMPLETED"
 const val REST_FLOW_STATUS_FAILED = "FAILED"
 
-private val RETRY_TIMEOUT = 6.minutes
+// @TODO: reduce timeout to 6 minutes following investigation in CORE-20228 into test slowness
+//private val RETRY_TIMEOUT = 6.minutes
+private val RETRY_TIMEOUT = 12.minutes
 
 fun startRestFlow(
     holdingId: String,


### PR DESCRIPTION
Increasing test timeout to investigate whether the failures described by CORE-20228 can pass given additional time.