### PR TITLE
CORE-20750 : Test for cpis with no cpks, using the findAll function in CpiMetaDataRepositoryImpl

### DIFF
--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CpiMetadataRepositoryImplTest {
 
-    private val dbConfig: EntityManagerConfiguration = DbUtils.getEntityManagerConfiguration("cpk_file_db")
+    private val dbConfig: EntityManagerConfiguration = DbUtils.getEntityManagerConfiguration("cpi_metadata_db")
     private val emf = EntityManagerFactoryFactoryImpl().create(
         "test_unit",
         CpiEntities.classes.toList(),

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
 import net.corda.db.schema.DbSchema
 import net.corda.db.testkit.DbUtils
 import net.corda.libs.cpi.datamodel.CpiEntities
+import net.corda.libs.cpi.datamodel.entities.internal.CpiCpkEntity
 import net.corda.libs.cpi.datamodel.entities.internal.CpiMetadataEntity
 import net.corda.libs.cpi.datamodel.repository.factory.CpiCpkRepositoryFactory
 import net.corda.libs.packaging.core.CpiIdentifier
@@ -51,6 +52,7 @@ class CpiMetadataRepositoryImplTest {
         // This is required because when the tests run using Jenkins a real database is used and the data
         // is not wiped out. The tests in this class require a clean CpkFileEntity table.
         emf.transaction {
+            it.createQuery("DELETE FROM ${CpiCpkEntity::class.simpleName}").executeUpdate()
             it.createQuery("DELETE FROM ${CpiMetadataEntity::class.simpleName}").executeUpdate()
         }
     }

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
@@ -15,6 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.UUID
 
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -50,10 +51,12 @@ class CpiMetadataRepositoryImplTest {
     }
 
     @Test
-    fun `findAll stores CPI MetaData without any cpks successfully`(){
+    fun `findAll finds CPI metadata without any CPKs successfully`(){
         emf.transaction {
             val hashValue = SecureHashImpl("SHA-256", byteArrayOf(0))
-            val cpiIdentifier = CpiIdentifier("test","1.0", hashValue)
+            val randomID = UUID.randomUUID()
+            val randomIDString = "$randomID"
+            val cpiIdentifier = CpiIdentifier(randomIDString,"1.0", hashValue)
             cpiMetadataRepository.put(
                 em = it,
                 cpiId = cpiIdentifier,

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
@@ -55,8 +55,7 @@ class CpiMetadataRepositoryImplTest {
         emf.transaction {
             val hashValue = SecureHashImpl("SHA-256", byteArrayOf(0))
             val randomID = UUID.randomUUID()
-            val randomIDString = "$randomID"
-            val cpiIdentifier = CpiIdentifier(randomIDString,"1.0", hashValue)
+            val cpiIdentifier = CpiIdentifier(randomID.toString(),"1.0", hashValue)
             cpiMetadataRepository.put(
                 em = it,
                 cpiId = cpiIdentifier,

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
@@ -49,8 +49,9 @@ class CpiMetadataRepositoryImplTest {
 
     @BeforeEach
     fun clearCpkFileTable(){
-        // This is required because when the tests run using Jenkins a real database is used and the data
-        // is not wiped out. The tests in this class require a clean CpkFileEntity table.
+        //The CpiMetaDataEntity table is linked to the CpiCpkEntity table
+        //If we delete the CpiMetadataEntity first, failures occur due to the foreign key constraints
+        //So the deletion of the CpiCpkEntity table is needed to be deleted first before the CpiMetadataEntity
         emf.transaction {
             it.createQuery("DELETE FROM ${CpiCpkEntity::class.simpleName}").executeUpdate()
             it.createQuery("DELETE FROM ${CpiMetadataEntity::class.simpleName}").executeUpdate()
@@ -63,7 +64,7 @@ class CpiMetadataRepositoryImplTest {
     }
 
     @Test
-    fun `cpis with no cpks`(){
+    fun `put stores CPI MetaData without any cpks successfully`(){
         emf.transaction {
             val hashValue = SecureHashImpl("SHA-256", byteArrayOf(0))
             val cpiIndentifier = CpiIdentifier("test","1.0", hashValue)

--- a/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
+++ b/libs/virtual-node/cpi-datamodel/src/integrationTest/kotlin/net/corda/libs/cpi/datamodel/entities/tests/CpiMetadataRepositoryImplTest.kt
@@ -1,0 +1,83 @@
+package net.corda.libs.cpi.datamodel.entities.tests
+
+import net.corda.crypto.core.SecureHashImpl
+import net.corda.db.admin.impl.ClassloaderChangeLog
+import net.corda.db.admin.impl.LiquibaseSchemaMigratorImpl
+import net.corda.db.schema.DbSchema
+import net.corda.db.testkit.DbUtils
+import net.corda.libs.cpi.datamodel.CpiEntities
+import net.corda.libs.cpi.datamodel.entities.internal.CpiMetadataEntity
+import net.corda.libs.cpi.datamodel.repository.factory.CpiCpkRepositoryFactory
+import net.corda.libs.packaging.core.CpiIdentifier
+import net.corda.orm.EntityManagerConfiguration
+import net.corda.orm.impl.EntityManagerFactoryFactoryImpl
+import net.corda.orm.utils.transaction
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CpiMetadataRepositoryImplTest {
+
+    private val dbConfig: EntityManagerConfiguration = DbUtils.getEntityManagerConfiguration("cpk_file_db")
+    private val emf = EntityManagerFactoryFactoryImpl().create(
+        "test_unit",
+        CpiEntities.classes.toList(),
+        dbConfig
+    )
+
+    private val cpiMetadataRepository = CpiCpkRepositoryFactory().createCpiMetadataRepository()
+
+    init {
+        val dbChange = ClassloaderChangeLog(
+            linkedSetOf(
+                ClassloaderChangeLog.ChangeLogResourceFiles(
+                    DbSchema::class.java.packageName,
+                    listOf("net/corda/db/schema/config/db.changelog-master.xml"),
+                    DbSchema::class.java.classLoader
+                )
+            )
+        )
+        dbConfig.dataSource.connection.use { connection ->
+            LiquibaseSchemaMigratorImpl().updateDb(connection, dbChange)
+        }
+    }
+
+    @BeforeEach
+    fun clearCpkFileTable(){
+        // This is required because when the tests run using Jenkins a real database is used and the data
+        // is not wiped out. The tests in this class require a clean CpkFileEntity table.
+        emf.transaction {
+            it.createQuery("DELETE FROM ${CpiMetadataEntity::class.simpleName}").executeUpdate()
+        }
+    }
+
+    @AfterAll
+    fun cleanUp() {
+        emf.close()
+    }
+
+    @Test
+    fun `cpis with no cpks`(){
+        emf.transaction {
+            val hashValue = SecureHashImpl("SHA-256", byteArrayOf(0))
+            val cpiIndentifier = CpiIdentifier("test","1.0", hashValue)
+            cpiMetadataRepository.put(
+                em = it,
+                cpiId = cpiIndentifier,
+                cpiFileName = "filename",
+                fileChecksum = hashValue,
+                groupId = "group",
+                groupPolicy = "group-policy",
+                fileUploadRequestId = "uploadRequestId",
+                cpks = listOf()
+            )
+
+            val cpiData = cpiMetadataRepository.findAll(em = it)
+            assertThat(cpiData).isNotEmpty
+        }
+    }
+}


### PR DESCRIPTION
Added tests to for cpis with no cpks, the reason as there was an issue in reconciliation which needed to be fixed. 