### PR TITLE
CORE-20795: Add exception handling and retry to KafkaAdmin and VirtualNodeInfoProcessor

### DIFF
--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessor.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessor.kt
@@ -120,7 +120,14 @@ class VirtualNodeInfoProcessor(private val onStatusUpCallback: () -> Unit, priva
         }
 
         val currentSnapshot = virtualNodeInfoMap.getAllAsCordaObjects()
-        listeners.forEach { it.value.onUpdate(setOf(newRecord.key.toCorda()), currentSnapshot) }
+        try {
+            listeners.forEach { it.value.onUpdate(setOf(newRecord.key.toCorda()), currentSnapshot) }
+        } catch (exception: Exception) {
+            log.error("Virtual Node Info service could not update", exception)
+            onErrorCallback()
+            return
+        }
+
     }
 
     fun getAll(): List<VirtualNodeInfo> =

--- a/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessor.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/main/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessor.kt
@@ -127,7 +127,6 @@ class VirtualNodeInfoProcessor(private val onStatusUpCallback: () -> Unit, priva
             onErrorCallback()
             return
         }
-
     }
 
     fun getAll(): List<VirtualNodeInfo> =

--- a/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessorTest.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessorTest.kt
@@ -376,7 +376,5 @@ class VirtualNodeInfoProcessorTest {
         assertThat(onError).isFalse
         assertDoesNotThrow { processor.onNext(Record("", holdingIdentity.toAvro(), virtualNodeInfo.toAvro()), null, emptyMap()) }
         assertThat(onError).isTrue
-
     }
-
 }

--- a/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessorTest.kt
+++ b/components/virtual-node/virtual-node-info-read-service/src/test/kotlin/net/corda/virtualnode/read/impl/VirtualNodeInfoProcessorTest.kt
@@ -4,8 +4,10 @@ import net.corda.crypto.core.SecureHashImpl
 import net.corda.libs.packaging.core.CpiIdentifier
 import net.corda.messaging.api.records.Record
 import net.corda.test.util.identity.createTestHoldingIdentity
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.virtualnode.HoldingIdentity
 import net.corda.virtualnode.VirtualNodeInfo
+import net.corda.virtualnode.read.VirtualNodeInfoListener
 import net.corda.virtualnode.toAvro
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -16,6 +18,10 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import java.time.Instant
 import java.util.UUID
 
@@ -351,4 +357,26 @@ class VirtualNodeInfoProcessorTest {
         processor.onSnapshot(mapOf(holdingIdentityOther.toAvro() to virtualNodeInfo.toAvro()))
         assertThat(onError).isTrue
     }
+
+    @Test
+    fun `exception is caught and onError called if update fails`() {
+        val exceptionalListener = mock<VirtualNodeInfoListener>()
+
+        var onError = false
+        val processor = VirtualNodeInfoProcessor({ /* don't care */ }, { onError = true })
+
+        processor.registerCallback(exceptionalListener)
+
+        Mockito.`when`(exceptionalListener.onUpdate(any(), any())).thenThrow(CordaRuntimeException(""))
+
+        val holdingIdentity = createTestHoldingIdentity("CN=Bob, O=Bob Corp, L=LDN, C=GB", "groupId")
+        val virtualNodeInfo =
+            newVirtualNodeInfo(holdingIdentity, CpiIdentifier("name", "version", secureHash))
+
+        assertThat(onError).isFalse
+        assertDoesNotThrow { processor.onNext(Record("", holdingIdentity.toAvro(), virtualNodeInfo.toAvro()), null, emptyMap()) }
+        assertThat(onError).isTrue
+
+    }
+
 }

--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/admin/KafkaAdmin.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/admin/KafkaAdmin.kt
@@ -1,11 +1,34 @@
 package net.corda.messagebus.kafka.admin
 
 import net.corda.messagebus.api.admin.Admin
