### PR TITLE
CORE-20093: Use one crypto worker to read default master wrapping key tag

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceImpl.kt
@@ -221,7 +221,7 @@ class KeyRotationRestResourceImpl @Activate constructor(
                 val deserializedValueOfOneRecord =
                     checkNotNull(unmanagedKeyStatusDeserializer.deserialize(records.first().value))
                 return KeyRotationStatusResponse(
-                    MASTER_WRAPPING_KEY_ROTATION_IDENTIFIER,
+                    records.first().metadata[KeyRotationMetadataValues.DEFAULT_MASTER_KEY_ALIAS].toString(),
                     rotationStatus,
                     deserializedValueOfOneRecord.createdTimestamp,
                     getLatestTimestamp(records),

--- a/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
+++ b/components/crypto/crypto-rest/src/test/kotlin/net/corda/crypto/rest/impl/KeyRotationRestResourceTest.kt
@@ -8,6 +8,7 @@ import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.config.impl.CryptoHSMConfig
 import net.corda.crypto.config.impl.HSM
+import net.corda.crypto.core.KeyRotationMetadataValues
 import net.corda.crypto.core.KeyRotationStatus
 import net.corda.crypto.core.MASTER_WRAPPING_KEY_ROTATION_IDENTIFIER
 import net.corda.crypto.rest.KeyRotationRestResource
@@ -99,7 +100,12 @@ class KeyRotationRestResourceTest {
                     "random",
                     "random".toByteArray(),
                     0,
-                    Metadata(mapOf("status" to "In Progress"))
+                    Metadata(
+                        mapOf(
+                            KeyRotationMetadataValues.STATUS to "In Progress",
+                            KeyRotationMetadataValues.DEFAULT_MASTER_KEY_ALIAS to MASTER_WRAPPING_KEY_ROTATION_IDENTIFIER
+                        )
+                    )
                 )
             )
         }

