### PR TITLE
CORE-20247: Add logs of key rotation records in state manager

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -188,6 +188,13 @@ class KeyRotationRestResourceImpl @Activate constructor(
 
         when (tenantId) {
             MASTER_WRAPPING_KEY_ROTATION_IDENTIFIER -> { // do unmanaged key rotation status
+                logger.info("Request for master wrapping key rotation status. Listing all key rotation records in state manager: " +
+                        "${stateManager.findByMetadata(MetadataFilter(
+                            KeyRotationMetadataValues.STATUS_TYPE,
+                            Operation.Equals,
+                            KeyRotationRecordType.KEY_ROTATION
+                        ))}"
+                )
                 val records = stateManager.findByMetadataMatchingAll(
                     listOf(
                         MetadataFilter(
@@ -223,6 +230,13 @@ class KeyRotationRestResourceImpl @Activate constructor(
             }
 
             else -> { // do managed key rotation status
+                logger.info("Request for managed key rotation status. Listing all key rotation records in state manager: " +
+                        "${stateManager.findByMetadata(MetadataFilter(
+                            KeyRotationMetadataValues.STATUS_TYPE,
+                            Operation.Equals,
+                            KeyRotationRecordType.KEY_ROTATION
+                        ))}"
+                )
                 val records = stateManager.findByMetadataMatchingAll(
                     listOf(
                         MetadataFilter(KeyRotationMetadataValues.TENANT_ID, Operation.Equals, tenantId),

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -362,6 +362,7 @@ class CryptoRekeyBusProcessor(
      * @return false if records were failed to be created
      */
     private fun createStateManagerRecords(records: Collection<State>): Boolean {
+        logger.info("Creating following records in state manager for key rotation: $records")
         var failedToCreate: Set<String>?
         var toCreate = records
         var recordsCreated = false

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessor.kt
@@ -142,7 +142,7 @@ class CryptoRewrapBusProcessor(
             }
 
             tenantIdSigningKeysRecords.entries.single().let { (_, state) ->
-                logger.debug(
+                logger.info(
                     "Updating state manager record for tenantId ${request.tenantId} " +
                             "after re-wrapping ${request.keyUuid}."
                 )
@@ -195,7 +195,7 @@ class CryptoRewrapBusProcessor(
             }
 
             tenantIdWrappingKeysRecords.forEach { (_, state) ->
-                logger.debug(
+                logger.info(
                     "Updating state manager record for tenantId ${request.tenantId} " +
                         "after re-wrapping ${request.targetKeyAlias}."
                 )


### PR DESCRIPTION
To aid debugging flaky key rotation tests, we need to check why the rest worker cannot see key rotation records in the state manager. We don't have a way to retrieve all the records from the state manager, so printing all key rotation related records at least.
In addition, we also log what key rotation records are stored in crypto worker to cross check with rest worker.