### PR TITLE
ES-2466: Add Claim to JenkinsfileCombinedWorkerPluginsSmokeTests

### DIFF
--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -67,6 +67,7 @@ pipeline {
     stages {
         stage('check out') {
             steps {
+                testing
                 script {
                     gitUtils.checkoutGitRevisionOfTriggeringJob(params.COMMIT_TO_CHECKOUT)
                 }

--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -127,6 +127,7 @@ pipeline {
     }
     post {
         always {
+            step([$class: 'ClaimPublisher'])
             script {      
                     findBuildScans()
                     pipelineUtils.getPodLogs("postgres")

--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -116,7 +116,6 @@ pipeline {
                     timeout(time: 30, unit: 'MINUTES')
                 }
                 steps {
-                    sh 'exit 1'
                    gradlew('pluginSmoketest -PisCombinedWorker=true')
                 }
                 post {

--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -62,12 +62,12 @@ pipeline {
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
         timestamps()
+        test1212()
     }
 
     stages {
         stage('check out') {
             steps {
-                testing
                 script {
                     gitUtils.checkoutGitRevisionOfTriggeringJob(params.COMMIT_TO_CHECKOUT)
                 }

--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -62,7 +62,6 @@ pipeline {
     options {
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
         timestamps()
-        test1212()
     }
 
     stages {
@@ -113,6 +112,7 @@ pipeline {
             }
         }
         stage('plugin smoke tests') {
+            testing
                 options {
                     timeout(time: 30, unit: 'MINUTES')
                 }

--- a/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
+++ b/.ci/JenkinsfileCombinedWorkerPluginsSmokeTests
@@ -112,11 +112,11 @@ pipeline {
             }
         }
         stage('plugin smoke tests') {
-            testing
                 options {
                     timeout(time: 30, unit: 'MINUTES')
                 }
                 steps {
+                    sh 'exit 1'
                    gradlew('pluginSmoketest -PisCombinedWorker=true')
                 }
                 post {


### PR DESCRIPTION
**Description**
Claim plugin is missing from combined-worker-plugin-smoke-tests as seen here https://r3holdco.slack.com/archives/C039J1A3ZQB/p1718382476075759?thread_ts=1718381496.116219&cid=C039J1A3ZQB

**Tested Against**
"Claim it" can now be seen under this build's status
https://ci02.dev.r3.com/job/Corda5/view/Full%20Health%205.3/job/corda-runtime-os-combined-worker-plugins-smoke-tests/view/change-requests/job/PR-6222/6/
