### PR TITLE
ES-2351: 5.2 release branch versions should be bumped to 5.2.1

### DIFF
--- a/.ci/JenkinsfileCommentRebuild
+++ b/.ci/JenkinsfileCommentRebuild
@@ -6,5 +6,5 @@ cancelQueuedJobByName(env.JOB_NAME)
 
 githubCommentBuildTests(
     branch: 'release/5.2',
-    chartVersion: '^5.2.0-alpha',
+    chartVersion: '^5.2.1-alpha',
 )

--- a/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
+++ b/.ci/e2eTests/JenkinsfileEnterpriseSmokeTests
@@ -5,7 +5,7 @@
 @Library('corda-shared-build-pipeline-steps@5.2') _
 
 endToEndPipeline(
-    helmVersion: '^5.2.0-beta',
+    helmVersion: '^5.2.1-beta',
     helmRepoSuffix: 'release/ent/5.2',
     helmRepo: 'corda-ent-docker',
     dailyBuildCron: '',

--- a/.run/Combined Worker Local.run.xml
+++ b/.run/Combined Worker Local.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Combined Worker Local" type="JarApplication">
-    <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.2.0.0-SNAPSHOT.jar" />
+    <option name="JAR_PATH" value="$PROJECT_DIR$/applications/workers/release/combined-worker/build/bin/corda-combined-worker-5.2.1.0-SNAPSHOT.jar" />
     <option name="VM_PARAMETERS" value="-Dco.paralleluniverse.fibers.verifyInstrumentation=true" />
     <option name="PROGRAM_PARAMETERS" value="--instance-id=0 -mbus.busType=DATABASE -spassphrase=password -ssalt=salt -spassphrase=password -ssalt=salt -ddatabase.user=user -ddatabase.pass=password -ddatabase.jdbc.url=jdbc:postgresql://localhost:5432/cordacluster -ddatabase.jdbc.directory=$ProjectFileDir$/applications/workers/release/combined-worker/drivers -rtls.crt.path=$ProjectFileDir$/applications/workers/release/combined-worker/tls/rest/server.crt -rtls.key.path=$ProjectFileDir$/applications/workers/release/combined-worker/tls/rest/server.key -rtls.ca.crt.path=$ProjectFileDir$/applications/workers/release/combined-worker/tls/rest/ca-chain-bundle.crt" />
     <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />

--- a/applications/tools/p2p-test/app-simulator/scripts/settings.sh
+++ b/applications/tools/p2p-test/app-simulator/scripts/settings.sh
@@ -5,7 +5,7 @@
 NAMESPACE_PREFIX="${USER//./}"
 
 # Chart and Docker Image versions to deploy
-CORDA_CHART_VERSION="^5.2.0-beta"
+CORDA_CHART_VERSION="^5.2.1-beta"
 REPO_TOP_LEVEL_DIR=$(cd "$SCRIPT_DIR"; git rev-parse --show-toplevel)
 CORDA_VERSION="$(cat $REPO_TOP_LEVEL_DIR/gradle.properties | grep cordaProductVersion | awk -F= '{print $2}' | xargs).0"
 if [ -z $DOCKER_IMAGE_VERSION ]; then

--- a/charts/corda-lib/Chart.yaml
+++ b/charts/corda-lib/Chart.yaml
@@ -15,10 +15,10 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.2.0
+version: 5.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "unstable-5.2.0"
+appVersion: "unstable-5.2.1"

--- a/charts/corda/Chart.yaml
+++ b/charts/corda/Chart.yaml
@@ -15,15 +15,15 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.2.0
+version: 5.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "unstable-5.2.0"
+appVersion: "unstable-5.2.1"
 
 dependencies:
   - name: "corda-lib"
-    version: "5.2.0"
+    version: "5.2.1"
     repository: "file://../corda-lib"

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ platformVersion = 50201
 
 # Versioning constants.
 ## The release/marketing version
-cordaProductVersion=5.2.0
+cordaProductVersion=5.2.1
 ## The revision number. This lines up the versioning of the runtime-os repo with the API repo, which allows the build
 ## system to assume the same versioning scheme.
 cordaRuntimeRevision=0
@@ -38,8 +38,8 @@ commonsVersion = 1.7
 commonsLangVersion = 3.12.0
 commonsTextVersion = 1.10.0
 # Corda API libs revision (change in 4th digit indicates a breaking change)
-# Change to 5.2.0.xx-SNAPSHOT to pick up maven local published copy
-cordaApiVersion=5.2.0.52-beta+
+# Change to 5.2.1.xx-SNAPSHOT to pick up maven local published copy
+cordaApiVersion=5.2.1.52-beta+
 
 disruptorVersion=3.4.4
 felixConfigAdminVersion=1.9.26
@@ -97,7 +97,7 @@ jibCoreVersion=0.23.0
 artifactoryPluginVersion = 4.28.2
 
 # corda-cli plugin host
-pluginHostVersion=5.2.0-beta+
+pluginHostVersion=5.2.1-beta+
 systemLambdaVersion=1.2.1
 
 # DB integration tests

--- a/tools/corda-runtime-gradle-plugin/README.md
+++ b/tools/corda-runtime-gradle-plugin/README.md
@@ -7,7 +7,7 @@ Add the following extension properties
 
 ```groovy
     cordaRuntimeGradlePlugin {
-        notaryVersion = "5.2.0.0"
+        notaryVersion = "5.2.1.0"
         notaryCpiName = "NotaryServer"
         corDappCpiName = "MyCorDapp"
         cpiUploadTimeout = "30000"
@@ -85,7 +85,7 @@ services:
     ]
 
   corda:
-    image: corda-os-docker.software.r3.com/corda-os-combined-worker-kafka:5.2.0.0
+    image: corda-os-docker.software.r3.com/corda-os-combined-worker-kafka:5.2.1.0
     depends_on:
       - postgresql
       - kafka
@@ -132,7 +132,7 @@ services:
       - 5432:5432
 
   corda:
-    image: corda-os-docker.software.r3.com/corda-os-combined-worker:5.2.0.0
+    image: corda-os-docker.software.r3.com/corda-os-combined-worker:5.2.1.0
     depends_on:
       - postgresql
     environment:

--- a/tools/corda-runtime-gradle-plugin/src/integrationTest/resources/config/combined-worker-compose.yml
+++ b/tools/corda-runtime-gradle-plugin/src/integrationTest/resources/config/combined-worker-compose.yml
@@ -49,7 +49,7 @@ services:
     ]
 
   corda:
-    image: corda-os-docker.software.r3.com/corda-os-combined-worker-kafka:5.2.0.0-RC02
+    image: corda-os-docker.software.r3.com/corda-os-combined-worker-kafka:5.2.1.0-RC02
     depends_on:
       - postgresql
       - kafka

--- a/values-prereqs.yaml
+++ b/values-prereqs.yaml
@@ -17,7 +17,7 @@
 imagePullPolicy: "IfNotPresent"
 image:
   registry: "corda-os-docker-dev.software.r3.com"
-  tag: "latest-local-5.2.0"
+  tag: "latest-local-5.2.1"
 
 logging:
   format: "text"

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@
 imagePullPolicy: "IfNotPresent"
 image:
   registry: "corda-os-docker-dev.software.r3.com"
-  tag: "latest-local-5.2.0"
+  tag: "latest-local-5.2.1"
 
 logging:
   format: "text"


### PR DESCRIPTION
Now that 5.2 has shipped, we can increment the patch version to 5.2.1  on various C5 repos.