### PR TITLE
ES-2012: Create secrets pre-upgrade as well as pre-install

### DIFF
--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -401,9 +401,11 @@ metadata:
   name: {{ $secretName }}
   annotations:
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook": pre-install, pre-upgrade
 {{- if $options.cleanup }}
+    "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded
+{{- else }}
+    "helm.sh/hook": pre-install, pre-upgrade
 {{- end }}
   labels:
     {{- include "corda.labels" $ | nindent 4 }}

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -401,7 +401,7 @@ metadata:
   name: {{ $secretName }}
   annotations:
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
 {{- if $options.cleanup }}
     "helm.sh/hook-delete-policy": hook-succeeded
 {{- end }}

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -158,14 +158,6 @@ Kafka bootstrap servers
 {{- end }}
 
 {{/*
-Dummy debug secret name
-*/}}
-{{- define "corda.dummyDebugSecretName" -}}
-{{ default (printf "%s-dummy-debug" (include "corda.fullname" .)) }}
-{{- end }}
-
-
-{{/*
 Initial REST API admin secret name
 */}}
 {{- define "corda.restApiAdminSecretName" -}}
@@ -213,22 +205,6 @@ Initial REST API admin secret password key
 {{- else -}}
 password
 {{- end -}}
-{{- end -}}
-
-{{/*
-Dummy debug secret environment variable
-*/}}
-{{- define "corda.dummyDebugSecretEnv" -}}
-- name: DUMMY_DEBUG_USERNAME
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "corda.dummyDebugSecretName" . }}
-      key: username
-- name: DUMMY_DEBUG_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ include "corda.dummyDebugSecretName" . }}
-      key: password
 {{- end -}}
 
 {{/*

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -401,11 +401,13 @@ metadata:
   name: {{ $secretName }}
   annotations:
     "helm.sh/hook-weight": "-1"
-{{- if $options.cleanup }}
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
+{{- if $options.hook }}
+    "helm.sh/hook": {{ $options.hook }}
 {{- else }}
     "helm.sh/hook": pre-install, pre-upgrade
+{{- end }}
+{{- if $options.cleanup }}
+    "helm.sh/hook-delete-policy": hook-succeeded
 {{- end }}
   labels:
     {{- include "corda.labels" $ | nindent 4 }}

--- a/charts/corda-lib/templates/_helpers.tpl
+++ b/charts/corda-lib/templates/_helpers.tpl
@@ -158,6 +158,14 @@ Kafka bootstrap servers
 {{- end }}
 
 {{/*
+Dummy debug secret name
+*/}}
+{{- define "corda.dummyDebugSecretName" -}}
+{{ default (printf "%s-dummy-debug" (include "corda.fullname" .)) }}
+{{- end }}
+
+
+{{/*
 Initial REST API admin secret name
 */}}
 {{- define "corda.restApiAdminSecretName" -}}
@@ -205,6 +213,22 @@ Initial REST API admin secret password key
 {{- else -}}
 password
 {{- end -}}
+{{- end -}}
+
+{{/*
+Dummy debug secret environment variable
+*/}}
+{{- define "corda.dummyDebugSecretEnv" -}}
+- name: DUMMY_DEBUG_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "corda.dummyDebugSecretName" . }}
+      key: username
+- name: DUMMY_DEBUG_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "corda.dummyDebugSecretName" . }}
+      key: password
 {{- end -}}
 
 {{/*

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -270,6 +270,7 @@ spec:
             value: {{ required (printf "Must specify workers.%s.kafka.sasl.password.value, workers.%s.kafka.sasl.password.valueFrom.secretKeyRef.name, kafka.sasl.password.value, or kafka.sasl.password.valueFrom.secretKeyRef.name" $worker $worker) $.Values.kafka.sasl.password.value }}
             {{- end }}
           {{- end }}
+        {{- include "corda.dummyDebugSecretEnv" $ | nindent 10 }}
         {{- if not (($.Values).vault).url }}
         {{- include "corda.configSaltAndPassphraseEnv" $ | nindent 10 }}
         {{- end }}

--- a/charts/corda-lib/templates/_worker.tpl
+++ b/charts/corda-lib/templates/_worker.tpl
@@ -270,7 +270,6 @@ spec:
             value: {{ required (printf "Must specify workers.%s.kafka.sasl.password.value, workers.%s.kafka.sasl.password.valueFrom.secretKeyRef.name, kafka.sasl.password.value, or kafka.sasl.password.valueFrom.secretKeyRef.name" $worker $worker) $.Values.kafka.sasl.password.value }}
             {{- end }}
           {{- end }}
-        {{- include "corda.dummyDebugSecretEnv" $ | nindent 10 }}
         {{- if not (($.Values).vault).url }}
         {{- include "corda.configSaltAndPassphraseEnv" $ | nindent 10 }}
         {{- end }}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -97,13 +97,3 @@
 }}
 {{-   end -}}
 {{- end -}}
-{{/* DEBUG: dummy secret absent in the pre-upgrade version */}}
-{{ - include "corda.secret"
-  ( list
-    $
-    .Values.bootstrap.restApiAdmin
-    "bootstrap.restApiAdmin"
-    ( include "corda.corda.dummyDebugSecretName" . )
-    ( dict "username" ( dict "required" true ) "password" ( dict "generate" 12 ) )
-  )
-}}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -28,7 +28,7 @@
               ( printf "bootstrap.db.%s" $db )
               ( printf "%s-%s-db" ( include "corda.fullname" $ ) ( kebabcase $db ) )
               ( dict "username" ( dict "required" true ) "password" ( dict "generate" 12 ) )
