### PR TITLE
CORE-19976 Prevent components from being marked as 'DOWN' instead of 'ERROR'

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/ThreadLooper.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/ThreadLooper.kt
@@ -173,7 +173,9 @@ class ThreadLooper(
         try {
             loopFunction()
             _isRunning = false
-            lifecycleCoordinator.close()
+            if (lifecycleCoordinator.status != LifecycleStatus.ERROR) {
+                lifecycleCoordinator.close()
+            }
         } catch (t: Throwable) {
             val msg = "runConsumeLoop Throwable caught, subscription in an unrecoverable bad state"
             log.error(msg, t)


### PR DESCRIPTION
Addresses an issue where a subscription, on encountering a fatal exception, causes the coordinator to transition to 'DOWN'. This leaves the component marked as 'DOWN' instead of 'ERROR', which means it will not be restarted by K8s.