### PR TITLE
CORE-20736: Update reconcilePermissionSummaries to support groups

### DIFF
--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
@@ -15,6 +15,19 @@ data class InternalPermissionQueryDto(
 )
 
 /**
+ * Internal permission query data transfer object holding data for one permission, its associated parent group and user/group id.
+ */
+data class InternalPermissionWithParentGroupQueryDto(
+    val id: String,
+    val permissionId: String,
+    val groupVisibility: String?,
+    val virtualNode: String?,
+    val permissionString: String,
+    val permissionType: PermissionType,
+    val parentGroupId: String?
+)
+
+/**
  * Internal permission query data transfer object holding the login name and if user is enabled.
  */
 data class InternalUserEnabledQueryDto(

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
@@ -16,6 +16,7 @@ data class InternalPermissionQueryDto(
 
 /**
  * Internal permission query data transfer object holding data for one permission, its associated parent group and user/group id.
+ * [loginName] will be null if it is a group.
  */
 data class InternalPermissionWithParentGroupQueryDto(
     val id: String,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
@@ -19,7 +19,7 @@ data class InternalPermissionQueryDto(
  */
 data class InternalPermissionWithParentGroupQueryDto(
     val id: String,
-    val permissionId: String,
+    val permissionId: String?,
     val groupVisibility: String?,
     val virtualNode: String?,
     val permissionString: String?,

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
@@ -22,10 +22,25 @@ data class InternalPermissionWithParentGroupQueryDto(
     val permissionId: String,
     val groupVisibility: String?,
     val virtualNode: String?,
-    val permissionString: String,
-    val permissionType: PermissionType,
+    val permissionString: String?,
+    val permissionType: PermissionType?,
     val parentGroupId: String?,
     val loginName: String?
+)
+
+data class InternalUserGroup(
+    val id: String,
+    val parentId: String?,
+    val loginName: String?,
+    val permissionsList: List<Permission>
+)
+
+data class Permission(
+    val id: String,
+    val groupVisibility: String?,
+    val virtualNode: String?,
+    val permissionString: String,
+    val permissionType: PermissionType
 )
 
 /**

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
@@ -24,7 +24,8 @@ data class InternalPermissionWithParentGroupQueryDto(
     val virtualNode: String?,
     val permissionString: String,
     val permissionType: PermissionType,
-    val parentGroupId: String?
+    val parentGroupId: String?,
+    val loginName: String?
 )
 
 /**

--- a/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
+++ b/libs/permissions/permission-datamodel/src/main/kotlin/net/corda/permissions/query/dto/InternalPermissionQueryDto.kt
@@ -29,14 +29,17 @@ data class InternalPermissionWithParentGroupQueryDto(
     val loginName: String?
 )
 
+/**
+ * Internal data class which represents a group or a user with associated permissions depending on whether the loginName is null or not.
+ */
 data class InternalUserGroup(
     val id: String,
     val parentId: String?,
     val loginName: String?,
-    val permissionsList: List<Permission>
+    val permissionsList: List<InternalPermission>
 )
 
-data class Permission(
+data class InternalPermission(
     val id: String,
     val groupVisibility: String?,
     val virtualNode: String?,

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/repository/PermissionRepositoryImpl.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/repository/PermissionRepositoryImpl.kt
@@ -179,7 +179,7 @@ class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFa
         val userPermissions = mutableMapOf<UserLogin, List<InternalPermissionQueryDto>>()
 
         // For each root node build a tree and calculate the permissions for each user
-        parentIdToChildListMap[ROOT]!!.forEach { root ->
+        parentIdToChildListMap[ROOT]?.forEach { root ->
             buildTree(root, parentIdToChildListMap)
             calculatePermissions(root, mutableListOf(), userPermissions)
         }

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/repository/PermissionRepositoryImpl.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/repository/PermissionRepositoryImpl.kt
@@ -3,13 +3,13 @@ package net.corda.libs.permissions.storage.reader.impl.repository
 import net.corda.libs.permissions.storage.reader.repository.PermissionRepository
 import net.corda.libs.permissions.storage.reader.repository.UserLogin
 import net.corda.libs.permissions.storage.reader.summary.InternalUserPermissionSummary
+import net.corda.libs.permissions.storage.reader.util.PermissionUserUtil
 import net.corda.orm.utils.transaction
 import net.corda.permissions.model.Group
 import net.corda.permissions.model.Permission
 import net.corda.permissions.model.Role
 import net.corda.permissions.model.User
 import net.corda.permissions.query.dto.InternalPermissionQueryDto
-import net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto
 import net.corda.permissions.query.dto.InternalUserEnabledQueryDto
 import java.time.Instant
 import javax.persistence.EntityManager
@@ -17,49 +17,6 @@ import javax.persistence.EntityManagerFactory
 
 @Suppress("TooManyFunctions")
 class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFactory) : PermissionRepository {
-
-    companion object {
-        // Query to get all the Permissions for each Group
-        // InternalPermissionWithParentGroupQueryDto.loginName is empty to signify that it is a Group
-        const val userGroupPermissionsQuery =
-            """
-                SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(
-                g.id,
-                p.id,
-                p.groupVisibility.id, 
-                p.virtualNode, 
-                p.permissionString, 
-                p.permissionType,
-                g.parentGroup.id,
-                ''
-            )
-            FROM Group g
-            JOIN RoleGroupAssociation rga ON rga.group.id = g.id
-            JOIN Role r ON rga.role.id = r.id
-            JOIN RolePermissionAssociation rpa ON rpa.role.id = r.id
-            JOIN Permission p ON rpa.permission.id = p.id
-            """
-
-        // Query to get all the Permissions for each User
-        const val allUsersPermissionQuery =
-            """
-                SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(
-                u.id,
-                p.id,
-                p.groupVisibility.id, 
-                p.virtualNode, 
-                p.permissionString, 
-                p.permissionType,
-                u.parentGroup.id,
-                u.loginName
-            )
-            FROM User u
-            JOIN RoleUserAssociation rua ON rua.user.id = u.id
-            JOIN Role r ON rua.role.id = r.id
-            JOIN RolePermissionAssociation rpa ON rpa.role.id = r.id
-            JOIN Permission p ON rpa.permission.id = p.id
-            """
-    }
 
     override fun findAllUsers(): List<User> {
         return findAll("SELECT u from User u")
@@ -93,7 +50,7 @@ class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFa
         entityManagerFactory.transaction { entityManager ->
             val timeOfPermissionSummary = Instant.now()
             val userLoginsWithEnabledFlag = findAllUserLoginsAndEnabledFlags(entityManager)
-            val userPermissionsFromRolesAndGroups = findPermissionsForUsersFromGroupAndRoleAssignment(entityManager)
+            val userPermissionsFromRolesAndGroups = PermissionUserUtil.calculatePermissionsForUsers(entityManager)
 
             return aggregatePermissionSummariesForUsers(
                 userLoginsWithEnabledFlag,
@@ -143,115 +100,5 @@ class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFa
         val query = "SELECT NEW net.corda.permissions.query.dto.InternalUserEnabledQueryDto(u.loginName, u.enabled) FROM User u"
         return em.createQuery(query, InternalUserEnabledQueryDto::class.java)
             .resultList
-    }
-
-    private fun findPermissionsForUsersFromGroupAndRoleAssignment(em: EntityManager): Map<UserLogin, List<InternalPermissionQueryDto>> {
-        // Gets a map with a key of Group ID and value of its associated list of Permissions
-        val groupPermissionMap = em.createQuery(
-            userGroupPermissionsQuery,
-            InternalPermissionWithParentGroupQueryDto::class.java
-        ).resultList.groupBy { it.id }
-
-        // Gets a map with a key of User ID and value of its associated list of Permissions
-        val userPermissionMap = em.createQuery(
-            allUsersPermissionQuery,
-            InternalPermissionWithParentGroupQueryDto::class.java
-        ).resultList.groupBy { it.id }
-
-        // Generate a map that allows us to find all children given a parentId
-        val parentIdToChildListMap = HashMap<String?, MutableList<Node>>()
-        getParentToChildListMap(parentIdToChildListMap, groupPermissionMap)
-        getParentToChildListMap(parentIdToChildListMap, userPermissionMap)
-
-        return calculatePermissions(parentIdToChildListMap)
-    }
-
-    private fun getParentToChildListMap(
-        parentIdToChildListMap: HashMap<String?, MutableList<Node>>,
-        permissionMap: Map<String, List<InternalPermissionWithParentGroupQueryDto>>
-    ) {
-        // For each element check if the first permission's parentId exists in parentIdToChildListMap and add the Node to its value
-        // otherwise create a new entry with the parentGroupId and add the Node
-        permissionMap.forEach { (_, permissionsList) ->
-            parentIdToChildListMap.computeIfAbsent(permissionsList.first().parentGroupId) { mutableListOf() }
-                .add(Node(permissionsList))
-        }
-    }
-
-    // Builds the tree from the root node
-    private fun buildTree(
-        node: Node,
-        parentIdToChildListMap: HashMap<String?, MutableList<Node>>
-    ) {
-        parentIdToChildListMap[node.permissionList.first().id]?.forEach { child ->
-            node.addChild(child)
-            buildTree(child, parentIdToChildListMap)
-        }
-    }
-
-    private fun calculatePermissions(
-        parentIdToChildListMap: HashMap<String?, MutableList<Node>>
-    ): Map<UserLogin, List<InternalPermissionQueryDto>> {
-        val userPermissions = mutableMapOf<UserLogin, List<InternalPermissionQueryDto>>()
-        // For each root node build a tree and calculate the permissions for each user
-        val root = null
-        parentIdToChildListMap[root]?.forEach { rootNode ->
-            buildTree(rootNode, parentIdToChildListMap)
-            calculatePermissions(rootNode, mutableListOf(), userPermissions)
-        }
-
-        return userPermissions
-    }
-
-    // Calculates all the permissions for each user by traversing the tree and adding the permissions to the userPermissions map
-    private fun calculatePermissions(
-        node: Node,
-        permissions: MutableList<InternalPermissionWithParentGroupQueryDto>,
-        userPermissions: MutableMap<UserLogin, List<InternalPermissionQueryDto>>
-    ) {
-        // Adds the current Node's permissions to the permissions list
-        permissions.addAll(node.permissionList)
-
-        // If the current Node has no children, add the permissions to the userPermissions map
-        if (!node.hasChildren()) {
-            // If there is no loginName, it means it is a group and we don't want to add it to the userPermissions map
-            if (!node.permissionList.first().loginName.isNullOrEmpty()) {
-                userPermissions[node.permissionList.first().loginName!!] = permissions.map {
-                    InternalPermissionQueryDto(
-                        it.loginName!!,
-                        it.permissionId,
-                        it.groupVisibility,
-                        it.virtualNode,
-                        it.permissionString,
-                        it.permissionType
-                    )
-                }
-            }
-        } else {
-            // Recursively calls calculatePermissions for each child of the current Node
-            node.children.forEach { child ->
-                calculatePermissions(
-                    child,
-                    permissions,
-                    userPermissions
-                )
-            }
-        }
-
-        // Remove the current Node's permissions from the permissions list when we go up the tree
-        for (count in 1..node.permissionList.size) {
-            permissions.removeLast()
-        }
-    }
-
-    private data class Node(val permissionList: List<InternalPermissionWithParentGroupQueryDto>) {
-        val children: MutableList<Node> = mutableListOf()
-
-        fun addChild(node: Node) {
-            children.add(node)
-        }
-
-        fun hasChildren(): Boolean =
-            children.size >= 1
     }
 }

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/repository/PermissionRepositoryImpl.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/repository/PermissionRepositoryImpl.kt
@@ -14,6 +14,7 @@ import java.time.Instant
 import javax.persistence.EntityManager
 import javax.persistence.EntityManagerFactory
 
+@Suppress("TooManyFunctions")
 class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFactory) : PermissionRepository {
 
     override fun findAllUsers(): List<User> {
@@ -49,10 +50,12 @@ class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFa
             val timeOfPermissionSummary = Instant.now()
             val userLoginsWithEnabledFlag = findAllUserLoginsAndEnabledFlags(entityManager)
             val userPermissionsFromRoles = findPermissionsForUsersFromRoleAssignment(entityManager)
+            val userPermissionsFromGroups = findPermissionsForUsersFromGroupRoleAssignment(entityManager)
 
             return aggregatePermissionSummariesForUsers(
                 userLoginsWithEnabledFlag,
                 userPermissionsFromRoles,
+                userPermissionsFromGroups,
                 timeOfPermissionSummary
             )
         }
@@ -77,13 +80,20 @@ class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFa
     private fun aggregatePermissionSummariesForUsers(
         userLogins: List<InternalUserEnabledQueryDto>,
         userPermissionsFromRoles: Map<UserLogin, List<InternalPermissionQueryDto>>,
+        userPermissionsFromGroups: Map<UserLogin, List<InternalPermissionQueryDto>>,
         timeOfPermissionSummary: Instant,
     ): Map<String, InternalUserPermissionSummary> {
         return userLogins.associateBy({ it.loginName }) {
             // rolePermissionsQuery features inner joins so a user without roles won't be present in this map
-            val permissionsInheritedFromRoles = userPermissionsFromRoles[it.loginName] ?: emptyList()
+            val permissionsInheritedFromRoles = (userPermissionsFromRoles[it.loginName] ?: emptyList()) +
+                (userPermissionsFromGroups[it.loginName] ?: emptyList())
 
-            InternalUserPermissionSummary(it.loginName, it.enabled, permissionsInheritedFromRoles, timeOfPermissionSummary)
+            InternalUserPermissionSummary(
+                it.loginName,
+                it.enabled,
+                permissionsInheritedFromRoles,
+                timeOfPermissionSummary
+            )
         }
     }
 
@@ -113,5 +123,87 @@ class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFa
             .resultList
             .sortedWith(PermissionQueryDtoComparator())
             .groupBy { it.loginName }
+    }
+
+    private fun findPermissionsForUsersFromGroupRoleAssignment(em: EntityManager): Map<UserLogin, List<InternalPermissionQueryDto>> {
+        // Query to get all the root groups
+        val allRootGroups =
+            em.createQuery("SELECT g.id FROM Group g WHERE g.parentGroup IS NULL", String::class.java).resultList
+
+        var userPermissionsList: MutableList<InternalPermissionQueryDto> = mutableListOf()
+
+        allRootGroups.forEach {
+            var rootGroupPermissions: MutableList<String> = mutableListOf()
+
+            getAllUserPermissions(em, it, rootGroupPermissions, userPermissionsList)
+        }
+
+        return userPermissionsList
+            .sortedWith(PermissionQueryDtoComparator())
+            .groupBy { it.loginName }
+    }
+
+    // Recursively updates a list with all the users and their permissions
+    private fun getAllUserPermissions(
+        em: EntityManager,
+        currentGroupId: String,
+        parentPermissionIds: MutableList<String>,
+        userPermissionsList: MutableList<InternalPermissionQueryDto>
+    ) {
+        // Query to get Permission Ids for a specific group(not including parent group permissions)
+        val permissionIdsOfGroupQuery =
+            """
+                SELECT DISTINCT p.id
+                FROM Group g
+                JOIN RoleGroupAssociation rga ON rga.group.id = :groupId
+                JOIN Role r ON rga.role.id = r.id
+                JOIN RolePermissionAssociation rpa ON rpa.role.id = r.id
+                JOIN Permission p ON rpa.permission.id = p.id
+            """
+
+        // Query to get Permission Dto with specified Parent Group Id and Permission Id
+        val userGroupPermissionsQuery =
+            """
+                SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionQueryDto(
+                    u.loginName,
+                    p.id,
+                    p.groupVisibility.id, 
+                    p.virtualNode, 
+                    p.permissionString, 
+                    p.permissionType
+                )
+                FROM User u, Permission p
+                WHERE u.parentGroup.id = :groupId AND p.id = :permissionId
+            """
+
+        // Adds the Permission Ids of the current group to the parentPermissionIds list
+        parentPermissionIds.addAll(
+            em.createQuery(permissionIdsOfGroupQuery, String::class.java)
+                .setParameter("groupId", currentGroupId)
+                .resultList
+        )
+
+        // For every user directly associated with the current group,
+        // create an InternalPermissionQueryDto for each permission and add to the userPermissionList
+        parentPermissionIds.forEach {
+            userPermissionsList.addAll(
+                em.createQuery(userGroupPermissionsQuery, InternalPermissionQueryDto::class.java)
+                    .setParameter("groupId", currentGroupId)
+                    .setParameter("permissionId", it)
+                    .resultList
+            )
+        }
+
+        // Get all Group Ids that are children of the current group and recursively call this function for each child
+        val childGroupIds =
+            em.createQuery("SELECT g.id FROM Group g WHERE g.parentGroup.id = :groupId", String::class.java)
+                .setParameter("groupId", currentGroupId)
+                .resultList
+
+        if (childGroupIds.isNotEmpty()) {
+            childGroupIds.forEach {
+                getAllUserPermissions(em, it, parentPermissionIds, userPermissionsList)
+            }
+        }
     }
 }

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/repository/PermissionRepositoryImpl.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/repository/PermissionRepositoryImpl.kt
@@ -130,10 +130,10 @@ class PermissionRepositoryImpl(private val entityManagerFactory: EntityManagerFa
         val allRootGroups =
             em.createQuery("SELECT g.id FROM Group g WHERE g.parentGroup IS NULL", String::class.java).resultList
 
-        var userPermissionsList: MutableList<InternalPermissionQueryDto> = mutableListOf()
+        val userPermissionsList: MutableList<InternalPermissionQueryDto> = mutableListOf()
 
         allRootGroups.forEach {
-            var rootGroupPermissions: MutableList<String> = mutableListOf()
+            val rootGroupPermissions: MutableList<String> = mutableListOf()
 
             getAllUserPermissions(em, it, rootGroupPermissions, userPermissionsList)
         }

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/summary/PermissionSummaryReconcilerImpl.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/impl/summary/PermissionSummaryReconcilerImpl.kt
@@ -72,23 +72,23 @@ class PermissionSummaryReconcilerImpl : PermissionSummaryReconciler {
 
         // we want ordering of permissions to be preserved
         for (i in permissionsDb.indices) {
-            if (permissionsDb[i].permissionString != permissionsCache[i].permissionString) {
+            if (permissionsDb.elementAt(i).permissionString != permissionsCache[i].permissionString) {
                 return permissionSummaryDb.toAvroUserPermissionSummary()
             }
 
-            if (permissionsDb[i].permissionType.name != permissionsCache[i].permissionType.name) {
+            if (permissionsDb.elementAt(i).permissionType.name != permissionsCache[i].permissionType.name) {
                 return permissionSummaryDb.toAvroUserPermissionSummary()
             }
 
-            if (permissionsDb[i].groupVisibility != permissionsCache[i].groupVisibility) {
+            if (permissionsDb.elementAt(i).groupVisibility != permissionsCache[i].groupVisibility) {
                 return permissionSummaryDb.toAvroUserPermissionSummary()
             }
 
-            if (permissionsDb[i].virtualNode != permissionsCache[i].virtualNode) {
+            if (permissionsDb.elementAt(i).virtualNode != permissionsCache[i].virtualNode) {
                 return permissionSummaryDb.toAvroUserPermissionSummary()
             }
 
-            if (permissionsDb[i].id != permissionsCache[i].id) {
+            if (permissionsDb.elementAt(i).id != permissionsCache[i].id) {
                 return permissionSummaryDb.toAvroUserPermissionSummary()
             }
         }

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/summary/InternalUserPermissionSummary.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/summary/InternalUserPermissionSummary.kt
@@ -2,6 +2,7 @@ package net.corda.libs.permissions.storage.reader.summary
 
 import net.corda.permissions.query.dto.InternalPermissionQueryDto
 import java.time.Instant
+import java.util.SortedSet
 
 /**
  * Internal permission summary object holding a list of permission query DTOs summarizing the permissions read from data storage for each
@@ -10,6 +11,6 @@ import java.time.Instant
 data class InternalUserPermissionSummary(
     val loginName: String,
     val enabled: Boolean,
-    val permissions: List<InternalPermissionQueryDto>,
+    val permissions: SortedSet<InternalPermissionQueryDto>,
     val lastUpdateTimestamp: Instant
 )

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -8,7 +8,7 @@ private typealias UserLogin = String
 internal object PermissionUserUtil {
     // Query to get all the Permissions for each Group
     // InternalPermissionWithParentGroupQueryDto.loginName is empty to signify that it is a Group
-    const val userGroupPermissionsQuery =
+    const val allGroupPermissionsQuery =
         """
                 SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(
                 g.id,
@@ -49,7 +49,7 @@ internal object PermissionUserUtil {
     fun calculatePermissionsForUsers(em: EntityManager): Map<UserLogin, List<InternalPermissionQueryDto>> {
         // Gets a map with a key of Group ID and value of its associated list of Permissions
         val groupPermissionMap = em.createQuery(
-            userGroupPermissionsQuery,
+            allGroupPermissionsQuery,
             InternalPermissionWithParentGroupQueryDto::class.java
         ).resultList.groupBy { it.id }
 

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -71,7 +71,7 @@ internal object PermissionUserUtil {
         val userList = getUserGroupPermissions(em, allUsersPermissionsQuery)
 
         logger.debug("List of Group permissions: {}", groupList)
-        logger.debug("List of User permissions {}", userList)
+        logger.debug("List of User permissions: {}", userList)
 
         // Generate a map that allows us to find all children given a parentId
         val parentIdToChildListMap = HashMap<String?, MutableList<Node>>()

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -6,10 +6,10 @@ import javax.persistence.EntityManager
 
 private typealias UserLogin = String
 internal object PermissionUserUtil {
-        // Query to get all the Permissions for each Group
-        // InternalPermissionWithParentGroupQueryDto.loginName is empty to signify that it is a Group
-        const val userGroupPermissionsQuery =
-            """
+    // Query to get all the Permissions for each Group
+    // InternalPermissionWithParentGroupQueryDto.loginName is empty to signify that it is a Group
+    const val userGroupPermissionsQuery =
+        """
                 SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(
                 g.id,
                 p.id,
@@ -27,9 +27,9 @@ internal object PermissionUserUtil {
             JOIN Permission p ON rpa.permission.id = p.id
             """
 
-        // Query to get all the Permissions for each User
-        const val allUsersPermissionsQuery =
-            """
+    // Query to get all the Permissions for each User
+    const val allUsersPermissionsQuery =
+        """
                 SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(
                 u.id,
                 p.id,

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -71,10 +71,10 @@ internal object PermissionUserUtil {
     ): Map<String, InternalUserPermissionSummary> {
         return userLogins.associateBy({ user -> user.loginName }) { user ->
             // rolePermissionsQuery features inner joins so a user without roles won't be present in this map
-            val permissionsInheritedFromRoles = (
-                    (userPermissionsFromRolesAndGroups[user.loginName] ?: emptyList()).toSortedSet(
-                        PermissionQueryDtoComparator())
-                    )
+            val permissionsInheritedFromRoles =
+                (userPermissionsFromRolesAndGroups[user.loginName] ?: emptyList()).toSortedSet(
+                    PermissionQueryDtoComparator()
+                )
 
             InternalUserPermissionSummary(
                 user.loginName,

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -1,0 +1,158 @@
+package net.corda.libs.permissions.storage.reader.util
+
+import net.corda.permissions.query.dto.InternalPermissionQueryDto
+import net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto
+import javax.persistence.EntityManager
+
+private typealias UserLogin = String
+internal object PermissionUserUtil {
+        // Query to get all the Permissions for each Group
+        // InternalPermissionWithParentGroupQueryDto.loginName is empty to signify that it is a Group
+        const val userGroupPermissionsQuery =
+            """
+                SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(
+                g.id,
+                p.id,
+                p.groupVisibility.id, 
+                p.virtualNode, 
+                p.permissionString, 
+                p.permissionType,
+                g.parentGroup.id,
+                ''
+            )
+            FROM Group g
+            JOIN RoleGroupAssociation rga ON rga.group.id = g.id
+            JOIN Role r ON rga.role.id = r.id
+            JOIN RolePermissionAssociation rpa ON rpa.role.id = r.id
+            JOIN Permission p ON rpa.permission.id = p.id
+            """
+
+        // Query to get all the Permissions for each User
+        const val allUsersPermissionsQuery =
+            """
+                SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(
+                u.id,
+                p.id,
+                p.groupVisibility.id, 
+                p.virtualNode, 
+                p.permissionString, 
+                p.permissionType,
+                u.parentGroup.id,
+                u.loginName
+            )
+            FROM User u
+            JOIN RoleUserAssociation rua ON rua.user.id = u.id
+            JOIN Role r ON rua.role.id = r.id
+            JOIN RolePermissionAssociation rpa ON rpa.role.id = r.id
+            JOIN Permission p ON rpa.permission.id = p.id
+            """
+    fun calculatePermissionsForUsers(em: EntityManager): Map<UserLogin, List<InternalPermissionQueryDto>> {
+        // Gets a map with a key of Group ID and value of its associated list of Permissions
+        val groupPermissionMap = em.createQuery(
+            userGroupPermissionsQuery,
+            InternalPermissionWithParentGroupQueryDto::class.java
+        ).resultList.groupBy { it.id }
+
+        // Gets a map with a key of User ID and value of its associated list of Permissions
+        val userPermissionMap = em.createQuery(
+            allUsersPermissionsQuery,
+            InternalPermissionWithParentGroupQueryDto::class.java
+        ).resultList.groupBy { it.id }
+
+        // Generate a map that allows us to find all children given a parentId
+        val parentIdToChildListMap = HashMap<String?, MutableList<Node>>()
+        getParentToChildListMap(parentIdToChildListMap, groupPermissionMap)
+        getParentToChildListMap(parentIdToChildListMap, userPermissionMap)
+
+        return calculatePermissions(parentIdToChildListMap)
+    }
+
+    private fun getParentToChildListMap(
+        parentIdToChildListMap: HashMap<String?, MutableList<Node>>,
+        permissionMap: Map<String, List<InternalPermissionWithParentGroupQueryDto>>
+    ) {
+        // For each element check if the first permission's parentId exists in parentIdToChildListMap and add the Node to its value
+        // otherwise create a new entry with the parentGroupId and add the Node
+        permissionMap.forEach { (_, permissionsList) ->
+            parentIdToChildListMap.computeIfAbsent(permissionsList.first().parentGroupId) { mutableListOf() }
+                .add(Node(permissionsList))
+        }
+    }
+
+    // Builds the tree from the root node
+    private fun buildTree(
+        node: Node,
+        parentIdToChildListMap: HashMap<String?, MutableList<Node>>
+    ) {
+        parentIdToChildListMap[node.permissionList.first().id]?.forEach { child ->
+            node.addChild(child)
+            buildTree(child, parentIdToChildListMap)
+        }
+    }
+
+    private fun calculatePermissions(
+        parentIdToChildListMap: HashMap<String?, MutableList<Node>>
+    ): Map<UserLogin, List<InternalPermissionQueryDto>> {
+        val userPermissions = mutableMapOf<UserLogin, List<InternalPermissionQueryDto>>()
+        // For each root node build a tree and calculate the permissions for each user
+        val root = null
+        parentIdToChildListMap[root]?.forEach { rootNode ->
+            buildTree(rootNode, parentIdToChildListMap)
+            calculatePermissions(rootNode, mutableListOf(), userPermissions)
+        }
+
+        return userPermissions
+    }
+
+    // Calculates all the permissions for each user by traversing the tree and adding the permissions to the userPermissions map
+    private fun calculatePermissions(
+        node: Node,
+        permissions: MutableList<InternalPermissionWithParentGroupQueryDto>,
+        userPermissions: MutableMap<UserLogin, List<InternalPermissionQueryDto>>
+    ) {
+        // Adds the current Node's permissions to the permissions list
+        permissions.addAll(node.permissionList)
+
+        // If the current Node has no children, add the permissions to the userPermissions map
+        if (!node.hasChildren()) {
+            // If there is no loginName, it means it is a group and we don't want to add it to the userPermissions map
+            if (!node.permissionList.first().loginName.isNullOrEmpty()) {
+                userPermissions[node.permissionList.first().loginName!!] = permissions.map {
+                    InternalPermissionQueryDto(
+                        it.loginName!!,
+                        it.permissionId,
+                        it.groupVisibility,
+                        it.virtualNode,
+                        it.permissionString,
+                        it.permissionType
+                    )
+                }
+            }
+        } else {
+            // Recursively calls calculatePermissions for each child of the current Node
+            node.children.forEach { child ->
+                calculatePermissions(
+                    child,
+                    permissions,
+                    userPermissions
+                )
+            }
+        }
+
+        // Remove the current Node's permissions from the permissions list when we go up the tree
+        for (count in 1..node.permissionList.size) {
+            permissions.removeLast()
+        }
+    }
+
+    private data class Node(val permissionList: List<InternalPermissionWithParentGroupQueryDto>) {
+        val children: MutableList<Node> = mutableListOf()
+
+        fun addChild(node: Node) {
+            children.add(node)
+        }
+
+        fun hasChildren(): Boolean =
+            children.size >= 1
+    }
+}

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -12,8 +12,13 @@ import java.time.Instant
 import javax.persistence.EntityManager
 
 internal object PermissionUserUtil {
-    // Query to get all the Permissions for each Group
-    // InternalPermissionWithParentGroupQueryDto.loginName is empty to signify that it is a Group
+    /**
+     * Query to get all the Permissions for each Group.
+     * InternalPermissionWithParentGroupQueryDto.loginName is empty to signify that it is a Group.
+     * We are using LEFT JOIN to get all the Groups even if they don't have any permissions and
+     * p.id, p.permissionString, p.permissionType will be null if a Group exists without any permissions.
+     * This is necessary to get all the relationships between all Groups as some Groups may inherit permissions from other Groups.
+     */
     const val allGroupPermissionsQuery =
         """
                 SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(
@@ -33,7 +38,12 @@ internal object PermissionUserUtil {
             LEFT JOIN Permission p ON rpa.permission.id = p.id
             """
 
-    // Query to get all the Permissions for each User
+    /**
+     * Query to get all the Permissions for each User.
+     * We are using LEFT JOIN to get all the Users even if they don't have any permissions and
+     * p.id, p.permissionString, p.permissionType will be null if a User exists without any permissions.
+     * This is necessary as some Users may inherit permissions from Groups.
+     */
     const val allUsersPermissionsQuery =
         """
                 SELECT DISTINCT NEW net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto(

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -69,11 +69,10 @@ internal object PermissionUserUtil {
         userPermissionsFromRolesAndGroups: Map<UserLogin, List<InternalPermissionQueryDto>>,
         timeOfPermissionSummary: Instant,
     ): Map<String, InternalUserPermissionSummary> {
-        val userPermissionMap = userPermissionsFromRolesAndGroups.filter { it.value.isNotEmpty() }
         return userLogins.associateBy({ user -> user.loginName }) { user ->
             // rolePermissionsQuery features inner joins so a user without roles won't be present in this map
             val permissionsInheritedFromRoles = (
-                    (userPermissionMap[user.loginName] ?: emptyList()).toSortedSet(
+                    (userPermissionsFromRolesAndGroups[user.loginName] ?: emptyList()).toSortedSet(
                         PermissionQueryDtoComparator())
                     )
 
@@ -101,7 +100,7 @@ internal object PermissionUserUtil {
                 permissionList.firstOrNull()?.loginName,
                 permissionList.filter { !it.permissionString.isNullOrEmpty() }.map { permission ->
                     Permission(
-                        permission.permissionId,
+                        permission.permissionId!!,
                         permission.groupVisibility,
                         permission.virtualNode,
                         permission.permissionString!!,

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -119,7 +119,7 @@ internal object PermissionUserUtil {
             if (!node.permissionList.first().loginName.isNullOrEmpty()) {
                 userPermissions[node.permissionList.first().loginName!!] = permissions.map {
                     InternalPermissionQueryDto(
-                        it.loginName!!,
+                        node.permissionList.first().loginName!!,
                         it.permissionId,
                         it.groupVisibility,
                         it.virtualNode,

--- a/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/main/kotlin/net/corda/libs/permissions/storage/reader/util/PermissionUserUtil.kt
@@ -173,7 +173,7 @@ internal object PermissionUserUtil {
     // Builds the tree from the root node
     private fun buildTree(
         node: Node,
-        parentIdToChildListMap: HashMap<String?, MutableList<Node>>
+        parentIdToChildListMap: Map<String?, MutableList<Node>>
     ) {
         parentIdToChildListMap[node.userGroup.id]?.forEach { child ->
             node.addChild(child)
@@ -182,7 +182,7 @@ internal object PermissionUserUtil {
     }
 
     private fun calculatePermissions(
-        parentIdToChildListMap: HashMap<String?, MutableList<Node>>
+        parentIdToChildListMap: Map<String?, MutableList<Node>>
     ): Map<UserLogin, InternalUserGroup> {
         val userPermissions = mutableMapOf<UserLogin, InternalUserGroup>()
         // For each root node build a tree and calculate the permissions for each user
@@ -198,13 +198,13 @@ internal object PermissionUserUtil {
     // Calculates all the permissions for each user by traversing the tree and adding the permissions to the userPermissions map
     private fun calculatePermissions(
         node: Node,
-        permissions: MutableList<InternalPermission>,
+        parentPermissions: List<InternalPermission>,
         userPermissions: MutableMap<UserLogin, InternalUserGroup>
     ) {
         val userGroup = node.userGroup
         // Adds the current Node's permissions to the permissions list
+        val permissions = mutableListOf<InternalPermission>().apply { addAll(parentPermissions) }
         permissions.addAll(userGroup.permissionsList)
-
         // If the current Node is a user then add the permissions to the userPermissions map.
         // A node represents a user if it does not have children and the loginName is not null or empty.
         if (!node.hasChildren()) {
@@ -221,11 +221,6 @@ internal object PermissionUserUtil {
                 )
             }
         }
-
-        // Remove the current Node's permissions from the permissions list when we go up the tree
-        for (count in 1..userGroup.permissionsList.size) {
-            permissions.removeLast()
-        }
     }
 
     private data class Node(val userGroup: InternalUserGroup) {
@@ -236,6 +231,6 @@ internal object PermissionUserUtil {
         }
 
         fun hasChildren(): Boolean =
-            children.size >= 1
+            children.isNotEmpty()
     }
 }

--- a/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/PermissionStorageReaderImplTest.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/PermissionStorageReaderImplTest.kt
@@ -335,7 +335,7 @@ class PermissionStorageReaderImplTest {
         whenever(permissionRepository.findAllRoles()).thenReturn(listOf(role))
         whenever(permissionRepository.findAllPermissions()).thenReturn(listOf(permission))
 
-        val summariesDb = mapOf(user.loginName to InternalUserPermissionSummary(user.loginName, true, emptyList(), Instant.now()))
+        val summariesDb = mapOf(user.loginName to InternalUserPermissionSummary(user.loginName, true, sortedSetOf(), Instant.now()))
         val summariesCached = mapOf(user.loginName to avroSummaryEmptyPermissions)
         whenever(permissionRepository.findAllPermissionSummaries()).thenReturn(summariesDb)
         whenever(permissionValidationCache.permissionSummaries).thenReturn(summariesCached)
@@ -348,7 +348,7 @@ class PermissionStorageReaderImplTest {
         val groupRecord = Record(REST_PERM_GROUP_TOPIC, group.id, avroGroup)
         val roleRecord = Record(REST_PERM_ROLE_TOPIC, role.id, avroRole)
         val permissionRecord = Record(REST_PERM_ENTITY_TOPIC, permission.id, avroPermission)
-        val permissionSummayRecord = Record(PERMISSIONS_USER_SUMMARY_TOPIC, user.loginName, avroSummaryWithPermission)
+        val permissionSummaryRecord = Record(PERMISSIONS_USER_SUMMARY_TOPIC, user.loginName, avroSummaryWithPermission)
 
         val captor = argumentCaptor<List<Record<String, Any>>>()
         verify(publisher, times(5)).publish(captor.capture())
@@ -356,7 +356,7 @@ class PermissionStorageReaderImplTest {
         assertEquals(listOf(groupRecord), captor.secondValue)
         assertEquals(listOf(roleRecord), captor.thirdValue)
         assertEquals(listOf(permissionRecord), captor.allValues[3])
-        assertEquals(listOf(permissionSummayRecord), captor.allValues[4])
+        assertEquals(listOf(permissionSummaryRecord), captor.allValues[4])
     }
 
     @Test
@@ -383,7 +383,7 @@ class PermissionStorageReaderImplTest {
         val groupRecord = Record(REST_PERM_GROUP_TOPIC, group.id, value = null)
         val roleRecord = Record(REST_PERM_ROLE_TOPIC, role.id, value = null)
         val permissionRecord = Record(REST_PERM_ENTITY_TOPIC, permission.id, value = null)
-        val permissionSummayRecord = Record(PERMISSIONS_USER_SUMMARY_TOPIC, user.loginName, null)
+        val permissionSummaryRecord = Record(PERMISSIONS_USER_SUMMARY_TOPIC, user.loginName, null)
 
         val captor = argumentCaptor<List<Record<String, Any>>>()
         verify(publisher, times(5)).publish(captor.capture())
@@ -391,7 +391,7 @@ class PermissionStorageReaderImplTest {
         assertEquals(listOf(groupRecord), captor.secondValue)
         assertEquals(listOf(roleRecord), captor.thirdValue)
         assertEquals(listOf(permissionRecord), captor.allValues[3])
-        assertEquals(listOf(permissionSummayRecord), captor.allValues[4])
+        assertEquals(listOf(permissionSummaryRecord), captor.allValues[4])
     }
 
     @Test
@@ -525,7 +525,7 @@ class PermissionStorageReaderImplTest {
 
     @Test
     fun `reconcilePermissionSummaries does not publish empty list when no users need reconciled`() {
-        val summariesDb = mapOf(user.loginName to InternalUserPermissionSummary(user.loginName, true, emptyList(), Instant.now()))
+        val summariesDb = mapOf(user.loginName to InternalUserPermissionSummary(user.loginName, true, sortedSetOf(), Instant.now()))
         val summariesCached = mapOf(user.loginName to avroSummaryEmptyPermissions)
         whenever(permissionRepository.findAllPermissionSummaries()).thenReturn(summariesDb)
         whenever(permissionValidationCache.permissionSummaries).thenReturn(summariesCached)
@@ -539,8 +539,8 @@ class PermissionStorageReaderImplTest {
     @Test
     fun `reconcilePermissionSummaries publishes records for users requiring reconciliation`() {
         val summariesDb = mapOf(
-            "login1" to InternalUserPermissionSummary("login1", true, emptyList(), Instant.now()),
-            "login2" to InternalUserPermissionSummary("login2", true, emptyList(), Instant.now()),
+            "login1" to InternalUserPermissionSummary("login1", true, sortedSetOf(), Instant.now()),
+            "login2" to InternalUserPermissionSummary("login2", true, sortedSetOf(), Instant.now()),
         )
         val summariesCached = mapOf(
             "login3" to AvroUserPermissionSummary("login3", true, listOf(AvroPermissionSummary()), Instant.now())

--- a/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/summary/PermissionSummaryReconcilerImplTest.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/summary/PermissionSummaryReconcilerImplTest.kt
@@ -27,7 +27,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.DENY),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -80,7 +80,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.DENY),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -145,7 +145,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "F", PermissionType.DENY),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -200,7 +200,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -257,7 +257,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", "grp", null, "A", PermissionType.ALLOW)
             ),
             now
@@ -303,7 +303,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", null, "vrtnode", "A", PermissionType.ALLOW)
             ),
             now
@@ -349,7 +349,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", null, "vrtnode", "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", "grp", null, "B", PermissionType.DENY)
             ),
@@ -401,7 +401,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.DENY),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -439,7 +439,7 @@ internal class PermissionSummaryReconcilerImplTest {
         val dbSummary = InternalUserPermissionSummary(
             "loginName",
             true,
-            listOf(
+            sortedSetOf(
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.DENY)
             ),
@@ -489,7 +489,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName" to InternalUserPermissionSummary(
                 "loginName",
                 true,
-                listOf(
+                sortedSetOf(
                     InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW)
                 ),
                 now
@@ -497,7 +497,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "addedUser" to InternalUserPermissionSummary(
                 "addedUser",
                 true,
-                listOf(
+                sortedSetOf(
                     InternalPermissionQueryDto("addedUser", "id1", "grp", "vrtnode", "A", PermissionType.ALLOW)
                 ),
                 now
@@ -545,7 +545,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName" to InternalUserPermissionSummary(
                 "loginName",
                 true,
-                listOf(
+                sortedSetOf(
                     InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW)
                 ),
                 now
@@ -580,7 +580,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName" to InternalUserPermissionSummary(
                 "loginName",
                 true,
-                listOf(
+                sortedSetOf(
                     InternalPermissionQueryDto("loginName", "new", "grp", "vrtnode", "A", PermissionType.ALLOW)
                 ),
                 now
@@ -628,7 +628,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName" to InternalUserPermissionSummary(
                 "loginName",
                 false,
-                listOf(
+                sortedSetOf(
                     InternalPermissionQueryDto("loginName", "id", "grp", "vrtnode", "A", PermissionType.ALLOW)
                 ),
                 now
@@ -667,7 +667,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName" to InternalUserPermissionSummary(
                 "loginName",
                 true,
-                listOf(
+                sortedSetOf(
                     InternalPermissionQueryDto("loginName", "id", "grp", "vrtnode", "A", PermissionType.ALLOW)
                 ),
                 now

--- a/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/summary/PermissionSummaryReconcilerImplTest.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/summary/PermissionSummaryReconcilerImplTest.kt
@@ -15,6 +15,12 @@ import net.corda.data.permissions.PermissionType as AvroPermissionType
 import net.corda.data.permissions.summary.PermissionSummary as AvroPermissionSummary
 import net.corda.data.permissions.summary.UserPermissionSummary as AvroUserPermissionSummary
 
+internal class TestPermissionQueryDtoComparator : Comparator<InternalPermissionQueryDto> {
+    override fun compare(o1: InternalPermissionQueryDto, o2: InternalPermissionQueryDto): Int {
+        return 1
+    }
+}
+
 internal class PermissionSummaryReconcilerImplTest {
 
     private val reconciler = PermissionSummaryReconcilerImpl()
@@ -28,6 +34,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.DENY),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -81,6 +88,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.DENY),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -146,6 +154,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "F", PermissionType.DENY),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -201,6 +210,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -258,6 +268,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", "grp", null, "A", PermissionType.ALLOW)
             ),
             now
@@ -304,6 +315,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", null, "vrtnode", "A", PermissionType.ALLOW)
             ),
             now
@@ -350,6 +362,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", null, "vrtnode", "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", "grp", null, "B", PermissionType.DENY)
             ),
@@ -402,6 +415,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.DENY),
                 InternalPermissionQueryDto("loginName", "id3", null, null, "C", PermissionType.DENY),
@@ -440,6 +454,7 @@ internal class PermissionSummaryReconcilerImplTest {
             "loginName",
             true,
             sortedSetOf(
+                TestPermissionQueryDtoComparator(),
                 InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW),
                 InternalPermissionQueryDto("loginName", "id2", null, null, "B", PermissionType.DENY)
             ),
@@ -490,6 +505,7 @@ internal class PermissionSummaryReconcilerImplTest {
                 "loginName",
                 true,
                 sortedSetOf(
+                    TestPermissionQueryDtoComparator(),
                     InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW)
                 ),
                 now
@@ -498,6 +514,7 @@ internal class PermissionSummaryReconcilerImplTest {
                 "addedUser",
                 true,
                 sortedSetOf(
+                    TestPermissionQueryDtoComparator(),
                     InternalPermissionQueryDto("addedUser", "id1", "grp", "vrtnode", "A", PermissionType.ALLOW)
                 ),
                 now
@@ -546,6 +563,7 @@ internal class PermissionSummaryReconcilerImplTest {
                 "loginName",
                 true,
                 sortedSetOf(
+                    TestPermissionQueryDtoComparator(),
                     InternalPermissionQueryDto("loginName", "id1", null, null, "A", PermissionType.ALLOW)
                 ),
                 now
@@ -581,6 +599,7 @@ internal class PermissionSummaryReconcilerImplTest {
                 "loginName",
                 true,
                 sortedSetOf(
+                    TestPermissionQueryDtoComparator(),
                     InternalPermissionQueryDto("loginName", "new", "grp", "vrtnode", "A", PermissionType.ALLOW)
                 ),
                 now
@@ -629,6 +648,7 @@ internal class PermissionSummaryReconcilerImplTest {
                 "loginName",
                 false,
                 sortedSetOf(
+                    TestPermissionQueryDtoComparator(),
                     InternalPermissionQueryDto("loginName", "id", "grp", "vrtnode", "A", PermissionType.ALLOW)
                 ),
                 now
@@ -668,6 +688,7 @@ internal class PermissionSummaryReconcilerImplTest {
                 "loginName",
                 true,
                 sortedSetOf(
+                    TestPermissionQueryDtoComparator(),
                     InternalPermissionQueryDto("loginName", "id", "grp", "vrtnode", "A", PermissionType.ALLOW)
                 ),
                 now

--- a/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/util/PermissionUserUtilTest.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/util/PermissionUserUtilTest.kt
@@ -8,6 +8,7 @@ import net.corda.permissions.model.PermissionType
 import net.corda.permissions.query.dto.InternalPermissionQueryDto
 import net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto
 import net.corda.permissions.query.dto.InternalUserEnabledQueryDto
+import net.corda.permissions.query.dto.Permission
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doAnswer
@@ -139,11 +140,11 @@ class PermissionUserUtilTest {
             )
         )
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
-        assertThat(calculatedPermissions["user1"]).size().isEqualTo(3)
-        assertThat(calculatedPermissions["user1"]).containsExactlyInAnyOrder(
-            InternalPermissionQueryDto("user1", "permissionId1", null, null, "ABC", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId2", null, null, "XYZ", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId3", null, null, "XYZ", PermissionType.DENY)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).containsExactlyInAnyOrder(
+            Permission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            Permission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            Permission("permissionId3", null, null, "XYZ", PermissionType.DENY)
         )
     }
 
@@ -218,14 +219,14 @@ class PermissionUserUtilTest {
             )
         )
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
-        assertThat(calculatedPermissions["user1"]).size().isEqualTo(6)
-        assertThat(calculatedPermissions["user1"]).containsExactlyInAnyOrder(
-            InternalPermissionQueryDto("user1", "permissionId1", null, null, "ABC", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId2", null, null, "XYZ", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId3", null, null, "DEF", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId4", null, null, "GHI", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId5", null, null, "XYZ", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId6", null, null, "XYZ", PermissionType.DENY)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(6)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).containsExactlyInAnyOrder(
+            Permission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            Permission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            Permission("permissionId3", null, null, "DEF", PermissionType.ALLOW),
+            Permission("permissionId4", null, null, "GHI", PermissionType.ALLOW),
+            Permission("permissionId5", null, null, "XYZ", PermissionType.ALLOW),
+            Permission("permissionId6", null, null, "XYZ", PermissionType.DENY)
         )
     }
 
@@ -315,12 +316,12 @@ class PermissionUserUtilTest {
             )
         )
         assertThat(calculatedPermissions).containsOnlyKeys("user1", "user2", "user3", "user4", "user5", "user6")
-        assertThat(calculatedPermissions["user1"]).size().isEqualTo(5)
-        assertThat(calculatedPermissions["user2"]).size().isEqualTo(3)
-        assertThat(calculatedPermissions["user3"]).size().isEqualTo(3)
-        assertThat(calculatedPermissions["user4"]).size().isEqualTo(2)
-        assertThat(calculatedPermissions["user5"]).size().isEqualTo(2)
-        assertThat(calculatedPermissions["user6"]).size().isEqualTo(1)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(5)
+        assertThat(calculatedPermissions["user2"]?.permissionsList).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user3"]?.permissionsList).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user4"]?.permissionsList).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user5"]?.permissionsList).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user6"]?.permissionsList).size().isEqualTo(1)
     }
 
     @Test
@@ -345,7 +346,7 @@ class PermissionUserUtilTest {
                 )
             )
         )
-        assertThat(calculatedPermissions["user1"]).isEmpty()
+        assertThat(calculatedPermissions["user1"]?.permissionsList).isEmpty()
 
         val aggregatedPermissions = aggregatePermissionSummariesForUsers(
             listOf(
@@ -400,11 +401,11 @@ class PermissionUserUtilTest {
             )
         )
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
-        assertThat(calculatedPermissions["user1"]).size().isEqualTo(3)
-        assertThat(calculatedPermissions["user1"]).containsExactlyInAnyOrder(
-            InternalPermissionQueryDto("user1", "permissionId1", null, null, "ABC", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId2", null, null, "XYZ", PermissionType.ALLOW),
-            InternalPermissionQueryDto("user1", "permissionId3", null, null, "DEF", PermissionType.ALLOW)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).containsExactlyInAnyOrder(
+            Permission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            Permission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            Permission("permissionId3", null, null, "DEF", PermissionType.ALLOW)
         )
     }
 
@@ -432,9 +433,9 @@ class PermissionUserUtilTest {
             )
         )
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
-        assertThat(calculatedPermissions["user1"]).size().isEqualTo(1)
-        assertThat(calculatedPermissions["user1"]).containsExactlyInAnyOrder(
-            InternalPermissionQueryDto("user1", "permissionId1", null, null, "XYZ", PermissionType.ALLOW)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(1)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).containsExactlyInAnyOrder(
+            Permission("permissionId1", null, null, "XYZ", PermissionType.ALLOW)
         )
     }
 
@@ -527,14 +528,14 @@ class PermissionUserUtilTest {
             )
         )
         assertThat(calculatedPermissions).containsOnlyKeys("user1", "user2", "user3", "user4", "user5", "user6", "user7", "user8")
-        assertThat(calculatedPermissions["user1"]).size().isEqualTo(2)
-        assertThat(calculatedPermissions["user2"]).size().isEqualTo(2)
-        assertThat(calculatedPermissions["user3"]).size().isEqualTo(1)
-        assertThat(calculatedPermissions["user4"]).size().isEqualTo(2)
-        assertThat(calculatedPermissions["user5"]).size().isEqualTo(3)
-        assertThat(calculatedPermissions["user6"]).size().isEqualTo(1)
-        assertThat(calculatedPermissions["user7"]).size().isEqualTo(0)
-        assertThat(calculatedPermissions["user8"]).size().isEqualTo(0)
+        assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user2"]?.permissionsList).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user3"]?.permissionsList).size().isEqualTo(1)
+        assertThat(calculatedPermissions["user4"]?.permissionsList).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user5"]?.permissionsList).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user6"]?.permissionsList).size().isEqualTo(1)
+        assertThat(calculatedPermissions["user7"]?.permissionsList).size().isEqualTo(0)
+        assertThat(calculatedPermissions["user8"]?.permissionsList).size().isEqualTo(0)
     }
 
     @Test
@@ -589,7 +590,7 @@ class PermissionUserUtilTest {
             )
         )
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
-        assertThat(calculatedPermissions["user1"]!!.size).isEqualTo(4)
+        assertThat(calculatedPermissions["user1"]?.permissionsList?.size).isEqualTo(4)
 
         val aggregatedPermissions = aggregatePermissionSummariesForUsers(
             listOf(

--- a/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/util/PermissionUserUtilTest.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/util/PermissionUserUtilTest.kt
@@ -1,0 +1,294 @@
+package net.corda.libs.permissions.storage.reader.impl.util
+
+import net.corda.libs.permissions.storage.reader.util.PermissionUserUtil.aggregatePermissionSummariesForUsers
+import net.corda.libs.permissions.storage.reader.util.PermissionUserUtil.allGroupPermissionsQuery
+import net.corda.libs.permissions.storage.reader.util.PermissionUserUtil.allUsersPermissionsQuery
+import net.corda.libs.permissions.storage.reader.util.PermissionUserUtil.calculatePermissionsForUsers
+import net.corda.permissions.model.PermissionType
+import net.corda.permissions.query.dto.InternalPermissionQueryDto
+import net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto
+import net.corda.permissions.query.dto.InternalUserEnabledQueryDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import java.time.Instant
+import javax.persistence.EntityManager
+
+class PermissionUserUtilTest {
+
+    private fun createEntityManager(
+        groupPermissionEntity: List<InternalPermissionWithParentGroupQueryDto>,
+        userPermissionEntity: List<InternalPermissionWithParentGroupQueryDto>
+    ): EntityManager = mock<EntityManager> {
+        on {
+            createQuery(
+                eq(allGroupPermissionsQuery),
+                eq(InternalPermissionWithParentGroupQueryDto::class.java)
+            )
+        } doAnswer {
+            mock {
+                on { resultList } doReturn groupPermissionEntity
+            }
+        }
+
+        on {
+            createQuery(
+                eq(allUsersPermissionsQuery),
+                eq(InternalPermissionWithParentGroupQueryDto::class.java)
+            )
+        } doAnswer {
+            mock {
+                on { resultList } doReturn userPermissionEntity
+            }
+        }
+    }
+
+    @Test
+    fun `empty list of user and group permissions returns an empty map`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                emptyList(),
+                emptyList()
+            )
+        )
+        assertThat(calculatedPermissions).isEmpty()
+    }
+
+    @Test
+    fun `list of group permissions and empty list of user permissions returns an empty map`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "XYZ", PermissionType.DENY, "groupId1", null)
+                ),
+                emptyList()
+            )
+        )
+        assertThat(calculatedPermissions).isEmpty()
+    }
+
+    @Test
+    fun `list of user permissions and empty list of group permissions returns the same user permissions`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                emptyList(),
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, "user1"),
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, null, "user1"),
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId3", null, null, "XYZ", PermissionType.DENY, null, "user1")
+                )
+            )
+        )
+        assertThat(calculatedPermissions).containsOnlyKeys("user1")
+        assertThat(calculatedPermissions["user1"]).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user1"]).containsExactlyInAnyOrder(
+            InternalPermissionQueryDto("user1", "permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId3", null, null, "XYZ", PermissionType.DENY)
+        )
+    }
+
+    @Test
+    fun `single user with parent group hierarchy returns the permissions of the user and its associated groups` () {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "DEF", PermissionType.ALLOW, "groupId2", null)
+                ),
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId4", null, null, "GHI", PermissionType.ALLOW, "groupId3", "user1"),
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId5", null, null, "XYZ", PermissionType.ALLOW, "groupId3", "user1"),
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId6", null, null, "XYZ", PermissionType.DENY, "groupId3", "user1")
+                )
+            )
+        )
+        assertThat(calculatedPermissions).containsOnlyKeys("user1")
+        assertThat(calculatedPermissions["user1"]).size().isEqualTo(6)
+        assertThat(calculatedPermissions["user1"]).containsExactlyInAnyOrder(
+            InternalPermissionQueryDto("user1", "permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId3", null, null, "DEF", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId4", null, null, "GHI", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId5", null, null, "XYZ", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId6", null, null, "XYZ", PermissionType.DENY)
+        )
+    }
+
+    @Test
+    fun `users at different group levels return the correct number of permissions`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "DEF", PermissionType.ALLOW, "groupId2", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId4", "permissionId4", null, null, "GHI", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId5", "permissionId5", null, null, "JKL", PermissionType.ALLOW, "groupId2", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId6", "permissionId6", null, null, "MNO", PermissionType.ALLOW, "groupId3", null),
+                ),
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId7", null, null, "GHI", PermissionType.DENY, "groupId6", "user1"),
+                    InternalPermissionWithParentGroupQueryDto("userId2", null, null, null, null, null, "groupId3", "user2"),
+                    InternalPermissionWithParentGroupQueryDto("userId3", null, null, null, null, null, "groupId5", "user3"),
+                    InternalPermissionWithParentGroupQueryDto("userId4", null, null, null, null, null, "groupId2", "user4"),
+                    InternalPermissionWithParentGroupQueryDto("userId5", null, null, null, null, null, "groupId4", "user5"),
+                    InternalPermissionWithParentGroupQueryDto("userId6", null, null, null, null, null, "groupId1", "user6")
+                )
+            )
+        )
+        assertThat(calculatedPermissions).containsOnlyKeys("user1", "user2", "user3", "user4", "user5", "user6")
+        assertThat(calculatedPermissions["user1"]).size().isEqualTo(5)
+        assertThat(calculatedPermissions["user2"]).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user3"]).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user4"]).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user5"]).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user6"]).size().isEqualTo(1)
+    }
+
+    @Test
+    fun `users and groups without any permissions are filtered out and aggregation adds user with empty list of permissions`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, "groupId2", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId2", null, null, null, null, null, null, null),
+                ),
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("userId1", null, null, null, null, null, "groupId2", "user1")
+                )
+            )
+        )
+        assertThat(calculatedPermissions["user1"]).isEmpty()
+
+        val aggregatedPermissions = aggregatePermissionSummariesForUsers(
+            listOf(
+                InternalUserEnabledQueryDto("user1", true)
+            ),
+            calculatedPermissions,
+            Instant.now()
+            )
+        assertThat(aggregatedPermissions).containsOnlyKeys("user1")
+        assertThat(aggregatedPermissions["user1"]!!.permissions).isEmpty()
+    }
+
+    @Test
+    fun `user without permissions but has inherited permissions from groups is correctly returned`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "DEF", PermissionType.ALLOW, "groupId2", null),
+                ),
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("userId1", null, null, null, null, null, "groupId3", "user1"),
+                )
+            )
+        )
+        assertThat(calculatedPermissions).containsOnlyKeys("user1")
+        assertThat(calculatedPermissions["user1"]).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user1"]).containsExactlyInAnyOrder(
+            InternalPermissionQueryDto("user1", "permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            InternalPermissionQueryDto("user1", "permissionId3", null, null, "DEF", PermissionType.ALLOW)
+        )
+    }
+
+    @Test
+    fun `user with parent group without permissions but has inherited permissions from grandparent group is correctly returned`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("groupId1", null, null, null, null, null, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId1", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId3", null, null, null, null, null, "groupId2", null),
+                ),
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("userId1", null, null, null, null, null, "groupId3", "user1"),
+                )
+            )
+        )
+        assertThat(calculatedPermissions).containsOnlyKeys("user1")
+        assertThat(calculatedPermissions["user1"]).size().isEqualTo(1)
+        assertThat(calculatedPermissions["user1"]).containsExactlyInAnyOrder(
+            InternalPermissionQueryDto("user1", "permissionId1", null, null, "XYZ", PermissionType.ALLOW)
+        )
+    }
+    @Test
+    fun `multiple trees of different groups and associated users test`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "DEF", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId4", "permissionId4", null, null, "GHI", PermissionType.ALLOW, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId5", "permissionId5", null, null, "JKL", PermissionType.ALLOW, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId6", "permissionId6", null, null, "MNO", PermissionType.ALLOW, "groupId5", null),
+                    InternalPermissionWithParentGroupQueryDto("groupId7", null, null, null, null, null, null, null)
+                ),
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("userId1", null, null, null, null, null, "groupId2", "user1"),
+                    InternalPermissionWithParentGroupQueryDto("userId2", null, null, null, null, null, "groupId3", "user2"),
+                    InternalPermissionWithParentGroupQueryDto("userId3", null, null, null, null, null, "groupId4", "user3"),
+                    InternalPermissionWithParentGroupQueryDto("userId4", null, null, null, null, null, "groupId6", "user4"),
+                    InternalPermissionWithParentGroupQueryDto("userId5", "permissionId7", null, null, "ABC", PermissionType.DENY, "groupId6", "user5"),
+                    InternalPermissionWithParentGroupQueryDto("userId6", null, null, null, null, null, "groupId5", "user6"),
+                    InternalPermissionWithParentGroupQueryDto("userId7", null, null, null, null, null, "groupId7", "user7"),
+                    InternalPermissionWithParentGroupQueryDto("userId8", null, null, null, null, null, null, "user8")
+                )
+            )
+        )
+        assertThat(calculatedPermissions).containsOnlyKeys("user1", "user2", "user3", "user4", "user5", "user6", "user7", "user8")
+        assertThat(calculatedPermissions["user1"]).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user2"]).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user3"]).size().isEqualTo(1)
+        assertThat(calculatedPermissions["user4"]).size().isEqualTo(2)
+        assertThat(calculatedPermissions["user5"]).size().isEqualTo(3)
+        assertThat(calculatedPermissions["user6"]).size().isEqualTo(1)
+        assertThat(calculatedPermissions["user7"]).size().isEqualTo(0)
+        assertThat(calculatedPermissions["user8"]).size().isEqualTo(0)
+    }
+
+    @Test
+    fun `aggregation function will remove duplicate permissions on the same user and sort DENY before ALLOW for the same permission`() {
+        val calculatedPermissions = calculatePermissionsForUsers(
+            createEntityManager(
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId2", null, null, "ABC", PermissionType.DENY, null, null),
+                    InternalPermissionWithParentGroupQueryDto("groupId2", null, null, null, null, null, "groupId1", null),
+                ),
+                listOf(
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId2", null, null, "ABC", PermissionType.DENY, "groupId2", "user1"),
+                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, "groupId2", "user1"),
+                )
+            )
+        )
+        assertThat(calculatedPermissions).containsOnlyKeys("user1")
+        assertThat(calculatedPermissions["user1"]!!.size).isEqualTo(4)
+
+        val aggregatedPermissions = aggregatePermissionSummariesForUsers(
+            listOf(
+                InternalUserEnabledQueryDto("user1", true)
+            ),
+            calculatedPermissions,
+            Instant.now()
+        )
+        assertThat(aggregatedPermissions).containsOnlyKeys("user1")
+        assertThat(aggregatedPermissions["user1"]!!.permissions.size).isEqualTo(2)
+
+        // containsExactly() will check the order of the elements and we should expect DENY first
+        assertThat(aggregatedPermissions["user1"]!!.permissions).containsExactly(
+            InternalPermissionQueryDto("user1", "permissionId2", null, null, "ABC", PermissionType.DENY),
+            InternalPermissionQueryDto("user1", "permissionId1", null, null, "ABC", PermissionType.ALLOW)
+        )
+    }
+}

--- a/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/util/PermissionUserUtilTest.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/util/PermissionUserUtilTest.kt
@@ -62,9 +62,36 @@ class PermissionUserUtilTest {
         val calculatedPermissions = calculatePermissionsForUsers(
             createEntityManager(
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "XYZ", PermissionType.DENY, "groupId1", null)
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        null,
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId2",
+                        "permissionId2",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.ALLOW,
+                        "groupId1",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId3",
+                        "permissionId3",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.DENY,
+                        "groupId1",
+                        null
+                    )
                 ),
                 emptyList()
             )
@@ -78,9 +105,36 @@ class PermissionUserUtilTest {
             createEntityManager(
                 emptyList(),
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, "user1"),
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, null, "user1"),
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId3", null, null, "XYZ", PermissionType.DENY, null, "user1")
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        null,
+                        "user1"
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId2",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.ALLOW,
+                        null,
+                        "user1"
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId3",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.DENY,
+                        null,
+                        "user1"
+                    )
                 )
             )
         )
@@ -94,18 +148,72 @@ class PermissionUserUtilTest {
     }
 
     @Test
-    fun `single user with parent group hierarchy returns the permissions of the user and its associated groups` () {
+    fun `single user with parent group hierarchy returns the permissions of the user and its associated groups`() {
         val calculatedPermissions = calculatePermissionsForUsers(
             createEntityManager(
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "DEF", PermissionType.ALLOW, "groupId2", null)
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        null,
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId2",
+                        "permissionId2",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.ALLOW,
+                        "groupId1",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId3",
+                        "permissionId3",
+                        null,
+                        null,
+                        "DEF",
+                        PermissionType.ALLOW,
+                        "groupId2",
+                        null
+                    )
                 ),
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId4", null, null, "GHI", PermissionType.ALLOW, "groupId3", "user1"),
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId5", null, null, "XYZ", PermissionType.ALLOW, "groupId3", "user1"),
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId6", null, null, "XYZ", PermissionType.DENY, "groupId3", "user1")
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId4",
+                        null,
+                        null,
+                        "GHI",
+                        PermissionType.ALLOW,
+                        "groupId3",
+                        "user1"
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId5",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.ALLOW,
+                        "groupId3",
+                        "user1"
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId6",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.DENY,
+                        "groupId3",
+                        "user1"
+                    )
                 )
             )
         )
@@ -126,15 +234,78 @@ class PermissionUserUtilTest {
         val calculatedPermissions = calculatePermissionsForUsers(
             createEntityManager(
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "DEF", PermissionType.ALLOW, "groupId2", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId4", "permissionId4", null, null, "GHI", PermissionType.ALLOW, "groupId1", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId5", "permissionId5", null, null, "JKL", PermissionType.ALLOW, "groupId2", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId6", "permissionId6", null, null, "MNO", PermissionType.ALLOW, "groupId3", null),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        null,
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId2",
+                        "permissionId2",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.ALLOW,
+                        "groupId1",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId3",
+                        "permissionId3",
+                        null,
+                        null,
+                        "DEF",
+                        PermissionType.ALLOW,
+                        "groupId2",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId4",
+                        "permissionId4",
+                        null,
+                        null,
+                        "GHI",
+                        PermissionType.ALLOW,
+                        "groupId1",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId5",
+                        "permissionId5",
+                        null,
+                        null,
+                        "JKL",
+                        PermissionType.ALLOW,
+                        "groupId2",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId6",
+                        "permissionId6",
+                        null,
+                        null,
+                        "MNO",
+                        PermissionType.ALLOW,
+                        "groupId3",
+                        null
+                    ),
                 ),
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId7", null, null, "GHI", PermissionType.DENY, "groupId6", "user1"),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId7",
+                        null,
+                        null,
+                        "GHI",
+                        PermissionType.DENY,
+                        "groupId6",
+                        "user1"
+                    ),
                     InternalPermissionWithParentGroupQueryDto("userId2", null, null, null, null, null, "groupId3", "user2"),
                     InternalPermissionWithParentGroupQueryDto("userId3", null, null, null, null, null, "groupId5", "user3"),
                     InternalPermissionWithParentGroupQueryDto("userId4", null, null, null, null, null, "groupId2", "user4"),
@@ -157,7 +328,16 @@ class PermissionUserUtilTest {
         val calculatedPermissions = calculatePermissionsForUsers(
             createEntityManager(
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, "groupId2", null),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        "groupId2",
+                        null
+                    ),
                     InternalPermissionWithParentGroupQueryDto("groupId2", null, null, null, null, null, null, null),
                 ),
                 listOf(
@@ -173,7 +353,7 @@ class PermissionUserUtilTest {
             ),
             calculatedPermissions,
             Instant.now()
-            )
+        )
         assertThat(aggregatedPermissions).containsOnlyKeys("user1")
         assertThat(aggregatedPermissions["user1"]!!.permissions).isEmpty()
     }
@@ -183,9 +363,36 @@ class PermissionUserUtilTest {
         val calculatedPermissions = calculatePermissionsForUsers(
             createEntityManager(
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "DEF", PermissionType.ALLOW, "groupId2", null),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        null,
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId2",
+                        "permissionId2",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.ALLOW,
+                        "groupId1",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId3",
+                        "permissionId3",
+                        null,
+                        null,
+                        "DEF",
+                        PermissionType.ALLOW,
+                        "groupId2",
+                        null
+                    ),
                 ),
                 listOf(
                     InternalPermissionWithParentGroupQueryDto("userId1", null, null, null, null, null, "groupId3", "user1"),
@@ -207,7 +414,16 @@ class PermissionUserUtilTest {
             createEntityManager(
                 listOf(
                     InternalPermissionWithParentGroupQueryDto("groupId1", null, null, null, null, null, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId1", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId2",
+                        "permissionId1",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.ALLOW,
+                        "groupId1",
+                        null
+                    ),
                     InternalPermissionWithParentGroupQueryDto("groupId3", null, null, null, null, null, "groupId2", null),
                 ),
                 listOf(
@@ -221,17 +437,72 @@ class PermissionUserUtilTest {
             InternalPermissionQueryDto("user1", "permissionId1", null, null, "XYZ", PermissionType.ALLOW)
         )
     }
+
     @Test
     fun `multiple trees of different groups and associated users test`() {
         val calculatedPermissions = calculatePermissionsForUsers(
             createEntityManager(
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId2", "permissionId2", null, null, "XYZ", PermissionType.ALLOW, "groupId1", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId3", "permissionId3", null, null, "DEF", PermissionType.ALLOW, "groupId1", null),
-                    InternalPermissionWithParentGroupQueryDto("groupId4", "permissionId4", null, null, "GHI", PermissionType.ALLOW, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId5", "permissionId5", null, null, "JKL", PermissionType.ALLOW, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId6", "permissionId6", null, null, "MNO", PermissionType.ALLOW, "groupId5", null),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        null,
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId2",
+                        "permissionId2",
+                        null,
+                        null,
+                        "XYZ",
+                        PermissionType.ALLOW,
+                        "groupId1",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId3",
+                        "permissionId3",
+                        null,
+                        null,
+                        "DEF",
+                        PermissionType.ALLOW,
+                        "groupId1",
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId4",
+                        "permissionId4",
+                        null,
+                        null,
+                        "GHI",
+                        PermissionType.ALLOW,
+                        null,
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId5",
+                        "permissionId5",
+                        null,
+                        null,
+                        "JKL",
+                        PermissionType.ALLOW,
+                        null,
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId6",
+                        "permissionId6",
+                        null,
+                        null,
+                        "MNO",
+                        PermissionType.ALLOW,
+                        "groupId5",
+                        null
+                    ),
                     InternalPermissionWithParentGroupQueryDto("groupId7", null, null, null, null, null, null, null)
                 ),
                 listOf(
@@ -239,7 +510,16 @@ class PermissionUserUtilTest {
                     InternalPermissionWithParentGroupQueryDto("userId2", null, null, null, null, null, "groupId3", "user2"),
                     InternalPermissionWithParentGroupQueryDto("userId3", null, null, null, null, null, "groupId4", "user3"),
                     InternalPermissionWithParentGroupQueryDto("userId4", null, null, null, null, null, "groupId6", "user4"),
-                    InternalPermissionWithParentGroupQueryDto("userId5", "permissionId7", null, null, "ABC", PermissionType.DENY, "groupId6", "user5"),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId5",
+                        "permissionId7",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.DENY,
+                        "groupId6",
+                        "user5"
+                    ),
                     InternalPermissionWithParentGroupQueryDto("userId6", null, null, null, null, null, "groupId5", "user6"),
                     InternalPermissionWithParentGroupQueryDto("userId7", null, null, null, null, null, "groupId7", "user7"),
                     InternalPermissionWithParentGroupQueryDto("userId8", null, null, null, null, null, null, "user8")
@@ -262,13 +542,49 @@ class PermissionUserUtilTest {
         val calculatedPermissions = calculatePermissionsForUsers(
             createEntityManager(
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, null, null),
-                    InternalPermissionWithParentGroupQueryDto("groupId1", "permissionId2", null, null, "ABC", PermissionType.DENY, null, null),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        null,
+                        null
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "groupId1",
+                        "permissionId2",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.DENY,
+                        null,
+                        null
+                    ),
                     InternalPermissionWithParentGroupQueryDto("groupId2", null, null, null, null, null, "groupId1", null),
                 ),
                 listOf(
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId2", null, null, "ABC", PermissionType.DENY, "groupId2", "user1"),
-                    InternalPermissionWithParentGroupQueryDto("userId1", "permissionId1", null, null, "ABC", PermissionType.ALLOW, "groupId2", "user1"),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId2",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.DENY,
+                        "groupId2",
+                        "user1"
+                    ),
+                    InternalPermissionWithParentGroupQueryDto(
+                        "userId1",
+                        "permissionId1",
+                        null,
+                        null,
+                        "ABC",
+                        PermissionType.ALLOW,
+                        "groupId2",
+                        "user1"
+                    ),
                 )
             )
         )

--- a/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/util/PermissionUserUtilTest.kt
+++ b/libs/permissions/permission-storage-reader-impl/src/test/kotlin/net/corda/libs/permissions/storage/reader/impl/util/PermissionUserUtilTest.kt
@@ -5,10 +5,10 @@ import net.corda.libs.permissions.storage.reader.util.PermissionUserUtil.allGrou
 import net.corda.libs.permissions.storage.reader.util.PermissionUserUtil.allUsersPermissionsQuery
 import net.corda.libs.permissions.storage.reader.util.PermissionUserUtil.calculatePermissionsForUsers
 import net.corda.permissions.model.PermissionType
+import net.corda.permissions.query.dto.InternalPermission
 import net.corda.permissions.query.dto.InternalPermissionQueryDto
 import net.corda.permissions.query.dto.InternalPermissionWithParentGroupQueryDto
 import net.corda.permissions.query.dto.InternalUserEnabledQueryDto
-import net.corda.permissions.query.dto.Permission
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doAnswer
@@ -142,9 +142,9 @@ class PermissionUserUtilTest {
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
         assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(3)
         assertThat(calculatedPermissions["user1"]?.permissionsList).containsExactlyInAnyOrder(
-            Permission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
-            Permission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
-            Permission("permissionId3", null, null, "XYZ", PermissionType.DENY)
+            InternalPermission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            InternalPermission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            InternalPermission("permissionId3", null, null, "XYZ", PermissionType.DENY)
         )
     }
 
@@ -221,12 +221,12 @@ class PermissionUserUtilTest {
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
         assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(6)
         assertThat(calculatedPermissions["user1"]?.permissionsList).containsExactlyInAnyOrder(
-            Permission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
-            Permission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
-            Permission("permissionId3", null, null, "DEF", PermissionType.ALLOW),
-            Permission("permissionId4", null, null, "GHI", PermissionType.ALLOW),
-            Permission("permissionId5", null, null, "XYZ", PermissionType.ALLOW),
-            Permission("permissionId6", null, null, "XYZ", PermissionType.DENY)
+            InternalPermission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            InternalPermission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            InternalPermission("permissionId3", null, null, "DEF", PermissionType.ALLOW),
+            InternalPermission("permissionId4", null, null, "GHI", PermissionType.ALLOW),
+            InternalPermission("permissionId5", null, null, "XYZ", PermissionType.ALLOW),
+            InternalPermission("permissionId6", null, null, "XYZ", PermissionType.DENY)
         )
     }
 
@@ -403,9 +403,9 @@ class PermissionUserUtilTest {
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
         assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(3)
         assertThat(calculatedPermissions["user1"]?.permissionsList).containsExactlyInAnyOrder(
-            Permission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
-            Permission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
-            Permission("permissionId3", null, null, "DEF", PermissionType.ALLOW)
+            InternalPermission("permissionId1", null, null, "ABC", PermissionType.ALLOW),
+            InternalPermission("permissionId2", null, null, "XYZ", PermissionType.ALLOW),
+            InternalPermission("permissionId3", null, null, "DEF", PermissionType.ALLOW)
         )
     }
 
@@ -435,7 +435,7 @@ class PermissionUserUtilTest {
         assertThat(calculatedPermissions).containsOnlyKeys("user1")
         assertThat(calculatedPermissions["user1"]?.permissionsList).size().isEqualTo(1)
         assertThat(calculatedPermissions["user1"]?.permissionsList).containsExactlyInAnyOrder(
-            Permission("permissionId1", null, null, "XYZ", PermissionType.ALLOW)
+            InternalPermission("permissionId1", null, null, "XYZ", PermissionType.ALLOW)
         )
     }
 
@@ -602,7 +602,7 @@ class PermissionUserUtilTest {
         assertThat(aggregatedPermissions).containsOnlyKeys("user1")
         assertThat(aggregatedPermissions["user1"]!!.permissions.size).isEqualTo(2)
 
-        // containsExactly() will check the order of the elements and we should expect DENY first
+        // containsExactly() will check the order of the elements, and we should expect DENY first
         assertThat(aggregatedPermissions["user1"]!!.permissions).containsExactly(
             InternalPermissionQueryDto("user1", "permissionId2", null, null, "ABC", PermissionType.DENY),
             InternalPermissionQueryDto("user1", "permissionId1", null, null, "ABC", PermissionType.ALLOW)


### PR DESCRIPTION
- Creates a tree of all users and group permissions and traverses the tree to get all permissions associated with a user in its hierarchy
- Moved permission calculation and aggregation function to its own util class
- Created test class for util functions to cover as many cases for the tree