### PR TITLE
CORE-20708 Ensure API response is 2XX before parsing

### DIFF
--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/utils/ClusterUtils.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/utils/ClusterUtils.kt
@@ -31,7 +31,7 @@ fun ClusterBuilder.eventuallyUploadCpi(
         interval(retryInterval)
         command { cpiStatus(requestId) }
         condition {
-            it.code == 200 && it.toJson()["status"].textValue() == "OK"
+            it.code == ResponseCode.OK.statusCode && it.toJson()["status"].textValue() == "OK"
         }
         immediateFailCondition {
             it.code == ResponseCode.CONFLICT.statusCode

--- a/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
+++ b/applications/workers/workers-smoketest/src/smokeTest/kotlin/net/corda/applications/workers/smoketest/virtualnode/VirtualNodeRestTest.kt
@@ -93,7 +93,7 @@ class VirtualNodeRestTest : ClusterReadiness by ClusterReadinessChecker() {
                 timeout(retryTimeout)
                 interval(retryInterval)
                 command { importCertificate(CODE_SIGNER_CERT, CODE_SIGNER_CERT_USAGE, CODE_SIGNER_CERT_ALIAS) }
-                condition { it.code == 204 }
+                condition { it.code == ResponseCode.NO_CONTENT.statusCode }
             }
         }
     }
@@ -130,7 +130,7 @@ class VirtualNodeRestTest : ClusterReadiness by ClusterReadinessChecker() {
                 timeout(retryTimeout)
                 interval(retryInterval)
                 command { cpiList() }
-                condition { it.code == 200 && it.toJson()["cpis"].size() > 0 }
+                condition { it.code == ResponseCode.OK.statusCode && it.toJson()["cpis"].size() > 0 }
             }.toJson()
 
             assertThat(json["cpis"].size()).isGreaterThan(0)
@@ -158,7 +158,7 @@ class VirtualNodeRestTest : ClusterReadiness by ClusterReadinessChecker() {
                     val nodes = vNodeList().toJson()["virtualNodes"].map {
                         it["holdingIdentity"]["x500Name"].textValue()
                     }
-                    response.code == 200 && nodes.contains(aliceX500)
+                    response.code == ResponseCode.OK.statusCode && nodes.contains(aliceX500)
                 }
             }
         }
@@ -173,7 +173,7 @@ class VirtualNodeRestTest : ClusterReadiness by ClusterReadinessChecker() {
                 interval(retryInterval)
                 command { getVNode(aliceHoldingId) }
                 condition { response ->
-                    response.code == 200 &&
+                    response.code == ResponseCode.OK.statusCode &&
                             response.toJson()["holdingIdentity"]["x500Name"].textValue().contains(aliceX500)
                 }
             }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/ClusterUtils.kt
