### PR TITLE
CORE-20675 Fix race condition in P2P lifecycle

### DIFF
--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/RPCSubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/RPCSubscriptionDominoTile.kt
@@ -8,6 +8,7 @@ import net.corda.messaging.api.subscription.RPCSubscription
 import net.corda.messaging.api.subscription.config.RPCConfig
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 
+@Suppress("LongParameterList")
 class RPCSubscriptionDominoTile<REQUEST, RESPONSE>(
     coordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionGenerator: () -> RPCSubscription<REQUEST, RESPONSE>,

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/RPCSubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/RPCSubscriptionDominoTile.kt
@@ -14,7 +14,6 @@ class RPCSubscriptionDominoTile<REQUEST, RESPONSE>(
     subscriptionGenerator: () -> RPCSubscription<REQUEST, RESPONSE>,
     rpcConfig: RPCConfig<REQUEST, RESPONSE>,
     configurationReadService: ConfigurationReadService,
-    configKey: String,
     dependentChildren: Collection<LifecycleCoordinatorName>,
     managedChildren: Collection<NamedLifecycle>
 ) : SubscriptionDominoTileBase(
@@ -22,7 +21,6 @@ class RPCSubscriptionDominoTile<REQUEST, RESPONSE>(
     subscriptionGenerator,
     SubscriptionConfig(rpcConfig.groupName, rpcConfig.clientName),
     configurationReadService,
-    configKey,
     dependentChildren,
     managedChildren
 )

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/RPCSubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/RPCSubscriptionDominoTile.kt
@@ -1,5 +1,6 @@
 package net.corda.lifecycle.domino.logic.util
 
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.NamedLifecycle
@@ -11,12 +12,16 @@ class RPCSubscriptionDominoTile<REQUEST, RESPONSE>(
     coordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionGenerator: () -> RPCSubscription<REQUEST, RESPONSE>,
     rpcConfig: RPCConfig<REQUEST, RESPONSE>,
+    configurationReadService: ConfigurationReadService,
+    configKey: String,
     dependentChildren: Collection<LifecycleCoordinatorName>,
     managedChildren: Collection<NamedLifecycle>
-): SubscriptionDominoTileBase(
+) : SubscriptionDominoTileBase(
     coordinatorFactory,
     subscriptionGenerator,
     SubscriptionConfig(rpcConfig.groupName, rpcConfig.clientName),
+    configurationReadService,
+    configKey,
     dependentChildren,
     managedChildren
 )

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/StateAndEventSubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/StateAndEventSubscriptionDominoTile.kt
@@ -13,9 +13,8 @@ class StateAndEventSubscriptionDominoTile<K, S, E>(
     subscriptionGenerator: () -> StateAndEventSubscription<K, S, E>,
     subscriptionConfig: SubscriptionConfig,
     configurationReadService: ConfigurationReadService,
-    configKey: String,
     dependentChildren: Collection<LifecycleCoordinatorName>,
     managedChildren: Collection<NamedLifecycle>
 ): SubscriptionDominoTileBase(
-    coordinatorFactory, subscriptionGenerator, subscriptionConfig, configurationReadService, configKey, dependentChildren, managedChildren
+    coordinatorFactory, subscriptionGenerator, subscriptionConfig, configurationReadService, dependentChildren, managedChildren
 )

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/StateAndEventSubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/StateAndEventSubscriptionDominoTile.kt
@@ -7,6 +7,7 @@ import net.corda.lifecycle.domino.logic.NamedLifecycle
 import net.corda.messaging.api.subscription.StateAndEventSubscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 
+@Suppress("LongParameterList")
 class StateAndEventSubscriptionDominoTile<K, S, E>(
     coordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionGenerator: () -> StateAndEventSubscription<K, S, E>,

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/StateAndEventSubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/StateAndEventSubscriptionDominoTile.kt
@@ -1,5 +1,6 @@
 package net.corda.lifecycle.domino.logic.util
 
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.NamedLifecycle
@@ -10,6 +11,10 @@ class StateAndEventSubscriptionDominoTile<K, S, E>(
     coordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionGenerator: () -> StateAndEventSubscription<K, S, E>,
     subscriptionConfig: SubscriptionConfig,
+    configurationReadService: ConfigurationReadService,
+    configKey: String,
     dependentChildren: Collection<LifecycleCoordinatorName>,
     managedChildren: Collection<NamedLifecycle>
-): SubscriptionDominoTileBase(coordinatorFactory, subscriptionGenerator, subscriptionConfig, dependentChildren, managedChildren)
+): SubscriptionDominoTileBase(
+    coordinatorFactory, subscriptionGenerator, subscriptionConfig, configurationReadService, configKey, dependentChildren, managedChildren
+)

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTile.kt
@@ -7,6 +7,7 @@ import net.corda.lifecycle.domino.logic.NamedLifecycle
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 
+@Suppress("LongParameterList")
 class SubscriptionDominoTile<K, V>(
     coordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionGenerator: () -> Subscription<K, V>,

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTile.kt
@@ -1,5 +1,6 @@
 package net.corda.lifecycle.domino.logic.util
 
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.domino.logic.NamedLifecycle
@@ -10,6 +11,10 @@ class SubscriptionDominoTile<K, V>(
     coordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionGenerator: () -> Subscription<K, V>,
     subscriptionConfig: SubscriptionConfig,
+    configurationReadService: ConfigurationReadService,
+    configKey: String,
     dependentChildren: Collection<LifecycleCoordinatorName>,
     managedChildren: Collection<NamedLifecycle>
-): SubscriptionDominoTileBase(coordinatorFactory, subscriptionGenerator, subscriptionConfig, dependentChildren, managedChildren)
+) : SubscriptionDominoTileBase(
+    coordinatorFactory, subscriptionGenerator, subscriptionConfig, configurationReadService, configKey, dependentChildren, managedChildren
+)

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTile.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTile.kt
@@ -13,9 +13,8 @@ class SubscriptionDominoTile<K, V>(
     subscriptionGenerator: () -> Subscription<K, V>,
     subscriptionConfig: SubscriptionConfig,
     configurationReadService: ConfigurationReadService,
-    configKey: String,
     dependentChildren: Collection<LifecycleCoordinatorName>,
     managedChildren: Collection<NamedLifecycle>
 ) : SubscriptionDominoTileBase(
-    coordinatorFactory, subscriptionGenerator, subscriptionConfig, configurationReadService, configKey, dependentChildren, managedChildren
+    coordinatorFactory, subscriptionGenerator, subscriptionConfig, configurationReadService, dependentChildren, managedChildren
 )

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBase.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBase.kt
@@ -3,7 +3,6 @@ package net.corda.lifecycle.domino.logic.util
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
-import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -43,6 +42,7 @@ import org.slf4j.LoggerFactory
  * they are all up).
  * @param managedChildren the children that the class will start, when it is started.
  */
+@Suppress("LongParameterList")
 abstract class SubscriptionDominoTileBase(
     coordinatorFactory: LifecycleCoordinatorFactory,
     private val subscriptionGenerator: () -> SubscriptionBase,

--- a/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBase.kt
+++ b/components/domino-logic/src/main/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBase.kt
@@ -48,7 +48,6 @@ abstract class SubscriptionDominoTileBase(
     private val subscriptionGenerator: () -> SubscriptionBase,
     private val subscriptionConfig: SubscriptionConfig,
     private val configurationReadService: ConfigurationReadService,
-    private val configKey: String,
     final override val dependentChildren: Collection<LifecycleCoordinatorName>,
     final override val managedChildren: Collection<NamedLifecycle>
 ): DominoTile() {

--- a/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBaseTest.kt
+++ b/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBaseTest.kt
@@ -1,6 +1,5 @@
 package net.corda.lifecycle.domino.logic.util
 
-import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -12,6 +11,7 @@ import net.corda.lifecycle.RegistrationStatusChangeEvent
 import net.corda.lifecycle.StartEvent
 import net.corda.lifecycle.domino.logic.DominoTile
 import net.corda.lifecycle.domino.logic.NamedLifecycle
+import net.corda.lifecycle.domino.logic.util.SubscriptionDominoTileBase.ConfigPublished
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.SubscriptionBase
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
@@ -28,9 +28,6 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class SubscriptionDominoTileBaseTest {
-    private companion object {
-        const val CONFIG_KEY = "configKey"
-    }
     private val subscriptionName = LifecycleCoordinatorName("sub-name", "1")
     private val subscriptionRegistration = mock<RegistrationHandle>()
     private val childrenOneRegistration = mock<RegistrationHandle>()
@@ -118,7 +115,7 @@ class SubscriptionDominoTileBaseTest {
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenOneRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
-        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
+        handler.lastValue.processEvent(ConfigPublished, coordinator)
         verify(subscription, times(1)).start()
         assertThat(subscriptionTile.isRunning).isFalse
 
@@ -131,7 +128,7 @@ class SubscriptionDominoTileBaseTest {
         val subscriptionTile = SubscriptionDominoTile(coordinatorFactory, { subscription }, subscriptionConfig, emptySet(), emptySet())
 
         subscriptionTile.start()
-        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
+        handler.lastValue.processEvent(ConfigPublished, coordinator)
         verify(subscription, times(1)).start()
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenOneRegistration, LifecycleStatus.UP), coordinator)
@@ -156,7 +153,7 @@ class SubscriptionDominoTileBaseTest {
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.UP), coordinator)
-        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
+        handler.lastValue.processEvent(ConfigPublished, coordinator)
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.DOWN), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.DOWN), coordinator)
@@ -180,7 +177,7 @@ class SubscriptionDominoTileBaseTest {
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.UP), coordinator)
-        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
+        handler.lastValue.processEvent(ConfigPublished, coordinator)
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.ERROR), coordinator)
         verify(coordinator, atLeast(1)).closeManagedResources(setOf(SubscriptionDominoTileBase.SUBSCRIPTION))
