### PR TITLE
CORE-20768 Improve logging around registration commands

### DIFF
--- a/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
+++ b/components/membership/registration-impl/src/main/kotlin/net/corda/membership/impl/registration/dynamic/RegistrationProcessor.kt
@@ -36,6 +36,7 @@ import net.corda.membership.read.MembershipGroupReaderProvider
 import net.corda.messaging.api.processor.StateAndEventProcessor
 import net.corda.messaging.api.processor.StateAndEventProcessor.State
 import net.corda.messaging.api.records.Record
+import net.corda.utilities.debug
 import net.corda.utilities.time.Clock
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -134,56 +135,53 @@ class RegistrationProcessor(
         state: State<RegistrationState>?,
         event: Record<String, RegistrationCommand>,
     ): StateAndEventProcessor.Response<RegistrationState> {
-        val stateValue = state?.value
-        logger.info(
-            "Received registration command for registration ID '${stateValue?.registrationId}', " +
-                "member '${stateValue?.registeringMember?.x500Name}'."
-        )
+        logger.debug { "Received registration command with key '${event.key}'." }
         val result = try {
+            val stateValue = state?.value
             when (val command = event.value?.command) {
                 is QueueRegistration -> {
-                    logger.logCommand(QueueRegistration::class.java)
+                    logger.info { QueueRegistration::class.java }
                     handlers[QueueRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is CheckForPendingRegistration -> {
-                    logger.logCommand(CheckForPendingRegistration::class.java)
+                    logger.info { CheckForPendingRegistration::class.java }
                     handlers[CheckForPendingRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is StartRegistration -> {
-                    logger.logCommand(StartRegistration::class.java)
+                    logger.info { StartRegistration::class.java }
                     handlers[StartRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is VerifyMember -> {
-                    logger.logCommand(VerifyMember::class.java)
+                    logger.info { VerifyMember::class.java }
                     handlers[VerifyMember::class.java]?.invoke(stateValue, event)
                 }
 
                 is ProcessMemberVerificationResponse -> {
-                    logger.logCommand(ProcessMemberVerificationResponse::class.java)
+                    logger.info { ProcessMemberVerificationResponse::class.java }
                     handlers[ProcessMemberVerificationResponse::class.java]?.invoke(stateValue, event)
                 }
 
                 is ApproveRegistration -> {
-                    logger.logCommand(ApproveRegistration::class.java)
+                    logger.info { ApproveRegistration::class.java }
                     handlers[ApproveRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is DeclineRegistration -> {
-                    logger.logCommand(DeclineRegistration::class.java)
+                    logger.info { DeclineRegistration::class.java }
                     logger.warn("Declining registration because: ${command.reason}")
                     handlers[DeclineRegistration::class.java]?.invoke(stateValue, event)
                 }
 
                 is ProcessMemberVerificationRequest -> {
-                    logger.logCommand(ProcessMemberVerificationRequest::class.java)
+                    logger.info { ProcessMemberVerificationRequest::class.java }
                     handlers[ProcessMemberVerificationRequest::class.java]?.invoke(stateValue, event)
                 }
 
                 is PersistMemberRegistrationState -> {
-                    logger.logCommand(PersistMemberRegistrationState::class.java)
+                    logger.info { PersistMemberRegistrationState::class.java }
                     handlers[PersistMemberRegistrationState::class.java]?.invoke(stateValue, event)
                 }
 
@@ -211,7 +209,7 @@ class RegistrationProcessor(
         return RegistrationHandlerResult(state, emptyList())
     }
 
-    private fun <T> Logger.logCommand(command: Class<T>) {
-        info("Processing registration command: ${command.simpleName}.")
+    private fun <T> Logger.info(command: () -> Class<T>) {
+        info("Processing registration command: ${command().simpleName}.")
     }
 }


### PR DESCRIPTION
Fixes logging around registration commands in `RegistrationProcessor`.

Resultant logs from `RegistrationProcessor` and individual handlers following these changes:
```
2024-07-05T11:15:16.356Z [durable processing thread membership.ops.async.commands-membership.async.request] INFO  net.corda.membership.service.impl.MemberOpsAsyncProcessor {} - Processing registration f7e14001-f3f0-4345-9c30-ab1318dd0bc6 to CN=Bob-1737fade-ef15-4589-ba4b-c91345e18824, OU=Application, O=R3, L=London, C=GB.
2024-07-05T11:15:30.401Z [Thread-77] INFO  net.corda.membership.impl.registration.dynamic.RegistrationProcessor {} - Processing registration command: QueueRegistration.
2024-07-05T11:15:30.403Z [Thread-77] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM queueing registration request. {registration-id=4c31df01-e510-44fd-ab8b-de8700259fd0, member-holding-id=4630FE3FAC2A, member-name=CN=Bob-1737fade-ef15-4589-ba4b-c91345e18824, OU=Application, O=R3, L=London, C=GB, group-id=40742290-276f-4b22-8a27-cf2a9689f285, mgm-holding-id=06246E3C0ECA, mgm-name=OU=1737fade-ef15-4589-ba4b-c91345e18824, O=Mgm, L=London, C=GB}
2024-07-05T11:15:30.905Z [Thread-77] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.QueueRegistrationHandler {} - MGM successfully queued the registration request. {registration-id=4c31df01-e510-44fd-ab8b-de8700259fd0, member-holding-id=4630FE3FAC2A, member-name=CN=Bob-1737fade-ef15-4589-ba4b-c91345e18824, OU=Application, O=R3, L=London, C=GB, group-id=40742290-276f-4b22-8a27-cf2a9689f285, mgm-holding-id=06246E3C0ECA, mgm-name=OU=1737fade-ef15-4589-ba4b-c91345e18824, O=Mgm, L=London, C=GB}
2024-07-05T11:15:30.943Z [Thread-77] INFO  net.corda.membership.impl.registration.dynamic.RegistrationProcessor {} - Processing registration command: CheckForPendingRegistration.
2024-07-05T11:15:30.944Z [Thread-77] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Looking for the next request for member. {member-holding-id=4630FE3FAC2A, member-name=CN=Bob-1737fade-ef15-4589-ba4b-c91345e18824, OU=Application, O=R3, L=London, C=GB, group-id=40742290-276f-4b22-8a27-cf2a9689f285, mgm-holding-id=06246E3C0ECA, mgm-name=OU=1737fade-ef15-4589-ba4b-c91345e18824, O=Mgm, L=London, C=GB}
2024-07-05T11:15:16.776Z [durable processing thread membership.ops.async.commands-membership.async.request] INFO  net.corda.membership.service.impl.MemberOpsAsyncProcessor {} - Processed registration f7e14001-f3f0-4345-9c30-ab1318dd0bc6 to CN=Bob-1737fade-ef15-4589-ba4b-c91345e18824, OU=Application, O=R3, L=London, C=GB.
2024-07-05T11:15:31.011Z [Thread-77] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.CheckForPendingRegistrationHandler {} - Retrieved next request for member from the database. Proceeding with registration. {member-holding-id=4630FE3FAC2A, member-name=CN=Bob-1737fade-ef15-4589-ba4b-c91345e18824, OU=Application, O=R3, L=London, C=GB, group-id=40742290-276f-4b22-8a27-cf2a9689f285, mgm-holding-id=06246E3C0ECA, mgm-name=OU=1737fade-ef15-4589-ba4b-c91345e18824, O=Mgm, L=London, C=GB, registration-id=4c31df01-e510-44fd-ab8b-de8700259fd0}
2024-07-05T11:15:31.032Z [Thread-77] INFO  net.corda.membership.impl.registration.dynamic.RegistrationProcessor {} - Processing registration command: StartRegistration.
2024-07-05T11:15:31.603Z [Thread-77] INFO  net.corda.membership.impl.registration.dynamic.handler.mgm.StartRegistrationHandler {} - Registering member with MGM. {registration-id=4c31df01-e510-44fd-ab8b-de8700259fd0, member-holding-id=4630FE3FAC2A, member-name=CN=Bob-1737fade-ef15-4589-ba4b-c91345e18824, OU=Application, O=R3, L=London, C=GB, group-id=40742290-276f-4b22-8a27-cf2a9689f285, mgm-holding-id=06246E3C0ECA, mgm-name=OU=1737fade-ef15-4589-ba4b-c91345e18824, O=Mgm, L=London, C=GB}
```