### PR TITLE
CORE-20301 Ensure cpk metadata is retrieved using same fake service used to load CPI

### DIFF
--- a/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
+++ b/testing/ledger/ledger-common-base-integration-test/src/main/kotlin/net/corda/ledger/common/integration/test/CommonLedgerIntegrationTest.kt
@@ -16,7 +16,6 @@ import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.getObjectByKey
 import net.corda.sandboxgroupcontext.getSandboxSingletonService
 import net.corda.serialization.checkpoint.CheckpointSerializer
-import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.fetchService
 import net.corda.testing.sandboxes.lifecycle.AllTestsLifecycle
@@ -84,8 +83,7 @@ abstract class CommonLedgerIntegrationTest {
         val virtualNodeInfo = virtualNode.loadVirtualNode(testingCpb)
         logger.info("Created virtual node with ID ${virtualNodeInfo.holdingIdentity.shortHash}")
         logger.info("Reading metadata for CPI ${virtualNodeInfo.cpiIdentifier}")
-        val cpiLoader = setup.fetchService<CpiLoader>(TIMEOUT_MILLIS)
-        val cpiMetadata = cpiLoader.getCpiMetadata(virtualNodeInfo.cpiIdentifier).get()
+        val cpiMetadata = virtualNode.getCpiMetadata(virtualNodeInfo.cpiIdentifier).get()
             ?: fail("CpiMetadata is null ${virtualNodeInfo.cpiIdentifier}")
         val cpks = cpiMetadata.cpksMetadata.mapTo(linkedSetOf(), CpkMetadata::fileChecksum)
 

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/VirtualNodeService.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/VirtualNodeService.kt
@@ -1,5 +1,7 @@
 package net.corda.testing.sandboxes.testkit
 
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.virtualnode.VirtualNodeInfo
 import java.util.concurrent.CompletableFuture
@@ -8,4 +10,5 @@ interface VirtualNodeService {
     fun loadVirtualNode(resourceName: String): VirtualNodeInfo
     fun releaseVirtualNode(virtualNodeContext: VirtualNodeContext): CompletableFuture<*>?
     fun unloadVirtualNode(completion: CompletableFuture<*>)
+    fun getCpiMetadata(id: CpiIdentifier): CompletableFuture<CpiMetadata?>
 }

--- a/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
+++ b/testing/sandboxes-testkit/src/main/kotlin/net/corda/testing/sandboxes/testkit/impl/VirtualNodeServiceImpl.kt
@@ -1,8 +1,9 @@
 package net.corda.testing.sandboxes.testkit.impl
 
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.sandboxgroupcontext.VirtualNodeContext
 import net.corda.sandboxgroupcontext.service.SandboxGroupContextComponent
-import net.corda.testing.sandboxes.CpiLoader
 import net.corda.testing.sandboxes.SandboxSetup
 import net.corda.testing.sandboxes.VirtualNodeLoader
 import net.corda.testing.sandboxes.testkit.VirtualNodeService
@@ -20,9 +21,6 @@ import java.util.UUID
 @Component(service = [ VirtualNodeService::class ])
 class VirtualNodeServiceImpl @Activate constructor(
     @Reference
-    private val cpiLoader: CpiLoader,
-
-    @Reference
     private val virtualNodeLoader: VirtualNodeLoader,
 
     @Reference(target = SandboxSetup.SANDBOX_SERVICE_FILTER)
@@ -31,7 +29,6 @@ class VirtualNodeServiceImpl @Activate constructor(
     private companion object {
         private const val X500_NAME = "CN=Testing, OU=Application, O=R3, L=London, C=GB"
         private val ONE_SECOND = ofSeconds(1)
-
         private fun generateHoldingIdentity()
             = HoldingIdentity(MemberX500Name.parse(X500_NAME), UUID.randomUUID().toString())
     }
@@ -57,5 +54,9 @@ class VirtualNodeServiceImpl @Activate constructor(
             @Suppress("ExplicitGarbageCollectionCall")
             System.gc()
         } while (!sandboxGroupContextComponent.waitFor(completion, ONE_SECOND))
+    }
+
+    override fun getCpiMetadata(id: CpiIdentifier): CompletableFuture<CpiMetadata?> {
+        return virtualNodeLoader.getCpiMetadata(id)
     }
 }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/VirtualNodeLoader.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/VirtualNodeLoader.kt
@@ -1,11 +1,14 @@
 package net.corda.testing.sandboxes
 
 import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
+import java.util.concurrent.CompletableFuture
 
 interface VirtualNodeLoader {
     fun loadVirtualNode(resourceName: String, holdingIdentity: HoldingIdentity): VirtualNodeInfo
     fun unloadVirtualNode(virtualNodeInfo: VirtualNodeInfo)
     fun forgetCPI(id: CpiIdentifier)
+    fun getCpiMetadata(id: CpiIdentifier): CompletableFuture<CpiMetadata?>
 }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/VirtualNodeLoaderImpl.kt
@@ -3,6 +3,7 @@ package net.corda.testing.sandboxes.impl
 import net.corda.crypto.core.ShortHash
 import net.corda.libs.packaging.Cpi
 import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.libs.packaging.core.CpiMetadata
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.reconciliation.VersionedRecord
 import net.corda.testing.sandboxes.CpiLoader
@@ -19,6 +20,7 @@ import org.osgi.service.component.propertytypes.ServiceRanking
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 
@@ -74,6 +76,10 @@ class VirtualNodeLoaderImpl @Activate constructor(
 
     override fun forgetCPI(id: CpiIdentifier) {
         resourcesLookup.remove(id)?.also(cpiResources::remove)
+    }
+
+    override fun getCpiMetadata(id: CpiIdentifier): CompletableFuture<CpiMetadata?> {
+        return cpiLoader.getCpiMetadata(id)
     }
 
     override fun getAll(): List<VirtualNodeInfo> {


### PR DESCRIPTION
This is a back-port of https://github.com/corda/corda-runtime-os/pull/5767
Addresses the following tickets:
- https://r3-cev.atlassian.net/browse/CORE-20301
- https://r3-cev.atlassian.net/browse/CORE-20039