### PR TITLE
ES-1946: Update CODEOWNERS for 5.2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@
 /testing/uniqueness/                                            @corda/notaries
 
 # Code freeze reviewers
-* @driessamyn @jasonbyrner3 @ronanbrowne @rick-r3 @simon-johnson-r3 @blsemo @Omar-awad @aditisdesai @vinir3 @vkolomeyko @thiagoviana @Sakpal @dickon @owenstanford @davidcurrie @mbrkic-r3
+* @driessamyn @jasonbyrner3 @ronanbrowne @rick-r3 @simon-johnson-r3 @blsemo @Omar-awad @aditisdesai @vinir3 @vkolomeyko @thiagoviana @Sakpal @owenstanford @davidcurrie


### PR DESCRIPTION
- Remove members no longer in org