### PR TITLE
CORE-8415: Filter out unwanted SLF4J bundle in tests

### DIFF
--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -63,9 +63,16 @@ Test-Cases: \${classes;HIERARCHY_INDIRECTLY_ANNOTATED;org.junit.platform.commons
     }
 }
 
+def slf4j2Dependency = libs.slf4j.api.get()
+
+def bundlesSet = files(sourceSets.integrationTest.runtimeClasspath.filter {
+    // Filter out SLF4J bundle as it will be conflicting with special bundle we provide for OSGi testing purposes: slf4jv1
+    !(it.path.contains("${slf4j2Dependency.name}-${slf4j2Dependency.version}"))
+}, configurations.archives.artifacts.files)
+
 def resolve = tasks.register('resolve', Resolve) {
     dependsOn jar, testingBundle
-    bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
+    bundles = bundlesSet
     bndrun = file('test.bndrun')
     outputBndrun = layout.buildDirectory.file('resolved-test.bndrun')
     doFirst {
@@ -81,7 +88,7 @@ def testOSGi = tasks.register('testOSGi', TestOSGi) {
         languageVersion = of(17)
     }
     resultsDirectory = file("$testResultsDir/integrationTest")
-    bundles = files(sourceSets.integrationTest.runtimeClasspath, configurations.archives.artifacts.files)
+    bundles = bundlesSet
     bndrun = resolve.flatMap { it.outputBndrun }
 
     // These properties are for Quasar's framework extension, should it be present.

--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -71,9 +71,8 @@ def bundlesSet = files(sourceSets.integrationTest.runtimeClasspath.filter {
 }, configurations.archives.artifacts.files)
 
 def resolve = tasks.register('resolve', Resolve) {
-    println("slf4j2Dependency: ${slf4j2Dependency.name}-${slf4j2Dependency.version}")
-    println("bundleSet:")
-    bundlesSet.forEach { println("    " + it.absolutePath) }
+    // println("bundleSet:")
+    // bundlesSet.forEach { println("    " + it.absolutePath) }
 
     dependsOn jar, testingBundle
     bundles = bundlesSet

--- a/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
+++ b/buildSrc/src/main/groovy/corda.osgi-test-conventions.gradle
@@ -71,6 +71,10 @@ def bundlesSet = files(sourceSets.integrationTest.runtimeClasspath.filter {
 }, configurations.archives.artifacts.files)
 
 def resolve = tasks.register('resolve', Resolve) {
+    println("slf4j2Dependency: ${slf4j2Dependency.name}-${slf4j2Dependency.version}")
+    println("bundleSet:")
+    bundlesSet.forEach { println("    " + it.absolutePath) }
+
     dependsOn jar, testingBundle
     bundles = bundlesSet
     bndrun = file('test.bndrun')

--- a/components/ledger/ledger-verification/test.bndrun
+++ b/components/ledger/ledger-verification/test.bndrun
@@ -37,7 +37,6 @@
     bnd.identity;id='net.bytebuddy.byte-buddy',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
-    bnd.identity;id='slf4j.api',\
     bnd.identity;id='slf4j.simple',\
     bnd.identity;id='org.liquibase.core',\
     bnd.identity;id='com.opencsv',\

--- a/components/ledger/ledger-verification/test.bndrun
+++ b/components/ledger/ledger-verification/test.bndrun
@@ -37,6 +37,7 @@
     bnd.identity;id='net.bytebuddy.byte-buddy',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
+    bnd.identity;id='net.corda.slf4jv1',\
     bnd.identity;id='slf4j.simple',\
     bnd.identity;id='org.liquibase.core',\
     bnd.identity;id='com.opencsv',\

--- a/components/security-manager/build.gradle
+++ b/components/security-manager/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     integrationTestImplementation "org.osgi:org.osgi.service.component:$osgiServiceComponentVersion"
     integrationTestImplementation project(':testing:security-manager-utilities')
     integrationTestImplementation "net.corda:corda-application"
-    integrationTestImplementation 'org.slf4j:slf4j-api'
+    integrationTestRuntimeOnly project(':testing:slf4jv1')
     integrationTestRuntimeOnly("org.apache.felix:org.apache.felix.framework.security:$felixSecurityVersion") {
         exclude group: 'org.osgi'
     }

--- a/components/virtual-node/sandbox-group-context-service/test.bndrun
+++ b/components/virtual-node/sandbox-group-context-service/test.bndrun
@@ -46,7 +46,6 @@
     bnd.identity;id='net.corda.test-impl-two',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
-    bnd.identity;id='slf4j.api',\
     bnd.identity;id='slf4j.simple'
 
 -runstartlevel: \

--- a/components/virtual-node/sandbox-group-context-service/test.bndrun
+++ b/components/virtual-node/sandbox-group-context-service/test.bndrun
@@ -46,6 +46,7 @@
     bnd.identity;id='net.corda.test-impl-two',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
+    bnd.identity;id='net.corda.slf4jv1',\
     bnd.identity;id='slf4j.simple'
 
 -runstartlevel: \

--- a/libs/configuration/configuration-validation/build.gradle
+++ b/libs/configuration/configuration-validation/build.gradle
@@ -28,4 +28,5 @@ dependencies {
             because "Version bundled with current version of 'com.networknt:json-schema-validator' does not have OSGi manifest."
         }
     }
+    integrationTestRuntimeOnly project(':testing:slf4jv1')
 }

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -53,11 +53,11 @@ dependencies {
     testRuntimeOnly "org.ow2.asm:asm:$asmVersion"
 
     integrationTestImplementation project(':libs:kotlin-reflection:kotlin-reflection-test-example')
-    integrationTestImplementation 'org.slf4j:slf4j-api'
     integrationTestImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
     integrationTestImplementation libs.junit
     integrationTestRuntimeOnly libs.junit.engine
     integrationTestRuntimeOnly libs.junit.platform
+    integrationTestRuntimeOnly project(':testing:slf4jv1')
     integrationTestRuntimeOnly libs.slf4j.simple
 }
 

--- a/libs/kotlin-reflection/build.gradle
+++ b/libs/kotlin-reflection/build.gradle
@@ -54,10 +54,10 @@ dependencies {
 
     integrationTestImplementation project(':libs:kotlin-reflection:kotlin-reflection-test-example')
     integrationTestImplementation "org.apache.felix:org.apache.felix.framework:$felixVersion"
+    integrationTestImplementation project(':testing:slf4jv1')
     integrationTestImplementation libs.junit
     integrationTestRuntimeOnly libs.junit.engine
     integrationTestRuntimeOnly libs.junit.platform
-    integrationTestRuntimeOnly project(':testing:slf4jv1')
     integrationTestRuntimeOnly libs.slf4j.simple
 }
 

--- a/libs/layered-property-map/build.gradle
+++ b/libs/layered-property-map/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     testImplementation project(":testing:test-utilities")
 
     integrationTestImplementation project(":libs:layered-property-map:layered-property-map-test-converter")
+    integrationTestRuntimeOnly project(':testing:slf4jv1')
 }

--- a/libs/sandbox-internal/test.bndrun
+++ b/libs/sandbox-internal/test.bndrun
@@ -31,7 +31,6 @@
     bnd.identity;id='co.paralleluniverse.quasar-core',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
-    bnd.identity;id='slf4j.api',\
     bnd.identity;id='slf4j.simple'
 
 -runstartlevel: \

--- a/libs/sandbox-internal/test.bndrun
+++ b/libs/sandbox-internal/test.bndrun
@@ -31,6 +31,7 @@
     bnd.identity;id='co.paralleluniverse.quasar-core',\
     bnd.identity;id='junit-jupiter-engine',\
     bnd.identity;id='junit-platform-launcher',\
+    bnd.identity;id='net.corda.slf4jv1',\
     bnd.identity;id='slf4j.simple'
 
 -runstartlevel: \

--- a/testing/p2p/inmemory-messaging-impl/build.gradle
+++ b/testing/p2p/inmemory-messaging-impl/build.gradle
@@ -25,4 +25,5 @@ dependencies {
 
     integrationTestApi project(":testing:test-utilities")
     testImplementation project(":libs:lifecycle:lifecycle-impl")
+    integrationTestRuntimeOnly project(':testing:slf4jv1')
 }

--- a/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
+++ b/testing/sandboxes/src/main/kotlin/net/corda/testing/sandboxes/impl/SandboxSetupImpl.kt
@@ -70,7 +70,7 @@ class SandboxSetupImpl @Activate constructor(
             "org.apache.felix.scr",
             "org.hibernate.orm.core",
             "org.jetbrains.kotlin.osgi-bundle",
-            "slf4j.api"
+            "net.corda.slf4jv1"
         ))
 
         private val REPLACEMENT_SERVICES = unmodifiableSet(setOf(

--- a/testing/slf4jv1/build.gradle
+++ b/testing/slf4jv1/build.gradle
@@ -1,3 +1,5 @@
+import static aQute.bnd.version.MavenVersion.parseMavenString
+
 // This re-exports the SLF4J V1 API packages including org.slf4j.event and org.slf4j.spi which micrometer and kafka
 // client depends on.
 // This is only used in testOSGi gradle tasks. The real system exports SLF4J from the system bundle.
@@ -18,11 +20,15 @@ dependencies {
 tasks.named('jar', Jar) {
     archiveBaseName = 'corda-slf4jv1'
 
+    ext {
+        bundleVersion = parseMavenString(libs.slf4j.api.get().version).OSGiVersion
+    }
+
     bundle {
         bnd """\
 Bundle-Name: SLF4JV1
 Bundle-SymbolicName: \${project.group}.slf4jv1
-Bundle-Version: \\${cordaProductVersion}
+Bundle-Version: \\${task.bundleVersion}
 Export-Package: \\
      org.slf4j.event;uses:="org.slf4j,org.slf4j.helpers";version=2.0.13,\\
      org.slf4j.event;version=1.7.36,\\

--- a/testing/slf4jv1/build.gradle
+++ b/testing/slf4jv1/build.gradle
@@ -1,5 +1,3 @@
-import static aQute.bnd.version.MavenVersion.parseMavenString
-
 // This re-exports the SLF4J V1 API packages including org.slf4j.event and org.slf4j.spi which micrometer and kafka
 // client depends on.
 // This is only used in testOSGi gradle tasks. The real system exports SLF4J from the system bundle.
@@ -20,15 +18,11 @@ dependencies {
 tasks.named('jar', Jar) {
     archiveBaseName = 'corda-slf4jv1'
 
-    ext {
-        bundleVersion = parseMavenString(antlrVersion).OSGiVersion
-    }
-
     bundle {
         bnd """\
 Bundle-Name: SLF4JV1
 Bundle-SymbolicName: \${project.group}.slf4jv1
-Bundle-Version: \\${task.bundleVersion}
+Bundle-Version: \\${cordaProductVersion}
 Export-Package: \\
      org.slf4j.event;uses:="org.slf4j,org.slf4j.helpers";version=2.0.13,\\
      org.slf4j.event;version=1.7.36,\\


### PR DESCRIPTION
For OSGi tests only bundle from `:testing:slf4jv1` will be used.