### PR TITLE
CORE-19384 Abandoned events within the S&E pattern due to rebalances are never processed

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -243,6 +243,7 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
         } catch (ex: StateAndEventConsumer.RebalanceInProgressException) {
             log.warn ("Abandoning processing of events(keys: ${events.joinToString { it.key.toString() }}, " +
                     "size: ${events.size}) due to rebalance", ex)
+            stateAndEventConsumer.resetEventOffsetPosition()
             return true
         }
 


### PR DESCRIPTION
Changed `StateAndEventSubscriptionImpl` to reset event offsets when `RebalanceInProgressException` occurs so that abandoned events are reprocessed.