### PR TITLE
CORE-19220 Delivery tracker message cache

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageCache.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageCache.kt
@@ -57,9 +57,6 @@ internal class DataMessageCache(
         }
     }
 
-    override fun close() {
-    }
-
     override fun changed() {
         updateCacheSize(config.config.maxCacheSizeMegabytes)
     }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageCache.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageCache.kt
@@ -1,0 +1,131 @@
+package net.corda.p2p.linkmanager.tracker
+
+import com.github.benmanes.caffeine.cache.Cache
+import com.github.benmanes.caffeine.cache.Caffeine
+import net.corda.cache.caffeine.CacheFactoryImpl
+import net.corda.data.p2p.app.AppMessage
+import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.StateManager
+import net.corda.lifecycle.Resource
+import net.corda.schema.registry.AvroSchemaRegistry
+import net.corda.schema.registry.deserialize
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
+
+class DataMessageCache(
+    private val stateManager: StateManager,
+    private val schemaRegistry: AvroSchemaRegistry,
+) : Resource {
+    private companion object {
+        val logger: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+//        const val KEY_PREFIX = "P2P-msg"
+        // TODO Get from config (DeliveryTracker)
+        val maxCacheSize = 1L
+        val maxCacheOffsetAge = 1L
+    }
+
+    private data class TrackedMessage(
+        val message: AppMessage,
+        val offset: Long,
+    )
+
+    private val messageCache: Cache<MessageId, TrackedMessage> =
+        CacheFactoryImpl().build(
+            "P2P-delivery-tracker-cache",
+            Caffeine.newBuilder()
+                .maximumSize(maxCacheSize)
+                .removalListener<MessageId?, TrackedMessage?> { _, value, _ ->
+                    value?.let { offsetToMessageId.remove(value.offset) }
+                }.evictionListener { key, value, _ ->
+                    if (key != null && value != null) {
+                        stateManager.put(key, value.message)
+                        offsetToMessageId.remove(value.offset)
+                    }
+                }
+        )
+
+    private val offsetToMessageId = ConcurrentHashMap<Long, MessageId>()
+
+    fun get(key: MessageId): AppMessage? {
+        return messageCache.getIfPresent(key)?.message ?: stateManager.getIfPresent(key)
+    }
+
+    fun put(key: MessageId, message: AppMessage, offset: Long) {
+        messageCache.put(key, TrackedMessage(message, offset))
+        offsetToMessageId[offset] = key
+        persistOlderCacheEntries()
+    }
+
+    fun invalidate(key: MessageId) {
+        messageCache.getIfPresent(key)?.let {
+            logger.trace("Discarding cached delivery tracker entry for '{}'.", key)
+            messageCache.invalidate(key)
+        } ?: {
+            logger.trace("Deleting delivery tracker entry from state manager for '{}'.", key)
+            stateManager.deleteIfPresent(key)
+        }
+    }
+
+    private fun StateManager.getIfPresent(key: String): AppMessage? {
+        return try {
+            get(setOf(key)).values.firstOrNull()?.let {
+                schemaRegistry.deserialize<AppMessage>(ByteBuffer.wrap(it.value))
+            }
+        } catch (e: Exception) {
+            logger.error("Unexpected error while trying to fetch message state for '{}'.", key, e)
+            null
+        }
+    }
+
+    private fun StateManager.deleteIfPresent(key: String) {
+        get(setOf(key)).values.firstOrNull()?.let { state ->
+            var stateToDelete = state
+            var retryCount = 0
+            var failedDeletes = mapOf<String, State>()
+            do {
+                try {
+                    failedDeletes = delete(setOf(stateToDelete))
+                } catch (e: Exception) {
+                    logger.error("Unexpected error while trying to delete message state from the state manager.", e)
+                }
+                if (failedDeletes.isNotEmpty()) {
+                    stateToDelete = failedDeletes.values.first()
+                }
+            } while (retryCount++ < 3 && failedDeletes.isNotEmpty())
+
+            if (failedDeletes.isNotEmpty()) {
+                logger.error("Failed to delete the state for key '{}' after '{} attempts.", key, retryCount)
+            }
+        }
+        // TODO refactor retry
+    }
+
+    private fun StateManager.put(id: MessageId, message: AppMessage) {
+        val newState = State(id, schemaRegistry.serialize(message).array())
+        create(setOf(newState)).forEach {
+            logger.warn("Failed to persist message '{}' for tracking delivery.", it)
+        }
+        // TODO retry
+    }
+
+    private fun persistOlderCacheEntries() {
+        val threshold = offsetToMessageId.keys.max() - maxCacheOffsetAge
+        offsetToMessageId.filterKeys { it < threshold }.forEach { entry ->
+            val messageId = entry.value
+            messageCache.getIfPresent(messageId)?.message?.let {
+                stateManager.put(messageId, it)
+                messageCache.invalidate(messageId)
+            } ?: offsetToMessageId.remove(entry.key)
+
+        }
+    }
+
+//    private fun MessageId.toKey() = "$KEY_PREFIX$this"
+
+    override fun close() {
+    }
+}
+
+private typealias MessageId = String

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageStore.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageStore.kt
@@ -3,6 +3,7 @@ package net.corda.p2p.linkmanager.tracker
 import net.corda.data.p2p.app.AppMessage
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
+import net.corda.p2p.linkmanager.tracker.exception.DataMessageStoreException
 import net.corda.schema.registry.AvroSchemaRegistry
 import net.corda.schema.registry.deserialize
 import org.slf4j.LoggerFactory

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/tracker/exception/DeliveryTrackerExceptions.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/tracker/exception/DeliveryTrackerExceptions.kt
@@ -1,5 +1,7 @@
-package net.corda.p2p.linkmanager.tracker
+package net.corda.p2p.linkmanager.tracker.exception
 
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
 class DataMessageStoreException(msg: String) : CordaRuntimeException(msg)
