### PR TITLE
CORE-8856 Adding lambda to suspendible function to trigger bug

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/ledger/UtxoLedgerTests.kt
@@ -25,6 +25,7 @@ import net.corda.e2etest.utilities.startRestFlow
 import net.corda.v5.crypto.SecureHash
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.api.TestInstance
@@ -109,7 +110,7 @@ class UtxoLedgerTests : ClusterReadiness by ClusterReadinessChecker() {
     }
 
 
-    @Test
+    @RepeatedTest(100)
     fun `Utxo Ledger - create a transaction containing states and finalize it then evolve it`(testInfo: TestInfo) {
         val idGenerator = TestRequestIdGenerator(testInfo)
         val input = "test input"

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -16,6 +16,7 @@ import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionInternal
 import net.corda.ledger.utxo.flow.impl.transaction.UtxoSignedTransactionWithDependencies
 import net.corda.sandbox.CordaSystemFlow
 import net.corda.utilities.debug
+import net.corda.utilities.info
 import net.corda.utilities.trace
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.flows.CordaInject
@@ -122,7 +123,7 @@ class UtxoFinalityFlowV1(
     @Suspendable
     private fun persistUnverifiedTransaction() {
         persistenceService.persist(initialTransaction, TransactionStatus.UNVERIFIED)
-        log.debug { "Recorded transaction with initial signatures $transactionId" }
+        log.info { "Recorded transaction with initial signatures $transactionId" }
     }
 
     // Send initialTransaction, transferAdditionalSignatures, and filteredTransactionsAndSignatures

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -285,7 +285,7 @@ class UtxoFinalityFlowV1(
             if (log.isTraceEnabled) {
                 log.info {
                     "Notarizing transaction $transactionId using pluggable notary client flow of " +
-                            "${notarizationFlow::class.java.name} with notary $notary. Attempt number $attemptNumber"
+                        "${notarizationFlow::class.java.name} with notary $notary. Attempt number $attemptNumber"
                 }
             }
             flowEngine.subFlow(notarizationFlow)
@@ -301,13 +301,13 @@ class UtxoFinalityFlowV1(
             } catch (e: NotaryExceptionGeneral) {
                 log.info {
                     "Received general error from notarization for transaction: ${transaction.id} on attempt: $attemptNumber. " +
-                            "Error: ${e.message} Retrying notarisation."
+                        "Error: ${e.message} Retrying notarisation."
                 }
                 continue
             } catch (e: NotaryExceptionUnknown) {
                 log.info {
                     "Received unknown error from notarization for transaction: ${transaction.id} on attempt: $attemptNumber. " +
-                            "Error: ${e.message} Retrying notarisation."
+                        "Error: ${e.message} Retrying notarisation."
                 }
                 continue
             } catch (e: CordaRuntimeException) {
@@ -322,7 +322,7 @@ class UtxoFinalityFlowV1(
                     Payload.Failure<List<DigitalSignatureAndMetadata>>(message, failureReason.value),
                     sessions.toSet()
                 )
-                log.info{ message }
+                log.info { message }
                 throw e
             }
         }
@@ -330,14 +330,14 @@ class UtxoFinalityFlowV1(
         if (log.isTraceEnabled) {
             log.info {
                 "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of transaction " +
-                        transactionId
+                    transactionId
             }
         }
 
         if (notarySignatures.isEmpty()) {
             val message =
                 "Notary $notary did not return any signatures after requesting notarization of transaction $transactionId"
-            log.info{ message }
+            log.info { message }
             persistInvalidTransaction(transaction)
             flowMessaging.sendAll(
                 Payload.Failure<List<DigitalSignatureAndMetadata>>(

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -366,9 +366,9 @@ class UtxoFinalityFlowV1(
         }
 
         if (log.isDebugEnabled) {
-            log.debug(
+            log.debug {
                 "Successfully notarized transaction $transactionId using notary $notary and received ${notarySignatures.size} signature(s)"
-            )
+            }
         }
 
         return notarizedTransaction to notarySignatures

--- a/libs/utilities/src/main/kotlin/net/corda/utilities/KotlinUtils.kt
+++ b/libs/utilities/src/main/kotlin/net/corda/utilities/KotlinUtils.kt
@@ -25,6 +25,10 @@ inline fun Logger.debug(msg: () -> String) {
     if (isDebugEnabled) debug(msg())
 }
 
+inline fun Logger.info(msg: () -> String) {
+    info(msg())
+}
+
 /**
  * Extension method for easier construction of [Duration]s in terms of integer days: `val twoDays = 2.days`.
  * @see Duration.ofDays


### PR DESCRIPTION
During the development of `5.0`, we were seeing flows failing with the error `java.lang.VerifyError: Bad local variable type`. It was discovered that this was triggered by lambda functions being used within suspendible functions.

The root cause was then discovered to be a difference in how JVM and ASM store local variables in the frame, which caused the previous exception to be thrown when a function was suspended and resumed. A bug was raised against the maintainers of ASM [HERE](https://gitlab.ow2.org/asm/asm/-/issues/317991), and I see that this has now been actioned.

This PR adds a lambda to a suspendible function in an attempt to trigger the previous issue, or to show that the fix to ASM has resolved it. **It needs not be merged; it's intended only as an investigation.**