### PR TITLE
CORE-20548 add verbose mode to json blob inspector

### DIFF
--- a/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/Command.kt
+++ b/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/Command.kt
@@ -32,8 +32,7 @@ class Command : Callable<Int> {
 
     override fun call(): Int {
         val bytes = (inputFile?.let { FileInputStream(it) } ?: System.`in`).readFully().sequence()
-        val (decoded, description) = Encoding.decodedBytes(bytes, includeOriginalBytes, beVerbose, encoding, encodingStart, format)
-        if (description != null) println(description)
+        val decoded = Encoding.decodedBytes(bytes, includeOriginalBytes, beVerbose, encoding, encodingStart, format)
         println(decoded.result.prettyPrint())
         return 0
     }

--- a/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/Command.kt
+++ b/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/Command.kt
@@ -27,9 +27,13 @@ class Command : Callable<Int> {
     @CommandLine.Option(names = ["-b", "--skipWritingBytes"], description = ["Skip writing original bytes."])
     var includeOriginalBytes: Boolean = true
 
+    @CommandLine.Option(names = ["-v", "--verbose"], description = ["Show more information about the json."])
+    var beVerbose: Boolean = false
+
     override fun call(): Int {
         val bytes = (inputFile?.let { FileInputStream(it) } ?: System.`in`).readFully().sequence()
-        val decoded = Encoding.decodedBytes(bytes, includeOriginalBytes, encoding, encodingStart, format)
+        val (decoded, description) = Encoding.decodedBytes(bytes, includeOriginalBytes, beVerbose, encoding, encodingStart, format)
+        if (description != null) println(description)
         println(decoded.result.prettyPrint())
         return 0
     }

--- a/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/SerializationFormatDecoder.kt
+++ b/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/SerializationFormatDecoder.kt
@@ -3,6 +3,12 @@ package net.corda.blobinspector
 import java.io.InputStream
 
 interface SerializationFormatDecoder {
-    fun decode(stream: InputStream, recurseDepth: Int, originalBytes: ByteArray, includeOriginalBytes: Boolean): DecodedBytes
+    fun decode(
+        stream: InputStream,
+        recurseDepth: Int,
+        originalBytes: ByteArray,
+        includeOriginalBytes: Boolean,
+        beVerbose: Boolean
+    ): DecodedBytes
     fun duplicate(): SerializationFormatDecoder
 }

--- a/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/kryo/KryoSerializationFormatDecoder.kt
+++ b/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/kryo/KryoSerializationFormatDecoder.kt
@@ -5,7 +5,13 @@ import net.corda.blobinspector.SerializationFormatDecoder
 import java.io.InputStream
 
 class KryoSerializationFormatDecoder : SerializationFormatDecoder {
-    override fun decode(stream: InputStream, recurseDepth: Int, originalBytes: ByteArray, includeOriginalBytes: Boolean): DecodedBytes {
+    override fun decode(
+        stream: InputStream,
+        recurseDepth: Int,
+        originalBytes: ByteArray,
+        includeOriginalBytes: Boolean,
+        beVerbose: Boolean
+    ): DecodedBytes {
         TODO("Not yet implemented")
     }
 

--- a/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/metadata/MetadataSerializationFormatDecoder.kt
+++ b/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/metadata/MetadataSerializationFormatDecoder.kt
@@ -9,21 +9,26 @@ import net.corda.blobinspector.sequence
 import java.io.InputStream
 
 class MetadataSerializationFormatDecoder(
-    private val recurse: (ByteSequence, Int, Boolean) -> Any?,
+    private val recurse: (ByteSequence, Int, Boolean, Boolean) -> Any?,
     private val hasHeader: Boolean
 ) : SerializationFormatDecoder {
     override fun duplicate(): SerializationFormatDecoder {
         return MetadataSerializationFormatDecoder(recurse, hasHeader)
     }
 
-    override fun decode(stream: InputStream, recurseDepth: Int, originalBytes: ByteArray, includeOriginalBytes: Boolean): DecodedBytes {
+    override fun decode(
+        stream: InputStream,
+        recurseDepth: Int,
+        originalBytes: ByteArray,
+        includeOriginalBytes: Boolean,
+        beVerbose: Boolean
+    ): DecodedBytes {
         val bytes = stream.readFully()
         val (version, jsonBytes) = extractVersionAndBytes(bytes)
-        println("Metadata schema version = $version")
         val objectMapper = ObjectMapper()
         val jsonMap = objectMapper.readValue(jsonBytes.decodeToString(), Map::class.java)
 
-        val rendering: MutableMap<String, Any?> = mutableMapOf("_value" to jsonMap)
+        val rendering: MutableMap<String, Any?> = mutableMapOf("_value" to jsonMap, "_version" to version)
         if (includeOriginalBytes) {
             rendering["_bytes"] = originalBytes
         }

--- a/applications/tools/universal-blob-inspector/src/test/kotlin/net/corda/blobinspector/AppTest.kt
+++ b/applications/tools/universal-blob-inspector/src/test/kotlin/net/corda/blobinspector/AppTest.kt
@@ -11,49 +11,49 @@ class AppTest {
 
     @Test
     fun parseCashSignedTransaction() {
-        val(exitCode, output) = runInSeparateJVM("cash-stx-db.blob")
+        val(exitCode, output) = runInSeparateJVM("cash-stx-db.blob", listOf("-v"))
         assertTrue(exitCode == 0)
         assertTrue(output.contains("Corda OS 4+ / ENT 3+ AMQP"))
     }
 
     @Test
     fun parseCashWireTransaction() {
-        val(exitCode, output) = runInSeparateJVM("cash-wtx.blob")
+        val(exitCode, output) = runInSeparateJVM("cash-wtx.blob", listOf("-v"))
         assertTrue(exitCode == 0)
         assertTrue(output.contains("Corda OS 4+ / ENT 3+ AMQP"))
     }
 
     @Test
     fun parseNetworkParameters() {
-        val(exitCode, output) = runInSeparateJVM("network-parameters")
+        val(exitCode, output) = runInSeparateJVM("network-parameters", listOf("-v"))
         assertTrue(exitCode == 0)
         assertTrue(output.contains("Corda OS 4+ / ENT 3+ AMQP"))
     }
 
     @Test
     fun parseNetworkNodeInfo() {
-        val(exitCode, output) = runInSeparateJVM("node-info")
+        val(exitCode, output) = runInSeparateJVM("node-info", listOf("-v"))
         assertTrue(exitCode == 0)
         assertTrue(output.contains("Corda OS 4+ / ENT 3+ AMQP"))
     }
 
     @Test
     fun parseOlderCpk() {
-        val(exitCode, output) = runInSeparateJVM("OlderCpk.bin")
+        val(exitCode, output) = runInSeparateJVM("OlderCpk.bin", listOf("-v"))
         assertTrue(exitCode == 0)
         assertTrue(output.contains("Corda 5 GA AMQP"))
     }
 
     @Test
     fun parseUpgradingCpk() {
-        val(exitCode, output) = runInSeparateJVM("UpgradingCpk.bin")
+        val(exitCode, output) = runInSeparateJVM("UpgradingCpk.bin", listOf("-v"))
         assertTrue(exitCode == 0)
         assertTrue(output.contains("Corda 5 GA AMQP"))
     }
 
     @Test
     fun parseC5WireTx() {
-        val(exitCode, output) = runInSeparateJVM("C5WireTx.bin")
+        val(exitCode, output) = runInSeparateJVM("C5WireTx.bin", listOf("-v"))
         assertTrue(exitCode == 0)
         assertTrue(output.contains("Corda 5 GA AMQP"))
     }
@@ -62,14 +62,15 @@ class AppTest {
     fun parseMetadataV0() {
         val(exitCode, output) = runInSeparateJVM("metadatav0.bin")
         assertTrue(exitCode == 0)
-        assertTrue(output.contains("Metadata schema version = 00"))
+        assertTrue(output.contains("\"_version\" : \"00\""))
     }
 
     @Test
     fun parseMetadataV1() {
         val(exitCode, output) = runInSeparateJVM("metadatav1.bin")
+        println("output:\n$output")
         assertTrue(exitCode == 0)
-        assertTrue(output.contains("Metadata schema version = 01"))
+        assertTrue(output.contains("\"_version\" : \"01\""))
     }
 
     @Test
@@ -84,6 +85,13 @@ class AppTest {
         val(exitCode, output) = runInSeparateJVM("C5WireTx.bin")
         assertTrue(exitCode == 0)
         assertTrue(output.contains("_bytes"))
+    }
+
+    @Test
+    fun runNonVerboseMode() {
+        val(exitCode, output) = runInSeparateJVM("C5WireTx.bin")
+        assertTrue(exitCode == 0)
+        assertTrue(output.startsWith("{"))
     }
 
     private fun runInSeparateJVM(binaryFileName: String, flags: List<String> = emptyList()): Pair<Int, String> {


### PR DESCRIPTION
- added `_version` for tx metadata
- added print line for overridden encoding
- without `-v` flag, only json will be printed

**with -v flag**
```
Primary encoding Corda OS 4+ / ENT 3+ AMQP
{
  "_value" : {
    "_class" : "net.corda.core.transactions.WireTransaction",
    "componentGroups" : [ {
      "_class" : "net.corda.core.transactions.ComponentGroup",
      "components" : [ {
        "_class" : "net.corda.core.serialization.SerializedBytes",
        "bytes" : "({_value={_class=net.corda.core.contracts.StateRef, index=0, txhash={_class=net.corda.core.crypto.SecureHash$SHA256, bytes=[7983AD452C6E19DAA7909B7A4953033A8F88B066C540E08294DD3BC48572CF55]}}, _bytes=[B@9f116cc}, Primary encoding Corda OS 4+ / ENT 3+ AMQP)"
      } ],
      "groupIndex" : 0
    }
...
```
**without -v flag**
```
{
  "_value" : {
    "_class" : "net.corda.core.transactions.WireTransaction",
    "componentGroups" : [ {
      "_class" : "net.corda.core.transactions.ComponentGroup",
      "components" : [ {
        "_class" : "net.corda.core.serialization.SerializedBytes",
        "bytes" : "({_value={_class=net.corda.core.contracts.StateRef, index=0, txhash={_class=net.corda.core.crypto.SecureHash$SHA256, bytes=[7983AD452C6E19DAA7909B7A4953033A8F88B066C540E08294DD3BC48572CF55]}}, _bytes=[B@67d48005}, null)"
      } ],
      "groupIndex" : 0
    }
...
```