### PR TITLE
CORE-20706: Fix CPI Reconciliation

### DIFF
--- a/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/impl/CpiMetadataRepositoryImpl.kt
+++ b/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/repository/impl/CpiMetadataRepositoryImpl.kt
@@ -76,8 +76,8 @@ internal class CpiMetadataRepositoryImpl: CpiMetadataRepository {
         // Joining the other tables to ensure all data is fetched eagerly
         return em.createQuery(
             "FROM ${CpiMetadataEntity::class.simpleName} cpi_ " +
-                    "INNER JOIN FETCH cpi_.cpks cpk_ " +
-                    "INNER JOIN FETCH cpk_.metadata cpk_meta_ " +
+                    "LEFT JOIN FETCH cpi_.cpks cpk_ " +
+                    "LEFT JOIN FETCH cpk_.metadata cpk_meta_ " +
                     "ORDER BY cpi_.name, cpi_.version, cpi_.signerSummaryHash",
             CpiMetadataEntity::class.java
         ).resultList.map { cpiMetadataEntity ->


### PR DESCRIPTION
CPI reconciliation previously did not retrieve CPIs that had no CPKs associated with them. This was due to a bug in the SQL query used to retrieve them, which used an inner join. This PR changes that to a left join, which will remove CPKs with no CPI from the response but will keep CPIs with no CPKs in the response