### PR TITLE
CORE-19384: Add reset after RebalanceInProgressException

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -243,6 +243,7 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
         } catch (ex: StateAndEventConsumer.RebalanceInProgressException) {
             log.warn ("Abandoning processing of events(keys: ${events.joinToString { it.key.toString() }}, " +
                     "size: ${events.size}) due to rebalance", ex)
+            stateAndEventConsumer.resetEventOffsetPosition()
             return true
         }
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
@@ -528,7 +528,7 @@ class StateAndEventSubscriptionImplTest {
                 else ->
                     mutableListOf()
             }
-        }.whenever(eventConsumer).poll(any())
+        }.whenever(stateAndEventConsumer).pollEvents()
         doThrow(StateAndEventConsumer.RebalanceInProgressException("test"))
             .whenever(stateAndEventConsumer).resetPollInterval()
 

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
@@ -1,10 +1,5 @@
 package net.corda.messaging.subscription
 
-import java.time.Duration
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.messagebus.api.CordaTopicPartition
@@ -41,6 +36,11 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class StateAndEventSubscriptionImplTest {
 
@@ -558,5 +558,6 @@ class StateAndEventSubscriptionImplTest {
         verify(producer, never()).sendRecordOffsetsToTransaction(any(), any())
         verify(producer, never()).commitTransaction()
         verify(chunkSerializerService, never()).getChunkKeysToClear(any(), anyOrNull(), anyOrNull())
+        verify(stateAndEventConsumer.resetEventOffsetPosition(), times(1))
     }
 }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
@@ -514,7 +514,7 @@ class StateAndEventSubscriptionImplTest {
     }
 
     @Test
-    fun `repartition during batch processing stops the batch, does not resume consumers and does not publish outputs`() {
+    fun `repartition during batch processing stops the batch, does not resume consumers or publish outputs and resets event offset position`() {
         val (builder, producer, stateAndEventConsumer) = setupMocks(0)
         val records = mutableListOf<CordaConsumerRecord<String, String>>()
         records.add(CordaConsumerRecord(TOPIC, 1, 1, "key1", "value1", 1))
@@ -558,45 +558,6 @@ class StateAndEventSubscriptionImplTest {
         verify(producer, never()).sendRecordOffsetsToTransaction(any(), any())
         verify(producer, never()).commitTransaction()
         verify(chunkSerializerService, never()).getChunkKeysToClear(any(), anyOrNull(), anyOrNull())
-    }
-
-    @Test
-    fun `repartition during batch processing results in a reset of the event offset position`() {
-        val (builder, _, stateAndEventConsumer) = setupMocks(0)
-        val records = mutableListOf<CordaConsumerRecord<String, String>>()
-        records.add(CordaConsumerRecord(TOPIC, 1, 1, "key1", "value1", 1))
-
-        var callCount = 0
-        doAnswer {
-            when (callCount++) {
-                0 ->
-                    records
-                else ->
-                    mutableListOf()
-            }
-        }.whenever(stateAndEventConsumer).pollEvents()
-        doThrow(StateAndEventConsumer.RebalanceInProgressException("test"))
-            .whenever(stateAndEventConsumer).resetPollInterval()
-
-        val subscription = StateAndEventSubscriptionImpl<Any, Any, Any>(
-            config,
-            builder,
-            mock(),
-            cordaAvroSerializer,
-            lifecycleCoordinatorFactory,
-            chunkSerializerService
-        )
-
-        subscription.start()
-
-        /**
-         * wait for a second poll to be called before we complete
-         * as we need to be sure the first poll has completed processing
-         * before we go to the asserts
-         */
-        waitWhile(Duration.ofSeconds(TEST_TIMEOUT_SECONDS)) { subscription.isRunning && callCount <= 1 }
-        subscription.close()
-
         verify(stateAndEventConsumer, times(1)).resetEventOffsetPosition()
     }
 }

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
@@ -513,6 +513,7 @@ class StateAndEventSubscriptionImplTest {
         verify(chunkSerializerService, times(1)).getChunkKeysToClear(any(), anyOrNull(), anyOrNull())
     }
 
+    @Suppress("MaxLineLength")
     @Test
     fun `repartition during batch processing stops the batch, does not resume consumers or publish outputs and resets event offset position`() {
         val (builder, producer, stateAndEventConsumer) = setupMocks(0)

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImplTest.kt
@@ -558,6 +558,6 @@ class StateAndEventSubscriptionImplTest {
         verify(producer, never()).sendRecordOffsetsToTransaction(any(), any())
         verify(producer, never()).commitTransaction()
         verify(chunkSerializerService, never()).getChunkKeysToClear(any(), anyOrNull(), anyOrNull())
-        verify(stateAndEventConsumer.resetEventOffsetPosition(), times(1))
+        verify(stateAndEventConsumer, times(1)).resetEventOffsetPosition()
     }
 }


### PR DESCRIPTION
When [lost membership requests](https://r3-cev.atlassian.net/browse/CORE-18374) were investigated  it seems to be a problem that occurs during rebalance in the state and event pattern. After the rebalance the commits that were not successful don't get re-processed and are instead skipped over. [As part of handling this](https://r3-cev.atlassian.net/browse/CORE-20668), the PR adds a reset of the event offset position so we try processing again from the correct place after a RebalanceInProgressException.