### PR TITLE
CORE-20702: Add REST API version check to E2E utilities

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -45,7 +45,7 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
     }
 
     private fun checkIfNotPreviousVersion(): Boolean {
-        return REST_API_VERSION_PATH != "v5_1" && REST_API_VERSION_PATH != "v5_2"
+        return REST_API_VERSION_PATH != RestApiVersion.C5_1.versionPath && REST_API_VERSION_PATH != RestApiVersion.C5_2.versionPath
     }
 
     internal val vNodeCreatorClient: HttpsClient by lazy {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -47,7 +47,12 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
     internal val vNodeCreatorClient: HttpsClient by lazy {
         lock.withLock {
             val vNodeCreatorRole = checkVNodeCreatorRoleExists()
-            if (vNodeCreatorRole != null && checkVNodeCreatorUserDoesNotExist()) {
+            if (
+                REST_API_VERSION_PATH != "v5_1" &&
+                REST_API_VERSION_PATH != "v5_2" &&
+                vNodeCreatorRole != null &&
+                checkVNodeCreatorUserDoesNotExist()
+            ) {
                 logger.info(
                     "Creating user '$vNodeCreatorName' with role '${vNodeCreatorRole["roleName"].textValue()}'"
                 )

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -44,15 +44,14 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
         return getRbacUser(vNodeCreatorName).body.contains("User '$vNodeCreatorName' not found")
     }
 
+    private fun checkIfNotPreviousVersion(): Boolean {
+        return REST_API_VERSION_PATH != "v5_1" && REST_API_VERSION_PATH != "v5_2"
+    }
+
     internal val vNodeCreatorClient: HttpsClient by lazy {
         lock.withLock {
             val vNodeCreatorRole = checkVNodeCreatorRoleExists()
-            if (
-                REST_API_VERSION_PATH != "v5_1" &&
-                REST_API_VERSION_PATH != "v5_2" &&
-                vNodeCreatorRole != null &&
-                checkVNodeCreatorUserDoesNotExist()
-            ) {
+            if (checkIfNotPreviousVersion() && vNodeCreatorRole != null && checkVNodeCreatorUserDoesNotExist()) {
                 logger.info(
                     "Creating user '$vNodeCreatorName' with role '${vNodeCreatorRole["roleName"].textValue()}'"
                 )


### PR DESCRIPTION
- Added REST API version check when initialising vNodeCreatorClient

Upgrade tests with fix: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda5-upgrade-tests/detail/PR-657/1/tests/ (tests fail due to previous unrelated issue)

E2E tests: https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda5-e2e-tests/detail/PR-657/9/tests