### PR TITLE
CORE-20728: Fix vNodeCreatorRole already assigned

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -73,8 +73,19 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
                     command {
                         assignRoleToUser(vNodeCreatorName, vNodeCreatorRole["id"].textValue())
                     }
-                    condition { it.code == 200 }
+                    condition { it.code == 200 || it.code == 409 }
                 }
+
+                assertWithRetry {
+                    command {
+                     getRbacUser(vNodeCreatorName)
+                    }
+                    condition {
+                        it.body.toJson()["roleAssociations"].first()["roleId"].textValue().equals(vNodeCreatorRole["id"].textValue())
+                    }
+                }
+
+
                 UnirestHttpsClient(clusterInfo.rest.uri, vNodeCreatorName, vNodeCreatorName)
             } else {
                 initialClient


### PR DESCRIPTION
Added a condition to check that the vNodeCreatorRole has been assigned to the vNodeCreatorUser, to fix the EntityAssociationAlreadyExistsException. 