### PR TITLE
CORE-20780 Added mapping of valid LifecycleStatus transitions

### DIFF
--- a/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
+++ b/libs/lifecycle/lifecycle-impl/src/main/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImpl.kt
@@ -145,12 +145,13 @@ class LifecycleCoordinatorImpl(
 
     /**
      * Checks if a transition between two given states is possible within our defined [transitions] map.
+     * If the states are the same, the transition is always possible.
      *
      * @param from The [LifecycleStatus] we are transitioning from.
      * @param to The [LifecycleStatus] we are transitioning to.
      */
     private fun canTransition(from: LifecycleStatus, to: LifecycleStatus): Boolean {
-        return transitions[from]?.contains(to) ?: false
+        return (from == to) || transitions[from]?.contains(to) ?: false
     }
 
     /**

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImplTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImplTest.kt
@@ -1,10 +1,5 @@
 package net.corda.lifecycle.impl
 
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledFuture
-import java.util.concurrent.TimeUnit
-import kotlin.random.Random
 import net.corda.lifecycle.CustomEvent
 import net.corda.lifecycle.DependentComponents
 import net.corda.lifecycle.ErrorEvent
@@ -31,6 +26,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
@@ -38,6 +35,11 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 
 // These tests create simple lifecycle coordinator, provide an event handler to do some processing of events, and then
 // deliver some series of events to the coordinator to process. There are some subtleties to keep in mind when adding to
@@ -1387,6 +1389,47 @@ internal class LifecycleCoordinatorImplTest {
 
         coordinator.stop()
         verify(dependency).stop()
+    }
+
+    @ParameterizedTest(name = "coordinator cannot transition from ERROR status to {0}")
+    @EnumSource(value = LifecycleStatus::class, names = ["UP", "DOWN"])
+    fun `coordinator cannot transition from ERROR status to UP or DOWN`(targetStatus: LifecycleStatus) {
+        val coordinator = createTestCoordinator { _, _ -> }
+        coordinator.postEvent(StartEvent())
+
+        // Set the coordinator to an error state
+        coordinator.updateStatus(LifecycleStatus.ERROR)
+        assertThat(coordinator.status).isEqualTo(LifecycleStatus.ERROR)
+
+        // Ensure that any further transitions result in a NO-OP
+        coordinator.updateStatus(targetStatus)
+        assertThat(coordinator.status).isEqualTo(LifecycleStatus.ERROR)
+    }
+
+    @ParameterizedTest(name = "coordinator can transition from UP status to {0}")
+    @EnumSource(value = LifecycleStatus::class, names = ["DOWN", "ERROR"])
+    fun `coordinator can transition from UP status to DOWN or ERROR`(targetStatus: LifecycleStatus) {
+        val coordinator = createTestCoordinator { _, _ -> }
+        coordinator.postEvent(StartEvent())
+
+        coordinator.updateStatus(LifecycleStatus.UP)
+        assertEquals(LifecycleStatus.UP, coordinator.status)
+
+        coordinator.updateStatus(targetStatus)
+        assertEquals(targetStatus, coordinator.status)
+    }
+
+    @ParameterizedTest(name = "coordinator can transition from DOWN status to {0}")
+    @EnumSource(value = LifecycleStatus::class, names = ["UP", "ERROR"])
+    fun `coordinator can transition from DOWN status to UP or ERROR`(targetStatus: LifecycleStatus) {
+        val coordinator = createTestCoordinator { _, _ -> }
+        coordinator.postEvent(StartEvent())
+
+        coordinator.updateStatus(LifecycleStatus.DOWN)
+        assertEquals(LifecycleStatus.DOWN, coordinator.status)
+
+        coordinator.updateStatus(targetStatus)
+        assertEquals(targetStatus, coordinator.status)
     }
 
     private fun createCoordinator(

--- a/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
+++ b/libs/lifecycle/lifecycle-test-impl/src/main/kotlin/net/corda/lifecycle/test/impl/LifecycleTest.kt
@@ -139,6 +139,7 @@ class LifecycleTest<T : Lifecycle>(
      */
     fun bringDependencyUp(coordinatorName: LifecycleCoordinatorName) {
         val coordinator = registry.getCoordinator(coordinatorName)
+        coordinator.stop()
         coordinator.start()
         coordinator.updateStatus(LifecycleStatus.UP)
     }


### PR DESCRIPTION
As of today, there is no safeguard which constrains the possible state transitions for a given Lifecycle component. This caused issues in `CORE-19976,` where a component in `LifecycleStatus.ERROR` was changed to `LifecycleStatus.DOWN` which should not be possible.

This instance was fixed in the client code with the check:
```
if (lifecycleCoordinator.status != LifecycleStatus.ERROR) {
    lifecycleCoordinator.close()
}
```

This PR introduces more robust mechanisms for defining the possible transitions. Any transition outside of this is treated as a no-up, and the attempt is logged in the trace logs.