### PR TITLE
CORE-19840 Send backchain when receiver has filtered transaction

### DIFF
--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -562,13 +562,13 @@ class UtxoPersistenceServiceImplTest {
                     assertThat(dbInput.field<Instant>("consumed")).isNull()
                 }
 
-            val signatures = signedTransaction.signatures
+            val signatures = signedTransaction.signatures.sortedBy { it.by.toString() }
             val txSignatures = dbTransaction.field<Collection<Any>?>("signatures")
             assertThat(txSignatures)
                 .isNotNull
                 .hasSameSizeAs(signatures)
             txSignatures!!
-                .sortedBy { it.field<Int>("index") }
+                .sortedBy { it.field<Int>("publicKeyHash") }
                 .zip(signatures)
                 .forEach { (dbSignature, signature) ->
                     assertThat(dbSignature.field<ByteArray>("signature")).isEqualTo(

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/UtxoPersistenceServiceImplTest.kt
@@ -570,8 +570,7 @@ class UtxoPersistenceServiceImplTest {
             txSignatures!!
                 .sortedBy { it.field<Int>("index") }
                 .zip(signatures)
-                .forEachIndexed { index, (dbSignature, signature) ->
-                    assertThat(dbSignature.field<Int>("index")).isEqualTo(index)
+                .forEach { (dbSignature, signature) ->
                     assertThat(dbSignature.field<ByteArray>("signature")).isEqualTo(
                         serializationService.serialize(
                             signature
@@ -2159,10 +2158,9 @@ class UtxoPersistenceServiceImplTest {
                 }
             )
             transaction.field<MutableCollection<Any>>("signatures").addAll(
-                signedTransaction.signatures.mapIndexed { index, signature ->
+                signedTransaction.signatures.map { signature ->
                     entityFactory.createUtxoTransactionSignatureEntity(
                         transaction,
-                        index,
                         serializationService.serialize(signature).bytes,
                         signature.by.toString(),
                         createdTs

--- a/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/datamodel/UtxoEntityFactory.kt
+++ b/components/ledger/ledger-persistence/src/integrationTest/kotlin/net/corda/ledger/persistence/utxo/tests/datamodel/UtxoEntityFactory.kt
@@ -90,14 +90,12 @@ class UtxoEntityFactory(private val entityManagerFactory: EntityManagerFactory) 
 
     fun createUtxoTransactionSignatureEntity(
         utxoTransaction: Any,
-        signatureIndex: Int,
         signature: ByteArray,
         publicKeyHash: String,
         created: Instant
     ): Any {
-        return utxoTransactionSignature.constructors.single { it.parameterCount == 5 }.newInstance(
+        return utxoTransactionSignature.constructors.single { it.parameterCount == 4 }.newInstance(
             utxoTransaction,
-            signatureIndex,
             signature,
             publicKeyHash,
             created

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -83,7 +83,7 @@ interface UtxoPersistenceService {
         account: String
     )
 
-    fun persistTransactionSignatures(id: String, signatures: List<ByteArray>, startingIndex: Int)
+    fun persistTransactionSignatures(id: String, signatures: List<ByteArray>)
 
     /**
      * Retrieve matching filtered transactions and signatures a list of state references.

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoPersistenceService.kt
@@ -37,7 +37,7 @@ interface UtxoPersistenceService {
      *
      * @return A map of the transaction IDs found and their statuses.
      */
-    fun findTransactionIdsAndStatuses(transactionIds: List<String>): Map<SecureHash, String>
+    fun findSignedTransactionIdsAndStatuses(transactionIds: List<String>): Map<SecureHash, String>
 
     /**
      * Find a signed ledger transaction in the persistence context given it's [id] and return it with the status it is stored with. This

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -148,8 +148,7 @@ interface UtxoRepository {
     fun persistTransactionSignatures(
         entityManager: EntityManager,
         signatures: List<TransactionSignature>,
-        timestamp: Instant,
-        withOnConflictUpdate: Boolean
+        timestamp: Instant
     )
 
     /**
@@ -225,7 +224,7 @@ interface UtxoRepository {
         val notaryName: String,
     )
 
-    data class TransactionSignature(val transactionId: String, val index: Int, val signatureBytes: ByteArray, val publicKeyHash: SecureHash)
+    data class TransactionSignature(val transactionId: String, val signatureBytes: ByteArray, val publicKeyHash: SecureHash)
 
     data class FilteredTransaction(
         val transactionId: String,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/UtxoRepository.kt
@@ -18,7 +18,7 @@ import javax.persistence.EntityManager
 interface UtxoRepository {
 
     /** Retrieves transaction IDs and their statuses if its ID is included in the [transactionIds] list. */
-    fun findTransactionIdsAndStatuses(
+    fun findSignedTransactionIdsAndStatuses(
         entityManager: EntityManager,
         transactionIds: List<String>
     ): Map<SecureHash, String>
@@ -53,10 +53,10 @@ interface UtxoRepository {
     ): List<DigitalSignatureAndMetadata>
 
     /** Retrieves a transaction's status */
-    fun findTransactionStatus(
+    fun findSignedTransactionStatus(
         entityManager: EntityManager,
         id: String,
-    ): Pair<String, Boolean>?
+    ): String?
 
     /** Marks visible states of transactions consumed */
     fun markTransactionVisibleStatesConsumed(
@@ -148,7 +148,8 @@ interface UtxoRepository {
     fun persistTransactionSignatures(
         entityManager: EntityManager,
         signatures: List<TransactionSignature>,
-        timestamp: Instant
+        timestamp: Instant,
+        withOnConflictUpdate: Boolean
     )
 
     /**

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -15,12 +15,13 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
         val VERIFIED = TransactionStatus.VERIFIED.value
     }
 
-    override val findTransactionIdsAndStatuses: String
+    override val findSignedTransactionIdsAndStatuses: String
         get() = """
             SELECT id, status 
             FROM {h-schema}utxo_transaction 
-            WHERE id IN (:transactionIds)"""
-            .trimIndent()
+            WHERE id IN (:transactionIds)
+            AND NOT (status = 'V' AND is_filtered = true)
+            """.trimIndent()
 
     override val findTransactionsPrivacySaltAndMetadata: String
         get() = """
@@ -72,11 +73,12 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
             ORDER BY signature_idx"""
             .trimIndent()
 
-    override val findTransactionStatus: String
+    override val findSignedTransactionStatus: String
         get() = """
-            SELECT status, is_filtered
+            SELECT status
             FROM {h-schema}utxo_transaction
-            WHERE id = :transactionId"""
+            WHERE id = :transactionId
+            AND NOT (status = 'V' AND is_filtered = true)"""
             .trimIndent()
 
     override val markTransactionVisibleStatesConsumed: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -69,8 +69,7 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
         get() = """
             SELECT signature
             FROM {h-schema}utxo_transaction_signature
-            WHERE transaction_id = :transactionId
-            ORDER BY signature_idx"""
+            WHERE transaction_id = :transactionId"""
             .trimIndent()
 
     override val findSignedTransactionStatus: String

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/AbstractUtxoQueryProvider.kt
@@ -21,7 +21,7 @@ abstract class AbstractUtxoQueryProvider : UtxoQueryProvider {
             FROM {h-schema}utxo_transaction 
             WHERE id IN (:transactionIds)
             AND NOT (status = 'V' AND is_filtered = true)
-            """.trimIndent()
+        """.trimIndent()
 
     override val findTransactionsPrivacySaltAndMetadata: String
         get() = """

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/PostgresUtxoQueryProvider.kt
@@ -88,24 +88,12 @@ class PostgresUtxoQueryProvider @Activate constructor(
             """.trimIndent()
         }
 
-    override val persistTransactionSignaturesWithOnConflictDoNothing: (batchSize: Int) -> String
+    override val persistTransactionSignatures: (batchSize: Int) -> String
         get() = { batchSize ->
             """
-            INSERT INTO utxo_transaction_signature(transaction_id, signature_idx, signature, pub_key_hash, created)
-            VALUES ${List(batchSize) { "(?, ?, ?, ?, ?)" }.joinToString(",")}
+            INSERT INTO utxo_transaction_signature(transaction_id, pub_key_hash, signature, created)
+            VALUES ${List(batchSize) { "(?, ?, ?, ?)" }.joinToString(",")}
             ON CONFLICT DO NOTHING
-            """.trimIndent()
-        }
-
-    override val persistTransactionSignaturesWithOnConflictUpdate: (batchSize: Int) -> String
-        get() = { batchSize ->
-            """
-            INSERT INTO utxo_transaction_signature(transaction_id, signature_idx, signature, pub_key_hash, created)
-            VALUES ${List(batchSize) { "(?, ?, ?, ?, ?)" }.joinToString(",")}
-            ON CONFLICT(transaction_id, signature_idx) DO
-            UPDATE SET signature_idx = EXCLUDED.signature_idx, signature = EXCLUDED.signature, pub_key_hash = EXCLUDED.pub_key_hash, 
-            created = EXCLUDED.created
-            WHERE pub_key_hash != EXCLUDED.pub_key_hash || signature != EXCLUDED.signature
             """.trimIndent()
         }
 

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoPersistenceServiceImpl.kt
@@ -395,7 +395,7 @@ class UtxoPersistenceServiceImpl(
     }
 
     override fun persistTransactionSignatures(id: String, signatures: List<ByteArray>) {
-        val transactionSignatures = signatures.mapIndexed { index, bytes ->
+        val transactionSignatures = signatures.map { bytes ->
             val signature = serializationService.deserialize<DigitalSignatureAndMetadata>(bytes)
             UtxoRepository.TransactionSignature(
                 id,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -104,12 +104,7 @@ interface UtxoQueryProvider {
     /**
      * @property persistTransactionSignature SQL text for [UtxoRepositoryImpl.persistTransactionSignature].
      */
-    val persistTransactionSignaturesWithOnConflictDoNothing: (batchSize: Int) -> String
-
-    /**
-     * @property persistTransactionSignature SQL text for [UtxoRepositoryImpl.persistTransactionSignature].
-     */
-    val persistTransactionSignaturesWithOnConflictUpdate: (batchSize: Int) -> String
+    val persistTransactionSignatures: (batchSize: Int) -> String
 
     /**
      * @property persistMerkleProof SQL text for [UtxoRepositoryImpl.persistMerkleProof].

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoQueryProvider.kt
@@ -31,9 +31,18 @@ interface UtxoQueryProvider {
     val findTransactionSignatures: String
 
     /**
-     * @property findTransactionStatus SQL text for [UtxoRepositoryImpl.findTransactionStatus].
+     * @property findSignedTransactionStatus SQL text for [UtxoRepositoryImpl.findSignedTransactionStatus].
+     *
+     * VERIFIED, UNVERIFIED, DRAFT and INVALID are all returned where `is_filtered` = false.
+     *
+     * Where `is_filtered` = true, the following rules apply:
+     *
+     * - VERIFIED can exist with is_filtered = true when there is only a filtered transaction => not returned.
+     * - UNVERIFIED can exist with is_filtered = true when there is an unverified signed and filtered transaction => returned.
+     * - DRAFT cannot exist with is_filtered = true => doesn't exist.
+     * - INVALID filtered transaction => doesn't exist.
      */
-    val findTransactionStatus: String
+    val findSignedTransactionStatus: String
 
     /**
      * @property markTransactionVisibleStatesConsumed SQL text for
@@ -95,7 +104,12 @@ interface UtxoQueryProvider {
     /**
      * @property persistTransactionSignature SQL text for [UtxoRepositoryImpl.persistTransactionSignature].
      */
-    val persistTransactionSignatures: (batchSize: Int) -> String
+    val persistTransactionSignaturesWithOnConflictDoNothing: (batchSize: Int) -> String
+
+    /**
+     * @property persistTransactionSignature SQL text for [UtxoRepositoryImpl.persistTransactionSignature].
+     */
+    val persistTransactionSignaturesWithOnConflictUpdate: (batchSize: Int) -> String
 
     /**
      * @property persistMerkleProof SQL text for [UtxoRepositoryImpl.persistMerkleProof].
@@ -118,9 +132,18 @@ interface UtxoQueryProvider {
     val persistSignedGroupParameters: String
 
     /**
-     * @property findTransactionIdsAndStatuses SQL text for [UtxoRepositoryImpl.findTransactionIdsAndStatuses].
+     * @property findSignedTransactionIdsAndStatuses SQL text for [UtxoRepositoryImpl.findSignedTransactionIdsAndStatuses].
+     *
+     * VERIFIED, UNVERIFIED, DRAFT and INVALID are all returned where `is_filtered` = false.
+     *
+     * Where `is_filtered` = true, the following rules apply:
+     *
+     * - VERIFIED can exist with is_filtered = true when there is only a filtered transaction => not returned.
+     * - UNVERIFIED can exist with is_filtered = true when there is an unverified signed and filtered transaction => returned.
+     * - DRAFT cannot exist with is_filtered = true => doesn't exist.
+     * - INVALID filtered transaction => doesn't exist.
      */
-    val findTransactionIdsAndStatuses: String
+    val findSignedTransactionIdsAndStatuses: String
 
     /**
      * @property findMerkleProofs SQL text for [UtxoRepositoryImpl.findMerkleProofs].

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRepositoryImpl.kt
@@ -93,11 +93,11 @@ class UtxoRepositoryImpl(
         )
     }
 
-    override fun findTransactionIdsAndStatuses(
+    override fun findSignedTransactionIdsAndStatuses(
         entityManager: EntityManager,
         transactionIds: List<String>
     ): Map<SecureHash, String> {
-        return entityManager.createNativeQuery(queryProvider.findTransactionIdsAndStatuses, Tuple::class.java)
+        return entityManager.createNativeQuery(queryProvider.findSignedTransactionIdsAndStatuses, Tuple::class.java)
             .setParameter("transactionIds", transactionIds)
             .resultListAsTuples()
             .associate { r -> parseSecureHash(r.get(0) as String) to r.get(1) as String }
@@ -166,11 +166,11 @@ class UtxoRepositoryImpl(
             .map { r -> serializationService.deserialize(r.get(0) as ByteArray) }
     }
 
-    override fun findTransactionStatus(entityManager: EntityManager, id: String): Pair<String, Boolean>? {
-        return entityManager.createNativeQuery(queryProvider.findTransactionStatus, Tuple::class.java)
+    override fun findSignedTransactionStatus(entityManager: EntityManager, id: String): String? {
+        return entityManager.createNativeQuery(queryProvider.findSignedTransactionStatus, Tuple::class.java)
             .setParameter("transactionId", id)
             .resultListAsTuples()
-            .map { r -> r.get(0) as String to r.get(1) as Boolean }
+            .map { r -> r.get(0) as String }
             .singleOrNull()
     }
 
@@ -395,12 +395,18 @@ class UtxoRepositoryImpl(
     override fun persistTransactionSignatures(
         entityManager: EntityManager,
         signatures: List<UtxoRepository.TransactionSignature>,
-        timestamp: Instant
+        timestamp: Instant,
+        withOnConflictUpdate: Boolean
     ) {
+        val query = if (withOnConflictUpdate) {
+            queryProvider.persistTransactionSignaturesWithOnConflictUpdate
+        } else {
+            queryProvider.persistTransactionSignaturesWithOnConflictDoNothing
+        }
         entityManager.connection { connection ->
             batchPersistenceService.persistBatch(
                 connection,
-                queryProvider.persistTransactionSignatures,
+                query,
                 signatures
             ) { statement, parameterIndex, signature ->
                 statement.setString(parameterIndex.next(), signature.transactionId)

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/UtxoRequestHandlerSelectorImpl.kt
@@ -28,7 +28,7 @@ import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoExecuteNamedQ
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindFilteredTransactionsAndSignaturesRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedGroupParametersRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedLedgerTransactionRequestHandler
-import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindTransactionIdsAndStatusesRequestHandler
+import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindSignedTransactionIdsAndStatusesRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindTransactionRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindTransactionsWithStatusCreatedBetweenTimeRequestHandler
 import net.corda.ledger.persistence.utxo.impl.request.handlers.UtxoFindUnconsumedStatesByTypeRequestHandler
@@ -188,7 +188,7 @@ class UtxoRequestHandlerSelectorImpl @Activate constructor(
                 )
             }
             is FindTransactionIdsAndStatuses -> {
-                UtxoFindTransactionIdsAndStatusesRequestHandler(
+                UtxoFindSignedTransactionIdsAndStatusesRequestHandler(
                     req,
                     externalEventContext,
                     persistenceService,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindSignedTransactionIdsAndStatusesRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoFindSignedTransactionIdsAndStatusesRequestHandler.kt
@@ -11,7 +11,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.v5.application.serialization.SerializationService
 import java.nio.ByteBuffer
 
-class UtxoFindTransactionIdsAndStatusesRequestHandler(
+class UtxoFindSignedTransactionIdsAndStatusesRequestHandler(
     private val findTransactions: FindTransactionIdsAndStatuses,
     private val externalEventContext: ExternalEventContext,
     private val persistenceService: UtxoPersistenceService,
@@ -20,7 +20,7 @@ class UtxoFindTransactionIdsAndStatusesRequestHandler(
 ) : RequestHandler {
 
     override fun execute(): List<Record<*, *>> {
-        val existingTransactions = persistenceService.findTransactionIdsAndStatuses(findTransactions.ids)
+        val existingTransactions = persistenceService.findSignedTransactionIdsAndStatuses(findTransactions.ids)
         return listOf(
             externalEventResponseFactory.success(
                 externalEventContext,

--- a/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionSignaturesRequestHandler.kt
+++ b/components/ledger/ledger-persistence/src/main/kotlin/net/corda/ledger/persistence/utxo/impl/request/handlers/UtxoPersistTransactionSignaturesRequestHandler.kt
@@ -20,7 +20,6 @@ class UtxoPersistTransactionSignaturesRequestHandler(
         persistenceService.persistTransactionSignatures(
             persistTransactionSignatures.id,
             persistTransactionSignatures.signatures.map { it.array() },
-            persistTransactionSignatures.startingIndex
         )
 
         return listOf(

--- a/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionSignatureEntity.kt
+++ b/components/ledger/ledger-persistence/testing-datamodel/src/main/kotlin/com/example/ledger/testing/datamodel/utxo/UtxoTransactionSignatureEntity.kt
@@ -22,13 +22,10 @@ data class UtxoTransactionSignatureEntity(
     @get:JoinColumn(name = "transaction_id", nullable = false, updatable = false)
     var transaction: UtxoTransactionEntity,
 
-    @get:Id
-    @get:Column(name = "signature_idx", nullable = false)
-    var index: Int,
-
     @get:Column(name = "signature", nullable = false)
     var signature: ByteArray,
 
+    @get:Id
     @get:Column(name = "pub_key_hash", nullable = false)
     var publicKeyHash: String,
 
@@ -42,7 +39,6 @@ data class UtxoTransactionSignatureEntity(
         other as UtxoTransactionSignatureEntity
 
         if (transaction != other.transaction) return false
-        if (index != other.index) return false
         if (!signature.contentEquals(other.signature)) return false
         if (publicKeyHash != other.publicKeyHash) return false
         if (created != other.created) return false
@@ -52,7 +48,6 @@ data class UtxoTransactionSignatureEntity(
 
     override fun hashCode(): Int {
         var result = transaction.hashCode()
-        result = 31 * result + index
         result = 31 * result + signature.contentHashCode()
         result = 31 * result + publicKeyHash.hashCode()
         result = 31 * result + created.hashCode()
@@ -63,5 +58,5 @@ data class UtxoTransactionSignatureEntity(
 @Embeddable
 data class UtxoTransactionSignatureEntityId(
     var transaction: UtxoTransactionEntity,
-    var index: Int
+    var publicKeyHash: String
 ) : Serializable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1.kt
@@ -202,7 +202,7 @@ class TransactionBackchainReceiverFlowV1(
         var transactionsToCheck = transactionsToRetrieve.toMutableList()
 
         while (transactionsToCheck.isNotEmpty()) {
-            val transactionsFromDb = utxoLedgerPersistenceService.findTransactionIdsAndStatuses(transactionsToCheck)
+            val transactionsFromDb = utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(transactionsToCheck)
 
             // Check if we have any invalid transactions. If yes, we can't continue the back-chain resolution.
             val invalidTransactions = transactionsFromDb.filterValues { it == INVALID }.keys

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -244,7 +244,7 @@ class UtxoFinalityFlowV1(
 
     @Suspendable
     private fun persistCounterpartySignatures(id: SecureHash, newSignatures: Set<DigitalSignatureAndMetadata>) {
-        persistenceService.persistTransactionSignatures(id, newSignatures.toList())
+        persistenceService.persistTransactionSignatures(id, newSignatures)
         log.debug { "Recorded transaction with all parties' signatures $transactionId" }
     }
 

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1.kt
@@ -122,7 +122,7 @@ class UtxoReceiveFinalityFlowV1(
         return if (transferAdditionalSignatures) {
             receiveSignaturesAndAddToTransaction(transaction).let { (it, signatures) ->
                 verifyAllReceivedSignatures(it)
-                persistenceService.persistTransactionSignatures(it.id, signatures.toList())
+                persistenceService.persistTransactionSignatures(it.id, signatures)
                 it
             }
         } else {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -143,7 +143,7 @@ interface UtxoLedgerPersistenceService {
     ): TransactionExistenceStatus
 
     @Suspendable
-    fun persistTransactionSignatures(id: SecureHash, startingIndex: Int, signatures: List<DigitalSignatureAndMetadata>)
+    fun persistTransactionSignatures(id: SecureHash, signatures: List<DigitalSignatureAndMetadata>)
 
     /**
      * Persists a list of filtered transactions and their signatures represented as [UtxoFilteredTransactionAndSignatures]

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -57,7 +57,7 @@ interface UtxoLedgerPersistenceService {
      * @return A list of the transaction IDs found and their statuses.
      */
     @Suspendable
-    fun findTransactionIdsAndStatuses(ids: Collection<SecureHash>): Map<SecureHash, TransactionStatus>
+    fun findSignedTransactionIdsAndStatuses(ids: Collection<SecureHash>): Map<SecureHash, TransactionStatus>
 
     /**
      * Find a verified [UtxoSignedLedgerTransaction] in the persistence context given it's [id]. This involves resolving its input and

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceService.kt
@@ -143,7 +143,7 @@ interface UtxoLedgerPersistenceService {
     ): TransactionExistenceStatus
 
     @Suspendable
-    fun persistTransactionSignatures(id: SecureHash, signatures: List<DigitalSignatureAndMetadata>)
+    fun persistTransactionSignatures(id: SecureHash, signatures: Set<DigitalSignatureAndMetadata>)
 
     /**
      * Persists a list of filtered transactions and their signatures represented as [UtxoFilteredTransactionAndSignatures]

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -25,8 +25,8 @@ import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindFilteredT
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
-import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionIdsAndStatusesExternalEventFactory
-import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionIdsAndStatusesParameters
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedTransactionIdsAndStatusesExternalEventFactory
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedTransactionIdsAndStatusesParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionsWithStatusCreatedBetweenTimeExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionsWithStatusCreatedBetweenTimeParameters
@@ -129,12 +129,12 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun findTransactionIdsAndStatuses(ids: Collection<SecureHash>): Map<SecureHash, TransactionStatus> {
+    override fun findSignedTransactionIdsAndStatuses(ids: Collection<SecureHash>): Map<SecureHash, TransactionStatus> {
         return recordSuspendable({ ledgerPersistenceFlowTimer(FindTransactionIdsAndStatuses) }) @Suspendable {
             wrapWithPersistenceException {
                 externalEventExecutor.execute(
-                    FindTransactionIdsAndStatusesExternalEventFactory::class.java,
-                    FindTransactionIdsAndStatusesParameters(ids.map { it.toString() })
+                    FindSignedTransactionIdsAndStatusesExternalEventFactory::class.java,
+                    FindSignedTransactionIdsAndStatusesParameters(ids.map { it.toString() })
                 )
             }
         }.firstOrNull()?.let {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -24,9 +24,9 @@ import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindFilteredT
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindFilteredTransactionsAndSignaturesParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedLedgerTransactionParameters
-import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedTransactionIdsAndStatusesExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindSignedTransactionIdsAndStatusesParameters
+import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionParameters
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionsWithStatusCreatedBetweenTimeExternalEventFactory
 import net.corda.ledger.utxo.flow.impl.persistence.external.events.FindTransactionsWithStatusCreatedBetweenTimeParameters

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -228,7 +228,7 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
 
                     UtxoFilteredTransactionAndSignaturesImpl(
                         utxoFilteredTransaction,
-                        signatures.filter { signature -> newTxNotaryKeyIds.contains(signature.by) }
+                        signatures.filter { signature -> newTxNotaryKeyIds.contains(signature.by) }.toSet()
                     )
                 }
             }
@@ -308,7 +308,7 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun persistTransactionSignatures(id: SecureHash, signatures: List<DigitalSignatureAndMetadata>) {
+    override fun persistTransactionSignatures(id: SecureHash, signatures: Set<DigitalSignatureAndMetadata>) {
         return recordSuspendable(
             { ledgerPersistenceFlowTimer(LedgerPersistenceMetricOperationName.PersistTransactionSignatures) }
         ) @Suspendable {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImpl.kt
@@ -308,11 +308,7 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
     }
 
     @Suspendable
-    override fun persistTransactionSignatures(
-        id: SecureHash,
-        startingIndex: Int,
-        signatures: List<DigitalSignatureAndMetadata>
-    ) {
+    override fun persistTransactionSignatures(id: SecureHash, signatures: List<DigitalSignatureAndMetadata>) {
         return recordSuspendable(
             { ledgerPersistenceFlowTimer(LedgerPersistenceMetricOperationName.PersistTransactionSignatures) }
         ) @Suspendable {
@@ -321,7 +317,6 @@ class UtxoLedgerPersistenceServiceImpl @Activate constructor(
                     PersistTransactionSignaturesExternalEventFactory::class.java,
                     PersistTransactionSignaturesParameters(
                         id.toString(),
-                        startingIndex,
                         signatures.map { serializationService.serialize(it).bytes }
                     )
                 )

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindSignedTransactionIdsAndStatusesExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/FindSignedTransactionIdsAndStatusesExternalEventFactory.kt
@@ -8,16 +8,16 @@ import org.osgi.service.component.annotations.Component
 import java.time.Clock
 
 @Component(service = [ExternalEventFactory::class])
-class FindTransactionIdsAndStatusesExternalEventFactory :
-    AbstractUtxoLedgerExternalEventFactory<FindTransactionIdsAndStatusesParameters> {
+class FindSignedTransactionIdsAndStatusesExternalEventFactory :
+    AbstractUtxoLedgerExternalEventFactory<FindSignedTransactionIdsAndStatusesParameters> {
     @Activate
     constructor() : super()
     constructor(clock: Clock) : super(clock)
 
-    override fun createRequest(parameters: FindTransactionIdsAndStatusesParameters): Any {
+    override fun createRequest(parameters: FindSignedTransactionIdsAndStatusesParameters): Any {
         return FindTransactionIdsAndStatuses(parameters.transactionIds)
     }
 }
 
 @CordaSerializable
-data class FindTransactionIdsAndStatusesParameters(val transactionIds: List<String>)
+data class FindSignedTransactionIdsAndStatusesParameters(val transactionIds: List<String>)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/PersistTransactionSignaturesExternalEventFactory.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/persistence/external/events/PersistTransactionSignaturesExternalEventFactory.kt
@@ -18,15 +18,10 @@ class PersistTransactionSignaturesExternalEventFactory :
     override fun createRequest(parameters: PersistTransactionSignaturesParameters): Any {
         return PersistTransactionSignatures(
             parameters.id,
-            parameters.startingIndex,
             parameters.signatures.map { ByteBuffer.wrap(it) }
         )
     }
 }
 
 @CordaSerializable
-data class PersistTransactionSignaturesParameters(
-    val id: String,
-    val startingIndex: Int,
-    val signatures: List<ByteArray>
-)
+data class PersistTransactionSignaturesParameters(val id: String, val signatures: List<ByteArray>)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -31,7 +31,7 @@ data class UtxoSignedTransactionImpl(
     private val notarySignatureVerificationService: NotarySignatureVerificationServiceInternal,
     private val utxoLedgerTransactionFactory: UtxoLedgerTransactionFactory,
     override val wireTransaction: WireTransaction,
-    private val signatures: List<DigitalSignatureAndMetadata>
+    private val signatures: Set<DigitalSignatureAndMetadata>
 ) : UtxoSignedTransactionInternal {
 
     private val keyIdToSignatories: MutableMap<String, Map<SecureHash, PublicKey>> = mutableMapOf()
@@ -53,7 +53,7 @@ data class UtxoSignedTransactionImpl(
     }
 
     override fun getSignatures(): List<DigitalSignatureAndMetadata> {
-        return signatures
+        return signatures.toList()
     }
 
     override fun getInputStateRefs(): List<StateRef> {
@@ -182,7 +182,7 @@ data class UtxoSignedTransactionImpl(
     }
 
     override fun verifyAttachedNotarySignature() {
-        notarySignatureVerificationService.verifyNotarySignatures(this, notaryKey, signatures, keyIdToNotaryKeys)
+        notarySignatureVerificationService.verifyNotarySignatures(this, notaryKey, signatures.toList(), keyIdToNotaryKeys)
     }
 
     override fun verifyNotarySignature(signature: DigitalSignatureAndMetadata) {
@@ -241,12 +241,12 @@ data class UtxoSignedTransactionImpl(
         if (this === other) return true
         if (other !is UtxoSignedTransactionImpl) return false
         if (other.wireTransaction != wireTransaction) return false
-        if (other.signatures.toSet() != signatures.toSet()) return false
+        if (other.signatures != signatures) return false
 
         return true
     }
 
-    override fun hashCode(): Int = Objects.hash(wireTransaction, signatures.toSet())
+    override fun hashCode(): Int = Objects.hash(wireTransaction, signatures)
 
     override fun toString(): String {
         return "UtxoSignedTransactionImpl(id=$id, signatures=$signatures, wireTransaction=$wireTransaction)"

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/UtxoSignedTransactionImpl.kt
@@ -241,14 +241,12 @@ data class UtxoSignedTransactionImpl(
         if (this === other) return true
         if (other !is UtxoSignedTransactionImpl) return false
         if (other.wireTransaction != wireTransaction) return false
-        if (other.signatures.size != signatures.size) return false
+        if (other.signatures.toSet() != signatures.toSet()) return false
 
-        return other.signatures.withIndex().all {
-            it.value == signatures[it.index]
-        }
+        return true
     }
 
-    override fun hashCode(): Int = Objects.hash(wireTransaction, signatures)
+    override fun hashCode(): Int = Objects.hash(wireTransaction, signatures.toSet())
 
     override fun toString(): String {
         return "UtxoSignedTransactionImpl(id=$id, signatures=$signatures, wireTransaction=$wireTransaction)"

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -103,7 +103,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
             notarySignatureVerificationService,
             utxoLedgerTransactionFactory,
             wireTransaction,
-            signaturesWithMetadata
+            signaturesWithMetadata.toSet()
         )
     }
 
@@ -116,7 +116,7 @@ class UtxoSignedTransactionFactoryImpl @Activate constructor(
         notarySignatureVerificationService,
         utxoLedgerTransactionFactory,
         wireTransaction,
-        signaturesWithMetaData
+        signaturesWithMetaData.toSet()
     )
 
     @Suspendable

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionAndSignaturesSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoFilteredTransactionAndSignaturesSerializer.kt
@@ -1,0 +1,52 @@
+package net.corda.ledger.utxo.flow.impl.transaction.serializer.amqp
+
+import net.corda.ledger.utxo.data.transaction.UtxoFilteredTransactionAndSignaturesImpl
+import net.corda.sandbox.type.SandboxConstants.CORDA_UNINJECTABLE_SERVICE
+import net.corda.sandbox.type.UsedByFlow
+import net.corda.serialization.BaseProxySerializer
+import net.corda.serialization.InternalCustomSerializer
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.serialization.SerializationService
+import net.corda.v5.ledger.utxo.transaction.filtered.UtxoFilteredTransaction
+import org.osgi.service.component.annotations.Activate
+import org.osgi.service.component.annotations.Component
+import org.osgi.service.component.annotations.Reference
+import org.osgi.service.component.annotations.ServiceScope.PROTOTYPE
+
+/**
+ * [UtxoFilteredTransactionAndSignaturesSerializer] is needed to serialize [UtxoFilteredTransactionAndSignaturesImpl] as the default AMQP
+ * serialization does not like that [UTxoFilteredTransactionAndSignatures.signatures] returns a [List] but the underlying property (of the
+ * same name) is a [Set].
+ */
+@Component(
+    service = [ InternalCustomSerializer::class, UsedByFlow::class ],
+    property = [ CORDA_UNINJECTABLE_SERVICE ],
+    scope = PROTOTYPE
+)
+class UtxoFilteredTransactionAndSignaturesSerializer @Activate constructor(
+    @Reference(service = SerializationService::class)
+    private val serializationService: SerializationService
+) : BaseProxySerializer<UtxoFilteredTransactionAndSignaturesImpl, UtxoFilteredTransactionAndSignaturesProxy>(), UsedByFlow {
+
+    override fun toProxy(obj: UtxoFilteredTransactionAndSignaturesImpl): UtxoFilteredTransactionAndSignaturesProxy {
+        return UtxoFilteredTransactionAndSignaturesProxy(obj.filteredTransaction, obj.signatures)
+    }
+
+    override fun fromProxy(proxy: UtxoFilteredTransactionAndSignaturesProxy): UtxoFilteredTransactionAndSignaturesImpl {
+        return UtxoFilteredTransactionAndSignaturesImpl(proxy.filteredTransaction, proxy.signatures.toSet())
+    }
+
+    override val proxyType
+        get() = UtxoFilteredTransactionAndSignaturesProxy::class.java
+
+    override val type
+        get() = UtxoFilteredTransactionAndSignaturesImpl::class.java
+
+    override val withInheritance
+        get() = false
+}
+
+data class UtxoFilteredTransactionAndSignaturesProxy(
+    val filteredTransaction: UtxoFilteredTransaction,
+    val signatures: List<DigitalSignatureAndMetadata>
+)

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/amqp/UtxoSignedTransactionSerializer.kt
@@ -64,7 +64,7 @@ class UtxoSignedTransactionSerializer @Activate constructor(
                     notarySignatureVerificationService,
                     utxoLedgerTransactionFactory,
                     proxy.wireTransaction,
-                    proxy.signatures
+                    proxy.signatures.toSet()
                 )
             else ->
                 throw CordaRuntimeException("Unable to create UtxoSignedTransaction with Version='${proxy.version}'")

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializer.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/serializer/kryo/UtxoSignedTransactionKryoSerializer.kt
@@ -51,7 +51,7 @@ class UtxoSignedTransactionKryoSerializer @Activate constructor(
             notarySignatureVerificationService,
             utxoLedgerTransactionFactory,
             wireTransaction,
-            signatures
+            signatures.toSet()
         )
     }
 }

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/backchain/v1/TransactionBackchainReceiverFlowV1Test.kt
@@ -87,7 +87,7 @@ class TransactionBackchainReceiverFlowV1Test {
             on { getInt(BACKCHAIN_BATCH_CONFIG_PATH) } doReturn BACKCHAIN_BATCH_DEFAULT_SIZE
         }
         whenever(flowConfigService.getConfig(ConfigKeys.UTXO_LEDGER_CONFIG)).thenReturn(utxoConfig)
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(emptyMap())
     }
 
@@ -98,7 +98,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `transaction will not be requested if it is present in the database (VERIFIED) and DB data will not be in the topological sort`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(mapOf(TX_ID_1 to VERIFIED))
 
         whenever(session.sendAndReceive(eq(List::class.java), eq(TransactionBackchainRequestV1.Get(setOf(TX_ID_2))))).thenReturn(
@@ -144,7 +144,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `transaction that is in the DB and referenced by multiple transactions - one in DB and one retrievable will only be retrieved once`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,
@@ -234,7 +234,7 @@ class TransactionBackchainReceiverFlowV1Test {
     @Test
     fun `transaction will be requested if it is present in the database (UNVERIFIED) and its group params are not known`() {
         // Have a transaction with TX_ID_2 that is unverified, but it's in the database and has dependencies
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(mapOf(TX_ID_2 to UNVERIFIED))
 
         whenever(utxoLedgerPersistenceService.findSignedTransactionWithStatus(eq(TX_ID_2), eq(UNVERIFIED)))
@@ -294,7 +294,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `dependency of dependency of transaction will be fetched if it is in the database but group params not known`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,
@@ -416,7 +416,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `transaction will not be requested if it is present in the database (UNVERIFIED) but their dependencies will be`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(mapOf(TX_ID_2 to UNVERIFIED))
 
         whenever(utxoLedgerPersistenceService.findSignedTransactionWithStatus(eq(TX_ID_2), eq(UNVERIFIED)))
@@ -470,7 +470,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `flow will throw exception if any of the transactions are invalid`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_2 to UNVERIFIED,
@@ -507,7 +507,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `dependency of dependency of transaction will not be fetched if it is in the database`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,
@@ -589,7 +589,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `dependency of dependency of transaction will be fetched if it is not in the database`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,
@@ -679,7 +679,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `if transaction status changed to invalid from unverified exception will be thrown`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,
@@ -708,7 +708,7 @@ class TransactionBackchainReceiverFlowV1Test {
             .findSignedTransactionWithStatus(eq(TX_ID_1), eq(UNVERIFIED))
 
         verify(utxoLedgerPersistenceService, times(1))
-            .findTransactionIdsAndStatuses(eq(listOf(TX_ID_1)))
+            .findSignedTransactionIdsAndStatuses(eq(listOf(TX_ID_1)))
     }
 
     /**
@@ -717,7 +717,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `if transaction status was unverified then it disappeared from the DB it will be retrieved`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,
@@ -763,7 +763,7 @@ class TransactionBackchainReceiverFlowV1Test {
             .findSignedTransactionWithStatus(eq(TX_ID_1), eq(UNVERIFIED))
 
         verify(utxoLedgerPersistenceService, times(1))
-            .findTransactionIdsAndStatuses(eq(listOf(TX_ID_1)))
+            .findSignedTransactionIdsAndStatuses(eq(listOf(TX_ID_1)))
 
         verify(session, times(1)).sendAndReceive(
             eq(List::class.java),
@@ -777,7 +777,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `if transaction status was unverified then its status could not be fetched it will be retrieved`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,
@@ -823,7 +823,7 @@ class TransactionBackchainReceiverFlowV1Test {
             .findSignedTransactionWithStatus(eq(TX_ID_1), eq(UNVERIFIED))
 
         verify(utxoLedgerPersistenceService, times(1))
-            .findTransactionIdsAndStatuses(eq(listOf(TX_ID_1)))
+            .findSignedTransactionIdsAndStatuses(eq(listOf(TX_ID_1)))
 
         verify(session, times(1)).sendAndReceive(
             eq(List::class.java),
@@ -837,7 +837,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `if transaction status changed to verified from unverified it will not be retrieved`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,
@@ -859,7 +859,7 @@ class TransactionBackchainReceiverFlowV1Test {
             .findSignedTransactionWithStatus(eq(TX_ID_1), eq(UNVERIFIED))
 
         verify(utxoLedgerPersistenceService, times(1))
-            .findTransactionIdsAndStatuses(eq(listOf(TX_ID_1)))
+            .findSignedTransactionIdsAndStatuses(eq(listOf(TX_ID_1)))
 
         verify(session, never())
             .sendAndReceive(eq(List::class.java), any())
@@ -871,7 +871,7 @@ class TransactionBackchainReceiverFlowV1Test {
      */
     @Test
     fun `if transaction's dependency status changed to verified from unverified it will not be retrieved`() {
-        whenever(utxoLedgerPersistenceService.findTransactionIdsAndStatuses(any()))
+        whenever(utxoLedgerPersistenceService.findSignedTransactionIdsAndStatuses(any()))
             .thenReturn(
                 mapOf(
                     TX_ID_1 to UNVERIFIED,

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/common/TransactionDependencyResolutionFlowTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/common/TransactionDependencyResolutionFlowTest.kt
@@ -55,7 +55,7 @@ class TransactionDependencyResolutionFlowTest : UtxoLedgerTest() {
     private val filteredTransaction = mock<UtxoFilteredTransaction>()
     private val filteredDependency = UtxoFilteredTransactionAndSignaturesImpl(
         filteredTransaction,
-        listOf(notarySignature)
+        setOf(notarySignature)
     )
 
     private val mockFlowEngine = mock<FlowEngine>()

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoReceiveFinalityFlowV1Test.kt
@@ -164,9 +164,9 @@ class UtxoReceiveFinalityFlowV1Test {
         stxRefState
     )
     private val filteredTransaction = mock<UtxoFilteredTransaction>()
-    private val filteredTxAndSig = UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction, listOf(signatureNotary))
+    private val filteredTxAndSig = UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction, setOf(signatureNotary))
     private val filteredTransaction2 = mock<UtxoFilteredTransaction>()
-    private val filteredTxAndSig2 = UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction2, listOf(signatureNotary))
+    private val filteredTxAndSig2 = UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction2, setOf(signatureNotary))
     private val filteredTxPayload = listOf(filteredTxAndSig, filteredTxAndSig2)
     private val finalityPayload = FinalityPayload(signedTransaction, true)
     private val verifyingFinalityPayload = FinalityPayload(signedTransaction, true, filteredTxPayload)
@@ -259,8 +259,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            2,
-            listOf(signature3)
+            setOf(signature3)
         )
         verify(persistenceService).persist(notarizedTransaction, TransactionStatus.VERIFIED)
         verify(session).send(Payload.Success(listOf(signature1, signature2)))
@@ -335,8 +334,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            2,
-            listOf(signature3)
+            setOf(signature3)
         )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(signedTransactionWithOwnKeys, TransactionStatus.INVALID)
@@ -362,8 +360,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            2,
-            listOf(signature3)
+            setOf(signature3)
         )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(signedTransactionWithOwnKeys, TransactionStatus.INVALID)
@@ -384,8 +381,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            2,
-            listOf(signature3)
+            setOf(signature3)
         )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.INVALID), any())
@@ -410,8 +406,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            2,
-            listOf(signature3)
+            setOf(signature3)
         )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(signedTransactionWithOwnKeys, TransactionStatus.INVALID)
@@ -437,8 +432,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            2,
-            listOf(signature3)
+            setOf(signature3)
         )
         verify(persistenceService, never()).persist(any(), eq(TransactionStatus.VERIFIED), any())
         verify(persistenceService).persist(signedTransactionWithOwnKeys, TransactionStatus.INVALID)
@@ -467,8 +461,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransactionWith1Key, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            1,
-            listOf()
+            setOf()
         )
         verify(persistenceService).persist(notarizedTransaction, TransactionStatus.VERIFIED)
         verify(session).send(Payload.Success(listOf(signature1)))
@@ -537,8 +530,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransaction, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            1,
-            listOf()
+            setOf()
         )
         verify(persistenceService).persist(notarizedTransaction, TransactionStatus.VERIFIED)
     }
@@ -651,8 +643,7 @@ class UtxoReceiveFinalityFlowV1Test {
         verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
         verify(persistenceService).persistTransactionSignatures(
             ID,
-            2,
-            listOf(signature3)
+            setOf(signature3)
         )
     }
 
@@ -692,7 +683,7 @@ class UtxoReceiveFinalityFlowV1Test {
             whenever(it.notaryName).thenReturn(notaryX500Name)
         }
 
-        val filteredTxAndSig = UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction, listOf(signatureAnotherNotary))
+        val filteredTxAndSig = UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction, setOf(signatureAnotherNotary))
         val filteredTxPayload = listOf(filteredTxAndSig)
         val finalityPayload = FinalityPayload(signedTransaction, true, filteredTxPayload)
 
@@ -862,6 +853,26 @@ class UtxoReceiveFinalityFlowV1Test {
                 listOf(stxInputState),
                 listOf(stxRefState)
             )
+    }
+
+    @Test
+    fun `do not persist existing transaction signatures when receiving signatures from peers`() {
+        whenever(signedTransaction.addMissingSignatures()).thenReturn(signedTransactionWithOwnKeys to listOf(signature1, signature2))
+        whenever(session.receive(List::class.java)).thenReturn(listOf(signature1, signature2, signature3))
+        whenever(session.receive(Payload::class.java)).thenReturn(Payload.Success(listOf(signatureNotary)))
+
+        callReceiveFinalityFlow()
+
+        verify(signedTransaction).addMissingSignatures()
+
+        verify(signedTransactionWithOwnKeys).addSignature(signature3)
+        verify(persistenceService, times(1)).persist(signedTransactionWithOwnKeys, TransactionStatus.UNVERIFIED)
+        verify(persistenceService).persistTransactionSignatures(
+            ID,
+            setOf(signature3)
+        )
+        verify(persistenceService).persist(notarizedTransaction, TransactionStatus.VERIFIED)
+        verify(session).send(Payload.Success(listOf(signature1, signature2)))
     }
 
     private fun callReceiveFinalityFlow(validator: UtxoTransactionValidator = UtxoTransactionValidator { }) {

--- a/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
+++ b/components/ledger/ledger-utxo-flow/src/test/kotlin/net/corda/ledger/utxo/flow/impl/persistence/UtxoLedgerPersistenceServiceImplTest.kt
@@ -230,7 +230,7 @@ class UtxoLedgerPersistenceServiceImplTest {
     @Test
     fun `persistFilteredTransactionsAndSignatures executes successfully`() {
         val filteredTransaction = mock<UtxoFilteredTransactionImpl>()
-        val signature = listOf(mock<DigitalSignatureAndMetadata>())
+        val signature = setOf(mock<DigitalSignatureAndMetadata>())
 
         utxoLedgerPersistenceService.persistFilteredTransactionsAndSignatures(
             listOf(UtxoFilteredTransactionAndSignaturesImpl(filteredTransaction, signature)),
@@ -252,7 +252,7 @@ class UtxoLedgerPersistenceServiceImplTest {
         whenever(wireTransaction.componentGroupLists).thenReturn(List(UtxoComponentGroup.values().size) { listOf() })
         whenever(wireTransaction.metadata).thenReturn(metadata)
 
-        val signatures = listOf(mock<DigitalSignatureAndMetadata>())
+        val signatures = setOf(mock<DigitalSignatureAndMetadata>())
         val expectedObj = UtxoSignedTransactionImpl(
             serializationService,
             transactionSignatureService,
@@ -264,7 +264,7 @@ class UtxoLedgerPersistenceServiceImplTest {
         val testId = parseSecureHash("SHA256:1234567890123456")
 
         whenever(serializationService.deserialize<Pair<SignedTransactionContainer, String>>(any<ByteArray>(), any()))
-            .thenReturn(SignedTransactionContainer(wireTransaction, signatures) to "V")
+            .thenReturn(SignedTransactionContainer(wireTransaction, signatures.toList()) to "V")
 
         whenever(utxoSignedTransactionFactory.create(any<WireTransaction>(), any())).thenReturn(expectedObj)
 
@@ -351,8 +351,8 @@ class UtxoLedgerPersistenceServiceImplTest {
             whenever(it.transactionId).thenReturn(testId)
         }
 
-        val expectedResultA = mapOf(testId to UtxoFilteredTransactionAndSignaturesImpl(utxoFilteredTransaction, listOf(signatureNotary1)))
-        val expectedResultB = mapOf(testId to UtxoFilteredTransactionAndSignaturesImpl(utxoFilteredTransaction, listOf(signatureNotary2)))
+        val expectedResultA = mapOf(testId to UtxoFilteredTransactionAndSignaturesImpl(utxoFilteredTransaction, setOf(signatureNotary1)))
+        val expectedResultB = mapOf(testId to UtxoFilteredTransactionAndSignaturesImpl(utxoFilteredTransaction, setOf(signatureNotary2)))
 
         // assert with notary composite key
         assertThat(

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.13-alpha-1714555494399
+cordaApiVersion=5.3.0.13-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
 # Change to 5.3.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.3.0.12-beta+
+cordaApiVersion=5.3.0.13-alpha-1714555494399
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoFilteredTransactionAndSignaturesImpl.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoFilteredTransactionAndSignaturesImpl.kt
@@ -12,6 +12,25 @@ data class UtxoFilteredTransactionAndSignaturesImpl(
 ) : UtxoFilteredTransactionAndSignatures {
     override fun getFilteredTransaction(): UtxoFilteredTransaction = filteredTransaction
     override fun getSignatures(): List<DigitalSignatureAndMetadata> = signatures
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as UtxoFilteredTransactionAndSignaturesImpl
+
+        if (filteredTransaction != other.filteredTransaction) return false
+        if (signatures.toSet() != other.signatures.toSet()) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = filteredTransaction.hashCode()
+        result = 31 * result + signatures.toSet().hashCode()
+        return result
+    }
+
+
 }
 
 fun UtxoFilteredTransactionAndSignatures.verifyFilteredTransactionAndSignatures(

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoFilteredTransactionAndSignaturesImpl.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoFilteredTransactionAndSignaturesImpl.kt
@@ -29,8 +29,6 @@ data class UtxoFilteredTransactionAndSignaturesImpl(
         result = 31 * result + signatures.hashCode()
         return result
     }
-
-
 }
 
 fun UtxoFilteredTransactionAndSignatures.verifyFilteredTransactionAndSignatures(

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoFilteredTransactionAndSignaturesImpl.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoFilteredTransactionAndSignaturesImpl.kt
@@ -8,10 +8,10 @@ import net.corda.v5.membership.NotaryInfo
 
 data class UtxoFilteredTransactionAndSignaturesImpl(
     private val filteredTransaction: UtxoFilteredTransaction,
-    private val signatures: List<DigitalSignatureAndMetadata>
+    private val signatures: Set<DigitalSignatureAndMetadata>
 ) : UtxoFilteredTransactionAndSignatures {
     override fun getFilteredTransaction(): UtxoFilteredTransaction = filteredTransaction
-    override fun getSignatures(): List<DigitalSignatureAndMetadata> = signatures
+    override fun getSignatures(): List<DigitalSignatureAndMetadata> = signatures.toList()
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -19,14 +19,14 @@ data class UtxoFilteredTransactionAndSignaturesImpl(
         other as UtxoFilteredTransactionAndSignaturesImpl
 
         if (filteredTransaction != other.filteredTransaction) return false
-        if (signatures.toSet() != other.signatures.toSet()) return false
+        if (signatures != other.signatures) return false
 
         return true
     }
 
     override fun hashCode(): Int {
         var result = filteredTransaction.hashCode()
-        result = 31 * result + signatures.toSet().hashCode()
+        result = 31 * result + signatures.hashCode()
         return result
     }
 

--- a/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoFilteredTransactionAndSignaturesImpl.kt
+++ b/libs/ledger/ledger-utxo-data/src/main/kotlin/net/corda/ledger/utxo/data/transaction/UtxoFilteredTransactionAndSignaturesImpl.kt
@@ -12,23 +12,6 @@ data class UtxoFilteredTransactionAndSignaturesImpl(
 ) : UtxoFilteredTransactionAndSignatures {
     override fun getFilteredTransaction(): UtxoFilteredTransaction = filteredTransaction
     override fun getSignatures(): List<DigitalSignatureAndMetadata> = signatures.toList()
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as UtxoFilteredTransactionAndSignaturesImpl
-
-        if (filteredTransaction != other.filteredTransaction) return false
-        if (signatures != other.signatures) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = filteredTransaction.hashCode()
-        result = 31 * result + signatures.hashCode()
-        return result
-    }
 }
 
 fun UtxoFilteredTransactionAndSignatures.verifyFilteredTransactionAndSignatures(

--- a/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
+++ b/notary-plugins/notary-plugin-contract-verifying/notary-plugin-contract-verifying-server/src/test/kotlin/com/r3/corda/notary/plugin/contractverifying/server/ContractVerifyingNotaryServerFlowImplTest.kt
@@ -136,7 +136,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
 
     private val filteredTxAndSignature = UtxoFilteredTransactionAndSignaturesImpl(
         filteredTransaction,
-        listOf(notarySignatureAlice)
+        setOf(notarySignatureAlice)
     )
     private val filteredTxsAndSignatures = listOf(filteredTxAndSignature)
 
@@ -261,7 +261,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         )
         val filteredTransactionSignatures = UtxoFilteredTransactionAndSignaturesImpl(
             filteredTransaction,
-            listOf(notarySignatureAlice)
+            setOf(notarySignatureAlice)
         )
         whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
             ContractVerifyingNotarizationPayload(
@@ -396,7 +396,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         whenever(filteredTransaction.outputStateAndRefs).thenReturn(mockOutputStateProof)
         val filteredTransactionsAndSignatures = UtxoFilteredTransactionAndSignaturesImpl(
             filteredTransaction,
-            listOf(notarySignatureAlice)
+            setOf(notarySignatureAlice)
         )
 
         whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
@@ -422,7 +422,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
         whenever(filteredTransaction.verify()).thenThrow(IllegalArgumentException("DUMMY ERROR"))
         val filteredTransactionsAndSignatures = UtxoFilteredTransactionAndSignaturesImpl(
             filteredTransaction,
-            listOf(notarySignatureAlice)
+            setOf(notarySignatureAlice)
         )
 
         whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
@@ -496,7 +496,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
 
         val filteredTransactionsAndSignatures = UtxoFilteredTransactionAndSignaturesImpl(
             filteredTransaction,
-            listOf(notarySignatureAlice)
+            setOf(notarySignatureAlice)
         )
 
         whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
@@ -528,7 +528,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
 
         val filteredTransactionsAndSignatures = UtxoFilteredTransactionAndSignaturesImpl(
             filteredTransaction,
-            listOf(notarySignatureAlice)
+            setOf(notarySignatureAlice)
         )
 
         whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(
@@ -561,7 +561,7 @@ class ContractVerifyingNotaryServerFlowImplTest {
 
         val filteredTransactionsAndSignatures = UtxoFilteredTransactionAndSignaturesImpl(
             filteredTransaction,
-            listOf(notarySignatureAlice)
+            setOf(notarySignatureAlice)
         )
 
         whenever(session.receive(ContractVerifyingNotarizationPayload::class.java)).thenReturn(

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -132,40 +132,20 @@ class HsqldbUtxoQueryProvider @Activate constructor(
         }
 
     // can we do it without always updating the created timestamp if the correct signatures already exist
-    override val persistTransactionSignaturesWithOnConflictDoNothing: (batchSize: Int) -> String
+    override val persistTransactionSignatures: (batchSize: Int) -> String
         get() = { batchSize ->
             """
             MERGE INTO utxo_transaction_signature AS uts
             USING (VALUES${
                 List(batchSize) {
-                    "(?, CAST(? AS INT), CAST(? AS VARBINARY(1048576)), ?, CAST(? AS TIMESTAMP))"
+                    "(?, ?, CAST(? AS VARBINARY(1048576)), CAST(? AS TIMESTAMP))"
                 }.joinToString(",")
             })
-                AS x(transaction_id, signature_idx, signature, pub_key_hash, created)
-            ON uts.transaction_id = x.transaction_id AND uts.signature_idx = x.signature_idx
+                AS x(transaction_id, pub_key_hash, signature, created)
+            ON uts.transaction_id = x.transaction_id AND uts.pub_key_hash = x.pub_key_hash
             WHEN NOT MATCHED THEN
-                INSERT (transaction_id, signature_idx, signature, pub_key_hash, created)
-                VALUES (x.transaction_id, x.signature_idx, x.signature, x.pub_key_hash, x.created)
-            """.trimIndent()
-        }
-
-    override val persistTransactionSignaturesWithOnConflictUpdate: (batchSize: Int) -> String
-        get() = { batchSize ->
-            """
-            MERGE INTO utxo_transaction_signature AS uts
-            USING (VALUES${
-                List(batchSize) {
-                    "(?, CAST(? AS INT), CAST(? AS VARBINARY(1048576)), ?, CAST(? AS TIMESTAMP))"
-                }.joinToString(",")
-            })
-                AS x(transaction_id, signature_idx, signature, pub_key_hash, created)
-            ON uts.transaction_id = x.transaction_id AND uts.signature_idx = x.signature_idx
-            WHEN MATCHED AND (pub_key_hash != x.pub_key_hash OR signature != x.signature)
-            THEN UPDATE SET uts.transaction_id = x.transaction_id, uts.signature_idx = x.signature_idx, uts.pub_key_hash = x.pub_key_hash,
-                uts.created = x.created
-            WHEN NOT MATCHED THEN
-                INSERT (transaction_id, signature_idx, signature, pub_key_hash, created)
-                VALUES (x.transaction_id, x.signature_idx, x.signature, x.pub_key_hash, x.created)
+                INSERT (transaction_id, pub_key_hash, signature, created)
+                VALUES (x.transaction_id, x.pub_key_hash, x.signature, x.created)
             """.trimIndent()
         }
 

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -131,7 +131,8 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             """.trimIndent()
         }
 
-    override val persistTransactionSignatures: (batchSize: Int) -> String
+    // can we do it without always updating the created timestamp if the correct signatures already exist
+    override val persistTransactionSignaturesWithOnConflictDoNothing: (batchSize: Int) -> String
         get() = { batchSize ->
             """
             MERGE INTO utxo_transaction_signature AS uts
@@ -142,6 +143,26 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             })
                 AS x(transaction_id, signature_idx, signature, pub_key_hash, created)
             ON uts.transaction_id = x.transaction_id AND uts.signature_idx = x.signature_idx
+            WHEN NOT MATCHED THEN
+                INSERT (transaction_id, signature_idx, signature, pub_key_hash, created)
+                VALUES (x.transaction_id, x.signature_idx, x.signature, x.pub_key_hash, x.created)
+            """.trimIndent()
+        }
+
+    override val persistTransactionSignaturesWithOnConflictUpdate: (batchSize: Int) -> String
+        get() = { batchSize ->
+            """
+            MERGE INTO utxo_transaction_signature AS uts
+            USING (VALUES${
+                List(batchSize) {
+                    "(?, CAST(? AS INT), CAST(? AS VARBINARY(1048576)), ?, CAST(? AS TIMESTAMP))"
+                }.joinToString(",")
+            })
+                AS x(transaction_id, signature_idx, signature, pub_key_hash, created)
+            ON uts.transaction_id = x.transaction_id AND uts.signature_idx = x.signature_idx
+            WHEN MATCHED AND (pub_key_hash != x.pub_key_hash OR signature != x.signature)
+            THEN UPDATE SET uts.transaction_id = x.transaction_id, uts.signature_idx = x.signature_idx, uts.pub_key_hash = x.pub_key_hash,
+                uts.created = x.created
             WHEN NOT MATCHED THEN
                 INSERT (transaction_id, signature_idx, signature, pub_key_hash, created)
                 VALUES (x.transaction_id, x.signature_idx, x.signature, x.pub_key_hash, x.created)

--- a/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
+++ b/testing/ledger/ledger-hsqldb/src/main/kotlin/net/corda/testing/ledger/utxo/HsqldbUtxoQueryProvider.kt
@@ -131,7 +131,6 @@ class HsqldbUtxoQueryProvider @Activate constructor(
             """.trimIndent()
         }
 
-    // can we do it without always updating the created timestamp if the correct signatures already exist
     override val persistTransactionSignatures: (batchSize: Int) -> String
         get() = { batchSize ->
             """

--- a/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
+++ b/testing/ledger/ledger-utxo-testkit/src/main/kotlin/net/corda/ledger/utxo/testkit/UtxoSignedTransactionExample.kt
@@ -63,6 +63,6 @@ fun getUtxoSignedTransactionExample(
         notarySignatureVerificationService,
         utxoLedgerTransactionFactory,
         wireTransaction,
-        listOf(getSignatureWithMetadataExample())
+        setOf(getSignatureWithMetadataExample())
     )
 }


### PR DESCRIPTION
Changed a number of methods to only return information about signed transactions, ensuring that filtered transactions were not leaking through in the returned data.

Doing this allowed a transaction to be sent by `sendTransaction` and `sendTransactionWithBackchain`, however, this highlighted an issue where storing a filtered transaction and then overwriting it with a signed transaction led to the transaction signatures having the wrong indexes. This caused duplicate and missing signatures (the primary issue).

To resolve the transaction signature issue, the signature table has been changed to make the `transaction_id` and `pub_key_hash` the primary key, and the `signature_idx` has been dropped altogether. This resolves the issue because a `transaction_id` and `pub_key_hash` pair will always be unique, so we can always correctly identify new signatures via the key. Conflicts will continue to be resolved by `ON CONFLICT DO NOTHING`.

Additional changes were made to change the `signatures` field in `UtxoSignedTransactionImpl` and `UtxoFilteredTransactionAndSignatures` to be a `Set` to further align with the changes made in the database.