### PR TITLE
ES-2329 : Disable 5.1 builds triggered via Cron job

### DIFF
--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -31,10 +31,6 @@ pipeline {
         }
     }
 
-    triggers {
-        cron(gitUtils.isReleaseBranch() ? 'H 00 * * *' : '')
-    }
-
     environment {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         BUILD_CACHE_CREDENTIALS = credentials('gradle-ent-cache-credentials')

--- a/.ci/e2eTests/JenkinsfileCombinedWorkerLinux
+++ b/.ci/e2eTests/JenkinsfileCombinedWorkerLinux
@@ -1,5 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 combinedWorkerPipeline(
-    agentOs : 'linux'
+    agentOs : 'linux',
+    dailyBuildCron: ''
 )

--- a/.ci/e2eTests/JenkinsfileCombinedWorkerWindows
+++ b/.ci/e2eTests/JenkinsfileCombinedWorkerWindows
@@ -1,5 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 combinedWorkerPipeline(
-    agentOs : 'windows'
+    agentOs : 'windows',
+    dailyBuildCron: ''
 )

--- a/.ci/e2eTests/JenkinsfileUnstableTest
+++ b/.ci/e2eTests/JenkinsfileUnstableTest
@@ -2,9 +2,10 @@
 
 endToEndPipeline(
     assembleAndCompile: true,
+    dailyBuildCron: '',
     multiCluster: true,
     gradleTestTargetsToExecute: ['smokeTest', 'e2eTest'],
     usePackagedCordaHelmChart: false,
     gradleAdditionalArgs : '-PrunUnstableTests -Dscan.tag.UnstableTests',
-    javaVersion: '17'
+    javaVersion: '17',
 )

--- a/.ci/e2eTests/JenkinsfileUnstableTest
+++ b/.ci/e2eTests/JenkinsfileUnstableTest
@@ -7,5 +7,5 @@ endToEndPipeline(
     gradleTestTargetsToExecute: ['smokeTest', 'e2eTest'],
     usePackagedCordaHelmChart: false,
     gradleAdditionalArgs : '-PrunUnstableTests -Dscan.tag.UnstableTests',
-    javaVersion: '17',
+    javaVersion: '17'
 )

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,6 +1,7 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
+    dailyBuildCron: '',
     runIntegrationTests: true,
     publishRepoPrefix: 'corda-ent-maven',
     createPostgresDb: true,

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -5,6 +5,5 @@ cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5',
     snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d",
     cpuCount: 7,
-    javaVersion: '17',
-    
+    javaVersion: '17'
 )

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,8 +1,10 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaSnykScanPipeline (
+    dailyBuildCron: '',    
     snykTokenId: 'r3-snyk-corda5',
     snykAdditionalCommands: "--all-sub-projects --configuration-matching='^runtimeClasspath\$' -d",
     cpuCount: 7,
-    javaVersion: '17'
+    javaVersion: '17',
+    
 )

--- a/.ci/nightly/JenkinsfileUnstableTests
+++ b/.ci/nightly/JenkinsfileUnstableTests
@@ -2,6 +2,7 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
+    dailyBuildCron: '',    
     runIntegrationTests: true,
     createPostgresDb: true,
     gradleAdditionalArgs: '-PrunUnstableTests',

--- a/.ci/nightly/JenkinsfileWindowsCompatibility
+++ b/.ci/nightly/JenkinsfileWindowsCompatibility
@@ -3,6 +3,6 @@
 windowsCompatibility(
     runIntegrationTests: true,
     createPostgresDb: true,
-    dailyBuildCron: 'H 03 * * *',
+    dailyBuildCron: '',
     runCombinedWorker: true
     )

--- a/.ci/patterns-lib-functional/patterns.Jenkinsfile
+++ b/.ci/patterns-lib-functional/patterns.Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
     }
     
     triggers {
-        cron '@midnight'
+        cron ''
     }
 
     stages {

--- a/.ci/patterns-lib-functional/patterns.Jenkinsfile
+++ b/.ci/patterns-lib-functional/patterns.Jenkinsfile
@@ -36,10 +36,6 @@ pipeline {
         timeout(time: 30, unit: 'MINUTES')
         timestamps()
     }
-    
-    triggers {
-        cron ''
-    }
 
     stages {
         stage('Prepare') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
+    dailyBuildCron: '',
     runIntegrationTests: true,
     createPostgresDb: true,
     publishOSGiImage: true,


### PR DESCRIPTION
As there are no plans for a further 5.1.X release, disable nightly builds on this stream, this action has been confirmed with product.