### PR TITLE
CORE-20434: Remove rest and crypto cluster-level tenants from the docs

### DIFF
--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/KeyRotationRestResource.kt
@@ -27,8 +27,8 @@ interface KeyRotationRestResource : RestResource {
     /**
      * The [getKeyRotationStatus] gets the latest key rotation status for [tenantId] if one exists.
      *
-     * @param tenantId Can either be a holding identity ID, the value 'master' for master wrapping key or one of the
-     *       values 'p2p', 'rest', 'crypto' for corresponding cluster-level services.
+     * @param tenantId Can either be a holding identity ID, the value 'master' for master wrapping key, or the value
+     *      'p2p' for a cluster-level tenant of the P2P services.
      *
      * @return Total number of keys which need rotating grouped by tenantId or tenantId's wrapping keys and
      *      the number of already re-wrapped keys.
@@ -41,17 +41,17 @@ interface KeyRotationRestResource : RestResource {
         responseDescription = "Number of keys which need rotating grouped by tenantId or tenantId's wrapping keys.",
     )
     fun getKeyRotationStatus(
-        @RestPathParameter(description = "Can either be a holding identity ID, the value 'master' for master wrapping " +
-                "key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' "+
-                "tenant ID does not support key rotation and should not be used.")
+        @RestPathParameter(description = "Can either be a holding identity ID, the value 'master' for master " +
+                "wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services"
+        )
         tenantId: String
     ): KeyRotationStatusResponse
 
     /**
      * Initiates a master wrapping key, a cluster-level tenant wrapping key or a vNode wrapping key rotation process.
      *
-     * @param tenantId Can either be a holding identity ID, the value 'master' for master wrapping key or one of the
-     *       values 'p2p', 'rest', 'crypto' for corresponding cluster-level services.
+     * @param tenantId Can either be a holding identity ID, the value 'master' for master wrapping key, or the value
+     *      'p2p' for a cluster-level tenant of the P2P services.
      *
      * @return Key rotation response where the requestId is the unique ID for the key rotation start request.
      *
@@ -67,9 +67,9 @@ interface KeyRotationRestResource : RestResource {
         successCode = SC_ACCEPTED,
     )
     fun startKeyRotation(
-        @RestPathParameter(description = "Can either be a holding identity ID, the value 'master' for master wrapping " +
-                "key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the" +
-                " 'p2p' tenant ID does not support key rotation and should not be used.")
+        @RestPathParameter(description = "Can either be a holding identity ID, the value 'master' for master " +
+                "wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services"
+        )
         tenantId: String
     ): ResponseEntity<KeyRotationResponse>
 }

--- a/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
+++ b/components/crypto/crypto-rest/src/main/kotlin/net/corda/crypto/rest/response/KeyRotationStatusResponse.kt
@@ -5,8 +5,8 @@ import java.time.Instant
 /**
  * The result of a key rotation status request.
  *
- * @param tenantId Either a holding identity ID, the value 'master' for master wrapping key or one of the values
-*          'p2p', 'rest', 'crypto' for corresponding cluster-level tenant.
+ * @param tenantId Can either be a holding identity ID, the value 'master' for master wrapping key, or the value
+ *      'p2p' for a cluster-level tenant of the P2P services.
  * @param status Overall status of the key rotation. Either In Progress or Done.
  * @param rotationInitiatedTimestamp Timestamp of when the key rotation request was received.
  * @param lastUpdatedTimestamp The last updated timestamp.

--- a/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/TenantInfoService.kt
+++ b/components/crypto/crypto-softhsm-impl/src/main/kotlin/net/corda/crypto/softhsm/TenantInfoService.kt
@@ -15,7 +15,7 @@ interface TenantInfoService {
     /**
      * Populate settings for a specific category on a specific tenant, and return those settings.
      * 
-     * @param tenantId the tenant (virtual node or special purpose cluster level 
+     * @param tenantId the tenant (virtual node or special purpose cluster-level tenant)
      * @param category indicates what the keys will be used for, and should be one of the constants 
      *                 defined in CryptoConsts.Categories
      * @param cryptoService a reference to the crypto service, which is used to allocate a wrapping key

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificateRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificateRestResource.kt
@@ -268,8 +268,8 @@ interface CertificateRestResource : RestResource {
      * subjectAlternativeNames = ["localhost"], contextMap = {"signatureSpec": "SHA256withECDSA"})
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param keyId Identifier of the public key that will be included in the certificate.
      * @param x500Name The X.500 name that will be the subject associated with the request.
      * @param subjectAlternativeNames Optional. Used to specify additional subject names.
@@ -285,8 +285,8 @@ interface CertificateRestResource : RestResource {
     )
     fun generateCsr(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(description = "Identifier of the public key that will be included in the certificate")

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificatesRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/CertificatesRestResource.kt
@@ -274,8 +274,8 @@ interface CertificatesRestResource : RestResource {
      * subjectAlternativeNames = ["localhost"], contextMap = {"signatureSpec": "SHA256withECDSA"})
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param keyId Identifier of the public key that will be included in the certificate.
      * @param x500Name The X.500 name that will be the subject associated with the request.
      * @param subjectAlternativeNames Optional. Used to specify additional subject names.
@@ -291,8 +291,8 @@ interface CertificatesRestResource : RestResource {
     )
     fun generateCsr(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(description = "Identifier of the public key that will be included in the certificate")

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/HsmRestResource.kt
@@ -30,8 +30,8 @@ interface HsmRestResource : RestResource {
      * hsmOps.assignedHsm(tenantId = "p2p", category = "TLS")
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param category The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT',
      * 'TLS', or 'JWT_KEY'.
      *
@@ -52,8 +52,8 @@ interface HsmRestResource : RestResource {
     )
     fun assignedHsm(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(
@@ -74,8 +74,8 @@ interface HsmRestResource : RestResource {
      * hsmOps.assignSoftHsm(tenantId = "p2p", category = "CI")
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param category The category of the HSM; can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT',
      * 'TLS', or 'JWT_KEY'.
      *
@@ -96,8 +96,8 @@ interface HsmRestResource : RestResource {
     )
     fun assignSoftHsm(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/KeyRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/KeyRestResource.kt
@@ -34,11 +34,11 @@ interface KeyRestResource : RestResource {
      * ```
      * keysOps.listSchemes(tenantId = "58B6030FABDD", hsmCategory = "SESSION_INIT")
      *
-     * keysOps.listSchemes(tenantId = "rest", hsmCategory = "SESSION_INIT")
+     * keysOps.listSchemes(tenantId = "p2p", hsmCategory = "SESSION_INIT")
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param hsmCategory Can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT', 'TLS', or 'JWT_KEY'.
      *
      * @return The list of scheme codes which are supported by the associated HSM integration.
@@ -50,8 +50,8 @@ interface KeyRestResource : RestResource {
     )
     fun listSchemes(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(
@@ -83,8 +83,8 @@ interface KeyRestResource : RestResource {
      * ids = ["3B9A266F96E2", "4A9A266F96E2"])
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param skip Optional. The response paging information, number of records to skip.
      * @param take Optional. The response paging information, that is, the number of records to return. The actual
      * number returned may be less than requested.
@@ -114,8 +114,8 @@ interface KeyRestResource : RestResource {
     @Suppress("LongParameterList")
     fun listKeys(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestQueryParameter(
@@ -194,8 +194,8 @@ interface KeyRestResource : RestResource {
      * keysOps.generateKeyPair(tenantId = "p2p", alias = "alias", hsmCategory = "TLS", scheme = "CORDA.RSA")
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param alias The alias under which the new key pair will be stored.
      * @param hsmCategory Category of the HSM which handles the key pairs. Can be one of 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY',
      * 'SESSION_INIT', 'TLS', 'JWT_KEY'.
@@ -211,8 +211,8 @@ interface KeyRestResource : RestResource {
     )
     fun generateKeyPair(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(
@@ -239,11 +239,11 @@ interface KeyRestResource : RestResource {
      * ```
      * keysOps.generateKeyPem(tenantId = "58B6030FABDD", keyId = "3B9A266F96E2")
      *
-     * keysOps.generateKeyPem(tenantId = "rest", keyId = "3B9A266F96E2")
+     * keysOps.generateKeyPem(tenantId = "p2p", keyId = "3B9A266F96E2")
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param keyId Identifier of the public key to be retrieved.
      *
      * @return The public key in PEM format.
@@ -255,8 +255,8 @@ interface KeyRestResource : RestResource {
     )
     fun generateKeyPem(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(description = "Identifier of the public key to be retrieved")

--- a/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/KeysRestResource.kt
+++ b/components/membership/membership-rest/src/main/kotlin/net/corda/membership/rest/v1/KeysRestResource.kt
@@ -40,11 +40,11 @@ interface KeysRestResource : RestResource {
      * ```
      * keysOps.listSchemes(tenantId = "58B6030FABDD", hsmCategory = "SESSION_INIT")
      *
-     * keysOps.listSchemes(tenantId = "rest", hsmCategory = "SESSION_INIT")
+     * keysOps.listSchemes(tenantId = "p2p", hsmCategory = "SESSION_INIT")
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param hsmCategory Can be the value 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY', 'SESSION_INIT', 'TLS', or 'JWT_KEY'.
      *
      * @return The list of scheme codes which are supported by the associated HSM integration.
@@ -56,8 +56,8 @@ interface KeysRestResource : RestResource {
     )
     fun listSchemes(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(
@@ -89,8 +89,8 @@ interface KeysRestResource : RestResource {
      * ids = ["3B9A266F96E2", "4A9A266F96E2"])
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param skip Optional. The response paging information, number of records to skip.
      * @param take Optional. The response paging information, that is, the number of records to return. The actual
      * number returned may be less than requested.
@@ -120,8 +120,8 @@ interface KeysRestResource : RestResource {
     @Suppress("LongParameterList")
     fun listKeys(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestQueryParameter(
@@ -200,8 +200,8 @@ interface KeysRestResource : RestResource {
      * keysOps.generateKeyPair(tenantId = "p2p", alias = "alias", hsmCategory = "TLS", scheme = "CORDA.RSA")
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param alias The alias under which the new key pair will be stored.
      * @param hsmCategory Category of the HSM which handles the key pairs. Can be one of 'ACCOUNTS', 'CI', 'LEDGER', 'NOTARY',
      * 'SESSION_INIT', 'TLS', 'JWT_KEY'.
@@ -217,8 +217,8 @@ interface KeysRestResource : RestResource {
     )
     fun generateKeyPair(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(
@@ -245,11 +245,11 @@ interface KeysRestResource : RestResource {
      * ```
      * keysOps.generateKeyPem(tenantId = "58B6030FABDD", keyId = "3B9A266F96E2")
      *
-     * keysOps.generateKeyPem(tenantId = "rest", keyId = "3B9A266F96E2")
+     * keysOps.generateKeyPem(tenantId = "p2p", keyId = "3B9A266F96E2")
      * ```
      *
-     * @param tenantId Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P
-     * services, or the value 'rest' for a cluster-level tenant of the REST.
+     * @param tenantId Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P
+     * services.
      * @param keyId Identifier of the public key to be retrieved.
      *
      * @return The public key in PEM format.
@@ -261,8 +261,8 @@ interface KeysRestResource : RestResource {
     )
     fun generateKeyPem(
         @RestPathParameter(
-            description = "Can either be a holding identity ID, the value 'p2p' for a cluster-level" +
-                " tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST"
+            description = "Can either be a holding identity ID or the value 'p2p' for a cluster-level" +
+                " tenant of the P2P services"
         )
         tenantId: String,
         @RestPathParameter(description = "Identifier of the public key to be retrieved")

--- a/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoTenants.kt
+++ b/libs/crypto/crypto-core/src/main/kotlin/net/corda/crypto/core/CryptoTenants.kt
@@ -1,7 +1,7 @@
 package net.corda.crypto.core
 
 /**
- * Defines constants defining the cluster level tenant ids and a helper function.
+ * Defines constants defining the cluster-level tenant ids and a helper function.
  * Cluster level tenants are those that can own an asymmetric key pairs.
  */
 object CryptoTenants {
@@ -11,7 +11,7 @@ object CryptoTenants {
     const val P2P: String = "p2p"
 
     /**
-     * Lists all cluster level tenants.
+     * Lists all cluster-level tenants.
      */
     val allClusterTenants: Set<String> = setOf(
         P2P,

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v1.json
@@ -439,11 +439,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1110,11 +1110,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1158,11 +1158,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1235,11 +1235,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1392,11 +1392,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1462,11 +1462,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1516,11 +1516,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_1.json
@@ -439,11 +439,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1110,11 +1110,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1158,11 +1158,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1235,11 +1235,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1392,11 +1392,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1462,11 +1462,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1516,11 +1516,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_2.json
@@ -442,11 +442,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1124,11 +1124,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1172,11 +1172,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1249,11 +1249,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1406,11 +1406,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1476,11 +1476,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1530,11 +1530,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -4359,11 +4359,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' tenant ID does not support key rotation and should not be used.",
+          "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' tenant ID does not support key rotation and should not be used.",
+            "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -4394,11 +4394,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' tenant ID does not support key rotation and should not be used.",
+          "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' tenant ID does not support key rotation and should not be used.",
+            "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
@@ -442,11 +442,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1124,11 +1124,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1172,11 +1172,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1249,11 +1249,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1406,11 +1406,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1476,11 +1476,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -1530,11 +1530,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+          "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'p2p' for a cluster-level tenant of the P2P services, or the value 'rest' for a cluster-level tenant of the REST",
+            "description" : "Can either be a holding identity ID or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -4359,11 +4359,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' tenant ID does not support key rotation and should not be used.",
+          "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' tenant ID does not support key rotation and should not be used.",
+            "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }
@@ -4394,11 +4394,11 @@
         "parameters" : [ {
           "name" : "tenantid",
           "in" : "path",
-          "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' tenant ID does not support key rotation and should not be used.",
+          "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services",
           "required" : true,
           "schema" : {
             "type" : "string",
-            "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key or one of the values 'rest', 'crypto' for corresponding cluster-level services.  NOTE: the 'p2p' tenant ID does not support key rotation and should not be used.",
+            "description" : "Can either be a holding identity ID, the value 'master' for master wrapping key, or the value 'p2p' for a cluster-level tenant of the P2P services",
             "nullable" : false,
             "example" : "string"
           }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -238,8 +238,9 @@ fun ClusterInfo.whenNoKeyExists(
 /**
  * This method triggers rotation of keys for master and managed crypto wrapping keys.
  * It takes 2 input parameters, the tenantId (in string type) and the status code (Int type)
- *   @param tenantId The tenantId whose wrapping keys will be rotated, or value 'master' for master wrapping key
- *          rotation, or one of the values 'p2p', 'rest', 'crypto' for corresponding cluster-level tenant rotation.
+ *  @param tenantId The tenantId whose wrapping keys will be rotated. The tenantId can either be
+ *          a holding identity ID, the value 'master' for master wrapping key or the value 'p2p' for corresponding
+ *          cluster-level services.
  *   @param expectedHttpStatusCode Status code that should be displayed when the API is hit,
  *   helps to validate both positive or negative scenarios.
  */
@@ -256,9 +257,9 @@ fun ClusterInfo.rotateCryptoWrappingKeys(
 /**
  * This method fetch the status of keys for master and managed crypto wrapping key rotation.
  * It takes 2 input parameters, the tenantId (in String type) and the status code (in Int type)
- *  @param tenantId The tenantId of which the status of the last key rotation will be shown. TenantId can either be
- *         a holding identity ID, the value 'master' for master wrapping key or one of the values 'p2p', 'rest',
- *         'crypto' for corresponding cluster-level services.
+ *  @param tenantId The tenantId of which the status of the last key rotation will be shown. The tenantId can either be
+ *         a holding identity ID, the value 'master' for master wrapping key or the value 'p2p' for corresponding
+ *         cluster-level services.
  *  @param expectedHttpStatusCode Status code that should be displayed when the API is hit,
  *      helps to validate both positive or negative scenarios.
  */


### PR DESCRIPTION
We have now removed rest and crypto cluster-level tenants. Update our docs to reflect this.