### PR TITLE
CORE-8856 Removing quasar lambda warnings from UtxoFinalityFlow

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/UtxoLedgerServiceImpl.kt
@@ -59,9 +59,8 @@ import java.time.Instant
  * A service implementation class which is typically injected in to any cordApp which wishes to interact with
  * the UTXO ledger.
  *
- * Therefore the methods of this class are always running from within flow sandboxes, and are subject
- * to the limitations of flows. In particular since flows use Quasar every method that can block must be annotated.
- * @Suspendable and since it is not possible to annotate lambdas they sometimes cannot be used.
+ * Therefore, the methods of this class are always running from within flow sandboxes, and are subject
+ * to the limitations of flows. Since flows use Quasar, every method that can block must be annotated @Suspendable.
  */
 
 @Suppress("LongParameterList", "TooManyFunctions")

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -284,7 +284,7 @@ class UtxoFinalityFlowV1(
 
             log.trace {
                 "Notarizing transaction $transactionId using pluggable notary client flow of " +
-                        "${notarizationFlow::class.java.name} with notary $notary. Attempt number $attemptNumber"
+                    "${notarizationFlow::class.java.name} with notary $notary. Attempt number $attemptNumber"
             }
 
             flowEngine.subFlow(notarizationFlow)
@@ -328,7 +328,7 @@ class UtxoFinalityFlowV1(
 
         log.trace {
             "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of transaction " +
-                    transactionId
+                transactionId
         }
 
         if (notarySignatures.isEmpty()) {

--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/flows/finality/v1/UtxoFinalityFlowV1.kt
@@ -86,7 +86,7 @@ class UtxoFinalityFlowV1(
         val transferAdditionalSignatures = sessions.size > 1
 
         addTransactionIdToFlowContext(flowEngine, transactionId)
-        log.trace("Starting finality flow for transaction: {}", transactionId)
+        log.trace { "Starting finality flow for transaction: $transactionId" }
         verifyExistingSignatures(initialTransaction)
         verifyTransaction(initialTransaction)
 
@@ -115,7 +115,7 @@ class UtxoFinalityFlowV1(
         val (notarizedTransaction, notarySignatures) = notarize(transaction, filteredTransactionsAndSignatures)
         persistNotarizedTransaction(notarizedTransaction)
         sendNotarySignaturesToCounterparties(notarySignatures)
-        log.trace("Finalisation of transaction {} has been finished.", transactionId)
+        log.trace { "Finalisation of transaction $transactionId has been finished." }
         return notarizedTransaction
     }
 
@@ -281,13 +281,12 @@ class UtxoFinalityFlowV1(
                 pluggableNotaryDetails,
                 NotarizationType.WRITE
             )
-            // `log.trace {}` and `log.debug {}` are not used in this method due to a Quasar issue.
-            if (log.isTraceEnabled) {
-                log.trace(
-                    "Notarizing transaction $transactionId using pluggable notary client flow of " +
+
+            log.trace {
+                "Notarizing transaction $transactionId using pluggable notary client flow of " +
                         "${notarizationFlow::class.java.name} with notary $notary. Attempt number $attemptNumber"
-                )
             }
+
             flowEngine.subFlow(notarizationFlow)
         }
 
@@ -327,11 +326,9 @@ class UtxoFinalityFlowV1(
             }
         }
 
-        if (log.isTraceEnabled) {
-            log.trace(
-                "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of transaction " +
+        log.trace {
+            "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of transaction " +
                     transactionId
-            )
         }
 
         if (notarySignatures.isEmpty()) {
@@ -365,10 +362,8 @@ class UtxoFinalityFlowV1(
             }
         }
 
-        if (log.isDebugEnabled) {
-            log.debug(
-                "Successfully notarized transaction $transactionId using notary $notary and received ${notarySignatures.size} signature(s)"
-            )
+        log.debug {
+            "Successfully notarized transaction $transactionId using notary $notary and received ${notarySignatures.size} signature(s)"
         }
 
         return notarizedTransaction to notarySignatures


### PR DESCRIPTION
Following ASM shipping a fix for the bug we raised against them last year regarding this issue, we no longer face limitations on where we use lambdas within suspendible methods. This PR removes the comments warning about this, and replaces manual checks such as:

```
if (log.isTraceEnabled) {
    log.trace(
        "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of transaction " + transactionId
    )
}
```
with the lambda-based equivalent, not requiring manual checks of `.isTraceEnabled`:

```
log.trace {
    "Received ${notarySignatures.size} signature(s) from notary $notary after requesting notarization of transaction " + transactionId
}
```