### PR TITLE
CORE-19682: Send acks only after message was published successfully

### DIFF
--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundLinkManager.kt
@@ -46,14 +46,16 @@ internal class InboundLinkManager(
         commonComponents.sessionManager,
         groupPolicyProvider,
         membershipGroupReaderProvider,
+        publisher,
         clock
     )
     private val inboundMessageSubscription = {
-        subscriptionFactory.createEventLogSubscription(
+        subscriptionFactory.createEventSourceSubscription(
             subscriptionConfig,
             processor,
             messagingConfiguration,
             partitionAssignmentListener = null,
+            consumerOffsetProvider = null,
         )
     }
     private val subscriptionConfig = SubscriptionConfig(INBOUND_MESSAGE_PROCESSOR_GROUP, Schemas.P2P.LINK_IN_TOPIC)

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -80,7 +80,14 @@ internal class InboundMessageProcessor(
                     if (err == null) {
                         publisher.publish(listOf(ack))
                     } else {
-                        logger.info("Failed to publish ack message.", err)
+                        val lastIem = traceable.item.records.lastOrNull()
+                        val topic = lastIem?.topic
+                        val message = (lastIem?.value as? AppMessage)?.message as? AuthenticatedMessage
+                        logger.info(
+                            "Failed to publish message ${message?.header?.messageId} to the '$topic' topic. " +
+                            "The message ack was not published to allow the delivery tracker to retry it.",
+                            err,
+                        )
                     }
                 }
             }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -2,13 +2,13 @@ package net.corda.p2p.linkmanager.inbound
 
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.read.MembershipGroupReaderProvider
-import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
 import net.corda.data.p2p.AuthenticatedMessageAck
 import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.data.p2p.DataMessagePayload
 import net.corda.data.p2p.LinkInMessage
+import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.MessageAck
 import net.corda.data.p2p.app.AppMessage
 import net.corda.data.p2p.app.AuthenticatedMessage
@@ -19,6 +19,7 @@ import net.corda.data.p2p.crypto.InitiatorHandshakeMessage
 import net.corda.data.p2p.crypto.InitiatorHelloMessage
 import net.corda.data.p2p.crypto.ResponderHandshakeMessage
 import net.corda.data.p2p.crypto.ResponderHelloMessage
+import net.corda.data.p2p.linkmanager.LinkManagerResponse
 import net.corda.p2p.crypto.protocol.api.Session
 import net.corda.p2p.linkmanager.LinkManager
 import net.corda.p2p.linkmanager.common.AvroSealedClasses
@@ -27,6 +28,8 @@ import net.corda.p2p.linkmanager.membership.NetworkMessagingValidator
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.data.p2p.markers.LinkManagerReceivedMarker
+import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
+import net.corda.messaging.api.processor.EventSourceProcessor
 import net.corda.p2p.linkmanager.ItemWithSource
 import net.corda.p2p.linkmanager.metrics.recordInboundMessagesMetric
 import net.corda.p2p.linkmanager.metrics.recordInboundSessionMessagesMetric
@@ -34,6 +37,7 @@ import net.corda.p2p.linkmanager.metrics.recordOutboundSessionMessagesMetric
 import net.corda.p2p.linkmanager.sessions.StatefulSessionManagerImpl.Companion.LINK_MANAGER_SUBSYSTEM
 import net.corda.schema.Schemas
 import net.corda.tracing.traceEventProcessing
+import net.corda.utilities.Either
 import net.corda.utilities.debug
 import net.corda.utilities.flags.Features
 import net.corda.utilities.time.Clock
@@ -46,12 +50,13 @@ internal class InboundMessageProcessor(
     private val sessionManager: SessionManager,
     private val groupPolicyProvider: GroupPolicyProvider,
     private val membershipGroupReaderProvider: MembershipGroupReaderProvider,
+    private val publisher: PublisherWithDominoLogic,
     private val clock: Clock,
     private val networkMessagingValidator: NetworkMessagingValidator =
         NetworkMessagingValidator(membershipGroupReaderProvider),
     private val features: Features = Features(),
 ) :
