### PR TITLE
ES-2296: Updating C5 Base Image to 17.0.11

### DIFF
--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -130,7 +130,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<String> baseImageTag =
-            getObjects().property(String).convention('17.0.10-17.48')
+            getObjects().property(String).convention('17.0.11-17.50')
 
     @Input
     final Property<String> subDir =

--- a/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
+++ b/buildSrc/src/main/groovy/DeployableContainerBuilder.groovy
@@ -130,7 +130,7 @@ abstract class DeployableContainerBuilder extends DefaultTask {
 
     @Input
     final Property<String> baseImageTag =
-            getObjects().property(String).convention('17.0.11-17.50')
+            getObjects().property(String).convention('17.0.11')
 
     @Input
     final Property<String> subDir =


### PR DESCRIPTION
**Description**
azul/zulu-openjdk:17.0.11 is now available. Updating base image to reflect this.