@@ -203,7 +200,7 @@ class SubscriptionDominoTileBaseTest {
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.UP), coordinator)
-        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
+        handler.lastValue.processEvent(ConfigPublished, coordinator)
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.ERROR), coordinator)
         assertThat(subscriptionTile.status).isEqualTo(LifecycleStatus.ERROR)
@@ -223,6 +220,6 @@ class SubscriptionDominoTileBaseTest {
         dependentChildren: Collection<LifecycleCoordinatorName>,
         managedChildren: Collection<NamedLifecycle>
     ): SubscriptionDominoTileBase(
-        coordinatorFactory, subscription, subscriptionConfig, mock(), CONFIG_KEY, dependentChildren, managedChildren
+        coordinatorFactory, subscription, subscriptionConfig, mock(), dependentChildren, managedChildren
     )
 }

--- a/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBaseTest.kt
+++ b/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBaseTest.kt
@@ -1,5 +1,6 @@
 package net.corda.lifecycle.domino.logic.util
 
+import net.corda.configuration.read.ConfigChangedEvent
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -27,7 +28,9 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 
 class SubscriptionDominoTileBaseTest {
-
+    private companion object {
+        const val CONFIG_KEY = "configKey"
+    }
     private val subscriptionName = LifecycleCoordinatorName("sub-name", "1")
     private val subscriptionRegistration = mock<RegistrationHandle>()
     private val childrenOneRegistration = mock<RegistrationHandle>()
@@ -115,6 +118,7 @@ class SubscriptionDominoTileBaseTest {
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenOneRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
+        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
         verify(subscription, times(1)).start()
         assertThat(subscriptionTile.isRunning).isFalse
 
@@ -127,6 +131,7 @@ class SubscriptionDominoTileBaseTest {
         val subscriptionTile = SubscriptionDominoTile(coordinatorFactory, { subscription }, subscriptionConfig, emptySet(), emptySet())
 
         subscriptionTile.start()
+        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
         verify(subscription, times(1)).start()
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenOneRegistration, LifecycleStatus.UP), coordinator)
@@ -151,6 +156,7 @@ class SubscriptionDominoTileBaseTest {
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.UP), coordinator)
+        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.DOWN), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.DOWN), coordinator)
@@ -174,6 +180,7 @@ class SubscriptionDominoTileBaseTest {
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.UP), coordinator)
+        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.ERROR), coordinator)
         verify(coordinator, atLeast(1)).closeManagedResources(setOf(SubscriptionDominoTileBase.SUBSCRIPTION))
