### PR TITLE
ES-2384: Include marker pom description

### DIFF
--- a/tools/corda-runtime-gradle-plugin/build.gradle
+++ b/tools/corda-runtime-gradle-plugin/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java-gradle-plugin'
+    id 'corda.javadoc-generation'
     id 'com.r3.internal.gradle.plugins.r3Publish'
     id 'org.jetbrains.kotlin.jvm'
-    id 'corda.javadoc-generation'
 }
 
 ext {
@@ -45,6 +45,12 @@ gradlePlugin {
 
 publishing {
     publications {
+        mavenJava(MavenPublication) {
+            from components.java
+            artifact(javadocJar) {
+                classifier "javadoc"
+            }
+        }
         configureEach {
             pom {
                 name = 'corda-runtime-gradle-plugin'

--- a/tools/corda-runtime-gradle-plugin/build.gradle
+++ b/tools/corda-runtime-gradle-plugin/build.gradle
@@ -37,6 +37,7 @@ gradlePlugin {
             id = 'net.corda.gradle.plugin'
             implementationClass = 'net.corda.gradle.plugin.CordaRuntimeGradlePlugin'
             displayName = 'corda-runtime-gradle-plugin'
+            description = 'A Gradle plugin that wraps a subset of the SDK functions to facilitate their use in developer and CI scenarios.'
         }
     }
     automatedPublishing = true


### PR DESCRIPTION
Changes required for Maven staging rules/checks. 

Error:
```
failureMessage | Invalid POM: /net/corda/gradle/plugin/net.corda.gradle.plugin.gradle.plugin/5.2.1.0-RC02/net.corda.gradle.plugin.gradle.plugin-5.2.1.0-RC02.pom: Project description missing
```

