### PR TITLE
CORE-20738: Registration not closed error from LifecycleProcessor

### DIFF
--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
@@ -1,7 +1,5 @@
 package net.corda.lifecycle.impl
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ScheduledFuture
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.ErrorEvent
 import net.corda.lifecycle.LifecycleCoordinator
@@ -18,6 +16,8 @@ import net.corda.lifecycle.registry.LifecycleRegistryException
 import net.corda.utilities.debug
 import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledFuture
 
 /**
  * Perform processing of lifecycle events.
@@ -213,7 +213,7 @@ internal class LifecycleProcessor(
         }
         state.trackedRegistrations.clear()
         state.registrations.forEach {
-            logger.error("$it on ${coordinator.name} not closed.")
+            logger.warn("$it on ${coordinator.name} not closed.")
             it.updateCoordinatorStatus(coordinator, LifecycleStatus.ERROR)
         }
         state.registrations.clear()


### PR DESCRIPTION
The resiliency tests on the 5.2 pipeline have begun failing with an ERROR level log that a Registration is not closed. 
It seems that the workers shutting down in this case is the normal shutdown which occurs when config is received, e.g. Container definition changed, will be restarted. 

There is known limitation of registration logic around shutdown and there's a specific order things have to close.
As this is suddenly failing, and failing consistently, the specific order things have to close in may have been disrupted by this recent change in that area https://github.com/corda/corda-runtime-os/pull/6189 to fix a P2P race condition problem.

As this issue is only observed on shutdown and we do not observe any other functional problems, this PR will downgrade the ERROR level log to a WARN level log.