### PR TITLE
CORE-20543 Retry sending unauthenticated message to MGM

### DIFF
--- a/components/link-manager/build.gradle
+++ b/components/link-manager/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:p2p-crypto")
     implementation project(":libs:messaging:messaging")
-    implementation project(":libs:messaging:messaging-impl")
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:configuration:configuration-core")
     implementation project(":libs:configuration:configuration-merger")

--- a/components/link-manager/build.gradle
+++ b/components/link-manager/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation project(":libs:p2p-crypto")
     implementation project(":libs:messaging:messaging")
+    implementation project(":libs:messaging:messaging-impl")
     implementation project(":libs:lifecycle:lifecycle")
     implementation project(":libs:configuration:configuration-core")
     implementation project(":libs:configuration:configuration-merger")

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
@@ -4,9 +4,11 @@ import net.corda.configuration.read.ConfigurationReadService
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.domino.logic.LifecycleWithDominoTile
+import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
 import net.corda.lifecycle.domino.logic.util.SubscriptionDominoTile
 import net.corda.membership.grouppolicy.GroupPolicyProvider
 import net.corda.membership.read.MembershipGroupReaderProvider
+import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
@@ -15,6 +17,7 @@ import net.corda.p2p.linkmanager.hosting.LinkManagerHostingMap
 import net.corda.p2p.linkmanager.delivery.DeliveryTracker
 import net.corda.schema.Schemas
 import net.corda.utilities.time.Clock
