### PR TITLE
CORE-20797 Adding handling for CordaMessageAPIProducerRequiresReset exception

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
@@ -3,6 +3,7 @@ package net.corda.messaging.mediator
 import net.corda.messagebus.api.producer.CordaProducer
 import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
 import net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessagingClient
@@ -70,7 +71,7 @@ class MessageBusClient(
 
         future.completeExceptionally(
             if (fatal) CordaMessageAPIFatalException(message, exception)
-            else CordaMessageAPIProducerRequiresReset(message, exception)
+            else CordaMessageAPIIntermittentException(message, exception)
         )
     }
 

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
@@ -23,6 +23,8 @@ class MessageBusClient(
     override fun send(message: MediatorMessage<*>): MediatorMessage<*> {
         val future = CompletableFuture<Unit>()
         val record = message.toCordaProducerRecord()
+
+        // CordaMessageAPIProducerRequiresReset could be thrown here
         producer.send(record) { ex ->
             setFutureFromResponse(ex, future, record.topic)
         }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/MessageBusClient.kt
@@ -3,6 +3,7 @@ package net.corda.messaging.mediator
 import net.corda.messagebus.api.producer.CordaProducer
 import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
+import net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset
 import net.corda.messaging.api.mediator.MediatorMessage
 import net.corda.messaging.api.mediator.MessagingClient
 import net.corda.messaging.api.mediator.MessagingClient.Companion.MSG_PROP_ENDPOINT
@@ -13,18 +14,19 @@ import java.util.concurrent.CompletableFuture
 
 class MessageBusClient(
     override val id: String,
-    private val producer: CordaProducer,
+    private val createProducer: () -> CordaProducer,
 ) : MessagingClient {
 
     private companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java.enclosingClass)
     }
 
+    var producer: CordaProducer = createProducer()
+
     override fun send(message: MediatorMessage<*>): MediatorMessage<*> {
         val future = CompletableFuture<Unit>()
         val record = message.toCordaProducerRecord()
 
-        // CordaMessageAPIProducerRequiresReset could be thrown here
         producer.send(record) { ex ->
             setFutureFromResponse(ex, future, record.topic)
         }
@@ -40,15 +42,56 @@ class MessageBusClient(
         future: CompletableFuture<Unit>,
         topic: String
     ) {
-        if (exception == null) {
-            future.complete(Unit)
-        } else {
-            val message = "Producer clientId $id for topic $topic failed to send."
-            log.warn(message, exception)
-            future.completeExceptionally(CordaMessageAPIFatalException(message, exception))
+        val message = "Producer clientId $id for topic $topic failed to send."
+        when (exception) {
+            null -> future.complete(Unit)
+            is CordaMessageAPIProducerRequiresReset -> {
+                logErrorAndSetFuture("$message Resetting producer.", exception, future, false)
+                resetProducer()
+            }
+            else -> logErrorAndSetFuture(message, exception, future, true)
         }
     }
 
+    /**
+     * Log the [message] and [exception] and set the [future] with the appropriate exception.
+     */
+    private fun logErrorAndSetFuture(
+        message: String,
+        exception: Exception,
+        future: CompletableFuture<Unit>,
+        fatal: Boolean
+    ) {
+        if (fatal) {
+            log.error(message, exception)
+        } else {
+            log.warn(message, exception)
+        }
+
+        future.completeExceptionally(
+            if (fatal) CordaMessageAPIFatalException(message, exception)
+            else CordaMessageAPIProducerRequiresReset(message, exception)
+        )
+    }
+
+    /**
+     * Reset the producer by closing the current producer and creating a new one.
+     */
+    private fun resetProducer() {
+        try {
+            producer.close()
+        } catch (ex: Exception) {
+            log.warn(
+                "Failed to close message bus messaging client [$id] safely.", ex
+            )
+        }
+
+        producer = createProducer()
+    }
+
+    /**
+     * Close the producer
+     */
     override fun close() {
         try {
             producer.close()

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessageBusClientFactory.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/mediator/factory/MessageBusClientFactory.kt
@@ -37,15 +37,12 @@ class MessageBusClientFactory(
             throwOnSerializationError = false
         )
 
-        val eventProducer = cordaProducerBuilder.createProducer(
-            eventProducerConfig,
-            messageBusConfig,
-            config.onSerializationError
-        )
-
-        return MessageBusClient(
-            id,
-            eventProducer,
-        )
+        return MessageBusClient(id) {
+            cordaProducerBuilder.createProducer(
+                eventProducerConfig,
+                messageBusConfig,
+                config.onSerializationError
+            )
+        }
     }
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
@@ -247,6 +247,7 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
             val record = CordaProducerRecord(config.topic, correlationId, request)
             futureTracker.addFuture(correlationId, future, partition)
             try {
+                // CordaMessageAPIProducerRequiresReset could be thrown here
                 producer?.sendRecords(listOf(record))
             } catch (ex: Exception) {
                 future.completeExceptionally(CordaRPCAPISenderException("Failed to publish", ex))

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/publisher/CordaRPCSenderImpl.kt
@@ -22,6 +22,7 @@ import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messagebus.api.producer.builder.CordaProducerBuilder
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
+import net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset
 import net.corda.messaging.api.exception.CordaRPCAPIResponderException
 import net.corda.messaging.api.exception.CordaRPCAPISenderException
 import net.corda.messaging.api.publisher.RPCSender
@@ -93,8 +94,8 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
             attempts++
             try {
                 log.debug { "Creating rpc response consumer. Attempt: $attempts" }
-                val producerConfig = ProducerConfig(config.clientId, config.instanceId, false, ProducerRoles.RPC_SENDER)
-                producer = cordaProducerBuilder.createProducer(producerConfig, config.messageBusConfig)
+
+                resetProducer()
 
                 val consumerConfig = ConsumerConfig(config.group, config.clientId, ConsumerRoles.RPC_SENDER)
                 cordaConsumerBuilder.createConsumer(
@@ -247,14 +248,50 @@ internal class CordaRPCSenderImpl<REQUEST : Any, RESPONSE : Any>(
             val record = CordaProducerRecord(config.topic, correlationId, request)
             futureTracker.addFuture(correlationId, future, partition)
             try {
-                // CordaMessageAPIProducerRequiresReset could be thrown here
                 producer?.sendRecords(listOf(record))
             } catch (ex: Exception) {
-                future.completeExceptionally(CordaRPCAPISenderException("Failed to publish", ex))
-                log.warn("Failed to publish. Exception: ${ex.message}", ex)
+                val message = "Failed to send request $correlationId."
+
+                when (ex) {
+                    is CordaMessageAPIProducerRequiresReset -> {
+                        logErrorAndSetFuture("$message Resetting producer.", ex, future)
+                        resetProducer()
+                    }
+                    else -> {
+                        logErrorAndSetFuture(message, ex, future)
+                    }
+                }
             }
         }
 
         return future
+    }
+
+    /**
+     * Log the [message] and [exception] and set the [future] with the appropriate exception.
+     */
+    private fun logErrorAndSetFuture(
+        message: String,
+        exception: Exception,
+        future: CompletableFuture<RESPONSE>,
+    ) {
+        log.warn(message, exception)
+        future.completeExceptionally(CordaRPCAPISenderException(message, exception))
+    }
+
+    /**
+     * Reset the producer by closing the current producer, if it exists, and creating a new one.
+     */
+    private fun resetProducer() {
+        try {
+            producer?.close()
+        } catch (ex: Exception) {
+            log.warn("Failed to close producer safely.", ex)
+        }
+
+        producer = cordaProducerBuilder.createProducer(
+            ProducerConfig(config.clientId, config.instanceId, false, ProducerRoles.RPC_SENDER),
+            config.messageBusConfig
+        )
     }
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
@@ -1,6 +1,5 @@
 package net.corda.messaging.subscription
 
-import java.util.UUID
 import net.corda.lifecycle.LifecycleCoordinatorFactory
 import net.corda.lifecycle.LifecycleCoordinatorName
 import net.corda.lifecycle.LifecycleStatus
@@ -31,6 +30,7 @@ import net.corda.metrics.CordaMetrics
 import net.corda.schema.Schemas.getDLQTopic
 import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
+import java.util.UUID
 
 /**
  * Implementation of an EventLogSubscription.
@@ -167,6 +167,7 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
                 processDurableRecords(consumer.poll(config.pollTimeout), producer, consumer)
                 attempts = 0
             } catch (ex: Exception) {
+                // CordaMessageAPIProducerRequiresReset could be thrown here
                 when (ex) {
                     is CordaMessageAPIFatalException -> {
                         throw ex

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/EventLogSubscriptionImpl.kt
@@ -16,6 +16,7 @@ import net.corda.messagebus.api.producer.CordaProducerRecord
 import net.corda.messagebus.api.producer.builder.CordaProducerBuilder
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
+import net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset
 import net.corda.messaging.api.processor.EventLogProcessor
 import net.corda.messaging.api.subscription.Subscription
 import net.corda.messaging.api.subscription.listener.PartitionAssignmentListener
@@ -74,6 +75,9 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
         .withTag(CordaMetrics.Tag.OperationName, MetricsConstants.ON_NEXT_OPERATION)
         .build()
 
+    private lateinit var cordaProducer: CordaProducer
+    private lateinit var cordaConsumer: CordaConsumer<K, V>
+
     override val isRunning: Boolean
         get() = threadLooper.isRunning
 
@@ -99,36 +103,14 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
             attempts++
             try {
                 log.debug { "Attempt: $attempts" }
-                deadLetterRecords = mutableListOf()
-                val rebalanceListener = if (partitionAssignmentListener == null) {
-                    LoggingConsumerRebalanceListener(config.clientId)
-                } else {
-                    ForwardingRebalanceListener(config.topic, config.clientId, partitionAssignmentListener)
-                }
-                val consumerConfig = ConsumerConfig(config.group, config.clientId, ConsumerRoles.EVENT_LOG)
 
-                cordaConsumerBuilder.createConsumer(
-                    consumerConfig,
-                    config.messageBusConfig,
-                    processor.keyClass,
-                    processor.valueClass,
-                    { data ->
-                        log.error("Failed to deserialize record from ${config.topic}")
-                        deadLetterRecords.add(data)
-                    },
-                    rebalanceListener
-                ).use { cordaConsumer ->
-                    cordaConsumer.subscribe(config.topic)
-                    val producerConfig =
-                        ProducerConfig(config.clientId, config.instanceId, true, ProducerRoles.EVENT_LOG, false)
-                    cordaProducerBuilder.createProducer(producerConfig, config.messageBusConfig) { data ->
-                        log.warn("Failed to serialize record from ${config.topic}")
-                        deadLetterRecords.add(data)
-                    }.use { cordaProducer ->
-                        threadLooper.updateLifecycleStatus(LifecycleStatus.UP)
-                        pollAndProcessRecords(cordaConsumer, cordaProducer)
-                    }
-                }
+                createProducer()
+                createConsumer()
+
+                cordaConsumer.subscribe(config.topic)
+
+                threadLooper.updateLifecycleStatus(LifecycleStatus.UP)
+                pollAndProcessRecords(cordaConsumer, cordaProducer)
 
                 attempts = 0
             } catch (ex: Exception) {
@@ -167,10 +149,14 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
                 processDurableRecords(consumer.poll(config.pollTimeout), producer, consumer)
                 attempts = 0
             } catch (ex: Exception) {
-                // CordaMessageAPIProducerRequiresReset could be thrown here
                 when (ex) {
                     is CordaMessageAPIFatalException -> {
                         throw ex
+                    }
+                    is CordaMessageAPIProducerRequiresReset -> {
+                        resetProducer()
+                        attempts++
+                        handlePollAndProcessIntermittentError(attempts, consumer, ex)
                     }
                     is CordaMessageAPIIntermittentException -> {
                         attempts++
@@ -264,5 +250,61 @@ internal class EventLogSubscriptionImpl<K : Any, V : Any>(
                 }
             }
         }
+    }
+
+    /**
+     * Create a producer with the given [config].
+     */
+    private fun createProducer() {
+        val producerConfig = ProducerConfig(
+            clientId=config.clientId,
+            instanceId=config.instanceId,
+            transactional=true,
+            role=ProducerRoles.EVENT_LOG,
+            throwOnSerializationError=false
+        )
+
+        cordaProducer = cordaProducerBuilder.createProducer(producerConfig, config.messageBusConfig) { data ->
+            log.warn("Failed to serialize record from ${config.topic}")
+            deadLetterRecords.add(data)
+        }
+    }
+
+    /**
+     * Create a consumer with the given [config] and [partitionAssignmentListener].
+     */
+    private fun createConsumer() {
+        deadLetterRecords = mutableListOf()
+        val rebalanceListener = if (partitionAssignmentListener == null) {
+            LoggingConsumerRebalanceListener(config.clientId)
+        } else {
+            ForwardingRebalanceListener(config.topic, config.clientId, partitionAssignmentListener)
+        }
+
+        val consumerConfig = ConsumerConfig(config.group, config.clientId, ConsumerRoles.EVENT_LOG)
+        cordaConsumer = cordaConsumerBuilder.createConsumer(
+            consumerConfig,
+            config.messageBusConfig,
+            processor.keyClass,
+            processor.valueClass,
+            { data ->
+                log.error("Failed to deserialize record from ${config.topic}")
+                deadLetterRecords.add(data)
+            },
+            rebalanceListener
+        )
+    }
+
+    /**
+     * Reset the producer by closing the current producer, and creating a new one.
+     */
+    private fun resetProducer() {
+        try {
+            cordaProducer.close()
+        } catch (ex: Exception) {
+            log.warn("Failed to close producer safely.", ex)
+        }
+
+        createProducer()
     }
 }

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
@@ -126,7 +126,6 @@ internal class RPCSubscriptionImpl<REQUEST : Any, RESPONSE : Any>(
             try {
                 processRecords(consumerRecords, producer)
             } catch (ex: Exception) {
-                // CordaMessageAPIProducerRequiresReset could be thrown here
                 when (ex::class.java) {
                     in ExceptionUtils.CordaMessageAPIException -> {
                         throw ex

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/RPCSubscriptionImpl.kt
@@ -1,8 +1,5 @@
 package net.corda.messaging.subscription
 
-import java.nio.ByteBuffer
-import java.time.Instant
-import java.util.concurrent.CompletableFuture
 import net.corda.avro.serialization.CordaAvroDeserializer
 import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.ExceptionEnvelope
@@ -32,6 +29,9 @@ import net.corda.messaging.utils.ExceptionUtils
 import net.corda.metrics.CordaMetrics
 import net.corda.utilities.debug
 import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
 
 /**
  * RPC subscription implementation utilizing a message bus with producer and consumer to achieve asynchronous
@@ -126,6 +126,7 @@ internal class RPCSubscriptionImpl<REQUEST : Any, RESPONSE : Any>(
             try {
                 processRecords(consumerRecords, producer)
             } catch (ex: Exception) {
+                // CordaMessageAPIProducerRequiresReset could be thrown here
                 when (ex::class.java) {
                     in ExceptionUtils.CordaMessageAPIException -> {
                         throw ex

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -247,7 +247,6 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
             return true
         }
 
-        // CordaMessageAPIProducerRequiresReset could be thrown here
         commitTimer.recordCallable {
             producer.beginTransaction()
             producer.sendRecords(outputRecords.toCordaProducerRecords())

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/StateAndEventSubscriptionImpl.kt
@@ -247,6 +247,7 @@ internal class StateAndEventSubscriptionImpl<K : Any, S : Any, E : Any>(
             return true
         }
 
+        // CordaMessageAPIProducerRequiresReset could be thrown here
         commitTimer.recordCallable {
             producer.beginTransaction()
             producer.sendRecords(outputRecords.toCordaProducerRecords())

--- a/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/RPCSubscriptionImplTest.kt
+++ b/libs/messaging/messaging-impl/src/test/kotlin/net/corda/messaging/subscription/RPCSubscriptionImplTest.kt
@@ -360,6 +360,7 @@ class RPCSubscriptionImplTest {
         waitWhile(Duration.ofSeconds(TEST_TIMEOUT_SECONDS)) { subscription.isRunning }
 
         verify(kafkaConsumer, times(2)).subscribe(config.topic)
+        verify(cordaProducerBuilder, times(2)).createProducer(any(), any(), anyOrNull())
         assertThat(processor.incomingRecords.size).isEqualTo(1)
         assertFalse(firstTime)
 


### PR DESCRIPTION
We define an exception, `CordaMessageAPIProducerRequiresReset`, which signals that our producer should be reset/recreated before we continue. Unfortunately, this exception is not being correctly caught and handled correctly in all cases, resulting in FATAL exceptions which bounce pods unnecessarily.

The `CordaProducer` in question is used in the following places:

#### 1. `CordaKafkaProducerImpl`
This class correctly handles these exceptions and resets its producer internally.

#### 2. `MessageBusClient`
Added handling to reset the producer. Originally, the producer was created in the `MessageBusClient` factory; in order for the client itself to recreate the producer when necessary, we delegate the creation as so:
```
Before:
class MessageBusClient(
    override val id: String,
    private val producer: CordaProducer
)

After:
class MessageBusClient(
    override val id: String,
    private val createProducer: () -> CordaProducer,
)
```
and the factory now creates the client as below:
```
return MessageBusClient(id) {
    cordaProducerBuilder.createProducer(
        eventProducerConfig,
        messageBusConfig,
        config.onSerializationError
    )
}
```
Unit tests have been added to verify the producer is correctly recreated as required.

#### 3. `CordaRPCSenderImpl`
Extended exception handling to recreate the producer on a `CordaMessageAPIProducerRequiresReset`.

#### 4. `EventLogSubscriptionImpl`
This producer is already recreated on all intermittent exceptions, with lifecycle managed via a `use` block. Modified unit tests to verify the recreation behaviour.

#### 5. `RPCSubscriptionImpl`
This producer is already recreated on all intermittent exceptions, with lifecycle managed via a `use` block. Modified unit tests to verify the recreation behaviour.

#### 6. `StateAndEventSubscriptionImpl`
The producer is reset on all intermittent exceptions, which captures the `CordaMessageAPIProducerRequiresReset` which subclasses the `CordaMessageAPIIntermittentException`. I've added unit tests which verify this behaviour.
