### PR TITLE
CORE-20592: Kafka connection testing - change classification of CommitFailedException

### DIFF
--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleProcessor.kt
@@ -1,7 +1,5 @@
 package net.corda.lifecycle.impl
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ScheduledFuture
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.ErrorEvent
 import net.corda.lifecycle.LifecycleCoordinator
@@ -18,6 +16,8 @@ import net.corda.lifecycle.registry.LifecycleRegistryException
 import net.corda.utilities.debug
 import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ScheduledFuture
 
 /**
  * Perform processing of lifecycle events.
@@ -161,7 +161,8 @@ internal class LifecycleProcessor(
     }
 
     private fun processStopEvent(event: StopEvent, coordinator: LifecycleCoordinatorInternal): Boolean {
-        logger.debug { "Processing stop event for ${coordinator.name}" }
+        logger.info ( "Coordinator status is: ${coordinator.status} Processing stop event $event for" +
+                " ${coordinator.name}" )
         if (state.isRunning) {
             state.isRunning = false
             val (newStatus, reason) = if (event.errored) {

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -70,8 +70,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
             ArithmeticException::class.java,
             FencedInstanceIdException::class.java,
             InconsistentGroupProtocolException::class.java,
-            InvalidOffsetException::class.java,
-            CommitFailedException::class.java
+            InvalidOffsetException::class.java
         )
         val transientExceptions: Set<Class<out Throwable>> = setOf(
             TimeoutException::class.java,
@@ -79,7 +78,8 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
             InterruptException::class.java,
             KafkaException::class.java,
             ConcurrentModificationException::class.java,
-            RebalanceInProgressException::class.java
+            RebalanceInProgressException::class.java,
+            CommitFailedException::class.java
         )
     }
 

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -193,7 +193,7 @@ class CordaKafkaConsumerImplTest {
         cordaKafkaConsumer = createConsumer(consumer)
 
         doThrow(CommitFailedException()).whenever(consumer).commitSync()
-        assertThatExceptionOfType(CordaMessageAPIFatalException::class.java).isThrownBy {
+        assertThatExceptionOfType(CordaMessageAPIIntermittentException::class.java).isThrownBy {
             cordaKafkaConsumer.syncCommitOffsets()
         }
         verify(consumer, times(1)).commitSync()
@@ -211,13 +211,13 @@ class CordaKafkaConsumerImplTest {
     }
 
     @Test
-    fun testCommitOffsetsFatal() {
+    fun testCommitOffsetsThrowIntermittent() {
         consumer = mock()
         cordaKafkaConsumer = createConsumer(consumer)
 
         val consumerRecord = CordaConsumerRecord(eventTopic, 1, 5L, "", "value", 0)
         doThrow(CommitFailedException()).whenever(consumer).commitSync(anyMap())
-        assertThatExceptionOfType(CordaMessageAPIFatalException::class.java).isThrownBy {
+        assertThatExceptionOfType(CordaMessageAPIIntermittentException::class.java).isThrownBy {
             cordaKafkaConsumer.syncCommitOffsets(consumerRecord, "meta data")
         }
         verify(consumer, times(1)).commitSync(anyMap())

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/ThreadLooper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/ThreadLooper.kt
@@ -4,7 +4,6 @@ import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleStatus
 import net.corda.messaging.config.ResolvedSubscriptionConfig
 import org.slf4j.Logger
-import java.lang.IllegalStateException
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.thread
 import kotlin.concurrent.withLock
@@ -215,6 +214,7 @@ class ThreadLooper(
             loopFunction()
             _isRunning = false
             if (lifecycleCoordinator.status != LifecycleStatus.ERROR) {
+                log.warn("CLOSING LOG LINE. Status is : ${lifecycleCoordinator.status}")
                 lifecycleCoordinator.close()
             }
         } catch (t: Throwable) {


### PR DESCRIPTION
Change CommitFailedException classification from fatal to transient. 
This is required as the kafka connection tests exposed that we mark CommitFailedException as fatal and therefore do not retry. A CommitFailedException means we should abort the transaction but by classifying it as fatal we will bubble this up and we will not retry on any level. A CommitFailedException is fatal at the transaction level but not at the worker level so this should be changed. 