--- a/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
+++ b/components/crypto/crypto-service-impl/src/main/kotlin/net/corda/crypto/service/impl/bus/CryptoRekeyBusProcessor.kt
@@ -297,6 +297,7 @@ class CryptoRekeyBusProcessor(
                     IndividualKeyRotationRequest(
                         request.requestId,
                         tenantId,
+                        defaultUnmanagedWrappingKeyName,
                         alias,
                         null, // keyUuid not used in unmanaged key rotation
                         KeyType.UNMANAGED
@@ -318,6 +319,7 @@ class CryptoRekeyBusProcessor(
                     IndividualKeyRotationRequest(
                         request.requestId,
                         request.tenantId,
+                        null,
                         null,
                         it.toString(),
                         KeyType.MANAGED

--- a/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
+++ b/components/crypto/crypto-service-impl/src/test/kotlin/net/corda/crypto/service/impl/bus/CryptoRewrapBusProcessorTests.kt
@@ -48,7 +48,6 @@ class CryptoRewrapBusProcessorTests {
 
     companion object {
         private val tenantId = UUID.randomUUID().toString()
-        private const val OLD_PARENT_KEY_ALIAS = "alias1"
         private const val WRAPPING_KEY_ALIAS = "alias"
         private const val DEFAULT_MASTER_WRAP_KEY_ALIAS = "defaultKeyAlias"
     }
@@ -117,14 +116,12 @@ class CryptoRewrapBusProcessorTests {
             cryptoService,
             stateManager,
             unmanagedCordaAvroSerializationFactory,
-            DEFAULT_MASTER_WRAP_KEY_ALIAS
         )
 
         managedCryptoRewrapBusProcessor = CryptoRewrapBusProcessor(
             cryptoService,
             stateManager,
             managedCordaAvroSerializationFactory,
-            DEFAULT_MASTER_WRAP_KEY_ALIAS
         )
     }
 
@@ -138,6 +135,7 @@ class CryptoRewrapBusProcessorTests {
                     IndividualKeyRotationRequest(
                         UUID.randomUUID().toString(),
                         tenantId,
+                        DEFAULT_MASTER_WRAP_KEY_ALIAS,
                         "alias1",
                         null,
                         KeyType.UNMANAGED
@@ -160,6 +158,7 @@ class CryptoRewrapBusProcessorTests {
                         IndividualKeyRotationRequest(
                             UUID.randomUUID().toString(),
                             null,
+                            DEFAULT_MASTER_WRAP_KEY_ALIAS,
                             "alias1",
                             null,
                             KeyType.UNMANAGED
@@ -183,6 +182,57 @@ class CryptoRewrapBusProcessorTests {
                         UUID.randomUUID().toString(),
                         IndividualKeyRotationRequest(
                             UUID.randomUUID().toString(),
+                            "",
+                            DEFAULT_MASTER_WRAP_KEY_ALIAS,
+                            "alias1",
+                            null,
+                            KeyType.UNMANAGED
+                        )
+                    )
+                )
+            ).isEmpty()
+        )
+
+        verify(cryptoService, never()).rewrapWrappingKey(any(), any(), any())
+        verify(stateManager, never()).update(any())
+    }
+
+    @Test
+    fun `unmanaged rewrap with null master wrapping key should be ignored`() {
+        assertTrue(
+            unmanagedCryptoRewrapBusProcessor.onNext(
+                listOf(
+                    Record(
+                        "TBC",
+                        UUID.randomUUID().toString(),
+                        IndividualKeyRotationRequest(
+                            UUID.randomUUID().toString(),
+                            tenantId,
+                            null,
+                            "alias1",
+                            null,
+                            KeyType.UNMANAGED
+                        )
+                    )
+                )
+            ).isEmpty()
+        )
+
+        verify(cryptoService, never()).rewrapWrappingKey(any(), any(), any())
+        verify(stateManager, never()).update(any())
+    }
+
+    @Test
+    fun `unmanaged rewrap with empty master wrapping key should be ignored`() {
+        assertTrue(
+            unmanagedCryptoRewrapBusProcessor.onNext(
+                listOf(
+                    Record(
+                        "TBC",
+                        UUID.randomUUID().toString(),
+                        IndividualKeyRotationRequest(
+                            UUID.randomUUID().toString(),
+                            tenantId,
                             "",
                             "alias1",
                             null,
@@ -208,6 +258,7 @@ class CryptoRewrapBusProcessorTests {
                         IndividualKeyRotationRequest(
                             UUID.randomUUID().toString(),
                             tenantId,
+                            DEFAULT_MASTER_WRAP_KEY_ALIAS,
                             null,
                             null,
                             KeyType.UNMANAGED
@@ -232,6 +283,7 @@ class CryptoRewrapBusProcessorTests {
                         IndividualKeyRotationRequest(
                             UUID.randomUUID().toString(),
                             tenantId,
+                            DEFAULT_MASTER_WRAP_KEY_ALIAS,
                             "",
                             "",
                             KeyType.UNMANAGED
@@ -256,6 +308,7 @@ class CryptoRewrapBusProcessorTests {
                         IndividualKeyRotationRequest(
                             UUID.randomUUID().toString(),
                             tenantId,
+                            DEFAULT_MASTER_WRAP_KEY_ALIAS,
                             "alias1",
                             UUID.randomUUID().toString(),
                             KeyType.UNMANAGED
@@ -281,6 +334,7 @@ class CryptoRewrapBusProcessorTests {
                         UUID.randomUUID().toString(),
                         tenantId,
                         null,
+                        null,
                         uuid.toString(),
                         KeyType.MANAGED
                     )
@@ -300,6 +354,7 @@ class CryptoRewrapBusProcessorTests {
                         UUID.randomUUID().toString(),
                         IndividualKeyRotationRequest(
                             UUID.randomUUID().toString(),
+                            null,
                             null,
                             null,
                             UUID.randomUUID().toString(),
@@ -326,6 +381,32 @@ class CryptoRewrapBusProcessorTests {
                             UUID.randomUUID().toString(),
                             "",
                             null,
+                            null,
+                            UUID.randomUUID().toString(),
+                            KeyType.MANAGED
+                        )
+                    )
+                )
+            ).isEmpty()
+        )
+
+        verify(cryptoService, never()).rewrapWrappingKey(any(), any(), any())
+        verify(stateManager, never()).update(any())
+    }
+
+    @Test
+    fun `managed rewrap with master wrapping key set should be ignored`() {
+        assertTrue(
+            managedCryptoRewrapBusProcessor.onNext(
+                listOf(
+                    Record(
+                        "TBC",
+                        UUID.randomUUID().toString(),
+                        IndividualKeyRotationRequest(
+                            UUID.randomUUID().toString(),
+                            tenantId,
+                            DEFAULT_MASTER_WRAP_KEY_ALIAS,
+                            "alias1",
                             UUID.randomUUID().toString(),
                             KeyType.MANAGED
                         )
@@ -349,6 +430,7 @@ class CryptoRewrapBusProcessorTests {
                         IndividualKeyRotationRequest(
                             UUID.randomUUID().toString(),
                             tenantId,
+                            null,
                             "alias1",
                             UUID.randomUUID().toString(),
                             KeyType.MANAGED
@@ -375,6 +457,7 @@ class CryptoRewrapBusProcessorTests {
                             tenantId,
                             null,
                             null,
+                            null,
                             KeyType.MANAGED
                         )
                     )
@@ -397,6 +480,7 @@ class CryptoRewrapBusProcessorTests {
                         IndividualKeyRotationRequest(
                             UUID.randomUUID().toString(),
                             tenantId,
+                            null,
                             null,
                             "",
                             KeyType.MANAGED
@@ -422,6 +506,7 @@ class CryptoRewrapBusProcessorTests {
                             UUID.randomUUID().toString(),
                             tenantId,
                             null,
+                            null,
                             "invalid uuid",
                             KeyType.MANAGED
                         )
@@ -445,6 +530,7 @@ class CryptoRewrapBusProcessorTests {
                     IndividualKeyRotationRequest(
                         UUID.randomUUID().toString(),
                         tenantId,
+                        null,
                         null,
                         uuid.toString(),
                         KeyType.MANAGED

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.11-beta+
+cordaApiVersion=5.3.0.12-alpha-1713782925670
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.12-alpha-1713782925670
+cordaApiVersion=5.3.0.12-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
+++ b/processors/crypto-processor/src/main/kotlin/net/corda/processors/crypto/internal/CryptoProcessorImpl.kt
@@ -407,7 +407,6 @@ class CryptoProcessorImpl @Activate constructor(
             messagingConfig,
             stateManager,
             cordaAvroSerializationFactory,
-            defaultUnmanagedWrappingKeyName,
             cryptoService
         )
         createSessionEncryptionSubscription(coordinator, retryingConfig, cryptoService)
@@ -468,14 +467,12 @@ class CryptoProcessorImpl @Activate constructor(
         messagingConfig: SmartConfig,
         stateManager: StateManager,
         cordaAvroSerializationFactory: CordaAvroSerializationFactory,
-        defaultUnmanagedWrappingKeyName: String,
         cryptoService: CryptoService
     ) {
         val rewrapProcessor = CryptoRewrapBusProcessor(
             cryptoService,
             stateManager,
             cordaAvroSerializationFactory,
-            defaultUnmanagedWrappingKeyName,
         )
         val rewrapGroupName = "crypto.key.rotation.individual"
         coordinator.createManagedResource(REWRAP_SUBSCRIPTION) {


### PR DESCRIPTION
Retrieve default master wrapping key alias only in rekey bus processor. 
Use IndividualKeyRotationRequest kafka message to pass the default master wrapping key alias to rewrap bus processor.

When retrieving the status of key rotation, show the default master wrapping key alias instead of the hardcoded 'master' value.

API PR: [#1607](https://github.com/corda/corda-api/pull/1607)
E2E tests PR: [#588](https://github.com/corda/corda-e2e-tests/pull/588)