### PR TITLE
CORE-0: Revert "Bump log4jVersion from 2.23.0 to 2.23.1 (#6226)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ micrometerVersion = "1.12.4"
 nimbusVersion = "11.13"
 kafkaClientVersion = "3.7.0_1"
 kubernetesClientVersion = "6.13.0"
-log4jVersion = "2.23.1"
+log4jVersion = "2.23.0"
 # If upgrading liquibase to 4.28, enable `LiquibaseSchemaMigratorImplTest.when updateDb create DB schema`
 # and `LiquibaseSchemaMigratorImplTest.when createUpdateSql generate DB schema` on Windows
 liquibaseVersion = "4.28.0"


### PR DESCRIPTION
This reverts commit 7a06fbc399db8cb9260a83ca25137ee280bfdbc0.

Due to: https://github.com/apache/logging-log4j2/issues/2703