### PR TITLE
ES-2396: Generated REST client Serializer workaround

### DIFF
--- a/libs/rest/generated-rest-client/build.gradle
+++ b/libs/rest/generated-rest-client/build.gradle
@@ -154,20 +154,9 @@ tasks.register('applyWorkaroundForStringResponseType') {
     }
 }
 
-tasks.register('applyWorkaroundForSerializer') {
-    dependsOn 'openApiGenerate'
-    doLast {
-        def targetLine = '.findAndRegisterModules()'
-        def replacementLine = '.findAndRegisterModules().registerModule(com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())'
-        def fileName = "${project.buildDir}/generated/src/main/kotlin/net/corda/restclient/generated/infrastructure/Serializer.kt"
-        file(fileName).text = file(fileName).text.replace(targetLine, replacementLine)
-    }
-}
-
 tasks.register('applyWorkarounds') {
     dependsOn 'applyWorkaroundForCertificateApi'
     dependsOn 'applyWorkaroundForStringResponseType'
-//    dependsOn 'applyWorkaroundForSerializer'
 }
 
 tasks.named('compileKotlin') {

--- a/libs/rest/generated-rest-client/build.gradle
+++ b/libs/rest/generated-rest-client/build.gradle
@@ -167,7 +167,7 @@ tasks.register('applyWorkaroundForSerializer') {
 tasks.register('applyWorkarounds') {
     dependsOn 'applyWorkaroundForCertificateApi'
     dependsOn 'applyWorkaroundForStringResponseType'
-    dependsOn 'applyWorkaroundForSerializer'
+//    dependsOn 'applyWorkaroundForSerializer'
 }
 
 tasks.named('compileKotlin') {

--- a/libs/rest/generated-rest-client/src/test/kotlin/net/corda/restclient/generated/TestKnownIssues.kt
+++ b/libs/rest/generated-rest-client/src/test/kotlin/net/corda/restclient/generated/TestKnownIssues.kt
@@ -49,7 +49,8 @@ class TestKnownIssues {
     }
 
     /**
-     * See comment for workaround details
+     * Test that `String` type responses are not being deserialized.
+     * See the workaround details
      * https://r3-cev.atlassian.net/browse/ES-2378?focusedCommentId=306841
      */
     @Test
@@ -107,7 +108,8 @@ class TestKnownIssues {
     }
 
     /**
-     * See comment for workaround details
+     * Test that `String` type responses are not being deserialized.
+     * See the workaround details
      * https://r3-cev.atlassian.net/browse/ES-2378?focusedCommentId=306841
      */
     @Test
@@ -141,7 +143,8 @@ class TestKnownIssues {
     }
 
     /**
-     * See comment for workaround details
+     * Test that `String` type responses are not being deserialized.
+     * See the workaround details
      * https://r3-cev.atlassian.net/browse/ES-2378?focusedCommentId=306841
      */
     @Test
@@ -170,7 +173,8 @@ class TestKnownIssues {
     }
 
     /**
-     * See comment for workaround details
+     * Test that `String` type responses are not being deserialized.
+     * See the workaround details
      * https://r3-cev.atlassian.net/browse/ES-2378?focusedCommentId=306841
      */
     @Test
@@ -202,7 +206,8 @@ class TestKnownIssues {
     }
 
     /**
-     * See comment for workaround details
+     * Test that `String` type responses are not being deserialized.
+     * See the workaround details
      * https://r3-cev.atlassian.net/browse/ES-2378?focusedCommentId=306841
      */
     @Test
@@ -222,9 +227,10 @@ class TestKnownIssues {
     }
 
     /**
-     * The generated client can't deserialize the Instant type natively
-     * The suggested fix is to add the dependency on libs.jackson.datatype.jsr310
-     * After adding the dependency this now works locally, but still fails on Jenkins
+     * Test that the dependency on `libs.jackson.datatype.jsr310` is consumed correctly
+     * by the generated client and propagated to the using code, including Corda CLI,
+     * enabling the correct deserialization of the `Instant` type.
+     * See details: https://r3-cev.atlassian.net/browse/ES-2396
     */
     @Test
     fun testGetRole() {


### PR DESCRIPTION
### [ES-2396](https://r3-cev.atlassian.net/browse/ES-2396)
- Remove the workaround. Since raising, the issue seems to have been resolved upstream: after removing the workaround, all tests are passing, including the `corda-runtime-os-e2e-tests/pr-merge` pipeline.
- Supporting e2e run to fully test things using the artifacts produced by this PR, including Corda CLI and e2e test utilities: 
  - https://ci02.dev.r3.com/job/Corda5/job/corda5-e2e-tests/job/PR-655/2/
  - E2E PR: https://github.com/corda/corda-e2e-tests/pull/655/files
- Update kdoc on the existing tests for other known issues with the generated rest client

[ES-2396]: https://r3-cev.atlassian.net/browse/ES-2396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