### PR TITLE
CORE-20247: InvalidParamsException: unable to find master wrapping key XXXXX in tenant YYYYY

### DIFF
--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
@@ -9,8 +9,8 @@ import net.corda.crypto.softhsm.HSMRepository
 import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
-import net.corda.utilities.convertToBytes
 import net.corda.utilities.debug
+import net.corda.utilities.toBytes
 import net.corda.v5.base.util.EncodingUtils.toHex
 import org.slf4j.LoggerFactory
 import java.time.Instant
@@ -184,7 +184,7 @@ class HSMRepositoryImpl(
     }
 
     private fun generateRandomShortAlias() =
-        toHex(UUID.randomUUID().convertToBytes()).take(12)
+        toHex(UUID.randomUUID().toBytes()).take(12)
 }
 
 // NOTE: this should be on the Entity.

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/impl/HSMRepositoryImpl.kt
@@ -9,16 +9,16 @@ import net.corda.crypto.softhsm.HSMRepository
 import net.corda.data.crypto.wire.hsm.HSMAssociationInfo
 import net.corda.orm.utils.transaction
 import net.corda.orm.utils.use
+import net.corda.utilities.convertToBytes
+import net.corda.utilities.debug
 import net.corda.v5.base.util.EncodingUtils.toHex
 import org.slf4j.LoggerFactory
-import java.lang.IllegalStateException
 import java.time.Instant
 import java.util.UUID
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 import javax.persistence.PersistenceException
 import javax.persistence.Tuple
-import net.corda.utilities.debug
 
 /**
  * Database operations for HSM.
@@ -133,7 +133,7 @@ class HSMRepositoryImpl(
                     tenantAssociation
                 }
             }
-        } catch(e: PersistenceException) {
+        } catch (e: PersistenceException) {
             val match = e.cause?.message?.contains("ConstraintViolationException") ?: false
             // NOTE: this is not great, but we must be able to detect a constraint violation in case
             //  of a race condition, however, the JPA exception type doesn't give us enough info, so we check
@@ -184,7 +184,7 @@ class HSMRepositoryImpl(
     }
 
     private fun generateRandomShortAlias() =
-        toHex(UUID.randomUUID().toString().toByteArray()).take(12)
+        toHex(UUID.randomUUID().convertToBytes()).take(12)
 }
 
 // NOTE: this should be on the Entity.

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/UuidUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/UuidUtils.kt
@@ -1,0 +1,15 @@
+package net.corda.utilities
+
+import java.nio.ByteBuffer
+import java.util.UUID
+
+/**
+ * Converts UUID straight to bytes instead of converting uuid.ToString().ToByteArray()
+ * which dilutes the randomness if only part of the uuid is taken later on.
+ */
+fun UUID.convertToBytes(): ByteArray {
+    val bb = ByteBuffer.wrap(ByteArray(16))
+    bb.putLong(this.mostSignificantBits)
+    bb.putLong(this.leastSignificantBits)
+    return bb.array()
+}

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/UuidUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/UuidUtils.kt
@@ -7,7 +7,7 @@ import java.util.UUID
  * Converts UUID straight to bytes instead of converting uuid.toString().toByteArray()
  * which dilutes the randomness if only part of the uuid is taken later on.
  */
-fun UUID.convertToBytes(): ByteArray {
+fun UUID.toBytes(): ByteArray {
     val bb = ByteBuffer.wrap(ByteArray(16))
     bb.putLong(this.mostSignificantBits)
     bb.putLong(this.leastSignificantBits)

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/UuidUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/UuidUtils.kt
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 import java.util.UUID
 
 /**
- * Converts UUID straight to bytes instead of converting uuid.ToString().ToByteArray()
+ * Converts UUID straight to bytes instead of converting uuid.toString().toByteArray()
  * which dilutes the randomness if only part of the uuid is taken later on.
  */
 fun UUID.convertToBytes(): ByteArray {


### PR DESCRIPTION
In rare cases we have got a clash when generating key alias. This caused wrapping key not being saved in tenant's db as the alias was already cached as used. When generating key pair for the alias, wrapping key couldn't be find and the operation has failed.
The clashes happened, because we converted random uuid into string and then into bytes before converting it to hex and taking 12 chars. Conversion to string diluted the randomness of the uuid.
We are introducing a new function that converts uuid into bytes directly, keeping the randomness and therefore preventing the clashes to happen much less often.

Here is the output of random uuid (0), using new conversion + `toHexString` (1) and using old conversion `toString().toByteArray()` + `toHexString` (2)

```kotlin
0: 4b40ae93-2342-4295-9ee7-7b0e4dff12cb
1: 4B40AE93234242959EE77B0E4DFF12CB
2: 34623430616539332D323334322D343239352D396565372D376230653464666631326362
0: 2b57f797-ab8c-47ff-9dfa-3f9c2f4d836b
1: 2B57F797AB8C47FF9DFA3F9C2F4D836B
2: 32623537663739372D616238632D343766662D396466612D336639633266346438333662
0: 83452f7a-a4db-4b73-91ca-e8130cb5a0d7
1: 83452F7AA4DB4B7391CAE8130CB5A0D7
2: 38333435326637612D613464622D346237332D393163612D653831333063623561306437
``` 