### PR TITLE
ES-2383: Update certificate workaround with known limitation

### DIFF
--- a/libs/rest/generated-rest-client/README.md
+++ b/libs/rest/generated-rest-client/README.md
@@ -16,6 +16,12 @@ We've added some test cases to cover them, so if your build is failing with "Has
 take a look at the test cases, as there are links to JIRA tickets with details.  
 The `applyWorkarounds` task should have taken care of this, but may have become out of date.
 
+## Limitations
+
+The CertificateApi has a known limitation where we are unable to send a list of files.  
+The spec allows for a list of files to be sent, and you can achieve this via Swagger and cURL, but the generated client does not support this.  
+The workaround is to send the files one at a time. If you provide a list of files, only the first file will be sent.
+
 ## DTO
 
 There are a small number of data classes which don't already exist in the codebase, but are listed in the spec. We will need to maintain those.

--- a/libs/rest/generated-rest-client/src/test/kotlin/net/corda/restclient/generated/TestKnownIssues.kt
+++ b/libs/rest/generated-rest-client/src/test/kotlin/net/corda/restclient/generated/TestKnownIssues.kt
@@ -68,8 +68,8 @@ class TestKnownIssues {
     }
 
     /**
-     * See comment for workaround details
-     * https://r3-cev.atlassian.net/browse/ES-2162?focusedCommentId=303584
+     * This is a known limitation with the OpenApi generator
+     * https://r3-cev.atlassian.net/browse/ES-2383?focusedCommentId=307181
      */
     @Test
     fun testClusterCertRequestHandlesListCorrectly() {
@@ -87,8 +87,8 @@ class TestKnownIssues {
     }
 
     /**
-     * See comment for workaround details
-     * https://r3-cev.atlassian.net/browse/ES-2162?focusedCommentId=303584
+     * This is a known limitation with the OpenApi generator
+     * https://r3-cev.atlassian.net/browse/ES-2383?focusedCommentId=307181
      */
     @Test
     fun testVNodeCertRequestHandlesListCorrectly() {


### PR DESCRIPTION
After investigation it looks like this workaround is permanent 
https://r3-cev.atlassian.net/browse/ES-2383?focusedCommentId=307181
The Spec is valid, so we're not going to change that; the limitation is down to the OpenApi generator itself.
I've added info to the README so any consumers of the generated-rest-client should be aware.