### PR TITLE
CORE-20770: Fix ChangeParentGroup endpoint path to lowercase

### DIFF
--- a/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/group/GroupEndpoint.kt
+++ b/libs/permissions/permission-endpoint/src/main/kotlin/net/corda/libs/permissions/endpoints/v1/group/GroupEndpoint.kt
@@ -44,7 +44,7 @@ interface GroupEndpoint : RestResource {
     ): ResponseEntity<GroupResponseType>
 
     @HttpPUT(
-        path = "{groupId}/parent/changeParentId/{newParentGroupId}",
+        path = "{groupId}/parent/changeparentid/{newParentGroupId}",
         description = "This method changes the parent group of a specified group.",
         responseDescription = """
             The group with the updated parent group with the following attributes:

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -799,7 +799,7 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
     @Suppress("unused")
     // This method is used to change the parent group of an existing RBAC group
     fun changeParentGroup(groupId: String, newParentGroupId: String?): SimpleResponse {
-        return initialClient.put("/api/$REST_API_VERSION_PATH/group/$groupId/parent/changeParentId/$newParentGroupId", "")
+        return initialClient.put("/api/$REST_API_VERSION_PATH/group/$groupId/parent/changeparentid/$newParentGroupId", "")
     }
 
     @Suppress("unused")


### PR DESCRIPTION
- `ChangeParentGroup` endpoint was returning a 301 status code because the endpoint path was different. Changed to lowercase as endpoints paths are converted to lowercase