### PR TITLE
ES-2492: Add extra output to onboarding commands

### DIFF
--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -131,7 +131,7 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             uniquenessDmlConnection = null,
         )
         val longerWait = getLongerWait()
-        println("Creating Virtual Node: ${request.x500Name}")
+        println("Creating Virtual Node.")
         val shortHashId = VirtualNode(restClient).createAndWaitForActive(request, longerWait)
         println("Holding identity short hash of '$name' is: '$shortHashId'")
         shortHashId

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -130,8 +130,6 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             uniquenessDdlConnection = null,
             uniquenessDmlConnection = null,
         )
-        // Suspected flakiness here - https://r3-cev.atlassian.net/browse/CORE-20760
-        Thread.sleep(3000)
         val longerWait = getLongerWait()
         println("Creating Virtual Node: ${request.x500Name}")
         val shortHashId = VirtualNode(restClient).createAndWaitForActive(request, longerWait)

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/BaseOnboard.kt
@@ -130,6 +130,8 @@ abstract class BaseOnboard : Runnable, RestCommand() {
             uniquenessDdlConnection = null,
             uniquenessDmlConnection = null,
         )
+        // Suspected flakiness here - https://r3-cev.atlassian.net/browse/CORE-20760
+        Thread.sleep(3000)
         val longerWait = getLongerWait()
         println("Creating Virtual Node: ${request.x500Name}")
         val shortHashId = VirtualNode(restClient).createAndWaitForActive(request, longerWait)

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
@@ -88,7 +88,10 @@ class OnboardMember : Runnable, BaseOnboard() {
         if (cpbFile?.canRead() != true) {
             throw OnboardException("Please set either CPB file or CPI hash")
         } else {
-            uploadCpb(cpbFile!!)
+            val checksumValue = uploadCpb(cpbFile!!)
+            // Suspected flakiness between getting checksum and creating member vnode - https://r3-cev.atlassian.net/browse/CORE-20760
+            Thread.sleep(1000)
+            checksumValue
         }
     }
 

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMember.kt
@@ -197,9 +197,6 @@ class OnboardMember : Runnable, BaseOnboard() {
 
             setupNetwork()
 
-            println("Provided registration context: ")
-            println(memberRegistrationRequest)
-
             register(waitForFinalStatus)
 
             if (waitForFinalStatus) {

--- a/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
+++ b/tools/plugins/network/src/main/kotlin/net/corda/cli/plugins/network/OnboardMgm.kt
@@ -90,6 +90,7 @@ class OnboardMgm : Runnable, BaseOnboard() {
         cpiFile.parentFile.mkdirs()
 
         val cpiName = "MGM-${UUID.randomUUID()}"
+        println("Creating and uploading CPI: $cpiName.")
         runCatching {
             CpiV2Creator.createCpi(
                 null,


### PR DESCRIPTION
The onboarding commands of the CLI are opaque, and when an error occurs it is not always clear and obvious where in the journey the process got to.

Regarding the sleep: https://r3-cev.atlassian.net/browse/CORE-20760?focusedCommentId=311371