### PR TITLE
CORE-20708: Cherry pick of: Wait for the cluster to be ready before sending REST calls

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
@@ -3,6 +3,7 @@ package net.corda.e2etest.utilities.config
 import com.fasterxml.jackson.databind.JsonNode
 import kong.unirest.UnirestException
 import net.corda.e2etest.utilities.ClusterInfo
+import net.corda.e2etest.utilities.ClusterReadinessChecker
 import net.corda.e2etest.utilities.DEFAULT_CLUSTER
 import net.corda.e2etest.utilities.assertWithRetryIgnoringExceptions
 import net.corda.e2etest.utilities.cluster
@@ -150,6 +151,9 @@ fun ClusterInfo.waitForConfigurationChange(
                 }.hasCauseInstanceOf(IOException::class.java)
             }
         }
+
+        // check cluster is ready. No need to aggressively poll too much as its expected the cluster to be down for a number of seconds
+        ClusterReadinessChecker().assertIsReady(Duration.ofMinutes(2), Duration.ofMillis(1000))
 
         // Wait for the service to become available again and have the expected configuration value
         assertWithRetryIgnoringExceptions {


### PR DESCRIPTION
Cherry picking to fix 5.3
This will ensure config has propagated through the system. Currently the tests wait until the client stops throwing exceptions when trying to connect to the REST worker to detect that its back up, This results in some strange timing issues which affect test stability