### PR TITLE
CORE-20317 Performance tune persistance of filtered transactions

### DIFF
--- a/components/ledger/ledger-persistence/build.gradle
+++ b/components/ledger/ledger-persistence/build.gradle
@@ -58,7 +58,6 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
     implementation "org.hibernate:hibernate-core:$hibernateVersion"
 
-    testImplementation project(':libs:ledger:ledger-utxo-data')
     testImplementation project(':testing:db-testkit')
     testImplementation project(':testing:persistence-testkit')
 

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -619,13 +619,14 @@ class UtxoPersistenceServiceImplTest {
     fun `persist and find filtered transactions`() {
         val signatures = createSignatures(Instant.now())
         val signedTransaction = createSignedTransaction(signatures = signatures)
-        val account = "Account"
 
         val filteredTransactionToStore = createFilteredTransaction(signedTransaction)
 
         persistenceService.persistFilteredTransactions(
             mapOf(filteredTransactionToStore to signatures),
-            account
+            emptyList(),
+            emptyList(),
+            "Account"
         )
 
         val filteredTxResults = (persistenceService as UtxoPersistenceServiceImpl).findFilteredTransactions(
@@ -658,7 +659,6 @@ class UtxoPersistenceServiceImplTest {
     @Test
     fun `filtered transaction cannot be persisted if no metadata is present`() {
         val signedTransaction = createSignedTransaction()
-        val account = "Account"
 
         val filteredTransaction = createFilteredTransaction(signedTransaction)
         val noMetadataFtx = filteredTransactionFactory.create(
@@ -668,7 +668,7 @@ class UtxoPersistenceServiceImplTest {
             filteredTransaction.privacySalt.bytes
         )
 
-        assertThatThrownBy { persistenceService.persistFilteredTransactions(mapOf(noMetadataFtx to emptyList()), account) }
+        assertThatThrownBy { persistenceService.persistFilteredTransactions(mapOf(noMetadataFtx to emptyList()), emptyList(), emptyList(), "Account") }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasStackTraceContaining("Could not find metadata in the filtered transaction with id: ${filteredTransaction.id}")
     }
@@ -693,7 +693,7 @@ class UtxoPersistenceServiceImplTest {
 
         val filteredTransaction = createFilteredTransaction(signedTransaction)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
@@ -724,7 +724,7 @@ class UtxoPersistenceServiceImplTest {
 
         val filteredTransaction = createFilteredTransaction(signedTransaction)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -754,7 +754,7 @@ class UtxoPersistenceServiceImplTest {
 
         val filteredTransaction = createFilteredTransaction(signedTransaction)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
@@ -785,7 +785,7 @@ class UtxoPersistenceServiceImplTest {
 
         val filteredTransaction = createFilteredTransaction(signedTransaction)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -815,7 +815,7 @@ class UtxoPersistenceServiceImplTest {
 
         val filteredTransaction = createFilteredTransaction(signedTransaction)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
@@ -846,7 +846,7 @@ class UtxoPersistenceServiceImplTest {
 
         val filteredTransaction = createFilteredTransaction(signedTransaction)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -865,7 +865,7 @@ class UtxoPersistenceServiceImplTest {
         val filteredTransaction2 = createFilteredTransaction(signedTransaction, indexes = listOf(1))
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction1 to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction1 to signatures), emptyList(), emptyList(), "account")
 
         val (createdTimestamp, updatedTimestamp) = entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
@@ -875,7 +875,7 @@ class UtxoPersistenceServiceImplTest {
             transaction.field<Instant>("created") to transaction.field<Instant>("updated")
         }
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction2 to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction2 to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
@@ -897,7 +897,7 @@ class UtxoPersistenceServiceImplTest {
         val filteredTransaction3 = createFilteredTransaction(signedTransaction, indexes = listOf(2))
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction1 to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction1 to signatures), emptyList(), emptyList(), "account")
 
         val merkleProofIds1 = entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -908,7 +908,7 @@ class UtxoPersistenceServiceImplTest {
 
         assertThat(merkleProofIds1).hasSize(5)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction2 to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction2 to signatures), emptyList(), emptyList(), "account")
 
         val merkleProofIds2 = entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -922,7 +922,7 @@ class UtxoPersistenceServiceImplTest {
         assertThat(merkleProofIds2).containsAll(merkleProofIds1)
         assertThat(merkleProofIds2 - merkleProofIds1).hasSize(2)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction3 to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction3 to signatures), emptyList(), emptyList(), "account")
 
         val merkleProofIds3 = entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -961,7 +961,7 @@ class UtxoPersistenceServiceImplTest {
         val filteredTransaction = createFilteredTransaction(signedTransaction, indexes = listOf(0, 1))
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         val merkleProofIds1 = entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -972,7 +972,7 @@ class UtxoPersistenceServiceImplTest {
 
         assertThat(merkleProofIds1).hasSize(5)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         val merkleProofIds2 = entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -1010,7 +1010,7 @@ class UtxoPersistenceServiceImplTest {
         val filteredTransaction = createFilteredTransaction(signedTransaction, indexes = visibleStateIndexes)
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(),"account")
 
         entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -1025,6 +1025,139 @@ class UtxoPersistenceServiceImplTest {
         }
     }
 
+    // persist the same filtered transaction id
+    // have the same leaves revealed
+    // pass in the same reference state refs into both calls
+    // the created timestamp on the reference states should be that of the original insert
+
+    // persist the same filtered transaction id
+    // have different leaves revealed, but have the reference state(s) revealed in both
+    // the differences represent new reference states which should be inserted
+    // the new reference states should be inserted
+
+    // persist the same filtered transaction id
+    // have different leaves revealed, but have the reference state(s) revealed in both
+    // the differences represent new input states which should be inserted
+    // the new input states should be inserted
+    @Test
+    fun `persist filtered transaction containing only a reference state when the reference state already exists does not persist the filtered transaction`() {
+        val outputStates = listOf(TestContractState1(), TestContractState1(), TestContractState2())
+        val signatures = createSignatures(Instant.now())
+        val signedTransaction = createSignedTransaction(outputStates = outputStates, signatures = signatures)
+        val filteredTransaction = createFilteredTransaction(signedTransaction, indexes = listOf(0))
+        val transactionReader = TestUtxoTransactionReader(
+            signedTransaction,
+            "account",
+            VERIFIED,
+            emptyList(),
+            serializer = serializationService
+        )
+        val entityFactory = UtxoEntityFactory(entityManagerFactory)
+
+        persistenceService.persistTransaction(transactionReader)
+        persistenceService.persistFilteredTransactions(
+            mapOf(filteredTransaction to signatures),
+            emptyList(),
+            listOf(StateRef(signedTransaction.id, 0)),
+            "account"
+        )
+
+        val merkleProofIds = entityManagerFactory.transaction { em ->
+            val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
+                .setParameter("transactionId", signedTransaction.id.toString())
+                .resultList
+            proofs.map { it.field<String>("merkleProofId") }
+        }
+
+        assertThat(merkleProofIds).isEmpty()
+    }
+
+    @Test
+    fun `persist filtered transaction containing reference states when a reference state already exists persists the filtered transaction`() {
+        val outputStates = listOf(TestContractState1(), TestContractState1(), TestContractState2())
+        val signatures = createSignatures(Instant.now())
+        val signedTransaction = createSignedTransaction(outputStates = outputStates, signatures = signatures)
+        val filteredTransaction1 = createFilteredTransaction(signedTransaction, indexes = listOf(0))
+        val filteredTransaction2 = createFilteredTransaction(signedTransaction, indexes = listOf(0, 1))
+        val entityFactory = UtxoEntityFactory(entityManagerFactory)
+
+        persistenceService.persistFilteredTransactions(
+            mapOf(filteredTransaction1 to signatures),
+            emptyList(),
+            listOf(StateRef(signedTransaction.id, 0)),
+            "account"
+        )
+
+        val merkleProofIds1 = entityManagerFactory.transaction { em ->
+            val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
+                .setParameter("transactionId", signedTransaction.id.toString())
+                .resultList
+            proofs.map { it.field<String>("merkleProofId") }
+        }
+
+        assertThat(merkleProofIds1).hasSize(5)
+
+        persistenceService.persistFilteredTransactions(
+            mapOf(filteredTransaction2 to signatures),
+            emptyList(),
+            listOf(StateRef(signedTransaction.id, 0), StateRef(signedTransaction.id, 1)),
+            "account"
+        )
+
+        val merkleProofIds2 = entityManagerFactory.transaction { em ->
+            val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
+                .setParameter("transactionId", signedTransaction.id.toString())
+                .resultList
+            proofs.map { it.field<String>("merkleProofId") }
+        }
+
+        // Only the output and output info groups change, so only 2 new rows are inserted into the database
+        assertThat(merkleProofIds2).hasSize(7)
+    }
+
+    @Test
+    fun `persist filtered transaction containing input states when a reference state already exists persists the filtered transaction`() {
+        val outputStates = listOf(TestContractState1(), TestContractState1(), TestContractState2())
+        val signatures = createSignatures(Instant.now())
+        val signedTransaction = createSignedTransaction(outputStates = outputStates, signatures = signatures)
+        val filteredTransaction1 = createFilteredTransaction(signedTransaction, indexes = listOf(0))
+        val filteredTransaction2 = createFilteredTransaction(signedTransaction, indexes = listOf(0, 1, 2))
+        val entityFactory = UtxoEntityFactory(entityManagerFactory)
+
+        persistenceService.persistFilteredTransactions(
+            mapOf(filteredTransaction1 to signatures),
+            emptyList(),
+            listOf(StateRef(signedTransaction.id, 0)),
+            "account"
+        )
+
+        val merkleProofIds1 = entityManagerFactory.transaction { em ->
+            val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
+                .setParameter("transactionId", signedTransaction.id.toString())
+                .resultList
+            proofs.map { it.field<String>("merkleProofId") }
+        }
+
+        assertThat(merkleProofIds1).hasSize(5)
+
+        persistenceService.persistFilteredTransactions(
+            mapOf(filteredTransaction2 to signatures),
+            listOf(StateRef(signedTransaction.id, 1), StateRef(signedTransaction.id, 2)),
+            listOf(StateRef(signedTransaction.id, 0)),
+            "account"
+        )
+
+        val merkleProofIds2 = entityManagerFactory.transaction { em ->
+            val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
+                .setParameter("transactionId", signedTransaction.id.toString())
+                .resultList
+            proofs.map { it.field<String>("merkleProofId") }
+        }
+
+        // Only the output and output info groups change, so only 2 new rows are inserted into the database
+        assertThat(merkleProofIds2).hasSize(7)
+    }
+
     @Test
     fun `find filtered transaction with many outputs`() {
         val upperLimit = if (DbUtils.databaseType == DbUtils.DatabaseType.HSQL) 1000 else 10000
@@ -1036,7 +1169,7 @@ class UtxoPersistenceServiceImplTest {
         val signedTransaction = createSignedTransaction(outputStates = outputStates.values.toList(), signatures = signatures)
         val filteredTransaction = createFilteredTransaction(signedTransaction, indexes = visibleStateIndexes)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         val loadedFilteredTransactions =
             (persistenceService as UtxoPersistenceServiceImpl).findFilteredTransactions(listOf(signedTransaction.id.toString()))
@@ -1069,7 +1202,7 @@ class UtxoPersistenceServiceImplTest {
         )
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         val (createdTimestamp, updatedTimestamp) = entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
@@ -1106,7 +1239,7 @@ class UtxoPersistenceServiceImplTest {
         )
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -1155,7 +1288,7 @@ class UtxoPersistenceServiceImplTest {
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
         // persist filtered tx as a dependency of subsequent signed tx
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
@@ -1288,7 +1421,7 @@ class UtxoPersistenceServiceImplTest {
         }
 
         // persist verified filtered txA as a dependency of signed txB
-        persistenceService.persistFilteredTransactions(mapOf(txAFilteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(txAFilteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, txASignedTransaction.id.toString())
@@ -1374,7 +1507,7 @@ class UtxoPersistenceServiceImplTest {
         )
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         val (createdTimestamp, updatedTimestamp) = entityManagerFactory.transaction { em ->
             val transaction = em.find(entityFactory.utxoTransaction, signedTransaction.id.toString())
@@ -1411,7 +1544,7 @@ class UtxoPersistenceServiceImplTest {
         )
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)
@@ -1442,7 +1575,7 @@ class UtxoPersistenceServiceImplTest {
             emptyList(),
             serializer = serializationService
         )
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
         persistenceService.persistTransaction(transactionReader, emptyMap())
         val (loadedSignedTransaction, _) = persistenceService.findSignedTransaction(signedTransaction.id.toString(), VERIFIED)
         assertThat(loadedSignedTransaction).isEqualTo(signedTransaction)
@@ -1461,7 +1594,7 @@ class UtxoPersistenceServiceImplTest {
             serializer = serializationService
         )
         persistenceService.persistTransaction(transactionReader, emptyMap())
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
         val (loadedSignedTransaction, _) = persistenceService.findSignedTransaction(signedTransaction.id.toString(), VERIFIED)
         assertThat(loadedSignedTransaction).isEqualTo(signedTransaction)
     }
@@ -1471,7 +1604,7 @@ class UtxoPersistenceServiceImplTest {
         val signatures = createSignatures(Instant.now())
         val signedTransaction = createSignedTransaction(signatures = signatures)
         val filteredTransaction = createFilteredTransaction(signedTransaction)
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
         assertThat(persistenceService.findSignedTransaction(signedTransaction.id.toString(), VERIFIED).first).isNull()
         assertThat(persistenceService.findSignedTransaction(signedTransaction.id.toString(), UNVERIFIED).first).isNull()
         assertThat(persistenceService.findSignedTransaction(signedTransaction.id.toString(), DRAFT).first).isNull()
@@ -1508,7 +1641,7 @@ class UtxoPersistenceServiceImplTest {
             emptyList(),
             serializer = serializationService
         )
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
         persistenceService.persistTransaction(transactionReader, emptyMap())
         assertThat(persistenceService.findSignedTransaction(signedTransaction.id.toString(), VERIFIED).first).isNull()
         assertThat(persistenceService.findSignedTransaction(signedTransaction.id.toString(), UNVERIFIED).first).isEqualTo(signedTransaction)
@@ -1596,7 +1729,7 @@ class UtxoPersistenceServiceImplTest {
             serializer = serializationService
         )
         persistenceService.persistTransaction(transactionReader, emptyMap())
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
         val loadedFilteredTransactions = (persistenceService as UtxoPersistenceServiceImpl)
             .findFilteredTransactions(listOf(signedTransaction.id.toString()))
         assertThat(loadedFilteredTransactions).hasSize(1)
@@ -1627,7 +1760,7 @@ class UtxoPersistenceServiceImplTest {
             emptyList(),
             serializer = serializationService
         )
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
         persistenceService.persistTransaction(transactionReader, emptyMap())
         // Returns the filtered transaction here, which bypasses the signed transaction filtering
         val loadedFilteredTransactions = (persistenceService as UtxoPersistenceServiceImpl)
@@ -1655,7 +1788,7 @@ class UtxoPersistenceServiceImplTest {
             emptyList(),
             serializer = serializationService
         )
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
         persistenceService.persistTransaction(transactionReader, emptyMap())
         // Returns the filtered transaction here, which bypasses the signed transaction filtering
         val loadedFilteredTransactions = (persistenceService as UtxoPersistenceServiceImpl)
@@ -1691,7 +1824,7 @@ class UtxoPersistenceServiceImplTest {
             serializer = serializationService
         )
         persistenceService.persistTransaction(transactionReader, emptyMap())
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), "account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
         // Returns the filtered transaction here, which bypasses the signed transaction filtering
         val loadedFilteredTransactions = (persistenceService as UtxoPersistenceServiceImpl)
             .findFilteredTransactions(listOf(signedTransaction.id.toString()))

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -1032,20 +1032,6 @@ class UtxoPersistenceServiceImplTest {
         }
     }
 
-    // persist the same filtered transaction id
-    // have the same leaves revealed
-    // pass in the same reference state refs into both calls
-    // the created timestamp on the reference states should be that of the original insert
-
-    // persist the same filtered transaction id
-    // have different leaves revealed, but have the reference state(s) revealed in both
-    // the differences represent new reference states which should be inserted
-    // the new reference states should be inserted
-
-    // persist the same filtered transaction id
-    // have different leaves revealed, but have the reference state(s) revealed in both
-    // the differences represent new input states which should be inserted
-    // the new input states should be inserted
     @Test
     fun `persist filtered transaction containing only a reference state when the reference state already exists does not persist the filtered transaction`() {
         val outputStates = listOf(TestContractState1(), TestContractState1(), TestContractState2())
@@ -1080,7 +1066,7 @@ class UtxoPersistenceServiceImplTest {
     }
 
     @Test
-    fun `persist filtered transaction containing reference states when a reference state already exists persists the filtered transaction`() {
+    fun `persist filtered transaction containing reference states when one of the reference state already exists persists the filtered transaction`() {
         val outputStates = listOf(TestContractState1(), TestContractState1(), TestContractState2())
         val signatures = createSignatures(Instant.now())
         val signedTransaction = createSignedTransaction(outputStates = outputStates, signatures = signatures)

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -668,7 +668,14 @@ class UtxoPersistenceServiceImplTest {
             filteredTransaction.privacySalt.bytes
         )
 
-        assertThatThrownBy { persistenceService.persistFilteredTransactions(mapOf(noMetadataFtx to emptyList()), emptyList(), emptyList(), "Account") }
+        assertThatThrownBy {
+            persistenceService.persistFilteredTransactions(
+                mapOf(noMetadataFtx to emptyList()),
+                emptyList(),
+                emptyList(),
+                "Account"
+            )
+        }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasStackTraceContaining("Could not find metadata in the filtered transaction with id: ${filteredTransaction.id}")
     }
@@ -1010,7 +1017,7 @@ class UtxoPersistenceServiceImplTest {
         val filteredTransaction = createFilteredTransaction(signedTransaction, indexes = visibleStateIndexes)
         val entityFactory = UtxoEntityFactory(entityManagerFactory)
 
-        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(),"account")
+        persistenceService.persistFilteredTransactions(mapOf(filteredTransaction to signatures), emptyList(), emptyList(), "account")
 
         entityManagerFactory.transaction { em ->
             val proofs = em.createNamedQuery("UtxoMerkleProofEntity.findByTransactionId", entityFactory.merkleProof)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -78,6 +78,8 @@ interface UtxoPersistenceService {
      */
     fun persistFilteredTransactions(
         filteredTransactionsAndSignatures: Map<FilteredTransaction, List<DigitalSignatureAndMetadata>>,
+        inputStateRefs: List<StateRef>,
+        referenceStateRefs: List<StateRef>,
         account: String
     )
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -210,6 +210,10 @@ interface UtxoRepository {
         limit: Int,
     ): List<String>
 
+    fun incrementTransactionRepairAttemptCount(entityManager: EntityManager, id: String)
+
+    fun stateRefsExist(entityManager: EntityManager, stateRefs: List<StateRef>): List<Pair<String, Int>>
+
     data class TransactionComponent(val transactionId: String, val groupIndex: Int, val leafIndex: Int, val leafData: ByteArray)
 
     data class VisibleTransactionOutput(
@@ -239,8 +243,4 @@ interface UtxoRepository {
     )
 
     data class TransactionMerkleProofLeaf(val merkleProofId: String, val leafIndex: Int)
-
-    fun incrementTransactionRepairAttemptCount(entityManager: EntityManager, id: String)
-
-    fun stateRefsExist(entityManager: EntityManager, stateRefs: List<StateRef>): List<Pair<String, Int>>
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -90,13 +90,10 @@ interface UtxoRepository {
 
     /** Persists unverified transaction (operation is idempotent) */
     @Suppress("LongParameterList")
-    fun persistFilteredTransaction(
+    fun persistFilteredTransactions(
         entityManager: EntityManager,
-        id: String,
-        privacySalt: ByteArray,
-        account: String,
+        filteredTransactions: List<FilteredTransaction>,
         timestamp: Instant,
-        metadataHash: String,
     )
 
     /** Updates an existing verified transaction */
@@ -150,7 +147,6 @@ interface UtxoRepository {
     /** Persists transaction [signature] (operation is idempotent) */
     fun persistTransactionSignatures(
         entityManager: EntityManager,
-        transactionId: String,
         signatures: List<TransactionSignature>,
         timestamp: Instant
     )
@@ -224,7 +220,14 @@ interface UtxoRepository {
         val notaryName: String,
     )
 
-    data class TransactionSignature(val index: Int, val signatureBytes: ByteArray, val publicKeyHash: SecureHash)
+    data class TransactionSignature(val transactionId: String, val index: Int, val signatureBytes: ByteArray, val publicKeyHash: SecureHash)
+
+    data class FilteredTransaction(
+        val transactionId: String,
+        val privacySalt: ByteArray,
+        val account: String,
+        val metadataHash: String
+    )
 
     data class TransactionMerkleProof(
         val merkleProofId: String,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -238,4 +238,6 @@ interface UtxoRepository {
     data class TransactionMerkleProofLeaf(val merkleProofId: String, val leafIndex: Int)
 
     fun incrementTransactionRepairAttemptCount(entityManager: EntityManager, id: String)
+
+    fun stateRefsExist(entityManager: EntityManager, stateRefs: List<StateRef>): List<Pair<String, Int>>
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -118,6 +118,17 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
             ORDER BY tx.created, tc_output.transaction_id, tc_output.leaf_idx"""
             .trimIndent()
 
+    override val stateRefsExist: (batchSize: Int) -> String
+        get() = { _ ->
+            """
+            SELECT transaction_id, leaf_idx
+            FROM {h-schema}utxo_transaction_component
+            WHERE (transaction_id||':'|| leaf_idx) in (:stateRefs)
+            AND group_idx = ${UtxoComponentGroup.OUTPUTS_INFO.ordinal}
+        """.trimIndent()
+
+        }
+
     override val updateTransactionStatus: String
         get() = """
             UPDATE {h-schema}utxo_transaction SET status = :newStatus, updated = :updatedAt

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -118,16 +118,6 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
             ORDER BY tx.created, tc_output.transaction_id, tc_output.leaf_idx"""
             .trimIndent()
 
-    override val stateRefsExist: (batchSize: Int) -> String
-        get() = { _ ->
-            """
-            SELECT transaction_id, leaf_idx
-            FROM {h-schema}utxo_transaction_component
-            WHERE (transaction_id||':'|| leaf_idx) in (:stateRefs)
-            AND group_idx = ${UtxoComponentGroup.OUTPUTS_INFO.ordinal}
-            """.trimIndent()
-        }
-
     override val updateTransactionStatus: String
         get() = """
             UPDATE {h-schema}utxo_transaction SET status = :newStatus, updated = :updatedAt

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -125,8 +125,7 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
             FROM {h-schema}utxo_transaction_component
             WHERE (transaction_id||':'|| leaf_idx) in (:stateRefs)
             AND group_idx = ${UtxoComponentGroup.OUTPUTS_INFO.ordinal}
-        """.trimIndent()
-
+            """.trimIndent()
         }
 
     override val updateTransactionStatus: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -58,7 +58,7 @@ import java.time.Instant
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList", "TooManyFunctions", "LargeClass")
 class UtxoPersistenceServiceImpl(
     private val entityManagerFactory: EntityManagerFactory,
     private val repository: UtxoRepository,
@@ -511,6 +511,7 @@ class UtxoPersistenceServiceImpl(
         }
     }
 
+    @Suppress("LongMethod")
     override fun persistFilteredTransactions(
         filteredTransactionsAndSignatures: Map<FilteredTransaction, List<DigitalSignatureAndMetadata>>,
         inputStateRefs: List<StateRef>,
@@ -534,8 +535,8 @@ class UtxoPersistenceServiceImpl(
             }
 
             // locally cache the persistence of the metadata, allowing to skip for subsequent persists
-            // return the [TransactionMerkleProof], [TransactionMerkleProofLeaf], [TransactionComponent] and [TransactionSignature] outside the loop to batch insert once per table.
-            // should also make the filtered transaction persist batched
+            // return the [TransactionMerkleProof], [TransactionMerkleProofLeaf], [TransactionComponent] and [TransactionSignature]
+            // outside the loop to batch insert once per table. should also make the filtered transaction persist batched
 
             val seenMetadata = mutableSetOf<SecureHash>()
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -534,10 +534,6 @@ class UtxoPersistenceServiceImpl(
                 emptySet()
             }
 
-            // locally cache the persistence of the metadata, allowing to skip for subsequent persists
-            // return the [TransactionMerkleProof], [TransactionMerkleProofLeaf], [TransactionComponent] and [TransactionSignature]
-            // outside the loop to batch insert once per table. should also make the filtered transaction persist batched
-
             val seenMetadata = mutableSetOf<SecureHash>()
 
             val filteredTransactionsToPersist = filteredTransactionsAndSignatures

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -52,6 +52,11 @@ interface UtxoQueryProvider {
     val resolveStateRefs: String
 
     /**
+     * @property stateRefsExist SQL text for [UtxoRepositoryImpl.stateRefsExist].
+     */
+    val stateRefsExist: (batchSize: Int) -> String
+
+    /**
      * @property persistTransaction SQL text for [UtxoRepositoryImpl.persistTransaction].
      */
     val persistTransaction: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -69,7 +69,7 @@ interface UtxoQueryProvider {
     /**
      * @property persistFilteredTransaction SQL text for [UtxoRepositoryImpl.persistFilteredTransaction].
      */
-    val persistFilteredTransaction: String
+    val persistFilteredTransaction: (batchSize: Int) -> String
 
     /**
      * @property persistTransactionMetadata SQL text for [UtxoRepositoryImpl.persistTransactionMetadata].

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -634,7 +634,7 @@ class UtxoRepositoryImpl(
                     }
                     val resultSet = statement.executeQuery()
                     while (resultSet.next()) {
-                        results += resultSet.getString(0) to resultSet.getInt(1)
+                        results += resultSet.getString(1) to resultSet.getInt(2)
                     }
                 }
             }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistFilteredTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistFilteredTransactionRequestHandler.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.persistence.utxo.impl.request.handlers
 
+import net.corda.crypto.core.SecureHashImpl
 import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext
 import net.corda.data.ledger.persistence.PersistFilteredTransactionsAndSignatures
@@ -13,6 +14,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.utilities.serialization.deserialize
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.ledger.utxo.StateRef
 
 class UtxoPersistFilteredTransactionRequestHandler(
     private val persistFilteredTransactions: PersistFilteredTransactionsAndSignatures,
@@ -30,6 +32,18 @@ class UtxoPersistFilteredTransactionRequestHandler(
 
         persistenceService.persistFilteredTransactions(
             filteredTransactionsAndSignatures,
+            persistFilteredTransactions.inputStateRefs.map { stateRef ->
+                StateRef(
+                    SecureHashImpl(stateRef.transactionId.algorithm, stateRef.transactionId.bytes.array()),
+                    stateRef.index
+                )
+            },
+            persistFilteredTransactions.referenceStateRefs.map { stateRef ->
+                StateRef(
+                    SecureHashImpl(stateRef.transactionId.algorithm, stateRef.transactionId.bytes.array()),
+                    stateRef.index
+                )
+            },
             externalEventContext.findAccount()
         )
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -214,7 +214,8 @@ class UtxoReceiveFinalityFlowV1(
         persistenceService.persistFilteredTransactionsAndSignatures(
             filteredTransactionsAndSignatures,
             inputStateAndRefs.map { it.ref },
-            referenceStateAndRefs.map { it.ref })
+            referenceStateAndRefs.map { it.ref }
+        )
 
         return InitialTransactionPayload(
             initialTransaction,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -202,16 +202,19 @@ class UtxoReceiveFinalityFlowV1(
 
         val inputStateAndRefs = initialTransaction.inputStateRefs.map { stateRef ->
             requireNotNull(dependentStateAndRefs[stateRef]) {
-                "Missing input state and ref from the filtered transaction"
+                "Missing input state and ref $stateRef from the filtered transaction"
             }
         }
         val referenceStateAndRefs = initialTransaction.referenceStateRefs.map { stateRef ->
             requireNotNull(dependentStateAndRefs[stateRef]) {
-                "Missing reference state and ref from the filtered transaction"
+                "Missing reference state and ref $stateRef from the filtered transaction"
             }
         }
 
-        persistenceService.persistFilteredTransactionsAndSignatures(filteredTransactionsAndSignatures)
+        persistenceService.persistFilteredTransactionsAndSignatures(
+            filteredTransactionsAndSignatures,
+            inputStateAndRefs.map { it.ref },
+            referenceStateAndRefs.map { it.ref })
 
         return InitialTransactionPayload(
             initialTransaction,
@@ -219,6 +222,7 @@ class UtxoReceiveFinalityFlowV1(
             inputStateAndRefs,
             referenceStateAndRefs
         )
+        // do nothing
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -223,7 +223,6 @@ class UtxoReceiveFinalityFlowV1(
             inputStateAndRefs,
             referenceStateAndRefs
         )
-        // do nothing
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactionbuilder/v1/ReceiveAndUpdateTransactionBuilderFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactionbuilder/v1/ReceiveAndUpdateTransactionBuilderFlowV1.kt
@@ -89,7 +89,11 @@ class ReceiveAndUpdateTransactionBuilderFlowV1(
             }
 
             // Persist the verified filtered transactions
-            persistenceService.persistFilteredTransactionsAndSignatures(receivedFilteredTransactions)
+            persistenceService.persistFilteredTransactionsAndSignatures(
+                receivedFilteredTransactions,
+                updatedTransactionBuilder.inputStateRefs,
+                updatedTransactionBuilder.referenceStateRefs
+            )
         }
 
         return updatedTransactionBuilder

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/common/TransactionDependencyResolutionFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/common/TransactionDependencyResolutionFlow.kt
@@ -14,6 +14,7 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.NotarySignatureVerificationService
+import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionAndSignatures
 import net.corda.v5.membership.GroupParametersLookup
 import org.slf4j.LoggerFactory
@@ -23,7 +24,9 @@ class TransactionDependencyResolutionFlow(
     private val transactionId: SecureHash,
     private val notaryName: MemberX500Name,
     private val transactionDependencies: Set<SecureHash>,
-    private val filteredDependencies: List<UtxoFilteredTransactionAndSignatures>?
+    private val filteredDependencies: List<UtxoFilteredTransactionAndSignatures>?,
+    private val inputStateRefs: List<StateRef>,
+    private val referenceStateRefs: List<StateRef>
 ) : SubFlow<Unit> {
 
     private companion object {
@@ -74,7 +77,7 @@ class TransactionDependencyResolutionFlow(
                 }
 
                 // Persist the verified filtered transactions
-                ledgerPersistenceService.persistFilteredTransactionsAndSignatures(filteredDependencies)
+                ledgerPersistenceService.persistFilteredTransactionsAndSignatures(filteredDependencies, inputStateRefs, referenceStateRefs)
             }
         }
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/common/TransactionDependencyResolutionFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/common/TransactionDependencyResolutionFlow.kt
@@ -24,10 +24,9 @@ class TransactionDependencyResolutionFlow(
     private val session: FlowSession,
     private val transactionId: SecureHash,
     private val notaryName: MemberX500Name,
-    private val transactionDependencies: Set<SecureHash>,
-    private val filteredDependencies: List<UtxoFilteredTransactionAndSignatures>?,
     private val inputStateRefs: List<StateRef>,
-    private val referenceStateRefs: List<StateRef>
+    private val referenceStateRefs: List<StateRef>,
+    private val filteredDependencies: List<UtxoFilteredTransactionAndSignatures>?
 ) : SubFlow<Unit> {
 
     private companion object {
@@ -48,6 +47,10 @@ class TransactionDependencyResolutionFlow(
 
     @Suspendable
     override fun call() {
+        val transactionDependencies = (inputStateRefs.asSequence() + referenceStateRefs.asSequence())
+            .map { it.transactionId }
+            .toSet()
+
         if (transactionDependencies.isNotEmpty()) {
             if (filteredDependencies.isNullOrEmpty()) {
                 // If we have dependencies but no filtered dependencies then we need to perform backchain resolution

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/common/TransactionDependencyResolutionFlow.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/common/TransactionDependencyResolutionFlow.kt
@@ -19,6 +19,7 @@ import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionAndS
 import net.corda.v5.membership.GroupParametersLookup
 import org.slf4j.LoggerFactory
 
+@Suppress("LongParameterList")
 class TransactionDependencyResolutionFlow(
     private val session: FlowSession,
     private val transactionId: SecureHash,

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveSignedTransactionFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveSignedTransactionFlowV1.kt
@@ -60,7 +60,9 @@ class ReceiveSignedTransactionFlowV1(
                 receivedTransaction.id,
                 receivedTransaction.notaryName,
                 receivedTransaction.dependencies,
-                transactionPayload.filteredDependencies
+                transactionPayload.filteredDependencies,
+                receivedTransaction.inputStateRefs,
+                receivedTransaction.referenceStateRefs
             )
         )
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveSignedTransactionFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveSignedTransactionFlowV1.kt
@@ -2,7 +2,6 @@ package net.corda.ledger.utxo.flow.impl.flows.transactiontransmission.v1
 
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.common.flow.flows.Payload
-import net.corda.ledger.utxo.flow.impl.flows.backchain.dependencies
 import net.corda.ledger.utxo.flow.impl.flows.finality.getVisibleStateIndexes
 import net.corda.ledger.utxo.flow.impl.flows.transactiontransmission.common.TransactionDependencyResolutionFlow
 import net.corda.ledger.utxo.flow.impl.flows.transactiontransmission.common.UtxoTransactionPayload

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveSignedTransactionFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveSignedTransactionFlowV1.kt
@@ -59,10 +59,9 @@ class ReceiveSignedTransactionFlowV1(
                 session,
                 receivedTransaction.id,
                 receivedTransaction.notaryName,
-                receivedTransaction.dependencies,
-                transactionPayload.filteredDependencies,
                 receivedTransaction.inputStateRefs,
-                receivedTransaction.referenceStateRefs
+                receivedTransaction.referenceStateRefs,
+                transactionPayload.filteredDependencies
             )
         )
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveWireTransactionFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveWireTransactionFlowV1.kt
@@ -49,7 +49,9 @@ class ReceiveWireTransactionFlowV1(
                 wrappedUtxoWireTransaction.id,
                 wrappedUtxoWireTransaction.notaryName,
                 wrappedUtxoWireTransaction.dependencies,
-                transactionPayload.filteredDependencies
+                transactionPayload.filteredDependencies,
+                wrappedUtxoWireTransaction.inputStateRefs,
+                wrappedUtxoWireTransaction.referenceStateRefs
             )
         )
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveWireTransactionFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/v1/ReceiveWireTransactionFlowV1.kt
@@ -48,10 +48,9 @@ class ReceiveWireTransactionFlowV1(
                 session,
                 wrappedUtxoWireTransaction.id,
                 wrappedUtxoWireTransaction.notaryName,
-                wrappedUtxoWireTransaction.dependencies,
-                transactionPayload.filteredDependencies,
                 wrappedUtxoWireTransaction.inputStateRefs,
-                wrappedUtxoWireTransaction.referenceStateRefs
+                wrappedUtxoWireTransaction.referenceStateRefs,
+                transactionPayload.filteredDependencies
             )
         )
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -155,7 +155,9 @@ interface UtxoLedgerPersistenceService {
      */
     @Suspendable
     fun persistFilteredTransactionsAndSignatures(
-        filteredTransactionsAndSignatures: List<UtxoFilteredTransactionAndSignatures>
+        filteredTransactionsAndSignatures: List<UtxoFilteredTransactionAndSignatures>,
+        inputStateRefs: List<StateRef>,
+        referenceStateRefs: List<StateRef>
     )
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -149,7 +149,18 @@ interface UtxoLedgerPersistenceService {
      * Persists a list of filtered transactions and their signatures represented as [UtxoFilteredTransactionAndSignatures]
      * objects.
      *
+     * The [inputStateRefs] and [referenceStateRefs] are passed into this method to optimise the persistence of the input
+     * [filteredTransactionsAndSignatures]. [inputStateRefs] represents the inputs of a transaction and [referenceStateRefs] represents the
+     * references of the same transaction, where [filteredTransactionsAndSignatures] contains the actual state content for those states. The
+     * optimisation allows us to skip persisting reference states and the filtered transactions that originally created them if they are
+     * already stored in the vault. Any filtered transactions that created states contained in [inputStateRefs] must always be persisted and
+     * cannot be optimised further.
+     *
      * @param filteredTransactionsAndSignatures A list containing the filtered transactions and signatures to persist.
+     * @param inputStateRefs A list of input [StateRef]s from a transaction where the states themselves are provided as outputs in
+     * [filteredTransactionsAndSignatures].
+     * @param referenceStateRefs A list of [StateRef]s from a transaction where the states themselves are provided as outputs in
+     * [filteredTransactionsAndSignatures].
      *
      * @throws CordaPersistenceException if an error happens during persist operation.
      */

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -324,7 +324,9 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
 
     @Suspendable
     override fun persistFilteredTransactionsAndSignatures(
-        filteredTransactionsAndSignatures: List<UtxoFilteredTransactionAndSignatures>
+        filteredTransactionsAndSignatures: List<UtxoFilteredTransactionAndSignatures>,
+        inputStateRefs: List<StateRef>,
+        referenceStateRefs: List<StateRef>
     ) {
         val filteredTransactionAndSignatureMap = filteredTransactionsAndSignatures.associate {
             (it.filteredTransaction as UtxoFilteredTransactionImpl).filteredTransaction to it.signatures
@@ -336,7 +338,11 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     PersistFilteredTransactionsExternalEventFactory::class.java,
-                    PersistFilteredTransactionParameters(serialize(filteredTransactionAndSignatureMap))
+                    PersistFilteredTransactionParameters(
+                        serialize(filteredTransactionAndSignatureMap),
+                        inputStateRefs,
+                        referenceStateRefs
+                    )
                 )
             }
         }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/PersistFilteredTransactionsExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/PersistFilteredTransactionsExternalEventFactory.kt
@@ -1,8 +1,11 @@
 package net.corda.ledger.utxo.flow.impl.persistence.external.events
 
+import net.corda.crypto.core.bytes
+import net.corda.data.crypto.SecureHash
 import net.corda.data.ledger.persistence.PersistFilteredTransactionsAndSignatures
 import net.corda.flow.external.events.factory.ExternalEventFactory
 import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.ledger.utxo.StateRef
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import java.nio.ByteBuffer
@@ -15,11 +18,30 @@ class PersistFilteredTransactionsExternalEventFactory : AbstractUtxoLedgerExtern
     constructor(clock: Clock) : super(clock)
 
     override fun createRequest(parameters: PersistFilteredTransactionParameters): Any {
-        return PersistFilteredTransactionsAndSignatures(ByteBuffer.wrap(parameters.filteredTransactionsAndSignaturesMap))
+        return PersistFilteredTransactionsAndSignatures
+            .newBuilder()
+            .setFilteredTransactionsAndSignatures(ByteBuffer.wrap(parameters.filteredTransactionsAndSignaturesMap))
+            .setInputStateRefs(parameters.inputStateRefs.toAvro())
+            .setReferenceStateRefs(parameters.referenceStateRefs.toAvro())
+            .build()
+    }
+
+    private fun List<StateRef>.toAvro(): List<net.corda.data.ledger.utxo.StateRef> {
+        return map { stateRef ->
+            net.corda.data.ledger.utxo.StateRef(
+                SecureHash(
+                    stateRef.transactionId.algorithm,
+                    ByteBuffer.wrap(stateRef.transactionId.bytes)
+                ),
+                stateRef.index
+            )
+        }
     }
 }
 
 @CordaSerializable
 data class PersistFilteredTransactionParameters(
-    val filteredTransactionsAndSignaturesMap: ByteArray
+    val filteredTransactionsAndSignaturesMap: ByteArray,
+    val inputStateRefs: List<StateRef>,
+    val referenceStateRefs: List<StateRef>
 )

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/common/TransactionDependencyResolutionFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/common/TransactionDependencyResolutionFlowTest.kt
@@ -81,7 +81,7 @@ class TransactionDependencyResolutionFlowTest : UtxoLedgerTest() {
             on { notaries } doReturn listOf(mockNotary)
         }
         whenever(mockGroupParametersLookup.currentGroupParameters).thenReturn(mockGroupParameters)
-        whenever(mockLedgerPersistenceService.persistFilteredTransactionsAndSignatures(any())).doAnswer {
+        whenever(mockLedgerPersistenceService.persistFilteredTransactionsAndSignatures(any(), any(), any())).doAnswer {
             @Suppress("unchecked_cast")
             filteredDependencyStorage.addAll(it.arguments.first() as List<UtxoFilteredTransactionAndSignatures>)
             Unit
@@ -167,14 +167,18 @@ class TransactionDependencyResolutionFlowTest : UtxoLedgerTest() {
         transactionId: SecureHash,
         notaryName: MemberX500Name,
         transactionDependencies: Set<SecureHash>,
-        filteredDependencies: List<UtxoFilteredTransactionAndSignatures>? = null
+        filteredDependencies: List<UtxoFilteredTransactionAndSignatures>? = null,
+        inputStateRefs: List<StateRef> = emptyList(),
+        referenceStateRefs: List<StateRef> = emptyList()
     ) {
         val flow = TransactionDependencyResolutionFlow(
             session,
             transactionId,
             notaryName,
             transactionDependencies,
-            filteredDependencies
+            filteredDependencies,
+            inputStateRefs,
+            referenceStateRefs
         )
         flow.flowEngine = mockFlowEngine
         flow.ledgerPersistenceService = mockLedgerPersistenceService

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/common/TransactionDependencyResolutionFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/common/TransactionDependencyResolutionFlowTest.kt
@@ -162,6 +162,7 @@ class TransactionDependencyResolutionFlowTest : UtxoLedgerTest() {
         assertThat(filteredDependencyStorage).containsExactly(filteredDependency)
     }
 
+    @Suppress("LongParameterList")
     private fun callReceiveTransactionFlow(
         session: FlowSession,
         transactionId: SecureHash,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -856,7 +856,8 @@ class UtxoReceiveFinalityFlowV1Test {
         assertThatThrownBy { callReceiveFinalityFlow() }
 
         // assert persisting filtered transactions and signatures never happened since they are invalid.
-        verify(persistenceService, never()).persistFilteredTransactionsAndSignatures(listOf(filteredTxAndSig, filteredTxAndSig2), any(), any())
+        verify(persistenceService, never())
+            .persistFilteredTransactionsAndSignatures(listOf(filteredTxAndSig, filteredTxAndSig2), any(), any())
     }
 
     private fun callReceiveFinalityFlow(validator: UtxoTransactionValidator = UtxoTransactionValidator { }) {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -856,7 +856,7 @@ class UtxoReceiveFinalityFlowV1Test {
         assertThatThrownBy { callReceiveFinalityFlow() }
 
         // assert persisting filtered transactions and signatures never happened since they are invalid.
-        verify(persistenceService, never()).persistFilteredTransactionsAndSignatures(listOf(filteredTxAndSig, filteredTxAndSig2))
+        verify(persistenceService, never()).persistFilteredTransactionsAndSignatures(listOf(filteredTxAndSig, filteredTxAndSig2), any(), any())
     }
 
     private fun callReceiveFinalityFlow(validator: UtxoTransactionValidator = UtxoTransactionValidator { }) {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -834,7 +834,7 @@ class UtxoReceiveFinalityFlowV1Test {
         assertThatThrownBy { callReceiveFinalityFlow() }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining(
-                "Missing input state and ref from the filtered transaction"
+                "Missing input state and ref $stxInputState from the filtered transaction"
             )
 
         // assert that the filtered transaction receives and dependencies don't match
@@ -857,7 +857,11 @@ class UtxoReceiveFinalityFlowV1Test {
 
         // assert persisting filtered transactions and signatures never happened since they are invalid.
         verify(persistenceService, never())
-            .persistFilteredTransactionsAndSignatures(listOf(filteredTxAndSig, filteredTxAndSig2), any(), any())
+            .persistFilteredTransactionsAndSignatures(
+                listOf(filteredTxAndSig, filteredTxAndSig2),
+                listOf(stxInputState),
+                listOf(stxRefState)
+            )
     }
 
     private fun callReceiveFinalityFlow(validator: UtxoTransactionValidator = UtxoTransactionValidator { }) {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactionbuilder/v1/ReceiveAndUpdateTransactionBuilderFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactionbuilder/v1/ReceiveAndUpdateTransactionBuilderFlowV1Test.kt
@@ -95,7 +95,7 @@ class ReceiveAndUpdateTransactionBuilderFlowV1Test : UtxoLedgerTest() {
 
         storedFilteredTransactions.clear()
         whenever(mockGroupParametersLookup.currentGroupParameters).thenReturn(groupParameters)
-        whenever(mockPersistenceService.persistFilteredTransactionsAndSignatures(any())).thenAnswer {
+        whenever(mockPersistenceService.persistFilteredTransactionsAndSignatures(any(), any(), any())).thenAnswer {
             @Suppress("unchecked_cast")
             storedFilteredTransactions.addAll(it.arguments.first() as List<UtxoFilteredTransactionAndSignatures>)
         }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -234,8 +234,8 @@ class UtxoLedgerPersistenceServiceImplTest {
 
         utxoLedgerPersistenceService.persistFilteredTransactionsAndSignatures(
             listOf(UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction, signature)),
-            any(),
-            any()
+            emptyList(),
+            emptyList()
         )
 
         verify(serializationService).serialize(any<Any>())

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -233,7 +233,9 @@ class UtxoLedgerPersistenceServiceImplTest {
         val signature = listOf(mock<DigitalSignatureAndMetadata>())
 
         utxoLedgerPersistenceService.persistFilteredTransactionsAndSignatures(
-            listOf(UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction, signature))
+            listOf(UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction, signature)),
+            any(),
+            any()
         )
 
         verify(serializationService).serialize(any<Any>())

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityRequestProcessor.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/EntityRequestProcessor.kt
@@ -9,7 +9,6 @@ import net.corda.messaging.api.processor.SyncRPCProcessor
 import net.corda.persistence.common.EntitySandboxService
 import net.corda.persistence.common.ResponseFactory
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
-import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
 
 /**
@@ -34,15 +33,18 @@ class EntityRequestProcessor(
     override val responseClass = FlowEvent::class.java
 
     private companion object {
-        val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
-        val processorService = ProcessorService()
+        private val logger = LoggerFactory.getLogger(EntityRequestProcessor::class.java)
+        private val processorService = ProcessorService()
     }
 
     override fun process(request: EntityRequest): FlowEvent {
-        logger.debug { "process processing request $request" }
-
         val record = processorService.processEvent(
-            logger, request, entitySandboxService, currentSandboxGroupContext, responseFactory, requestsIdsRepository
+            logger,
+            request,
+            entitySandboxService,
+            currentSandboxGroupContext,
+            responseFactory,
+            requestsIdsRepository
         )
         return record.value as FlowEvent
     }

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/ProcessorService.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/ProcessorService.kt
@@ -57,8 +57,6 @@ class ProcessorService {
         ) {
             var requestOutcome = "FAILED"
             try {
-                logger.info("Handling ${request.request::class.java.name} for holdingIdentity ${holdingIdentity.shortHash.value}")
-
                 val cpkFileHashes = request.flowExternalEventContext.contextProperties.items.filter {
                     it.key.startsWith(FlowContextPropertyKeys.CPK_FILE_CHECKSUM)
                 }.map { it.value.toSecureHash() }.toSet()

--- a/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/ProcessorService.kt
+++ b/components/persistence/entity-processor-service-impl/src/main/kotlin/net/corda/entityprocessor/impl/internal/ProcessorService.kt
@@ -25,6 +25,7 @@ import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.utilities.MDC_CLIENT_ID
 import net.corda.utilities.MDC_EXTERNAL_EVENT_ID
+import net.corda.utilities.trace
 import net.corda.utilities.translateFlowContextToMDC
 import net.corda.utilities.withMDC
 import net.corda.v5.application.flows.FlowContextPropertyKeys
@@ -49,6 +50,8 @@ class ProcessorService {
         val startTime = System.nanoTime()
         val clientRequestId = request.flowExternalEventContext.contextProperties.toMap()[MDC_CLIENT_ID] ?: ""
         val holdingIdentity = request.holdingIdentity.toCorda()
+
+        logger.trace { "Handling ${request.request::class.java.name} for holdingIdentity ${holdingIdentity.shortHash.value}" }
 
         val result = withMDC(
             mapOf(

--- a/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
+++ b/components/uniqueness/uniqueness-checker-impl/src/main/kotlin/net/corda/uniqueness/checker/impl/BatchedUniquenessCheckerImpl.kt
@@ -344,25 +344,17 @@ class BatchedUniquenessCheckerImpl(
                         }
                         // Input state conflict check
                         inputStateConflicts.isNotEmpty() -> {
+                            val conflicts = inputStateConflicts.map { stateDetailsCache[it]!! }
                             log.info("Request for transaction ${request.txId} failed due to conflicting " +
-                                    "input states $inputStateConflicts")
-                            handleRejectedRequest(
-                                request,
-                                UniquenessCheckErrorInputStateConflictImpl(
-                                    inputStateConflicts.map { stateDetailsCache[it]!! }
-                                )
-                            )
+                                    "input states $conflicts")
+                            handleRejectedRequest(request, UniquenessCheckErrorInputStateConflictImpl(conflicts))
                         }
                         // Reference state conflict check
                         referenceStateConflicts.isNotEmpty() -> {
+                            val conflicts = referenceStateConflicts.map { stateDetailsCache[it]!! }
                             log.info("Request for transaction ${request.txId} failed due to conflicting " +
-                                    "reference states $referenceStateConflicts")
-                            handleRejectedRequest(
-                                request,
-                                UniquenessCheckErrorReferenceStateConflictImpl(
-                                    referenceStateConflicts.map { stateDetailsCache[it]!! }
-                                )
-                            )
+                                    "reference states $conflicts")
+                            handleRejectedRequest(request, UniquenessCheckErrorReferenceStateConflictImpl(conflicts))
                         }
                         // Time window check
                         !isTimeWindowValid(

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.11-alpha-1713354614102
+cordaApiVersion=5.3.0.11-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.11-beta+
+cordaApiVersion=5.3.0.11-alpha-1713354614102
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.10-beta+
+cordaApiVersion=5.3.0.11-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/WrappedUtxoWireTransaction.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/WrappedUtxoWireTransaction.kt
@@ -83,12 +83,6 @@ class WrappedUtxoWireTransaction(
         }
     }
 
-    val dependencies: Set<SecureHash>
-        get() = this
-            .let { it.inputStateRefs.asSequence() + it.referenceStateRefs.asSequence() }
-            .map { it.transactionId }
-            .toSet()
-
     private inline fun <reified T> deserialize(group: UtxoComponentGroup): List<T> {
         return wireTransaction.getComponentGroupList(group.ordinal).map { serializationService.deserialize(it) }
     }

--- a/testing/ledger/ledger-hsqldb/build.gradle
+++ b/testing/ledger/ledger-hsqldb/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(':components:ledger:ledger-persistence')
     implementation project(':libs:db:db-orm')
+    implementation project(':libs:ledger:ledger-utxo-data')
     implementation project(':libs:utilities')
     implementation project(':testing:db-hsqldb-json')
     implementation 'org.slf4j:slf4j-api'

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -46,8 +46,9 @@ class HsqldbUtxoQueryProvider @Activate constructor(
                 VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""
             .trimIndent()
 
-    override val persistFilteredTransaction: String
-        get() = """
+    override val persistFilteredTransaction: (batchSize: Int) -> String
+        get() = { batchSize ->
+            """
             MERGE INTO {h-schema}utxo_transaction AS ut
             USING (VALUES :id, CAST(:privacySalt AS VARBINARY(64)), :accountId, CAST(:createdAt AS TIMESTAMP), '$VERIFIED', CAST(:updatedAt AS TIMESTAMP), :metadataHash, TRUE)
                 AS x(id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
@@ -57,7 +58,8 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             WHEN NOT MATCHED THEN
                 INSERT (id, privacy_salt, account_id, created, status, updated, metadata_hash, is_filtered)
                 VALUES (x.id, x.privacy_salt, x.account_id, x.created, x.status, x.updated, x.metadata_hash, x.is_filtered)"""
-            .trimIndent()
+                .trimIndent()
+        }
 
     override val persistTransactionMetadata: String
         get() = """


### PR DESCRIPTION
The persistence of filtered transactions was identified as a slow point
in the happy path when using a contract verifying notary.

To address this slowness, multiple changes have been introduced:

1) Improved batch inserts for the filtered transaction tables.
  
    Batching was already used when inserting into the filtered transaction
  tables; however, it was batching per filtered transaction. While this
  improved performance compared to non-batched inserts, the 
  performance could still be improved for when multiple filtered
  transactions persisted simultaneously. Moving the batching up
  a level so that one batch can contain data from multiple filtered
  transactions resolved this.

2) Not inserting reference states that already exist in the member's
vault.
  
    First, check if any reference states have already been stored in 
  the member's vault and stop persisting filtered transactions
  that only contain the already seen reference states. All other
  filtered transactions must still be inserted, especially ones
  containing input states as they will not have been stored before. This
  not only removes wasted inserts, it also helps reduce the likelihood
  that database transactions wait for each other due to row locks
  around filtered transaction tables related to reference states.

3) Only inserting each unique transaction metadata once per call to
`persistFilteredTransactions`. 
  
    This removes unneeded inserts that are going to hit the
  `ON CONFLICT DO NOTHING` anyway.