### PR TITLE
CORE-20799: Change CommitFailedException classification

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImpl.kt
@@ -70,8 +70,7 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
             ArithmeticException::class.java,
             FencedInstanceIdException::class.java,
             InconsistentGroupProtocolException::class.java,
-            InvalidOffsetException::class.java,
-            CommitFailedException::class.java
+            InvalidOffsetException::class.java
         )
         val transientExceptions: Set<Class<out Throwable>> = setOf(
             TimeoutException::class.java,
@@ -79,7 +78,8 @@ class CordaKafkaConsumerImpl<K : Any, V : Any>(
             InterruptException::class.java,
             KafkaException::class.java,
             ConcurrentModificationException::class.java,
-            RebalanceInProgressException::class.java
+            RebalanceInProgressException::class.java,
+            CommitFailedException::class.java
         )
     }
 

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/consumer/CordaKafkaConsumerImplTest.kt
@@ -193,7 +193,7 @@ class CordaKafkaConsumerImplTest {
         cordaKafkaConsumer = createConsumer(consumer)
 
         doThrow(CommitFailedException()).whenever(consumer).commitSync()
-        assertThatExceptionOfType(CordaMessageAPIFatalException::class.java).isThrownBy {
+        assertThatExceptionOfType(CordaMessageAPIIntermittentException::class.java).isThrownBy {
             cordaKafkaConsumer.syncCommitOffsets()
         }
         verify(consumer, times(1)).commitSync()
@@ -211,13 +211,13 @@ class CordaKafkaConsumerImplTest {
     }
 
     @Test
-    fun testCommitOffsetsFatal() {
+    fun testCommitOffsetsThrowIntermittent() {
         consumer = mock()
         cordaKafkaConsumer = createConsumer(consumer)
 
         val consumerRecord = CordaConsumerRecord(eventTopic, 1, 5L, "", "value", 0)
         doThrow(CommitFailedException()).whenever(consumer).commitSync(anyMap())
-        assertThatExceptionOfType(CordaMessageAPIFatalException::class.java).isThrownBy {
+        assertThatExceptionOfType(CordaMessageAPIIntermittentException::class.java).isThrownBy {
             cordaKafkaConsumer.syncCommitOffsets(consumerRecord, "meta data")
         }
         verify(consumer, times(1)).commitSync(anyMap())


### PR DESCRIPTION
Change CommitFailedException classification from fatal to transient.
This is required as the kafka connection tests exposed that we mark CommitFailedException as fatal and therefore do not retry. A CommitFailedException means we should abort the transaction but by classifying it as fatal we will bubble this up and we will not retry on any level. A CommitFailedException is fatal at the transaction level but not at the worker level so this should be changed.