+import net.corda.utilities.retry.Linear
+import net.corda.utilities.retry.tryWithBackoff
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.apache.kafka.clients.admin.AdminClient
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ExecutionException
 
 class KafkaAdmin(private val adminClient: AdminClient) : Admin {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
+    }
+
     override fun getTopics(): Set<String> {
-        return adminClient.listTopics().names().get()
+        return try {
+            tryWithBackoff(
+                logger = logger,
+                maxRetries = 3,
+                maxTimeMillis = 3000,
+                backoffStrategy = Linear(200)
+            ) {
+                adminClient.listTopics().names().get()
+            }
+        } catch (e: ExecutionException) {
+            logger.warn("could not get Topics")
+            throw CordaRuntimeException(e.message)
+        }
+
     }
 
     override fun close() {

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.concurrent.ExecutionException
 
@@ -83,5 +85,7 @@ class KafkaAdminTest {
         val admin = KafkaAdmin(adminClient)
 
         assertThrows<CordaRuntimeException> { admin.getTopics() }
+
+        verify(kafkaFuture, times(3)).get()
     }
 }

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
@@ -8,7 +8,6 @@ import org.apache.kafka.common.errors.TimeoutException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -38,23 +37,18 @@ class KafkaAdminTest {
     @Test
     fun `getTopics will retry an exception and be successful when retries not exceeded`() {
         val adminClient = mock<AdminClient>()
-        val kafkaFuture: KafkaFuture<Set<String>> = mock()
+        val kafkaFuture = mock<KafkaFuture<Set<String>>>()
 
         val topicResult = mock<ListTopicsResult>()
-        Mockito.`when`(adminClient.listTopics()).thenReturn(topicResult)
-        Mockito.`when`(topicResult.names()).thenReturn(kafkaFuture)
+        whenever(topicResult.names()).thenReturn(kafkaFuture)
+        whenever(adminClient.listTopics()).thenReturn(topicResult)
 
         //retries hardcoded in getTopics to max 3 attempts
 
-        var attemptNumber = 1
-        Mockito.`when`(kafkaFuture.get()).thenAnswer {
-            if (attemptNumber <= 2) {
-                attemptNumber++
-                throw (ExecutionException(TimeoutException("timed out")))
-            } else {
-                setOf("topic1")
-            }
-        }
+        whenever(kafkaFuture.get())
+            .thenThrow(ExecutionException(TimeoutException("timed out")))
+            .thenThrow(ExecutionException(TimeoutException("timed out")))
+            .thenReturn(setOf("topic1"))
 
         val admin = KafkaAdmin(adminClient)
 
@@ -64,28 +58,20 @@ class KafkaAdminTest {
     @Test
     fun `getTopics will retry an exception and rethrow when retries exceeded`() {
         val adminClient = mock<AdminClient>()
-        val kafkaFuture: KafkaFuture<Set<String>> = mock()
+        val kafkaFuture = mock<KafkaFuture<Set<String>>>()
 
         val topicResult = mock<ListTopicsResult>()
-        Mockito.`when`(adminClient.listTopics()).thenReturn(topicResult)
-        Mockito.`when`(topicResult.names()).thenReturn(kafkaFuture)
+        whenever(topicResult.names()).thenReturn(kafkaFuture)
+        whenever(adminClient.listTopics()).thenReturn(topicResult)
 
         //retries hardcoded in getTopics to max 3 attempts
 
-        var attemptNumber = 1
-        Mockito.`when`(kafkaFuture.get()).thenAnswer {
-            if (attemptNumber <= 3) {
-                attemptNumber++
-                throw (ExecutionException(TimeoutException("timed out")))
-            } else {
-                setOf("topic1")
-            }
-        }
+        whenever(kafkaFuture.get())
+            .thenThrow(ExecutionException(TimeoutException("timed out")))
 
         val admin = KafkaAdmin(adminClient)
 
         assertThrows<CordaRuntimeException> { admin.getTopics() }
-
         verify(kafkaFuture, times(3)).get()
     }
 }

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
@@ -42,10 +42,12 @@ class KafkaAdminTest {
         Mockito.`when`(adminClient.listTopics()).thenReturn(topicResult)
         Mockito.`when`(topicResult.names()).thenReturn(kafkaFuture)
 
-        var retryNumber = 0
+        //retries hardcoded in getTopics to max 3 attempts
+
+        var attemptNumber = 1
         Mockito.`when`(kafkaFuture.get()).thenAnswer {
-            if (retryNumber <= 3) {
-                retryNumber++
+            if (attemptNumber <= 2) {
+                attemptNumber++
                 throw (ExecutionException(TimeoutException("timed out")))
             } else {
                 setOf("topic1")
@@ -66,10 +68,12 @@ class KafkaAdminTest {
         Mockito.`when`(adminClient.listTopics()).thenReturn(topicResult)
         Mockito.`when`(topicResult.names()).thenReturn(kafkaFuture)
 
-        var retryNumber = 0
+        //retries hardcoded in getTopics to max 3 attempts
+
+        var attemptNumber = 1
         Mockito.`when`(kafkaFuture.get()).thenAnswer {
-            if (retryNumber <= 8) {
-                retryNumber++
+            if (attemptNumber <= 3) {
+                attemptNumber++
                 throw (ExecutionException(TimeoutException("timed out")))
             } else {
                 setOf("topic1")

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/admin/KafkaAdminTest.kt
@@ -1,19 +1,24 @@
 package net.corda.messagebus.kafka.admin
 
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import org.apache.kafka.clients.admin.AdminClient
 import org.apache.kafka.clients.admin.ListTopicsResult
 import org.apache.kafka.common.KafkaFuture
+import org.apache.kafka.common.errors.TimeoutException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.concurrent.ExecutionException
 
 class KafkaAdminTest {
 
-    private var adminClient = mock<AdminClient>()
-
     @Test
-    fun `When list topics then return all none internal topics from kafka`() {
+    fun `listTopics returns all internal topics from kafka`() {
+        var adminClient = mock<AdminClient>()
+
         val kafkaFuture = mock<KafkaFuture<Set<String>>>().apply {
             whenever(get()).thenReturn(setOf("topic1"))
         }
@@ -23,8 +28,56 @@ class KafkaAdminTest {
 
         whenever(adminClient.listTopics()).thenReturn(result)
 
-        val target = KafkaAdmin(adminClient)
+        val admin = KafkaAdmin(adminClient)
 
-        assertThat(target.getTopics()).containsOnly("topic1")
+        assertThat(admin.getTopics()).containsOnly("topic1")
+    }
+
+    @Test
+    fun `getTopics will retry an exception and be successful when retries not exceeded`() {
+        val adminClient = mock<AdminClient>()
+        val kafkaFuture: KafkaFuture<Set<String>> = mock()
+
+        val topicResult = mock<ListTopicsResult>()
+        Mockito.`when`(adminClient.listTopics()).thenReturn(topicResult)
+        Mockito.`when`(topicResult.names()).thenReturn(kafkaFuture)
+
+        var retryNumber = 0
+        Mockito.`when`(kafkaFuture.get()).thenAnswer {
+            if (retryNumber <= 3) {
+                retryNumber++
+                throw (ExecutionException(TimeoutException("timed out")))
+            } else {
+                setOf("topic1")
+            }
+        }
+
+        val admin = KafkaAdmin(adminClient)
+
+        assertThat(admin.getTopics()).containsOnly("topic1")
+    }
+
+    @Test
+    fun `getTopics will retry an exception and rethrow when retries exceeded`() {
+        val adminClient = mock<AdminClient>()
+        val kafkaFuture: KafkaFuture<Set<String>> = mock()
+
+        val topicResult = mock<ListTopicsResult>()
+        Mockito.`when`(adminClient.listTopics()).thenReturn(topicResult)
+        Mockito.`when`(topicResult.names()).thenReturn(kafkaFuture)
+
+        var retryNumber = 0
+        Mockito.`when`(kafkaFuture.get()).thenAnswer {
+            if (retryNumber <= 8) {
+                retryNumber++
+                throw (ExecutionException(TimeoutException("timed out")))
+            } else {
+                setOf("topic1")
+            }
+        }
+
+        val admin = KafkaAdmin(adminClient)
+
+        assertThrows<CordaRuntimeException> { admin.getTopics() }
     }
 }


### PR DESCRIPTION
This issue appeared while running kafka connection tests which kill the kafka broker.

In a flow worker compacted subscription we got a `org.apache.kafka.common.errors.TimeoutException` and handled it as fatal. 

This is because we have no error handling in our `KafkaAdmin` class for the exceptions that can be thrown by `KafkaFuture.get()` . The `KafkaAdmin` client is called from the `VirtualNodeInfoProcessor` which also does not catch this. 

This PR adds retry logic to the KafkaAdmin for `getTopics` and in the case of exhausting these retries, error handling in `VirtualNodeInfoProcessor` to handle this better and prevent this exception bubbling further. 