### PR TITLE
ES-2393: Remove reference from eks-e2e (e2e-tests-credentials) and replace with eks-e2e-01 (kubernetes-eks-e2e-01-credentials)

### DIFF
--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -47,7 +47,7 @@ pipeline {
         CORDA_DEV_POSTGRES_PASSWORD="${env.POSTGRES_CREDENTIALS_PSW}"
         CORDA_DEV_CLUSTER_DB_NAME="${postgresDb}"
         CORDA_USE_CACHE = "corda-remotes"
-        KUBECONFIG = credentials("e2e-tests-credentials")
+        KUBECONFIG = credentials("kubernetes-eks-e2e-01-credentials")
         CORDA_CLI_USER_HOME = "/tmp/corda-cli-home"
         CORDA_GRADLE_SCAN_KEY = credentials('gradle-build-scans-key')
         GRADLE_USER_HOME = "/host_tmp/gradle"
@@ -74,7 +74,7 @@ pipeline {
         }
         stage('create DBs') {
             environment {
-                KUBECONFIG = credentials('e2e-tests-credentials')
+                KUBECONFIG = credentials('kubernetes-eks-e2e-01-credentials')
             }
             steps {
                 script {

--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -23,7 +23,7 @@ pipeline {
     agent {
         docker {
             image 'build-zulu-openjdk:17'
-            label 'docker'
+            label 'docker-private-network'
             registryUrl 'https://engineering-docker.software.r3.com/'
             registryCredentialsId 'artifactory-credentials'
             args '-v /tmp:/host_tmp '

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -20,7 +20,7 @@ PipelineUtils pipelineUtils = new PipelineUtils(this)
 GitUtils gitUtils = new GitUtils(this)
 
 @Field
-String agentLabel = 'docker'
+String agentLabel = 'docker-private-network'
 
 if (env.CHANGE_ID || gitUtils.isReleaseTag()) {
     agentLabel = 'docker-on-demand'

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -20,10 +20,10 @@ PipelineUtils pipelineUtils = new PipelineUtils(this)
 GitUtils gitUtils = new GitUtils(this)
 
 @Field
-String agentLabel = 'docker-private-network'
+String agentLabel = 'docker'
 
 if (env.CHANGE_ID || gitUtils.isReleaseTag()) {
-    agentLabel = 'docker-on-demand'
+    agentLabel = 'docker-private-network'
 }
 
 pipeline {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -50,7 +50,7 @@ pipeline {
         CORDA_DEV_POSTGRES_PASSWORD="${env.POSTGRES_CREDENTIALS_PSW}"
         CORDA_DEV_CLUSTER_DB_NAME="${postgresDb}"
         CORDA_USE_CACHE = "corda-remotes"
-        KUBECONFIG = credentials("e2e-tests-credentials")
+        KUBECONFIG = credentials("kubernetes-eks-e2e-01-credentials")
         CORDA_CLI_USER_HOME = "/tmp/corda-cli-home"
         CORDA_GRADLE_SCAN_KEY = credentials('gradle-build-scans-key')
         GRADLE_USER_HOME = "/host_tmp/gradle"
@@ -77,7 +77,7 @@ pipeline {
         }
         stage('create DBs') {
             environment {
-                KUBECONFIG = credentials('e2e-tests-credentials')
+                KUBECONFIG = credentials('kubernetes-eks-e2e-01-credentials')
             }
             steps {
                 script {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -22,6 +22,10 @@ GitUtils gitUtils = new GitUtils(this)
 @Field
 String agentLabel = 'docker-private-network'
 
+if (env.CHANGE_ID || gitUtils.isReleaseTag()) {
+    agentLabel = 'docker-on-demand-private-network'
+}
+
 pipeline {
     agent {
         docker {

--- a/.ci/e2eTests/JenkinsfileCombinedWorker
+++ b/.ci/e2eTests/JenkinsfileCombinedWorker
@@ -20,11 +20,7 @@ PipelineUtils pipelineUtils = new PipelineUtils(this)
 GitUtils gitUtils = new GitUtils(this)
 
 @Field
-String agentLabel = 'docker'
-
-if (env.CHANGE_ID || gitUtils.isReleaseTag()) {
-    agentLabel = 'docker-private-network'
-}
+String agentLabel = 'docker-private-network'
 
 pipeline {
     agent {

--- a/.ci/patterns-lib-functional/patterns.Jenkinsfile
+++ b/.ci/patterns-lib-functional/patterns.Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_USE_CACHE = "corda-remotes"
-        KUBECONFIG=credentials("e2e-tests-credentials")
+        KUBECONFIG=credentials("kubernetes-eks-e2e-01-credentials")
         CORDA_CLI_USER_HOME="/tmp/corda-cli-home"
         GRADLE_USER_HOME = "/host_tmp/gradle"
         CORDA_REVISION = "${env.GIT_COMMIT}"

--- a/.ci/patterns-lib-functional/patterns.Jenkinsfile
+++ b/.ci/patterns-lib-functional/patterns.Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     agent {
         docker {
             image 'build-zulu-openjdk:17'
-            label 'docker'
+            label 'docker-private-network'
             registryUrl 'https://engineering-docker.software.r3.com/'
             registryCredentialsId 'artifactory-credentials'
             // Used to mount storage from the host as a volume to persist the cache between builds


### PR DESCRIPTION
Following on from the migration from eks-e2e AWS EKS cluster to eks-e2e-01  AWS EKS cluster, references to the older credentials set on Jenkins should be updated to the new credentials. 