### PR TITLE
CORE-20907: stop external message api from sending messages that are too large

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
@@ -22,7 +22,6 @@ class ExternalMessagingImpl(
     cordaAvroSerializationFactory: CordaAvroSerializationFactory
 ) : ExternalMessaging, UsedByFlow, SingletonSerializeAsToken {
 
-    private val maxAllowedMessageSize: Long = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.maxMessageSize
     private val serializer = cordaAvroSerializationFactory.createAvroSerializer<Any>()
 
     @Activate
@@ -41,6 +40,7 @@ class ExternalMessagingImpl(
 
     private fun validateSize(message: String) {
         val bytesSize = serializer.serialize(message)
+        val maxAllowedMessageSize = maxMessageSize()
         if (bytesSize != null && maxAllowedMessageSize < bytesSize.size) {
             throw CordaRuntimeException(
                 "Cannot send external messaging content as " +
@@ -57,5 +57,7 @@ class ExternalMessagingImpl(
             .getExecutingFiber()
             .suspend(FlowIORequest.SendExternalMessage(channelName, messageId, message))
     }
+
+    private fun maxMessageSize() = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.maxMessageSize
 }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
@@ -1,10 +1,12 @@
 package net.corda.flow.application.messaging
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.messaging.ExternalMessaging
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -16,17 +18,28 @@ import java.util.UUID
 @Component(service = [ExternalMessaging::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE)
 class ExternalMessagingImpl(
     private val flowFiberService: FlowFiberService,
-    private val idFactoryFunc: () -> String
+    private val idFactoryFunc: () -> String,
+    cordaAvroSerializationFactory: CordaAvroSerializationFactory
 ) : ExternalMessaging, UsedByFlow, SingletonSerializeAsToken {
+
+    private val maxAllowedMessageSize: Long = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.maxMessageSize
+    private val serializer = cordaAvroSerializationFactory.createAvroSerializer<Any>()
 
     @Activate
     constructor(
         @Reference(service = FlowFiberService::class)
-        flowFiberService: FlowFiberService
-    ) : this(flowFiberService, { UUID.randomUUID().toString() })
+        flowFiberService: FlowFiberService,
+        @Reference(service = CordaAvroSerializationFactory::class)
+        cordaAvroSerializationFactory: CordaAvroSerializationFactory
+    ) : this(flowFiberService, { UUID.randomUUID().toString() }, cordaAvroSerializationFactory)
 
     @Suspendable
     override fun send(channelName: String, message: String) {
+        val bytesSize = serializer.serialize(message)
+        if (bytesSize != null && maxAllowedMessageSize < bytesSize.size) {
+            throw CordaRuntimeException("Cannot send external messaging content as " +
+                    "it exceeds the max message size allowed. Message Size: [${bytesSize.size}], Max Size: [$maxAllowedMessageSize}]")
+        }
         send(channelName, idFactoryFunc(), message)
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
@@ -39,12 +39,12 @@ class ExternalMessagingImpl(
     }
 
     private fun validateSize(message: String) {
-        val bytesSize = serializer.serialize(message)
+        val bytesSize = serializer.serialize(message)?.size
         val maxAllowedMessageSize = maxMessageSize()
-        if (bytesSize != null && maxAllowedMessageSize < bytesSize.size) {
+        if (bytesSize != null && maxAllowedMessageSize < bytesSize) {
             throw CordaRuntimeException(
                 "Cannot send external messaging content as " +
-                        "it exceeds the max message size allowed. Message Size: [${bytesSize.size}], Max Size: [$maxAllowedMessageSize}]"
+                        "it exceeds the max message size allowed. Message Size: [$bytesSize], Max Size: [$maxAllowedMessageSize}]"
             )
         }
     }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
@@ -35,16 +35,24 @@ class ExternalMessagingImpl(
 
     @Suspendable
     override fun send(channelName: String, message: String) {
+        validateSize(message)
+        send(channelName, idFactoryFunc(), message)
+    }
+
+    private fun validateSize(message: String) {
         val bytesSize = serializer.serialize(message)
         if (bytesSize != null && maxAllowedMessageSize < bytesSize.size) {
-            throw CordaRuntimeException("Cannot send external messaging content as " +
-                    "it exceeds the max message size allowed. Message Size: [${bytesSize.size}], Max Size: [$maxAllowedMessageSize}]")
+            throw CordaRuntimeException(
+                "Cannot send external messaging content as " +
+                        "it exceeds the max message size allowed. Message Size: [${bytesSize.size}], Max Size: [$maxAllowedMessageSize}]"
+            )
         }
-        send(channelName, idFactoryFunc(), message)
     }
 
     @Suspendable
     override fun send(channelName: String, messageId: String, message: String) {
+        validateSize(message)
+
         flowFiberService
             .getExecutingFiber()
             .suspend(FlowIORequest.SendExternalMessage(channelName, messageId, message))

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/ExternalMessagingImplTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/messaging/ExternalMessagingImplTest.kt
@@ -1,15 +1,33 @@
 package net.corda.flow.messaging
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.flow.application.messaging.ExternalMessagingImpl
 import net.corda.flow.application.services.MockFlowFiberService
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.v5.base.exceptions.CordaRuntimeException
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class ExternalMessagingImplTest {
 
     private val flowFiberService = MockFlowFiberService()
-    private val target = ExternalMessagingImpl(flowFiberService) { "random_id" }
+    private val mockSerializationFactory = mock<CordaAvroSerializationFactory>()
+    private val mockSerializer = mock<CordaAvroSerializer<Any>>()
+    private lateinit var target: ExternalMessagingImpl
+
+    @BeforeEach
+    fun setup() {
+        whenever(mockSerializationFactory.createAvroSerializer<Any>()).thenReturn(mockSerializer)
+        whenever(mockSerializer.serialize(anyOrNull())).thenReturn(byteArrayOf(1, 2, 3))
+        whenever(flowFiberService.flowCheckpoint.maxMessageSize).thenReturn(100000)
+        target = ExternalMessagingImpl(flowFiberService, { "random_id" }, mockSerializationFactory)
+    }
 
     @Test
     fun `send channel and message issues IO request`() {
@@ -21,6 +39,14 @@ class ExternalMessagingImplTest {
             "msg1"
         )
         verify(flowFiberService.flowFiber).suspend(expectedIoRequest)
+    }
+
+    @Test
+    fun `send payload exceeds max message size`() {
+        whenever(flowFiberService.flowCheckpoint.maxMessageSize).thenReturn(1)
+        target = ExternalMessagingImpl(flowFiberService, { "random_id" }, mockSerializationFactory)
+
+        assertThrows<CordaRuntimeException> {  target.send("ch1", "msg1") }
     }
 
     @Test


### PR DESCRIPTION
API: https://github.com/corda/corda-api/pull/1714

Currently there is no validation to stop the user from sending a message which exceeds the max allowed message size. It has been observed that this will cause a fatal exception in the mediator message pattern. Subsequently the flow partition with the affected flow will become blocked and unable to progress.