### PR TITLE
R3SOL-1765 privacy salt provider

### DIFF
--- a/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoBaselinedTransactionBuilder.kt
+++ b/components/ledger/ledger-utxo-flow/src/main/kotlin/net/corda/ledger/utxo/flow/impl/transaction/verifier/UtxoBaselinedTransactionBuilder.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.utxo.flow.impl.transaction.verifier
 
+import net.corda.ledger.common.data.transaction.PrivacySalt
 import net.corda.ledger.lib.utxo.flow.impl.timewindow.TimeWindowBetweenImpl
 import net.corda.ledger.lib.utxo.flow.impl.timewindow.TimeWindowUntilImpl
 import net.corda.ledger.lib.utxo.flow.impl.transaction.ContractStateAndEncumbranceTag
@@ -40,6 +41,7 @@ class UtxoBaselinedTransactionBuilder private constructor(
         get() = currentTransactionBuilder.referenceStateRefs
     override val outputStates: List<ContractStateAndEncumbranceTag>
         get() = currentTransactionBuilder.outputStates
+    override var privacySalt: PrivacySalt? = null
 
     override fun getNotaryName(): MemberX500Name? = currentTransactionBuilder.notaryName
 

--- a/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.lib.utxo.flow.impl.transaction
 
+import net.corda.ledger.common.data.transaction.PrivacySalt
 import net.corda.ledger.lib.utxo.flow.impl.timewindow.TimeWindowBetweenImpl
 import net.corda.ledger.lib.utxo.flow.impl.timewindow.TimeWindowUntilImpl
 import net.corda.ledger.lib.utxo.flow.impl.transaction.factory.UtxoSignedTransactionFactory
@@ -16,7 +17,6 @@ import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 import java.security.PublicKey
 import java.time.Instant
 import java.util.Objects
-import net.corda.ledger.common.data.transaction.PrivacySalt
 
 @Suppress("TooManyFunctions", "LongParameterList")
 class UtxoTransactionBuilderImpl(
@@ -32,9 +32,8 @@ class UtxoTransactionBuilderImpl(
     override val outputStates: MutableList<ContractStateAndEncumbranceTag> = mutableListOf()
 ) : UtxoTransactionBuilderInternal {
 
-    override var privacySalt: PrivacySalt?
-        get() = TODO("Not yet implemented")
-        set(value) {}
+    override var privacySalt: PrivacySalt? = null
+
     private var alreadySigned = false
 
     override fun addCommand(command: Command): UtxoTransactionBuilder {

--- a/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
+++ b/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderImpl.kt
@@ -16,6 +16,7 @@ import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 import java.security.PublicKey
 import java.time.Instant
 import java.util.Objects
+import net.corda.ledger.common.data.transaction.PrivacySalt
 
 @Suppress("TooManyFunctions", "LongParameterList")
 class UtxoTransactionBuilderImpl(
@@ -31,6 +32,9 @@ class UtxoTransactionBuilderImpl(
     override val outputStates: MutableList<ContractStateAndEncumbranceTag> = mutableListOf()
 ) : UtxoTransactionBuilderInternal {
 
+    override var privacySalt: PrivacySalt?
+        get() = TODO("Not yet implemented")
+        set(value) {}
     private var alreadySigned = false
 
     override fun addCommand(command: Command): UtxoTransactionBuilder {

--- a/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
+++ b/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
@@ -23,14 +23,8 @@ interface UtxoTransactionBuilderInternal : UtxoTransactionBuilder, UtxoTransacti
      */
     fun append(other: UtxoTransactionBuilderData): UtxoTransactionBuilderInternal
 
+    /**
+     * Privacy salt used in the transaction. If not set, the privacy salt will be generated.
+     */
     var privacySalt: PrivacySalt?
-        /**
-         * Gets the privacy salt, if set.
-         */
-        get
-
-        /**
-         * Sets the privacy salt.
-         */
-        set
 }

--- a/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
+++ b/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
@@ -24,9 +24,13 @@ interface UtxoTransactionBuilderInternal : UtxoTransactionBuilder, UtxoTransacti
     fun append(other: UtxoTransactionBuilderData): UtxoTransactionBuilderInternal
 
     var privacySalt: PrivacySalt?
-}
+        /**
+         * Gets the privacy salt, if set.
+         */
+        get
 
-// set privacy salt variable / dedup id on thread local
-// create transaction builder
-// turn into signed transaction -> this uses the thread local value
-// unset thread local
+        /**
+         * Sets the privacy salt.
+         */
+        set
+}

--- a/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
+++ b/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderInternal.kt
@@ -1,5 +1,6 @@
 package net.corda.ledger.lib.utxo.flow.impl.transaction
 
+import net.corda.ledger.common.data.transaction.PrivacySalt
 import net.corda.v5.ledger.utxo.transaction.UtxoTransactionBuilder
 
 interface UtxoTransactionBuilderInternal : UtxoTransactionBuilder, UtxoTransactionBuilderData {
@@ -21,4 +22,11 @@ interface UtxoTransactionBuilderInternal : UtxoTransactionBuilder, UtxoTransacti
      * But keeps potential duplications in user-defined types. (commands and output states)
      */
     fun append(other: UtxoTransactionBuilderData): UtxoTransactionBuilderInternal
+
+    var privacySalt: PrivacySalt?
 }
+
+// set privacy salt variable / dedup id on thread local
+// create transaction builder
+// turn into signed transaction -> this uses the thread local value
+// unset thread local

--- a/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
+++ b/libs/ledger-lib-utxo-flow/src/main/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/factory/impl/UtxoSignedTransactionFactoryImpl.kt
@@ -60,7 +60,7 @@ class UtxoSignedTransactionFactoryImpl(
         val metadataBytes = serializeMetadata(metadata)
         val componentGroups = calculateComponentGroups(utxoTransactionBuilder, metadataBytes)
 
-        val privacySalt = privacySaltProviderService.generatePrivacySalt()
+        val privacySalt = utxoTransactionBuilder.privacySalt ?: privacySaltProviderService.generatePrivacySalt()
         val wireTransaction = wireTransactionFactory.create(componentGroups, privacySalt)
 
         utxoLedgerTransactionVerificationService.verify(utxoLedgerTransactionFactory.create(wireTransaction))

--- a/libs/ledger-lib-utxo-flow/src/test/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
+++ b/libs/ledger-lib-utxo-flow/src/test/kotlin/net/corda/ledger/lib/utxo/flow/impl/transaction/UtxoTransactionBuilderImplTest.kt
@@ -2,6 +2,7 @@ package net.corda.ledger.lib.utxo.flow.impl.transaction
 
 import net.corda.crypto.core.SecureHashImpl
 import net.corda.ledger.common.data.transaction.CordaPackageSummaryImpl
+import net.corda.ledger.common.data.transaction.PrivacySaltImpl
 import net.corda.ledger.common.data.transaction.TransactionMetadataInternal
 import net.corda.ledger.common.test.dummyCpkSignerSummaryHash
 import net.corda.ledger.common.testkit.publicKeyExample
@@ -450,5 +451,22 @@ class UtxoTransactionBuilderImplTest : UtxoLedgerTest() {
             utxoTransactionBuilder
                 .addReferenceStates(List(2) { stateRef1 })
         }.isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `Privacy salt should return null by default`() {
+        val privacySalt = utxoTransactionBuilder.privacySalt
+
+        assertThat(privacySalt).isNull()
+    }
+
+    @Test
+    fun `Privacy salt should return the value set`() {
+        val privacySalt = PrivacySaltImpl("longlonglonglonglonglonglonglongbytes".toByteArray())
+        val builder = utxoTransactionBuilder.also {
+            it.privacySalt = privacySalt
+        }
+
+        assertThat(builder.privacySalt).isEqualTo(privacySalt)
     }
 }


### PR DESCRIPTION
this PR 
- added `privacySalt` member variable to `UtxoTransactionBuilderInternal` so that it can be set from dlt and use it for transaction in dlt. 
- made conditionally use available `privacySalt` depending on platform (dlt or c5)