### PR TITLE
CORE-20708: Gateway timeout and bad gateway - Don't fail on 50X responses while waiting for config to update

### DIFF
--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
@@ -161,8 +161,7 @@ fun ClusterInfo.waitForConfigurationChange(
             command { getConfig(section) }
             condition {
                 val bodyJSON = it.body.toJson()
-                it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
-                        && bodyJSON.sourceConfigNode()[key] != null && bodyJSON.sourceConfigNode()[key].toString() == value
+                bodyJSON["sourceConfig"] != null && bodyJSON.sourceConfigNode()[key] != null && bodyJSON.sourceConfigNode()[key].toString() == value
             }
         }
     }


### PR DESCRIPTION
Bad Gateway and Gateway timeout were occurring in several builds across pipelines in 5.2 and 5.3. A fix went in for this to check the rest worker was ready before the test requests started. The issue has re-occurred, because the rest worker may not come down fast enough so the test asserts the worker is ready, before it has had a chance to go down.

This PR will update this code to ignore 50X response codes while waiting for the config to update, and rely on the timeout to avoid the test getting stuck. 

```
assertWithRetryIgnoringExceptions {
            timeout(timeout)
            command { getConfig(section) }
            condition {
                val bodyJSON = it.body.toJson()
                it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
                        && bodyJSON.sourceConfigNode()[key] != null && bodyJSON.sourceConfigNode()[key].toString() == value
            }
        }
```