### PR TITLE
CORE-20229: Remove transaction from findVirtualNodeOperationByRequestId

### DIFF
--- a/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
+++ b/libs/virtual-node/virtual-node-datamodel/src/main/kotlin/net/corda/libs/virtualnode/datamodel/repository/VirtualNodeRepositoryImpl.kt
@@ -13,6 +13,7 @@ import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeEntity
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationEntity
 import net.corda.libs.virtualnode.datamodel.entities.VirtualNodeOperationState
 import net.corda.orm.utils.transaction
+import net.corda.orm.utils.use
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.OperationalStatus
@@ -59,7 +60,7 @@ class VirtualNodeRepositoryImpl : VirtualNodeRepository {
     }
 
     override fun findVirtualNodeOperationByRequestId(entityManager: EntityManager, requestId: String): VirtualNodeOperationDto {
-        entityManager.transaction {
+        entityManager.use {
             val operationStatuses = entityManager.createQuery(
                 "from ${VirtualNodeOperationEntity::class.java.simpleName} where requestId = :requestId " +
                     "order by latestUpdateTimestamp desc",


### PR DESCRIPTION
This code path has been observed to block while liquibase migrations run. It is possible that this use of `transcation` is acting like a lock.