+
+class DataMessageCacheException(msg: String) : CordaRuntimeException(msg)

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageCacheTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageCacheTest.kt
@@ -1,3 +1,153 @@
 package net.corda.p2p.linkmanager.tracker
 
-class DataMessageCacheTest {}
+import net.corda.data.p2p.app.AppMessage
+import net.corda.libs.statemanager.api.State
+import net.corda.libs.statemanager.api.StateManager
+import net.corda.lifecycle.LifecycleCoordinator
+import net.corda.lifecycle.LifecycleCoordinatorFactory
+import net.corda.lifecycle.LifecycleEventHandler
+import net.corda.lifecycle.LifecycleStatus
+import net.corda.lifecycle.RegistrationHandle
+import net.corda.lifecycle.RegistrationStatusChangeEvent
+import net.corda.lifecycle.domino.logic.ComplexDominoTile
+import net.corda.schema.registry.AvroSchemaRegistry
+import net.corda.schema.registry.deserialize
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import java.nio.ByteBuffer
+
+class DataMessageCacheTest {
+    private val knownKey = "test"
+    private val valueBytes = knownKey.toByteArray()
+    private val states = mapOf(
+        knownKey to mock<State> {
+            on { key } doReturn knownKey
+            on { value } doReturn valueBytes
+        }
+    )
+    private val createCaptor = argumentCaptor<Collection<State>>()
+    private val deleteCaptor = argumentCaptor<Collection<State>>()
+    private val stateManager = mock<StateManager> {
+        on { name } doReturn mock()
+        on { get(setOf(knownKey)) } doReturn states
+        on { create(createCaptor.capture()) } doReturn emptySet()
+        on { delete(deleteCaptor.capture()) } doReturn emptyMap()
+    }
+    private val appMessage = mock<AppMessage>()
+    private val schemaRegistry = mock<AvroSchemaRegistry> {
+        on { serialize(any()) } doReturn ByteBuffer.wrap(valueBytes)
+        on { deserialize<AppMessage>(ByteBuffer.wrap(valueBytes)) } doReturn appMessage
+    }
+    private val configDominoTile = mock<ComplexDominoTile> {
+        on { coordinatorName } doReturn mock()
+    }
+    private val config = mock<DeliveryTrackerConfiguration> {
+        on { dominoTile } doReturn configDominoTile
+        on { config } doReturn DeliveryTrackerConfiguration.Configuration(
+            maxCacheSizeMegabytes = 100,
+            maxCacheOffsetAge = 50000,
+            statePersistencePeriodSeconds = 1.0,
+            outboundBatchProcessingTimeoutSeconds = 30.0,
+            maxNumberOfPersistenceRetries = 3,
+        )
+    }
+    private val handler = argumentCaptor<LifecycleEventHandler>()
+    private val followStatusChangesByNameHandlers = mutableSetOf<RegistrationHandle>()
+    private val coordinator = mock<LifecycleCoordinator> {
+        on { followStatusChangesByName(any()) } doAnswer {
+            val handler = mock<RegistrationHandle>()
+            followStatusChangesByNameHandlers.add(handler)
+            handler
+        }
+    }
+    private val coordinatorFactory = mock<LifecycleCoordinatorFactory> {
+        on { createCoordinator(any(), handler.capture()) } doReturn coordinator
+    }
+
+    private val cache = DataMessageCache(
+        coordinatorFactory,
+        stateManager,
+        schemaRegistry,
+        config,
+    )
+
+    @Test
+    fun `onStart will listen to configuration changes`() {
+        followStatusChangesByNameHandlers.forEach { followStatusChangesByNameHandler ->
+            handler.firstValue.processEvent(
+                RegistrationStatusChangeEvent(
+                    followStatusChangesByNameHandler,
+                    LifecycleStatus.UP,
+                ),
+                coordinator,
+            )
+        }
+
+        verify(config).lister(cache)
+    }
+
+    @Nested
+    inner class GetTests {
+        @Test
+        fun `get can return a value previously cached using put`() {
+            val testMessage = mock<AppMessage>()
+            val key = "key"
+            cache.put(key, testMessage, DataMessageCache.PartitionAndOffset(1, 1))
+
+            val result = cache.get(key)
+
+            assertThat(result).isEqualTo(testMessage)
+        }
+
+        @Test
+        fun `get will query the state manager if entry is not in the cache`() {
+            val result = cache.get(knownKey)
+
+            assertThat(result).isEqualTo(appMessage)
+            verify(stateManager).get(setOf(knownKey))
+        }
+    }
+
+    @Nested
+    inner class PutTests {
+        @Test
+        fun `put will persist older cache entries to state manager`() {
+            val testMessage = mock<AppMessage>()
+            val key1 = "key-1"
+            val key2 = "key-2"
+            cache.put(key1, testMessage, DataMessageCache.PartitionAndOffset(1, 10))
+
+            cache.put(key2, testMessage, DataMessageCache.PartitionAndOffset(1, 55000))
+
+            assertThat(createCaptor.firstValue.single().key).isEqualTo(key1)
+        }
+    }
+
+    @Nested
+    inner class InvalidateTests {
+        @Test
+        fun `invalidate will delete from state manager if key not in cache`() {
+            cache.invalidate(knownKey)
+
+            assertThat(deleteCaptor.firstValue.single().key).isEqualTo(knownKey)
+        }
+
+        @Test
+        fun `invalidate discards previously added cache entry`() {
+            val testMessage = mock<AppMessage>()
+            val key = "key"
+            cache.put(key, testMessage, DataMessageCache.PartitionAndOffset(1, 1))
+
+            cache.invalidate(key)
+
+            assertThat(cache.get(key)).isNull()
+        }
+    }
+}

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageCacheTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageCacheTest.kt
@@ -1,0 +1,3 @@
+package net.corda.p2p.linkmanager.tracker
+
+class DataMessageCacheTest {}

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageStoreTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/tracker/DataMessageStoreTest.kt
@@ -5,6 +5,7 @@ import net.corda.data.p2p.app.AuthenticatedMessage
 import net.corda.data.p2p.app.AuthenticatedMessageHeader
 import net.corda.libs.statemanager.api.State
 import net.corda.libs.statemanager.api.StateManager
+import net.corda.p2p.linkmanager.tracker.exception.DataMessageStoreException
 import net.corda.schema.registry.AvroSchemaRegistry
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy


### PR DESCRIPTION
The data message cache is responsible for storing data messages in memory while they are tracked. To avoid the cache growing too large, two constraints are put on the cache - the first is an overall size based on the total storage space represented by all messages in the cache, the second is an age of items in the cache based on Kafka offset.