### PR TITLE
CORE-20358 backport handling of clock skew in queries

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -1,6 +1,7 @@
 package net.corda.flow.state.impl
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import net.corda.data.ExceptionEnvelope
 import net.corda.data.KeyValuePair
@@ -46,7 +47,7 @@ class FlowCheckpointImpl(
     }
 
     private companion object {
-        val objectMapper = ObjectMapper().registerKotlinModule()
+        val objectMapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
     }
 
     private val pipelineStateManager = PipelineStateManager(checkpoint.pipelineState)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoOutputRecordFactory.kt
@@ -14,6 +14,7 @@ import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.virtualnode.HoldingIdentity
+import java.time.Instant
 
 interface UtxoOutputRecordFactory {
     fun getTokenCacheChangeEventRecords(
@@ -40,6 +41,12 @@ interface UtxoOutputRecordFactory {
     ): Record<String, FlowEvent>
 
     fun getPersistTransactionSuccessRecord(
+        persistedAt: Instant,
+        externalEventContext: ExternalEventContext
+    ): Record<String, FlowEvent>
+
+    fun getPersistTransactionIfDoesNotExistSuccessRecord(
+        transactionStatus: String,
         externalEventContext: ExternalEventContext
     ): Record<String, FlowEvent>
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -9,7 +9,6 @@ import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoVisibleTransactionOutputDto
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
@@ -61,9 +60,9 @@ interface UtxoPersistenceService {
     fun persistTransaction(
         transaction: UtxoTransactionReader,
         utxoTokenMap: Map<StateRef, UtxoToken> = emptyMap()
-    ): List<CordaPackageSummary>
+    ): Instant
 
-    fun persistTransactionIfDoesNotExist(transaction: UtxoTransactionReader): Pair<String?, List<CordaPackageSummary>>
+    fun persistTransactionIfDoesNotExist(transaction: UtxoTransactionReader): String
 
     fun updateStatus(id: String, transactionStatus: TransactionStatus)
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoOutputRecordFactoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoOutputRecordFactoryImpl.kt
@@ -26,6 +26,7 @@ import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.observer.UtxoToken
 import net.corda.virtualnode.HoldingIdentity
 import java.nio.ByteBuffer
+import java.time.Instant
 
 class UtxoOutputRecordFactoryImpl(
     private val responseFactory: ResponseFactory,
@@ -127,11 +128,30 @@ class UtxoOutputRecordFactoryImpl(
     }
 
     override fun getPersistTransactionSuccessRecord(
+        persistedAt: Instant,
         externalEventContext: ExternalEventContext
     ): Record<String, FlowEvent> {
         return responseFactory.successResponse(
             externalEventContext,
-            EntityResponse(emptyList(), KeyValuePairList(emptyList()), null),
+            EntityResponse(
+                listOf(ByteBuffer.wrap(serializationService.serialize(persistedAt).bytes)),
+                KeyValuePairList(emptyList()),
+                null
+            ),
+        )
+    }
+
+    override fun getPersistTransactionIfDoesNotExistSuccessRecord(
+        transactionStatus: String,
+        externalEventContext: ExternalEventContext
+    ): Record<String, FlowEvent> {
+        return responseFactory.successResponse(
+            externalEventContext,
+            EntityResponse(
+                listOf(ByteBuffer.wrap(serializationService.serialize(transactionStatus).bytes)),
+                KeyValuePairList(emptyList()),
+                null
+            ),
         )
     }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -46,7 +46,6 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.extensions.merkle.MerkleTreeHashDigestProvider
-import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
 import net.corda.v5.ledger.utxo.ContractState
 import net.corda.v5.ledger.utxo.StateAndRef
@@ -254,26 +253,27 @@ class UtxoPersistenceServiceImpl(
 
     private fun hash(data: ByteArray) = sandboxDigestService.hash(data, DigestAlgorithmName.SHA2_256).toString()
 
-    override fun persistTransaction(transaction: UtxoTransactionReader, utxoTokenMap: Map<StateRef, UtxoToken>): List<CordaPackageSummary> {
+    override fun persistTransaction(transaction: UtxoTransactionReader, utxoTokenMap: Map<StateRef, UtxoToken>): Instant {
         return persistTransaction(transaction, utxoTokenMap) { block ->
             entityManagerFactory.transaction { em -> block(em) }
         }
     }
 
-    override fun persistTransactionIfDoesNotExist(transaction: UtxoTransactionReader): Pair<String?, List<CordaPackageSummary>> {
+    override fun persistTransactionIfDoesNotExist(transaction: UtxoTransactionReader): String {
         entityManagerFactory.transaction { em ->
             val transactionIdString = transaction.id.toString()
             val (status, isFiltered) = repository.findTransactionStatus(em, transactionIdString) ?: run {
-                return null to persistTransaction(transaction, emptyMap()) { block -> block(em) }
+                persistTransaction(transaction, emptyMap()) { block -> block(em) }
+                return ""
             }
             // VERIFIED can exist with is_filtered = true when there is only a filtered transaction
             // UNVERIFIED can exist with is_filtered = true when there is a unverified signed and filtered transaction
             // DRAFT cannot exist with is_filtered = true
             // INVALID filtered transaction cannot exist
             if (status == TransactionStatus.VERIFIED.value && isFiltered) {
-                return null to emptyList()
+                return ""
             }
-            return status to emptyList()
+            return status
         }
     }
 
@@ -281,7 +281,7 @@ class UtxoPersistenceServiceImpl(
         transaction: UtxoTransactionReader,
         utxoTokenMap: Map<StateRef, UtxoToken>,
         optionalTransactionBlock: ((EntityManager) -> Unit) -> Unit
-    ): List<CordaPackageSummary> {
+    ): Instant {
         val nowUtc = utcClock.instant()
         val transactionIdString = transaction.id.toString()
 
@@ -424,7 +424,7 @@ class UtxoPersistenceServiceImpl(
             )
         }
 
-        return emptyList()
+        return nowUtc
     }
 
     override fun persistTransactionSignatures(id: String, signatures: List<ByteArray>, startingIndex: Int) {

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -143,8 +143,7 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
                 UtxoPersistTransactionIfDoesNotExistRequestHandler(
                     UtxoTransactionReaderImpl(sandbox, externalEventContext, req),
                     externalEventContext,
-                    externalEventResponseFactory,
-                    serializationService,
+                    outputRecordFactory,
                     persistenceService
                 )
             }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionIfDoesNotExistRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionIfDoesNotExistRequestHandler.kt
@@ -1,21 +1,16 @@
 package net.corda.ledger.persistence.utxo.impl.request.handlers
 
-import net.corda.data.KeyValuePairList
 import net.corda.data.flow.event.external.ExternalEventContext
-import net.corda.data.persistence.EntityResponse
-import net.corda.flow.external.events.responses.factory.ExternalEventResponseFactory
 import net.corda.ledger.persistence.common.RequestHandler
+import net.corda.ledger.persistence.utxo.UtxoOutputRecordFactory
 import net.corda.ledger.persistence.utxo.UtxoPersistenceService
 import net.corda.ledger.persistence.utxo.UtxoTransactionReader
 import net.corda.messaging.api.records.Record
-import net.corda.v5.application.serialization.SerializationService
-import java.nio.ByteBuffer
 
 class UtxoPersistTransactionIfDoesNotExistRequestHandler(
     private val transaction: UtxoTransactionReader,
     private val externalEventContext: ExternalEventContext,
-    private val externalEventResponseFactory: ExternalEventResponseFactory,
-    private val serializationService: SerializationService,
+    private val utxoOutputRecordFactory: UtxoOutputRecordFactory,
     private val persistenceService: UtxoPersistenceService
 ) : RequestHandler {
 
@@ -25,10 +20,7 @@ class UtxoPersistTransactionIfDoesNotExistRequestHandler(
 
         // should this do token related side effect things?
         return listOf(
-            externalEventResponseFactory.success(
-                externalEventContext,
-                EntityResponse(listOf(ByteBuffer.wrap(serializationService.serialize(result).bytes)), KeyValuePairList(emptyList()), null)
-            )
+            utxoOutputRecordFactory.getPersistTransactionIfDoesNotExistSuccessRecord(result, externalEventContext)
         )
     }
 }

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionRequestHandler.kt
@@ -37,10 +37,10 @@ constructor(
         val utxoTokenMap = listOfPairsStateAndUtxoToken.associate { it.first.ref to it.second }
 
         // persist the transaction
-        persistenceService.persistTransaction(transaction, utxoTokenMap)
+        val persistedAt = persistenceService.persistTransaction(transaction, utxoTokenMap)
 
         // return output records
-        return listOf(utxoOutputRecordFactory.getPersistTransactionSuccessRecord(externalEventContext))
+        return listOf(utxoOutputRecordFactory.getPersistTransactionSuccessRecord(persistedAt, externalEventContext))
     }
 
     private fun getTokens(
@@ -60,6 +60,7 @@ constructor(
             val observer = tokenObservers.getObserverFor(stateAndRef.state.contractStateType)
             if (observer != null) {
                 return@flatMap onCommit(observer, stateAndRef) { obs, context ->
+                    @Suppress("removal")
                     obs.onCommit(
                         context.stateAndRef.state.contractState,
                         context.digestService

--- a/components/ledger/ledger-utxo-flow/build.gradle
+++ b/components/ledger/ledger-utxo-flow/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'net.corda:corda-ledger-utxo'
     implementation 'net.corda:corda-topic-schema'
     implementation libs.jackson.module.kotlin
+    implementation project(':components:flow:flow-service')
     implementation project(':components:ledger:ledger-common-flow-api')
     implementation project(':components:ledger:ledger-common-flow')
     implementation project(':components:ledger:notary-worker-selection')

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -1,7 +1,7 @@
 package net.corda.ledger.utxo.flow.impl
 
-import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.ledger.common.data.transaction.TransactionStatus
 import net.corda.ledger.utxo.flow.impl.flows.finality.UtxoFinalityFlow
@@ -69,7 +69,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
     @Reference(service = ResultSetFactory::class) private val resultSetFactory: ResultSetFactory,
     @Reference(service = UtxoLedgerTransactionVerificationService::class)
     private val transactionVerificationService: UtxoLedgerTransactionVerificationService,
-    @Reference(service = FlowCheckpointService::class) private val flowCheckpointService: FlowCheckpointService,
+    @Reference(service = FlowFiberService::class) private val flowFiberService: FlowFiberService
 ) : UtxoLedgerService, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
@@ -203,7 +203,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
             offset = 0,
             resultClass,
             clock,
-            flowCheckpointService
+            flowFiberService.getExecutingFiber().getExecutionContext()
         )
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl
 
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.ledger.common.data.transaction.TransactionStatus
@@ -67,7 +68,8 @@ class UtxoLedgerServiceImpl @Activate constructor(
     @Reference(service = ExternalEventExecutor::class) private val externalEventExecutor: ExternalEventExecutor,
     @Reference(service = ResultSetFactory::class) private val resultSetFactory: ResultSetFactory,
     @Reference(service = UtxoLedgerTransactionVerificationService::class)
-    private val transactionVerificationService: UtxoLedgerTransactionVerificationService
+    private val transactionVerificationService: UtxoLedgerTransactionVerificationService,
+    @Reference(service = FlowCheckpointService::class) private val flowCheckpointService: FlowCheckpointService,
 ) : UtxoLedgerService, UsedByFlow, SingletonSerializeAsToken {
 
     private companion object {
@@ -200,7 +202,8 @@ class UtxoLedgerServiceImpl @Activate constructor(
             limit = Int.MAX_VALUE,
             offset = 0,
             resultClass,
-            clock
+            clock,
+            flowCheckpointService
         )
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
@@ -108,7 +108,7 @@ class TransactionBackchainReceiverFlowV1(
                 }
 
                 retrieveGroupParameters(retrievedTransaction)
-                val (status, _) = utxoLedgerPersistenceService.persistIfDoesNotExist(retrievedTransaction, UNVERIFIED)
+                val status = utxoLedgerPersistenceService.persistIfDoesNotExist(retrievedTransaction, UNVERIFIED)
 
                 transactionsToRetrieve.remove(retrievedTransactionId)
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -356,8 +356,8 @@ class UtxoFinalityFlowV1(
     @Suspendable
     private fun persistNotarizedTransaction(transaction: UtxoSignedTransactionInternal) {
         val visibleStatesIndexes = transaction.getVisibleStateIndexes(visibilityChecker)
-        persistenceService.persist(transaction, TransactionStatus.VERIFIED, visibleStatesIndexes)
-        log.debug { "Recorded notarized transaction $transactionId" }
+        val persistedAt = persistenceService.persist(transaction, TransactionStatus.VERIFIED, visibleStatesIndexes)
+        log.debug { "Recorded notarized transaction $transactionId persisted at $persistedAt" }
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -7,7 +7,6 @@ import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
-import net.corda.v5.ledger.common.transaction.CordaPackageSummary
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
@@ -132,7 +131,8 @@ interface UtxoLedgerPersistenceService {
      * @param transaction UTXO signed transaction to persist.
      * @param transactionStatus Transaction's status
      *
-     * @return list of [CordaPackageSummary] for missing CPKs (that were not linked)
+     * @return list of [String] that represents transaction's status that tells us whether it existed or not.
+     * if it exists already it'll be the status in db, if not empty string to represent non-existent
      *
      * @throws CordaPersistenceException if an error happens during persist operation.
      */

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -112,7 +112,7 @@ interface UtxoLedgerPersistenceService {
      * @param transactionStatus Transaction's status
      * @param visibleStatesIndexes Indexes of visible states.
      *
-     * @return list of [CordaPackageSummary] for missing CPKs (that were not linked)
+     * @return [Instant] timestamp of when the transaction is stored in DB.
      *
      * @throws CordaPersistenceException if an error happens during persist operation.
      */
@@ -121,7 +121,7 @@ interface UtxoLedgerPersistenceService {
         transaction: UtxoSignedTransaction,
         transactionStatus: TransactionStatus,
         visibleStatesIndexes: List<Int> = emptyList()
-    ): List<CordaPackageSummary>
+    ): Instant
 
     @Suspendable
     fun updateStatus(id: SecureHash, transactionStatus: TransactionStatus)
@@ -140,7 +140,7 @@ interface UtxoLedgerPersistenceService {
     fun persistIfDoesNotExist(
         transaction: UtxoSignedTransaction,
         transactionStatus: TransactionStatus
-    ): Pair<TransactionExistenceStatus, List<CordaPackageSummary>>
+    ): TransactionExistenceStatus
 
     @Suspendable
     fun persistTransactionSignatures(id: SecureHash, startingIndex: Int, signatures: List<DigitalSignatureAndMetadata>)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.utxo.flow.impl.persistence
 
 import io.micrometer.core.instrument.Timer
 import net.corda.crypto.core.fullIdHash
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.fiber.metrics.recordSuspendable
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
@@ -10,6 +11,7 @@ import net.corda.ledger.common.data.transaction.TransactionStatus.Companion.toTr
 import net.corda.ledger.common.data.transaction.filtered.FilteredTransaction
 import net.corda.ledger.utxo.data.transaction.SignedLedgerTransactionContainer
 import net.corda.ledger.utxo.data.transaction.UtxoFilteredTransactionAndSignaturesImpl
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerLastPersistedTimestamp
 import net.corda.ledger.utxo.flow.impl.cache.StateAndRefCache
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.FindFilteredTransactionsAndSignatures
 import net.corda.ledger.utxo.flow.impl.persistence.LedgerPersistenceMetricOperationName.FindSignedLedgerTransactionWithStatus
@@ -67,6 +69,7 @@ import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
 import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+import java.security.PrivilegedExceptionAction
 import java.security.PublicKey
 import java.time.Instant
 
@@ -77,22 +80,17 @@ import java.time.Instant
     scope = PROTOTYPE
 )
 class UtxoLedgerPersistenceServiceImpl @Activate constructor(
-    @Reference(service = CurrentSandboxGroupContext::class)
-    private val currentSandboxGroupContext: CurrentSandboxGroupContext,
-    @Reference(service = ExternalEventExecutor::class)
-    private val externalEventExecutor: ExternalEventExecutor,
-    @Reference(service = SerializationService::class)
-    private val serializationService: SerializationService,
-    @Reference(service = UtxoLedgerTransactionFactory::class)
-    private val utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory,
-    @Reference(service = UtxoSignedTransactionFactory::class)
-    private val utxoSignedTransactionFactory: UtxoSignedTransactionFactory,
-    @Reference(service = UtxoFilteredTransactionFactory::class)
-    private val utxoFilteredTransactionFactory: UtxoFilteredTransactionFactory,
-    @Reference(service = NotarySignatureVerificationService::class)
-    private val notarySignatureVerificationService: NotarySignatureVerificationService,
-    @Reference(service = StateAndRefCache::class)
-    private val stateAndRefCache: StateAndRefCache
+    @Reference(service = CurrentSandboxGroupContext::class) private val currentSandboxGroupContext: CurrentSandboxGroupContext,
+    @Reference(service = ExternalEventExecutor::class) private val externalEventExecutor: ExternalEventExecutor,
+    @Reference(service = SerializationService::class) private val serializationService: SerializationService,
+    @Reference(service = UtxoLedgerTransactionFactory::class) private val utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory,
+    @Reference(service = UtxoSignedTransactionFactory::class) private val utxoSignedTransactionFactory: UtxoSignedTransactionFactory,
+    @Reference(service = UtxoFilteredTransactionFactory::class) private val utxoFilteredTransactionFactory: UtxoFilteredTransactionFactory,
+    @Reference(
+        service = NotarySignatureVerificationService::class
+    ) private val notarySignatureVerificationService: NotarySignatureVerificationService,
+    @Reference(service = StateAndRefCache::class) private val stateAndRefCache: StateAndRefCache,
+    @Reference(service = FlowCheckpointService::class) private val flowCheckpointService: FlowCheckpointService
 ) : UtxoLedgerPersistenceService, UsedByFlow, SingletonSerializeAsToken {
 
     @Suspendable
@@ -112,7 +110,9 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
                     FindTransactionParameters(id.toString(), transactionStatus)
                 )
             }.firstOrNull()?.let {
-                val (transaction, status) = serializationService.deserialize<Pair<SignedTransactionContainer?, String?>>(it.array())
+                val (transaction, status) = serializationService.deserialize<Pair<SignedTransactionContainer?, String?>>(
+                    it.array()
+                )
                 if (status == null) {
                     return@let null
                 }
@@ -127,9 +127,7 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     FindTransactionIdsAndStatusesExternalEventFactory::class.java,
-                    FindTransactionIdsAndStatusesParameters(
-                        ids.map { it.toString() }
-                    )
+                    FindTransactionIdsAndStatusesParameters(ids.map { it.toString() })
                 )
             }
         }.firstOrNull()?.let {
@@ -155,7 +153,9 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
                     FindSignedLedgerTransactionParameters(id.toString(), transactionStatus)
                 )
             }.firstOrNull()?.let {
-                val (transaction, status) = serializationService.deserialize<Pair<SignedLedgerTransactionContainer?, String?>>(it.array())
+                val (transaction, status) = serializationService.deserialize<Pair<SignedLedgerTransactionContainer?, String?>>(
+                    it.array()
+                )
                 if (status == null) {
                     return@let null
                 }
@@ -204,10 +204,7 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
 
                     val utxoFilteredTransaction = utxoFilteredTransactionFactory.create(filteredTransaction)
                     notarySignatureVerificationService.verifyNotarySignatures(
-                        utxoFilteredTransaction,
-                        notaryKey,
-                        signatures,
-                        mutableMapOf()
+                        utxoFilteredTransaction, notaryKey, signatures, mutableMapOf()
                     )
 
                     require(notaryName == utxoFilteredTransaction.notaryName) {
@@ -241,10 +238,32 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
                     PersistTransactionExternalEventFactory::class.java,
-                    PersistTransactionParameters(serialize(transaction.toContainer()), transactionStatus, visibleStatesIndexes)
+                    PersistTransactionParameters(
+                        serialize(transaction.toContainer()),
+                        transactionStatus,
+                        visibleStatesIndexes
+                    )
                 )
-            }.first().let { serializationService.deserialize(it.array()) }
+            }.first().let {
+                val newLastPersistedTimestamp = serializationService.deserialize<Instant>(it.array())
+                updateTimeInCheckpoint(newLastPersistedTimestamp)
+                newLastPersistedTimestamp
+            }
         }
+    }
+
+    private fun updateTimeInCheckpoint(persistTimeStamp: Instant) {
+        @Suppress("deprecation", "removal")
+        java.security.AccessController.doPrivileged(
+            PrivilegedExceptionAction {
+                val previousTimeStamp =
+                    flowCheckpointService.getCheckpoint().readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
+                if (previousTimeStamp == null || previousTimeStamp.lastPersistedTimestamp < persistTimeStamp) {
+                    flowCheckpointService.getCheckpoint()
+                        .writeCustomState(UtxoLedgerLastPersistedTimestamp(persistTimeStamp))
+                }
+            }
+        )
     }
 
     @Suspendable
@@ -282,7 +301,11 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun persistTransactionSignatures(id: SecureHash, startingIndex: Int, signatures: List<DigitalSignatureAndMetadata>) {
+    override fun persistTransactionSignatures(
+        id: SecureHash,
+        startingIndex: Int,
+        signatures: List<DigitalSignatureAndMetadata>
+    ) {
         return recordSuspendable(
             { ledgerPersistenceFlowTimer(LedgerPersistenceMetricOperationName.PersistTransactionSignatures) }
         ) @Suspendable {
@@ -376,10 +399,8 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
     private fun serialize(payload: Any) = serializationService.serialize(payload).bytes
 
     private fun ledgerPersistenceFlowTimer(operationName: LedgerPersistenceMetricOperationName): Timer {
-        return CordaMetrics.Metric.Ledger.PersistenceFlowTime
-            .builder()
+        return CordaMetrics.Metric.Ledger.PersistenceFlowTime.builder()
             .forVirtualNode(currentSandboxGroupContext.get().virtualNodeContext.holdingIdentity.shortHash.toString())
-            .withTag(CordaMetrics.Tag.OperationName, operationName.name)
-            .build()
+            .withTag(CordaMetrics.Tag.OperationName, operationName.name).build()
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -59,11 +59,7 @@ class VaultNamedParameterizedQueryImpl<T>(
 
     @Suspendable
     override fun execute(): PagedQuery.ResultSet<T> {
-        getCreatedTimestampLimit()?.let {
-            require(it <= clock.instant()) {
-                "Timestamp limit must not be in the future."
-            }
-        } ?: setCreatedTimestampLimit(clock.instant())
+        getCreatedTimestampLimit() ?: setCreatedTimestampLimit(clock.instant())
 
         val resultSet = resultSetFactory.create(
             parameters,
@@ -90,8 +86,6 @@ class VaultNamedParameterizedQueryImpl<T>(
     }
 
     override fun setCreatedTimestampLimit(timestampLimit: Instant): VaultNamedParameterizedQuery<T> {
-        require(timestampLimit <= Instant.now()) { "Timestamp limit must not be in the future." }
-
         parameters[TIMESTAMP_LIMIT_PARAM_NAME] = timestampLimit
         return this
     }

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -1,8 +1,8 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
 import io.micrometer.core.instrument.Timer
-import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.flow.fiber.FlowFiberExecutionContext
 import net.corda.flow.fiber.metrics.recordSuspendable
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerLastPersistedTimestamp
@@ -29,7 +29,7 @@ class VaultNamedParameterizedQueryImpl<T>(
     private var offset: Int,
     private val resultClass: Class<T>,
     private val clock: Clock,
-    private val flowCheckpointService: FlowCheckpointService,
+    private val flowFiberExecutionContext: FlowFiberExecutionContext,
 ) : VaultNamedParameterizedQuery<T> {
 
     private companion object {
@@ -90,7 +90,7 @@ class VaultNamedParameterizedQueryImpl<T>(
 
     private fun getNowOrLatestAsOfLastPersistence(): Instant {
         return clock.instant().let { now ->
-            flowCheckpointService.getCheckpoint().readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
+            flowFiberExecutionContext.flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
                 ?.lastPersistedTimestamp?.let { prev ->
                     if (now < prev) prev else now
                 } ?: now

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -1,9 +1,11 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
 import io.micrometer.core.instrument.Timer
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.fiber.metrics.recordSuspendable
 import net.corda.flow.persistence.query.ResultSetFactory
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerLastPersistedTimestamp
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.VaultNamedQueryEventParams
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.VaultNamedQueryExternalEventFactory
 import net.corda.metrics.CordaMetrics
@@ -27,6 +29,7 @@ class VaultNamedParameterizedQueryImpl<T>(
     private var offset: Int,
     private val resultClass: Class<T>,
     private val clock: Clock,
+    private val flowCheckpointService: FlowCheckpointService,
 ) : VaultNamedParameterizedQuery<T> {
 
     private companion object {
@@ -59,7 +62,7 @@ class VaultNamedParameterizedQueryImpl<T>(
 
     @Suspendable
     override fun execute(): PagedQuery.ResultSet<T> {
-        getCreatedTimestampLimit() ?: setCreatedTimestampLimit(clock.instant())
+        getCreatedTimestampLimit() ?: setCreatedTimestampLimit(getNowOrLatestAsOfLastPersistence())
 
         val resultSet = resultSetFactory.create(
             parameters,
@@ -83,6 +86,15 @@ class VaultNamedParameterizedQueryImpl<T>(
         }
         resultSet.next()
         return resultSet
+    }
+
+    private fun getNowOrLatestAsOfLastPersistence(): Instant {
+        return clock.instant().let { now ->
+            flowCheckpointService.getCheckpoint().readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
+                ?.lastPersistedTimestamp?.let { prev ->
+                    if (now < prev) prev else now
+                } ?: now
+        }
     }
 
     override fun setCreatedTimestampLimit(timestampLimit: Instant): VaultNamedParameterizedQuery<T> {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
@@ -2,7 +2,6 @@ package net.corda.ledger.utxo.flow.impl.flows.backchain.v1
 
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.flow.application.services.FlowConfigService
-import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.data.transaction.TransactionStatus.INVALID
 import net.corda.ledger.common.data.transaction.TransactionStatus.UNVERIFIED
@@ -55,8 +54,6 @@ class TransactionBackchainReceiverFlowV1Test {
 
         val TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_1 = StateRef(TX_ID_3, 0)
         val TX_3_INPUT_REFERENCE_DEPENDENCY_STATE_REF_2 = StateRef(TX_ID_3, 1)
-
-        val PACKAGE_SUMMARY = CordaPackageSummaryImpl("name", "version", "hash", "checksum")
 
         const val BACKCHAIN_BATCH_CONFIG_PATH = "backchain.batchSize"
         const val BACKCHAIN_BATCH_DEFAULT_SIZE = 1
@@ -114,7 +111,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(groupParameters.hash).thenReturn(groupParametersHash1)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(retrievedTransaction2.id).thenReturn(TX_ID_2)
 
@@ -195,7 +192,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(retrievedTransaction2.metadata).thenReturn(tx1Metadata)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(utxoLedgerGroupParametersPersistenceService.find(groupParametersHash1))
             .thenReturn(mock())
@@ -282,7 +279,7 @@ class TransactionBackchainReceiverFlowV1Test {
             .thenReturn(null)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         // Both the original transaction and its dependency should be retrieved
         assertThat(callTransactionBackchainReceiverFlow(setOf(TX_ID_2)).complete())
@@ -399,7 +396,7 @@ class TransactionBackchainReceiverFlowV1Test {
         )
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         // Since both the base, dependency and dependency of dependency transaction were present in the database,
         // but TX_ID_4's group params not know it should have been retrieved and all should be in the topological sort
@@ -450,7 +447,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(retrievedTransaction2.metadata).thenReturn(tx1Metadata)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(utxoLedgerGroupParametersPersistenceService.find(groupParametersHash1))
             .thenReturn(mock())
@@ -660,7 +657,7 @@ class TransactionBackchainReceiverFlowV1Test {
         )
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(utxoLedgerGroupParametersPersistenceService.find(groupParametersHash1))
             .thenReturn(mock())
@@ -755,7 +752,7 @@ class TransactionBackchainReceiverFlowV1Test {
             .thenReturn(tx1Metadata)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(utxoLedgerGroupParametersPersistenceService.find(groupParametersHash1))
             .thenReturn(mock())
@@ -815,7 +812,7 @@ class TransactionBackchainReceiverFlowV1Test {
         )
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(utxoLedgerGroupParametersPersistenceService.find(groupParametersHash1))
             .thenReturn(mock())
@@ -945,7 +942,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(groupParameters.hash).thenReturn(groupParametersHash1)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
         whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
@@ -1008,7 +1005,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(groupParameters.hash).thenReturn(groupParametersHash1)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
         whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
@@ -1059,10 +1056,10 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(groupParameters.hash).thenReturn(groupParametersHash1)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(retrievedTransaction1, UNVERIFIED))
-            .thenReturn(TransactionExistenceStatus.VERIFIED to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.VERIFIED)
         whenever(retrievedTransaction1.metadata).thenReturn(tx1Metadata)
         whenever(tx1Metadata.getMembershipGroupParametersHash()).thenReturn(groupParametersHash1.toString())
 
@@ -1104,7 +1101,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(groupParameters.hash).thenReturn(groupParametersHash1)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.VERIFIED to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.VERIFIED)
         whenever(retrievedTransaction1.metadata).thenReturn(tx1Metadata)
         whenever(tx1Metadata.getMembershipGroupParametersHash()).thenReturn(groupParametersHash1.toString())
 
@@ -1149,7 +1146,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(groupParameters.hash).thenReturn(groupParametersHash1)
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(retrievedTransaction1, UNVERIFIED))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
         whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
@@ -1182,7 +1179,7 @@ class TransactionBackchainReceiverFlowV1Test {
         whenever(groupParameters.hash).thenReturn(SecureHashImpl("SHA", byteArrayOf(103, 104, 105, 106)))
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(retrievedTransaction1, UNVERIFIED))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
         whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
@@ -1216,7 +1213,7 @@ class TransactionBackchainReceiverFlowV1Test {
         )
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(retrievedTransaction1, UNVERIFIED))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         whenever(retrievedTransaction1.id).thenReturn(TX_ID_1)
         whenever(retrievedTransaction1.inputStateRefs).thenReturn(listOf(TX_3_INPUT_DEPENDENCY_STATE_REF_1))
@@ -1347,7 +1344,7 @@ class TransactionBackchainReceiverFlowV1Test {
         )
 
         whenever(utxoLedgerPersistenceService.persistIfDoesNotExist(any(), eq(UNVERIFIED)))
-            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST to listOf(PACKAGE_SUMMARY))
+            .thenReturn(TransactionExistenceStatus.DOES_NOT_EXIST)
 
         assertThat(callTransactionBackchainReceiverFlow(setOf(transactionId3, transactionId4)).complete()).isEqualTo(
             listOf(

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/ReceiveSignedTransactionFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/transactiontransmission/ReceiveSignedTransactionFlowV1Test.kt
@@ -24,6 +24,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Instant
 
 class ReceiveSignedTransactionFlowV1Test : UtxoLedgerTest() {
     private val mockFlowEngine = mock<FlowEngine>()
@@ -53,7 +54,7 @@ class ReceiveSignedTransactionFlowV1Test : UtxoLedgerTest() {
     @Test
     fun `flow should respond with success payload if sub-flow executes properly`() {
         whenever(transactionVerificationService.verify(any())).doAnswer { }
-        whenever(persistenceService.persist(any(), any(), any())).doReturn(emptyList())
+        whenever(persistenceService.persist(any(), any(), any())).doReturn(Instant.now())
         whenever(sessionAlice.receive(UtxoTransactionPayload::class.java)).thenReturn(
             UtxoTransactionPayload(
                 signedTransaction,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -4,8 +4,10 @@ import net.corda.crypto.cipher.suite.SignatureSpecImpl
 import net.corda.crypto.core.DigitalSignatureWithKeyId
 import net.corda.crypto.core.fullIdHash
 import net.corda.crypto.core.parseSecureHash
-import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.flow.fiber.FlowFiber
+import net.corda.flow.fiber.FlowFiberExecutionContext
+import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.state.FlowCheckpoint
 import net.corda.internal.serialization.SerializedBytesImpl
 import net.corda.ledger.common.data.transaction.SignedTransactionContainer
@@ -101,7 +103,9 @@ class UtxoLedgerPersistenceServiceImplTest {
     private val virtualNodeContext = mock<VirtualNodeContext>()
     private val currentSandboxGroupContext = mock<CurrentSandboxGroupContext>()
     private val stateAndRefCache = mock<StateAndRefCache>()
-    private val flowCheckpointService = mock<FlowCheckpointService>()
+    private val flowFiberService = mock<FlowFiberService>()
+    private val flowFiber = mock<FlowFiber>()
+    private val flowFiberExecutionContext = mock<FlowFiberExecutionContext>()
     private val flowCheckpoint = mock<FlowCheckpoint>()
 
     private val notaryServiceKey = mock<CompositeKey>()
@@ -126,7 +130,7 @@ class UtxoLedgerPersistenceServiceImplTest {
             utxoFilteredTransactionFactory,
             notarySignatureVerificationService,
             stateAndRefCache,
-            flowCheckpointService
+            flowFiberService
         )
 
         whenever(serializationService.serialize(any<Any>())).thenReturn(serializedBytes)
@@ -142,7 +146,9 @@ class UtxoLedgerPersistenceServiceImplTest {
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
         whenever(stateAndRefCache.putAll(any())).doAnswer {}
 
-        whenever(flowCheckpointService.getCheckpoint()).thenReturn(flowCheckpoint)
+        whenever(flowFiberService.getExecutingFiber()).thenReturn(flowFiber)
+        whenever(flowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext)
+        whenever(flowFiberExecutionContext.flowCheckpoint).thenReturn(flowCheckpoint)
 
         // Composite key containing both of the notary VNode keys
         whenever(notaryServiceKey.leafKeys).thenReturn(setOf(publicKeyNotaryVNode1, publicKeyNotaryVNode2))

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -8,7 +8,6 @@ import net.corda.ledger.utxo.flow.impl.persistence.external.events.VaultNamedQue
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
 import net.corda.sandboxgroupcontext.SandboxGroupContext
 import net.corda.sandboxgroupcontext.VirtualNodeContext
-import net.corda.utilities.days
 import net.corda.utilities.time.Clock
 import net.corda.v5.application.persistence.CordaPersistenceException
 import net.corda.v5.application.persistence.PagedQuery.ResultSet
@@ -90,13 +89,6 @@ class VaultNamedParameterizedQueryImplTest {
     @Test
     fun `setLimit cannot be zero`() {
         assertThatThrownBy { query.setLimit(0) }.isInstanceOf(IllegalArgumentException::class.java)
-    }
-
-    @Test
-    fun `cannot set timestamp limit to a future date`() {
-        assertThatThrownBy { query.setCreatedTimestampLimit(Instant.now().plusMillis(1.days.toMillis())) }
-            .isInstanceOf(IllegalArgumentException::class.java)
-            .hasStackTraceContaining("Timestamp limit must not be in the future.")
     }
 
     @Test

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -1,7 +1,7 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
-import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.flow.fiber.FlowFiberExecutionContext
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.persistence.query.StableResultSetExecutor
 import net.corda.flow.state.FlowCheckpoint
@@ -61,7 +61,7 @@ class VaultNamedParameterizedQueryImplTest {
     private val clock = mock<Clock>()
     private val resultSetExecutorCaptor = argumentCaptor<StableResultSetExecutor<Any>>()
     private val mapCaptor = argumentCaptor<Map<String, Any>>()
-    private val flowCheckpointService = mock<FlowCheckpointService>()
+    private val flowFiberExecutionContext = mock<FlowFiberExecutionContext>()
     private val flowCheckpoint = mock<FlowCheckpoint>()
 
     private val query = VaultNamedParameterizedQueryImpl(
@@ -74,7 +74,7 @@ class VaultNamedParameterizedQueryImplTest {
         offset = 0,
         resultClass = Any::class.java,
         clock = clock,
-        flowCheckpointService = flowCheckpointService
+        flowFiberExecutionContext = flowFiberExecutionContext
     )
 
     @BeforeEach
@@ -85,7 +85,7 @@ class VaultNamedParameterizedQueryImplTest {
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
-        whenever(flowCheckpointService.getCheckpoint()).thenReturn(flowCheckpoint)
+        whenever(flowFiberExecutionContext.flowCheckpoint).thenReturn(flowCheckpoint)
         whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
             .thenReturn(null)
     }
@@ -123,7 +123,7 @@ class VaultNamedParameterizedQueryImplTest {
         query.setCreatedTimestampLimit(customTimestamp)
 
         query.execute()
-        verify(flowCheckpointService, never()).getCheckpoint()
+        verify(flowFiberExecutionContext, never()).flowCheckpoint
         assertThat(
             mapCaptor.firstValue
         ).containsAllEntriesOf(mapOf(parameterNameOne to parameterOne, TIMESTAMP_LIMIT_PARAM_NAME to customTimestamp))

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -1,8 +1,11 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.persistence.query.StableResultSetExecutor
+import net.corda.flow.state.FlowCheckpoint
+import net.corda.ledger.utxo.data.transaction.UtxoLedgerLastPersistedTimestamp
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.ALICE_X500_HOLDING_IDENTITY
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.VaultNamedQueryExternalEventFactory
 import net.corda.sandboxgroupcontext.CurrentSandboxGroupContext
@@ -17,10 +20,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.time.Instant
@@ -29,10 +35,22 @@ class VaultNamedParameterizedQueryImplTest {
 
     private companion object {
         const val TIMESTAMP_LIMIT_PARAM_NAME = "Corda_TimestampLimit"
-        val now: Instant = Instant.now().minusSeconds(10)
-        val later: Instant = Instant.now().minusSeconds(10)
+        val customTimestamp: Instant = Instant.ofEpochSecond(1200)
+        val now: Instant = Instant.ofEpochSecond(3600)
+        val future: Instant = now.plusSeconds(2)
+        val past: Instant = now.minusSeconds(1)
         val results = listOf("A", "B")
+
+        @JvmStatic
+        private fun getTimeArguments(): Array<TimeArguments> = arrayOf(
+            TimeArguments(null, now),
+            TimeArguments(now, now),
+            TimeArguments(past, now),
+            TimeArguments(future, future)
+        )
     }
+
+    data class TimeArguments(val checkpointValue: Instant?, val expectedValue: Instant)
 
     private val externalEventExecutor = mock<ExternalEventExecutor>()
     private val sandbox = mock<SandboxGroupContext>()
@@ -43,6 +61,8 @@ class VaultNamedParameterizedQueryImplTest {
     private val clock = mock<Clock>()
     private val resultSetExecutorCaptor = argumentCaptor<StableResultSetExecutor<Any>>()
     private val mapCaptor = argumentCaptor<Map<String, Any>>()
+    private val flowCheckpointService = mock<FlowCheckpointService>()
+    private val flowCheckpoint = mock<FlowCheckpoint>()
 
     private val query = VaultNamedParameterizedQueryImpl(
         externalEventExecutor = externalEventExecutor,
@@ -53,17 +73,21 @@ class VaultNamedParameterizedQueryImplTest {
         limit = 1,
         offset = 0,
         resultClass = Any::class.java,
-        clock = clock
+        clock = clock,
+        flowCheckpointService = flowCheckpointService
     )
 
     @BeforeEach
     fun beforeEach() {
         whenever(resultSetFactory.create(mapCaptor.capture(), any(), any(), resultSetExecutorCaptor.capture())).thenReturn(resultSet)
         whenever(resultSet.next()).thenReturn(results)
-        whenever(clock.instant()).thenReturn(later)
+        whenever(clock.instant()).thenReturn(now)
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
+        whenever(flowCheckpointService.getCheckpoint()).thenReturn(flowCheckpoint)
+        whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
+            .thenReturn(null)
     }
 
     @Test
@@ -96,21 +120,34 @@ class VaultNamedParameterizedQueryImplTest {
         val parameterNameOne = "one"
         val parameterOne = "param one"
         query.setParameter(parameterNameOne, parameterOne)
-        query.setCreatedTimestampLimit(now)
+        query.setCreatedTimestampLimit(customTimestamp)
 
         query.execute()
-        assertThat(mapCaptor.firstValue).containsAllEntriesOf(mapOf(parameterNameOne to parameterOne, TIMESTAMP_LIMIT_PARAM_NAME to now))
+        verify(flowCheckpointService, never()).getCheckpoint()
+        assertThat(
+            mapCaptor.firstValue
+        ).containsAllEntriesOf(mapOf(parameterNameOne to parameterOne, TIMESTAMP_LIMIT_PARAM_NAME to customTimestamp))
     }
 
-    @Test
-    fun `execute sets the timestamp limit to now if not set when there are no other parameters`() {
+    @ParameterizedTest
+    @MethodSource("getTimeArguments")
+    fun `execute sets the timestamp limit to now or the future if in the context if not set when there are no other parameters`(
+        args: TimeArguments
+    ) {
+        whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
+            .thenReturn(args.checkpointValue?.let { UtxoLedgerLastPersistedTimestamp(it) })
         query.execute()
         verify(clock).instant()
-        assertThat(mapCaptor.firstValue).containsExactlyEntriesOf(mapOf(TIMESTAMP_LIMIT_PARAM_NAME to later))
+        assertThat(mapCaptor.firstValue).containsExactlyEntriesOf(mapOf(TIMESTAMP_LIMIT_PARAM_NAME to args.expectedValue))
     }
 
-    @Test
-    fun `execute sets the timestamp limit to now if not set when there are other parameters`() {
+    @ParameterizedTest
+    @MethodSource("getTimeArguments")
+    fun `execute sets the timestamp limit to now  or the future if in the context if not set when there are other parameters`(
+        args: TimeArguments
+    ) {
+        whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
+            .thenReturn(args.checkpointValue?.let { UtxoLedgerLastPersistedTimestamp(it) })
         val parameterNameOne = "one"
         val parameterOne = "param one"
         query.setParameter(parameterNameOne, parameterOne)
@@ -119,7 +156,7 @@ class VaultNamedParameterizedQueryImplTest {
         assertThat(mapCaptor.firstValue).containsExactlyEntriesOf(
             mapOf(
                 parameterNameOne to parameterOne,
-                TIMESTAMP_LIMIT_PARAM_NAME to later
+                TIMESTAMP_LIMIT_PARAM_NAME to args.expectedValue
             )
         )
     }

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoLedgerLastPersistedTimestamp.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoLedgerLastPersistedTimestamp.kt
@@ -1,0 +1,9 @@
+package net.corda.ledger.utxo.data.transaction
+
+import net.corda.v5.base.annotations.CordaSerializable
+import java.time.Instant
+
+@CordaSerializable
+data class UtxoLedgerLastPersistedTimestamp(
+    val lastPersistedTimestamp: Instant
+)

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -1,7 +1,7 @@
 package net.corda.ledger.utxo.test
 
-import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
 import net.corda.ledger.common.data.transaction.filtered.factory.impl.FilteredTransactionFactoryImpl
@@ -104,7 +104,7 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
         mockExternalEventExecutor,
         mockResultSetFactory,
         mockUtxoLedgerTransactionVerificationService,
-        mock<FlowCheckpointService>()
+        mock<FlowFiberService>()
     )
     val utxoSignedTransactionKryoSerializer = UtxoSignedTransactionKryoSerializer(
         serializationServiceWithWireTx,

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.test
 
+import net.corda.flow.application.services.FlowCheckpointService
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.pipeline.sandbox.FlowSandboxService
@@ -102,7 +103,8 @@ abstract class UtxoLedgerTest : CommonLedgerTest() {
         mockPluggableNotaryService,
         mockExternalEventExecutor,
         mockResultSetFactory,
-        mockUtxoLedgerTransactionVerificationService
+        mockUtxoLedgerTransactionVerificationService,
+        mock<FlowCheckpointService>()
     )
     val utxoSignedTransactionKryoSerializer = UtxoSignedTransactionKryoSerializer(
         serializationServiceWithWireTx,


### PR DESCRIPTION
Fixed in 5.3 already - handle potential clock skew between flow worker and persistence worker so that as of now queries can always get the latest states.