### PR TITLE
CORE-20245 Removing unnecessary timing logic in crypto smoke test which led to flakiness

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
@@ -26,7 +26,6 @@ import net.corda.messagebus.kafka.serialization.CordaAvroSerializationFactoryImp
 import net.corda.schema.registry.impl.AvroSchemaRegistryImpl
 import net.corda.test.util.time.AutoTickTestClock
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.byLessThan
 import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -41,7 +40,6 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.time.Instant
-import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 /**
@@ -194,7 +192,7 @@ class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
         assertThat(response.statusCode()).isEqualTo(404).withFailMessage("status code on response: ${response.statusCode()} url: $url")
     }
 
-    private val testClock = AutoTickTestClock(Instant.now(), Duration.ofSeconds(1))
+    private val testClock = AutoTickTestClock(Instant.MAX, Duration.ofSeconds(1))
 
     /**
      * Generate simple request to lookup for keys by their full key ids.
@@ -258,7 +256,7 @@ class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     private fun assertValidTimestamp(timestamp: Instant, clock: AutoTickTestClock? = null) {
         assertThat(timestamp).isAfter(Instant.MIN)
         if (clock != null) {
-            assertThat(timestamp).isCloseTo(clock.peekTime(), byLessThan(1, ChronoUnit.MINUTES))
+            assertThat(timestamp).isBeforeOrEqualTo(clock.peekTime())
         }
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
@@ -145,7 +145,6 @@ class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
             avroCryptoDeserializer.deserialize((responseEvent?.payload as ExternalEventResponse).payload.array())
 
         assertThat(deserializedExternalEventResponse).isNotNull
-        assertStandardSuccessResponse(deserializedExternalEventResponse!!, testClock)
         assertResponseContext(cryptoRequestContext, deserializedExternalEventResponse.context)
     }
 
@@ -192,8 +191,6 @@ class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
         assertThat(response.statusCode()).isEqualTo(404).withFailMessage("status code on response: ${response.statusCode()} url: $url")
     }
 
-    private val testClock = AutoTickTestClock(Instant.MAX, Duration.ofSeconds(1))
-
     /**
      * Generate simple request to lookup for keys by their full key ids.
      * Lookup will return no items in the response.
@@ -239,24 +236,6 @@ class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
             softly.assertThat(actual.other.items.size).isEqualTo(expected.other.items.size)
             softly.assertThat(actual.other.items.containsAll(expected.other.items))
             softly.assertThat(expected.other.items.containsAll(actual.other.items))
-        }
-    }
-
-    private fun assertStandardSuccessResponse(
-        response: FlowOpsResponse,
-        clock: AutoTickTestClock? = null
-    ) = getResultOfType<FlowOpsResponse>(response)
-        .run { assertValidTimestamp(response.context.requestTimestamp, clock) }
-
-    private inline fun <reified T> getResultOfType(response: FlowOpsResponse): T {
-        Assertions.assertInstanceOf(T::class.java, response)
-        return response as T
-    }
-
-    private fun assertValidTimestamp(timestamp: Instant, clock: AutoTickTestClock? = null) {
-        assertThat(timestamp).isAfter(Instant.MIN)
-        if (clock != null) {
-            assertThat(timestamp).isBeforeOrEqualTo(clock.peekTime())
         }
     }
 }

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
@@ -59,7 +59,6 @@ class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     companion object {
         const val TEST_CPI_NAME = "ledger-utxo-demo-app"
         const val TEST_CPB_LOCATION = "/META-INF/ledger-utxo-demo-app.cpb"
-        private const val POD_CLOCK_DIFF_TOLERANCE_SECONDS = 10L
     }
 
     private val testRunUniqueId = UUID.randomUUID()
@@ -187,14 +186,10 @@ class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
     )
 
     private fun assertResponseContext(expected: CryptoRequestContext, actual: CryptoResponseContext) {
-        val now = Instant.now()
         assertEquals(expected.tenantId, actual.tenantId)
         assertEquals(expected.requestId, actual.requestId)
         assertEquals(expected.requestingComponent, actual.requestingComponent)
         assertEquals(expected.requestTimestamp, actual.requestTimestamp)
-        assertThat(actual.responseTimestamp.toEpochMilli())
-            .isGreaterThanOrEqualTo(expected.requestTimestamp.minusSeconds(POD_CLOCK_DIFF_TOLERANCE_SECONDS).toEpochMilli())
-            .isLessThanOrEqualTo(now.plusSeconds(POD_CLOCK_DIFF_TOLERANCE_SECONDS).toEpochMilli())
         assertSoftly { softly ->
             softly.assertThat(actual.other.items.size).isEqualTo(expected.other.items.size)
             softly.assertThat(actual.other.items.containsAll(expected.other.items))

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/services/CryptoRestSmokeTests.kt
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -130,7 +128,7 @@ class CryptoRestSmokeTests : ClusterReadiness by ClusterReadinessChecker() {
             avroCryptoDeserializer.deserialize(response.payload.array())
 
         assertThat(deserializedExternalEventResponse).isNotNull
-        assertResponseContext(cryptoRequestContext, deserializedExternalEventResponse.context)
+        assertResponseContext(cryptoRequestContext, deserializedExternalEventResponse!!.context)
     }
 
     @Test


### PR DESCRIPTION
### Background:
These tests were created based on existing tests in `UniquenessCheckerRestSmokeTests.kt`. Those tests utilize a function `assertStandardSuccessResponse` which casts the response type to an expected type, and then makes some claims about its timestamp using `assertValidTimestamp`.

The original uniqueness checker tests use this to check that the response timestamp is within `Instant.MIN` and `Instant.MAX`, but this intent was lost in translation and the crypto tests instead checked that the response timestamp was within a minute of some `testClock` timestamp which was set to the time that the test class was initialized. As the order that these tests run in is not predictable, this was causing test failures when the test in question was run near the end.

### Changes:
Originally I fixed the definition of `assertStandardSuccessResponse` to align with the uniqueness checker tests, but found that it was now performing a pointless cast from `T -> T` and could be removed. The timestamp check on its own also provided no benefits, so I've refactored that also.

Aside from those changes, I've moved some logic which was duplicated across all test cases into common functions, and have fixed a typo in one of the test constants.