### PR TITLE
CORE-20748: Remove protocolVersion in C5_3 Rest API

### DIFF
--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
@@ -256,22 +256,6 @@ class RestServerRequestsTest : RestServerTestBase() {
     }
 
     @Test
-    fun `Verify no permission check on GetProtocolVersion`() {
-        val fullUrl = "testEntity/getProtocolVersion"
-        val helloResponse = client.call(
-            GET,
-            WebRequest<Any>(fullUrl),
-            userName,
-            password
-        )
-        assertEquals(HttpStatus.SC_OK, helloResponse.responseStatus)
-        assertEquals("3", helloResponse.body)
-
-        // Check that security managed has not been called for GetProtocolVersion which is exempt from permissions check
-        assertThat(securityManager.checksExecuted).hasSize(0)
-    }
-
-    @Test
     fun `Verify permission check is performed on entity retrieval`() {
         val fullUrlWithSlashes = "testentity/1234/"
         val fullUrlWithoutSlash = "testentity/1234"
@@ -431,30 +415,6 @@ class RestServerRequestsTest : RestServerTestBase() {
             password
         )
         assertEquals(HttpStatus.SC_OK, getPathResponse.responseStatus)
-    }
-
-    @Test
-    fun `GET valid user with valid permissions on requested get protocol version returns 200`() {
-        val getPathResponse = client.call(
-            GET,
-            WebRequest<Any>("health/getprotocolversion"),
-            userName,
-            password
-        )
-        assertEquals(HttpStatus.SC_OK, getPathResponse.responseStatus)
-        assertEquals("2", getPathResponse.body)
-    }
-
-    @Test
-    fun `GET invalid user without permissions on requested get protocol version returns 200`() {
-        val getPathResponse = client.call(
-            GET,
-            WebRequest<Any>("health/getprotocolversion"),
-            "invalid",
-            "invalid"
-        )
-        assertEquals(HttpStatus.SC_OK, getPathResponse.responseStatus)
-        assertEquals("2", getPathResponse.body)
     }
 
     @Test

--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
@@ -5,6 +5,7 @@ import io.javalin.core.util.Header.ACCESS_CONTROL_ALLOW_CREDENTIALS
 import io.javalin.core.util.Header.ACCESS_CONTROL_ALLOW_ORIGIN
 import io.javalin.core.util.Header.CACHE_CONTROL
 import io.javalin.core.util.Header.WWW_AUTHENTICATE
+import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.server.apigen.test.TestJavaPrimitivesRestResourceImpl
 import net.corda.rest.server.config.models.RestServerSettings
 import net.corda.rest.server.impl.apigen.processing.openapi.schema.toExample
