### PR TITLE
CORE-20405 Kryo serialization error in query object

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -203,7 +203,7 @@ class UtxoLedgerServiceImpl @Activate constructor(
             offset = 0,
             resultClass,
             clock,
-            flowFiberService.getExecutingFiber().getExecutionContext()
+            flowFiberService
         )
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -2,7 +2,6 @@ package net.corda.ledger.utxo.flow.impl.persistence
 
 import io.micrometer.core.instrument.Timer
 import net.corda.flow.external.events.executor.ExternalEventExecutor
-import net.corda.flow.fiber.FlowFiberExecutionContext
 import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.fiber.metrics.recordSuspendable
 import net.corda.flow.persistence.query.ResultSetFactory

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImpl.kt
@@ -3,6 +3,7 @@ package net.corda.ledger.utxo.flow.impl.persistence
 import io.micrometer.core.instrument.Timer
 import net.corda.flow.external.events.executor.ExternalEventExecutor
 import net.corda.flow.fiber.FlowFiberExecutionContext
+import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.fiber.metrics.recordSuspendable
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.ledger.utxo.data.transaction.UtxoLedgerLastPersistedTimestamp
@@ -29,7 +30,7 @@ class VaultNamedParameterizedQueryImpl<T>(
     private var offset: Int,
     private val resultClass: Class<T>,
     private val clock: Clock,
-    private val flowFiberExecutionContext: FlowFiberExecutionContext,
+    private val flowFiberService: FlowFiberService
 ) : VaultNamedParameterizedQuery<T> {
 
     private companion object {
@@ -90,7 +91,10 @@ class VaultNamedParameterizedQueryImpl<T>(
 
     private fun getNowOrLatestAsOfLastPersistence(): Instant {
         return clock.instant().let { now ->
-            flowFiberExecutionContext.flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
+            flowFiberService
+                .getExecutingFiber()
+                .getExecutionContext()
+                .flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java)
                 ?.lastPersistedTimestamp?.let { prev ->
                     if (now < prev) prev else now
                 } ?: now

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/VaultNamedParameterizedQueryImplTest.kt
@@ -1,7 +1,9 @@
 package net.corda.ledger.utxo.flow.impl.persistence
 
 import net.corda.flow.external.events.executor.ExternalEventExecutor
+import net.corda.flow.fiber.FlowFiber
 import net.corda.flow.fiber.FlowFiberExecutionContext
+import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.persistence.query.ResultSetFactory
 import net.corda.flow.persistence.query.StableResultSetExecutor
 import net.corda.flow.state.FlowCheckpoint
@@ -62,6 +64,8 @@ class VaultNamedParameterizedQueryImplTest {
     private val resultSetExecutorCaptor = argumentCaptor<StableResultSetExecutor<Any>>()
     private val mapCaptor = argumentCaptor<Map<String, Any>>()
     private val flowFiberExecutionContext = mock<FlowFiberExecutionContext>()
+    private val flowFiberService = mock<FlowFiberService>()
+    private val flowFiber = mock<FlowFiber>()
     private val flowCheckpoint = mock<FlowCheckpoint>()
 
     private val query = VaultNamedParameterizedQueryImpl(
@@ -74,7 +78,7 @@ class VaultNamedParameterizedQueryImplTest {
         offset = 0,
         resultClass = Any::class.java,
         clock = clock,
-        flowFiberExecutionContext = flowFiberExecutionContext
+        flowFiberService = flowFiberService
     )
 
     @BeforeEach
@@ -85,6 +89,8 @@ class VaultNamedParameterizedQueryImplTest {
         whenever(sandbox.virtualNodeContext).thenReturn(virtualNodeContext)
         whenever(virtualNodeContext.holdingIdentity).thenReturn(ALICE_X500_HOLDING_IDENTITY.toCorda())
         whenever(currentSandboxGroupContext.get()).thenReturn(sandbox)
+        whenever(flowFiberService.getExecutingFiber()).thenReturn(flowFiber)
+        whenever(flowFiber.getExecutionContext()).thenReturn(flowFiberExecutionContext)
         whenever(flowFiberExecutionContext.flowCheckpoint).thenReturn(flowCheckpoint)
         whenever(flowCheckpoint.readCustomState(UtxoLedgerLastPersistedTimestamp::class.java))
             .thenReturn(null)


### PR DESCRIPTION
`VaultNamedParameterizedQueryImpl` added a constructor parameter of `FlowFiberExecutionContext` which lead to a kryo serialization error as `flowFiberExecutionContext` should not be serialized.

This occurred due to a backport from 5.3, where a service that exists in 5.3 does not exist in 5.2.

This has been fixed by using `FlowFiberService` to get hold of the correct objects inside a method that won't be kryo serialized.