@@ -130,7 +130,7 @@ fun ClusterInfo.getOrCreateVirtualNodeFor(
     vNodeCreationSemaphore.runWith {
         val vNodesJson = assertWithRetryIgnoringExceptions {
             command { vNodeList() }
-            condition { it.code == 200 }
+            condition { it.code == ResponseCode.OK.statusCode }
             failMessage("Failed to retrieve virtual nodes")
         }.toJson()
 
@@ -206,9 +206,9 @@ fun ClusterInfo.createKeyFor(
             )
         }
         condition {
-            it.code == 200 &&
-                    it.toJson().isObject &&
-                    !it.toJson().isEmpty
+            it.code == ResponseCode.OK.statusCode
+                    && it.toJson().isObject
+                    && !it.toJson().isEmpty
         }
         failMessage("Failed to get keys for holding id '$tenantId' and alias '$alias'")
     }.toJson()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -289,20 +289,26 @@ fun ClusterInfo.waitForRegistrationStatus(
                 }
             }
             condition {
-                if (registrationId != null) {
-                    it.toJson().get("registrationStatus")?.textValue() == registrationStatus
-                } else {
-                    it.toJson().firstOrNull()?.get("registrationStatus")?.textValue() == registrationStatus
+                it.code == ResponseCode.OK.statusCode && run {
+                    val json = it.toJson()
+                    val status = if (registrationId != null) {
+                        json.get("registrationStatus")?.textValue()
+                    } else {
+                        json.firstOrNull()?.get("registrationStatus")?.textValue()
+                    }
+                    status == registrationStatus
                 }
             }
             immediateFailCondition {
-                val status = if (registrationId != null) {
-                    it.toJson().get("registrationStatus")?.textValue()
-                } else {
-                    it.toJson().firstOrNull()?.get("registrationStatus")?.textValue() == registrationStatus
+                it.code == ResponseCode.OK.statusCode && run {
+                    val json = it.toJson()
+                    val status = if (registrationId != null) {
+                        json.get("registrationStatus")?.textValue()
+                    } else {
+                        json.firstOrNull()?.get("registrationStatus")?.textValue() == registrationStatus
+                    }
+                    status != registrationStatus && finalRegistrationStates.contains(status)
                 }
-                (status != registrationStatus) &&
-                    (finalRegistrationStates.contains(status))
             }
             failMessage("Registration was not completed for $holdingIdentityShortHash")
         }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -307,7 +307,7 @@ fun ClusterInfo.waitForRegistrationStatus(
                     } else {
                         json.firstOrNull()?.get("registrationStatus")?.textValue() == registrationStatus
                     }
-                    status != registrationStatus && finalRegistrationStates.contains(status)
+                    (status != registrationStatus) && (finalRegistrationStates.contains(status))
                 }
             }
             failMessage("Registration was not completed for $holdingIdentityShortHash")

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/MembershipUtils.kt
@@ -303,11 +303,12 @@ fun ClusterInfo.waitForRegistrationStatus(
                 it.code == ResponseCode.OK.statusCode && run {
                     val json = it.toJson()
                     val status = if (registrationId != null) {
-                        json.get("registrationStatus")?.textValue()
+                        json["registrationStatus"]?.textValue()
                     } else {
-                        json.firstOrNull()?.get("registrationStatus")?.textValue() == registrationStatus
+                        json.firstOrNull()?.get("registrationStatus")?.textValue()
                     }
-                    (status != registrationStatus) && (finalRegistrationStates.contains(status))
+
+                    status != registrationStatus && finalRegistrationStates.contains(status)
                 }
             }
             failMessage("Registration was not completed for $holdingIdentityShortHash")

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/RbacTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/RbacTestUtils.kt
@@ -2,6 +2,7 @@ package net.corda.e2etest.utilities
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import net.corda.rest.ResponseCode
 import java.time.Instant
 
 object RbacTestUtils {
@@ -10,7 +11,7 @@ object RbacTestUtils {
         return DEFAULT_CLUSTER.cluster {
             val bodyAsString = assertWithRetryIgnoringExceptions {
                 command { getRbacRoles() }
-                condition { it.code == 200 }
+                condition { it.code == ResponseCode.OK.statusCode }
                 failMessage("Failed to get all the RBAC roles in the cluster")
             }.body
             ObjectMapper()

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/VirtualNodeUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/VirtualNodeUtils.kt
@@ -1,5 +1,6 @@
 package net.corda.e2etest.utilities
 
+import net.corda.rest.ResponseCode
 import net.corda.utilities.minutes
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
@@ -17,12 +18,9 @@ fun ClusterBuilder.awaitVirtualNodeOperationStatusCheck(
         timeout(timeout)
         command { getVNodeStatus(requestId) }
         condition {
-            if (it.code != 200) {
-                false
-            } else {
+            it.code == ResponseCode.OK.statusCode && run {
                 val json = it.toJson()
                 val status = json["status"].textValue()
-
                 !(status == "ACCEPTED" || status == "IN_PROGRESS")
             }
         }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
@@ -156,13 +156,13 @@ fun ClusterInfo.waitForConfigurationChange(
             timeout(timeout)
             command { getConfig(section) }
             condition {
-                if (it.code != OK.statusCode) {
-                    return@condition false
-                }
+                it.code != OK.statusCode && run {
+                    val bodyJSON = it.body.toJson()
 
-                val bodyJSON = it.body.toJson()
-                it.code == OK.statusCode && bodyJSON["sourceConfig"] != null
-                        && bodyJSON.sourceConfigNode()[key] != null && bodyJSON.sourceConfigNode()[key].toString() == value
+                    bodyJSON["sourceConfig"] != null &&
+                    bodyJSON.sourceConfigNode()[key] != null &&
+                    bodyJSON.sourceConfigNode()[key].toString() == value
+                }
             }
         }
     }

--- a/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
+++ b/testing/e2e-test-utilities/src/main/kotlin/net/corda/e2etest/utilities/config/ConfigTestUtils.kt
@@ -156,7 +156,7 @@ fun ClusterInfo.waitForConfigurationChange(
             timeout(timeout)
             command { getConfig(section) }
             condition {
-                it.code != OK.statusCode && run {
+                it.code == OK.statusCode && run {
                     val bodyJSON = it.body.toJson()
 
                     bodyJSON["sourceConfig"] != null &&


### PR DESCRIPTION
We were seeing some test failures tracked under `CORE-20708` where the function `assertWithRetryIgnoringExceptions` was blowing up due to test code which tried to deserialise response payloads without actually checking if the response was a `2XX`.

This PR modifies these conditions so that the response code is checked before JSON deserialization is attempted. I noted also that there was a 50/50 split in the test cases between:
1. `it.code == 200` / `it.code == 204`
2. `it.code == ResponseCode.OK.statusCode` / `it.code == ResponseCode.NO_CONTENT.statusCode`

and have modified all cases to use the latter approach, with descriptive shared consts.