@@ -261,7 +262,7 @@ class RestServerRequestsTest : RestServerTestBase() {
         val fullUrl = "testEntity/getProtocolVersion"
         val clientV52 = TestHttpClientUnirestImpl(
             "http://${restServerSettings.address.host}:${server.port}/" +
-                "${restServerSettings.context.basePath}/v5_2/"
+                "${restServerSettings.context.basePath}/${RestApiVersion.C5_2.versionPath}/"
         )
         val helloResponse = clientV52.call(
             GET,

--- a/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
+++ b/libs/rest/rest-server-impl/src/integrationTest/kotlin/net/corda/rest/server/impl/RestServerRequestsTest.kt
@@ -261,7 +261,7 @@ class RestServerRequestsTest : RestServerTestBase() {
         val fullUrl = "testEntity/getProtocolVersion"
         val clientV52 = TestHttpClientUnirestImpl(
             "http://${restServerSettings.address.host}:${server.port}/" +
-                    "${restServerSettings.context.basePath}/v5_2/"
+                "${restServerSettings.context.basePath}/v5_2/"
         )
         val helloResponse = clientV52.call(
             GET,

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/models/InvocationMethod.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/models/InvocationMethod.kt
@@ -1,10 +1,12 @@
 package net.corda.rest.server.impl.apigen.models
 
 import net.corda.rest.RestResource
+import net.corda.rest.response.ResponseEntity
 import java.lang.reflect.Method
 
 @Suppress("SpreadOperator")
 data class InvocationMethod(
     val method: Method,
-    val instance: RestResource
+    val instance: RestResource,
+    val transform: ((Any?) -> ResponseEntity<Any?>)? = null
 )

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/APIStructureRetriever.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/APIStructureRetriever.kt
@@ -340,7 +340,10 @@ internal class APIStructureRetriever(private val opsImplList: List<PluggableRest
         ).also { log.trace { """"Method "$name" to WS endpoint completed.""" } }
     }
 
-    private fun Method.getInvocationMethod(clazz: Class<out RestResource>? = null, transform: ((Any?) -> ResponseEntity<Any?>)? = null): InvocationMethod {
+    private fun Method.getInvocationMethod(
+        clazz: Class<out RestResource>? = null,
+        transform: ((Any?) -> ResponseEntity<Any?>)? = null
+    ): InvocationMethod {
         try {
             log.debug { "Get invocation method for \"${this.name}\"." }
             return InvocationMethod(

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/APIStructureRetriever.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/APIStructureRetriever.kt
@@ -26,6 +26,7 @@ import net.corda.rest.tools.annotations.extensions.path
 import net.corda.rest.tools.annotations.extensions.title
 import net.corda.rest.tools.annotations.validation.RestInterfaceValidator
 import net.corda.rest.tools.isStaticallyExposedGet
+import net.corda.rest.tools.maxVersion
 import net.corda.rest.tools.methodDescription
 import net.corda.rest.tools.responseDescription
 import net.corda.utilities.debug
@@ -169,7 +170,7 @@ internal class APIStructureRetriever(private val opsImplList: List<PluggableRest
                         method.kotlinFunction?.returnType?.isMarkedNullable ?: false
                     ),
                     method.getInvocationMethod(clazz),
-                    retrieveApiVersionsSet(annotation.minVersion, annotation.maxVersion)
+                    retrieveApiVersionsSet(annotation.minVersion, method.maxVersion)
                 )
             }
         }

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/MethodInvoker.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/MethodInvoker.kt
@@ -39,6 +39,7 @@ internal open class DefaultMethodInvoker(private val invocationMethod: Invocatio
         }
 
         val method = invocationMethod.method
+
         @Suppress("SpreadOperator")
         val invoked = when (args.size) {
             0 -> method.invoke(instance)

--- a/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/MethodInvoker.kt
+++ b/libs/rest/rest-server-impl/src/main/kotlin/net/corda/rest/server/impl/apigen/processing/MethodInvoker.kt
@@ -10,7 +10,6 @@ import net.corda.rest.server.impl.apigen.processing.streams.DurableReturnResult
 import net.corda.rest.server.impl.apigen.processing.streams.FiniteDurableReturnResult
 import net.corda.utilities.trace
 import org.slf4j.LoggerFactory
-import java.lang.IllegalArgumentException
 import java.util.function.Supplier
 import javax.security.auth.login.FailedLoginException
 
@@ -41,10 +40,15 @@ internal open class DefaultMethodInvoker(private val invocationMethod: Invocatio
 
         val method = invocationMethod.method
         @Suppress("SpreadOperator")
-        return when (args.size) {
+        val invoked = when (args.size) {
             0 -> method.invoke(instance)
             else -> method.invoke(instance, *args)
         }.also { log.trace { "Invoke method \"${invocationMethod.method.name}\" with args size: ${args.size} completed." } }
+        return if (invocationMethod.transform != null) {
+            invocationMethod.transform.invoke(invoked)
+        } else {
+            invoked
+        }
     }
 }
 

--- a/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/StaticExposedMethods.kt
+++ b/libs/rest/rest-tools/src/main/kotlin/net/corda/rest/tools/StaticExposedMethods.kt
@@ -1,9 +1,10 @@
 package net.corda.rest.tools
 
+import net.corda.rest.annotations.RestApiVersion
 import net.corda.rest.ws.DuplexChannel
 import java.lang.reflect.Method
 
-private data class MethodDocs(val methodDescription: String, val responseDescription: String)
+private data class MethodDocs(val methodDescription: String, val responseDescription: String, val maxVersion: RestApiVersion)
 
 /**
  * These methods are automatically exposed from the HTTP-RPC functionality as GET methods.
@@ -15,7 +16,8 @@ private val staticExposedGetMethods: Map<String, MethodDocs> =
     mapOf(
         "getProtocolVersion" to MethodDocs(
             "Returns the version of the endpoint",
-            "An integer value specifying the version of the endpoint"
+            "An integer value specifying the version of the endpoint",
+            RestApiVersion.C5_2
         )
     )
         .mapKeys { it.key.lowercase() }
@@ -32,6 +34,11 @@ val Method.methodDescription: String
 val Method.responseDescription: String
     get() {
         return staticExposedGetMethods[name.lowercase()]?.responseDescription ?: ""
+    }
+
+val Method.maxVersion: RestApiVersion
+    get() {
+        return staticExposedGetMethods[name.lowercase()]!!.maxVersion
     }
 
 fun Class<*>.isDuplexChannel(): Boolean = (this == DuplexChannel::class.java)

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
@@ -3416,35 +3416,6 @@
         }
       }
     },
-    "/user/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "RBAC User" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_user_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/user/otheruserpassword" : {
       "post" : {
         "tags" : [ "RBAC User" ],
@@ -3672,7 +3643,7 @@
             "description" : "Forbidden"
           }
         }
-    },
+      },
       "post" : {
         "tags" : [ "RBAC User" ],
         "description" : "This method adds a property to a user.",

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
@@ -224,35 +224,6 @@
         }
       }
     },
-    "/certificate/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Certificate" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_certificate_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/certificate/vnode/{holdingidentityid}/{usage}" : {
       "get" : {
         "tags" : [ "Certificate" ],
@@ -535,35 +506,6 @@
         }
       }
     },
-    "/config/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Configuration" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_config_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/config/{section}" : {
       "get" : {
         "tags" : [ "Configuration" ],
@@ -671,35 +613,6 @@
         }
       }
     },
-    "/cpi/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "CPI" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_cpi_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/cpi/status/{id}" : {
       "get" : {
         "tags" : [ "CPI" ],
@@ -724,35 +637,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/CpiUploadStatus"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/flow/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Flow Management" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_flow_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
                 }
               }
             }
@@ -956,35 +840,6 @@
         }
       }
     },
-    "/flowclass/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Flow Info" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_flowclass_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/flowclass/{holdingidentityshorthash}" : {
       "get" : {
         "tags" : [ "Flow Info" ],
@@ -1046,35 +901,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/GroupResponseType"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/group/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "RBAC Group" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_group_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
                 }
               }
             }
@@ -1341,64 +1167,6 @@
         }
       }
     },
-    "/hello/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Hello Rest" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_hello_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/hsm/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "HSM" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_hsm_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/hsm/soft/{tenantid}/{category}" : {
       "post" : {
         "tags" : [ "HSM" ],
@@ -1482,35 +1250,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/HsmAssociationInfo"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/key/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Key Management" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_key_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
                 }
               }
             }
@@ -1901,35 +1640,6 @@
         }
       }
     },
-    "/maintenance/virtualnode/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Virtual Node Maintenance" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_maintenance_virtualnode_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/maintenance/virtualnode/{virtualnodeshortid}/vault-schema/force-resync" : {
       "post" : {
         "tags" : [ "Virtual Node Maintenance" ],
@@ -1950,35 +1660,6 @@
         "responses" : {
           "200" : {
             "description" : "A list of the shortIDs or the exception encountered"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/members/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Member Lookup" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_members_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
           },
           "401" : {
             "description" : "Unauthorized"
@@ -2143,35 +1824,6 @@
         }
       }
     },
-    "/membership/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Member Registration" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_membership_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/membership/{holdingidentityshorthash}" : {
       "get" : {
         "tags" : [ "Member Registration" ],
@@ -2295,35 +1947,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/RestRegistrationRequestStatus"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/mgm/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "MGM" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_mgm_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
                 }
               }
             }
@@ -3233,35 +2856,6 @@
         }
       }
     },
-    "/mgmadmin/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "MGM Admin" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_mgmadmin_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/mgmadmin/{holdingidentityshorthash}/force-decline/{requestid}" : {
       "post" : {
         "tags" : [ "MGM Admin" ],
@@ -3293,35 +2887,6 @@
         "responses" : {
           "200" : {
             "description" : "Success"
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/network/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Network" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_network_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
           },
           "401" : {
             "description" : "Unauthorized"
@@ -3532,35 +3097,6 @@
         }
       }
     },
-    "/permission/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "RBAC Permission" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_permission_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/permission/{id}" : {
       "get" : {
         "tags" : [ "RBAC Permission" ],
@@ -3651,35 +3187,6 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/RoleResponseType"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
-    "/role/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "RBAC Role" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_role_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
                 }
               }
             }
@@ -4524,35 +4031,6 @@
         }
       }
     },
-    "/virtualnode/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Virtual Node" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_virtualnode_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/virtualnode/status/{requestid}" : {
       "get" : {
         "tags" : [ "Virtual Node" ],
@@ -4832,35 +4310,6 @@
         }
       }
     },
-    "/wrappingkey/getprotocolversion" : {
-      "get" : {
-        "tags" : [ "Key Rotation" ],
-        "description" : "Returns the version of the endpoint",
-        "operationId" : "get_wrappingkey_getprotocolversion",
-        "parameters" : [ ],
-        "responses" : {
-          "200" : {
-            "description" : "An integer value specifying the version of the endpoint",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "type" : "integer",
-                  "format" : "int32",
-                  "nullable" : false,
-                  "example" : 0
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "403" : {
-            "description" : "Forbidden"
-          }
-        }
-      }
-    },
     "/wrappingkey/rotation/{tenantid}" : {
       "get" : {
         "tags" : [ "Key Rotation" ],
@@ -5010,7 +4459,6 @@
             "example" : "string"
           },
           "status" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "IN_PROGRESS",
             "enum" : [ "ACCEPTED", "IN_PROGRESS", "SUCCEEDED", "FAILED", "ABORTED" ]
@@ -5078,7 +4526,6 @@
       },
       "ChangeOtherUserPasswordWrapperRequest" : {
         "required" : [ "password", "username" ],
-        "type" : "object",
         "properties" : {
           "password" : {
             "type" : "string",
@@ -5308,7 +4755,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -5403,7 +4849,6 @@
             "example" : "string"
           },
           "json" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
@@ -5488,7 +4933,6 @@
       },
       "GenerateCsrWrapperRequest" : {
         "required" : [ "x500Name" ],
-        "type" : "object",
         "properties" : {
           "contextMap" : {
             "type" : "object",
@@ -5787,37 +5231,31 @@
             "example" : "string"
           },
           "cryptoDdlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "cryptoDmlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "uniquenessDdlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "uniquenessDmlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "vaultDdlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "vaultDmlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
@@ -6009,7 +5447,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -6053,7 +5490,6 @@
             "example" : "string"
           },
           "permissionType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "DENY",
             "enum" : [ "ALLOW", "DENY" ]
@@ -6090,7 +5526,6 @@
             "example" : "string"
           },
           "status" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "REVOKED",
             "enum" : [ "AVAILABLE", "REVOKED", "CONSUMED", "AUTO_INVALIDATED" ]
@@ -6259,7 +5694,6 @@
             "example" : "2022-06-24T10:15:30Z"
           },
           "registrationStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "SENT_TO_MGM",
             "enum" : [ "NEW", "SENT_TO_MGM", "RECEIVED_BY_MGM", "STARTED_PROCESSING_BY_MGM", "PENDING_MEMBER_VERIFICATION", "PENDING_MANUAL_APPROVAL", "PENDING_AUTO_APPROVAL", "DECLINED", "INVALID", "FAILED", "APPROVED" ]
@@ -6374,7 +5808,6 @@
             "example" : "string"
           },
           "inactiveResponseType" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "IGNORE",
             "enum" : [ "ERROR", "IGNORE" ]
@@ -6430,7 +5863,6 @@
             "example" : "string"
           },
           "requestBody" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : false,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
@@ -6481,7 +5913,6 @@
         "type" : "object",
         "properties" : {
           "config" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : false,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
@@ -6532,37 +5963,31 @@
         "type" : "object",
         "properties" : {
           "cryptoDdlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "cryptoDmlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "uniquenessDdlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "uniquenessDmlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "vaultDdlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
           },
           "vaultDmlConnection" : {
-            "type" : "object",
             "description" : "Either nested JSON object or a valid JSON-escaped string.",
             "nullable" : true,
             "example" : "{\"command\":\"echo\", \"data\":{\"value\": \"hello-world\"}}"
@@ -6691,19 +6116,16 @@
             "$ref" : "#/components/schemas/RouteConfiguration"
           },
           "flowOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "flowP2pOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
           },
           "flowStartOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]
@@ -6732,7 +6154,6 @@
             "example" : "string"
           },
           "vaultDbOperationalStatus" : {
-            "type" : "object",
             "nullable" : false,
             "example" : "INACTIVE",
             "enum" : [ "ACTIVE", "INACTIVE" ]

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -863,8 +863,6 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
     fun getCryptoWrappingKeysRotationStatus(tenantId: String) =
         initialClient.get("/api/$REST_API_VERSION_PATH/wrappingkey/rotation/${tenantId}")
 
-    fun getWrappingKeysProtocolVersion() = initialClient.get("/api/$REST_API_VERSION_PATH/wrappingkey/getprotocolversion")
-
 }
 
 fun <T> cluster(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -281,7 +281,7 @@ fun ClusterInfo.getTime(
 ) = SimpleDateFormat("EEE,dd MMM yyyy HH:mm:ss zzz") // RFC 822
     .parse(cluster {
         assertWithRetry {
-            command { initialClient.post("/api/$REST_API_VERSION_PATH/hello/getprotocolversion", "") }
+            command { initialClient.post("/api/$REST_API_VERSION_PATH/hello?addressee=Test", "") }
             condition { it.code == ResponseCode.OK.statusCode }
         }
     }.headers.single { it.first == "Date" }.second

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -275,24 +275,13 @@ fun ClusterInfo.getStatusForWrappingKeysRotation(
 }
 
 /**
- * This method fetch the protocol version for unmanaged key Rotation.
- */
-fun ClusterInfo.getProtocolVersionForKeyRotation(
-) = cluster {
-    assertWithRetry {
-        command { getWrappingKeysProtocolVersion() }
-        condition { it.code == ResponseCode.OK.statusCode }
-    }
-}
-
-/**
  * This method fetches the local time of the corda cluster
  */
 fun ClusterInfo.getTime(
 ) = SimpleDateFormat("EEE,dd MMM yyyy HH:mm:ss zzz") // RFC 822
     .parse(cluster {
         assertWithRetry {
-            command { initialClient.get("/api/$REST_API_VERSION_PATH/hello/getprotocolversion") }
+            command { initialClient.post("/api/$REST_API_VERSION_PATH/hello/getprotocolversion", "") }
             condition { it.code == ResponseCode.OK.statusCode }
         }
     }.headers.single { it.first == "Date" }.second

--- a/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/CombinedWorkerHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/CombinedWorkerHelper.kt
@@ -24,7 +24,7 @@ object CombinedWorkerHelper {
         val start = Instant.now()
         while (true) {
             try {
-                restClient.helloRestClient.getHelloGetprotocolversion()
+                restClient.helloRestClient.postHello("Test")
                 return
             } catch (e: Exception) {
                 if (Duration.between(start, Instant.now()) < timeout) {

--- a/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/cordalifecycle/LifeCycleTasksTest.kt
+++ b/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/cordalifecycle/LifeCycleTasksTest.kt
@@ -16,7 +16,7 @@ class LifeCycleTasksTest : SmokeTestBase() {
 
     @BeforeEach
     fun verifyRestIsUnavailable() {
-        catchThrowable { restClient.helloRestClient.getHelloGetprotocolversion() }
+        catchThrowable { restClient.helloRestClient.postHello("Test") }
     }
 
     @AfterEach


### PR DESCRIPTION
- Remove protocolVersion in C5_3 by setting the maxVersion to C5_2
- Updated swaggerBaseline for C5_3
- protocolVersion is still needed in C5_1 and C5_2 so we have added a deprecation warning if protocolVersion is called