-              ( dict "cleanup" true )
+              ( dict "cleanup" true "hook" "pre-install" )
           )
 }}
 {{-   end }}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -103,7 +103,7 @@
     $
     .Values.bootstrap.restApiAdmin
     "bootstrap.restApiAdmin"
-    ( include "corda.corda.dummyDebugSecretName" . )
+    ( include "corda.dummyDebugSecretName" . )
     ( dict "username" ( dict "required" true ) "password" ( dict "generate" 12 ) )
   )
 }}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -98,7 +98,7 @@
 {{-   end -}}
 {{- end -}}
 {{/* DEBUG: dummy secret absent in the pre-upgrade version */}}
-{{- include "corda.secret"
+{{ - include "corda.secret"
   ( list
     $
     .Values.bootstrap.restApiAdmin

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -16,7 +16,7 @@
               ( printf "bootstrap.db.databases.[%d]" $index )
               ( include "corda.db.bootstrapCredentialsSecretName" ( list $ $bootConfig.id ) )
               ( dict "username" ( dict "required" true ) "password" ( dict "required" true ) )
-              ( dict "cleanup" true )
+              ( dict "cleanup" true "hook" "pre-install" )
           )
 }}
 {{-   end -}}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -103,7 +103,7 @@
     $
     .Values.bootstrap.restApiAdmin
     "bootstrap.restApiAdmin"
-    ( include "corda.dummyDebugSecretName" . )
+    ( include "corda.corda.dummyDebugSecretName" . )
     ( dict "username" ( dict "required" true ) "password" ( dict "generate" 12 ) )
   )
 }}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -97,3 +97,13 @@
 }}
 {{-   end -}}
 {{- end -}}
+{{/* DEBUG: dummy secret absent in the pre-upgrade version */}}
+{{ - include "corda.secret"
+  ( list
+    $
+    .Values.bootstrap.restApiAdmin
+    "bootstrap.restApiAdmin"
+    ( include "corda.corda.dummyDebugSecretName" . )
+    ( dict "username" ( dict "required" true ) "password" ( dict "generate" 12 ) )
+  )
+}}

--- a/charts/corda/templates/secrets.yaml
+++ b/charts/corda/templates/secrets.yaml
@@ -98,7 +98,7 @@
 {{-   end -}}
 {{- end -}}
 {{/* DEBUG: dummy secret absent in the pre-upgrade version */}}
-{{ - include "corda.secret"
+{{- include "corda.secret"
   ( list
     $
     .Values.bootstrap.restApiAdmin


### PR DESCRIPTION
### [ES-2012](https://r3-cev.atlassian.net/browse/ES-2012)

Tested on the `5.2.0` stream (`5.1` to `5.2` upgrade path) with `upgradeTestsPipeline`, modified deliberately to reproduce the issue:
- The pipeline change sets username via `"value:"` for the workers' Config and State Manager DBs: https://github.com/corda/corda-shared-build-pipeline-steps/commit/9261f282e62b65604932afb5d554d841a1b86a1e
- With the above only, upgrading to `5.2.0`, the original issue is reproducible. Failed helm upgrade: [https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda5-upgrade-tests/detail/asubbotin%2FES-2012%2Fupgrade-secret-creation-5.2/4/pipeline](https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda5-upgrade-tests/detail/asubbotin%2FES-2012%2Fupgrade-secret-creation-5.2/4/pipeline)
```
55s         Warning   FailedMount              pod/corda-bob-crypto-worker-5fc86c9787-xw8dh                   MountVolume.SetUp failed for volume "key-rotation-volume" : secret "corda-bob-crypto-key-rotation-db" not found
55s         Warning   FailedMount              pod/corda-bob-flow-worker-f4b8fd779-2rxj8                      MountVolume.SetUp failed for volume "flow-checkpoint-volume" : secret "corda-bob-flow-flow-checkpoint-db" not found
54s         Warning   FailedMount              pod/corda-bob-rest-worker-5d8b5bdf89-nb2sq                     MountVolume.SetUp failed for volume "key-rotation-volume" : secret "corda-bob-rest-key-rotation-db" not found
... skipped
```
- With the change applied, a `5.2.0-alpha` build was created: https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os/job/asubbotin%2FES-2012%2Fupgrade-secret-creation-5.2/5/
- Successful upgrade - issue is fixed: https://ci02.dev.r3.com/job/Corda5/job/corda5-upgrade-tests/job/asubbotin%2FES-2012%2Fupgrade-secret-creation-5.2/10/

[ES-2012]: https://r3-cev.atlassian.net/browse/ES-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