### PR TITLE
ES-2511: Fix flaky corda-runtime-gradle-plugin tests

### DIFF
--- a/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/CombinedWorkerHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/CombinedWorkerHelper.kt
@@ -11,9 +11,10 @@ import java.util.concurrent.TimeUnit
 val targetUrl = URI("https://localhost:8888")
 const val USER = "admin"
 const val PASSWORD = "admin"
-const val CORDA_RUNTIME_VERSION_STABLE = "5.3.0.0-HC01"
+const val CORDA_RUNTIME_VERSION_GRADLE_BETA = "^5.3.0-beta"
+const val CORDA_IMAGE_TAG_BETA = "unstable-5.3.0"
 // Get preTest image tag from the pipeline, or fallback to stable version
-val testEnvCordaImageTag = System.getenv("CORDA_IMAGE_TAG") ?: CORDA_RUNTIME_VERSION_STABLE
+val testEnvCordaImageTag = System.getenv("CORDA_IMAGE_TAG") ?: CORDA_IMAGE_TAG_BETA
 
 
 object CombinedWorkerHelper {

--- a/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/CombinedWorkerHelper.kt
+++ b/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/CombinedWorkerHelper.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 val targetUrl = URI("https://localhost:8888")
 const val USER = "admin"
 const val PASSWORD = "admin"
-const val CORDA_RUNTIME_VERSION_GRADLE_BETA = "^5.3.0-beta"
+const val CORDA_NOTARY_VERSION_STABLE = "5.3.0.0-HC01"
 const val CORDA_IMAGE_TAG_BETA = "unstable-5.3.0"
 // Get preTest image tag from the pipeline, or fallback to stable version
 val testEnvCordaImageTag = System.getenv("CORDA_IMAGE_TAG") ?: CORDA_IMAGE_TAG_BETA

--- a/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/GradleProperties.kt
+++ b/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/GradleProperties.kt
@@ -14,7 +14,7 @@ data class GradleProperties(
     val cordaClusterURL: String = "$targetUrl",
     val cordaRestUser: String = USER,
     val cordaRestPasswd: String = PASSWORD,
-    val notaryVersion: String = CORDA_RUNTIME_VERSION_GRADLE_BETA,
+    val notaryVersion: String = CORDA_NOTARY_VERSION_STABLE,
     val runtimeVersion: String = testEnvCordaImageTag, // Start/stop tasks should use preTest images or latest beta for scheduled runs
     val composeFilePath: String = "config/combined-worker-compose.yml",
     val networkConfigFile: String,

--- a/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/GradleProperties.kt
+++ b/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/GradleProperties.kt
@@ -14,8 +14,8 @@ data class GradleProperties(
     val cordaClusterURL: String = "$targetUrl",
     val cordaRestUser: String = USER,
     val cordaRestPasswd: String = PASSWORD,
-    val notaryVersion: String = CORDA_RUNTIME_VERSION_STABLE,
-    val runtimeVersion: String = testEnvCordaImageTag, // Start/stop tasks should use preTest images
+    val notaryVersion: String = CORDA_RUNTIME_VERSION_GRADLE_BETA,
+    val runtimeVersion: String = testEnvCordaImageTag, // Start/stop tasks should use preTest images or latest beta for scheduled runs
     val composeFilePath: String = "config/combined-worker-compose.yml",
     val networkConfigFile: String,
 ) {

--- a/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/network/SetupNetworkJourneyTest.kt
+++ b/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/network/SetupNetworkJourneyTest.kt
@@ -10,7 +10,6 @@ import net.corda.restclient.generated.models.RestRegistrationRequestStatus.Regis
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 
 class SetupNetworkJourneyTest : SmokeTestBase() {
@@ -57,7 +56,7 @@ class SetupNetworkJourneyTest : SmokeTestBase() {
         verifyRedeployNetwork(staticCpiNames, isStaticNetwork = true, myCorDappCpiChecksum)
     }
 
-    @RepeatedTest(20)
+    @Test
     fun setupDynamicNetworkVerifyVNodesAndCPIsThenRedeploy() {
         // Create a static network
         val vNodeSetupResult = executeWithRunner(

--- a/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/network/SetupNetworkJourneyTest.kt
+++ b/tools/corda-runtime-gradle-plugin/src/smokeTest/kotlin/net/corda/gradle/plugin/network/SetupNetworkJourneyTest.kt
@@ -10,6 +10,7 @@ import net.corda.restclient.generated.models.RestRegistrationRequestStatus.Regis
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 
 class SetupNetworkJourneyTest : SmokeTestBase() {
@@ -56,7 +57,7 @@ class SetupNetworkJourneyTest : SmokeTestBase() {
         verifyRedeployNetwork(staticCpiNames, isStaticNetwork = true, myCorDappCpiChecksum)
     }
 
-    @Test
+    @RepeatedTest(20)
     fun setupDynamicNetworkVerifyVNodesAndCPIsThenRedeploy() {
         // Create a static network
         val vNodeSetupResult = executeWithRunner(


### PR DESCRIPTION
### [ES-2511](https://r3-cev.atlassian.net/browse/ES-2511)

To mitigate the flakiness, this PR updates the test setup to use the latest 5.3 beta image for the Combined Worker instead of the version `5.3.0.0-HC01` used previously for the scheduled (nightly) runs. 


[ES-2511]: https://r3-cev.atlassian.net/browse/ES-2511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