### PR TITLE
CORE-20886 stop the registry from being updated when a coordinator is in status ERROR

### DIFF
--- a/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceTest.kt
+++ b/components/membership/membership-service-impl/src/test/kotlin/net/corda/membership/service/impl/MemberOpsServiceTest.kt
@@ -178,20 +178,6 @@ class MemberOpsServiceTest {
         }
     }
 
-    @Test
-    fun `component goes DOWN and comes back UP if subscription has error state and comes back`() {
-        getMemberOpsServiceTestContext().run {
-            testClass.start()
-            bringDependenciesUp()
-            sendConfigUpdate<MemberOpsService>(configs)
-
-            setDependencyToError(rpcSubName)
-            verifyIsDown<MemberOpsService>()
-            bringDependencyUp(rpcSubName)
-            verifyIsUp<MemberOpsService>()
-        }
-    }
-
     private fun getMemberOpsServiceTestContext(): LifecycleTest<MemberOpsService> {
         return LifecycleTest {
             addDependency(asyncRetrySubName)

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImplTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleCoordinatorImplTest.kt
@@ -1052,7 +1052,7 @@ internal class LifecycleCoordinatorImplTest {
 
     @Test
     @Suppress("TooGenericExceptionThrown")
-    fun `when a coordinator stops with an error the status is set to error`() {
+    fun `when a coordinator stops with an error the status is set to error and stays in error when start is called`() {
         var startLatch = CountDownLatch(1)
         val stopLatch = CountDownLatch(1)
         createCoordinator { event, _ ->
@@ -1074,11 +1074,11 @@ internal class LifecycleCoordinatorImplTest {
             assertTrue(stopLatch.await(TIMEOUT, TimeUnit.MILLISECONDS))
             assertEquals(LifecycleStatus.ERROR, it.status)
 
-            // Restart and prove that the status is set to DOWN.
+            // Restart and prove that the status stays in ERROR.
             startLatch = CountDownLatch(1)
             it.start()
             assertTrue(startLatch.await(TIMEOUT, TimeUnit.MILLISECONDS))
-            assertEquals(LifecycleStatus.DOWN, it.status)
+            assertEquals(LifecycleStatus.ERROR, it.status)
         }
     }
 

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleProcessorTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/LifecycleProcessorTest.kt
@@ -519,7 +519,7 @@ class LifecycleProcessorTest {
     }
 
     @Test
-    fun `starting from an errored state causes the status to be set back to down`() {
+    fun `starting from an errored state leaves the status in ERROR`() {
         val state = LifecycleStateManager(5)
         var processedStartEvents = 0
         val registry = mock<LifecycleRegistryCoordinatorAccess>()
@@ -536,9 +536,7 @@ class LifecycleProcessorTest {
         state.registrations.add(registration)
         state.postEvent(StartEvent())
         process(processor, coordinator = coordinator)
-        assertEquals(LifecycleStatus.DOWN, state.status)
-        verify(registration).updateCoordinatorStatus(coordinator, LifecycleStatus.DOWN)
-        verify(registry).updateStatus(NAME, LifecycleStatus.DOWN, STARTED_REASON)
+        assertEquals(LifecycleStatus.ERROR, state.status)
     }
 
     @Test

--- a/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/registry/LifecycleRegistryImplTest.kt
+++ b/libs/lifecycle/lifecycle-impl/src/test/kotlin/net/corda/lifecycle/impl/registry/LifecycleRegistryImplTest.kt
@@ -141,4 +141,32 @@ class LifecycleRegistryImplTest {
             registry.getCoordinator(aliceName)
         }
     }
+
+    @Test
+    fun `status update is blocked when current status is ERROR`() {
+        val registry = LifecycleRegistryImpl()
+        registry.registerCoordinator(aliceName, mock())
+        registry.updateStatus(aliceName, LifecycleStatus.ERROR, "Simulated error")
+
+        // Try updating from ERROR to UP
+        registry.updateStatus(aliceName, LifecycleStatus.UP, "Alice is up")
+
+        // Verify that the status remains ERROR
+        val statuses = registry.componentStatus()
+        assertEquals(CoordinatorStatus(aliceName, LifecycleStatus.ERROR, "Simulated error"), statuses[aliceName])
+    }
+
+    @Test
+    fun `removing a coordinator with ERROR status is blocked`() {
+        val registry = LifecycleRegistryImpl()
+        registry.registerCoordinator(aliceName, mock())
+        registry.updateStatus(aliceName, LifecycleStatus.ERROR, "Simulated error")
+
+        // Try removing the coordinator
+        registry.removeCoordinator(aliceName)
+
+        // Verify that the coordinator is still present
+        assertEquals(1, registry.componentStatus().size)
+        assertEquals(CoordinatorStatus(aliceName, LifecycleStatus.ERROR, "Simulated error"), registry.componentStatus()[aliceName])
+    }
 }


### PR DESCRIPTION
Numerous fixes were added to the 5.2 branch to stop Lifecyle coordinators from traversing from ERROR to UP/DOWN, however 2 use cases were missed. The lifecycle registry is the source of truth about the health of a worker and is inspected directly when the /status and /health REST endpoints are called. It is essential these report correctly when called by the k8s liveness probe to allow for unhealthy workers to be restarted.

1.) when a stop a event is received, the registry is directly updated from within the Lifecyle processor with a new status. This is eagerly blocked here when the current status is ERROR. Separately, within the registry itself any status update from ERROR is also blocked as a last resort.

2.) when a close event is received, the coordinator is removed from the registry. This could mask a worker in ERROR state by removing it from the registry. This is also blocked at the registry level.

3.) Additionally, calling start() on a coordinator in ERROR state would reset it to DOWN. This is also blocked eagerly at the LifeCycleProccessor Level.