### PR TITLE
CORE-20273 Upgrade netty version

### DIFF
--- a/components/gateway/build.gradle
+++ b/components/gateway/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation project(":libs:utilities")
 
     implementation libs.typesafe.config
-    implementation "io.netty:netty-codec-http:$nettyVersion"
+    implementation libs.netty
     implementation "commons-validator:commons-validator:$commonsVersion"
     implementation libs.caffeine
     implementation project(':libs:schema-registry:schema-registry')

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,7 +60,6 @@ kotlinCoroutinesVersion=1.6.4
 liquibaseVersion = 4.19.0
 # Needed by Liquibase:
 beanutilsVersion=1.9.4
-nettyVersion = 4.1.94.Final
 # com.networknt:json-schema-validator cannot be upgraded beyond 1.0.79 because it requires an OSGi bundle containing SLF4j with a version in the range [2.0,3), whereas Corda currently provides 1.7.36.
 networkntJsonSchemaVersion = 1.0.79
 comEthloTimeItuVersion = 1.7.3

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ pf4jVersion = "3.10.0"
 unirestVersion = "3.14.5"
 zipkinCoreVersion = "2.27.1"
 zipkinReporterVersion = "3.3.0"
+nettyVersion = "4.1.108.Final"
 
 # Testing
 assertjVersion = "3.25.3"
@@ -125,6 +126,7 @@ snappy-java = { group = "org.xerial.snappy", name = "snappy-java", version.ref =
 zipkin-core = { group = "io.zipkin.zipkin2", name = "zipkin", version.ref = "zipkinCoreVersion" }
 zipkin-sender-urlconnection = { group = "io.zipkin.reporter2", name = "zipkin-sender-urlconnection", version.ref = "zipkinReporterVersion" }
 zipkin-reporter-brave = { group = "io.zipkin.reporter2", name = "zipkin-reporter-brave", version.ref = "zipkinReporterVersion" }
+netty = { group = "io.netty", name = "netty-codec-http", version.ref = "nettyVersion" }
 
 gradle-enterprise = { group = "com.gradle", name = "gradle-enterprise-gradle-plugin", version.ref = "gradleEnterpriseVersion" }
 


### PR DESCRIPTION
Upgrades netty version to 4.1.108.Final

Multi-cluster test run: [link](https://ci02.dev.r3.com/job/Corda5/job/corda-e2e-tests-multi-cluster-tests/job/yash%252F5.2%252Ftest/3/)