### PR TITLE
CORE-20721: Allow RBAC group parentGroupId to be nullable

### DIFF
--- a/components/permissions/permission-rest-resource-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/group/impl/GroupEndpointImpl.kt
+++ b/components/permissions/permission-rest-resource-impl/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/group/impl/GroupEndpointImpl.kt
@@ -60,7 +60,7 @@ class GroupEndpointImpl @Activate constructor(
         return ResponseEntity.created(createGroupResult.convertToEndpointType())
     }
 
-    override fun changeParentGroup(groupId: String, newParentGroupId: String): ResponseEntity<GroupResponseType> {
+    override fun changeParentGroup(groupId: String, newParentGroupId: String?): ResponseEntity<GroupResponseType> {
         val principal = getRestThreadLocalContext()
 
         val groupResponseDto = withPermissionManager(permissionManagementService.permissionManager, logger) {

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/group/GroupEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/group/GroupEndpoint.kt
@@ -60,7 +60,7 @@ interface GroupEndpoint : RestResource {
         @RestPathParameter(description = "ID of the group to change parent.")
         groupId: String,
         @RestPathParameter(description = "New parent group ID.")
-        newParentGroupId: String
+        newParentGroupId: String?
     ): ResponseEntity<GroupResponseType>
 
     @HttpPUT(

--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/group/types/GroupContentResponseType.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/group/types/GroupContentResponseType.kt
@@ -26,7 +26,7 @@ data class GroupContentResponseType(
     /**
      * ID of the parent group.
      */
-    val parentGroupId: String,
+    val parentGroupId: String?,
 
     /**
      * Group properties.

--- a/libs/permissions/permission-manager/src/main/kotlin/net/corda/libs/permissions/manager/request/ChangeGroupParentIdDto.kt
+++ b/libs/permissions/permission-manager/src/main/kotlin/net/corda/libs/permissions/manager/request/ChangeGroupParentIdDto.kt
@@ -12,5 +12,5 @@ data class ChangeGroupParentIdDto(
     /**
      * ID of the new parent Group.
      */
-    val newParentGroupId: String
+    val newParentGroupId: String?
 )

--- a/libs/permissions/permission-manager/src/main/kotlin/net/corda/libs/permissions/manager/response/GroupContentResponseDto.kt
+++ b/libs/permissions/permission-manager/src/main/kotlin/net/corda/libs/permissions/manager/response/GroupContentResponseDto.kt
@@ -9,7 +9,7 @@ data class GroupContentResponseDto(
     val id: String,
     val lastUpdatedTimestamp: Instant,
     val groupName: String,
-    val parentGroupId: String,
+    val parentGroupId: String?,
     val properties: List<PropertyResponseDto>,
     val roleAssociations: List<RoleAssociationResponseDto>,
     val users: Set<String>,

--- a/libs/permissions/permission-manager/src/main/kotlin/net/corda/libs/permissions/manager/response/GroupResponseDto.kt
+++ b/libs/permissions/permission-manager/src/main/kotlin/net/corda/libs/permissions/manager/response/GroupResponseDto.kt
@@ -10,7 +10,7 @@ data class GroupResponseDto(
     val lastUpdatedTimestamp: Instant,
     val version: Int,
     val groupName: String,
-    val parentGroupId: String,
+    val parentGroupId: String?,
     val properties: List<PropertyResponseDto>,
     val roleAssociations: List<RoleAssociationResponseDto>
 )

--- a/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/validation/EntityValidationUtil.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/main/kotlin/net/corda/libs/permissions/storage/writer/impl/validation/EntityValidationUtil.kt
@@ -91,7 +91,7 @@ class EntityValidationUtil(private val entityManager: EntityManager) {
             WHERE ${Group::parentGroup.name}.${Group::id.name} = :groupId
         """.trimIndent()
 
-        val numSubgroups = entityManager.createQuery(subgroupsQuery, Long::class.java)
+        val numSubgroups = entityManager.createQuery(subgroupsQuery, Long::class.javaObjectType)
             .setParameter("groupId", groupId)
             .singleResult
 
@@ -100,7 +100,7 @@ class EntityValidationUtil(private val entityManager: EntityManager) {
             WHERE ${User::parentGroup.name}.${Group::id.name} = :groupId
         """.trimIndent()
 
-        val numUsers = entityManager.createQuery(usersQuery, Long::class.java)
+        val numUsers = entityManager.createQuery(usersQuery, Long::class.javaObjectType)
             .setParameter("groupId", groupId)
             .singleResult
 

--- a/libs/permissions/permission-storage-writer-impl/src/test/kotlin/net/corda/libs/permissions/storage/writer/impl/group/GroupWriterImplTest.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/test/kotlin/net/corda/libs/permissions/storage/writer/impl/group/GroupWriterImplTest.kt
@@ -349,7 +349,7 @@ class GroupWriterImplTest {
         val group = Group("groupId", Instant.now(), "groupName", null)
 
         val query = mock<TypedQuery<Long>>()
-        whenever(entityManager.createQuery(any(), eq(Long::class.java))).thenReturn(query)
+        whenever(entityManager.createQuery(any(), eq(Long::class.javaObjectType))).thenReturn(query)
         whenever(query.setParameter(any<String>(), any<String>())).thenReturn(query)
         whenever(query.singleResult).thenReturn(0)
 
@@ -389,7 +389,7 @@ class GroupWriterImplTest {
         group.roleGroupAssociations.add(assoc)
 
         val query = mock<TypedQuery<Long>>()
-        whenever(entityManager.createQuery(any(), eq(Long::class.java))).thenReturn(query)
+        whenever(entityManager.createQuery(any(), eq(Long::class.javaObjectType))).thenReturn(query)
         whenever(query.setParameter(any<String>(), any<String>())).thenReturn(query)
         whenever(query.singleResult).thenReturn(1)
 

--- a/libs/permissions/permission-storage-writer-impl/src/test/kotlin/net/corda/libs/permissions/storage/writer/impl/validation/EntityValidationUtilTest.kt
+++ b/libs/permissions/permission-storage-writer-impl/src/test/kotlin/net/corda/libs/permissions/storage/writer/impl/validation/EntityValidationUtilTest.kt
@@ -239,7 +239,7 @@ class EntityValidationUtilTest {
             on { id }.thenReturn(groupId)
         }
         val query = mock<TypedQuery<Long>>()
-        whenever(entityManager.createQuery(any(), eq(Long::class.java))).thenReturn(query)
+        whenever(entityManager.createQuery(any(), eq(Long::class.javaObjectType))).thenReturn(query)
         whenever(query.setParameter("groupId", groupId)).thenReturn(query)
         whenever(query.singleResult).thenReturn(0L)
 
@@ -255,7 +255,7 @@ class EntityValidationUtilTest {
             on { id }.thenReturn(groupId)
         }
         val query = mock<TypedQuery<Long>>()
-        whenever(entityManager.createQuery(any(), eq(Long::class.java))).thenReturn(query)
+        whenever(entityManager.createQuery(any(), eq(Long::class.javaObjectType))).thenReturn(query)
         whenever(query.setParameter("groupId", groupId)).thenReturn(query)
         whenever(query.singleResult).thenReturn(1L)
 

--- a/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
+++ b/processors/rest-processor/src/integrationTest/resources/swaggerBaseline-v5_3.json
@@ -1010,7 +1010,7 @@
           "schema" : {
             "type" : "string",
             "description" : "New parent group ID.",
-            "nullable" : false,
+            "nullable" : true,
             "example" : "string"
           }
         } ],
@@ -4979,7 +4979,7 @@
         }
       },
       "GroupContentResponseType" : {
-        "required" : [ "id", "name", "parentGroupId", "properties", "roleAssociations", "subgroups", "updateTimestamp", "users" ],
+        "required" : [ "id", "name", "properties", "roleAssociations", "subgroups", "updateTimestamp", "users" ],
         "type" : "object",
         "properties" : {
           "id" : {
@@ -4994,7 +4994,7 @@
           },
           "parentGroupId" : {
             "type" : "string",
-            "nullable" : false,
+            "nullable" : true,
             "example" : "string"
           },
           "properties" : {

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -798,7 +798,7 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
 
     @Suppress("unused")
     // This method is used to change the parent group of an existing RBAC group
-    fun changeParentGroup(groupId: String, newParentGroupId: String): SimpleResponse {
+    fun changeParentGroup(groupId: String, newParentGroupId: String?): SimpleResponse {
         return initialClient.put("/api/$REST_API_VERSION_PATH/group/$groupId/parent/changeParentId/$newParentGroupId", "")
     }
 

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -814,12 +814,6 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
         return initialClient.delete("/api/$REST_API_VERSION_PATH/group/$groupId/role/$roleId")
     }
 
-    @Suppress("unused")
-    // This method is used to get the content of an existing RBAC group
-    fun getGroupContent(groupId: String): SimpleResponse {
-        return initialClient.get("/api/$REST_API_VERSION_PATH/group/$groupId")
-    }
-
     /** Start a flow */
     fun flowStart(
         holdingIdentityShortHash: String,


### PR DESCRIPTION
- Allows the parentGroupId to be nullable, since without it being made nullable we are unable to create an initial/base group
- Fix `java.lang.IllegalArgumentException: Type specified for TypedQuery [long] is incompatible with query return type [class java.lang.Long]` when attempting to delete a group