### PR TITLE
CORE-20694: Snappy version upgrade/change

### DIFF
--- a/applications/tools/universal-blob-inspector/build.gradle
+++ b/applications/tools/universal-blob-inspector/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "org.apache.qpid:proton-j:$protonjVersion"
 
     // Snappy (de)compression
-    implementation libs.snappy.java
+    implementation "org.iq80.snappy:snappy:$snappyVersion"
 
     // Command line parsing
     implementation "info.picocli:picocli:$picocliVersion"

--- a/applications/tools/universal-blob-inspector/build.gradle
+++ b/applications/tools/universal-blob-inspector/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation "org.apache.qpid:proton-j:$protonjVersion"
 
     // Snappy (de)compression
-    implementation "org.iq80.snappy:snappy:$snappyVersion"
+    implementation libs.snappy.java
 
     // Command line parsing
     implementation "info.picocli:picocli:$picocliVersion"

--- a/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/Encoding.kt
+++ b/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/Encoding.kt
@@ -5,7 +5,7 @@ import net.corda.blobinspector.amqp.DynamicDescriptorRegistry
 import net.corda.blobinspector.amqp.Envelope
 import net.corda.blobinspector.kryo.KryoSerializationFormatDecoder
 import net.corda.blobinspector.metadata.MetadataSerializationFormatDecoder
-import org.xerial.snappy.SnappyFramedInputStream
+import org.iq80.snappy.SnappyFramedInputStream
 import java.io.InputStream
 import java.util.zip.DeflaterInputStream
 

--- a/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/Encoding.kt
+++ b/applications/tools/universal-blob-inspector/src/main/kotlin/net/corda/blobinspector/Encoding.kt
@@ -5,7 +5,7 @@ import net.corda.blobinspector.amqp.DynamicDescriptorRegistry
 import net.corda.blobinspector.amqp.Envelope
 import net.corda.blobinspector.kryo.KryoSerializationFormatDecoder
 import net.corda.blobinspector.metadata.MetadataSerializationFormatDecoder
-import org.iq80.snappy.SnappyFramedInputStream
+import org.xerial.snappy.SnappyFramedInputStream
 import java.io.InputStream
 import java.util.zip.DeflaterInputStream
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -71,7 +71,7 @@ protonjVersion=0.34.1
 quasarVersion = 0.9.1_r3-SNAPSHOT
 reflectAsmVersion = 1.11.9
 # Snappy version used for serialization
-snappyVersion=0.4
+snappyVersion=0.5
 jsonCanonicalizerVersion=1.1
 
 # Enable OSGi JDBC

--- a/libs/serialization/serialization-encoding/build.gradle
+++ b/libs/serialization/serialization-encoding/build.gradle
@@ -33,6 +33,7 @@ Bundle-Name: Corda serialization encoding library
 Bundle-SymbolicName: \${project.group}.serialization.encoding
 Import-Package:\
     !org.apache.hadoop.io.compress,\
+    !org.apache.hadoop.conf,\
     sun.misc;resolution:=optional,\
     *
 -includeresource: @snappy-${snappyVersion}.jar


### PR DESCRIPTION
Switch to org.xerial.snappy where possible, and update to the latest version of snappy in serialization utils.