@@ -196,6 +203,7 @@ class SubscriptionDominoTileBaseTest {
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.UP), coordinator)
+        handler.lastValue.processEvent(ConfigChangedEvent(setOf(CONFIG_KEY), emptyMap()), coordinator)
 
         handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.ERROR), coordinator)
         assertThat(subscriptionTile.status).isEqualTo(LifecycleStatus.ERROR)
@@ -214,6 +222,7 @@ class SubscriptionDominoTileBaseTest {
         subscriptionConfig: SubscriptionConfig,
         dependentChildren: Collection<LifecycleCoordinatorName>,
         managedChildren: Collection<NamedLifecycle>
-    ): SubscriptionDominoTileBase(coordinatorFactory, subscription, subscriptionConfig, dependentChildren, managedChildren)
-
+    ): SubscriptionDominoTileBase(
+        coordinatorFactory, subscription, subscriptionConfig, mock(), CONFIG_KEY, dependentChildren, managedChildren
+    )
 }

--- a/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBaseTest.kt
+++ b/components/domino-logic/src/test/kotlin/net/corda/lifecycle/domino/logic/util/SubscriptionDominoTileBaseTest.kt
@@ -1,5 +1,7 @@
 package net.corda.lifecycle.domino.logic.util
 
+import net.corda.configuration.read.ConfigurationHandler
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.lifecycle.LifecycleCoordinator
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -84,6 +86,25 @@ class SubscriptionDominoTileBaseTest {
     }
 
     @Test
