### PR TITLE
CORE-0: Explicitly specify JUnit platform version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ nettyVersion = "4.1.109.Final"
 # Testing
 assertjVersion = "3.26.0"
 junitVersion = "5.10.3"
+junitPlatformVersion = "1.10.2"
 mockitoVersion = "5.12.0"
 mockitoKotlinVersion = "5.3.1"
 
@@ -88,7 +89,7 @@ junit = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "ju
 junit-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junitVersion" }
 junit-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junitVersion" }
 junit-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitVersion" }
-junit-platform = { group = "org.junit.platform", name = "junit-platform-launcher" }
+junit-platform = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitPlatformVersion" }
 kafka-client = { group = "org.apache.servicemix.bundles", name = "org.apache.servicemix.bundles.kafka-clients", version.ref = "kafkaClientVersion" }
 kotlin-stdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlinVersion" }
 kotlin-stdlib-common = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-common", version.ref = "kotlinVersion" }


### PR DESCRIPTION
Or else smoke tests do not run locally like so:
```
Could not determine the dependencies of task ':libs:db:db-admin-impl:test'.	
> Could not resolve all task dependencies for configuration ':libs:db:db-admin-impl:testRuntimeClasspath'.	
   > Could not find org.junit.platform:junit-platform-launcher:.	
     Required by:	
         project :libs:db:db-admin-impl
```