### PR TITLE
CORE-18382 Base Flow Engine fiber timeout on flow config value

### DIFF
--- a/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
+++ b/components/flow/flow-service/src/integrationTest/kotlin/net/corda/flow/testing/context/FlowServiceTestContext.kt
@@ -118,7 +118,7 @@ class FlowServiceTestContext @Activate constructor(
         FlowConfig.PROCESSING_MAX_RETRY_DELAY to 16000,
         FlowConfig.PROCESSING_FLOW_MAPPER_CLEANUP_TIME to 30000,
         FlowConfig.PROCESSING_MAX_RETRY_WINDOW_DURATION to 300000,
-        MessagingConfig.Subscription.PROCESSOR_TIMEOUT to 60000,
+        FlowConfig.PROCESSING_FLOW_FIBER_TIMEOUT to 11250,
         MessagingConfig.MAX_ALLOWED_MSG_SIZE to 972800
     )
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
@@ -120,7 +120,7 @@ class FlowEventProcessorImpl(
     ): StateAndEventProcessor.Response<Checkpoint> {
         // flow result timeout must be lower than the processor timeout as the processor thread will be killed by the subscription consumer
         // thread after this period and so this timeout would never be reached and given a chance to return otherwise.
-        val flowTimeout = flowConfig.getLong(FlowConfig.PROCESSING_MAX_RETRY_ATTEMPTS)
+        val flowTimeout = flowConfig.getLong(FlowConfig.PROCESSING_FLOW_FIBER_TIMEOUT)
         val result = try {
             tryWithBackoff(
                 logger = log,

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImpl.kt
@@ -23,7 +23,6 @@ import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
 import net.corda.schema.configuration.FlowConfig
-import net.corda.schema.configuration.MessagingConfig.Subscription.PROCESSOR_TIMEOUT
 import net.corda.tracing.TraceContext
 import net.corda.tracing.traceStateAndEventExecution
 import net.corda.utilities.debug
@@ -121,7 +120,7 @@ class FlowEventProcessorImpl(
     ): StateAndEventProcessor.Response<Checkpoint> {
         // flow result timeout must be lower than the processor timeout as the processor thread will be killed by the subscription consumer
         // thread after this period and so this timeout would never be reached and given a chance to return otherwise.
-        val flowTimeout = (flowConfig.getLong(PROCESSOR_TIMEOUT) * 0.75).toLong()
+        val flowTimeout = flowConfig.getLong(FlowConfig.PROCESSING_MAX_RETRY_ATTEMPTS)
         val result = try {
             tryWithBackoff(
                 logger = log,

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/TestConstants.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/TestConstants.kt
@@ -4,7 +4,6 @@ import com.typesafe.config.ConfigFactory
 import net.corda.data.identity.HoldingIdentity
 import net.corda.libs.configuration.SmartConfigFactory
 import net.corda.schema.configuration.FlowConfig
-import net.corda.schema.configuration.MessagingConfig
 import net.corda.v5.base.types.MemberX500Name
 
 const val BOB_X500 = "CN=Bob, O=Bob Corp, L=LDN, C=GB"
@@ -22,7 +21,7 @@ val MINIMUM_SMART_CONFIG = SmartConfigFactory.createWithoutSecurityServices().cr
         mapOf<String, Any>(
             FlowConfig.PROCESSING_MAX_RETRY_ATTEMPTS to 5,
             FlowConfig.PROCESSING_MAX_RETRY_WINDOW_DURATION to 10000,
-            MessagingConfig.Subscription.PROCESSOR_TIMEOUT to 60000
+            FlowConfig.PROCESSING_FLOW_FIBER_TIMEOUT to 11250
         )
     )
 )

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/impl/FlowEventProcessorImplTest.kt
@@ -39,6 +39,7 @@ import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
 import net.corda.schema.Schemas.Flow.FLOW_SESSION
 import net.corda.schema.configuration.ConfigKeys.FLOW_CONFIG
+import net.corda.schema.configuration.FlowConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -206,6 +207,13 @@ class FlowEventProcessorImplTest {
             verify(flowEventPipeline).executeFlow(any())
             verify(flowEventPipeline).globalPostProcessing()
         }
+    }
+
+    @Test
+    fun `ensure the correct flow config timeout value is used`() {
+        val expectedTimeoutValue = MINIMUM_SMART_CONFIG.getLong(FlowConfig.PROCESSING_FLOW_FIBER_TIMEOUT)
+        processor.onNext(state, getFlowEventRecord(FlowEvent(flowKey, payload)))
+        verify(flowEventPipeline).executeFlow(expectedTimeoutValue)
     }
 
     @Test


### PR DESCRIPTION
### Problem
Currently, the Flow fiber timeout value is taken from `subscription.processorTimeout` messaging config which is now unrelated to the Flow Engine.

### Solution
Introduce a new value in the flow config: `processing.fiberTimeout` and replace the value in [FlowEventProcessorImpl.kt](https://github.com/corda/corda-runtime-os/pull/6106/files#diff-057116ae1069928d91003c46941b74f59b13d5cb94e112d21ff30a15663e60ea) with it.