### PR TITLE
CORE-16921 Add configurable maximum payload size

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowMessagingImpl.kt
@@ -184,8 +184,8 @@ class FlowMessagingImpl @Activate constructor(
             val serializedPayload = serialize(payload)
             checkPayloadMaxSize(serializedPayload, flowFiberService)
             flowSessionInternal.getSessionInfo() to when (session) {
-                is VersionSendingFlowSession -> session.getPayloadToSend(serialize(payload))
-                else -> serialize(payload)
+                is VersionSendingFlowSession -> session.getPayloadToSend(serializedPayload)
+                else -> serializedPayload
             }
         }.toMap()
         fiber.suspend(FlowIORequest.Send(sessionPayload))

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/services/impl/FlowMessagingImpl.kt
@@ -7,6 +7,7 @@ import net.corda.flow.application.serialization.FlowSerializationService
 import net.corda.flow.application.sessions.FlowSessionInternal
 import net.corda.flow.application.sessions.SessionInfo
 import net.corda.flow.application.sessions.factory.FlowSessionFactory
+import net.corda.flow.application.sessions.utils.SessionUtils.checkPayloadMaxSize
 import net.corda.flow.application.sessions.utils.SessionUtils.verifySessionStatusNotErrorOrClose
 import net.corda.flow.application.versioning.impl.sessions.VersionReceivingFlowSession
 import net.corda.flow.application.versioning.impl.sessions.VersionSendingFlowSession