+    fun `subscription tile registers for config updates when started`() {
+        val configReadService = mock<ConfigurationReadService>()
+        val subscriptionTile = SubscriptionDominoTile(
+            coordinatorFactory,
+            { subscription },
+            subscriptionConfig,
+            emptySet(),
+            emptySet(),
+            configurationReadService = configReadService
+        )
+
+        var argumentCaptor = argumentCaptor<ConfigurationHandler>()
+        subscriptionTile.start()
+        verify(configReadService).registerForUpdates(argumentCaptor.capture())
+        argumentCaptor.lastValue.onNewConfiguration(emptySet(), emptyMap())
+        verify(coordinator).postEvent(ConfigPublished)
+    }
+
+    @Test
     fun `subscription tile stops all managed children when stopped`() {
         val subscriptionTile = SubscriptionDominoTile(
             coordinatorFactory,
@@ -100,7 +121,7 @@ class SubscriptionDominoTileBaseTest {
     }
 
     @Test
-    fun `subscription tile waits for dependent children before starting the subscription`() {
+    fun `subscription tile waits for dependent children and config before starting the subscription`() {
         val subscriptionTile = SubscriptionDominoTile(
             coordinatorFactory,
             { subscription },
@@ -124,7 +145,32 @@ class SubscriptionDominoTileBaseTest {
     }
 
     @Test
-    fun `if there are no dependent children, subscription is started immediately`() {
+    fun `subscription tile waits for config and then dependent children before starting the subscription`() {
+        val subscriptionTile = SubscriptionDominoTile(
+            coordinatorFactory,
+            { subscription },
+            subscriptionConfig,
+            children.map { it.coordinatorName },
+            children.map { it.toNamedLifecycle() }
+        )
+
+        subscriptionTile.start()
+        verify(subscription, never()).start()
+
+        handler.lastValue.processEvent(ConfigPublished, coordinator)
+        handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenOneRegistration, LifecycleStatus.UP), coordinator)
+        handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenTwoRegistration, LifecycleStatus.UP), coordinator)
+        handler.lastValue.processEvent(RegistrationStatusChangeEvent(childrenThreeRegistration, LifecycleStatus.UP), coordinator)
+        verify(subscription, times(1)).start()
+        assertThat(subscriptionTile.isRunning).isFalse
+
+        handler.lastValue.processEvent(RegistrationStatusChangeEvent(subscriptionRegistration, LifecycleStatus.UP), coordinator)
+        assertThat(subscriptionTile.isRunning).isTrue
+    }
+
+
+    @Test
+    fun `if there are no dependent children, subscription is started once config is published`() {
         val subscriptionTile = SubscriptionDominoTile(coordinatorFactory, { subscription }, subscriptionConfig, emptySet(), emptySet())
 
         subscriptionTile.start()
@@ -213,13 +259,15 @@ class SubscriptionDominoTileBaseTest {
         }
     }
 
+    @Suppress("LongParameterList")
     class SubscriptionDominoTile<K, V>(
         coordinatorFactory: LifecycleCoordinatorFactory,
         subscription: () -> Subscription<K, V>,
         subscriptionConfig: SubscriptionConfig,
         dependentChildren: Collection<LifecycleCoordinatorName>,
-        managedChildren: Collection<NamedLifecycle>
+        managedChildren: Collection<NamedLifecycle>,
+        configurationReadService: ConfigurationReadService = mock(),
     ): SubscriptionDominoTileBase(
-        coordinatorFactory, subscription, subscriptionConfig, mock(), dependentChildren, managedChildren
+        coordinatorFactory, subscription, subscriptionConfig, configurationReadService, dependentChildren, managedChildren
     )
 }

--- a/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/certificates/RevocationCheckerTest.kt
+++ b/components/gateway/src/integrationTest/kotlin/net/corda/p2p/gateway/certificates/RevocationCheckerTest.kt
@@ -48,7 +48,7 @@ class RevocationCheckerTest {
             @Suppress("UNCHECKED_CAST")
             (context.arguments()[1] as  () -> RPCSubscription<RevocationCheckRequest, RevocationCheckResponse>)()
         }
-        revocationChecker = RevocationChecker(subscriptionFactory, mock(), mock())
+        revocationChecker = RevocationChecker(subscriptionFactory, mock(), mock(), mock())
     }
 
     @AfterEach

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/Gateway.kt
@@ -46,6 +46,7 @@ class Gateway(
         lifecycleCoordinatorFactory,
         messagingConfiguration,
         cryptoOpsClient,
+        configurationReaderService,
     )
     private val inboundMessageHandler = InboundMessageHandler(
         lifecycleCoordinatorFactory,
@@ -70,7 +71,8 @@ class Gateway(
     private val revocationChecker = RevocationChecker(
         subscriptionFactory,
         messagingConfiguration,
-        lifecycleCoordinatorFactory
+        lifecycleCoordinatorFactory,
+        configurationReaderService,
     )
 
     @VisibleForTesting

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/certificates/RevocationChecker.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/certificates/RevocationChecker.kt
@@ -29,11 +29,14 @@ import java.security.cert.PKIXBuilderParameters
 import java.security.cert.PKIXRevocationChecker
 import java.security.cert.X509CertSelector
 import java.util.concurrent.CompletableFuture
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 class RevocationChecker(
     subscriptionFactory: SubscriptionFactory,
     messagingConfig: SmartConfig,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    configurationReadService: ConfigurationReadService,
     certificateFactory: CertificateFactory = CertificateFactory.getInstance(certificateFactoryType),
     certPathValidator: CertPathValidator = CertPathValidator.getInstance(certificateAlgorithm)
 ): LifecycleWithDominoTile {
@@ -148,6 +151,8 @@ class RevocationChecker(
         lifecycleCoordinatorFactory,
         subscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_LINK_MANAGER_CONFIG,
         emptySet(),
         emptySet()
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/certificates/RevocationChecker.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/certificates/RevocationChecker.kt
@@ -30,7 +30,6 @@ import java.security.cert.PKIXRevocationChecker
 import java.security.cert.X509CertSelector
 import java.util.concurrent.CompletableFuture
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 class RevocationChecker(
@@ -153,7 +152,6 @@ class RevocationChecker(
         subscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_LINK_MANAGER_CONFIG,
         emptySet(),
         emptySet()
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/certificates/RevocationChecker.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/certificates/RevocationChecker.kt
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture
 import net.corda.configuration.read.ConfigurationReadService
 import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
+@Suppress("LongParameterList")
 class RevocationChecker(
     subscriptionFactory: SubscriptionFactory,
     messagingConfig: SmartConfig,

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStore.kt
@@ -30,7 +30,6 @@ import java.util.Objects
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class DynamicKeyStore(
@@ -104,7 +103,6 @@ internal class DynamicKeyStore(
         subscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStore.kt
@@ -29,12 +29,15 @@ import java.security.cert.CertificateFactory
 import java.util.Objects
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class DynamicKeyStore(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
     messagingConfiguration: SmartConfig,
+    configurationReadService: ConfigurationReadService,
     private val cryptoOpsClient: CryptoOpsClient,
     private val certificateFactory: CertificateFactory = CertificateFactory.getInstance("X.509"),
     private val keyStoreFactory: (
@@ -100,6 +103,8 @@ internal class DynamicKeyStore(
         lifecycleCoordinatorFactory,
         subscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
@@ -20,7 +20,6 @@ import java.security.cert.CertificateFactory
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 internal class TrustStoresMap(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
@@ -53,7 +52,6 @@ internal class TrustStoresMap(
         subscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList()
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMap.kt
@@ -19,11 +19,14 @@ import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 internal class TrustStoresMap(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
     messagingConfiguration: SmartConfig,
+    configurationReadService: ConfigurationReadService,
     private val certificateFactory: CertificateFactory = CertificateFactory.getInstance("X.509"),
 ) :
     LifecycleWithDominoTile {
@@ -49,6 +52,8 @@ internal class TrustStoresMap(
         lifecycleCoordinatorFactory,
         subscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList()
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/CommonComponents.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/CommonComponents.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.gateway.messaging.internal
 
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.crypto.client.CryptoOpsClient
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -16,6 +17,7 @@ internal class CommonComponents(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     messagingConfiguration: SmartConfig,
     cryptoOpsClient: CryptoOpsClient,
+    configurationReadService: ConfigurationReadService,
 ) : LifecycleWithDominoTile {
     val features: Features = Features()
 
@@ -23,12 +25,14 @@ internal class CommonComponents(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
         messagingConfiguration,
+        configurationReadService,
         cryptoOpsClient,
     )
     val trustStoresMap = TrustStoresMap(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
-        messagingConfiguration
+        messagingConfiguration,
+        configurationReadService,
     )
     private val children: Collection<DominoTile> =
         listOf(

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/InboundMessageHandler.kt
@@ -85,11 +85,13 @@ internal class InboundMessageHandler(
     private val sessionPartitionMapper = SessionPartitionMapperImpl(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
-        messagingConfiguration
+        configurationReaderService,
+        messagingConfiguration,
     )
 
     private val dynamicCertificateSubjectStore = DynamicCertificateSubjectStore(
         lifecycleCoordinatorFactory,
+        configurationReaderService,
         subscriptionFactory,
         messagingConfiguration
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
@@ -41,7 +41,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 /**
  * This is an implementation of an [PubSubProcessor] used to consume messages from a P2P message subscription. The received
@@ -84,7 +83,6 @@ internal class OutboundMessageHandler(
         outboundSubscription,
         subscriptionConfig,
         configurationReaderService,
-        P2P_LINK_MANAGER_CONFIG,
         setOf(connectionManager.dominoTile.coordinatorName, gatewayConfigReader.dominoTile.coordinatorName),
         setOf(connectionManager.dominoTile.toNamedLifecycle(), gatewayConfigReader.dominoTile.toNamedLifecycle())
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/internal/OutboundMessageHandler.kt
@@ -41,6 +41,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 /**
  * This is an implementation of an [PubSubProcessor] used to consume messages from a P2P message subscription. The received
@@ -82,6 +83,8 @@ internal class OutboundMessageHandler(
         lifecycleCoordinatorFactory,
         outboundSubscription,
         subscriptionConfig,
+        configurationReaderService,
+        P2P_LINK_MANAGER_CONFIG,
         setOf(connectionManager.dominoTile.coordinatorName, gatewayConfigReader.dominoTile.coordinatorName),
         setOf(connectionManager.dominoTile.toNamedLifecycle(), gatewayConfigReader.dominoTile.toNamedLifecycle())
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
@@ -13,7 +13,6 @@ import net.corda.schema.Schemas
 import net.corda.v5.base.types.MemberX500Name
 import java.util.concurrent.ConcurrentHashMap
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 
 internal class DynamicCertificateSubjectStore(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
@@ -39,7 +38,6 @@ internal class DynamicCertificateSubjectStore(
         subscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_GATEWAY_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStore.kt
@@ -12,9 +12,12 @@ import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas
 import net.corda.v5.base.types.MemberX500Name
 import java.util.concurrent.ConcurrentHashMap
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 
 internal class DynamicCertificateSubjectStore(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    configurationReadService: ConfigurationReadService,
     subscriptionFactory: SubscriptionFactory,
     messagingConfiguration: SmartConfig,
 ): LifecycleWithDominoTile {
@@ -35,6 +38,8 @@ internal class DynamicCertificateSubjectStore(
         lifecycleCoordinatorFactory,
         subscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_GATEWAY_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImpl.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImpl.kt
@@ -15,10 +15,13 @@ import net.corda.schema.Schemas.P2P.SESSION_OUT_PARTITIONS
 import net.corda.utilities.VisibleForTesting
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 
 class SessionPartitionMapperImpl(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
+    configurationReadService: ConfigurationReadService,
     messagingConfiguration: SmartConfig
 ) : SessionPartitionMapper, LifecycleWithDominoTile {
 
@@ -43,6 +46,8 @@ class SessionPartitionMapperImpl(
         lifecycleCoordinatorFactory,
         sessionPartitionSubscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_GATEWAY_CONFIG,
         emptySet(),
         emptySet()
     )

--- a/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImpl.kt
+++ b/components/gateway/src/main/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImpl.kt
@@ -16,7 +16,6 @@ import net.corda.utilities.VisibleForTesting
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 
 class SessionPartitionMapperImpl(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
@@ -47,7 +46,6 @@ class SessionPartitionMapperImpl(
         sessionPartitionSubscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_GATEWAY_CONFIG,
         emptySet(),
         emptySet()
     )

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/certificates/RevocationCheckerTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/certificates/RevocationCheckerTest.kt
@@ -36,7 +36,7 @@ class RevocationCheckerTest {
         (context.arguments()[1] as  () -> RPCSubscription<RevocationCheckRequest, RevocationCheckResponse>)()
     }
     init {
-        RevocationChecker(subscriptionFactory, mock(), mock())
+        RevocationChecker(subscriptionFactory, mock(), mock(), mock())
     }
 
     @AfterEach

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/DynamicKeyStoreTest.kt
@@ -85,6 +85,7 @@ class DynamicKeyStoreTest {
         lifecycleCoordinatorFactory,
         subscriptionFactoryForKeystore,
         nodeConfiguration,
+        mock(),
         cryptoOpsClient,
         certificateFactory
     ) { signer, certificatesStore ->

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/http/TrustStoresMapTest.kt
@@ -80,6 +80,7 @@ class TrustStoresMapTest {
         lifecycleCoordinatorFactory,
         subscriptionFactory,
         nodeConfiguration,
+        mock(),
         certificateFactory
     )
 

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStoreTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/mtls/DynamicCertificateSubjectStoreTest.kt
@@ -44,7 +44,7 @@ class DynamicCertificateSubjectStoreTest {
         (context.arguments()[1] as (() -> CompactedSubscription<String, ClientCertificateSubjects>)).invoke()
     }
     private val dynamicCertificateSubjectStore =
-        DynamicCertificateSubjectStore(lifecycleCoordinatorFactory, subscriptionFactory, nodeConfiguration)
+        DynamicCertificateSubjectStore(lifecycleCoordinatorFactory, mock(), subscriptionFactory, nodeConfiguration)
 
     @AfterEach
     fun cleanUp() {

--- a/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImplTest.kt
+++ b/components/gateway/src/test/kotlin/net/corda/p2p/gateway/messaging/session/SessionPartitionMapperImplTest.kt
@@ -58,7 +58,7 @@ class SessionPartitionMapperImplTest {
             "2" to SessionPartitions(listOf(3, 4))
         )
 
-        val sessionPartitionMapper = SessionPartitionMapperImpl(factory, subscriptionFactory, config)
+        val sessionPartitionMapper = SessionPartitionMapperImpl(factory, subscriptionFactory, mock(), config)
         doReturn(true).whenever(dominoTile.constructed().last()).isRunning
 
         processor.firstValue.onSnapshot(partitionsMapping)
@@ -75,7 +75,7 @@ class SessionPartitionMapperImplTest {
     @Test
     fun `getPartitions cannot be invoked, when component is not running`() {
         val sessionId = "test-session-id"
-        val sessionPartitionMapper = SessionPartitionMapperImpl(factory, subscriptionFactory, config)
+        val sessionPartitionMapper = SessionPartitionMapperImpl(factory, subscriptionFactory, mock(), config)
 
         assertThatThrownBy { sessionPartitionMapper.getPartitions(sessionId) }
             .isInstanceOf(IllegalStateException::class.java)
@@ -92,7 +92,7 @@ class SessionPartitionMapperImplTest {
 
     @Test
     fun `onSnapshot will complete the resource created future`() {
-        val sessionPartitionMapper = SessionPartitionMapperImpl(factory, subscriptionFactory, config)
+        val sessionPartitionMapper = SessionPartitionMapperImpl(factory, subscriptionFactory, mock(), config)
 
         processor.firstValue.onSnapshot(emptyMap())
         assertThat(sessionPartitionMapper.future.isDone).isTrue
@@ -101,7 +101,7 @@ class SessionPartitionMapperImplTest {
 
     @Test
     fun `empty record will remove the partition`() {
-        val sessionPartitionMapper = SessionPartitionMapperImpl(factory, subscriptionFactory, config)
+        val sessionPartitionMapper = SessionPartitionMapperImpl(factory, subscriptionFactory, mock(), config)
         doReturn(true).whenever(dominoTile.constructed().last()).isRunning
         processor.firstValue.onSnapshot(mapOf("session" to SessionPartitions(listOf(3))))
 

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/LinkManager.kt
@@ -48,6 +48,7 @@ class LinkManager(
             lifecycleCoordinatorFactory,
             subscriptionFactory,
             messagingConfiguration,
+            configurationReaderService,
         ),
     clock: Clock = UTCClock()
 ) : LifecycleWithDominoTile {
@@ -97,7 +98,8 @@ class LinkManager(
         subscriptionFactory = subscriptionFactory,
         messagingConfiguration = messagingConfiguration,
         clock = clock,
-    )
+        configurationReadService = configurationReaderService,
+        )
 
     override val dominoTile = ComplexDominoTile(
         this::class.java.simpleName,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/CommonComponents.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/common/CommonComponents.kt
@@ -105,6 +105,7 @@ internal class CommonComponents(
             messagingConfiguration,
             lifecycleCoordinatorFactory,
             stateManager,
+            configurationReaderService,
             SessionManagerImpl(
                 groupPolicyProvider,
                 membershipGroupReaderProvider,
@@ -150,6 +151,7 @@ internal class CommonComponents(
         subscriptionFactory,
         publisherFactory,
         lifecycleCoordinatorFactory,
+        configurationReaderService,
         messagingConfiguration,
     ).also {
         groupPolicyProvider.registerListener(LISTENER_NAME) { holdingIdentity, groupPolicy ->
@@ -160,6 +162,7 @@ internal class CommonComponents(
     private val tlsCertificatesPublisher = TlsCertificatesPublisher(
         subscriptionFactory,
         publisherFactory,
+        configurationReaderService,
         lifecycleCoordinatorFactory,
         messagingConfiguration,
     ).also {
@@ -172,6 +175,7 @@ internal class CommonComponents(
         lifecycleCoordinatorFactory,
         messagingConfiguration,
         groupPolicyProvider,
+        configurationReaderService,
     )
 
     private val externalDependencies = listOf(

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class DeliveryTracker(
@@ -80,7 +79,6 @@ internal class DeliveryTracker(
         messageTrackerSubscription,
         subscriptionConfig,
         configReadService,
-        P2P_LINK_MANAGER_CONFIG,
         setOf(
             replayScheduler.dominoTile.coordinatorName,
             LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/delivery/DeliveryTracker.kt
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class DeliveryTracker(
@@ -78,6 +79,8 @@ internal class DeliveryTracker(
         coordinatorFactory,
         messageTrackerSubscription,
         subscriptionConfig,
+        configReadService,
+        P2P_LINK_MANAGER_CONFIG,
         setOf(
             replayScheduler.dominoTile.coordinatorName,
             LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TlsCertificatesPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TlsCertificatesPublisher.kt
@@ -23,7 +23,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class TlsCertificatesPublisher(
@@ -121,7 +120,6 @@ internal class TlsCertificatesPublisher(
         subscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TlsCertificatesPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TlsCertificatesPublisher.kt
@@ -22,11 +22,14 @@ import net.corda.virtualnode.toAvro
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class TlsCertificatesPublisher(
     subscriptionFactory: SubscriptionFactory,
     publisherFactory: PublisherFactory,
+    configurationReadService: ConfigurationReadService,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     messagingConfiguration: SmartConfig,
 ) : LifecycleWithDominoTile, HostingMapListener {
@@ -117,6 +120,8 @@ internal class TlsCertificatesPublisher(
         lifecycleCoordinatorFactory,
         subscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TrustStoresPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TrustStoresPublisher.kt
@@ -25,7 +25,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class TrustStoresPublisher(
@@ -64,7 +63,6 @@ internal class TrustStoresPublisher(
         subscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TrustStoresPublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TrustStoresPublisher.kt
@@ -24,12 +24,15 @@ import org.slf4j.LoggerFactory
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class TrustStoresPublisher(
     subscriptionFactory: SubscriptionFactory,
     publisherFactory: PublisherFactory,
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
+    configurationReadService: ConfigurationReadService,
     messagingConfiguration: SmartConfig,
 ) : LifecycleWithDominoTile {
 
@@ -60,6 +63,8 @@ internal class TrustStoresPublisher(
         lifecycleCoordinatorFactory,
         subscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificateBusListener.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificateBusListener.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.linkmanager.forwarding.gateway.mtls
 
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.p2p.mtls.gateway.ClientCertificateSubjects
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
@@ -10,6 +11,7 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.P2P.GATEWAY_ALLOWED_CLIENT_CERTIFICATE_SUBJECTS
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class ClientCertificateBusListener<T : Any> private constructor(
@@ -23,6 +25,7 @@ internal class ClientCertificateBusListener<T : Any> private constructor(
             lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
             messagingConfiguration: SmartConfig,
             subscriptionFactory: SubscriptionFactory,
+            configurationReadService: ConfigurationReadService,
             topic: String,
             crossinline subjectFactory: (T) -> String,
         ): DominoTile {
@@ -49,6 +52,8 @@ internal class ClientCertificateBusListener<T : Any> private constructor(
                 subscriptionConfig = subscriptionConfig,
                 managedChildren = emptyList(),
                 dependentChildren = emptyList(),
+                configurationReadService = configurationReadService,
+                configKey = P2P_LINK_MANAGER_CONFIG,
                 subscriptionGenerator = {
                     subscriptionFactory.createDurableSubscription(
                         subscriptionConfig = subscriptionConfig,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificateBusListener.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificateBusListener.kt
@@ -11,7 +11,6 @@ import net.corda.messaging.api.records.Record
 import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.schema.Schemas.P2P.GATEWAY_ALLOWED_CLIENT_CERTIFICATE_SUBJECTS
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class ClientCertificateBusListener<T : Any> private constructor(
@@ -53,7 +52,6 @@ internal class ClientCertificateBusListener<T : Any> private constructor(
                 managedChildren = emptyList(),
                 dependentChildren = emptyList(),
                 configurationReadService = configurationReadService,
-                configKey = P2P_LINK_MANAGER_CONFIG,
                 subscriptionGenerator = {
                     subscriptionFactory.createDurableSubscription(
                         subscriptionConfig = subscriptionConfig,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificatePublisher.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificatePublisher.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.linkmanager.forwarding.gateway.mtls
 
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.p2p.mtls.MemberAllowedCertificateSubject
 import net.corda.data.p2p.mtls.MgmAllowedCertificateSubject
 import net.corda.libs.configuration.SmartConfig
@@ -21,6 +22,7 @@ internal class ClientCertificatePublisher(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     messagingConfiguration: SmartConfig,
     groupPolicyProvider: GroupPolicyProvider,
+    configurationReadService: ConfigurationReadService,
 ) : LifecycleWithDominoTile {
     private companion object {
         const val PUBLISHER_NAME = "linkmanager_mtls_client_certificate_publisher"
@@ -41,6 +43,7 @@ internal class ClientCertificatePublisher(
         lifecycleCoordinatorFactory,
         messagingConfiguration,
         subscriptionFactory,
+        configurationReadService,
         P2P_MTLS_MEMBER_CLIENT_CERTIFICATE_SUBJECT_TOPIC,
         MemberAllowedCertificateSubject::getSubject,
     )
@@ -49,6 +52,7 @@ internal class ClientCertificatePublisher(
         lifecycleCoordinatorFactory,
         messagingConfiguration,
         subscriptionFactory,
+        configurationReadService,
         P2P_MGM_ALLOWED_CLIENT_CERTIFICATE_SUBJECTS,
         MgmAllowedCertificateSubject::getSubject,
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/hosting/LinkManagerHostingMapImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/hosting/LinkManagerHostingMapImpl.kt
@@ -23,11 +23,14 @@ import net.corda.virtualnode.toCorda
 import java.nio.ByteBuffer
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import net.corda.configuration.read.ConfigurationReadService
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 internal class LinkManagerHostingMapImpl(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
     subscriptionFactory: SubscriptionFactory,
     configuration: SmartConfig,
+    configurationReadService: ConfigurationReadService,
 ) : LinkManagerHostingMap {
     companion object {
         private const val GROUP_NAME = "linkmanager_stub_hosting_map"
@@ -57,6 +60,8 @@ internal class LinkManagerHostingMapImpl(
         lifecycleCoordinatorFactory,
         subscription,
         subscriptionConfig,
+        configurationReadService = configurationReadService,
+        configKey = P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/hosting/LinkManagerHostingMapImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/hosting/LinkManagerHostingMapImpl.kt
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import net.corda.configuration.read.ConfigurationReadService
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 internal class LinkManagerHostingMapImpl(
     lifecycleCoordinatorFactory: LifecycleCoordinatorFactory,
@@ -61,7 +60,6 @@ internal class LinkManagerHostingMapImpl(
         subscription,
         subscriptionConfig,
         configurationReadService = configurationReadService,
-        configKey = P2P_LINK_MANAGER_CONFIG,
         emptyList(),
         emptyList(),
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundLinkManager.kt
@@ -12,7 +12,6 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.linkmanager.common.CommonComponents
 import net.corda.schema.Schemas
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 import net.corda.utilities.time.Clock
 
 @Suppress("LongParameterList")
@@ -50,7 +49,6 @@ internal class InboundLinkManager(
         inboundMessageSubscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_LINK_MANAGER_CONFIG,
         dependentChildren = listOf(
             LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
             LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/inbound/InboundLinkManager.kt
@@ -1,5 +1,6 @@
 package net.corda.p2p.linkmanager.inbound
 
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.libs.configuration.SmartConfig
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
@@ -11,6 +12,7 @@ import net.corda.messaging.api.subscription.config.SubscriptionConfig
 import net.corda.messaging.api.subscription.factory.SubscriptionFactory
 import net.corda.p2p.linkmanager.common.CommonComponents
 import net.corda.schema.Schemas
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 import net.corda.utilities.time.Clock
 
 @Suppress("LongParameterList")
@@ -22,6 +24,7 @@ internal class InboundLinkManager(
     subscriptionFactory: SubscriptionFactory,
     messagingConfiguration: SmartConfig,
     clock: Clock,
+    configurationReadService: ConfigurationReadService
 ) : LifecycleWithDominoTile {
     companion object {
         private const val INBOUND_MESSAGE_PROCESSOR_GROUP = "inbound_message_processor_group"
@@ -46,6 +49,8 @@ internal class InboundLinkManager(
         lifecycleCoordinatorFactory,
         inboundMessageSubscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_LINK_MANAGER_CONFIG,
         dependentChildren = listOf(
             LifecycleCoordinatorName.forComponent<GroupPolicyProvider>(),
             LifecycleCoordinatorName.forComponent<MembershipGroupReaderProvider>(),

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
@@ -19,6 +19,7 @@ import net.corda.p2p.linkmanager.delivery.DeliveryTracker
 import net.corda.schema.Schemas
 import net.corda.utilities.time.Clock
 import java.util.concurrent.Executors
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class OutboundLinkManager(
@@ -83,6 +84,8 @@ internal class OutboundLinkManager(
         lifecycleCoordinatorFactory,
         outboundMessageSubscription,
         subscriptionConfig,
+        configurationReaderService,
+        P2P_LINK_MANAGER_CONFIG,
         dependentChildren = listOf(
             deliveryTracker.dominoTile.coordinatorName,
             commonComponents.dominoTile.coordinatorName,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/outbound/OutboundLinkManager.kt
@@ -19,7 +19,6 @@ import net.corda.p2p.linkmanager.delivery.DeliveryTracker
 import net.corda.schema.Schemas
 import net.corda.utilities.time.Clock
 import java.util.concurrent.Executors
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 
 @Suppress("LongParameterList")
 internal class OutboundLinkManager(
@@ -85,7 +84,6 @@ internal class OutboundLinkManager(
         outboundMessageSubscription,
         subscriptionConfig,
         configurationReaderService,
-        P2P_LINK_MANAGER_CONFIG,
         dependentChildren = listOf(
             deliveryTracker.dominoTile.coordinatorName,
             commonComponents.dominoTile.coordinatorName,

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImpl.kt
@@ -60,6 +60,7 @@ import java.security.MessageDigest
 import java.time.Duration
 import java.util.Base64
 import java.util.UUID
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.p2p.crypto.InitiatorHandshakeMessage as AvroInitiatorHandshakeMessage
 import net.corda.data.p2p.crypto.InitiatorHelloMessage as AvroInitiatorHelloMessage
 import net.corda.data.p2p.crypto.ResponderHandshakeMessage as AvroResponderHandshakeMessage
@@ -72,6 +73,7 @@ internal class StatefulSessionManagerImpl(
     messagingConfig: SmartConfig,
     coordinatorFactory: LifecycleCoordinatorFactory,
     stateManager: StateManager,
+    configurationReadService: ConfigurationReadService,
     private val sessionManagerImpl: SessionManagerImpl,
     private val stateConvertor: StateConvertor,
     private val clock: Clock,
@@ -1183,6 +1185,7 @@ internal class StatefulSessionManagerImpl(
         messagingConfig,
         stateManager,
         stateConvertor,
+        configurationReadService,
         sessionCache,
         sessionManagerImpl,
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/events/StatefulSessionEventProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/events/StatefulSessionEventProcessor.kt
@@ -28,7 +28,6 @@ import net.corda.p2p.linkmanager.sessions.metadata.InboundSessionStatus
 import net.corda.p2p.linkmanager.sessions.metadata.OutboundSessionMetadata.Companion.toOutbound
 import net.corda.p2p.linkmanager.sessions.metadata.OutboundSessionStatus
 import net.corda.schema.Schemas
-import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -155,7 +154,6 @@ internal class StatefulSessionEventProcessor(
         sessionPartitionSubscription,
         subscriptionConfig,
         configurationReadService,
-        P2P_LINK_MANAGER_CONFIG,
         emptySet(),
         emptySet()
     )

--- a/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/events/StatefulSessionEventProcessor.kt
+++ b/components/link-manager/src/main/kotlin/net/corda/p2p/linkmanager/sessions/events/StatefulSessionEventProcessor.kt
@@ -3,6 +3,7 @@ package net.corda.p2p.linkmanager.sessions.events
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
+import net.corda.configuration.read.ConfigurationReadService
 import net.corda.data.p2p.event.SessionCreated
 import net.corda.data.p2p.event.SessionDeleted
 import net.corda.data.p2p.event.SessionDirection
@@ -27,6 +28,7 @@ import net.corda.p2p.linkmanager.sessions.metadata.InboundSessionStatus
 import net.corda.p2p.linkmanager.sessions.metadata.OutboundSessionMetadata.Companion.toOutbound
 import net.corda.p2p.linkmanager.sessions.metadata.OutboundSessionStatus
 import net.corda.schema.Schemas
+import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -37,7 +39,7 @@ internal class StatefulSessionEventProcessor(
     messagingConfiguration: SmartConfig,
     private val stateManager: StateManager,
     private val stateConvertor: StateConvertor,
-
+    configurationReadService: ConfigurationReadService,
     val sessionCache: SessionCache,
     private val sessionManagerImpl: SessionManagerImpl,
 ): LifecycleWithDominoTile {
@@ -152,6 +154,8 @@ internal class StatefulSessionEventProcessor(
         coordinatorFactory,
         sessionPartitionSubscription,
         subscriptionConfig,
+        configurationReadService,
+        P2P_LINK_MANAGER_CONFIG,
         emptySet(),
         emptySet()
     )

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TlsCertificatesPublisherTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TlsCertificatesPublisherTest.kt
@@ -79,6 +79,7 @@ class TlsCertificatesPublisherTest {
     private val publisher = TlsCertificatesPublisher(
         subscriptionFactory,
         publisherFactory,
+        mock(),
         lifecycleCoordinatorFactory,
         configuration,
     )

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TrustStoresPublisherTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/TrustStoresPublisherTest.kt
@@ -83,6 +83,7 @@ class TrustStoresPublisherTest {
         subscriptionFactory,
         publisherFactory,
         lifecycleCoordinatorFactory,
+        mock(),
         configuration,
     )
 

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificateBusListenerTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificateBusListenerTest.kt
@@ -55,6 +55,7 @@ class ClientCertificateBusListenerTest {
             lifecycleCoordinatorFactory,
             messagingConfiguration,
             subscriptionFactory,
+            mock(),
             "topic",
             Value::subject
         )

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificatePublisherTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/forwarding/gateway/mtls/ClientCertificatePublisherTest.kt
@@ -26,6 +26,7 @@ class ClientCertificatePublisherTest {
         lifecycleCoordinatorFactory,
         messagingConfiguration,
         mock(),
+        mock()
     )
 
     @Test

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/hosting/LinkManagerHostingMapImplTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/hosting/LinkManagerHostingMapImplTest.kt
@@ -105,7 +105,8 @@ class LinkManagerHostingMapImplTest {
     private val testObject = LinkManagerHostingMapImpl(
         lifecycleCoordinatorFactory,
         subscriptionFactory,
-        configuration
+        configuration,
+        mock()
     )
 
     @AfterEach

--- a/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImplTest.kt
+++ b/components/link-manager/src/test/kotlin/net/corda/p2p/linkmanager/sessions/StatefulSessionManagerImplTest.kt
@@ -112,6 +112,7 @@ class StatefulSessionManagerImplTest {
         mock(),
         coordinatorFactory,
         stateManager,
+        mock(),
         sessionManagerImpl,
         stateConvertor,
         clock,


### PR DESCRIPTION
Prevent subscriptions starting before historic Avro Schema's are published, in the Link Manager and Gateway. These historic schemas are read from Kafka, so we must read them first before we use them. 

The code inside `AvroSchemaProcessor` publishes a `SetupConfigSubscription` event to the `ConfigReadServiceEventHandler` which only publishes config after this event has happened. Hence if we wait for the config to be published before starting subscriptions the `AvroSchemaProcessor` must have published an initial snapshot of the schema data.


Testing
---
1. Start the combined worker on Corda 5.2 (with a Kafka message bus).
2. OnBoard an MGM and a Member.
3. Upgrade the Database from 5.2.0 to 5.2.1 (includes scaling down the combined worker).
4. Bring up the worker on 5.2.1 (and check there is no Failed to deserialize bytes returned message in the logs).