-    EventLogProcessor<String, LinkInMessage> {
+    EventSourceProcessor<String, LinkInMessage> {
 
     private companion object {
         val logger: Logger = LoggerFactory.getLogger(this::class.java.name)
@@ -64,14 +69,25 @@ internal class InboundMessageProcessor(
         override val message = record.value
     }
 
-    override fun onNext(events: List<EventLogRecord<String, LinkInMessage>>): List<Record<*, *>> {
-        return handleRequests(
+    override fun onNext(events: List<EventLogRecord<String, LinkInMessage>>) {
+        handleRequests(
             events.map { BusInboundMessage(it) }
-        ).flatMap { traceable ->
+        ).forEach { traceable ->
             traceEventProcessing(traceable.source.record, TRACE_EVENT_NAME) { traceable.item.records }
-            traceable.item.records
+            val future = publisher.publish(traceable.item.records).lastOrNull()
+            traceable.item.ack?.asRight()?.also { ack ->
+                future?.whenComplete { _, err ->
+                    if (err == null) {
+                        publisher.publish(listOf(ack))
+                    } else {
+                        logger.info("Failed to publish ack message.", err)
+                    }
+                }
+            }
+
         }
     }
+
     internal fun <T: InboundMessage> handleRequests(
         messages: Collection<T>,
     ): List<ItemWithSource<T, InboundResponse>> {
@@ -261,9 +277,14 @@ internal class InboundMessageProcessor(
                 "Processing message ${innerMessage.message.header.messageId} " +
                     "of type ${innerMessage.message.javaClass} from session ${session.sessionId}"
             }
-            makeAckMessageForFlowMessage(innerMessage.message, session)?.plus(
-                Record(Schemas.P2P.P2P_IN_TOPIC, innerMessage.key, AppMessage(innerMessage.message))
-            )
+            makeAckMessageForFlowMessage(innerMessage.message, session)?.let { ack ->
+                InboundResponse(
+                    listOf(
+                        Record(Schemas.P2P.P2P_IN_TOPIC, innerMessage.key, AppMessage(innerMessage.message))
+                    ),
+                    ack,
+                )
+            }
         } else if (sessionSource != messageSource.toCorda()) {
             logger.warn(
                 "The identity in the message's source header ($messageSource)" +
@@ -314,19 +335,18 @@ internal class InboundMessageProcessor(
     private fun makeAckMessageForFlowMessage(
         message: AuthenticatedMessage,
         session: Session
-    ): InboundResponse? {
+    ): Either<LinkManagerResponse, Record<String, LinkOutMessage>>? {
         // We route the ACK back to the original source
         val ackDest = message.header.source.toCorda()
         val ackSource = message.header.destination.toCorda()
         val ackMessage = MessageAck(AuthenticatedMessageAck(message.header.messageId))
         return if (features.enableP2PGatewayToLinkManagerOverHttp) {
-            InboundResponse(
-                emptyList(),
-                MessageConverter.createLinkManagerResponse(ackMessage, session),
+            Either.Left(
+                MessageConverter.createLinkManagerResponse(ackMessage, session)
             )
         } else {
             val ack = MessageConverter.linkOutMessageFromAck(
-                MessageAck(AuthenticatedMessageAck(message.header.messageId)),
+                ackMessage,
                 ackSource,
                 ackDest,
                 session,
@@ -338,7 +358,7 @@ internal class InboundMessageProcessor(
                 LinkManager.generateKey(),
                 ack
             )
-            InboundResponse(listOf(record))
+            Either.Right(record)
         }
     }
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessor.kt
@@ -84,7 +84,7 @@ internal class InboundMessageProcessor(
                         val topic = lastIem?.topic
                         val message = (lastIem?.value as? AppMessage)?.message as? AuthenticatedMessage
                         logger.info(
-                            "Failed to publish message ${message?.header?.messageId} to the '$topic' topic. " +
+                            "Failed to publish message '${message?.header?.messageId}' to the '$topic' topic. " +
                             "The message ack was not published to allow the delivery tracker to retry it.",
                             err,
                         )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundResponse.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundResponse.kt
@@ -1,15 +1,10 @@
 package net.corda.p2p.linkmanager.inbound
+import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.linkmanager.LinkManagerResponse
 import net.corda.messaging.api.records.Record
+import net.corda.utilities.Either
 
 internal data class InboundResponse(
     val records: List<Record<*, *>>,
-    val httpReply: LinkManagerResponse? = null,
-) {
-    fun plus(record: Record<*, *>): InboundResponse {
-        return InboundResponse(
-            records + record,
-            httpReply,
-        )
-    }
-}
+    val ack: Either<LinkManagerResponse, Record<String, LinkOutMessage>>? = null,
+)

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundRpcProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundRpcProcessor.kt
@@ -70,7 +70,7 @@ internal class InboundRpcProcessor(
         }
         return responses.map {
             ItemWithSource(
-                Either.Right(it.item.httpReply ?: LinkManagerResponse(null)),
+                Either.Right(it.item.ack?.asLeft() ?: LinkManagerResponse(null)),
                 it.source,
             )
         }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/inbound/InboundMessageProcessorTest.kt
@@ -27,6 +27,7 @@ import net.corda.data.p2p.event.SessionDirection
 import net.corda.data.p2p.event.SessionEvent
 import net.corda.data.p2p.markers.AppMessageMarker
 import net.corda.data.p2p.markers.LinkManagerReceivedMarker
+import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
 import net.corda.messaging.api.records.EventLogRecord
 import net.corda.messaging.api.records.Record
 import net.corda.p2p.crypto.protocol.api.AuthenticatedEncryptionSession
@@ -49,6 +50,7 @@ import net.corda.test.util.time.MockTimeFacilitiesProvider
 import net.corda.utilities.Either
 import net.corda.utilities.flags.Features
 import net.corda.utilities.seconds
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
@@ -65,6 +67,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
 
 class InboundMessageProcessorTest {
     companion object {
@@ -95,11 +98,16 @@ class InboundMessageProcessorTest {
     private val features = mock<Features> {
         on { enableP2PGatewayToLinkManagerOverHttp } doReturn false
     }
+    private val publishedRecords = argumentCaptor<List<Record<*, *>>>()
+    private val publisher = mock<PublisherWithDominoLogic> {
+        on { publish(publishedRecords.capture()) } doReturn listOf(CompletableFuture.completedFuture(Unit))
+    }
 
     private val processor = InboundMessageProcessor(
         sessionManager,
         membersAndGroups.second,
         membersAndGroups.first,
+        publisher,
         mockTimeFacilitiesProvider.clock,
         networkMessagingValidator,
         features,
@@ -121,14 +129,14 @@ class InboundMessageProcessorTest {
 
     @Test
     fun `ignores messages with null values`() {
-        val records = processor.onNext(
+        processor.onNext(
             listOf(
                 EventLogRecord(LINK_IN_TOPIC, "key", null, 0, 0),
                 EventLogRecord(LINK_IN_TOPIC, "key", null, 0, 0)
             )
         )
 
-        assertThat(records).isEmpty()
+        assertThat(publishedRecords.allValues).isEmpty()
         assertThat(loggingInterceptor.errors)
             .hasSize(2)
             .contains("Received null message. The message was discarded.")
@@ -136,14 +144,14 @@ class InboundMessageProcessorTest {
 
     @Test
     fun `ignores messages with unknown value`() {
-        val records = processor.onNext(
+        processor.onNext(
             listOf(
                 EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage("payload"), 0, 0),
                 EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(33), 0, 0)
             )
         )
 
-        assertThat(records).isEmpty()
+        assertThat(publishedRecords.allValues).isEmpty()
         assertThat(loggingInterceptor.errors)
             .contains("Received unknown payload type Integer. The message was discarded.")
             .contains("Received unknown payload type String. The message was discarded.")
@@ -187,12 +195,13 @@ class InboundMessageProcessorTest {
                 messageAndPayload.toByteBuffer(), ByteBuffer.wrap(byteArrayOf())
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
                 )
             )
 
+            val records = publishedRecords.allValues.flatten()
             assertThat(records).hasSize(2).anyMatch {
                 val value = it.value
                 it.topic == P2P_IN_TOPIC &&
@@ -216,6 +225,58 @@ class InboundMessageProcessorTest {
         }
 
         @Test
+        fun `AuthenticatedDataMessage with Inbound session will not publish ack if failed to publish the message`() {
+            val authenticatedMsg = AuthenticatedMessage(
+                AuthenticatedMessageHeader(
+                    remoteIdentity.toAvro(),
+                    myIdentity.toAvro(),
+                    null, MESSAGE_ID, "trace-id", "system-1", status
+                ),
+                ByteBuffer.wrap("payload".toByteArray())
+            )
+            val authenticatedMessageAndKey = AuthenticatedMessageAndKey(
+                authenticatedMsg,
+                "key"
+            )
+            val messageAndPayload = DataMessagePayload(authenticatedMessageAndKey)
+            val authenticationResult = mock<AuthenticationResult> {
+                on { header } doReturn commonHeader
+                on { mac } doReturn byteArrayOf()
+            }
+            val session = mock<AuthenticatedSession> {
+                on { createMac(any()) } doReturn authenticationResult
+            }
+            setupGetSessionsById(
+                SessionManager.SessionDirection.Inbound(
+                    SessionManager.Counterparties(
+                        remoteIdentity,
+                        myIdentity
+                    ),
+                    session
+                )
+            )
+            val dataMessage = AuthenticatedDataMessage(
+                commonHeader,
+                messageAndPayload.toByteBuffer(), ByteBuffer.wrap(byteArrayOf())
+            )
+            val publishedRecords = argumentCaptor<List<Record<*, *>>>()
+            whenever(
+                publisher.publish(publishedRecords.capture())
+            ).doReturn(listOf(CompletableFuture.failedFuture(CordaRuntimeException("Oops"))))
+
+            processor.onNext(
+                listOf(
+                    EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
+                )
+            )
+
+            assertThat(publishedRecords.allValues.flatten()).hasSize(1)
+                .allMatch {
+                    it.topic == P2P_IN_TOPIC
+                }
+        }
+
+        @Test
         fun `AuthenticatedDataMessage with Inbound session will produce a message on the P2P_IN_TOPIC topics and a response`() {
             val features = mock<Features> {
                 on { enableP2PGatewayToLinkManagerOverHttp } doReturn true
@@ -225,6 +286,7 @@ class InboundMessageProcessorTest {
                 sessionManager,
                 membersAndGroups.second,
                 membersAndGroups.first,
+                publisher,
                 mockTimeFacilitiesProvider.clock,
                 networkMessagingValidator,
                 features,
@@ -281,7 +343,7 @@ class InboundMessageProcessorTest {
                 softly.assertThat(record?.topic).isEqualTo(P2P_IN_TOPIC)
                 softly.assertThat(record?.key).isEqualTo("key")
                 softly.assertThat(value?.message).isEqualTo(authenticatedMsg)
-                val payload = reply?.item?.httpReply?.payload as? AuthenticatedDataMessage
+                val payload = reply?.item?.ack?.asLeft()?.payload as? AuthenticatedDataMessage
                 val messageAck = MessageAck.fromByteBuffer(payload?.payload)
                 val ack = messageAck.ack as? AuthenticatedMessageAck
                 softly.assertThat(ack?.messageId).isEqualTo(MESSAGE_ID)
@@ -311,12 +373,13 @@ class InboundMessageProcessorTest {
             )
             mockTimeFacilitiesProvider.advanceTime(1000.seconds)
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
                 )
             )
 
+            val records = publishedRecords.allValues.flatten()
             assertThat(records).hasSize(1).allMatch {
                 val value = it.value
                 it.topic == P2P_OUT_MARKERS && value is AppMessageMarker &&
@@ -342,13 +405,13 @@ class InboundMessageProcessorTest {
                 ByteBuffer.wrap(byteArrayOf()), ByteBuffer.wrap(byteArrayOf())
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
                 )
             )
 
-            assertThat(records).hasSize(0)
+            assertThat(publishedRecords.allValues).hasSize(0)
             verify(sessionManager, never()).messageAcknowledged(SESSION_ID)
             assertThat(loggingInterceptor.errors).allSatisfy {
                 assertThat(it).matches("Could not deserialize message for session Session.* The message was discarded\\.")
@@ -377,13 +440,13 @@ class InboundMessageProcessorTest {
                 messageAck.toByteBuffer(), ByteBuffer.wrap(byteArrayOf())
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
                 )
             )
 
-            assertThat(records).hasSize(0)
+            assertThat(publishedRecords.allValues).hasSize(0)
             assertThat(loggingInterceptor.errors)
                 .hasSize(1)
                 .anySatisfy {
@@ -414,13 +477,13 @@ class InboundMessageProcessorTest {
                 messageAndPayload.toByteBuffer(), ByteBuffer.wrap(byteArrayOf())
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
                 )
             )
 
-            assertThat(records).isEmpty()
+            assertThat(publishedRecords.allValues).isEmpty()
             assertThat(loggingInterceptor.warnings)
                 .hasSize(1)
                 .contains("Received message with SessionId = Session for which there is no active session. The message was discarded.")
@@ -444,11 +507,11 @@ class InboundMessageProcessorTest {
                 ByteBuffer.wrap("authTag".toByteArray())
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0))
             )
 
-            assertThat(records).isEmpty()
+            assertThat(publishedRecords.allValues).isEmpty()
             verify(networkMessagingValidator).isValidInbound(eq(myIdentity), eq(remoteIdentity))
         }
 
@@ -470,11 +533,11 @@ class InboundMessageProcessorTest {
                 ByteBuffer.wrap("authTag".toByteArray())
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0))
             )
 
-            assertThat(records).isEmpty()
+            assertThat(publishedRecords.allValues).isEmpty()
             verify(sessionManager, never()).messageAcknowledged(any())
             verify(networkMessagingValidator).isValidInbound(eq(myIdentity), eq(remoteIdentity))
         }
@@ -573,12 +636,13 @@ class InboundMessageProcessorTest {
                 )
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
                 )
             )
 
+            val records = publishedRecords.allValues.flatten()
             assertThat(records).hasSize(2).anyMatch {
                 val value = it.value
                 it.topic == P2P_IN_TOPIC &&
@@ -600,6 +664,64 @@ class InboundMessageProcessorTest {
         }
 
         @Test
+        fun `receiving data message with Inbound session will not ack if the session message failed`() {
+            val authenticatedMsg = AuthenticatedMessage(
+                AuthenticatedMessageHeader(
+                    remoteIdentity.toAvro(),
+                    myIdentity.toAvro(),
+                    null, MESSAGE_ID, "trace-id", "system-1", status
+                ),
+                ByteBuffer.wrap("payload".toByteArray())
+            )
+            val authenticatedMessageAndKey = AuthenticatedMessageAndKey(
+                authenticatedMsg,
+                "key"
+            )
+            val messageAndPayload = DataMessagePayload(authenticatedMessageAndKey)
+            val encryptionResult = mock<EncryptionResult> {
+                on { header } doReturn commonHeader
+                on { authTag } doReturn byteArrayOf()
+                on { encryptedPayload } doReturn messageAndPayload.toByteBuffer().array()
+            }
+            val dataMessage = AuthenticatedEncryptedDataMessage(
+                commonHeader,
+                messageAndPayload.toByteBuffer(), ByteBuffer.wrap(byteArrayOf())
+            )
+            val session = mock<AuthenticatedEncryptionSession> {
+                on { encryptData(any()) } doReturn encryptionResult
+                on {
+                    decryptData(
+                        commonHeader, messageAndPayload.toByteBuffer().array(), byteArrayOf()
+                    )
+                } doReturn messageAndPayload.toByteBuffer().array()
+            }
+            setupGetSessionsById(
+                SessionManager.SessionDirection.Inbound(
+                    SessionManager.Counterparties(
+                        remoteIdentity,
+                        myIdentity
+                    ),
+                    session
+                )
+            )
+            val publishedRecords = argumentCaptor<List<Record<*, *>>>()
+            whenever(
+                publisher.publish(publishedRecords.capture())
+            ).doReturn(listOf(CompletableFuture.failedFuture(CordaRuntimeException("Oops"))))
+
+            processor.onNext(
+                listOf(
+                    EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
+                )
+            )
+
+            assertThat(publishedRecords.allValues.flatten()).hasSize(1)
+                .allMatch {
+                    it.topic == P2P_IN_TOPIC
+                }
+        }
+
+        @Test
         fun `receiving data message with Inbound session will produce a message on the P2P_IN_TOPIC and a response`() {
             val features = mock<Features> {
                 on { enableP2PGatewayToLinkManagerOverHttp } doReturn true
@@ -609,6 +731,7 @@ class InboundMessageProcessorTest {
                 sessionManager,
                 membersAndGroups.second,
                 membersAndGroups.first,
+                publisher,
                 mockTimeFacilitiesProvider.clock,
                 networkMessagingValidator,
                 features,
@@ -669,7 +792,7 @@ class InboundMessageProcessorTest {
                 softly.assertThat(record?.key).isEqualTo("key")
                 val value = record?.value as? AppMessage
                 softly.assertThat(value?.message).isEqualTo(authenticatedMsg)
-                val payload = replies.firstOrNull()?.item?.httpReply?.payload as? AuthenticatedEncryptedDataMessage
+                val payload = replies.firstOrNull()?.item?.ack?.asLeft()?.payload as? AuthenticatedEncryptedDataMessage
                 softly.assertThat(payload?.header).isEqualTo(commonHeader)
                 softly.assertThat(payload?.encryptedPayload).isEqualTo(messageAndPayload.toByteBuffer())
             }
@@ -717,13 +840,13 @@ class InboundMessageProcessorTest {
                 )
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
                 )
             )
 
-            assertThat(records).isEmpty()
+            assertThat(publishedRecords.allValues).isEmpty()
             assertThat(loggingInterceptor.warnings)
                 .hasSize(1)
                 .anySatisfy {
@@ -777,13 +900,13 @@ class InboundMessageProcessorTest {
                 )
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0),
                 )
             )
 
-            assertThat(records).isEmpty()
+            assertThat(publishedRecords.allValues).isEmpty()
             assertThat(loggingInterceptor.warnings)
                 .hasSize(1)
                 .allSatisfy {
@@ -814,11 +937,11 @@ class InboundMessageProcessorTest {
                 )
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0))
             )
 
-            assertThat(records).isEmpty()
+            assertThat(publishedRecords.allValues).isEmpty()
             verify(networkMessagingValidator).isValidInbound(myIdentity, remoteIdentity)
         }
 
@@ -841,11 +964,11 @@ class InboundMessageProcessorTest {
                 )
             )
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(EventLogRecord(LINK_IN_TOPIC, "key", LinkInMessage(dataMessage), 0, 0))
             )
 
-            assertThat(records).isEmpty()
+            assertThat(publishedRecords.allValues).isEmpty()
             verify(sessionManager, never()).messageAcknowledged(any())
             verify(networkMessagingValidator).isValidInbound(myIdentity, remoteIdentity)
         }
@@ -1018,12 +1141,13 @@ class InboundMessageProcessorTest {
                 captor.firstValue.map { it to SessionManager.ProcessSessionMessagesResult(null, listOf(sessionCreationRecord)) }
             }
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", message, 0, 0),
                 )
             )
 
+            val records = publishedRecords.allValues.flatten()
             assertThat(records).hasSize(1).allSatisfy {
                 assertThat(it.topic).isEqualTo(SESSION_EVENTS)
                 assertThat(it.value).isSameAs(sessionCreated)
@@ -1046,12 +1170,13 @@ class InboundMessageProcessorTest {
                 captor.firstValue.map { it to response }
             }
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", message, 0, 0),
                 )
             )
 
+            val records = publishedRecords.allValues.flatten()
             val result = records.associate { it.topic to it.value }
             assertThat(result).hasSize(2)
             assertThat(result.keys).containsExactlyInAnyOrder(LINK_OUT_TOPIC, SESSION_EVENTS)
@@ -1081,12 +1206,13 @@ class InboundMessageProcessorTest {
                 captor.firstValue.map { it to response }
             }
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", message, 0, 0),
                 )
             )
 
+            val records = publishedRecords.allValues.flatten()
             val result = records.associate { it.topic to it.value }
             assertThat(result).hasSize(2)
             assertThat(result.keys).containsExactlyInAnyOrder(LINK_OUT_TOPIC, SESSION_EVENTS)
@@ -1107,12 +1233,13 @@ class InboundMessageProcessorTest {
             }
             val message = LinkInMessage(inboundUnauthenticatedMessage)
 
-            val records = processor.onNext(
+            processor.onNext(
                 listOf(
                     EventLogRecord(LINK_IN_TOPIC, "key", message, 0, 0),
                 )
             )
 
+            val records = publishedRecords.allValues.flatten()
             assertThat(records).hasSize(1).anySatisfy {
                 assertThat(it.topic).isEqualTo(P2P_IN_TOPIC)
                 assertThat(it.value).isInstanceOf(AppMessage::class.java)

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/Either.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/Either.kt
@@ -14,4 +14,18 @@ sealed interface Either<out T, out S> {
             is Right -> Right(mapper(this.b))
         }
     }
+
+    fun asLeft(): T? {
+        return when (this) {
+            is Left -> this.a
+            is Right -> null
+        }
+    }
+
+    fun asRight(): S? {
+        return when (this) {
+            is Right -> this.b
+            is Left -> null
+        }
+    }
 }

--- a/libs/utilities/src/test/kotlin/net/corda/utilities/EitherTest.kt
+++ b/libs/utilities/src/test/kotlin/net/corda/utilities/EitherTest.kt
@@ -18,4 +18,30 @@ class EitherTest {
 
         assertThat(either.mapRight { "$it" }).isEqualTo(Either.Right("200"))
     }
+
+    @Test
+    fun `asRight will return the right value`() {
+        val either = Either.Right(200)
+
+        assertThat(either.asRight()).isEqualTo(200)
+    }
+    @Test
+    fun `asRight will return the null for left value`() {
+        val either: Either<Int, String> = Either.Left(200)
+
+        assertThat(either.asRight()).isNull()
+    }
+
+    @Test
+    fun `asLeft will return the left value`() {
+        val either = Either.Left(200)
+
+        assertThat(either.asLeft()).isEqualTo(200)
+    }
+    @Test
+    fun `asLeft will return the null for right value`() {
+        val either: Either<Int, String> = Either.Right("200")
+
+        assertThat(either.asLeft()).isNull()
+    }
 }


### PR DESCRIPTION
Use the new non-transactional subscription with a publisher, and publish the acks only when the other messages have been sent successfully.
https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-e2e-tests-multi-cluster-tests/detail/yift%2Fcore-19682%2Facks-only-after-other-mesages/2/pipeline/