+import java.util.concurrent.Executors
 
 @Suppress("LongParameterList")
 internal class OutboundLinkManager(
@@ -31,7 +34,15 @@ internal class OutboundLinkManager(
 ) : LifecycleWithDominoTile {
     companion object {
         private const val OUTBOUND_MESSAGE_PROCESSOR_GROUP = "outbound_message_processor_group"
+        private const val OUTBOUND_MESSAGE_PROCESSOR_ID = "outbound_message_processor"
+
     }
+    private val publisher = PublisherWithDominoLogic(
+        publisherFactory,
+        lifecycleCoordinatorFactory,
+        PublisherConfig(OUTBOUND_MESSAGE_PROCESSOR_ID),
+        messagingConfiguration
+    )
     private val outboundMessageProcessor = OutboundMessageProcessor(
         commonComponents.sessionManager,
         linkManagerHostingMap,
@@ -41,8 +52,8 @@ internal class OutboundLinkManager(
         commonComponents.messagesPendingSession,
         clock,
         commonComponents.messageConverter,
-        publisherFactory,
-        messagingConfiguration,
+        publisher,
+        Executors.newSingleThreadScheduledExecutor { runnable -> Thread(runnable, OUTBOUND_MESSAGE_PROCESSOR_ID) }
     )
     private val deliveryTracker = DeliveryTracker(
         lifecycleCoordinatorFactory,
@@ -73,7 +84,11 @@ internal class OutboundLinkManager(
             deliveryTracker.dominoTile.coordinatorName,
             commonComponents.dominoTile.coordinatorName,
             commonComponents.inboundAssignmentListener.dominoTile.coordinatorName,
+            publisher.dominoTile.coordinatorName,
         ),
-        managedChildren = setOf(deliveryTracker.dominoTile.toNamedLifecycle())
+        managedChildren = setOf(
+            deliveryTracker.dominoTile.toNamedLifecycle(),
+            publisher.dominoTile.toNamedLifecycle(),
+        )
     )
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
@@ -41,6 +41,8 @@ internal class OutboundLinkManager(
         commonComponents.messagesPendingSession,
         clock,
         commonComponents.messageConverter,
+        publisherFactory,
+        messagingConfiguration,
     )
     private val deliveryTracker = DeliveryTracker(
         lifecycleCoordinatorFactory,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
@@ -87,9 +87,11 @@ internal class OutboundLinkManager(
             deliveryTracker.dominoTile.coordinatorName,
             commonComponents.dominoTile.coordinatorName,
             commonComponents.inboundAssignmentListener.dominoTile.coordinatorName,
+            publisher.dominoTile.coordinatorName,
         ),
         managedChildren = setOf(
             deliveryTracker.dominoTile.toNamedLifecycle(),
+            publisher.dominoTile.toNamedLifecycle(),
         )
     )
 
@@ -99,11 +101,9 @@ internal class OutboundLinkManager(
         onClose = { scheduledExecutor.shutdown() },
         dependentChildren = setOf(
             subscriptionTile.coordinatorName,
-            publisher.dominoTile.coordinatorName,
         ),
         managedChildren = setOf(
             subscriptionTile.toNamedLifecycle(),
-            publisher.dominoTile.toNamedLifecycle()
         )
     )
 }

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessor.kt
@@ -45,7 +45,6 @@ import java.time.Instant
 import net.corda.membership.lib.exceptions.BadGroupPolicyException
 import net.corda.messaging.api.publisher.config.PublisherConfig
 import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.messaging.utils.toRecord
 import net.corda.p2p.linkmanager.TraceableItem
 import net.corda.p2p.linkmanager.metrics.recordOutboundMessagesMetric
 import net.corda.p2p.linkmanager.metrics.recordOutboundSessionMessagesMetric
@@ -290,7 +289,17 @@ internal class OutboundMessageProcessor(
             scheduledExecutor.schedule(
                 {
                     logger.debug { "Republishing outbound unauthenticated message '$messageId'." }
-                    publisher.publish(listOf(toRecord()))
+                    publisher.publish(
+                        listOf(
+                            Record(
+                                topic = this.topic,
+                                key = this.key,
+                                value = this.value,
+                                timestamp = this.timestamp,
+                                headers = this.headers
+                            )
+                        )
+                    )
                 },
                 delay,
                 TimeUnit.MILLISECONDS,

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
@@ -821,7 +821,7 @@ class OutboundMessageProcessorTest {
         )
 
         val publishCaptor = argumentCaptor<Runnable>()
-        verify(scheduledExecutorService).schedule(publishCaptor.capture(), eq(1000L), eq(TimeUnit.MILLISECONDS))
+        verify(scheduledExecutorService).schedule(publishCaptor.capture(), eq(500L), eq(TimeUnit.MILLISECONDS))
         publishCaptor.firstValue.run()
         verify(publisher).publish(listOf(Record(Schemas.P2P.P2P_OUT_TOPIC, "key", appMessage)))
     }

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/outbound/OutboundMessageProcessorTest.kt
@@ -1,8 +1,6 @@
 package net.corda.p2p.linkmanager.outbound
 
 import net.corda.data.identity.HoldingIdentity
-import net.corda.membership.grouppolicy.GroupPolicyProvider
-import net.corda.messaging.api.records.EventLogRecord
 import net.corda.data.p2p.AuthenticatedMessageAndKey
 import net.corda.data.p2p.LinkOutMessage
 import net.corda.data.p2p.SessionPartitions
@@ -14,20 +12,26 @@ import net.corda.data.p2p.app.InboundUnauthenticatedMessageHeader
 import net.corda.data.p2p.app.MembershipStatusFilter
 import net.corda.data.p2p.app.OutboundUnauthenticatedMessage
 import net.corda.data.p2p.app.OutboundUnauthenticatedMessageHeader
+import net.corda.data.p2p.markers.AppMessageMarker
+import net.corda.data.p2p.markers.LinkManagerDiscardedMarker
+import net.corda.data.p2p.markers.LinkManagerProcessedMarker
+import net.corda.data.p2p.markers.LinkManagerReceivedMarker
+import net.corda.data.p2p.markers.TtlExpiredMarker
+import net.corda.lifecycle.domino.logic.util.PublisherWithDominoLogic
+import net.corda.membership.grouppolicy.GroupPolicyProvider
+import net.corda.membership.lib.exceptions.BadGroupPolicyException
+import net.corda.messaging.api.records.EventLogRecord
+import net.corda.messaging.api.records.Record
 import net.corda.p2p.crypto.protocol.api.AuthenticatedSession
 import net.corda.p2p.crypto.protocol.api.AuthenticationResult
+import net.corda.p2p.linkmanager.TraceableItem
+import net.corda.p2p.linkmanager.common.MessageConverter
 import net.corda.p2p.linkmanager.hosting.LinkManagerHostingMap
 import net.corda.p2p.linkmanager.inbound.InboundAssignmentListener
+import net.corda.p2p.linkmanager.membership.NetworkMessagingValidator
 import net.corda.p2p.linkmanager.sessions.PendingSessionMessageQueues
 import net.corda.p2p.linkmanager.sessions.SessionManager
 import net.corda.p2p.linkmanager.utilities.mockMembersAndGroups
-import net.corda.data.p2p.markers.AppMessageMarker
-import net.corda.data.p2p.markers.LinkManagerDiscardedMarker
-import net.corda.data.p2p.markers.LinkManagerReceivedMarker
-import net.corda.data.p2p.markers.LinkManagerProcessedMarker
-import net.corda.data.p2p.markers.TtlExpiredMarker
-import net.corda.libs.configuration.SmartConfig
-import net.corda.p2p.linkmanager.membership.NetworkMessagingValidator
 import net.corda.schema.Schemas
 import net.corda.test.util.identity.createTestHoldingIdentity
 import net.corda.test.util.time.MockTimeFacilitiesProvider
@@ -38,22 +42,18 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.nio.ByteBuffer
 import java.time.Instant
-import net.corda.membership.lib.exceptions.BadGroupPolicyException
-import net.corda.messaging.api.publisher.Publisher
-import net.corda.messaging.api.publisher.factory.PublisherFactory
-import net.corda.messaging.api.records.Record
-import net.corda.p2p.linkmanager.TraceableItem
-import net.corda.p2p.linkmanager.common.MessageConverter
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doThrow
-import org.mockito.kotlin.eq
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 
 class OutboundMessageProcessorTest {
     private val myIdentity = createTestHoldingIdentity("CN=PartyA, O=Corp, L=LDN, C=GB", "Group")
@@ -90,11 +90,8 @@ class OutboundMessageProcessorTest {
         on { validateInbound(any(), any()) } doReturn Either.Left(Unit)
         on { validateOutbound(any(), any()) } doReturn Either.Left(Unit)
     }
-    private val messagingConfig = mock<SmartConfig>()
-    private val publisher = mock<Publisher>()
-    private val publisherFactory = mock<PublisherFactory> {
-        on { createPublisher(any(), eq(messagingConfig)) } doReturn publisher
-    }
+    private val publisher = mock<PublisherWithDominoLogic>()
+    private val scheduledExecutorService = mock<ScheduledExecutorService>()
 
     private val processor = OutboundMessageProcessor(
         sessionManager,
@@ -105,8 +102,8 @@ class OutboundMessageProcessorTest {
         messagesPendingSession,
         mockTimeFacilitiesProvider.clock,
         messageConverter,
-        publisherFactory,
-        messagingConfig,
+        publisher,
+        scheduledExecutorService,
         networkMessagingValidator,
     )
 
@@ -615,8 +612,8 @@ class OutboundMessageProcessorTest {
             messagesPendingSession,
             mockTimeFacilitiesProvider.clock,
             messageConverter,
-            publisherFactory,
-            messagingConfig,
+            publisher,
+            scheduledExecutorService,
             networkMessagingValidator,
         )
 
@@ -662,8 +659,8 @@ class OutboundMessageProcessorTest {
             messagesPendingSession,
             mockTimeFacilitiesProvider.clock,
             messageConverter,
-            publisherFactory,
-            messagingConfig,
+            publisher,
+            scheduledExecutorService,
             networkMessagingValidator,
         )
 
@@ -792,6 +789,41 @@ class OutboundMessageProcessorTest {
         )
 
         assertThat(records).isEmpty()
+    }
+
+    @Test
+    fun `dropped outbound unauthenticated messages are scheduled to be republished`() {
+        whenever(
+            networkMessagingValidator.validateOutbound(any(), any())
+        ).doReturn(Either.Right("foo-bar"))
+        val payload = "test"
+        val unauthenticatedMsg = OutboundUnauthenticatedMessage(
+            OutboundUnauthenticatedMessageHeader(
+                remoteIdentity.toAvro(),
+                localIdentity.toAvro(),
+                "subsystem",
+                "messageId",
+            ),
+            ByteBuffer.wrap(payload.toByteArray()),
+        )
+        val appMessage = AppMessage(unauthenticatedMsg)
+
+        processor.onNext(
+            listOf(
+                EventLogRecord(
+                    Schemas.P2P.P2P_OUT_TOPIC,
+                    "key",
+                    appMessage,
+                    1,
+                    0
+                )
+            )
+        )
+
+        val publishCaptor = argumentCaptor<Runnable>()
+        verify(scheduledExecutorService).schedule(publishCaptor.capture(), eq(1000L), eq(TimeUnit.MILLISECONDS))
+        publishCaptor.firstValue.run()
+        verify(publisher).publish(listOf(Record(Schemas.P2P.P2P_OUT_TOPIC, "key", appMessage)))
     }
 
     @Test

--- a/tools/plugins/network/src/pluginSmokeTest/kotlin/net/corda/cli/plugins/network/OnboardMemberTest.kt
+++ b/tools/plugins/network/src/pluginSmokeTest/kotlin/net/corda/cli/plugins/network/OnboardMemberTest.kt
@@ -13,13 +13,11 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import picocli.CommandLine
 import java.io.File
 import java.util.UUID
 
-@Disabled
 class OnboardMemberTest {
     companion object {
         private const val CPB_FILE = "test-cordapp.cpb"


### PR DESCRIPTION
An outbound unauthenticated message (only sent during first-time communication from member to MGM) is dropped if the MGM-info has not propagated through to the group reader after it has been published by the registration service. Although the membership worker retries registration when it does not hear back from the MGM after 40 seconds, this delay causes test pipelines to fail. This change implements retries on the link manager worker so that the message is scheduled to be republished to `p2p.out` (up to 3 times with backoff logic).

```
2024-05-16 13:30:00.686 [durable processing thread outbound_message_processor_group-p2p.out] DEBUG net.corda.p2p.linkmanager.outbound.OutboundMessageProcessor {} - Processing outbound message Register-EB059D0A11A6-4433503c-119a-4928-9f7b-a03c0b5a5f89 to {"x500Name": "O=MGM-a0095d72-c4b2-42ff-9097-f2da9c3bdb3a, L=London, C=GB", "groupId": "731a2865-a260-4a21-8d90-a2274eb24615"}.
2024-05-16 13:30:00.690 [durable processing thread outbound_message_processor_group-p2p.out] WARN  net.corda.p2p.linkmanager.outbound.OutboundMessageProcessor {} - Dropping outbound unauthenticated message Register-EB059D0A11A6-4433503c-119a-4928-9f7b-a03c0b5a5f89 from {"x500Name": "O=Member-df3b2804-eb13-4c0f-af44-fa5d9f321cd2, L=London, C=GB", "groupId": "731a2865-a260-4a21-8d90-a2274eb24615"} to {"x500Name": "O=MGM-a0095d72-c4b2-42ff-9097-f2da9c3bdb3a, L=London, C=GB", "groupId": "731a2865-a260-4a21-8d90-a2274eb24615"} as the network membership status for the source identity (with name O=Member-df3b2804-eb13-4c0f-af44-fa5d9f321cd2, L=London, C=GB in group O=Member-df3b2804-eb13-4c0f-af44-fa5d9f321cd2, L=London, C=GB) is (null) and the destination's (with name O=MGM-a0095d72-c4b2-42ff-9097-f2da9c3bdb3a, L=London, C=GB in group 731a2865-a260-4a21-8d90-a2274eb24615) network membership status is (null).
2024-05-16 13:30:01.690 [OutboundMessageProcessor] DEBUG net.corda.p2p.linkmanager.outbound.OutboundMessageProcessor {} - Republishing outbound unauthenticated message 'Register-EB059D0A11A6-4433503c-119a-4928-9f7b-a03c0b5a5f89'.
2024-05-16 13:30:01.705 [durable processing thread outbound_message_processor_group-p2p.out] DEBUG net.corda.p2p.linkmanager.outbound.OutboundMessageProcessor {} - Processing outbound message Register-EB059D0A11A6-4433503c-119a-4928-9f7b-a03c0b5a5f89 to {"x500Name": "O=MGM-a0095d72-c4b2-42ff-9097-f2da9c3bdb3a, L=London, C=GB", "groupId": "731a2865-a260-4a21-8d90-a2274eb24615"}.

```

Re-enabled combined worker plugin smoke tests: [link](https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os-combined-worker-plugins-smoke-tests/view/change-requests/job/PR-6140/)
Multi-cluster E2E tests: [link](https://ci02.dev.r3.com/job/Corda5/job/corda-e2e-tests-multi-cluster-tests/job/yash%252F5.2%252Ftest/4/)