### PR TITLE
CORE-19022 Create `UtxoSignedTransactionWithDependencies` to optimise filtered dependencies

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -18,6 +18,7 @@ import net.corda.ledger.utxo.flow.impl.persistence.UtxoLedgerStateQueryService
 import net.corda.ledger.utxo.flow.impl.persistence.VaultNamedParameterizedQueryImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoBaselinedTransactionBuilder
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionWithDependencies
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderImpl
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoTransactionBuilderInternal
 import net.corda.ledger.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
@@ -153,11 +154,15 @@ class UtxoLedgerServiceImpl @Activate constructor(
     override fun findFilteredTransactionsAndSignatures(
         signedTransaction: UtxoSignedTransaction
     ): Map<SecureHash, UtxoFilteredTransactionAndSignatures> {
-        return utxoLedgerPersistenceService.findFilteredTransactionsAndSignatures(
-            signedTransaction.inputStateRefs + signedTransaction.referenceStateRefs,
-            signedTransaction.notaryKey,
-            signedTransaction.notaryName
-        )
+        return if (signedTransaction is UtxoSignedTransactionWithDependencies) {
+            signedTransaction.filteredDependencies.associateBy { it.filteredTransaction.id }
+        } else {
+            utxoLedgerPersistenceService.findFilteredTransactionsAndSignatures(
+                signedTransaction.inputStateRefs + signedTransaction.referenceStateRefs,
+                signedTransaction.notaryKey,
+                signedTransaction.notaryName
+            )
+        }
     }
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -285,7 +285,7 @@ class UtxoFinalityFlowV1(
         // the dependencies without having to query the database, otherwise we just use the regular signed transaction
         val notarizationFlow = newPluggableNotaryClientFlowInstance(
             filteredTransactionsAndSignatures?.let {
-                UtxoSignedTransactionWithDependencies(transaction as UtxoSignedTransaction, it)
+                UtxoSignedTransactionWithDependencies(transaction, it)
             } ?: transaction
         )
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -285,7 +285,7 @@ class UtxoFinalityFlowV1(
         // the dependencies without having to query the database, otherwise we just use the regular signed transaction
         val notarizationFlow = newPluggableNotaryClientFlowInstance(
             filteredTransactionsAndSignatures?.let {
-                UtxoSignedTransactionWithDependencies(transaction, it)
+                UtxoSignedTransactionWithDependencies(transaction as UtxoSignedTransaction, it)
             } ?: transaction
         )
 
@@ -366,7 +366,7 @@ class UtxoFinalityFlowV1(
     // function to avoid trying (and failing) to serialize the objects used internally.
     @VisibleForTesting
     internal fun newPluggableNotaryClientFlowInstance(
-        transaction: UtxoSignedTransactionInternal
+        transaction: UtxoSignedTransaction
     ): PluggableNotaryClientFlow {
         @Suppress("deprecation", "removal")
         return java.security.AccessController.doPrivileged(

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionWithDependencies.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionWithDependencies.kt
@@ -5,4 +5,4 @@ import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionAndS
 class UtxoSignedTransactionWithDependencies(
     private val delegate: UtxoSignedTransactionInternal,
     val filteredDependencies: List<UtxoFilteredTransactionAndSignatures>
-): UtxoSignedTransactionInternal by delegate
+) : UtxoSignedTransactionInternal by delegate

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionWithDependencies.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionWithDependencies.kt
@@ -1,0 +1,8 @@
+package net.corda.ledger.utxo.flow.impl.transaction
+
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionAndSignatures
+
+class UtxoSignedTransactionWithDependencies(
+    private val delegate: UtxoSignedTransactionInternal,
+    val filteredDependencies: List<UtxoFilteredTransactionAndSignatures>
+): UtxoSignedTransactionInternal by delegate

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionWithDependencies.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionWithDependencies.kt
@@ -1,8 +1,9 @@
 package net.corda.ledger.utxo.flow.impl.transaction
 
+import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionAndSignatures
 
 class UtxoSignedTransactionWithDependencies(
-    private val delegate: UtxoSignedTransactionInternal,
+    val delegate: UtxoSignedTransaction,
     val filteredDependencies: List<UtxoFilteredTransactionAndSignatures>
-) : UtxoSignedTransactionInternal by delegate
+) : UtxoSignedTransaction by delegate

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImplTest.kt
@@ -4,6 +4,8 @@ import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.sandbox.FlowSandboxGroupContext
 import net.corda.flow.pipeline.sessions.protocol.FlowProtocolStore
 import net.corda.ledger.common.testkit.publicKeyExample
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
+import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionWithDependencies
 import net.corda.ledger.utxo.test.UtxoLedgerTest
 import net.corda.ledger.utxo.testkit.UtxoCommandExample
 import net.corda.ledger.utxo.testkit.UtxoStateClassExample
@@ -19,8 +21,11 @@ import net.corda.v5.base.types.MemberX500Name
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.notary.plugin.api.PluggableNotaryClientFlow
 import net.corda.v5.ledger.utxo.ContractState
+import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransactionAndSignatures
 import net.corda.v5.membership.NotaryInfo
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Assertions
@@ -30,6 +35,9 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.security.PublicKey
 import kotlin.test.assertEquals
@@ -278,5 +286,45 @@ class UtxoLedgerServiceImplTest : UtxoLedgerTest() {
         }
 
         assertEquals(MyClientFlow::class.java.name, result.flowClass.name)
+    }
+
+    @Test
+    fun `findFilteredTransactionsAndSignatures will not go to the database if a UtxoSignedTransactionWithDependencies is passed in`() {
+        val filteredTransactionMock = mock<UtxoFilteredTransaction> {
+            on { id } doReturn mock()
+        }
+
+        val filteredTransactionAndSignatureMock = mock<UtxoFilteredTransactionAndSignatures> {
+            on { filteredTransaction } doReturn filteredTransactionMock
+        }
+
+        utxoLedgerService.findFilteredTransactionsAndSignatures(
+            UtxoSignedTransactionWithDependencies(
+                mock(),
+                listOf(filteredTransactionAndSignatureMock)
+            )
+        )
+
+        verify(mockUtxoLedgerPersistenceService, never()).findFilteredTransactionsAndSignatures(any(), any(), any())
+    }
+
+    @Test
+    fun `findFilteredTransactionsAndSignatures will go to the database if a UtxoSignedTransaction is passed in`() {
+        val ref = StateRef(mock(), 0)
+        val ref2 = StateRef(mock(), 1)
+
+        val signedTransactionInternal = mock<UtxoSignedTransactionInternal> {
+            on { inputStateRefs } doReturn listOf(ref)
+            on { referenceStateRefs } doReturn listOf(ref2)
+            on { notaryName } doReturn notaryX500Name
+            on { notaryKey } doReturn mock()
+        }
+
+        utxoLedgerService.findFilteredTransactionsAndSignatures(
+            signedTransactionInternal
+        )
+
+        verify(mockUtxoLedgerPersistenceService, times(1))
+            .findFilteredTransactionsAndSignatures(any(), any(), any())
     }
 }

--- a/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
+++ b/testing/ledger/ledger-utxo-base-test/src/main/kotlin/net/corda/ledger/utxo/test/UtxoLedgerTest.kt
@@ -31,7 +31,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
 abstract class UtxoLedgerTest : CommonLedgerTest() {
-    private val mockUtxoLedgerPersistenceService = mock<UtxoLedgerPersistenceService>()
+    protected val mockUtxoLedgerPersistenceService = mock<UtxoLedgerPersistenceService>()
     private val mockUtxoLedgerTransactionVerificationService = mock<UtxoLedgerTransactionVerificationService>()
     private val mockUtxoLedgerGroupParametersPersistenceService = mock<UtxoLedgerGroupParametersPersistenceService>()
     private val mockGroupParametersLookup = mockGroupParametersLookup()


### PR DESCRIPTION
### Overview

Create a new class called `UtxoSignedTransactionWithDependencies` which is a sub-type of `UtxoSignedTransactionInternal`. It only extends it with a property called `val filteredDependencies: List<UtxoFilteredTransactionAndSignatures>`.

This way we can create an instance of `UtxoSignedTransactionWithDependencies` with the filtered dependencies and can pass that to the notary flow rather than having to access the DB twice or create a cache.

The `findFilteredTransactionsAndSignatures` function will now check whether the passed in transaction is a `UtxoSignedTransactionWithDependencies` and if it is it will not go to the DB.

### Testing

- Added new unit tests to `UtxoLedgerServiceImplTest`
- Existing e2e tests passing