### PR TITLE
CORE-20797 Adding CordaMessageAPIProducerRequiresReset exception to ExceptionUtils

### DIFF
--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/ExceptionUtils.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/utils/ExceptionUtils.kt
@@ -2,10 +2,12 @@ package net.corda.messaging.utils
 
 import net.corda.messaging.api.exception.CordaMessageAPIFatalException
 import net.corda.messaging.api.exception.CordaMessageAPIIntermittentException
+import net.corda.messaging.api.exception.CordaMessageAPIProducerRequiresReset
 
 object ExceptionUtils {
     val CordaMessageAPIException: Set<Class<out Throwable>> = setOf(
         CordaMessageAPIFatalException::class.java,
-        CordaMessageAPIIntermittentException::class.java
+        CordaMessageAPIIntermittentException::class.java,
+        CordaMessageAPIProducerRequiresReset::class.java
     )
 }


### PR DESCRIPTION
Small fix to ensure exception clauses like the below successfully pick up `CordaMessageAPIProducerRequiresReset` exceptions and re-raise them:

```
when (ex::class.java) {
    in ExceptionUtils.CordaMessageAPIException -> {
        throw ex
    }
    [...]
}
```