### PR TITLE
CORE-20359: Disable failing tests until next Liquibase update

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,8 @@ nimbusVersion = "11.10.1"
 kafkaClientVersion = "3.6.1_1"
 kubernetesClientVersion = "6.11.0"
 log4jVersion = "2.23.0"
+# If upgrading liquibase to 4.28, enable `LiquibaseSchemaMigratorImplTest.when updateDb create DB schema`
+# and `LiquibaseSchemaMigratorImplTest.when createUpdateSql generate DB schema` on Windows
 liquibaseVersion = "4.27.0"
 mssqlDriverVersion = "11.2.3.jre17"
 postgresDriverVersion = "42.7.3"

--- a/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
+++ b/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
@@ -4,6 +4,7 @@ import liquibase.exception.ChangeLogParseException
 import net.corda.db.core.InMemoryDataSourceFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.StringWriter
@@ -23,7 +24,7 @@ class LiquibaseSchemaMigratorImplTest {
     val cl2 = ClassloaderChangeLog(
         linkedSetOf(
             ClassloaderChangeLog.ChangeLogResourceFiles(
-                this.javaClass.packageName, listOf("migration/db.changelog-master3.xml"), this.javaClass.classLoader
+                this.javaClass.packageName, listOf("migration/db.changelog-master3.xml")
             ),
         )
     )
@@ -37,10 +38,9 @@ class LiquibaseSchemaMigratorImplTest {
         }
     }
 
+    @Disabled
     @Test
     fun `when updateDb create DB schema`() {
-        println("cl1 = ${cl1.masterChangeLogFiles}")
-        println("cl2 = ${cl2.masterChangeLogFiles}")
         val lbm = LiquibaseSchemaMigratorImpl()
 
         lbm.updateDb(ds.connection, cl1)
@@ -67,6 +67,7 @@ class LiquibaseSchemaMigratorImplTest {
         assertThat(tables).doesNotContain("postgres_table")
     }
 
+    @Disabled
     @Test
     fun `when createUpdateSql generate DB schema`() {
         val lbm = LiquibaseSchemaMigratorImpl()

--- a/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
+++ b/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
@@ -39,6 +39,8 @@ class LiquibaseSchemaMigratorImplTest {
 
     @Test
     fun `when updateDb create DB schema`() {
+        println("cl1 = ${cl1.masterChangeLogFiles}")
+        println("cl2 = ${cl2.masterChangeLogFiles}")
         val lbm = LiquibaseSchemaMigratorImpl()
 
         lbm.updateDb(ds.connection, cl1)

--- a/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
+++ b/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
@@ -23,7 +23,7 @@ class LiquibaseSchemaMigratorImplTest {
     val cl2 = ClassloaderChangeLog(
         linkedSetOf(
             ClassloaderChangeLog.ChangeLogResourceFiles(
-                this.javaClass.packageName, listOf("migration/db.changelog-master3.xml")
+                this.javaClass.packageName, listOf("migration/db.changelog-master3.xml"), this.javaClass.classLoader
             ),
         )
     )

--- a/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
+++ b/libs/db/db-admin-impl/src/integrationTest/kotlin/net/corda/db/admin/impl/LiquibaseSchemaMigratorImplTest.kt
@@ -4,9 +4,10 @@ import liquibase.exception.ChangeLogParseException
 import net.corda.db.core.InMemoryDataSourceFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import java.io.StringWriter
 
 class LiquibaseSchemaMigratorImplTest {
@@ -38,7 +39,8 @@ class LiquibaseSchemaMigratorImplTest {
         }
     }
 
-    @Disabled
+    //Disabled due to bug in liquibase. Should be re-enabled after upgrading to 4.28
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     fun `when updateDb create DB schema`() {
         val lbm = LiquibaseSchemaMigratorImpl()
@@ -67,7 +69,8 @@ class LiquibaseSchemaMigratorImplTest {
         assertThat(tables).doesNotContain("postgres_table")
     }
 
-    @Disabled
+    //Disabled due to bug in liquibase. Should be re-enabled after upgrading to 4.28
+    @DisabledOnOs(OS.WINDOWS)
     @Test
     fun `when createUpdateSql generate DB schema`() {
         val lbm = LiquibaseSchemaMigratorImpl()


### PR DESCRIPTION
The recent Liquibase upgrade has introduced an error to tests where the path to the changelog file is in an invalid format. This is an issue with Liquibase itself, and has been fixed in the next release. Until then, we should mark the failing tests as disabled and re-enable them once we upgrade to the next version.