@@ -160,6 +161,7 @@ class FlowMessagingImpl @Activate constructor(
         @Suppress("unchecked_cast")
         val flowSessionInternals = sessions as Set<FlowSessionInternal>
         val serializedPayload = serialize(payload)
+        checkPayloadMaxSize(serializedPayload, flowFiberService)
         val sessionToPayload = flowSessionInternals.associate { session ->
             verifySessionStatusNotErrorOrClose(session.getSessionId(), flowFiberService)
             session.getSessionInfo() to when (session) {
@@ -179,6 +181,8 @@ class FlowMessagingImpl @Activate constructor(
         val sessionPayload = payloadsPerSession.map { (session, payload) ->
             val flowSessionInternal = session as FlowSessionInternal
             verifySessionStatusNotErrorOrClose(session.getSessionId(), flowFiberService)
+            val serializedPayload = serialize(payload)
+            checkPayloadMaxSize(serializedPayload, flowFiberService)
             flowSessionInternal.getSessionInfo() to when (session) {
                 is VersionSendingFlowSession -> session.getPayloadToSend(serialize(payload))
                 else -> serialize(payload)

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/utils/SessionUtils.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/utils/SessionUtils.kt
@@ -22,7 +22,7 @@ internal object SessionUtils {
         val maxPayloadSize = checkpoint.maxPayloadSize
 
         if (payloadSize > maxPayloadSize) {
-            throw FlowPlatformException("Payload size $payloadSize larger than allowed $maxPayloadSize")
+            throw FlowPlatformException("Payload size: $payloadSize bytes larger than allowed: $maxPayloadSize bytes.")
         }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/utils/SessionUtils.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/sessions/utils/SessionUtils.kt
@@ -2,6 +2,7 @@ package net.corda.flow.application.sessions.utils
 
 import net.corda.data.flow.state.session.SessionStateType
 import net.corda.flow.fiber.FlowFiberService
+import net.corda.flow.pipeline.exceptions.FlowPlatformException
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
 internal object SessionUtils {
@@ -12,6 +13,16 @@ internal object SessionUtils {
 
         if (setOf(SessionStateType.CLOSED, SessionStateType.ERROR).contains(status)) {
             throw CordaRuntimeException("Session: $sessionId Status is ${status?.name ?: "NULL"}")
+        }
+    }
+
+    fun checkPayloadMaxSize(serializedPayload: ByteArray, flowFiberService: FlowFiberService) {
+        val payloadSize = serializedPayload.size
+        val checkpoint = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint
+        val maxPayloadSize = checkpoint.maxPayloadSize
+
+        if (payloadSize > maxPayloadSize) {
+            throw FlowPlatformException("Payload size $payloadSize larger than allowed $maxPayloadSize")
         }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/state/impl/FlowCheckpointImpl.kt
@@ -18,6 +18,7 @@ import net.corda.flow.state.FlowCheckpoint
 import net.corda.flow.state.FlowContext
 import net.corda.flow.state.FlowStack
 import net.corda.libs.configuration.SmartConfig
+import net.corda.schema.configuration.FlowConfig.SESSION_FLOW_MAX_PAYLOAD
 import net.corda.schema.configuration.MessagingConfig.MAX_ALLOWED_MSG_SIZE
 import net.corda.v5.crypto.SecureHash
 import net.corda.virtualnode.HoldingIdentity
@@ -139,6 +140,9 @@ class FlowCheckpointImpl(
 
     override val maxMessageSize: Long
         get() = config.getLong(MAX_ALLOWED_MSG_SIZE)
+
+    override val maxPayloadSize: Long
+        get() = config.getLong(SESSION_FLOW_MAX_PAYLOAD)
 
     override val initialPlatformVersion: Int
         get() = checkpoint.initialPlatformVersion

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/FlowMessagingImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/FlowMessagingImplTest.kt
@@ -13,6 +13,7 @@ import net.corda.flow.application.sessions.factory.FlowSessionFactory
 import net.corda.flow.application.versioning.impl.sessions.VersionReceivingFlowSession
 import net.corda.flow.application.versioning.impl.sessions.VersionSendingFlowSession
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.pipeline.exceptions.FlowPlatformException
 import net.corda.flow.utils.mutableKeyValuePairList
 import net.corda.internal.serialization.SerializedBytesImpl
 import net.corda.v5.application.messaging.FlowContextPropertiesBuilder
@@ -23,6 +24,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -64,6 +66,8 @@ class FlowMessagingImplTest {
         val SESSION_INFO_THREE = SessionInfo(SESSION_ID_THREE, MemberX500Name("org", "LDN", "GB"))
         val SESSION_INFO_FOUR = SessionInfo(SESSION_ID_FOUR, MemberX500Name("org", "LDN", "GB"))
         val SESSION_INFO_FIVE = SessionInfo(SESSION_ID_FIVE, MemberX500Name("org", "LDN", "GB"))
+
+        val MAX_PAYLOAD_SIZE = (MockFlowFiberService().getExecutingFiber().getExecutionContext().flowCheckpoint.maxPayloadSize).toInt()
     }
 
     private val mockFlowFiberService = MockFlowFiberService()
@@ -782,6 +786,39 @@ class FlowMessagingImplTest {
     }
 
     @Test
+    fun `sendAll throws FlowPlatformException when payload size exceed maxPayloadSize limit`() {
+        val serializedPayload = ByteArray(MAX_PAYLOAD_SIZE + 1)
+
+        whenever(serializationService.serialize(PAYLOAD_ONE)).thenReturn(SerializedBytesImpl(serializedPayload))
+
+        assertThrows<FlowPlatformException> {
+            flowMessaging.sendAll(PAYLOAD_ONE, setOf(normalSessionOne, versionSendingSessionOne))
+        }
+    }
+
+    @Test
+    fun `sendAll does not throw when payload size is equal to the maxPayloadSize limit`() {
+        val serializedPayload = ByteArray(MAX_PAYLOAD_SIZE)
+
+        whenever(serializationService.serialize(PAYLOAD_ONE)).thenReturn(SerializedBytesImpl(serializedPayload))
+
+        assertDoesNotThrow {
+            flowMessaging.sendAll(PAYLOAD_ONE, setOf(normalSessionOne, versionSendingSessionOne))
+        }
+    }
+
+    @Test
+    fun `sendAll does not throw when payload size is below the maxPayloadSize limit`() {
+        val serializedPayload = ByteArray(MAX_PAYLOAD_SIZE - 1)
+
+        whenever(serializationService.serialize(PAYLOAD_ONE)).thenReturn(SerializedBytesImpl(serializedPayload))
+
+        assertDoesNotThrow {
+            flowMessaging.sendAll(PAYLOAD_ONE, setOf(normalSessionOne, versionSendingSessionOne))
+        }
+    }
+
+    @Test
     fun `sendAllMap with only non-version sending sessions suspends the flow to send the input payloads`() {
         whenever(mockFlowFiberService.flowFiber.suspend(sendSuspendCaptor.capture())).thenReturn(Unit)
         flowMessaging.sendAllMap(mapOf(normalSessionOne to PAYLOAD_ONE, versionReceivingSessionOne to PAYLOAD_TWO))
@@ -897,6 +934,43 @@ class FlowMessagingImplTest {
         flowMessaging.sendAllMap(emptyMap())
         verify(mockFlowFiberService.flowFiber, never()).suspend(any<FlowIORequest.Send>())
     }
+
+    @Test
+    fun `sendAllMap throws FlowPlatformException when at least one payload size exceed maxPayloadSize limit`() {
+        val serializedPayloadOne = ByteArray(MAX_PAYLOAD_SIZE + 1)
+        val serializedPayloadTwo = ByteArray(MAX_PAYLOAD_SIZE)
+
+        whenever(serializationService.serialize(PAYLOAD_ONE)).thenReturn(SerializedBytesImpl(serializedPayloadOne))
+        whenever(serializationService.serialize(PAYLOAD_TWO)).thenReturn(SerializedBytesImpl(serializedPayloadTwo))
+
+        assertThrows<FlowPlatformException> {
+            flowMessaging.sendAllMap(
+                mapOf(
+                    normalSessionOne to PAYLOAD_ONE,
+                    versionSendingSessionOne to PAYLOAD_TWO
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `sendAllMap does not throw when all payload sizes are within the maxPayloadSize limit (one lower, one equal)`() {
+        val serializedPayloadOne = ByteArray(MAX_PAYLOAD_SIZE)
+        val serializedPayloadTwo = ByteArray(MAX_PAYLOAD_SIZE - 1)
+
+        whenever(serializationService.serialize(PAYLOAD_ONE)).thenReturn(SerializedBytesImpl(serializedPayloadOne))
+        whenever(serializationService.serialize(PAYLOAD_TWO)).thenReturn(SerializedBytesImpl(serializedPayloadTwo))
+
+        assertDoesNotThrow {
+            flowMessaging.sendAllMap(
+                mapOf(
+                    normalSessionOne to PAYLOAD_ONE,
+                    versionSendingSessionOne to PAYLOAD_TWO
+                )
+            )
+        }
+    }
+
 
     @ParameterizedTest
     @EnumSource(value = SessionStateType::class, names = ["CLOSED", "ERROR"])

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/FlowMessagingImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/FlowMessagingImplTest.kt
@@ -67,7 +67,11 @@ class FlowMessagingImplTest {
         val SESSION_INFO_FOUR = SessionInfo(SESSION_ID_FOUR, MemberX500Name("org", "LDN", "GB"))
         val SESSION_INFO_FIVE = SessionInfo(SESSION_ID_FIVE, MemberX500Name("org", "LDN", "GB"))
 
-        val MAX_PAYLOAD_SIZE = (MockFlowFiberService().getExecutingFiber().getExecutionContext().flowCheckpoint.maxPayloadSize).toInt()
+        val MAX_PAYLOAD_SIZE = MockFlowFiberService()
+            .getExecutingFiber()
+            .getExecutionContext()
+            .flowCheckpoint.maxPayloadSize
+            .toInt()
     }
 
     private val mockFlowFiberService = MockFlowFiberService()

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/services/MockFlowFiberService.kt
@@ -69,6 +69,7 @@ class MockFlowFiberService : FlowFiberService {
         whenever(flowContext.flattenPlatformProperties()).thenReturn(platformContext)
         whenever(flowContext.platformProperties).thenReturn(platformProperties)
         whenever(flowCheckpoint.flowContext).thenReturn(flowContext)
+        whenever(flowCheckpoint.maxPayloadSize).thenReturn(1024)
     }
 
     override fun getExecutingFiber(): FlowFiber {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionImplTest.kt
@@ -39,7 +39,11 @@ class FlowSessionImplTest {
         const val SESSION_ID = "session id"
         const val HI = "hi"
         const val HELLO_THERE = "hello there"
-        val MAX_PAYLOAD_SIZE = (MockFlowFiberService().getExecutingFiber().getExecutionContext().flowCheckpoint.maxPayloadSize).toInt()
+        val MAX_PAYLOAD_SIZE = MockFlowFiberService()
+            .getExecutingFiber()
+            .getExecutionContext()
+            .flowCheckpoint.maxPayloadSize
+            .toInt()
         val received = mapOf(SESSION_ID to HELLO_THERE.toByteArray())
     }
 

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/application/sessions/FlowSessionImplTest.kt
@@ -9,6 +9,7 @@ import net.corda.flow.application.serialization.FlowSerializationService
 import net.corda.flow.application.services.MockFlowFiberService
 import net.corda.flow.application.sessions.impl.FlowSessionImpl
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.pipeline.exceptions.FlowPlatformException
 import net.corda.flow.state.FlowContext
 import net.corda.flow.utils.KeyValueStore
 import net.corda.internal.serialization.SerializedBytesImpl
@@ -18,6 +19,7 @@ import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -37,6 +39,7 @@ class FlowSessionImplTest {
         const val SESSION_ID = "session id"
         const val HI = "hi"
         const val HELLO_THERE = "hello there"
+        val MAX_PAYLOAD_SIZE = (MockFlowFiberService().getExecutingFiber().getExecutionContext().flowCheckpoint.maxPayloadSize).toInt()
         val received = mapOf(SESSION_ID to HELLO_THERE.toByteArray())
     }
 
@@ -160,6 +163,44 @@ class FlowSessionImplTest {
         verify(flowFiber).suspend(any<FlowIORequest.Send>())
     }
 
+    @Test
+    fun `calling send or sendAndReceive with a payload size above the configurable maxPayloadSize throws an exception`() {
+        val session = createInitiatingSession()
+        val payload = ByteArray(MAX_PAYLOAD_SIZE + 1)
+
+        whenever(serializationService.serialize(any<ByteArray>())).thenReturn(SerializedBytesImpl(payload))
+
+        assertThrows<FlowPlatformException> {
+            session.send(payload)
+            session.sendAndReceive(String::class.java, payload)
+        }
+    }
+
+    @Test
+    fun `calling send or sendAndReceive with a payload size equal to the configurable maxPayloadSize does not throw an exception`() {
+        val session = createInitiatingSession()
+        val payload = ByteArray(MAX_PAYLOAD_SIZE)
+
+        whenever(serializationService.serialize(any<ByteArray>())).thenReturn(SerializedBytesImpl(payload))
+
+        assertDoesNotThrow {
+            session.send(payload)
+            session.sendAndReceive(String::class.java, payload)
+        }
+    }
+
+    @Test
+    fun `calling send or sendAndReceive with a payload size below the configurable maxPayloadSize does not throw an exception`() {
+        val session = createInitiatingSession()
+        val payload = ByteArray(MAX_PAYLOAD_SIZE - 1)
+
+        whenever(serializationService.serialize(any<ByteArray>())).thenReturn(SerializedBytesImpl(payload))
+
+        assertDoesNotThrow {
+            session.send(payload)
+            session.sendAndReceive(String::class.java, payload)
+        }
+    }
 
     @Test
     fun `calling close when not CLOSED will cause the flow to suspend`() {

--- a/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
+++ b/libs/flows/flow-api/src/main/kotlin/net/corda/flow/state/FlowCheckpoint.kt
@@ -48,6 +48,8 @@ interface FlowCheckpoint : NonSerializable {
 
     val maxMessageSize: Long
 
+    val maxPayloadSize: Long
+
     val initialPlatformVersion: Int
 
     val isCompleted: Boolean


### PR DESCRIPTION
In some cases, sending large messages to counterparties might flood the kafka topics with too many chunks, making it too slow. Allowing a configurable max message size resolves this issue.