### PR TITLE
CORE-20892: use a unique producer transactional id when creating producers

### DIFF
--- a/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolver.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/main/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolver.kt
@@ -16,6 +16,7 @@ import org.apache.kafka.clients.producer.ProducerConfig.PARTITIONER_CLASS_CONFIG
 import org.osgi.framework.FrameworkUtil
 import org.slf4j.LoggerFactory
 import java.util.Properties
+import java.util.UUID
 
 /**
  * Resolve a Kafka bus configuration against the enforced and default configurations provided by the library.
@@ -175,7 +176,7 @@ internal class MessageBusConfigResolver(private val smartConfigFactory: SmartCon
 
     private fun ProducerConfig.toSmartConfig(): SmartConfig {
         val transactionalId = if (transactional) {
-            "$clientId-$instanceId"
+            "$clientId-$instanceId-${UUID.randomUUID()}"
         } else {
             null
         }

--- a/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
+++ b/libs/messaging/kafka-message-bus-impl/src/test/kotlin/net/corda/messagebus/kafka/config/MessageBusConfigResolverTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.Properties
 import java.util.stream.Stream
+import kotlin.test.assertTrue
 
 class MessageBusConfigResolverTest {
 
@@ -314,7 +315,7 @@ class MessageBusConfigResolverTest {
 
     private fun assertProducerProperties(expected: Properties, actual: Properties) {
         assertEquals(expected[CLIENT_ID_PROP], actual[CLIENT_ID_PROP])
-        assertEquals(expected[TRANSACTIONAL_ID_PROP], actual[TRANSACTIONAL_ID_PROP])
+        assertTrue(actual[TRANSACTIONAL_ID_PROP].toString().contains(expected[TRANSACTIONAL_ID_PROP].toString()))
         assertEquals(expected[ACKS_PROP], actual[ACKS_PROP])
         assertEquals(expected[BOOTSTRAP_SERVERS_PROP], actual[BOOTSTRAP_SERVERS_PROP])
         assertEquals(expected[SSL_KEYSTORE_PROP], actual[SSL_KEYSTORE_PROP])

--- a/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
+++ b/libs/messaging/messaging-impl/src/main/kotlin/net/corda/messaging/subscription/consumer/StateAndEventConsumerImpl.kt
@@ -221,7 +221,7 @@ internal class StateAndEventConsumerImpl<K : Any, S : Any, E : Any>(
         return when {
             inSyncPartitions.isNotEmpty() -> {
                 eventConsumer.poll(EVENT_POLL_TIMEOUT).also {
-                    log.debug { "Received ${it.size} events on keys ${it.joinToString { it.key.toString() }}" }
+                    log.trace { "Received ${it.size} events on keys ${it.joinToString { it.key.toString() }}" }
                 }
             }
             partitionsToSync.isEmpty() -> {


### PR DESCRIPTION
 This ensures  producers recreated will not overlap with older producers that have transactions timed out on the kafka broker. The brokers keep track of in flight transaction. Sometimes they can become stuck in an unhealthy state. When the producer is recreated, if it uses the same transaction.id config value for the client, the broker will expect the producer complete the previous transaction