### PR TITLE
CORE-20909 validate flow result cannot exceed max message size

### DIFF
--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
@@ -1,12 +1,10 @@
 package net.corda.flow.application.messaging
 
-import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.messaging.ExternalMessaging
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -18,28 +16,17 @@ import java.util.UUID
 @Component(service = [ExternalMessaging::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE)
 class ExternalMessagingImpl(
     private val flowFiberService: FlowFiberService,
-    private val idFactoryFunc: () -> String,
-    cordaAvroSerializationFactory: CordaAvroSerializationFactory
+    private val idFactoryFunc: () -> String
 ) : ExternalMessaging, UsedByFlow, SingletonSerializeAsToken {
-
-    private val maxAllowedMessageSize: Long = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.maxMessageSize
-    private val serializer = cordaAvroSerializationFactory.createAvroSerializer<Any>()
 
     @Activate
     constructor(
         @Reference(service = FlowFiberService::class)
-        flowFiberService: FlowFiberService,
-        @Reference(service = CordaAvroSerializationFactory::class)
-        cordaAvroSerializationFactory: CordaAvroSerializationFactory
-    ) : this(flowFiberService, { UUID.randomUUID().toString() }, cordaAvroSerializationFactory)
+        flowFiberService: FlowFiberService
+    ) : this(flowFiberService, { UUID.randomUUID().toString() })
 
     @Suspendable
     override fun send(channelName: String, message: String) {
-        val bytesSize = serializer.serialize(message)
-        if (bytesSize != null && maxAllowedMessageSize < bytesSize.size) {
-            throw CordaRuntimeException("Cannot send external messaging content as " +
-                    "it exceeds the max message size allowed. Message Size: [${bytesSize.size}], Max Size: [$maxAllowedMessageSize}]")
-        }
         send(channelName, idFactoryFunc(), message)
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/application/messaging/ExternalMessagingImpl.kt
@@ -1,10 +1,12 @@
 package net.corda.flow.application.messaging
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.flow.fiber.FlowFiberService
 import net.corda.flow.fiber.FlowIORequest
 import net.corda.sandbox.type.UsedByFlow
 import net.corda.v5.application.messaging.ExternalMessaging
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.serialization.SingletonSerializeAsToken
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
@@ -16,17 +18,28 @@ import java.util.UUID
 @Component(service = [ExternalMessaging::class, UsedByFlow::class], scope = ServiceScope.PROTOTYPE)
 class ExternalMessagingImpl(
     private val flowFiberService: FlowFiberService,
-    private val idFactoryFunc: () -> String
+    private val idFactoryFunc: () -> String,
+    cordaAvroSerializationFactory: CordaAvroSerializationFactory
 ) : ExternalMessaging, UsedByFlow, SingletonSerializeAsToken {
+
+    private val maxAllowedMessageSize: Long = flowFiberService.getExecutingFiber().getExecutionContext().flowCheckpoint.maxMessageSize
+    private val serializer = cordaAvroSerializationFactory.createAvroSerializer<Any>()
 
     @Activate
     constructor(
         @Reference(service = FlowFiberService::class)
-        flowFiberService: FlowFiberService
-    ) : this(flowFiberService, { UUID.randomUUID().toString() })
+        flowFiberService: FlowFiberService,
+        @Reference(service = CordaAvroSerializationFactory::class)
+        cordaAvroSerializationFactory: CordaAvroSerializationFactory
+    ) : this(flowFiberService, { UUID.randomUUID().toString() }, cordaAvroSerializationFactory)
 
     @Suspendable
     override fun send(channelName: String, message: String) {
+        val bytesSize = serializer.serialize(message)
+        if (bytesSize != null && maxAllowedMessageSize < bytesSize.size) {
+            throw CordaRuntimeException("Cannot send external messaging content as " +
+                    "it exceeds the max message size allowed. Message Size: [${bytesSize.size}], Max Size: [$maxAllowedMessageSize}]")
+        }
         send(channelName, idFactoryFunc(), message)
     }
 

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
@@ -1,12 +1,15 @@
 package net.corda.flow.pipeline.handlers.requests
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
 import net.corda.data.flow.state.waiting.WaitingFor
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.pipeline.addTerminationKeyToMeta
 import net.corda.flow.pipeline.events.FlowEventContext
+import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.flow.pipeline.factory.FlowMessageFactory
 import net.corda.flow.pipeline.factory.FlowRecordFactory
-import net.corda.flow.pipeline.addTerminationKeyToMeta
 import net.corda.flow.pipeline.handlers.requests.helper.getRecords
+import net.corda.flow.state.FlowCheckpoint
 import org.osgi.service.component.annotations.Activate
 import org.osgi.service.component.annotations.Component
 import org.osgi.service.component.annotations.Reference
@@ -18,7 +21,9 @@ class FlowFinishedRequestHandler @Activate constructor(
     @Reference(service = FlowMessageFactory::class)
     private val flowMessageFactory: FlowMessageFactory,
     @Reference(service = FlowRecordFactory::class)
-    private val flowRecordFactory: FlowRecordFactory
+    private val flowRecordFactory: FlowRecordFactory,
+    @Reference(service = CordaAvroSerializationFactory::class)
+    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory
 ) : FlowRequestHandler<FlowIORequest.FlowFinished> {
 
     private companion object {
@@ -26,6 +31,8 @@ class FlowFinishedRequestHandler @Activate constructor(
     }
 
     override val type = FlowIORequest.FlowFinished::class.java
+
+    private val serializer = cordaAvroSerializationFactory.createAvroSerializer<Any>()
 
     override fun getUpdatedWaitingFor(context: FlowEventContext<Any>, request: FlowIORequest.FlowFinished): WaitingFor? {
         return null
@@ -36,6 +43,7 @@ class FlowFinishedRequestHandler @Activate constructor(
         request: FlowIORequest.FlowFinished
     ): FlowEventContext<Any> {
         val checkpoint = context.checkpoint
+        validateResultSize(checkpoint, request)
 
         val status = flowMessageFactory.createFlowCompleteStatusMessage(checkpoint, request.result)
         val records = getRecords(flowRecordFactory, context, status)
@@ -46,5 +54,22 @@ class FlowFinishedRequestHandler @Activate constructor(
         context.flowMetrics.flowCompletedSuccessfully()
         val metaDataWithTermination = addTerminationKeyToMeta(context.metadata)
         return context.copy(outputRecords = context.outputRecords + records, metadata = metaDataWithTermination)
+    }
+
+    /**
+     * The flow status will contain the result string. Ensure it doesn't exceed the max message size allowed.
+     */
+    private fun validateResultSize(checkpoint: FlowCheckpoint, request: FlowIORequest.FlowFinished) {
+        val maxAllowedMessageSize = checkpoint.maxMessageSize
+        val result = request.result
+        if (result != null) {
+            val resultSize = serializer.serialize(result)?.size
+            if (resultSize != null && resultSize > maxAllowedMessageSize) {
+                throw FlowFatalException(
+                    "Flow attempted to return a result that is greater than the max message size allowed. Flow " +
+                            "result size [$resultSize]. Max Allowed Message Size [$maxAllowedMessageSize]"
+                )
+            }
+        }
     }
 }

--- a/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
+++ b/components/flow/flow-service/src/main/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandler.kt
@@ -23,7 +23,7 @@ class FlowFinishedRequestHandler @Activate constructor(
     @Reference(service = FlowRecordFactory::class)
     private val flowRecordFactory: FlowRecordFactory,
     @Reference(service = CordaAvroSerializationFactory::class)
-    private val cordaAvroSerializationFactory: CordaAvroSerializationFactory
+    cordaAvroSerializationFactory: CordaAvroSerializationFactory
 ) : FlowRequestHandler<FlowIORequest.FlowFinished> {
 
     private companion object {

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandlerTest.kt
@@ -1,5 +1,7 @@
 package net.corda.flow.pipeline.handlers.requests
 
+import net.corda.avro.serialization.CordaAvroSerializationFactory
+import net.corda.avro.serialization.CordaAvroSerializer
 import net.corda.data.flow.FlowKey
 import net.corda.data.flow.event.mapper.FlowMapperEvent
 import net.corda.data.flow.event.mapper.ScheduleCleanup
@@ -8,10 +10,15 @@ import net.corda.flow.BOB_X500_HOLDING_IDENTITY
 import net.corda.flow.RequestHandlerTestContext
 import net.corda.flow.SESSION_ID_1
 import net.corda.flow.fiber.FlowIORequest
+import net.corda.flow.pipeline.exceptions.FlowFatalException
 import net.corda.messaging.api.records.Record
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -22,15 +29,34 @@ class FlowFinishedRequestHandlerTest {
         val FLOW_KEY = FlowKey(SESSION_ID_1, BOB_X500_HOLDING_IDENTITY)
     }
 
-    private val testContext = RequestHandlerTestContext(Any())
     private val flowResult = "ok"
     private val ioRequest = FlowIORequest.FlowFinished(flowResult)
-    private val handler = FlowFinishedRequestHandler(testContext.flowMessageFactory, testContext.flowRecordFactory)
+    private val avroSerializationFactory = mock<CordaAvroSerializationFactory>()
+    private val serializer = mock<CordaAvroSerializer<Any>>()
+    private lateinit var testContext: RequestHandlerTestContext<Any>
+    private lateinit var handler: FlowFinishedRequestHandler
+
+    @BeforeEach
+    fun setup() {
+        whenever(serializer.serialize(any())).thenReturn(byteArrayOf(1, 2, 3))
+        whenever(avroSerializationFactory.createAvroSerializer<Any>(anyOrNull())).thenReturn(serializer)
+        testContext = RequestHandlerTestContext(Any())
+        whenever(testContext.flowCheckpoint.maxMessageSize).thenReturn(100000000)
+        handler = FlowFinishedRequestHandler(testContext.flowMessageFactory, testContext.flowRecordFactory, avroSerializationFactory)
+    }
 
     @Test
     fun `Updates the waiting for to nothing`() {
         val waitingFor = handler.getUpdatedWaitingFor(testContext.flowEventContext, ioRequest)
         assertThat(waitingFor?.value).isNull()
+    }
+
+    @Test
+    fun `Flow Result exceeds max size`() {
+        whenever(testContext.flowCheckpoint.maxMessageSize).thenReturn(1)
+        handler = FlowFinishedRequestHandler(testContext.flowMessageFactory, testContext.flowRecordFactory, avroSerializationFactory)
+
+        assertThrows<FlowFatalException> {  handler.getUpdatedWaitingFor(testContext.flowEventContext, ioRequest) }
     }
 
     @Test

--- a/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandlerTest.kt
+++ b/components/flow/flow-service/src/test/kotlin/net/corda/flow/pipeline/handlers/requests/FlowFinishedRequestHandlerTest.kt
@@ -56,7 +56,7 @@ class FlowFinishedRequestHandlerTest {
         whenever(testContext.flowCheckpoint.maxMessageSize).thenReturn(1)
         handler = FlowFinishedRequestHandler(testContext.flowMessageFactory, testContext.flowRecordFactory, avroSerializationFactory)
 
-        assertThrows<FlowFatalException> {  handler.getUpdatedWaitingFor(testContext.flowEventContext, ioRequest) }
+        assertThrows<FlowFatalException> {  handler.postProcess(testContext.flowEventContext, ioRequest) }
     }
 
     @Test


### PR DESCRIPTION
This PR ensures the flow result does not exceed the max allowed message size for payloads sent to the message bus. The flow result object is passed to the message bus via the FlowStatus object. If the message size is too large this will result in a fatal exception in the mediator and the flows topic partition will become blocked as the pattern will retry message after the worker restarts.