### PR TITLE
CORE-20401: Make sure multiple Warning HTTP headers possible

### DIFF
--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientHttpRequestContext.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientHttpRequestContext.kt
@@ -60,7 +60,9 @@ internal class ClientHttpRequestContext(private val ctx: Context) : ClientReques
     }
 
     override fun addPasswordExpiryHeader(expiryStatus: PasswordExpiryStatus) {
-        ctx.res.addHeader("Password-Expiry-Status", "199 - $expiryStatus")
+        ctx.res.addHeader(Header.WARNING, "199 - The password is close to expiry")
+        ctx.res.addHeader("Password-Expiry-Status", "$expiryStatus")
+
     }
 
     private fun addHeaderValues(values: Iterable<String>) {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientHttpRequestContext.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientHttpRequestContext.kt
@@ -60,7 +60,7 @@ internal class ClientHttpRequestContext(private val ctx: Context) : ClientReques
     }
 
     override fun addPasswordExpiryHeader(expiryStatus: PasswordExpiryStatus) {
-        ctx.res.addHeader(Header.WARNING, "199 - PasswordExpiryStatus is $expiryStatus")
+        ctx.res.addHeader("Password-Expiry-Status", "199 - $expiryStatus")
     }
 
     private fun addHeaderValues(values: Iterable<String>) {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientHttpRequestContext.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/ClientHttpRequestContext.kt
@@ -60,9 +60,7 @@ internal class ClientHttpRequestContext(private val ctx: Context) : ClientReques
     }
 
     override fun addPasswordExpiryHeader(expiryStatus: PasswordExpiryStatus) {
-        ctx.res.addHeader(Header.WARNING, "199 - The password is close to expiry")
-        ctx.res.addHeader("Password-Expiry-Status", "$expiryStatus")
-
+        ctx.res.addHeader(Header.WARNING, "199 - PasswordExpiryStatus is $expiryStatus")
     }
 
     private fun addHeaderValues(values: Iterable<String>) {

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/JsonResultBuilder.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/context/JsonResultBuilder.kt
@@ -14,7 +14,7 @@ fun Context.buildJsonResult(result: Any?, returnType: Class<*>) {
 
             // Add optional headers
             result.headers.forEach {
-                ctx.header(it.key, it.value)
+                ctx.res.addHeader(it.key, it.value)
             }
         }
         (result as? String) != null ->


### PR DESCRIPTION
The Warning header would not show password expiry if the endpoint was deprecated and would only show the deprecation warning. Change `JsonResultBuilder` to add header instead of creating a new header