### PR TITLE
CORE-20786: Fix for Flakey AmqpSerializationTests 

### DIFF
--- a/libs/corda-sdk/src/main/kotlin/net/corda/sdk/bootstrap/rbac/Permissions.kt
+++ b/libs/corda-sdk/src/main/kotlin/net/corda/sdk/bootstrap/rbac/Permissions.kt
@@ -79,13 +79,7 @@ object Permissions {
         "CreateRole" to "POST:/api/$VERSION_PATH_REGEX/role",
         "GetRole" to "GET:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX",
         "AddPermissionToRole" to "PUT:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX",
-        "DeletePermissionFromRole" to "DELETE:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX",
-
-        // Property manipulation permissions
-        "AddPropertyToUser" to "POST:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property",
-        "DeletePropertyFromUser" to "DELETE:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property/*",
-        "GetUserProperties" to "GET:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property",
-        "GetUsersByProperty" to "GET:/api/$VERSION_PATH_REGEX/user/findByProperty/*/*"
+        "DeletePermissionFromRole" to "DELETE:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX"
     ).toMap()
 
     val vNodeCreator: Map<String, String> = listOf(

--- a/libs/corda-sdk/src/main/kotlin/net/corda/sdk/bootstrap/rbac/Permissions.kt
+++ b/libs/corda-sdk/src/main/kotlin/net/corda/sdk/bootstrap/rbac/Permissions.kt
@@ -79,7 +79,13 @@ object Permissions {
         "CreateRole" to "POST:/api/$VERSION_PATH_REGEX/role",
         "GetRole" to "GET:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX",
         "AddPermissionToRole" to "PUT:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX",
-        "DeletePermissionFromRole" to "DELETE:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX"
+        "DeletePermissionFromRole" to "DELETE:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX",
+
+        // Property manipulation permissions
+        "AddPropertyToUser" to "POST:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property",
+        "DeletePropertyFromUser" to "DELETE:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property/*",
+        "GetUserProperties" to "GET:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property",
+        "GetUsersByProperty" to "GET:/api/$VERSION_PATH_REGEX/user/findByProperty/*/*"
     ).toMap()
 
     val vNodeCreator: Map<String, String> = listOf(

--- a/libs/corda-sdk/src/main/kotlin/net/corda/sdk/bootstrap/rbac/Permissions.kt
+++ b/libs/corda-sdk/src/main/kotlin/net/corda/sdk/bootstrap/rbac/Permissions.kt
@@ -79,14 +79,7 @@ object Permissions {
         "CreateRole" to "POST:/api/$VERSION_PATH_REGEX/role",
         "GetRole" to "GET:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX",
         "AddPermissionToRole" to "PUT:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX",
-        "DeletePermissionFromRole" to "DELETE:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX",
-
-        // Property manipulation permissions
-        "AddPropertyToUser" to "POST:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property",
-        "DeletePropertyFromUser" to "DELETE:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property/*",
-        "GetUserProperties" to "GET:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property",
-        "GetUsersByProperty" to "GET:/api/$VERSION_PATH_REGEX/user/findByProperty/*/*"
-
+        "DeletePermissionFromRole" to "DELETE:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX"
     ).toMap()
 
     val vNodeCreator: Map<String, String> = listOf(

--- a/libs/corda-sdk/src/main/kotlin/net/corda/sdk/bootstrap/rbac/Permissions.kt
+++ b/libs/corda-sdk/src/main/kotlin/net/corda/sdk/bootstrap/rbac/Permissions.kt
@@ -79,7 +79,14 @@ object Permissions {
         "CreateRole" to "POST:/api/$VERSION_PATH_REGEX/role",
         "GetRole" to "GET:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX",
         "AddPermissionToRole" to "PUT:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX",
-        "DeletePermissionFromRole" to "DELETE:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX"
+        "DeletePermissionFromRole" to "DELETE:/api/$VERSION_PATH_REGEX/role/$UUID_REGEX/permission/$UUID_REGEX",
+
+        // Property manipulation permissions
+        "AddPropertyToUser" to "POST:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property",
+        "DeletePropertyFromUser" to "DELETE:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property/*",
+        "GetUserProperties" to "GET:/api/$VERSION_PATH_REGEX/user/${RbacKeys.USER_URL_REGEX}/property",
+        "GetUsersByProperty" to "GET:/api/$VERSION_PATH_REGEX/user/findByProperty/*/*"
+
     ).toMap()
 
     val vNodeCreator: Map<String, String> = listOf(

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -78,10 +78,11 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
 
                 assertWithRetry {
                     command {
-                     getRbacUser(vNodeCreatorName)
+                        getRbacUser(vNodeCreatorName)
                     }
                     condition {
-                        it.body.toJson()["roleAssociations"].firstOrNull()?.get("roleId")?.textValue().equals(vNodeCreatorRole["id"].textValue())
+                        it.body.toJson()["roleAssociations"].firstOrNull()?.get("roleId")?.textValue()
+                            .equals(vNodeCreatorRole["id"].textValue())
                     }
                 }
 

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterBuilder.kt
@@ -81,7 +81,7 @@ class ClusterBuilder(clusterInfo: ClusterInfo, val REST_API_VERSION_PATH: String
                      getRbacUser(vNodeCreatorName)
                     }
                     condition {
-                        it.body.toJson()["roleAssociations"].first()["roleId"].textValue().equals(vNodeCreatorRole["id"].textValue())
+                        it.body.toJson()["roleAssociations"].firstOrNull()?.get("roleId")?.textValue().equals(vNodeCreatorRole["id"].textValue())
                     }
                 }
 


### PR DESCRIPTION
Prevents "Collection is empty" error that occurs in ClusterBuilder when checking that vNodeCreatorRole has been assigned. In the case where the role has not been assigned, it will return null and try again.