### PR TITLE
ES-2395: CordaRestClient to support non-static credentials

### DIFF
--- a/libs/rest/generated-rest-client/build.gradle
+++ b/libs/rest/generated-rest-client/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation libs.okHttp
 
     testImplementation libs.javalin
+    testRuntimeOnly libs.log4j.slf4j
 }
 
 // Pick up the generated code so we can use it in src/main & src/test

--- a/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
+++ b/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
@@ -116,13 +116,9 @@ class CordaRestClient(
 
             val urlWithDefaultBasePath = baseUrl.toString() + defaultBasePath
 
-            val builder = ApiClient.apply {
-                // TODO: is this necessary? Interceptor will set the Auth header anyway, overriding whatever there was before
-                // Make sure static credentials are not used
-                this.username = null
-                this.password = null
-            }.builder
+            val builder = ApiClient.builder
 
+            // Always add the basic auth header with the supplied credentials
             builder.addInterceptor { chain ->
                 val request = chain.request().newBuilder()
                     .header("Authorization", okhttp3.Credentials.basic(username, password))

--- a/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
+++ b/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
@@ -20,6 +20,7 @@ import net.corda.restclient.generated.apis.RBACUserApi
 import net.corda.restclient.generated.apis.VirtualNodeApi
 import net.corda.restclient.generated.apis.VirtualNodeMaintenanceApi
 import net.corda.restclient.generated.infrastructure.ApiClient
+import okhttp3.OkHttpClient
 import java.net.URI
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
@@ -111,14 +112,17 @@ class CordaRestClient(
 
             val urlWithDefaultBasePath = baseUrl.toString() + defaultBasePath
 
-            val builder = ApiClient.builder
+            val builder = OkHttpClient.Builder()
 
             // Always add the basic auth header with the supplied credentials
             builder.addInterceptor { chain ->
                 val request = chain.request().newBuilder()
                     .header("Authorization", okhttp3.Credentials.basic(username, password))
                     .build()
-                chain.proceed(request)
+                println("!!! Using credentials $username:$password to authenticate with ${request.url}")
+                val response = chain.proceed(request)
+                println("!!! Response code: ${response.code}")
+                response
             }
 
             // Disable SSL verification if insecure is true

--- a/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
+++ b/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
@@ -56,11 +56,6 @@ class CordaRestClient(
 
         /**
          * Create an instance of CordaRestClient with the given baseUrl, username and password.
-         * Please note, if you use this multiple times with different credentials, you will be overwriting the previous credentials.
-         * e.g.
-         * val adminClient = createHttpClient(baseUrl, "admin", adminPassword)
-         * val userClient = createHttpClient(baseUrl, "user", userPassword)
-         * The `adminClient` will have the credentials of the `userClient` after the second call.
          *
          * @param baseUrl The base URL of the Corda node.
          * @param username The username to authenticate with.

--- a/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
+++ b/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
@@ -118,9 +118,7 @@ class CordaRestClient(
                 val request = chain.request().newBuilder()
                     .header("Authorization", okhttp3.Credentials.basic(username, password))
                     .build()
-                println("!!! Using credentials $username:$password to authenticate with ${request.url}")
                 val response = chain.proceed(request)
-                println("!!! Response code: ${response.code}")
                 response
             }
 

--- a/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
+++ b/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
@@ -20,7 +20,6 @@ import net.corda.restclient.generated.apis.RBACUserApi
 import net.corda.restclient.generated.apis.VirtualNodeApi
 import net.corda.restclient.generated.apis.VirtualNodeMaintenanceApi
 import net.corda.restclient.generated.infrastructure.ApiClient
-import okhttp3.OkHttpClient
 import java.net.URI
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
@@ -31,8 +30,6 @@ import javax.net.ssl.X509TrustManager
 
 @Suppress("LongParameterList")
 class CordaRestClient(
-    private val baseUrl: String,
-    private val httpClient: OkHttpClient,
     val certificatesClient: CertificateApi,
     val configurationClient: ConfigurationApi,
     val cpiClient: CPIApi,
@@ -135,8 +132,6 @@ class CordaRestClient(
 
             val client = builder.build()
             return CordaRestClient(
-                baseUrl = urlWithDefaultBasePath,
-                httpClient = client,
                 certificatesClient = certificatesClient ?: CertificateApi(urlWithDefaultBasePath, client),
                 configurationClient = configurationClient ?: ConfigurationApi(urlWithDefaultBasePath, client),
                 cpiClient = cpiClient ?: CPIApi(urlWithDefaultBasePath, client),

--- a/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
+++ b/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
@@ -117,9 +117,18 @@ class CordaRestClient(
             val urlWithDefaultBasePath = baseUrl.toString() + defaultBasePath
 
             val builder = ApiClient.apply {
-                this.username = username
-                this.password = password
+                // TODO: is this necessary? Interceptor will set the Auth header anyway, overriding whatever there was before
+                // Make sure static credentials are not used
+                this.username = null
+                this.password = null
             }.builder
+
+            builder.addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("Authorization", okhttp3.Credentials.basic(username, password))
+                    .build()
+                chain.proceed(request)
+            }
 
             // Disable SSL verification if insecure is true
             if (insecure) {

--- a/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
+++ b/libs/rest/generated-rest-client/src/main/kotlin/net/corda/restclient/CordaRestClient.kt
@@ -19,7 +19,6 @@ import net.corda.restclient.generated.apis.RBACRoleApi
 import net.corda.restclient.generated.apis.RBACUserApi
 import net.corda.restclient.generated.apis.VirtualNodeApi
 import net.corda.restclient.generated.apis.VirtualNodeMaintenanceApi
-import net.corda.restclient.generated.infrastructure.ApiClient
 import okhttp3.OkHttpClient
 import java.net.URI
 import java.security.SecureRandom

--- a/libs/rest/generated-rest-client/src/test/kotlin/net/corda/restclient/generated/TestClientAuthHeader.kt
+++ b/libs/rest/generated-rest-client/src/test/kotlin/net/corda/restclient/generated/TestClientAuthHeader.kt
@@ -1,0 +1,77 @@
+package net.corda.restclient.generated
+
+import io.javalin.Javalin
+import io.javalin.http.ContentType
+import net.corda.restclient.CordaRestClient
+import net.corda.restclient.generated.infrastructure.ApiClient
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class TestClientAuthHeader {
+
+    companion object {
+        private lateinit var app: Javalin
+
+        @BeforeAll
+        @JvmStatic
+        fun setup() {
+            app = Javalin.create().start(0)
+            app.get("api/v5_3/mgm/1234/info") { ctx ->
+                val (user, password) = ctx.basicAuthCredentials()
+                ctx.contentType(ContentType.APPLICATION_JSON)
+                    .status(200)
+                    .result("$user:$password")
+            }
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun teardown() {
+            app.stop()
+        }
+
+    }
+
+    private val localhost = URI.create("http:localhost:${app.port()}")
+
+    private fun CordaRestClient.echoCredentials(): String {
+        return this.mgmClient.getMgmHoldingidentityshorthashInfo("1234")
+    }
+
+    @Test
+    fun defaultCredentialsAreCorrect() {
+        val defaultClient = CordaRestClient.createHttpClient(localhost)
+        assertThat(defaultClient.echoCredentials()).isEqualTo("admin:admin")
+    }
+
+    @Test
+    fun staticCredentialsAreIgnored() {
+        val defaultClient = CordaRestClient.createHttpClient(localhost, "foo", "bar")
+        assertThat(defaultClient.echoCredentials()).isEqualTo("foo:bar")
+        ApiClient.apply {
+            username = "foo-static"
+            password = "bar-static"
+        }
+        assertThat(defaultClient.echoCredentials()).isNotEqualTo("foo-static:bar-static")
+        assertThat(defaultClient.echoCredentials()).isNotEmpty()
+        assertThat(defaultClient.echoCredentials()).isEqualTo("foo:bar")
+    }
+
+    @Test
+    fun twoClientsUseUniqueCredentials() {
+        val client1 = CordaRestClient.createHttpClient(localhost, "user-one", "password-one")
+        val client2 = CordaRestClient.createHttpClient(localhost, "user-two", "password-two")
+        ApiClient.apply {
+            username = "user-static"
+            password = "password-static"
+        }
+        assertThat(client1.echoCredentials()).isNotEqualTo("user-static:password-static")
+        assertThat(client1.echoCredentials()).isEqualTo("user-one:password-one")
+
+        assertThat(client2.echoCredentials()).isNotEqualTo("user-static:password-static")
+        assertThat(client2.echoCredentials()).isEqualTo("user-two:password-two")
+    }
+}

--- a/tools/plugins/network/src/pluginSmokeTest/kotlin/net/corda/cli/plugins/network/OnboardMemberTest.kt
+++ b/tools/plugins/network/src/pluginSmokeTest/kotlin/net/corda/cli/plugins/network/OnboardMemberTest.kt
@@ -37,8 +37,8 @@ class OnboardMemberTest {
         private lateinit var defaulGroupPolicyLocation: String
         private val restClient = CordaRestClient.createHttpClient(
             baseUrl = DEFAULT_CLUSTER.rest.uri,
-            username = user,
-            password = password,
+            username = DEFAULT_CLUSTER.rest.user,
+            password = DEFAULT_CLUSTER.rest.password,
             insecure = true,
         )
 


### PR DESCRIPTION
### [ES-2395](https://r3-cev.atlassian.net/browse/ES-2395)

[ES-2395]: https://r3-cev.atlassian.net/browse/ES-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