### PR TITLE
CORE-19952: Add more logging in ClusterReadinessChecker to catch future occurrences of error

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/resources/log4j2-test.xml
+++ b/applications/workers/workers-smoketest/src/smokeTest/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] [%name] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] [%X{name}] %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/applications/workers/workers-smoketest/src/smokeTest/resources/log4j2-test.xml
+++ b/applications/workers/workers-smoketest/src/smokeTest/resources/log4j2-test.xml
@@ -2,7 +2,7 @@
 <Configuration status="INFO">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] [%name] %-5level %logger{36} - %msg%n"/>
         </Console>
     </Appenders>
     <Loggers>

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterReadiness.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterReadiness.kt
@@ -50,7 +50,7 @@ class ClusterReadinessChecker: ClusterReadiness {
                 .map {
                     async {
                         var lastResponse: HttpResponse<String>? = null
-                        val isReady: Boolean = tryUntil(timeOut, sleepDuration) {
+                        val isReady: Boolean = tryUntil(timeOut, sleepDuration, it.key) {
                             sendAndReceiveResponse(it.key, it.value).also {
                                 lastResponse = it
                             }
@@ -72,14 +72,14 @@ class ClusterReadinessChecker: ClusterReadiness {
         }
     }
 
-    private fun tryUntil(timeOut: Duration, sleepDuration: Duration, function: () -> HttpResponse<String>): Boolean {
+    private fun tryUntil(timeOut: Duration, sleepDuration: Duration, name: String, function: () -> HttpResponse<String>): Boolean {
         val startTime = Instant.now()
         while (Instant.now() < startTime.plusNanos(timeOut.toNanos())) {
             try {
                 val response = function()
                 val statusCode = response.statusCode()
                 if (statusCode in 200..299) {
-                    logger.info("Status successful with code $statusCode. Exiting tryUntil.")
+                    logger.info("Status successful for $name. Exiting tryUntil.")
                     return true
                 }
                 else {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterReadiness.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterReadiness.kt
@@ -79,6 +79,7 @@ class ClusterReadinessChecker: ClusterReadiness {
                 val response = function()
                 val statusCode = response.statusCode()
                 if (statusCode in 200..299) {
+                    logger.info("Status successful. Exiting tryUntil.")
                     return true
                 }
                 else {
@@ -98,6 +99,8 @@ class ClusterReadinessChecker: ClusterReadiness {
         val request = HttpRequest.newBuilder()
             .uri(URI.create(url))
             .build()
-        return client.send(request, HttpResponse.BodyHandlers.ofString())
+        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        logger.info("Returning status ${response.statusCode()} $name on $url.")
+        return response
     }
 }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterReadiness.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterReadiness.kt
@@ -79,7 +79,7 @@ class ClusterReadinessChecker: ClusterReadiness {
                 val response = function()
                 val statusCode = response.statusCode()
                 if (statusCode in 200..299) {
-                    logger.info("Status successful. Exiting tryUntil.")
+                    logger.info("Status successful with code $statusCode. Exiting tryUntil.")
                     return true
                 }
                 else {
@@ -99,8 +99,8 @@ class ClusterReadinessChecker: ClusterReadiness {
         val request = HttpRequest.newBuilder()
             .uri(URI.create(url))
             .build()
-        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-        logger.info("Returning status ${response.statusCode()} $name on $url.")
-        return response
+        return client.send(request, HttpResponse.BodyHandlers.ofString()).also {
+            logger.info("Returning status ${it.statusCode()} $name on $url.")
+        }
     }
 }


### PR DESCRIPTION
A build timed out due to a coroutine in ClusterReadinessChecker never returning. This PR introduces more logging to attempt to catch where this occurs.