### PR TITLE
CORE-20281: Add Logging for SandboxGroupContext Set and Removal

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -75,6 +75,11 @@ class FlowFiberImpl(
 
         try {
             setCurrentSandboxGroupContext()
+            try {
+                getExecutionContext().currentSandboxGroupContext.get()
+            } catch (e: IllegalStateException) {
+                log.warn("Cannot get SandboxGroupContext in thread ${Thread.currentThread().name}")
+            }
             // Ensure run() does not exit via any means without completing the future, in order not to indefinitely block
             // the flow event pipeline. Note that this is executed in a Quasar concurrent executor thread and Throwables are
             // consumed by that too, so if they are rethrown from here we do not get process termination or any other form
@@ -301,10 +306,12 @@ class FlowFiberImpl(
     private fun setCurrentSandboxGroupContext() {
         val context = getExecutionContext()
         context.currentSandboxGroupContext.set(context.sandboxGroupContext)
+        log.info("Set SandboxGroupContext in thread ${Thread.currentThread().name}")
     }
 
     private fun removeCurrentSandboxGroupContext() {
         getExecutionContext().currentSandboxGroupContext.remove()
+        log.info("Removed SandboxGroupContext from thread ${Thread.currentThread().name}")
     }
 
     private fun initialiseThreadContext() {

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -75,16 +75,16 @@ class FlowFiberImpl(
 
         try {
             setCurrentSandboxGroupContext()
-            try {
-                getExecutionContext().currentSandboxGroupContext.get()
-            } catch (e: IllegalStateException) {
-                log.warn("Cannot get SandboxGroupContext in thread ${Thread.currentThread().name}")
-            }
             // Ensure run() does not exit via any means without completing the future, in order not to indefinitely block
             // the flow event pipeline. Note that this is executed in a Quasar concurrent executor thread and Throwables are
             // consumed by that too, so if they are rethrown from here we do not get process termination or any other form
             // of critical error handling for free, only undefined behaviour.
             try {
+                try {
+                    getExecutionContext().currentSandboxGroupContext.get()
+                } catch (e: IllegalStateException) {
+                    log.warn("Cannot get SandboxGroupContext in thread ${Thread.currentThread().name}")
+                }
                 runFlow()
             } catch (e: FlowContinuationErrorException) {
                 // This exception happened because the flow fiber discovered it had failed for some already handled reason

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/fiber/FlowFiberImpl.kt
@@ -80,6 +80,7 @@ class FlowFiberImpl(
             // consumed by that too, so if they are rethrown from here we do not get process termination or any other form
             // of critical error handling for free, only undefined behaviour.
             try {
+                // CORE-20281: Adding for debugging purposes to diagnose issue.
                 try {
                     getExecutionContext().currentSandboxGroupContext.get()
                 } catch (e: IllegalStateException) {


### PR DESCRIPTION
There is a bug sometimes causing flows to be unable to access their SandboxGroupContext, so this PR adds more logging to try to get more information about why this is occurring.